### PR TITLE
Added support for shortcut disabling of an option e.g. --admin-on-ext- s...

### DIFF
--- a/src/EventStore/EventStore.Common/PowerArgs/HelperTypesInternal/ArgParser.cs
+++ b/src/EventStore/EventStore.Common/PowerArgs/HelperTypesInternal/ArgParser.cs
@@ -35,6 +35,18 @@ namespace PowerArgs
 
                     string value;
 
+                    // Handles a special case --arg-name- where we have a trailing -
+                    // it's a shortcut way of disabling an option
+                    if (key.StartsWith("-") && key.EndsWith("-"))
+                    {
+                        key = key.Substring(1, key.Length - 2);
+                        if (IsBool(key, context))
+                        {
+                            var redefinedArgs = new List<string>(args);
+                            redefinedArgs.Insert(i + 1, "false");
+                            args = redefinedArgs.ToArray();
+                        }
+                    }
                     // Handles long form syntax --argName=argValue.
                     if (key.StartsWith("-") && key.Contains("="))
                     {


### PR DESCRIPTION
When we see the trailing "-" we just add an additional argument value ("false") as if it was set in the command line.
e.g. --admin-on-ext- would end up being --admin-on-ext false
