### PR TITLE
buffer management bugfix : reading_from_the_stream_with_StreamCopyTo_ret...

### DIFF
--- a/src/EventStore/EventStore.BufferManagement.Tests/BufferPoolStreamTests.cs
+++ b/src/EventStore/EventStore.BufferManagement.Tests/BufferPoolStreamTests.cs
@@ -86,6 +86,19 @@ namespace EventStore.BufferManagement.Tests
             read = stream.Read(new byte[500], 0, 500);
             Assert.AreEqual(0, read);
         }
+
+        [Test]
+        public void reading_from_the_stream_with_StreamCopyTo_returns_all_data()
+        {
+            BufferPoolStream stream = new BufferPoolStream(BufferPool);
+            int size = 20123;
+            stream.Write(new byte[size], 0, size);
+            stream.Position = 0;
+
+            var destination = new MemoryStream();
+            stream.CopyTo(destination);
+            Assert.AreEqual(destination.Length, size);
+        }
     }
 
     [TestFixture]
@@ -98,6 +111,7 @@ namespace EventStore.BufferManagement.Tests
             stream.Write(new byte[500], 0, 500);
             Assert.AreEqual(500, stream.Position);
         }
+
     }
 
     [TestFixture]
@@ -146,5 +160,6 @@ namespace EventStore.BufferManagement.Tests
             stream.Seek(501, SeekOrigin.Begin);
         }
     }
+
 
 }

--- a/src/EventStore/EventStore.BufferManagement.Tests/BufferPoolTests.cs
+++ b/src/EventStore/EventStore.BufferManagement.Tests/BufferPoolTests.cs
@@ -292,13 +292,24 @@ namespace EventStore.BufferManagement.Tests
             pool.ReadFrom(0, new byte[5], 4, 2);
         }
 
-        [Test, ExpectedException(typeof(ArgumentOutOfRangeException))]
-        public void a_count_and_offset_together_are_longer_than_pool_length_throws_an_argumentoutofrangeexception()
+        [Test]
+        public void reading_from_a_position_bigger_than_buffer_length_reads_nothing()
         {
             BufferPool pool = new BufferPool(1, BufferManager);
             pool[0] = 12;
             pool[1] = 13;
-            pool.ReadFrom(3, new byte[5], 0, 5);
+            int read = pool.ReadFrom(3, new byte[5], 0, 5);
+            Assert.AreEqual(read, 0);
+        }
+
+        [Test]
+        public void reading_from_a_position_plus_count_bigger_than_buffer_length_reads_the_right_amount()
+        {
+            BufferPool pool = new BufferPool(1, BufferManager);
+            pool[0] = 12;
+            pool[1] = 13;
+            int read = pool.ReadFrom(0, new byte[5], 0, 5);
+            Assert.AreEqual(read, 2);
         }
 
         [Test]

--- a/src/EventStore/EventStore.BufferManagement/BufferPool.cs
+++ b/src/EventStore/EventStore.BufferManagement/BufferPool.cs
@@ -249,21 +249,21 @@ namespace EventStore.BufferManagement
         public int ReadFrom(int position, ArraySegment<byte> data)
         {
             CheckDisposed();
-            if (position + data.Count > _length) 
-                throw new ArgumentOutOfRangeException("data");
+            if (position > _length)
+                return 0;
             int copied = 0;
             int currentLocation = position;
             do
             {
                 Position l = GetPositionFor(currentLocation);
                 ArraySegment<byte> current = _buffers[l.Index];
-                int bytesToRead = _chunkSize - l.Offset;
+                int bytesToRead = Math.Min(_chunkSize - l.Offset, (_length - position) % _chunkSize);
                 bytesToRead = bytesToRead > data.Count - copied ? data.Count - copied : bytesToRead;
                 if (bytesToRead > 0)
                     Buffer.BlockCopy(current.Array, current.Offset + l.Offset, data.Array, data.Offset + copied, bytesToRead);
                 copied += bytesToRead;
                 currentLocation += bytesToRead;
-            } while (copied < data.Count);
+            } while (copied < data.Count && currentLocation < _length);
             return copied;            
         }
 


### PR DESCRIPTION
CopyTo method on BufferPoolStream throws exception when it should just copy all data it can untill the end of the stream.
