### PR TITLE
 Change template class attribute to className for IE10 compatibility 

### DIFF
--- a/src/EventStore/EventStore.SingleNode.Web/singlenode-web/js/es.menu.js
+++ b/src/EventStore/EventStore.SingleNode.Web/singlenode-web/js/es.menu.js
@@ -1,9 +1,9 @@
 es.util.loadMenu([
-    { "name": "Home", "link": "/web/home.htm", "class": "" },
-    { "name": "Streams", "link": "/web/streams.htm", "class": "" },
-    { "name": "Projections", "link": "/web/projections.htm", "class": "" },
-    { "name": "Query", "link": "/web/query.htm", "class": "" },
-    { "name": "Charts", "link": "/web/charts.htm", "class": "" },
-    { "name": "Health Charts", "link": "/web/health-charts.htm", "class": "" },
-    { "name": "Queues", "link": "/web/queues.htm", "class": "" }
+    { "name": "Home", "link": "/web/home.htm", "className": "" },
+    { "name": "Streams", "link": "/web/streams.htm", "className": "" },
+    { "name": "Projections", "link": "/web/projections.htm", "className": "" },
+    { "name": "Query", "link": "/web/query.htm", "className": "" },
+    { "name": "Charts", "link": "/web/charts.htm", "className": "" },
+    { "name": "Health Charts", "link": "/web/health-charts.htm", "className": "" },
+    { "name": "Queues", "link": "/web/queues.htm", "className": "" }
 ]);

--- a/src/EventStore/EventStore.Web/es-common-web/js/es.util.js
+++ b/src/EventStore/EventStore.Web/es-common-web/js/es.util.js
@@ -6,7 +6,7 @@ es.util = {};
 
 es.util.loadMenu = function (pages) {
 
-    var tmplStr = '<li class="{{>class}}"> <a href="{{>link}}"> {{>name}} </a> </li>';
+    var tmplStr = '<li class="{{>className}}"> <a href="{{>link}}"> {{>name}} </a> </li>';
     var tmpl = $.templates(tmplStr);
     var htmlString = tmpl.render(pages);
 


### PR DESCRIPTION
On IE10, the Template rendering fails when trying to compile a Template that contains a call to .class
I propose to rename it .className
