### PR TITLE
Override the default threadpool size on Mono

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -20,6 +20,9 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.WhatIfDescr, Opts.AppGroup)]
         public bool WhatIf { get; set; }
 
+	[ArgDescription(Opts.MonoMinThreadpoolSizeDescr, Opts.AppGroup)]
+        public int MonoMinThreadpoolSize { get; set; }
+
         [ArgDescription(Opts.InternalIpDescr, Opts.InterfacesGroup)]
         public IPAddress IntIp { get; set; }
         [ArgDescription(Opts.ExternalIpDescr, Opts.InterfacesGroup)]
@@ -153,6 +156,8 @@ namespace EventStore.ClusterNode
             Log = Opts.LogsDefault;
             Defines = Opts.DefinesDefault;
             WhatIf = Opts.WhatIfDefault;
+
+            MonoMinThreadpoolSize = Opts.MonoMinThreadpoolSizeDefault;
 
             IntIp = Opts.InternalIpDefault;
             ExtIp = Opts.ExternalIpDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 using EventStore.Common.Exceptions;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
@@ -56,7 +57,29 @@ namespace EventStore.ClusterNode
                                 string.Format("{0:yyyy-MM-dd_HH.mm.ss.ffffff}-Node{1}", _startupTimeStamp, nodePort));
         }
 
+        protected override void PreInit(ClusterNodeOptions options)
+        {
+            base.PreInit(options);
 
+	    //Never seen this problem occur on the .NET framework
+            if (!Runtime.IsMono)
+                return;
+
+	    //0 indicates we should leave the machine defaults alone
+            if (options.MonoMinThreadpoolSize == 0)
+                return;
+
+	    //Change the number of worker threads to be higher if our own setting
+	    // is higher than the current value
+            int minWorkerThreads, minIocpThreads;
+	    ThreadPool.GetMinThreads(out minWorkerThreads, out minIocpThreads);
+
+            if (minWorkerThreads >= options.MonoMinThreadpoolSize)
+                return;
+
+            if (!ThreadPool.SetMinThreads(options.MonoMinThreadpoolSize, minIocpThreads))
+                Log.Error("Cannot override the minimum number of Threadpool threads (machine default: {0}, specified value: {1})", minWorkerThreads, options.MonoMinThreadpoolSize);
+        }
 
         protected override void Create(ClusterNodeOptions opts)
         {

--- a/src/EventStore.Core/ProgramBase.cs
+++ b/src/EventStore.Core/ProgramBase.cs
@@ -52,6 +52,7 @@ namespace EventStore.Core
                 }
                 else
                 {
+                    PreInit(options);
                     Init(options);
                     CommitSuicideIfInBoehmOrOnBadVersionsOfMono(options);
                     Create(options);
@@ -86,6 +87,10 @@ namespace EventStore.Core
 
             Application.ExitSilent(_exitCode, "Normal exit.");
             return _exitCode;
+        }
+
+        protected virtual void PreInit(TOptions options)
+        {
         }
 
         private void CommitSuicideIfInBoehmOrOnBadVersionsOfMono(TOptions options)

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -45,6 +45,9 @@ namespace EventStore.Core.Util
         public const string ShowVersionDescr = "Show version.";
         public const bool   ShowVersionDefault = false;
 
+        public const string MonoMinThreadpoolSizeDescr = "Minimum number of worker threads when running under mono. Set to 0 to leave machine defaults.";
+        public const int MonoMinThreadpoolSizeDefault = 10;
+
         public const string ExtTcpHeartbeatTimeoutDescr = "Heartbeat timeout for external TCP sockets";
         public const int ExtTcpHeartbeatTimeoutDefault = 1000;
 


### PR DESCRIPTION
On Mono only, we use the value of --mono-min-threadpool-size (or equivalent) to set the number of worker threads during startup, before this is dumped to the config. Setting the value to 0 leaves the machine defaults alone, or uses the MONO_THREADS_PER_CPU environment variable if this has been set.

This fixes issues #296 and various issues from the mailing list with elections cycles on single core or otherwise low spec'd machines.
