### PR TITLE
Do not install mono-runtime for mono build

### DIFF
--- a/src/EventStore/Scripts/get-mono
+++ b/src/EventStore/Scripts/get-mono
@@ -53,7 +53,6 @@ apt-get install -y automake || err
 apt-get install -y gcc || err
 apt-get install -y build-essential || err
 apt-get install -y gettext || err
-apt-get install -y mono-runtime || err
 apt-get install -y mono-gmcs || err
 
 


### PR DESCRIPTION
The `get-mono` script does install the `mono-runtime` via apt-get before installing it from source. This leaves the machine in a state where the mono-runtime is installed on two different locations. This is because the `make install` from the mono source also installs the mono runtime.
