### PR TITLE
replace hardcoded dash with _separator

### DIFF
--- a/src/EventStore/EventStore.Projections.Core/Standard/CategorizeEventsByStreamPath.cs
+++ b/src/EventStore/EventStore.Projections.Core/Standard/CategorizeEventsByStreamPath.cs
@@ -51,7 +51,7 @@ namespace EventStore.Projections.Core.Standard
                         "Categorize stream projection handler has been initialized with separator: '{0}'", _separator));
             }
             // we will need to declare event types we are interested in
-            _categoryStreamPrefix = "$ce-";
+            _categoryStreamPrefix = "$ce" + _separator;
         }
 
         public void ConfigureSourceProcessingStrategy(QuerySourceProcessingStrategyBuilder builder)


### PR DESCRIPTION
Noticed a hardcoded hyphen in the standard `CategorizeEventsByStreamPath` projection. Replaced it with the passed in separator.
