### PR TITLE
Find certificates in stores by thumbprint or name

### DIFF
--- a/src/EventStore/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -58,8 +58,11 @@ namespace EventStore.ClusterNode
         public string[] HttpPrefixes { get { return _helper.Get(() => HttpPrefixes); } }
         public bool EnableTrustedAuth { get { return _helper.Get(() => EnableTrustedAuth); } }
 
-        public string CertificateStore { get { return _helper.Get(() => CertificateStore); } }
-        public string CertificateName { get { return _helper.Get(() => CertificateName); } }
+        public string CertificateStoreLocation { get { return _helper.Get(() => CertificateStoreLocation); } }
+        public string CertificateStoreName { get { return _helper.Get(() => CertificateStoreName); } }
+        public string CertificateSubjectName { get { return _helper.Get(() => CertificateSubjectName); } }
+        public string CertificateThumbprint { get { return _helper.Get(() => CertificateThumbprint); } }
+
         public string CertificateFile { get { return _helper.Get(() => CertificateFile); } }
         public string CertificatePassword { get { return _helper.Get(() => CertificatePassword); } }
 
@@ -128,8 +131,11 @@ namespace EventStore.ClusterNode
             _helper.RegisterArray(() => HttpPrefixes, Opts.HttpPrefixesCmd, Opts.HttpPrefixesEnv, ",", Opts.HttpPrefixesJson, Opts.HttpPrefixesDefault, Opts.HttpPrefixesDescr);
             _helper.Register(() => EnableTrustedAuth, Opts.EnableTrustedAuthCmd, Opts.EnableTrustedAuthEnv, Opts.EnableTrustedAuthJson, Opts.EnableTrustedAuthDefault, Opts.EnableTrustedAuthDescr);
 
-            _helper.RegisterRef(() => CertificateStore, Opts.CertificateStoreCmd, Opts.CertificateStoreEnv, Opts.CertificateStoreJson, Opts.CertificateStoreDefault, Opts.CertificateStoreDescr);
-            _helper.RegisterRef(() => CertificateName, Opts.CertificateNameCmd, Opts.CertificateNameEnv, Opts.CertificateNameJson, Opts.CertificateNameDefault, Opts.CertificateNameDescr);
+            _helper.RegisterRef(() => CertificateStoreLocation, Opts.CertificateStoreLocationCmd, Opts.CertificateStoreLocationEnv, Opts.CertificateStoreLocationJson, Opts.CertificateStoreLocationDefault, Opts.CertificateStoreLocationDescr);
+            _helper.RegisterRef(() => CertificateStoreName, Opts.CertificateStoreNameCmd, Opts.CertificateStoreNameEnv, Opts.CertificateStoreNameJson, Opts.CertificateStoreNameDefault, Opts.CertificateStoreNameDescr);
+            _helper.RegisterRef(() => CertificateSubjectName, Opts.CertificateSubjectNameCmd, Opts.CertificateSubjectNameEnv, Opts.CertificateSubjectNameJson, Opts.CertificateSubjectNameDefault, Opts.CertificateSubjectNameDescr);
+            _helper.RegisterRef(() => CertificateThumbprint, Opts.CertificateThumbprintCmd, Opts.CertificateThumbprintEnv, Opts.CertificateThumbprintJson, Opts.CertificateThumbprintDefault, Opts.CertificateThumbprintDescr);
+
             _helper.RegisterRef(() => CertificateFile, Opts.CertificateFileCmd, Opts.CertificateFileEnv, Opts.CertificateFileJson, Opts.CertificateFileDefault, Opts.CertificateFileDescr);
             _helper.RegisterRef(() => CertificatePassword, Opts.CertificatePasswordCmd, Opts.CertificatePasswordEnv, Opts.CertificatePasswordJson, Opts.CertificatePasswordDefault, Opts.CertificatePasswordDescr);
 

--- a/src/EventStore/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore/EventStore.ClusterNode/Program.cs
@@ -154,8 +154,8 @@ namespace EventStore.ClusterNode
             X509Certificate2 certificate = null;
             if (options.InternalSecureTcpPort > 0 || options.ExternalSecureTcpPort > 0)
             {
-                if (options.CertificateStore.IsNotEmptyString())
-                    certificate = LoadCertificateFromStore(options.CertificateStore, options.CertificateName);
+                if (options.CertificateStoreName.IsNotEmptyString())
+                    certificate = LoadCertificateFromStore(options.CertificateStoreLocation, options.CertificateStoreName, options.CertificateSubjectName, options.CertificateThumbprint);
                 else if (options.CertificateFile.IsNotEmptyString())
                     certificate = LoadCertificateFromFile(options.CertificateFile, options.CertificatePassword);
                 else

--- a/src/EventStore/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore/EventStore.Core/Util/Opts.cs
@@ -159,18 +159,8 @@ namespace EventStore.Core.Util
         public const string CommitTimeoutMsDescr = "Commit timeout (in milliseconds).";
         public static readonly int CommitTimeoutMsDefault = 2000; // 2 seconds
 
-        public const string CertificateStoreCmd = "certificate-store=";
-        public const string CertificateStoreEnv = "CERTIFICATE_STORE";
-        public const string CertificateStoreJson = "certificateStore";
-        public const string CertificateStoreDescr = "The name of certificate store.";
-        public static readonly string CertificateStoreDefault = string.Empty;
 
-        public const string CertificateNameCmd = "certificate-name=";
-        public const string CertificateNameEnv = "CERTIFICATE_NAME";
-        public const string CertificateNameJson = "certificateName";
-        public const string CertificateNameDescr = "The name of certificate in store.";
-        public static readonly string CertificateNameDefault = string.Empty;
-
+        //Loading certificates from files
         public const string CertificateFileCmd = "certificate-file=";
         public const string CertificateFileEnv = "CERTIFICATE_FILE";
         public const string CertificateFileJson = "certificateFile";
@@ -183,6 +173,31 @@ namespace EventStore.Core.Util
         public const string CertificatePasswordDescr = "The password to certificate in file.";
         public static readonly string CertificatePasswordDefault = string.Empty;
 
+        //Loading certificates from a certificate store
+        public const string CertificateStoreLocationCmd = "certificate-store-location=";
+        public const string CertificateStoreLocationEnv = "CERTIFICATE_STORE_LOCATION";
+        public const string CertificateStoreLocationJson = "certificateStoreLocation";
+        public const string CertificateStoreLocationDescr = "The certificate store location name.";
+        public static readonly string CertificateStoreLocationDefault = string.Empty;
+
+        public const string CertificateStoreNameCmd = "certificate-store-name=";
+        public const string CertificateStoreNameEnv = "CERTIFICATE_STORE_NAME";
+        public const string CertificateStoreNameJson = "certificateStoreName";
+        public const string CertificateStoreNameDescr = "The certificate store name.";
+        public static readonly string CertificateStoreNameDefault = string.Empty;
+
+        public const string CertificateSubjectNameCmd = "certificate-subject-name=";
+        public const string CertificateSubjectNameEnv = "CERTIFICATE_SUBJECT_NAME";
+        public const string CertificateSubjectNameJson = "certificateSubjectName";
+        public const string CertificateSubjectNameDescr = "The certificate subject name.";
+        public static readonly string CertificateSubjectNameDefault = string.Empty;
+
+        public const string CertificateThumbprintCmd = "certificate-thumbprint=";
+        public const string CertificateThumbprintEnv = "CERTIFICATE_THUMBPRINT";
+        public const string CertificateThumbprintJson = "certificateThumbprint";
+        public const string CertificateThumbprintDescr = "The certificate fingerprint/thumbprint.";
+        public static readonly string CertificateThumbprintDefault = string.Empty;
+        
         /*
          *  SINGLE NODE OPTIONS
          */

--- a/src/EventStore/EventStore.SingleNode/Program.cs
+++ b/src/EventStore/EventStore.SingleNode/Program.cs
@@ -97,8 +97,8 @@ namespace EventStore.SingleNode
             X509Certificate2 certificate = null;
             if (options.SecureTcpPort > 0)
             {
-                if (options.CertificateStore.IsNotEmptyString())
-                    certificate = LoadCertificateFromStore(options.CertificateStore, options.CertificateName);
+                if (options.CertificateStoreName.IsNotEmptyString())
+                    certificate = LoadCertificateFromStore(options.CertificateStoreLocation, options.CertificateStoreName, options.CertificateSubjectName, options.CertificateThumbprint);
                 else if (options.CertificateFile.IsNotEmptyString())
                     certificate = LoadCertificateFromFile(options.CertificateFile, options.CertificatePassword);
                 else

--- a/src/EventStore/EventStore.SingleNode/SingleNodeOptions.cs
+++ b/src/EventStore/EventStore.SingleNode/SingleNodeOptions.cs
@@ -38,11 +38,14 @@ namespace EventStore.SingleNode
         public string[] HttpPrefixes { get { return _helper.Get(() => HttpPrefixes); } }
         public bool EnableTrustedAuth { get { return _helper.Get(() => EnableTrustedAuth); } }
 
-        public string CertificateStore { get { return _helper.Get(() => CertificateStore); } }
-        public string CertificateName { get { return _helper.Get(() => CertificateName); } }
+        public string CertificateStoreLocation { get { return _helper.Get(() => CertificateStoreLocation); } }
+        public string CertificateStoreName { get { return _helper.Get(() => CertificateStoreName); } }
+        public string CertificateSubjectName { get { return _helper.Get(() => CertificateSubjectName); } }
+        public string CertificateThumbprint { get { return _helper.Get(() => CertificateThumbprint); } }
+
         public string CertificateFile { get { return _helper.Get(() => CertificateFile); } }
         public string CertificatePassword { get { return _helper.Get(() => CertificatePassword); } }
-
+        
         public int PrepareTimeoutMs { get { return _helper.Get(() => PrepareTimeoutMs); } }
         public int CommitTimeoutMs { get { return _helper.Get(() => CommitTimeoutMs); } }
 
@@ -85,8 +88,11 @@ namespace EventStore.SingleNode
             _helper.RegisterArray(() => HttpPrefixes, Opts.HttpPrefixesCmd, Opts.HttpPrefixesEnv, ",", Opts.HttpPrefixesJson, Opts.HttpPrefixesDefault, Opts.HttpPrefixesDescr);
             _helper.Register(() => EnableTrustedAuth, Opts.EnableTrustedAuthCmd, Opts.EnableTrustedAuthEnv, Opts.EnableTrustedAuthJson, Opts.EnableTrustedAuthDefault, Opts.EnableTrustedAuthDescr);
 
-            _helper.RegisterRef(() => CertificateStore, Opts.CertificateStoreCmd, Opts.CertificateStoreEnv, Opts.CertificateStoreJson, Opts.CertificateStoreDefault, Opts.CertificateStoreDescr);
-            _helper.RegisterRef(() => CertificateName, Opts.CertificateNameCmd, Opts.CertificateNameEnv, Opts.CertificateNameJson, Opts.CertificateNameDefault, Opts.CertificateNameDescr);
+            _helper.RegisterRef(() => CertificateStoreLocation, Opts.CertificateStoreLocationCmd, Opts.CertificateStoreLocationEnv, Opts.CertificateStoreLocationJson, Opts.CertificateStoreLocationDefault, Opts.CertificateStoreLocationDescr);
+            _helper.RegisterRef(() => CertificateStoreName, Opts.CertificateStoreNameCmd, Opts.CertificateStoreNameEnv, Opts.CertificateStoreNameJson, Opts.CertificateStoreNameDefault, Opts.CertificateStoreNameDescr);
+            _helper.RegisterRef(() => CertificateSubjectName, Opts.CertificateSubjectNameCmd, Opts.CertificateSubjectNameEnv, Opts.CertificateSubjectNameJson, Opts.CertificateSubjectNameDefault, Opts.CertificateSubjectNameDescr);
+            _helper.RegisterRef(() => CertificateThumbprint, Opts.CertificateThumbprintCmd, Opts.CertificateThumbprintEnv, Opts.CertificateThumbprintJson, Opts.CertificateThumbprintDefault, Opts.CertificateThumbprintDescr);
+
             _helper.RegisterRef(() => CertificateFile, Opts.CertificateFileCmd, Opts.CertificateFileEnv, Opts.CertificateFileJson, Opts.CertificateFileDefault, Opts.CertificateFileDescr);
             _helper.RegisterRef(() => CertificatePassword, Opts.CertificatePasswordCmd, Opts.CertificatePasswordEnv, Opts.CertificatePasswordJson, Opts.CertificatePasswordDefault, Opts.CertificatePasswordDescr);
 


### PR DESCRIPTION
Specify two new command line options and rename some others to make finding a certificate in a Windows certificate store more reasonable.

The new options for loading from a certificate store are:
      --certificate-store-location
      --certificate-store-name
      --certificate-thumbprint
      --certificate-subject-name

To use these options we require at least a store name, and one of thumbprint or subject name. If both thumbprint and subject name are specified, we use the thumbprint. If a certificate store location is specified that will also be used, otherwise we work as before.

In addition the options to load a certificate from a file on disk are still there:
      --certificate-file
      --certificate-password
