### PR TITLE
Changed behavior when reconnection limit is reached: closes the connecti...

### DIFF
--- a/src/EventStore/EventStore.Core.Tests/ClientAPI/connect.cs
+++ b/src/EventStore/EventStore.Core.Tests/ClientAPI/connect.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Net;
+using System.Threading;
+using EventStore.ClientAPI;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientAPI
+{
+    [TestFixture, Category("LongRunning")]
+    public class connect : SpecificationWithDirectoryPerTestFixture
+    {
+        [TestFixtureSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+        }
+
+        [TestFixtureTearDown]
+        public override void TestFixtureTearDown()
+        {
+            base.TestFixtureTearDown();
+        }
+
+        [Test]
+        [Category("Network")]
+        public void should_not_throw_exception_when_server_is_down()
+        {
+            using (var connection = EventStoreConnection.Create())
+            {
+                connection.Connect(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 12348));
+            }
+        }
+
+        [Test]
+        [Category("Network")]
+        public void should_throw_exception_when_trying_to_reopen_closed_connection()
+        {
+            var settings = ConnectionSettings.Create()
+                .LimitReconnectionsTo(0)
+                .SetReconnectionDelayTo(TimeSpan.Zero);
+
+            using (var connection = EventStoreConnection.Create(settings))
+            {
+                connection.Connect(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 12348));
+
+                Thread.Sleep(4000); //Ensure reconnection attempt
+
+                Assert.Throws<InvalidOperationException>(
+                    () => connection.Connect(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 12348)),
+                        "EventStoreConnection has been closed");
+            }
+        }
+
+        [Test]
+        [Category("Network")]
+        public void should_close_connection_after_configured_amount_of_failed_reconnections()
+        {
+            var settings = ConnectionSettings.Create()
+                .LimitReconnectionsTo(0)
+                .SetReconnectionDelayTo(TimeSpan.Zero);
+
+            using (var connection = EventStoreConnection.Create(settings))
+            {
+                connection.Connect(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 12348));
+
+                Thread.Sleep(4000); //Ensure reconnection attempt
+
+                Assert.Throws<InvalidOperationException>(
+                    () => connection.CreateStream("stream", Guid.NewGuid(), false, new byte[0]),
+                        "EventStoreConnection [127.0.0.1:12348] is not active.");
+            }
+        }
+    }
+}

--- a/src/EventStore/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="ClientAPI\append_to_stream.cs" />
     <Compile Include="ClientAPI\appending_to_explicitly_created_stream.cs" />
     <Compile Include="ClientAPI\appending_to_implicitly_created_stream.cs" />
+    <Compile Include="ClientAPI\connect.cs" />
     <Compile Include="ClientAPI\deleting_stream.cs" />
     <Compile Include="ClientAPI\creating_stream.cs" />
     <Compile Include="ClientAPI\event_store_connection_should.cs" />


### PR DESCRIPTION
...on instead of throwing an exception on background thread (and killing the process). A closed/disposed connection cannot be re-opened and should be discarded.
