### PR TITLE
Fix event date display in web interface (off by 1 day) 

### DIFF
--- a/src/EventStore/EventStore.Web/es-common-web/js/atom/render.js
+++ b/src/EventStore/EventStore.Web/es-common-web/js/atom/render.js
@@ -8,7 +8,7 @@
                     formatDate: function(s) {
                         var d = new Date(s);
 
-                        return (1900 + d.getYear()) + "-" + (1 + d.getMonth()) + "-" + (1 + d.getDate()) + " " +
+                        return (1900 + d.getYear()) + "-" + (1 + d.getMonth()) + "-" + d.getDate() + " " +
                             d.getHours() + ":" + d.getMinutes() + ":" + d.getSeconds();
                     }
                 }


### PR DESCRIPTION
js date.getMonth() is 0 based, but getDay() is not... usual js wtf.
Now it's fixed
