### PR TITLE
Fix client connecting via gossip seeds

### DIFF
--- a/src/EventStore/EventStore.ClientAPI/ClusterSettings.cs
+++ b/src/EventStore/EventStore.ClientAPI/ClusterSettings.cs
@@ -40,7 +40,29 @@ namespace EventStore.ClientAPI
         /// </summary>
         public TimeSpan GossipTimeout;
 
-        internal ClusterSettings(string clusterDns, int maxDiscoverAttempts, int externalGossipPort, IPEndPoint[] gossipSeeds, TimeSpan gossipTimeout)
+        /// <summary>
+        /// Used if we're connecting with gossip seeds
+        /// </summary>
+        /// <param name="gossipSeeds">Endpoints for seeding gossip</param>
+        /// <param name="maxDiscoverAttempts">Maximum number of attempts to discover the cluster</param>
+        /// <param name="gossipTimeout">Timeout for cluster gossip</param>
+        internal ClusterSettings(IPEndPoint[] gossipSeeds, int maxDiscoverAttempts, TimeSpan gossipTimeout)
+        {
+            ClusterDns = "";
+            MaxDiscoverAttempts = maxDiscoverAttempts;
+            ExternalGossipPort = 0;
+            GossipTimeout = gossipTimeout;
+            GossipSeeds = gossipSeeds;
+        }
+
+        /// <summary>
+        /// Used if we're discovering via DNS
+        /// </summary>
+        /// <param name="clusterDns">The DNS name to use for discovering endpoints</param>
+        /// <param name="maxDiscoverAttempts">The maximum number of attempts for discovering endpoints</param>
+        /// <param name="externalGossipPort">The well-known endpoint on which cluster managers are running</param>
+        /// <param name="gossipTimeout">Timeout for cluster gossip</param>
+        internal ClusterSettings(string clusterDns, int maxDiscoverAttempts, int externalGossipPort, TimeSpan gossipTimeout)
         {
             Ensure.NotNullOrEmpty(clusterDns, "clusterDns");
             if (maxDiscoverAttempts < -1)
@@ -51,7 +73,7 @@ namespace EventStore.ClientAPI
             MaxDiscoverAttempts = maxDiscoverAttempts;
             ExternalGossipPort = externalGossipPort;
             GossipTimeout = gossipTimeout;
-            GossipSeeds = gossipSeeds;
+            GossipSeeds = new IPEndPoint[0];
         }
     }
 }

--- a/src/EventStore/EventStore.ClientAPI/ClusterSettingsBuilder.cs
+++ b/src/EventStore/EventStore.ClientAPI/ClusterSettingsBuilder.cs
@@ -1,110 +1,27 @@
-﻿using System;
-using System.Net;
-using EventStore.ClientAPI.Common.Utils;
-
-namespace EventStore.ClientAPI
+﻿namespace EventStore.ClientAPI
 {
     /// <summary>
     /// Builder used for creating instances of ClusterSettings.
     /// </summary>
     public class ClusterSettingsBuilder
     {
-        private string _clusterDns;
-        private int _maxDiscoverAttempts = Consts.DefaultMaxClusterDiscoverAttempts;
-        private int _managerExternalHttpPort = Consts.DefaultClusterManagerExternalHttpPort;
-
-        private IPEndPoint[] _gossipSeeds;
-        private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
-
         /// <summary>
-        /// Sets the DNS name under which cluster nodes are listed.
+        /// Sets the client to discover nodes using a DNS name and a well-known port.
         /// </summary>
-        /// <param name="clusterDns">The DNS name under which cluster nodes are listed.</param>
-        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
-        public ClusterSettingsBuilder SetClusterDns(string clusterDns)
+        /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        public DnsClusterSettingsBuilder DiscoverClusterViaDns()
         {
-            Ensure.NotNullOrEmpty(clusterDns, "clusterDns");
-            _clusterDns = clusterDns;
-            return this;
+            return new DnsClusterSettingsBuilder();
         }
 
         /// <summary>
-        /// Sets the maximum number of attempts for DNS discovery.
+        /// Sets the client to discover cluster nodes by specifying the IP endpoints of
+        /// one or more of the nodes.
         /// </summary>
-        /// <param name="maxDiscoverAttempts">The maximum number of attempts for DNS discovery.</param>
-        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">If maxDiscoverAttempts is less than 0.</exception>
-        public ClusterSettingsBuilder SetMaxDiscoverAttempts(int maxDiscoverAttempts)
-        {
-            if (maxDiscoverAttempts < -1)
-                throw new ArgumentOutOfRangeException("maxDiscoverAttempts", string.Format("maxDiscoverAttempts value is out of range: {0}. Allowed range: [-1, infinity].", maxDiscoverAttempts));
-            _maxDiscoverAttempts = maxDiscoverAttempts;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the period after which gossip times out if none is received.
-        /// </summary>
-        /// <param name="timeout">The period after which gossip times out if none is received.</param>
-        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
-        public ClusterSettingsBuilder WithGossipTimeoutOf(TimeSpan timeout)
-        {
-            _gossipTimeout = timeout;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the port with which the client will communicate with cluster managers in
-        /// commercial versions of the Event Store. This should be the external HTTP port
-        /// of the manager.
-        /// </summary>
-        /// <param name="managerExternalHttpPort">The external HTTP port of cluster managers.</param>
-        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
-        public ClusterSettingsBuilder SetManagerExternalHttpPort(int managerExternalHttpPort)
-        {
-            Ensure.Positive(managerExternalHttpPort, "managerExternalHttpPort");
-            _managerExternalHttpPort = managerExternalHttpPort;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets the port on which cluster members gossip.
-        /// </summary>
-        /// <param name="gossipPort">The port on which cluster members gossip.</param>
-        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
-        public ClusterSettingsBuilder SetGossipPort(int gossipPort)
-        {
-            Ensure.Positive(gossipPort, "gossipPort");
-            _managerExternalHttpPort = gossipPort;
-            return this;
-        }
-
-        /// <summary>
-        /// Sets gossip seed endpoints for the client.
-        /// </summary>
-        /// <param name="gossipSeeds">IPEndPoints representing the endpoints of nodes from which to seed gossip.</param>
-        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
-        /// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
-        public ClusterSettingsBuilder WithGossipSeeds(params IPEndPoint[] gossipSeeds)
-        {
-            if (gossipSeeds == null || gossipSeeds.Length == 0)
-                throw new ArgumentException("Empty FakeDnsEntries collection.");
-            _gossipSeeds = gossipSeeds;
-            return this;
-        }
-
-        /// <summary>
-        /// Builds a <see cref="ClusterSettings"/> object from a <see cref="ClusterSettingsBuilder"/>.
-        /// </summary>
-        /// <param name="builder"><see cref="ClusterSettingsBuilder"/> from which to build a <see cref="ClusterSettings"/></param>
         /// <returns></returns>
-        public static implicit operator ClusterSettings(ClusterSettingsBuilder builder)
+        public GossipSeedClusterSettingsBuilder DiscoverClusterViaGossipSeeds()
         {
-            return new ClusterSettings(builder._clusterDns,
-                                       builder._maxDiscoverAttempts,
-                                       builder._managerExternalHttpPort,
-                                       builder._gossipSeeds,
-                                       builder._gossipTimeout);
+            return new GossipSeedClusterSettingsBuilder();
         }
     }
 }

--- a/src/EventStore/EventStore.ClientAPI/Core/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore/EventStore.ClientAPI/Core/ClusterDnsEndPointDiscoverer.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.Messages;
-using EventStore.ClientAPI.SystemData;
 using EventStore.ClientAPI.Transport.Http;
 using System.Linq;
 using HttpStatusCode = EventStore.ClientAPI.Transport.Http.HttpStatusCode;
@@ -33,7 +32,6 @@ namespace EventStore.ClientAPI.Core
                                             TimeSpan gossipTimeout)
         {
             Ensure.NotNull(log, "log");
-            Ensure.NotNullOrEmpty(clusterDns, "clusterDns");
 
             _log = log;
             _clusterDns = clusterDns;

--- a/src/EventStore/EventStore.ClientAPI/Core/GossipSeedEndPointDiscoverer.cs
+++ b/src/EventStore/EventStore.ClientAPI/Core/GossipSeedEndPointDiscoverer.cs
@@ -1,0 +1,210 @@
+﻿//using System;
+//using System.Collections.Generic;
+//using System.Linq;
+//using System.Net;
+//using System.Threading;
+//using System.Threading.Tasks;
+//using EventStore.ClientAPI.Common.Utils;
+//using EventStore.ClientAPI.Exceptions;
+//using EventStore.ClientAPI.Messages;
+//using EventStore.ClientAPI.Transport.Http;
+//using HttpStatusCode = EventStore.ClientAPI.Transport.Http.HttpStatusCode;
+
+//namespace EventStore.ClientAPI.Core
+//{
+//    internal class GossipSeedEndPointDiscoverer : IEndPointDiscoverer
+//    {
+//        private readonly ILogger _log;
+//        private readonly IPEndPoint[] _gossipSeeds;
+//        private readonly int _maxDiscoverAttempts;
+
+//        private readonly HttpAsyncClient _client;
+//        private ClusterMessages.MemberInfoDto[] _oldGossip;
+//        private TimeSpan _gossipTimeout;
+
+//        public GossipSeedEndPointDiscoverer(ILogger log,
+//                                            IPEndPoint[] gossipSeeds,
+//                                            TimeSpan gossipTimeout,
+//                                            int maxDiscoverAttempts)
+//        {
+//            Ensure.NotNull(log, "log");
+
+//            _log = log;
+//            _maxDiscoverAttempts = maxDiscoverAttempts;
+//            _gossipSeeds = gossipSeeds;
+//            _gossipTimeout = gossipTimeout;
+//            _client = new HttpAsyncClient(log);
+//        }
+
+//        public Task<NodeEndPoints> DiscoverAsync(IPEndPoint failedTcpEndPoint)
+//        {
+//            return Task.Factory.StartNew(() =>
+//            {
+//                for (int attempt = 1; attempt <= _maxDiscoverAttempts; ++attempt)
+//                {
+//                    //_log.Info("Discovering cluster. Attempt {0}/{1}...", attempt, _maxDiscoverAttempts);
+//                    try
+//                    {
+//                        var endPoints = DiscoverEndPoint(failedTcpEndPoint);
+//                        if (endPoints != null)
+//                        {
+//                            _log.Info("Discovering attempt {0}/{1} successful: best candidate is {2}.", attempt, _maxDiscoverAttempts, endPoints);
+//                            return endPoints.Value;
+//                        }
+
+//                        _log.Info("Discovering attempt {0}/{1} failed: no candidate found.", attempt, _maxDiscoverAttempts);
+//                    }
+//                    catch (Exception exc)
+//                    {
+//                        _log.Info("Discovering attempt {0}/{1} failed with error: {2}.", attempt, _maxDiscoverAttempts, exc);
+//                    }
+
+//                    Thread.Sleep(500);
+//                }
+//                throw new ClusterException(string.Format("Failed to discover candidate in {0} attempts.", _maxDiscoverAttempts));
+//            });
+//        }
+
+//        private NodeEndPoints? DiscoverEndPoint(IPEndPoint failedEndPoint)
+//        {
+//            var oldGossip = Interlocked.Exchange(ref _oldGossip, null);
+//            var gossipCandidates = oldGossip != null
+//                                           ? GetGossipCandidatesFromOldGossip(oldGossip, failedEndPoint)
+//                                           : GetGossipCandidatesFromDns();
+//            for (int i = 0; i < gossipCandidates.Length; ++i)
+//            {
+//                var gossip = TryGetGossipFrom(gossipCandidates[i]);
+//                if (gossip == null || gossip.Members == null || gossip.Members.Length == 0)
+//                    continue;
+
+//                var bestNode = TryDetermineBestNode(gossip.Members);
+//                if (bestNode != null)
+//                {
+//                    _oldGossip = gossip.Members;
+//                    return bestNode;
+//                }
+//            }
+
+//            return null;
+//        }
+
+//        private IPEndPoint[] GetGossipCandidatesFromDns()
+//        {
+//            //_log.Debug("ClusterDnsEndPointDiscoverer: GetGossipCandidatesFromDns");
+//            IPEndPoint[] endpoints = _gossipSeeds;
+//            RandomShuffle(endpoints, 0, endpoints.Length - 1);
+//            return endpoints;
+//        }
+
+
+//        private IPEndPoint[] GetGossipCandidatesFromOldGossip(IEnumerable<ClusterMessages.MemberInfoDto> oldGossip, IPEndPoint failedTcpEndPoint)
+//        {
+//            //_log.Debug("ClusterDnsEndPointDiscoverer: GetGossipCandidatesFromOldGossip, failedTcpEndPoint: {0}.", failedTcpEndPoint);
+//            var gossipCandidates = failedTcpEndPoint == null
+//                    ? oldGossip.ToArray()
+//                    : oldGossip.Where(x => !(x.ExternalTcpPort == failedTcpEndPoint.Port
+//                                             && IPAddress.Parse(x.ExternalTcpIp).Equals(failedTcpEndPoint.Address)))
+//                               .ToArray();
+//            return ArrangeGossipCandidates(gossipCandidates);
+//        }
+
+//        private IPEndPoint[] ArrangeGossipCandidates(ClusterMessages.MemberInfoDto[] members)
+//        {
+//            var result = new IPEndPoint[members.Length];
+//            int i = -1;
+//            int j = members.Length;
+//            for (int k = 0; k < members.Length; ++k)
+//            {
+//                if (members[k].State == ClusterMessages.VNodeState.Manager)
+//                    result[--j] = new IPEndPoint(IPAddress.Parse(members[k].ExternalHttpIp), members[k].ExternalHttpPort);
+//                else
+//                    result[++i] = new IPEndPoint(IPAddress.Parse(members[k].ExternalHttpIp), members[k].ExternalHttpPort);
+//            }
+//            RandomShuffle(result, 0, i); // shuffle nodes
+//            RandomShuffle(result, j, members.Length - 1); // shuffle managers
+
+//            return result;
+//        }
+
+//        private void RandomShuffle<T>(T[] arr, int i, int j)
+//        {
+//            if (i >= j)
+//                return;
+//            var rnd = new Random(Guid.NewGuid().GetHashCode());
+//            for (int k = i; k <= j; ++k)
+//            {
+//                var index = rnd.Next(k, j + 1);
+//                var tmp = arr[index];
+//                arr[index] = arr[k];
+//                arr[k] = tmp;
+//            }
+//        }
+
+//        private ClusterMessages.ClusterInfoDto TryGetGossipFrom(IPEndPoint endPoint)
+//        {
+//            //_log.Debug("ClusterDnsEndPointDiscoverer: Trying to get gossip from [{0}].", endPoint);
+
+//            ClusterMessages.ClusterInfoDto result = null;
+//            var completed = new ManualResetEventSlim(false);
+
+//            var url = endPoint.ToHttpUrl("/gossip?format=json");
+//            _client.Get(
+//                url,
+//                null,
+//                _gossipTimeout,
+//                response =>
+//                {
+//                    if (response.HttpStatusCode != HttpStatusCode.OK)
+//                    {
+//                        //_log.Info("[{0}] responded with {1} ({2})", endPoint, response.HttpStatusCode, response.StatusDescription);
+//                        completed.Set();
+//                        return;
+//                    }
+//                    try
+//                    {
+//                        result = response.Body.ParseJson<ClusterMessages.ClusterInfoDto>();
+//                        //_log.Debug("ClusterDnsEndPointDiscoverer: Got gossip from [{0}]:\n{1}.", endPoint, string.Join("\n", result.Members.Select(x => x.ToString())));
+//                    }
+//                    catch (Exception)
+//                    {
+//                        //_log.Info("Failed to get cluster info from [{0}]: deserialization error: {1}.", endPoint, e.Message);
+//                    }
+//                    completed.Set();
+//                },
+//                e =>
+//                {
+//                    //_log.Info("Failed to get cluster info from [{0}]: request failed, error: {1}.", endPoint, e.Message);
+//                    completed.Set();
+//                });
+
+//            completed.Wait();
+//            return result;
+//        }
+
+//        private NodeEndPoints? TryDetermineBestNode(IEnumerable<ClusterMessages.MemberInfoDto> members)
+//        {
+//            var notAllowedStates = new[]
+//            {
+//                ClusterMessages.VNodeState.Manager, 
+//                ClusterMessages.VNodeState.ShuttingDown,
+//                ClusterMessages.VNodeState.Shutdown
+//            };
+//            var node = members.Where(x => x.IsAlive)
+//                              .Where(x => !notAllowedStates.Contains(x.State))
+//                              .OrderByDescending(x => x.State)
+//                              .FirstOrDefault();
+//            if (node == null)
+//            {
+//                //_log.Info("Unable to locate suitable node. Gossip info:\n{0}.", string.Join("\n", members.Select(x => x.ToString())));
+//                return null;
+//            }
+
+//            var normTcp = new IPEndPoint(IPAddress.Parse(node.ExternalTcpIp), node.ExternalTcpPort);
+//            var secTcp = node.ExternalSecureTcpPort > 0
+//                                 ? new IPEndPoint(IPAddress.Parse(node.ExternalTcpIp), node.ExternalSecureTcpPort)
+//                                 : null;
+//            _log.Info("Discovering: found best choice [{0},{1}] ({2}).", normTcp, secTcp == null ? "n/a" : secTcp.ToString(), node.State);
+//            return new NodeEndPoints(normTcp, secTcp);
+//        }
+//    }
+//}

--- a/src/EventStore/EventStore.ClientAPI/Core/IEndPointDiscoverer.cs
+++ b/src/EventStore/EventStore.ClientAPI/Core/IEndPointDiscoverer.cs
@@ -1,29 +1,8 @@
-﻿using System;
-using System.Net;
+﻿using System.Net;
 using System.Threading.Tasks;
 
 namespace EventStore.ClientAPI.Core
 {
-    internal struct NodeEndPoints
-    {
-        public readonly IPEndPoint TcpEndPoint;
-        public readonly IPEndPoint SecureTcpEndPoint;
-
-        public NodeEndPoints(IPEndPoint tcpEndPoint, IPEndPoint secureTcpEndPoint)
-        {
-            if ((tcpEndPoint ?? secureTcpEndPoint) == null) throw new ArgumentException("Both endpoints are null.");
-            TcpEndPoint = tcpEndPoint;
-            SecureTcpEndPoint = secureTcpEndPoint;
-        }
-
-        public override string ToString()
-        {
-            return string.Format("[{0}, {1}]",
-                                 TcpEndPoint == null ? "n/a" : TcpEndPoint.ToString(),
-                                 SecureTcpEndPoint == null ? "n/a" : SecureTcpEndPoint.ToString());
-        }
-    }
-
     internal interface IEndPointDiscoverer
     {
         Task<NodeEndPoints> DiscoverAsync(IPEndPoint failedTcpEndPoint);

--- a/src/EventStore/EventStore.ClientAPI/Core/NodeEndPoints.cs
+++ b/src/EventStore/EventStore.ClientAPI/Core/NodeEndPoints.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Net;
+
+namespace EventStore.ClientAPI.Core
+{
+    internal struct NodeEndPoints
+    {
+        public readonly IPEndPoint TcpEndPoint;
+        public readonly IPEndPoint SecureTcpEndPoint;
+
+        public NodeEndPoints(IPEndPoint tcpEndPoint, IPEndPoint secureTcpEndPoint)
+        {
+            if ((tcpEndPoint ?? secureTcpEndPoint) == null) throw new ArgumentException("Both endpoints are null.");
+            TcpEndPoint = tcpEndPoint;
+            SecureTcpEndPoint = secureTcpEndPoint;
+        }
+
+        public override string ToString()
+        {
+            return string.Format("[{0}, {1}]",
+                TcpEndPoint == null ? "n/a" : TcpEndPoint.ToString(),
+                SecureTcpEndPoint == null ? "n/a" : SecureTcpEndPoint.ToString());
+        }
+    }
+}

--- a/src/EventStore/EventStore.ClientAPI/DnsClusterSettingsBuilder.cs
+++ b/src/EventStore/EventStore.ClientAPI/DnsClusterSettingsBuilder.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Net;
+using EventStore.ClientAPI.Common.Utils;
+
+namespace EventStore.ClientAPI
+{
+    /// <summary>
+    /// Fluent builder used to configure <see cref="ClusterSettings" /> for connecting to a cluster
+    /// using DNS discovery.
+    /// </summary>
+    public class DnsClusterSettingsBuilder
+    {
+        private string _clusterDns;
+        private int _maxDiscoverAttempts = Consts.DefaultMaxClusterDiscoverAttempts;
+        private int _managerExternalHttpPort = Consts.DefaultClusterManagerExternalHttpPort;
+        private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
+
+        /// <summary>
+        /// Sets the DNS name under which cluster nodes are listed.
+        /// </summary>
+        /// <param name="clusterDns">The DNS name under which cluster nodes are listed.</param>
+        /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        /// <exception cref="ArgumentNullException">If <see cref="clusterDns" /> is null or empty.</exception>
+        public DnsClusterSettingsBuilder SetClusterDns(string clusterDns)
+        {
+            Ensure.NotNullOrEmpty(clusterDns, "clusterDns");
+            _clusterDns = clusterDns;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum number of attempts for discovery.
+        /// </summary>
+        /// <param name="maxDiscoverAttempts">The maximum number of attempts for DNS discovery.</param>
+        /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="maxDiscoverAttempts" /> is less than or equal to 0.</exception>
+        public DnsClusterSettingsBuilder SetMaxDiscoverAttempts(int maxDiscoverAttempts)
+        {
+            if (maxDiscoverAttempts <= 0)
+                throw new ArgumentOutOfRangeException("maxDiscoverAttempts", string.Format("maxDiscoverAttempts value is out of range: {0}. Allowed range: [-1, infinity].", maxDiscoverAttempts));
+            _maxDiscoverAttempts = maxDiscoverAttempts;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the period after which gossip times out if none is received.
+        /// </summary>
+        /// <param name="timeout">The period after which gossip times out if none is received.</param>
+        /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        public DnsClusterSettingsBuilder SetGossipTimeout(TimeSpan timeout)
+        {
+            _gossipTimeout = timeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the well-known port on which the cluster gossip is taking place.
+        /// 
+        /// If you are using the commercial edition of Event Store HA, with Manager nodes in
+        /// place, this should be the port number of the External HTTP port on which the
+        /// managers are running.
+        /// 
+        /// If you are using the open source edition of Event Store HA, this should be the
+        /// External HTTP port that the nodes are running on. If you cannot use a well-known
+        /// port for this across all nodes, you can instead use gossip seed discovery and set
+        /// the <see cref="IPEndPoint" /> of some seed nodes instead.
+        /// </summary>
+        /// <param name="clusterGossipPort">The cluster gossip port.</param>
+        /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        public DnsClusterSettingsBuilder SetClusterGossipPort(int clusterGossipPort)
+        {
+            Ensure.Positive(clusterGossipPort, "clusterGossipPort");
+            _managerExternalHttpPort = clusterGossipPort;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds a <see cref="ClusterSettings"/> object from a <see cref="DnsClusterSettingsBuilder"/>.
+        /// </summary>
+        /// <param name="builder"><see cref="DnsClusterSettingsBuilder"/> from which to build a <see cref="ClusterSettings"/></param>
+        /// <returns></returns>
+        public static implicit operator ClusterSettings(DnsClusterSettingsBuilder builder)
+        {
+            return new ClusterSettings(builder._clusterDns,
+                builder._maxDiscoverAttempts,
+                builder._managerExternalHttpPort,
+                builder._gossipTimeout);
+        }
+    }
+}

--- a/src/EventStore/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -84,6 +84,8 @@
   <ItemGroup>
     <Compile Include="AllCheckpoint.cs" />
     <Compile Include="AllEventsSlice.cs" />
+    <Compile Include="Core\GossipSeedEndPointDiscoverer.cs" />
+    <Compile Include="Core\NodeEndPoints.cs" />
     <Compile Include="StreamCheckpoint.cs" />
     <Compile Include="ClientAuthenticationFailedEventArgs.cs" />
     <Compile Include="ClientErrorEventArgs.cs" />

--- a/src/EventStore/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
+++ b/src/EventStore/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Net;
+
+namespace EventStore.ClientAPI
+{
+    /// <summary>
+    /// Fluent builder used to configure <see cref="ClusterSettings" /> for connecting to a cluster
+    /// using gossip seeds.
+    /// </summary>
+    public class GossipSeedClusterSettingsBuilder
+    {
+        private IPEndPoint[] _gossipSeeds;
+        private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
+        private int _maxDiscoverAttempts = Consts.DefaultMaxClusterDiscoverAttempts;
+
+        /// <summary>
+        /// Sets gossip seed endpoints for the client.
+        /// </summary>
+        /// <param name="gossipSeeds">IPEndPoints representing the endpoints of nodes from which to seed gossip.</param>
+        /// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
+        /// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
+        public GossipSeedClusterSettingsBuilder SetGossipSeedEndPoints(params IPEndPoint[] gossipSeeds)
+        {
+            if (gossipSeeds == null || gossipSeeds.Length == 0)
+                throw new ArgumentException("Empty FakeDnsEntries collection.");
+            _gossipSeeds = gossipSeeds;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum number of attempts for discovery.
+        /// </summary>
+        /// <param name="maxDiscoverAttempts">The maximum number of attempts for DNS discovery.</param>
+        /// <returns>A <see cref="GossipSeedClusterSettingsBuilder"/> for further configuration.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If <see cref="maxDiscoverAttempts" /> is less than or equal to 0.</exception>
+        public GossipSeedClusterSettingsBuilder SetMaxDiscoverAttempts(int maxDiscoverAttempts)
+        {
+            if (maxDiscoverAttempts <= 0)
+                throw new ArgumentOutOfRangeException("maxDiscoverAttempts", string.Format("maxDiscoverAttempts value is out of range: {0}. Allowed range: [-1, infinity].", maxDiscoverAttempts));
+            _maxDiscoverAttempts = maxDiscoverAttempts;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the period after which gossip times out if none is received.
+        /// </summary>
+        /// <param name="timeout">The period after which gossip times out if none is received.</param>
+        /// <returns>A <see cref="GossipSeedClusterSettingsBuilder"/> for further configuration.</returns>
+        public GossipSeedClusterSettingsBuilder SetGossipTimeout(TimeSpan timeout)
+        {
+            _gossipTimeout = timeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Builds a <see cref="ClusterSettings"/> object from a <see cref="GossipSeedClusterSettingsBuilder"/>.
+        /// </summary>
+        /// <param name="builder"><see cref="GossipSeedClusterSettingsBuilder"/> from which to build a <see cref="ClusterSettings"/></param>
+        /// <returns></returns>
+        public static implicit operator ClusterSettings(GossipSeedClusterSettingsBuilder builder)
+        {
+            return new ClusterSettings(builder._gossipSeeds, builder._maxDiscoverAttempts, builder._gossipTimeout);
+        }
+    }
+}


### PR DESCRIPTION
- This fixes the issue reported on the list in the "connection to cluster using gossip seeds fails (client api)" thread.
- ClusterSettingsBuilder now forces you to choose first between DNS or Gossip Seed configuration and then presents only the correct configuration points.
- This is a breaking API change, however I think it's worth putting into the 3.0.0 release as the behaviour at the moment is completely broken.
