### PR TITLE
Removed redundant code.

### DIFF
--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -230,12 +230,6 @@ namespace EventStore.Transport.Http.EntityManagement
 
             if (response == null || response.Length == 0)
             {
-                if (_processing == 1)
-                {
-                    DisposeStreamAndCloseConnection("Timed out.");
-                    return;
-                }
-                
                 SetResponseLength(0);
                 CloseConnection(onError);
             }


### PR DESCRIPTION
The code that fell into this particular block resulted in the response content length not being set therefore produced the stray data.

Fixes #205
