### PR TITLE
make atom+xml the default codec for atom feeds

### DIFF
--- a/src/EventStore/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -38,19 +38,19 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
         private static readonly ICodec[] AtomCodecsWithoutBatches = new[]
                                                       {
+                                                          Codec.CreateCustom(Codec.Xml, ContentType.Atom, Helper.UTF8NoBom, false, false),
                                                           EventStoreJsonCodec,
                                                           Codec.Xml,
                                                           Codec.ApplicationXml,
-                                                          Codec.CreateCustom(Codec.Xml, ContentType.Atom, Helper.UTF8NoBom, false, false),
                                                           Codec.Json
                                                       };
 
         private static readonly ICodec[] AtomCodecs = new[]
                                                       {
+                                                          Codec.CreateCustom(Codec.Xml, ContentType.Atom, Helper.UTF8NoBom, false, false),                                                        
                                                           EventStoreJsonCodec,
                                                           Codec.Xml,
                                                           Codec.ApplicationXml,
-                                                          Codec.CreateCustom(Codec.Xml, ContentType.Atom, Helper.UTF8NoBom, false, false),
                                                           Codec.Json,
                                                           Codec.EventXml,
                                                           Codec.EventJson,
@@ -59,10 +59,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                                                       };
         private static readonly ICodec[] AtomWithHtmlCodecs = new[]
                                                               {
+                                                                  Codec.CreateCustom(Codec.Xml, ContentType.Atom, Helper.UTF8NoBom, false, false),
                                                                   EventStoreJsonCodec,
                                                                   Codec.Xml,
                                                                   Codec.ApplicationXml,
-                                                                  Codec.CreateCustom(Codec.Xml, ContentType.Atom, Helper.UTF8NoBom, false, false),
                                                                   Codec.Json,
                                                                   Codec.EventXml,
                                                                   Codec.EventJson,


### PR DESCRIPTION
As of now it defaults to json which causes problems with some tools as they dont set headers (I believe chrome is an example of this) we should also add the rel links in UI but not worth doing now. Will open an issue with new ui
