### PR TITLE
Remove unnecessary garbage collection flags

### DIFF
--- a/scripts/package-mono/run-node.sh
+++ b/scripts/package-mono/run-node.sh
@@ -1,3 +1,3 @@
 ##!/usr/bin/env bash
 
-LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH MONO_GC_DEBUG=clear-at-gc ./clusternode $@
+LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH ./clusternode $@


### PR DESCRIPTION
We no longer need the `clear-at-gc` set on Mono. Fixes #225.
