### PR TITLE
Handle more json serialization exceptions in a more user friendly way

### DIFF
--- a/src/EventStore/EventStore.Common/Options/EventStoreOptions.cs
+++ b/src/EventStore/EventStore.Common/Options/EventStoreOptions.cs
@@ -62,6 +62,12 @@ namespace EventStore.Common.Options
                     }
                     throw new OptionException(failureMessage, ex.Path);
                 }
+                catch (Newtonsoft.Json.JsonSerializationException ex)
+                {
+                    string failureMessage = "Invalid configuration file specified. ";
+                    failureMessage += ex.Message;
+                    throw new OptionException(failureMessage, String.Empty);
+                }
             }
             options = SetEnvironmentVariables<TOptions>(options, environmentPrefix);
             return options;

--- a/src/EventStore/EventStore.Core/ProgramBase.cs
+++ b/src/EventStore/EventStore.Core/ProgramBase.cs
@@ -144,7 +144,7 @@ namespace EventStore.Core
 
         private string FormatExceptionMessage(Exception ex)
         {
-            string msg = ex.Message + "\n" + ex.StackTrace.ToString();
+            string msg = ex.Message;
             var exc = ex.InnerException;
             int cnt = 0;
             while (exc != null)


### PR DESCRIPTION
Don't display the stack trace to consumers.
