### PR TITLE
fixed IndexOutOfRangeException in GetDirectoryRootInLinux: add -P switch to df to avoid line wrap

### DIFF
--- a/src/EventStore/EventStore.Core/Services/Monitoring/Stats/EsDriveInfo.cs
+++ b/src/EventStore/EventStore.Core/Services/Monitoring/Stats/EsDriveInfo.cs
@@ -99,7 +99,7 @@ namespace EventStore.Core.Services.Monitoring.Stats
 
             try
             {
-                var driveInfo = ShellExecutor.GetOutput("df", directory);
+                var driveInfo = ShellExecutor.GetOutput("df", string.Format("-P {0}", directory));
                 var driveInfoLines = driveInfo.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
                 var ourline = driveInfoLines[1];
                 var spaces = new Regex(@"[\s\t]+", RegexOptions.Compiled);


### PR DESCRIPTION
If the Filesystem is too long it will wrap to the next line which causes
an IndexOutOfRangeException when attempting to get the volume name.

Added the -P switch which will output it POSIX style and all on one
line.
