### PR TITLE
Fixed parsing of arguments for projection creation with credentials

### DIFF
--- a/src/EventStore/EventStore.Padmin/Command.cs
+++ b/src/EventStore/EventStore.Padmin/Command.cs
@@ -187,7 +187,7 @@ namespace EventStore.Padmin
 
         private static Tuple<string, string, UserCredentials> GetQueryAndCredentials(string[] commandArgs)
         {
-            if (commandArgs.Length == 3 || commandArgs.Length >= 4)
+            if (commandArgs.Length == 3 || commandArgs.Length > 4)
                 return null;
 
             if (commandArgs.Length == 1 || commandArgs.Length == 3)


### PR DESCRIPTION
Corrected argument validation that was producing an invalid arguments when running:
padmin create continous with credentials
