### PR TITLE
fix issue with linktos in atom feeds discussed on mailing list

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -198,6 +198,7 @@
     <Compile Include="Http\StreamSecurity\SpecificationWithUsers.cs" />
     <Compile Include="Http\StreamSecurity\stream_access.cs" />
     <Compile Include="Http\Streams\HttpSpecificationWithLinkToToDeletedEvents.cs" />
+    <Compile Include="Http\Streams\HttpSpecificationWithLinkToToEvents.cs" />
     <Compile Include="Http\Streams\idempotency.cs" />
     <Compile Include="Http\Streams\basic.cs" />
     <Compile Include="Http\Streams\feed.cs" />

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -222,6 +222,58 @@ namespace EventStore.Core.Tests.Http.Streams
             }
         }
 
+
+        [TestFixture, Category("LongRunning")]
+        public class when_reading_a_stream_forward_with_linkto : HttpSpecificationWithLinkToToEvents
+        {
+            private JObject _feed;
+            private List<JToken> _entries;
+            protected override void When()
+            {
+                _feed = GetJson<JObject>("/streams/" + LinkedStreamName + "/0/forward/10", accept: ContentType.Json);
+                _entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
+            }
+
+            [Test]
+            public void the_feed_has_one_event()
+            {
+                Assert.AreEqual(2, _entries.Count());
+            }
+
+            [Test]
+            public void the_second_edit_link_to_is_to_correct_uri()
+            {
+                var foo = _entries[1]["links"][0];
+                Assert.AreEqual("edit", foo["relation"].ToString());
+                Assert.AreEqual(MakeUrl("/streams/" + Stream2Name + "/0"), foo["uri"].ToString());
+            }
+
+            [Test]
+            public void the_second_alt_link_to_is_to_correct_uri()
+            {
+                var foo = _entries[1]["links"][1];
+                Assert.AreEqual("alternate", foo["relation"].ToString());
+                Assert.AreEqual(MakeUrl("/streams/" + Stream2Name + "/0"), foo["uri"].ToString());
+            }
+
+            [Test]
+            public void the_first_edit_link_to_is_to_correct_uri()
+            {
+                var foo = _entries[0]["links"][0];
+                Assert.AreEqual("edit", foo["relation"].ToString());
+                Assert.AreEqual(MakeUrl("/streams/" + StreamName + "/1"), foo["uri"].ToString());
+            }
+
+            [Test]
+            public void the_first_alt_link_to_is_to_correct_uri()
+            {
+                var foo = _entries[0]["links"][1];
+                Assert.AreEqual("alternate", foo["relation"].ToString());
+                Assert.AreEqual(MakeUrl("/streams/" + StreamName + "/1"), foo["uri"].ToString());
+            }
+        }
+
+
         [TestFixture, Category("LongRunning")]
         public class when_reading_a_stream_forward_with_maxcount_deleted_linktos : SpecificationWithLinkToToMaxCountDeletedEvents
         {

--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -237,7 +237,7 @@ namespace EventStore.Core.Services.Transport.Http
             {
                 entry = new EntryElement();
             }
-            if (evnt != null)
+            if (evnt != null && link == null)
             {
                 SetEntryProperties(evnt.EventStreamId, evnt.EventNumber, evnt.TimeStamp, requestedUrl, entry);
                 entry.SetSummary(evnt.EventType);


### PR DESCRIPTION
I know projection is still in beta, but this worked in rc9, and I might know what the problem is.

When the url for the event is generated for in the UI for the projection it seems it is using the sequential id for the projection rather than the sequential id in the original stream.

In my original stream I have the url http://localhost:2113/streams/Enhet-4361783b-8cec-4f3f-b9c8-50aab38d650e/2?embed=tryharder for an event and this is working in the UI for the stream.

In the category projection UI the same event get the url: http://localhost:2113/streams/Enhet-4361783b-8cec-4f3f-b9c8-50aab38d650e/85?embed=tryharder. As you can see the 2 after the stream id is changed to 85, and 85 is the number for that event in the stream.
