### PR TITLE
Support the ability to parse sections of a configuration file

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -121,8 +121,6 @@ namespace EventStore.ClusterNode
 
         [ArgDescription(Opts.AuthenticationTypeDescr, Opts.AuthGroup)]
         public string AuthenticationType { get; set; }
-        [ArgDescription(Opts.AuthenticationConfigFileDescr, Opts.AuthGroup)]
-        public string AuthenticationConfigFile { get; set; }
 
         [ArgDescription(Opts.PrepareTimeoutMsDescr, Opts.DbGroup)]
         public int PrepareTimeoutMs { get; set; }
@@ -200,7 +198,6 @@ namespace EventStore.ClusterNode
             SslValidateServer = Opts.SslValidateServerDefault;
 
             AuthenticationType = Opts.AuthenticationTypeDefault;
-            AuthenticationConfigFile = Opts.AuthenticationConfigFileDefault;
 
             UnsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
             PrepareTimeoutMs = Opts.PrepareTimeoutMsDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -184,7 +184,7 @@ namespace EventStore.ClusterNode
                 if (intSecTcp == null) throw new Exception("Usage of internal secure communication is specified, but no internal secure endpoint is specified!");
             }
 
-			var authenticationProviderFactory = GetAuthenticationProviderFactory(options.AuthenticationType, options.AuthenticationConfigFile);
+			var authenticationProviderFactory = GetAuthenticationProviderFactory(options.AuthenticationType, options.Config);
 
 			return new ClusterVNodeSettings(Guid.NewGuid(), 0,
 	                                        intTcp, intSecTcp, extTcp, extSecTcp, intHttp, extHttp,

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -138,6 +138,8 @@
     <Compile Include="Utils\Application.cs" />
     <Compile Include="Utils\FileStreamExtensions.cs" />
     <Compile Include="Utils\Empty.cs" />
+    <Compile Include="Utils\IPAddressConverter.cs" />
+    <Compile Include="Utils\IPEndPointArrayConverter.cs" />
     <Compile Include="Utils\IPEndPointComparer.cs" />
     <Compile Include="Utils\Json.cs" />
     <Compile Include="Utils\ShellExecutor.cs" />

--- a/src/EventStore.Common/Utils/IPAddressConverter.cs
+++ b/src/EventStore.Common/Utils/IPAddressConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace EventStore.Common.Utils
+{
+    public class IPAddressConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            var valueAsString = value as string;
+            if (valueAsString != null)
+            {
+                return IPAddress.Parse(valueAsString);
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}

--- a/src/EventStore.Common/Utils/IPEndPointArrayConverter.cs
+++ b/src/EventStore.Common/Utils/IPEndPointArrayConverter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace EventStore.Common.Utils
+{
+    public class IPEndPointArrayConverter : ArrayConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            var values = value as IEnumerable;
+            if (values != null)
+            {
+                var ipEndPointList = new List<IPEndPoint>();
+                foreach (var val in values)
+                {
+                    ipEndPointList.Add((IPEndPoint)new IPEndPointConverter().ConvertFrom(val));
+                }
+                return ipEndPointList.ToArray();
+            }
+            var valueAsString = value as string;
+            if (valueAsString != null)
+            {
+                var ipEndPointList = valueAsString.Split(new[] { "," }, StringSplitOptions.None).Select(x => new IPEndPointConverter().ConvertFrom(x));
+                return ipEndPointList.ToArray();
+            }
+
+            return base.ConvertFrom(context, culture, value);
+        }
+    }
+}


### PR DESCRIPTION
1. Exposing another method for parsing configuration files.
   This method takes as an optional parameter a group. This group specifies which section of the configuration file pertains to the options being parsed.

e.g.
DisconverViaDns: true
CustomSection:
    Key: x
    AnotherKey: y

This "CustomSection" can then be parsed by specifying the section in the configuration 
   EventStoreOptions<CustomOptions>(contentsOfConfig, "CustomSection")
