### PR TITLE
resolve issue with no response for secondary scavenge operation

### DIFF
--- a/src/EventStore/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -47,6 +47,16 @@ namespace EventStore.Core.Services.Storage
             {
                 ThreadPool.QueueUserWorkItem(_ => Scavenge(message));
             }
+            else 
+            {
+                message.Envelope.ReplyWith(
+                    new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId, 
+                                                                ClientMessage.ScavengeDatabase.ScavengeResult.InProgress,
+                                                                "Scavenge already in progress.", 
+                                                                TimeSpan.FromMilliseconds(0),
+                                                                0)
+                    );
+            }
         }
 
         private void Scavenge(ClientMessage.ScavengeDatabase message)


### PR DESCRIPTION
it will now send a message when its already running to say its in progress.
