### PR TITLE
Allowing long polling and Projection debug 4 CORS

### DIFF
--- a/src/EventStore/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -132,9 +132,9 @@ namespace EventStore.Transport.Http.EntityManagement
             try
             {
                 HttpEntity.Response.AddHeader("Access-Control-Allow-Methods", string.Join(", ", _allowedMethods));
-                HttpEntity.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type, X-Requested-With, X-PINGOTHER, Authorization");
+                HttpEntity.Response.AddHeader("Access-Control-Allow-Headers", "Content-Type, X-Requested-With, X-PINGOTHER, Authorization, ES-LongPoll");
                 HttpEntity.Response.AddHeader("Access-Control-Allow-Origin", "*");
-                HttpEntity.Response.AddHeader("Access-Control-Expose-Headers", "Location");
+                HttpEntity.Response.AddHeader("Access-Control-Expose-Headers", "Location, ES-Position");
                 if (HttpEntity.Response.StatusCode == HttpStatusCode.Unauthorized)
                     HttpEntity.Response.AddHeader("WWW-Authenticate", "Basic realm=\"ES\"");
             }


### PR DESCRIPTION
To be able to do long polling from different domain or HTML file `Access-Control-Allow-Headers` needs to contain `ES-LongPoll`.

To read position in Projection debugging, `Access-Control-Expose-Headers` needs to contain `ES-Position`
