### PR TITLE
Add support for building with Visual Studio 2012 toolset

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Event Store is written in a mixture of C#, C++ and JavaScript. It can run either
 
 ####Prerequisites
 
-	- Visual Studio 2010 (with .NET 4 and 64-bit C++ support)
+	- Visual Studio 2010 or 2012 (with .NET 4 and 64-bit C++ support)
 	- git on PATH
 	- svn on PATH
 
@@ -19,6 +19,8 @@ Event Store is written in a mixture of C#, C++ and JavaScript. It can run either
 Either use a Visual Studio 2010 x64 Command Prompt, or run
 
 	"C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x64
+
+Visual Studio 2012 x64 Command Prompt can also be used.
 
 ####Download and build v8
 
@@ -29,6 +31,8 @@ Either use a Visual Studio 2010 x64 Command Prompt, or run
 ####Build the v8 integration code
 
 	C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe /p:Configuration=Debug;Platform=x64 src\EventStore\Projections.Dev.WindowsOnly.sln 
+
+For Visual Studio 2012 add /p:PlatformToolset=v110
 
 This step produces a file named js1.dll, which contains the projections framework. If you already have access to a suitable version of this file (e.g. from the binary distribution) you can proceed to step 4, having made it available in src\EventStore\libs\x64.
 

--- a/src/EventStore/Scripts/v8/build-v8_release_x64.cmd
+++ b/src/EventStore/Scripts/v8/build-v8_release_x64.cmd
@@ -19,7 +19,7 @@ exit /b 1
 :setup-environment
 
     path %PATH%;%~dp0..\..\v8\third_party\python_26\;C:\Windows\Microsoft.NET\Framework64\v4.0.30319\;c:\Program Files (x86)\Git\bin; || goto :error
-    call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"  || goto :error
+    call "vcvars64.bat"  || goto :error
 
 exit /b 0
 

--- a/src/EventStore/Scripts/v8/build-v8_x64.cmd
+++ b/src/EventStore/Scripts/v8/build-v8_x64.cmd
@@ -19,7 +19,7 @@ exit /b 1
 :setup-environment
 
     path %PATH%;%~dp0..\..\v8\third_party\python_26\;C:\Windows\Microsoft.NET\Framework64\v4.0.30319\;c:\Program Files (x86)\Git\bin; || goto :error
-    call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64\vcvars64.bat"  || goto :error
+    call "vcvars64.bat"  || goto :error
 
 exit /b 0
 


### PR DESCRIPTION
First removed full path to vs2010 toolset. It's not needed since they are already in PATH (assuming we first run VS Command Prompt as described in original README)

Then to build EventStore.Projections, there are two ways 
1) proposed in this request: simply add /p:PlatformToolset=v110 as MSBuild parameter
2) other way would be to conditionally set `<PlatformToolset>` in v8 vcxproj, depending on the detected version installed. I wasn't sure about that approach.
