### PR TITLE
Adding Authorization header for Access-Control-Allow-Headers

### DIFF
--- a/src/EventStore/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -160,7 +160,7 @@ namespace EventStore.Transport.Http.EntityManagement
             try
             {
                 HttpEntity.Response.AddHeader("Access-Control-Allow-Methods", string.Join(", ", _allowedMethods));
-                HttpEntity.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type, X-Requested-With, X-PINGOTHER");
+                HttpEntity.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type, X-Requested-With, X-PINGOTHER, Authorization");
                 HttpEntity.Response.AddHeader("Access-Control-Allow-Origin", "*");
                 if (HttpEntity.Response.StatusCode == HttpStatusCode.Unauthorized)
                     HttpEntity.Response.AddHeader("WWW-Authenticate", "Basic realm=\"ES\"");


### PR DESCRIPTION
To make auth call from ajax without having to type username and password, we need to provide authorization header in request. Moreover this is the only way to do auth from 'file.html' based application, that is not hosted on the server. As otherwise origin in chrome/ff/etc. is set to null, which is causing that Access-Control-Allow-Origin wildcard '*' is not allowed.

however in IE it will not work, instead IE will ignore Authorization header and will show credentials popup.

http://connect.microsoft.com/IE/feedback/details/781303
http://stackoverflow.com/q/20784209/126800

if this change will not pass "security/verification/approval", then single page web app will not work on all browsers except IE (yeah, I know, but it's because of the bug in IE;))
