### PR TITLE
Fix Faulted System Projections with incompatible logger type in constructor

### DIFF
--- a/src/EventStore/EventStore.Projections.Core.Tests/Services/core_projection/FakeProjectionHandler.cs
+++ b/src/EventStore/EventStore.Projections.Core.Tests/Services/core_projection/FakeProjectionHandler.cs
@@ -36,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         private readonly Action<SourceDefinitionBuilder> _configureBuilder;
         private readonly IQuerySources _definition;
 
-        public FakeProjectionStateHandler(string source, Action<string> logger)
+        public FakeProjectionStateHandler(string source, Action<string, object[]> logger)
         {
             _definition = source.ParseJson<QuerySourcesDefinition>();
         }

--- a/src/EventStore/EventStore.Projections.Core.Tests/Services/projections_manager/FakeBiStateProjection.cs
+++ b/src/EventStore/EventStore.Projections.Core.Tests/Services/projections_manager/FakeBiStateProjection.cs
@@ -8,9 +8,9 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
     public class FakeBiStateProjection : IProjectionStateHandler
     {
         private readonly string _query;
-        private readonly Action<string> _logger;
+        private readonly Action<string, object[]> _logger;
 
-        public FakeBiStateProjection(string query, Action<string> logger)
+        public FakeBiStateProjection(string query, Action<string, object[]> logger)
         {
             _query = query;
             _logger = logger;
@@ -20,9 +20,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
         }
 
+        private void Log(string msg, params object[] args)
+        {
+            _logger(msg, args);
+        }
+
         public void ConfigureSourceProcessingStrategy(SourceDefinitionBuilder builder)
         {
-            _logger("ConfigureSourceProcessingStrategy(" + builder + ")");
+            Log("ConfigureSourceProcessingStrategy(" + builder + ")");
             builder.FromAll();
             builder.AllEvents();
             builder.SetByStream();
@@ -31,27 +36,27 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public void Load(string state)
         {
-            _logger("Load(" + state + ")");
+            Log("Load(" + state + ")");
         }
 
         public void LoadShared(string state)
         {
-            _logger("LoadShared(" + state + ")");
+            Log("LoadShared(" + state + ")");
         }
 
         public void Initialize()
         {
-            _logger("Initialize");
+            Log("Initialize");
         }
 
         public void InitializeShared()
         {
-            _logger("InitializeShared");
+            Log("InitializeShared");
         }
 
         public string GetStatePartition(CheckpointTag eventPosition, string category, ResolvedEvent data)
         {
-            _logger("GetStatePartition(" + "..." + ")");
+            Log("GetStatePartition(" + "..." + ")");
             throw new NotImplementedException();
         }
 
@@ -67,7 +72,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             newSharedState = null;
             if (data.EventType == "fail" || _query == "fail")
                 throw new Exception("failed");
-            _logger("ProcessEvent(" + "..." + ")");
+            Log("ProcessEvent(" + "..." + ")");
             newState = "{\"data\": 1}";
             newSharedState = "{\"data\": 2}";
             emittedEvents = null;
@@ -76,7 +81,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public bool ProcessPartitionCreated(string partition, CheckpointTag createPosition, ResolvedEvent data, out EmittedEventEnvelope[] emittedEvents)
         {
-            _logger("ProcessPartitionCreated");
+            Log("ProcessPartitionCreated");
             emittedEvents = null;
             return false;
         }

--- a/src/EventStore/EventStore.Projections.Core.Tests/Services/projections_manager/FakeForeachStreamProjection.cs
+++ b/src/EventStore/EventStore.Projections.Core.Tests/Services/projections_manager/FakeForeachStreamProjection.cs
@@ -8,10 +8,10 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
     public class FakeForeachStreamProjection : IProjectionStateHandler
     {
         private readonly string _query;
-        private readonly Action<string> _logger;
+        private readonly Action<string, object[]> _logger;
         private string _state;
 
-        public FakeForeachStreamProjection(string query, Action<string> logger)
+        public FakeForeachStreamProjection(string query, Action<string, object[]> logger)
         {
             _query = query;
             _logger = logger;
@@ -21,9 +21,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
         }
 
+        private void Log(string msg, params object[] args)
+        {
+            _logger(msg, args);
+        }
+
         public void ConfigureSourceProcessingStrategy(SourceDefinitionBuilder builder)
         {
-            _logger("ConfigureSourceProcessingStrategy(" + builder + ")");
+            Log("ConfigureSourceProcessingStrategy(" + builder + ")");
             builder.FromAll();
             builder.AllEvents();
             builder.SetByStream();
@@ -32,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public void Load(string state)
         {
-            _logger("Load(" + state + ")");
+            Log("Load(" + state + ")");
             _state = state;
         }
 
@@ -43,19 +48,19 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public void Initialize()
         {
-            _logger("Initialize");
+            Log("Initialize");
             _state = "";
         }
 
         public void InitializeShared()
         {
-            _logger("InitializeShared");
+            Log("InitializeShared");
             throw new NotImplementedException();
         }
 
         public string GetStatePartition(CheckpointTag eventPosition, string category, ResolvedEvent data)
         {
-            _logger("GetStatePartition(" + "..." + ")");
+            Log("GetStatePartition(" + "..." + ")");
             return @data.EventStreamId;
         }
 
@@ -71,7 +76,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             newSharedState = null;
             if (data.EventType == "fail" || _query == "fail")
                 throw new Exception("failed");
-            _logger("ProcessEvent(" + "..." + ")");
+            Log("ProcessEvent(" + "..." + ")");
             newState = "{\"data\": " + _state + data + "}";
             emittedEvents = null;
             return true;
@@ -79,7 +84,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public bool ProcessPartitionCreated(string partition, CheckpointTag createPosition, ResolvedEvent data, out EmittedEventEnvelope[] emittedEvents)
         {
-            _logger("Process ProcessPartitionCreated");
+            Log("Process ProcessPartitionCreated");
             emittedEvents = null;
             return false;
         }

--- a/src/EventStore/EventStore.Projections.Core.Tests/Services/projections_manager/FakeFromCatalogStreamProjection.cs
+++ b/src/EventStore/EventStore.Projections.Core.Tests/Services/projections_manager/FakeFromCatalogStreamProjection.cs
@@ -8,13 +8,18 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
     public class FakeFromCatalogStreamProjection : IProjectionStateHandler
     {
         private readonly string _query;
-        private readonly Action<string> _logger;
+        private readonly Action<string, object[]> _logger;
         private string _state;
 
-        public FakeFromCatalogStreamProjection(string query, Action<string> logger)
+        public FakeFromCatalogStreamProjection(string query, Action<string, object[]> logger)
         {
             _query = query;
             _logger = logger;
+        }
+
+        private void Log(string msg, params object[] args)
+        {
+            _logger(msg, args);
         }
 
         public void Dispose()
@@ -23,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public void ConfigureSourceProcessingStrategy(SourceDefinitionBuilder builder)
         {
-            _logger("ConfigureSourceProcessingStrategy(" + builder + ")");
+            Log("ConfigureSourceProcessingStrategy(" + builder + ")");
             builder.FromCatalogStream("catalog");
             builder.AllEvents();
             builder.SetByStream();
@@ -31,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public void Load(string state)
         {
-            _logger("Load(" + state + ")");
+            Log("Load(" + state + ")");
             _state = state;
         }
 
@@ -42,19 +47,19 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public void Initialize()
         {
-            _logger("Initialize");
+            Log("Initialize");
             _state = "";
         }
 
         public void InitializeShared()
         {
-            _logger("InitializeShared");
+            Log("InitializeShared");
             throw new NotImplementedException();
         }
 
         public string GetStatePartition(CheckpointTag eventPosition, string category, ResolvedEvent data)
         {
-            _logger("GetStatePartition(" + "..." + ")");
+            Log("GetStatePartition(" + "..." + ")");
             return @data.EventStreamId;
         }
 
@@ -70,7 +75,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             newSharedState = null;
             if (data.EventType == "fail" || _query == "fail")
                 throw new Exception("failed");
-            _logger("ProcessEvent(" + "..." + ")");
+            Log("ProcessEvent(" + "..." + ")");
             newState = "{\"data\": " + _state + data + "}";
             emittedEvents = null;
             return true;

--- a/src/EventStore/EventStore.Projections.Core.Tests/Services/projections_manager/FakeProjection.cs
+++ b/src/EventStore/EventStore.Projections.Core.Tests/Services/projections_manager/FakeProjection.cs
@@ -8,9 +8,9 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
     public class FakeProjection : IProjectionStateHandler
     {
         private readonly string _query;
-        private readonly Action<string> _logger;
+        private readonly Action<string, object[]> _logger;
 
-        public FakeProjection(string query, Action<string> logger)
+        public FakeProjection(string query, Action<string, object[]> logger)
         {
             _query = query;
             _logger = logger;
@@ -20,16 +20,21 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
         }
 
+        private void Log(string msg, params object[] args)
+        {
+            _logger(msg, args);
+        }
+
         public void ConfigureSourceProcessingStrategy(SourceDefinitionBuilder builder)
         {
-            _logger("ConfigureSourceProcessingStrategy(" + builder + ")");
+            Log("ConfigureSourceProcessingStrategy(" + builder + ")");
             builder.FromAll();
             builder.AllEvents();
         }
 
         public void Load(string state)
         {
-            _logger("Load(" + state + ")");
+            Log("Load(" + state + ")");
             throw new NotImplementedException();
         }
 
@@ -40,17 +45,17 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public void Initialize()
         {
-            _logger("Initialize");
+            Log("Initialize");
         }
 
         public void InitializeShared()
         {
-            _logger("InitializeShared");
+            Log("InitializeShared");
         }
 
         public string GetStatePartition(CheckpointTag eventPosition, string category, ResolvedEvent data)
         {
-            _logger("GetStatePartition(" + "..." + ")");
+            Log("GetStatePartition(" + "..." + ")");
             throw new NotImplementedException();
         }
 
@@ -66,7 +71,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             newSharedState = null;
             if (data.EventType == "fail" || _query == "fail")
                 throw new Exception("failed");
-            _logger("ProcessEvent(" + "..." + ")");
+            Log("ProcessEvent(" + "..." + ")");
             newState = "{\"data\": 1}";
             emittedEvents = null;
             return true;
@@ -74,7 +79,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         public bool ProcessPartitionCreated(string partition, CheckpointTag createPosition, ResolvedEvent data, out EmittedEventEnvelope[] emittedEvents)
         {
-            _logger("Process ProcessPartitionCreated");
+            Log("Process ProcessPartitionCreated");
             emittedEvents = null;
             return false;
         }

--- a/src/EventStore/EventStore.Projections.Core/Standard/CategorizeEventsByStreamPath.cs
+++ b/src/EventStore/EventStore.Projections.Core/Standard/CategorizeEventsByStreamPath.cs
@@ -13,7 +13,7 @@ namespace EventStore.Projections.Core.Standard
         private readonly string _categoryStreamPrefix;
         private readonly StreamCategoryExtractor _streamCategoryExtractor;
 
-        public CategorizeEventsByStreamPath(string source, Action<string> logger)
+        public CategorizeEventsByStreamPath(string source, Action<string, object[]> logger)
         {
             var extractor = StreamCategoryExtractor.GetExtractor(source, logger);
             // we will need to declare event types we are interested in

--- a/src/EventStore/EventStore.Projections.Core/Standard/CategorizeStreamByPath.cs
+++ b/src/EventStore/EventStore.Projections.Core/Standard/CategorizeStreamByPath.cs
@@ -10,7 +10,7 @@ namespace EventStore.Projections.Core.Standard
     {
         private readonly StreamCategoryExtractor _streamCategoryExtractor;
 
-        public CategorizeStreamByPath(string source, Action<string> logger)
+        public CategorizeStreamByPath(string source, Action<string, object[]> logger)
         {
             var extractor = StreamCategoryExtractor.GetExtractor(source, logger);
             // we will need to declare event types we are interested in

--- a/src/EventStore/EventStore.Projections.Core/Standard/IndexEventsByEventType.cs
+++ b/src/EventStore/EventStore.Projections.Core/Standard/IndexEventsByEventType.cs
@@ -13,7 +13,7 @@ namespace EventStore.Projections.Core.Standard
         private readonly string _indexStreamPrefix;
         private readonly string _indexCheckpointStream;
 
-        public IndexEventsByEventType(string source, Action<string> logger)
+        public IndexEventsByEventType(string source, Action<string, object[]> logger)
         {
             if (!string.IsNullOrWhiteSpace(source))
                 throw new InvalidOperationException("Empty source expected");

--- a/src/EventStore/EventStore.Projections.Core/Standard/IndexStreams.cs
+++ b/src/EventStore/EventStore.Projections.Core/Standard/IndexStreams.cs
@@ -8,7 +8,7 @@ namespace EventStore.Projections.Core.Standard
 {
     public class IndexStreams : IProjectionStateHandler
     {
-        public IndexStreams(string source, Action<string> logger)
+        public IndexStreams(string source, Action<string, object[]> logger)
         {
             var trimmedSource = source == null ? null : source.Trim();
             if (!string.IsNullOrEmpty(trimmedSource))

--- a/src/EventStore/EventStore.Projections.Core/Standard/StreamCategoryExtractor.cs
+++ b/src/EventStore/EventStore.Projections.Core/Standard/StreamCategoryExtractor.cs
@@ -8,7 +8,7 @@ namespace EventStore.Projections.Core.Standard
 
         public abstract string GetCategoryByStreamId(string streamId);
 
-        public static StreamCategoryExtractor GetExtractor(string source, Action<string> logger)
+        public static StreamCategoryExtractor GetExtractor(string source, Action<string, object[]> logger)
         {
             var trimmedSource = source == null ? null : source.Trim();
             if (string.IsNullOrEmpty(source))

--- a/src/EventStore/EventStore.Projections.Core/Standard/StubHandler.cs
+++ b/src/EventStore/EventStore.Projections.Core/Standard/StubHandler.cs
@@ -10,7 +10,7 @@ namespace EventStore.Projections.Core.Standard
         //private readonly char _separator;
         //private readonly string _categoryStreamPrefix;
 
-        public StubHandler(string source, Action<string> logger)
+        public StubHandler(string source, Action<string, object[]> logger)
         {
             if (!string.IsNullOrWhiteSpace(source))
                 throw new InvalidOperationException(

--- a/src/EventStore/EventStore.Web/Users/IndexUsersProjectionHandler.cs
+++ b/src/EventStore/EventStore.Web/Users/IndexUsersProjectionHandler.cs
@@ -14,7 +14,7 @@ namespace EventStore.Web.Users
         private const string UsersStream = "$users";
         private const string UserEventType = "$User";
 
-        public IndexUsersProjectionHandler(string query, Action<string> logger)
+        public IndexUsersProjectionHandler(string query, Action<string, object[]> logger)
         {
         }
 


### PR DESCRIPTION
Was getting the following error when attempting to create the system projections:

"Constructor on type 'EventStore.Projections.Core.Standard.IndexEventsByEventType' not found."

Looks like https://github.com/betgenius/EventStore/commit/d500282468584a631a01bf33103497eab69e905b changed the type of the logger from Action<string> to Action<string,object[]> but the constructors weren't updating so Activator.CreateInstance was failing in the ProjectionStateHandlerFactory
