### PR TITLE
ignore DriveType.Unknown drives as can't guarantee we have permissions

### DIFF
--- a/src/EventStore/EventStore.Core/Services/Monitoring/Stats/DrivesInfo.cs
+++ b/src/EventStore/EventStore.Core/Services/Monitoring/Stats/DrivesInfo.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Services.Monitoring.Stats
         {
             var sysDrives = DriveInfo.GetDrives();
             var drives = sysDrives
-                .Where(drive => drive.IsReady && drive.TotalSize > 0)
+                .Where(drive => drive.IsReady && drive.DriveType != DriveType.Unknown && drive.TotalSize > 0)
                 .Select(drive => new EsDriveInfo(drive.Name, drive.TotalSize, drive.AvailableFreeSpace))
                 .ToArray();
 


### PR DESCRIPTION
I just fired up EventStore and have noticed that DriveStats were failing.

I tracked this down to the fact that I have rebind mounts in which my current user does not have read access.   These come up with a drivetype of Unknown

To reproduce this.

As root

1) mount --bind /some/dir /some/otherdir 
2) make sure your user doesn't have read access to these directories.
3) run EventStore.

Now potentially we should be even more stringent on the drive types we wish to monitor.  Does anyone care about cdrom drive stats?
