### PR TITLE
I want to build on Ubuntu :)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -173,7 +173,7 @@ function buildV8() {
         echo "Unsupported platform $PLATFORM."
         exit 1
     fi
-    $make $makecall library=shared || err
+    $make $makecall werror=no library=shared || err
 
     pushd out/$makecall/lib.target > /dev/null
     cp libv8.so ../../../../src/EventStore/libs || err


### PR DESCRIPTION
Ubuntu runs a newer version of GCC than V8 likes. This is the flag that is required to make it work on that. 

You probably want an option to disable Werror as an input to the script rather than doing it by default like this.
