### PR TITLE
Http specs for linkTo max count deleted events

### DIFF
--- a/src/EventStore.Core.Tests/Http/Streams/SpecificationWithLinkToToMaxCountDeletedEvents.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/SpecificationWithLinkToToMaxCountDeletedEvents.cs
@@ -18,6 +18,7 @@ namespace EventStore.Core.Tests.Http.Streams
             LinkedStreamName = Guid.NewGuid().ToString();
             using (var conn = TestConnection.Create(_node.TcpEndPoint))
             {
+                conn.ConnectAsync().Wait();
                 conn.AppendToStreamAsync(DeletedStreamName, ExpectedVersion.Any, creds,
                     new EventData(Guid.NewGuid(), "testing1", true, Encoding.UTF8.GetBytes("{'foo' : 4}"), new byte[0]))
                     .Wait();

--- a/src/EventStore.Core.Tests/Http/Streams/basic.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/basic.cs
@@ -693,7 +693,7 @@ namespace EventStore.Core.Tests.Http.Streams
         }
 
         [TestFixture, Category("LongRunning")]
-        public class when_requesting_a_single_event_that_is_maxcount_deleted_linkto : HttpSpecificationWithLinkToToDeletedEvents
+        public class when_requesting_a_single_event_that_is_maxcount_deleted_linkto : SpecificationWithLinkToToMaxCountDeletedEvents
         {
             protected override void When()
             {

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -220,7 +220,7 @@ namespace EventStore.Core.Tests.Http.Streams
         }
 
         [TestFixture, Category("LongRunning")]
-        public class when_reading_a_stream_forward_with_maxcount_deleted_linktos : HttpSpecificationWithLinkToToDeletedEvents
+        public class when_reading_a_stream_forward_with_maxcount_deleted_linktos : SpecificationWithLinkToToMaxCountDeletedEvents
         {
             private JObject _feed;
             private List<JToken> _entries;
@@ -237,6 +237,23 @@ namespace EventStore.Core.Tests.Http.Streams
             }
         }
 
+        [TestFixture, Category("LongRunning")][Explicit("Failing test for Greg demonstrating NullReferenceException in Convert.cs")]
+        public class when_reading_a_stream_forward_with_maxcount_deleted_linktos_with_rich_entry : SpecificationWithLinkToToMaxCountDeletedEvents
+        {
+            private JObject _feed;
+            private List<JToken> _entries;
+            protected override void When()
+            {
+                _feed = GetJson<JObject>("/streams/" + LinkedStreamName + "/0/forward/10?embed=rich", accept: ContentType.Json); 
+                _entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
+            }
+
+            [Test]
+            public void the_feed_has_some_events()
+            {
+                Assert.AreEqual(1, _entries.Count());
+            }
+        }
 
         [TestFixture, Category("LongRunning")]
         public class when_reading_a_stream_forward_with_deleted_linktos_with_content_enabled : HttpSpecificationWithLinkToToDeletedEvents


### PR DESCRIPTION
Fixed up the two linkto maxcount deleted events tests to use the new base spec, and added another (failing) case that uses embed=rich. The other tests pass because they are EmbedLevel.None.

It was just because I was using the Web UI to view the linked stream that I was able to get the error in the first place - since the HTML content type resolves to EmbedLevel.PrettyBody.
