### PR TITLE
add bounding to client subscription queue

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
@@ -20,7 +20,7 @@ namespace EventStore.ClientAPI.ClientOperations
         private readonly Action<EventStoreSubscription, SubscriptionDropReason, Exception> _subscriptionDropped;
         private readonly bool _verboseLogging;
         private readonly Func<TcpPackageConnection> _getConnection;
-
+        private readonly int _maxQueueSize = 2000;
         private readonly Common.Concurrent.ConcurrentQueue<Action> _actionQueue = new Common.Concurrent.ConcurrentQueue<Action>();
         private int _actionExecuting;
         private EventStoreSubscription _subscription;
@@ -251,6 +251,7 @@ namespace EventStore.ClientAPI.ClientOperations
         private void ExecuteActionAsync(Action action)
         {
             _actionQueue.Enqueue(action);
+            if(_actionQueue.Count > _maxQueueSize) DropSubscription(SubscriptionDropReason.UserInitiated, new Exception("client buffer too big"));
             if (Interlocked.CompareExchange(ref _actionExecuting, 1, 0) == 0)
                 ThreadPool.QueueUserWorkItem(ExecuteActions);
         }


### PR DESCRIPTION
Just added a max bounding to the queue inside of a client subscription (while waiting to be pushed onto thread pool) this should not be hit in reasonable code.
