### PR TITLE
Add a -WhatIf to programs based on ProgramBase

### DIFF
--- a/src/EventStore/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -17,6 +17,8 @@ namespace EventStore.ClusterNode
         public string Config { get; set; }
         [ArgDescription(Opts.DefinesDescr, Opts.AppGroup)]
         public string[] Defines { get; set; }
+        [ArgDescription(Opts.WhatIfDescr, Opts.AppGroup)]
+        public bool WhatIf { get; set; }
 
         [ArgDescription(Opts.InternalIpDescr, Opts.InterfacesGroup)]
         public IPAddress IntIp { get; set; }
@@ -141,6 +143,7 @@ namespace EventStore.ClusterNode
             Version = Opts.ShowVersionDefault;
             Log = Opts.LogsDefault;
             Defines = Opts.DefinesDefault;
+            WhatIf = Opts.WhatIfDefault;
 
             IntIp = Opts.InternalIpDefault;
             ExtIp = Opts.ExternalIpDefault;

--- a/src/EventStore/EventStore.Common/Options/IOptions.cs
+++ b/src/EventStore/EventStore.Common/Options/IOptions.cs
@@ -8,5 +8,6 @@
         string Log { get; }
         string[] Defines { get; }
         bool Force { get; }
+        bool WhatIf { get; }
     }
 }

--- a/src/EventStore/EventStore.Core.Tests/Common/EventStoreOptionsTests/TestArgs.cs
+++ b/src/EventStore/EventStore.Core.Tests/Common/EventStoreOptionsTests/TestArgs.cs
@@ -9,6 +9,7 @@ namespace EventStore.Core.Tests.Common
         public string Config { get; set; }
         public string Log { get; set; }
         public string[] Defines { get; set; }
+        public bool WhatIf { get; set; }
         public bool Force { get; set; }
         public ProjectionType RunProjections { get; set; }
 

--- a/src/EventStore/EventStore.Core/ProgramBase.cs
+++ b/src/EventStore/EventStore.Core/ProgramBase.cs
@@ -140,6 +140,9 @@ namespace EventStore.Core
                      "GC:", GC.MaxGeneration == 0 ? "NON-GENERATION (PROBABLY BOEHM)" : string.Format("{0} GENERATIONS", GC.MaxGeneration + 1),
                      "LOGS:", LogManager.LogsDirectory,
                      EventStoreOptions.DumpOptions<TOptions>());
+
+            if (options.WhatIf)
+                Application.Exit(ExitCode.Success, "WhatIf option specified");
         }
 
         private string FormatExceptionMessage(Exception ex)

--- a/src/EventStore/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore/EventStore.Core/Util/Opts.cs
@@ -27,6 +27,9 @@ namespace EventStore.Core.Util
         public const string ForceDescr = "Force the Event Store to run in possibly harmful environments such as with Boehm GC.";
         public const bool ForceDefault = false;
 
+        public const string WhatIfDescr = "Print effective configuration to console and then exit.";
+        public const bool WhatIfDefault = false;
+
         public const string LogsDescr = "Path where to keep log files.";
         public static readonly string LogsDefault = string.Empty;
 

--- a/src/EventStore/EventStore.SingleNode/SingleNodeOptions.cs
+++ b/src/EventStore/EventStore.SingleNode/SingleNodeOptions.cs
@@ -17,6 +17,8 @@ namespace EventStore.SingleNode
         public string Config { get; set; }
         [ArgDescription(Opts.DefinesDescr, Opts.AppGroup)]
         public string[] Defines { get; set; }
+        [ArgDescription(Opts.WhatIfDescr, Opts.AppGroup)]
+        public bool WhatIf { get; set; }
 
         [ArgDescription(Opts.IpDescr, Opts.InterfacesGroup)]
         public IPAddress Ip { get; set; }
@@ -88,11 +90,11 @@ namespace EventStore.SingleNode
         public SingleNodeOptions()
         {
             Config = "singlenode-config.json";
-
             Help = Opts.ShowHelpDefault;
             Version = Opts.ShowVersionDefault;
             Log = Opts.LogsDefault;
             Defines = Opts.DefinesDefault;
+            WhatIf = Opts.WhatIfDefault;
 
             Ip = Opts.IpDefault;
             TcpPort = Opts.TcpPortDefault;

--- a/src/EventStore/EventStore.TestClient/ClientOptions.cs
+++ b/src/EventStore/EventStore.TestClient/ClientOptions.cs
@@ -20,6 +20,8 @@ namespace EventStore.TestClient
         public string Config { get; set; }
         [ArgDescription(Opts.DefinesDescr)]
         public string[] Defines { get; set; }
+        [ArgDescription(Opts.WhatIfDescr, Opts.AppGroup)]
+        public bool WhatIf { get; set; }
 
         [ArgDescription(Opts.IpDescr)]
         public IPAddress Ip { get; set; }
@@ -43,6 +45,7 @@ namespace EventStore.TestClient
             Version = Opts.ShowVersionDefault;
             Log = Opts.LogsDefault;
             Defines = Opts.DefinesDefault;
+            WhatIf = Opts.WhatIfDefault;
             Ip = IPAddress.Loopback;
             TcpPort = 1113;
             HttpPort = 2113;

--- a/src/EventStore/EventStore.Web.Playground/PlaygroundNodeOptions.cs
+++ b/src/EventStore/EventStore.Web.Playground/PlaygroundNodeOptions.cs
@@ -17,6 +17,8 @@ namespace EventStore.Web.Playground
         public string Config { get; set; }
         [ArgDescription(Opts.DefinesDescr)]
         public string[] Defines { get; set; }
+        [ArgDescription(Opts.WhatIfDescr, Opts.AppGroup)]
+        public bool WhatIf { get; set; }
 
         [ArgDescription(Opts.IpDescr)]
         public IPAddress Ip { get; set; }
@@ -41,6 +43,7 @@ namespace EventStore.Web.Playground
             Version = Opts.ShowVersionDefault;
             Log = Opts.LogsDefault;
             Defines = Opts.DefinesDefault;
+            WhatIf = Opts.WhatIfDefault;
 
             Ip = IPAddress.Loopback;
             TcpPort = 1113;


### PR DESCRIPTION
This option evaluates the configuration from the command line, configuration
files, environment and defaults as if the program was about to run, prints
it to the log and to the config, and then exists successfully. This can be
very useful when debugging configuration issues.
