### PR TITLE
Remove synchronous wrappers on transaction

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreTransaction.cs
+++ b/src/EventStore.ClientAPI/EventStoreTransaction.cs
@@ -39,15 +39,6 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
-        /// Commits this transaction
-        /// </summary>
-        /// <returns>Expected version for following write requests</returns>
-        public WriteResult Commit()
-        {
-            return CommitAsync().Result;
-        }
-
-        /// <summary>
         /// Asynchronously commits this transaction
         /// </summary>
         /// <returns>A <see cref="Task"/> that returns expected version for following write requests</returns>
@@ -57,24 +48,6 @@ namespace EventStore.ClientAPI
             if (_isCommitted) throw new InvalidOperationException("Transaction is already committed");
             _isCommitted = true;
             return _connection.CommitTransactionAsync(this, _userCredentials);
-        }
-
-        /// <summary>
-        /// Writes to a transaction in the event store asynchronously
-        /// </summary>
-        /// <param name="events">The events to write</param>
-        public void Write(IEnumerable<EventData> events)
-        {
-            WriteAsync(events).Wait();
-        }
-
-        /// <summary>
-        /// Writes to a transaction in the event store asynchronously
-        /// </summary>
-        /// <param name="events">The events to write</param>
-        public void Write(params EventData[] events)
-        {
-            WriteAsync((IEnumerable<EventData>)events).Wait();
         }
 
         /// <summary>

--- a/src/EventStore.Core.Tests/ClientAPI/Helpers/Writer.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Helpers/Writer.cs
@@ -76,13 +76,13 @@ namespace EventStore.Core.Tests.ClientAPI.Helpers
 
         public OngoingTransaction Write(params EventData[] events)
         {
-            _transaction.Write(events);
+            _transaction.WriteAsync(events).Wait();
             return this;
         }
 
         public WriteResult Commit()
         {
-            return _transaction.Commit();
+            return _transaction.CommitAsync().Result;
         }
     }
 }

--- a/src/EventStore.Core.Tests/ClientAPI/Security/authorized_default_credentials_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/authorized_default_credentials_security.cs
@@ -25,8 +25,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             ExpectNoException(() =>
             {
                 var trans = TransStart("write-stream", null, null);
-                trans.Write();
-                trans.Commit();
+                trans.WriteAsync().Wait();
+                trans.CommitAsync().Wait();
             });
 
             ExpectNoException(() => ReadMeta("metaread-stream", null, null));
@@ -48,12 +48,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             Expect<NotAuthenticatedException>(() => WriteStream("write-stream", "badlogin", "badpass"));
             Expect<NotAuthenticatedException>(() => TransStart("write-stream", "badlogin", "badpass"));
-            {
-                var transId = TransStart("write-stream", null, null).TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("badlogin", "badpass"));
-                ExpectNoException(() => trans.Write());
-                Expect<NotAuthenticatedException>(() => trans.Commit());
-            };
+
+            var transId = TransStart("write-stream", null, null).TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("badlogin", "badpass"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            Expect<NotAuthenticatedException>(() => trans.CommitAsync().Wait());
 
             Expect<NotAuthenticatedException>(() => ReadMeta("metaread-stream", "badlogin", "badpass"));
             Expect<NotAuthenticatedException>(() => WriteMeta("metawrite-stream", "badlogin", "badpass", "user1"));
@@ -74,12 +73,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             Expect<AccessDeniedException>(() => WriteStream("write-stream", "user2", "pa$$2"));
             Expect<AccessDeniedException>(() => TransStart("write-stream", "user2", "pa$$2"));
-            {
-                var transId = TransStart("write-stream", null, null).TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-                ExpectNoException(() => trans.Write());
-                Expect<AccessDeniedException>(() => trans.Commit());
-            };
+
+            var transId = TransStart("write-stream", null, null).TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            Expect<AccessDeniedException>(() => trans.CommitAsync().Wait());
 
             Expect<AccessDeniedException>(() => ReadMeta("metaread-stream", "user2", "pa$$2"));
             Expect<AccessDeniedException>(() => WriteMeta("metawrite-stream", "user2", "pa$$2", "user1"));

--- a/src/EventStore.Core.Tests/ClientAPI/Security/overriden_system_stream_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/overriden_system_stream_security.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using EventStore.ClientAPI;
+﻿using EventStore.ClientAPI;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.SystemData;
-using EventStore.Core.Services;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.ClientAPI.Security
@@ -30,12 +28,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream(stream, "user1", "pa$$1"));
             ExpectNoException(() => TransStart(stream, "user1", "pa$$1"));
-            {
-                var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta(stream, "user1", "pa$$1"));
             ExpectNoException(() => WriteMeta(stream, "user1", "pa$$1", null));
@@ -55,12 +52,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             Expect<AccessDeniedException>(() => WriteStream(stream, "user2", "pa$$2"));
             Expect<AccessDeniedException>(() => TransStart(stream, "user2", "pa$$2"));
-            {
-                var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-                ExpectNoException(() => trans.Write());
-                Expect<AccessDeniedException>(() => trans.Commit());
-            };
+
+            var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            Expect<AccessDeniedException>(() => trans.CommitAsync().Wait());
 
             Expect<AccessDeniedException>(() => ReadMeta(stream, "user2", "pa$$2"));
             Expect<AccessDeniedException>(() => WriteMeta(stream, "user2", "pa$$2", null));
@@ -80,12 +76,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             Expect<AccessDeniedException>(() => WriteStream(stream, null, null));
             Expect<AccessDeniedException>(() => TransStart(stream, null, null));
-            {
-                var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId);
-                ExpectNoException(() => trans.Write());
-                Expect<AccessDeniedException>(() => trans.Commit());
-            };
+
+            var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId);
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            Expect<AccessDeniedException>(() => trans.CommitAsync().Wait());
 
             Expect<AccessDeniedException>(() => ReadMeta(stream, null, null));
             Expect<AccessDeniedException>(() => WriteMeta(stream, null, null, null));
@@ -105,12 +100,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream(stream, "adm", "admpa$$"));
             ExpectNoException(() => TransStart(stream, "adm", "admpa$$"));
-            {
-                var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta(stream, "adm", "admpa$$"));
             ExpectNoException(() => WriteMeta(stream, "adm", "admpa$$", null));

--- a/src/EventStore.Core.Tests/ClientAPI/Security/overriden_system_stream_security_for_all.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/overriden_system_stream_security_for_all.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using EventStore.ClientAPI;
-using EventStore.ClientAPI.Exceptions;
+﻿using EventStore.ClientAPI;
 using EventStore.ClientAPI.SystemData;
 using EventStore.Core.Services;
 using NUnit.Framework;
@@ -31,12 +29,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream(stream, "user1", "pa$$1"));
             ExpectNoException(() => TransStart(stream, "user1", "pa$$1"));
-            {
-                var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta(stream, "user1", "pa$$1"));
             ExpectNoException(() => WriteMeta(stream, "user1", "pa$$1", null));
@@ -56,12 +53,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream(stream, null, null));
             ExpectNoException(() => TransStart(stream, null, null));
-            {
-                var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, null);
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId);
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta(stream, null, null));
             ExpectNoException(() => WriteMeta(stream, null, null, null));
@@ -81,12 +77,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream(stream, "adm", "admpa$$"));
             ExpectNoException(() => TransStart(stream, "adm", "admpa$$"));
-            {
-                var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta(stream, "adm", "admpa$$"));
             ExpectNoException(() => WriteMeta(stream, "adm", "admpa$$", null));

--- a/src/EventStore.Core.Tests/ClientAPI/Security/overriden_user_stream_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/overriden_user_stream_security.cs
@@ -33,8 +33,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             {
                 var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
                 var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
+                ExpectNoException(() => trans.WriteAsync().Wait());
+                ExpectNoException(() => trans.CommitAsync().Wait());
             };
 
             ExpectNoException(() => ReadMeta(stream, "user1", "pa$$1"));
@@ -58,8 +58,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             {
                 var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
                 var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-                ExpectNoException(() => trans.Write());
-                Expect<AccessDeniedException>(() => trans.Commit());
+                ExpectNoException(() => trans.WriteAsync().Wait());
+                Expect<AccessDeniedException>(() => trans.CommitAsync().Wait());
             };
 
             Expect<AccessDeniedException>(() => ReadMeta(stream, "user2", "pa$$2"));
@@ -83,8 +83,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             {
                 var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
                 var trans = Connection.ContinueTransaction(transId);
-                ExpectNoException(() => trans.Write());
-                Expect<AccessDeniedException>(() => trans.Commit());
+                ExpectNoException(() => trans.WriteAsync().Wait());
+                Expect<AccessDeniedException>(() => trans.CommitAsync().Wait());
             };
 
             Expect<AccessDeniedException>(() => ReadMeta(stream, null, null));
@@ -108,8 +108,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             {
                 var transId = TransStart(stream, "adm", "admpa$$").TransactionId;
                 var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
+                ExpectNoException(() => trans.WriteAsync().Wait());
+                ExpectNoException(() => trans.CommitAsync().Wait());
             };
 
             ExpectNoException(() => ReadMeta(stream, "adm", "admpa$$"));

--- a/src/EventStore.Core.Tests/ClientAPI/Security/system_stream_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/system_stream_security.cs
@@ -17,12 +17,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             Expect<AccessDeniedException>(() => WriteStream("$system-no-acl", "user1", "pa$$1"));
             Expect<AccessDeniedException>(() => TransStart("$system-no-acl", "user1", "pa$$1"));
-            {
-                var transId = TransStart("$system-no-acl", "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-                ExpectNoException(() => trans.Write());
-                Expect<AccessDeniedException>(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-no-acl", "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            Expect<AccessDeniedException>(() => trans.CommitAsync().Wait());
 
             Expect<AccessDeniedException>(() => ReadMeta("$system-no-acl", "user1", "pa$$1"));
             Expect<AccessDeniedException>(() => WriteMeta("$system-no-acl", "user1", "pa$$1", null));
@@ -39,12 +38,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream("$system-no-acl", "adm", "admpa$$"));
             ExpectNoException(() => TransStart("$system-no-acl", "adm", "admpa$$"));
-            {
-                var transId = TransStart("$system-no-acl", "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-no-acl", "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta("$system-no-acl", "adm", "admpa$$"));
             ExpectNoException(() => WriteMeta("$system-no-acl", "adm", "admpa$$", null));
@@ -61,12 +59,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             Expect<AccessDeniedException>(() => WriteStream("$system-acl", "user2", "pa$$2"));
             Expect<AccessDeniedException>(() => TransStart("$system-acl", "user2", "pa$$2"));
-            {
-                var transId = TransStart("$system-acl", "user1", "pa$$1").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-                ExpectNoException(() => trans.Write());
-                Expect<AccessDeniedException>(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-acl", "user1", "pa$$1").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            Expect<AccessDeniedException>(() => trans.CommitAsync().Wait());
 
             Expect<AccessDeniedException>(() => ReadMeta("$system-acl", "user2", "pa$$2"));
             Expect<AccessDeniedException>(() => WriteMeta("$system-acl", "user2", "pa$$2", "user1"));
@@ -83,12 +80,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream("$system-acl", "user1", "pa$$1"));
             ExpectNoException(() => TransStart("$system-acl", "user1", "pa$$1"));
-            {
-                var transId = TransStart("$system-acl", "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-acl", "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta("$system-acl", "user1", "pa$$1"));
             ExpectNoException(() => WriteMeta("$system-acl", "user1", "pa$$1", "user1"));
@@ -105,12 +101,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream("$system-acl", "adm", "admpa$$"));
             ExpectNoException(() => TransStart("$system-acl", "adm", "admpa$$"));
-            {
-                var transId = TransStart("$system-acl", "user1", "pa$$1").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-acl", "user1", "pa$$1").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta("$system-acl", "adm", "admpa$$"));
             ExpectNoException(() => WriteMeta("$system-acl", "adm", "admpa$$", "user1"));
@@ -128,12 +123,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             Expect<AccessDeniedException>(() => WriteStream("$system-adm", "user1", "pa$$1"));
             Expect<AccessDeniedException>(() => TransStart("$system-adm", "user1", "pa$$1"));
-            {
-                var transId = TransStart("$system-adm", "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-                ExpectNoException(() => trans.Write());
-                Expect<AccessDeniedException>(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-adm", "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            Expect<AccessDeniedException>(() => trans.CommitAsync().Wait());
 
             Expect<AccessDeniedException>(() => ReadMeta("$system-adm", "user1", "pa$$1"));
             Expect<AccessDeniedException>(() => WriteMeta("$system-adm", "user1", "pa$$1", SystemRoles.Admins));
@@ -150,12 +144,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream("$system-adm", "adm", "admpa$$"));
             ExpectNoException(() => TransStart("$system-adm", "adm", "admpa$$"));
-            {
-                var transId = TransStart("$system-adm", "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-adm", "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta("$system-adm", "adm", "admpa$$"));
             ExpectNoException(() => WriteMeta("$system-adm", "adm", "admpa$$", SystemRoles.Admins));
@@ -173,12 +166,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream("$system-all", null, null));
             ExpectNoException(() => TransStart("$system-all", null, null));
-            {
-                var transId = TransStart("$system-all", null, null).TransactionId;
-                var trans = Connection.ContinueTransaction(transId, null);
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-all", null, null).TransactionId;
+            var trans = Connection.ContinueTransaction(transId);
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta("$system-all", null, null));
             ExpectNoException(() => WriteMeta("$system-all", null, null, SystemRoles.All));
@@ -195,12 +187,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream("$system-all", "user1", "pa$$1"));
             ExpectNoException(() => TransStart("$system-all", "user1", "pa$$1"));
-            {
-                var transId = TransStart("$system-all", "user1", "pa$$1").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-all", "user1", "pa$$1").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta("$system-all", "user1", "pa$$1"));
             ExpectNoException(() => WriteMeta("$system-all", "user1", "pa$$1", SystemRoles.All));
@@ -217,12 +208,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
             ExpectNoException(() => WriteStream("$system-all", "adm", "admpa$$"));
             ExpectNoException(() => TransStart("$system-all", "adm", "admpa$$"));
-            {
-                var transId = TransStart("$system-all", "adm", "admpa$$").TransactionId;
-                var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
-                ExpectNoException(() => trans.Write());
-                ExpectNoException(() => trans.Commit());
-            };
+
+            var transId = TransStart("$system-all", "adm", "admpa$$").TransactionId;
+            var trans = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
+            ExpectNoException(() => trans.WriteAsync().Wait());
+            ExpectNoException(() => trans.CommitAsync().Wait());
 
             ExpectNoException(() => ReadMeta("$system-all", "adm", "admpa$$"));
             ExpectNoException(() => WriteMeta("$system-all", "adm", "admpa$$", SystemRoles.All));

--- a/src/EventStore.Core.Tests/ClientAPI/Security/transactional_write_stream_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/transactional_write_stream_security.cs
@@ -43,8 +43,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
         {
             var transId = TransStart("write-stream", "user1", "pa$$1").TransactionId;
             var t2 = Connection.ContinueTransaction(transId, new UserCredentials("badlogin", "badpass"));
-            t2.Write(CreateEvents());
-            Expect<NotAuthenticatedException>(() => t2.Commit());
+            t2.WriteAsync(CreateEvents()).Wait();
+            Expect<NotAuthenticatedException>(() => t2.CommitAsync().Wait());
         }
 
         [Test, Category("LongRunning"), Category("Network")]
@@ -52,8 +52,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
         {
             var transId = TransStart("write-stream", "user1", "pa$$1").TransactionId;
             var t2 = Connection.ContinueTransaction(transId);
-            t2.Write();
-            Expect<AccessDeniedException>(() => t2.Commit());
+            t2.WriteAsync().Wait();
+            Expect<AccessDeniedException>(() => t2.CommitAsync().Wait());
         }
 
         [Test, Category("LongRunning"), Category("Network")]
@@ -61,8 +61,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
         {
             var transId = TransStart("write-stream", "user1", "pa$$1").TransactionId;
             var t2 = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-            t2.Write();
-            Expect<AccessDeniedException>(() => t2.Commit());
+            t2.WriteAsync().Wait();
+            Expect<AccessDeniedException>(() => t2.CommitAsync().Wait());
         }
 
         [Test, Category("LongRunning"), Category("Network")]
@@ -70,8 +70,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
         {
             var transId = TransStart("write-stream", "user1", "pa$$1").TransactionId;
             var t2 = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-            t2.Write();
-            ExpectNoException(() => t2.Commit());
+            t2.WriteAsync().Wait();
+            ExpectNoException(() => t2.CommitAsync().Wait());
         }
 
         [Test, Category("LongRunning"), Category("Network")]
@@ -79,8 +79,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
         {
             var transId = TransStart("write-stream", "user1", "pa$$1").TransactionId;
             var t2 = Connection.ContinueTransaction(transId, new UserCredentials("adm", "admpa$$"));
-            t2.Write();
-            ExpectNoException(() => t2.Commit());
+            t2.WriteAsync().Wait();
+            ExpectNoException(() => t2.CommitAsync().Wait());
         }
 
 
@@ -90,8 +90,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             ExpectNoException(() =>
             {
                 var t = TransStart("noacl-stream", null, null);
-                t.Write(CreateEvents());
-                t.Commit();
+                t.WriteAsync(CreateEvents()).Wait();
+                t.CommitAsync().Wait();
             });
         }
 
@@ -107,14 +107,14 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             ExpectNoException(() =>
             {
                 var t = TransStart("noacl-stream", "user1", "pa$$1");
-                t.Write(CreateEvents());
-                t.Commit();
+                t.WriteAsync(CreateEvents()).Wait();
+                t.CommitAsync().Wait();
             });
             ExpectNoException(() =>
             {
                 var t = TransStart("noacl-stream", "user2", "pa$$2");
-                t.Write(CreateEvents());
-                t.Commit();
+                t.WriteAsync(CreateEvents()).Wait();
+                t.CommitAsync().Wait();
             });
         }
 
@@ -124,8 +124,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             ExpectNoException(() =>
             {
                 var t = TransStart("noacl-stream", "adm", "admpa$$");
-                t.Write(CreateEvents());
-                t.Commit();
+                t.WriteAsync(CreateEvents()).Wait();
+                t.CommitAsync().Wait();
             });
         }
 
@@ -136,8 +136,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             ExpectNoException(() =>
             {
                 var t = TransStart("normal-all", null, null);
-                t.Write(CreateEvents());
-                t.Commit();
+                t.WriteAsync(CreateEvents()).Wait();
+                t.CommitAsync().Wait();
             });
         }
 
@@ -153,14 +153,14 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             ExpectNoException(() =>
             {
                 var t = TransStart("normal-all", "user1", "pa$$1");
-                t.Write(CreateEvents());
-                t.Commit();
+                t.WriteAsync(CreateEvents()).Wait();
+                t.CommitAsync().Wait();
             });
             ExpectNoException(() =>
             {
                 var t = TransStart("normal-all", "user2", "pa$$2");
-                t.Write(CreateEvents());
-                t.Commit();
+                t.WriteAsync(CreateEvents()).Wait();
+                t.CommitAsync().Wait();
             });
         }
 
@@ -170,8 +170,8 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             ExpectNoException(() =>
             {
                 var t = TransStart("normal-all", "adm", "admpa$$");
-                t.Write(CreateEvents());
-                t.Commit();
+                t.WriteAsync(CreateEvents()).Wait();
+                t.CommitAsync().Wait();
             });
         }
     }

--- a/src/EventStore.Core.Tests/ClientAPI/isjson_flag_on_event.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/isjson_flag_on_event.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using EventStore.ClientAPI;
 using EventStore.Common.Utils;
-using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.ClientAPI.Helpers;
@@ -58,11 +55,15 @@ namespace EventStore.Core.Tests.ClientAPI
 
                 using (var transaction = connection.StartTransactionAsync(stream, ExpectedVersion.Any).Result)
                 {
-                    transaction.Write(
-                        new EventData(Guid.NewGuid(), "some-type", true, Helper.UTF8NoBom.GetBytes("{\"some\":\"json\"}"), null),
-                        new EventData(Guid.NewGuid(), "some-type", true, null, Helper.UTF8NoBom.GetBytes("{\"some\":\"json\"}")),
-                        new EventData(Guid.NewGuid(), "some-type", true, Helper.UTF8NoBom.GetBytes("{\"some\":\"json\"}"), Helper.UTF8NoBom.GetBytes("{\"some\":\"json\"}")));
-                    transaction.Commit();
+                    transaction.WriteAsync(
+                        new EventData(Guid.NewGuid(), "some-type", true,
+                            Helper.UTF8NoBom.GetBytes("{\"some\":\"json\"}"), null),
+                        new EventData(Guid.NewGuid(), "some-type", true, null,
+                            Helper.UTF8NoBom.GetBytes("{\"some\":\"json\"}")),
+                        new EventData(Guid.NewGuid(), "some-type", true,
+                            Helper.UTF8NoBom.GetBytes("{\"some\":\"json\"}"),
+                            Helper.UTF8NoBom.GetBytes("{\"some\":\"json\"}"))).Wait();
+                    transaction.CommitAsync().Wait();
                 }
 
                 var done = new ManualResetEventSlim();

--- a/src/EventStore.Core.Tests/ClientAPI/when_committing_empty_transaction.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/when_committing_empty_transaction.cs
@@ -34,7 +34,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
             using (var transaction = _connection.StartTransactionAsync("test-stream", 2).Result)
             {
-                Assert.AreEqual(2, transaction.Commit().NextExpectedVersion);
+                Assert.AreEqual(2, transaction.CommitAsync().Result.NextExpectedVersion);
             }
         }
 


### PR DESCRIPTION
Remove the synchronous wrapper methods for writing and commiting a
transaction in the client API. Starts to address #118. Fixes tests which
were relying on the synchronous variants.
