### PR TITLE
Set read batch size for CatchUp Subscriptions

### DIFF
--- a/src/EventStore/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -286,9 +286,10 @@ namespace EventStore.ClientAPI
                                                   Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
                                                   Action<EventStoreCatchUpSubscription> liveProcessingStarted,
                                                   Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped,
-                                                  bool verboseLogging)
+                                                  bool verboseLogging,
+                                                  int readBatchSize = 500)
                 : base(connection, log, string.Empty, resolveLinkTos, userCredentials, 
-                       eventAppeared, liveProcessingStarted, subscriptionDropped, verboseLogging)
+                       eventAppeared, liveProcessingStarted, subscriptionDropped, verboseLogging, readBatchSize)
         {
             _lastProcessedPosition = fromPositionExclusive ?? new Position(-1, -1);
             _nextReadPosition = fromPositionExclusive ?? Position.Start;
@@ -353,9 +354,10 @@ namespace EventStore.ClientAPI
                                                      Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
                                                      Action<EventStoreCatchUpSubscription> liveProcessingStarted,
                                                      Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped,
-                                                     bool verboseLogging)
+                                                     bool verboseLogging,
+                                                     int readBatchSize = 500)
             : base(connection, log, streamId, resolveLinkTos, userCredentials, 
-                   eventAppeared, liveProcessingStarted, subscriptionDropped, verboseLogging)
+                   eventAppeared, liveProcessingStarted, subscriptionDropped, verboseLogging, readBatchSize)
         {
             Ensure.NotNullOrEmpty(streamId, "streamId");
 

--- a/src/EventStore/EventStore.ClientAPI/EventStoreClusterConnection.cs
+++ b/src/EventStore/EventStore.ClientAPI/EventStoreClusterConnection.cs
@@ -229,10 +229,12 @@ namespace EventStore.ClientAPI
                 Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
-                UserCredentials userCredentials = null)
+                UserCredentials userCredentials = null,
+                int readBatchSize = 500)
         {
             return _conn.SubscribeToStreamFrom(stream, fromEventNumberExclusive, resolveLinkTos,
-                                               eventAppeared, liveProcessingStarted, subscriptionDropped, userCredentials);
+                                               eventAppeared, liveProcessingStarted,
+                                               subscriptionDropped, userCredentials, readBatchSize);
         }
 
         public EventStoreSubscription SubscribeToAll(
@@ -259,10 +261,11 @@ namespace EventStore.ClientAPI
                 Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
-                UserCredentials userCredentials = null)
+                UserCredentials userCredentials = null,
+                int readBatchSize = 500)
         {
             return _conn.SubscribeToAllFrom(fromPositionExclusive, resolveLinkTos,
-                                            eventAppeared, liveProcessingStarted, subscriptionDropped, userCredentials);
+                                            eventAppeared, liveProcessingStarted, subscriptionDropped, userCredentials, readBatchSize);
         }
 
         public WriteResult SetStreamMetadata(string stream, int expectedMetastreamVersion, StreamMetadata metadata, UserCredentials userCredentials = null)

--- a/src/EventStore/EventStore.ClientAPI/EventStoreNodeConnection.cs
+++ b/src/EventStore/EventStore.ClientAPI/EventStoreNodeConnection.cs
@@ -346,14 +346,15 @@ namespace EventStore.ClientAPI
                                                                          Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
                                                                          Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                                                                          Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
-                                                                         UserCredentials userCredentials = null)
+                                                                         UserCredentials userCredentials = null,
+                                                                         int readBatchSize = 500)
         {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNull(eventAppeared, "eventAppeared");
             var catchUpSubscription =
                     new EventStoreStreamCatchUpSubscription(this, _settings.Log, stream, fromEventNumberExclusive, 
                                                             resolveLinkTos, userCredentials, eventAppeared, 
-                                                            liveProcessingStarted, subscriptionDropped, _settings.VerboseLogging);
+                                                            liveProcessingStarted, subscriptionDropped, _settings.VerboseLogging, readBatchSize);
             catchUpSubscription.Start();
             return catchUpSubscription;
         }
@@ -388,13 +389,14 @@ namespace EventStore.ClientAPI
                 Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
-                UserCredentials userCredentials = null)
+                UserCredentials userCredentials = null,
+                int readBatchSize = 500)
         {
             Ensure.NotNull(eventAppeared, "eventAppeared");
             var catchUpSubscription = 
                     new EventStoreAllCatchUpSubscription(this, _settings.Log, fromPositionExclusive, resolveLinkTos,
                                                          userCredentials, eventAppeared, liveProcessingStarted, 
-                                                         subscriptionDropped, _settings.VerboseLogging);
+                                                         subscriptionDropped, _settings.VerboseLogging, readBatchSize);
             catchUpSubscription.Start();
             return catchUpSubscription;
         }

--- a/src/EventStore/EventStore.ClientAPI/IEventStoreConnection.cs
+++ b/src/EventStore/EventStore.ClientAPI/IEventStoreConnection.cs
@@ -380,7 +380,8 @@ namespace EventStore.ClientAPI
                 Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
-                UserCredentials userCredentials = null);
+                UserCredentials userCredentials = null,
+                int readBatchSize = 500);
 
         EventStoreSubscription SubscribeToAll(
                 bool resolveLinkTos, 
@@ -400,7 +401,8 @@ namespace EventStore.ClientAPI
                 Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
-                UserCredentials userCredentials = null);
+                UserCredentials userCredentials = null,
+                int readBatchSize = 500);
 
         WriteResult SetStreamMetadata(string stream, int expectedMetastreamVersion, StreamMetadata metadata, UserCredentials userCredentials = null);
 


### PR DESCRIPTION
Enables setting of an already existing option. Helps for known
unreliable nodes like EC2 micro.
