### PR TITLE
Fixed typo in xmldoc

### DIFF
--- a/src/EventStore.ClientAPI/StreamEventsSlice.cs
+++ b/src/EventStore.ClientAPI/StreamEventsSlice.cs
@@ -29,7 +29,7 @@ namespace EventStore.ClientAPI
         public readonly ReadDirection ReadDirection;
 
         /// <summary>
-        /// The events read represented as <see cref="RecordedEvent"/>
+        /// The events read represented as <see cref="ResolvedEvent"/>
         /// </summary>
         public readonly ResolvedEvent[] Events;
 


### PR DESCRIPTION
While the innards indeed are (and probably it once actually was) of the cited type, this misled me for some time.

Yes, that's what I get for trusting docs :)

Not 100% sure replacing the type doesnt lose implied info - Might be worth alluding to the fact e.g. that the ResolvedEvent may or may not actually be resolved ?
