### PR TITLE
Adding Exposed headers for CORS

### DIFF
--- a/src/EventStore/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -162,6 +162,7 @@ namespace EventStore.Transport.Http.EntityManagement
                 HttpEntity.Response.AddHeader("Access-Control-Allow-Methods", string.Join(", ", _allowedMethods));
                 HttpEntity.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type, X-Requested-With, X-PINGOTHER, Authorization");
                 HttpEntity.Response.AddHeader("Access-Control-Allow-Origin", "*");
+                HttpEntity.Response.AddHeader("Access-Control-Expose-Headers", "Location");
                 if (HttpEntity.Response.StatusCode == HttpStatusCode.Unauthorized)
                     HttpEntity.Response.AddHeader("WWW-Authenticate", "Basic realm=\"ES\"");
             }


### PR DESCRIPTION
By default, when doing CORS ajax request, following headers will be available:
- Cache-Control
- Content-Language
- Content-Type
- Expires
- Last-Modified
- Pragma

[source](http://www.w3.org/TR/cors/#simple-response-header)

[more info - point 4](http://www.w3.org/TR/cors/#resource-requests)

if we need to read anything else from headers (even-thou they are returned) we need to provide `Access-Control-Expose-Header`, otherwise browsers will not allow to get these headers from xhr response.

Exact case: [SO question](http://stackoverflow.com/questions/17038436/reading-response-headers-when-using-http-of-angularjs)

Im not sure if there are other headers that will need to be exposed, but `Location` is required for getting information about created projection
