### PR TITLE
Preserve IsJson when using transactions

### DIFF
--- a/src/EventStore/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -243,7 +243,8 @@ namespace EventStore.Core.Services.Storage
                                                             transactionInfo.EventStreamId,
                                                             evnt.EventType,
                                                             evnt.Data,
-                                                            evnt.Metadata);
+                                                            evnt.Metadata,
+                                                            evnt.IsJson);
                     var res = WritePrepareWithRetry(record);
                     logPosition = res.NewPos;
                 }

--- a/src/EventStore/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
+++ b/src/EventStore/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
@@ -87,12 +87,10 @@ namespace EventStore.Core.TransactionLog.LogRecords
                                         DateTime.UtcNow, PrepareFlags.TransactionBegin, null, NoData, NoData);
         }
 
-        public static PrepareLogRecord TransactionWrite(long logPosition, Guid correlationId, Guid eventId, long transactionPos, 
-                                                        int transactionOffset, string eventStreamId, string eventType, 
-                                                        byte[] data, byte[] metadata)
+        public static PrepareLogRecord TransactionWrite(long logPosition, Guid correlationId, Guid eventId, long transactionPos, int transactionOffset, string eventStreamId, string eventType, byte[] data, byte[] metadata, bool isJson)
         {
             return new PrepareLogRecord(logPosition, correlationId, eventId, transactionPos, transactionOffset,
-                                        eventStreamId, ExpectedVersion.Any, DateTime.UtcNow, PrepareFlags.Data, 
+                                        eventStreamId, ExpectedVersion.Any, DateTime.UtcNow, PrepareFlags.Data | (isJson ? PrepareFlags.IsJson : PrepareFlags.None), 
                                         eventType, data, metadata);
         }
 


### PR DESCRIPTION
When using the ClientApi, events written using
    let tx = cnx.StartTranaction(stream, version);
    tx.WriteEvents(events);
    tx.Commit()

don't preserve the isJson information passed  in EventData.
Thus, their Json text is not shown in the web interface.

There was no prb with cnx.AppendEvents(stream, version, events).
