### PR TITLE
using ResolvedEvent instead of ResolvedIndexEvent

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/ClientMessageConverterExtensions.cs
+++ b/src/EventStore.ClientAPI.Embedded/ClientMessageConverterExtensions.cs
@@ -8,37 +8,37 @@ namespace EventStore.ClientAPI.Embedded
 {
     internal static class ClientMessageConverterExtensions
     {
-        public static ClientMessage.ResolvedIndexedEvent[] ConvertToResolvedIndexEvents(this EventStore.Core.Data.ResolvedEvent[] events)
+        public static ClientMessage.ResolvedIndexedEvent[] ConvertToClientResolvedIndexEvents(this EventStore.Core.Data.ResolvedEvent[] events)
         {
             var resolvedEvents = new ClientMessage.ResolvedIndexedEvent[events.Length];
 
             for (int i = 0; i < events.Length; i++)
             {
-                resolvedEvents[i] = events[i].ConvertToResolvedIndexEvent();
+                resolvedEvents[i] = events[i].ConvertToClientResolvedIndexEvent();
             }
 
             return resolvedEvents;
         }
 
-        public static ClientMessage.ResolvedIndexedEvent ConvertToResolvedIndexEvent(this EventStore.Core.Data.ResolvedEvent @event)
+        public static ClientMessage.ResolvedIndexedEvent ConvertToClientResolvedIndexEvent(this EventStore.Core.Data.ResolvedEvent @event)
         {
             return new ClientMessage.ResolvedIndexedEvent(@event.Event.ToClientMessageEventRecord(),
                 @event.Link.ToClientMessageEventRecord());
         }
 
-        public static ClientMessage.ResolvedEvent[] ConvertToResolvedEvents(this EventStore.Core.Data.ResolvedEvent[] events)
+        public static ClientMessage.ResolvedEvent[] ConvertToClientResolvedEvents(this EventStore.Core.Data.ResolvedEvent[] events)
         {
             var resolvedEvents = new ClientMessage.ResolvedEvent[events.Length];
 
             for (int i = 0; i < events.Length; i++)
             {
-                resolvedEvents[i] = events[i].ConvertToResolvedEvent();
+                resolvedEvents[i] = events[i].ConvertToClientResolvedEvent();
             }
 
             return resolvedEvents;
         }
 
-        public static ClientMessage.ResolvedEvent ConvertToResolvedEvent(this EventStore.Core.Data.ResolvedEvent @event)
+        public static ClientMessage.ResolvedEvent ConvertToClientResolvedEvent(this EventStore.Core.Data.ResolvedEvent @event)
         {
             return new ClientMessage.ResolvedEvent(@event.Event.ToClientMessageEventRecord(),
                 @event.Link.ToClientMessageEventRecord(), @event.OriginalPosition.Value.CommitPosition,

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedResponders.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedResponders.cs
@@ -141,7 +141,7 @@ namespace EventStore.ClientAPI.Embedded
                 return new AllEventsSlice(ReadDirection.Backward,
                     new Position(response.CurrentPos.CommitPosition, response.CurrentPos.PreparePosition),
                     new Position(response.NextPos.CommitPosition, response.NextPos.PreparePosition),
-                    response.Events.ConvertToResolvedEvents());
+                    response.Events.ConvertToClientResolvedEvents());
 
             }
         }
@@ -178,7 +178,7 @@ namespace EventStore.ClientAPI.Embedded
                 return new AllEventsSlice(ReadDirection.Forward,
                     new Position(response.CurrentPos.CommitPosition, response.CurrentPos.PreparePosition),
                     new Position(response.NextPos.CommitPosition, response.NextPos.PreparePosition),
-                    response.Events.ConvertToResolvedEvents());
+                    response.Events.ConvertToClientResolvedEvents());
 
             }
         }
@@ -218,7 +218,7 @@ namespace EventStore.ClientAPI.Embedded
 
             protected override EventReadResult TransformResponse(ClientMessage.ReadEventCompleted response)
             {
-                return new EventReadResult(Convert(response.Result), _stream, _eventNumber, response.Record.ConvertToResolvedIndexEvent());
+                return new EventReadResult(Convert(response.Result), _stream, _eventNumber, response.Record.ConvertToClientResolvedIndexEvent());
             }
 
 
@@ -278,7 +278,7 @@ namespace EventStore.ClientAPI.Embedded
                     _stream,
                     _fromEventNumber,
                     ReadDirection.Backward,
-                    response.Events.ConvertToResolvedIndexEvents(),
+                    response.Events.ConvertToClientResolvedIndexEvents(),
                     response.NextEventNumber,
                     response.LastEventNumber,
                     response.IsEndOfStream);
@@ -338,7 +338,7 @@ namespace EventStore.ClientAPI.Embedded
                     _stream,
                     _fromEventNumber,
                     ReadDirection.Forward,
-                    response.Events.ConvertToResolvedIndexEvents(),
+                    response.Events.ConvertToClientResolvedIndexEvents(),
                     response.NextEventNumber,
                     response.LastEventNumber,
                     response.IsEndOfStream);

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscription.cs
@@ -62,7 +62,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public void EventAppeared(EventStore.Core.Data.ResolvedEvent resolvedEvent)
         {
-            _eventAppeared(_subscription, new ResolvedEvent(resolvedEvent.ConvertToResolvedEvent()));
+            _eventAppeared(_subscription, new ResolvedEvent(resolvedEvent.ConvertToClientResolvedEvent()));
         }
 
 


### PR DESCRIPTION
ResolvedIndexEvent has no OriginalPosition therefore the catchup subscription skips it
