### PR TITLE
PersistentConnection resolve linked events

### DIFF
--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -527,7 +527,7 @@ namespace EventStore.Core.Services.Transport.Tcp
 
         private TcpPackage WrapPersistentSubscriptionStreamEventAppeared(ClientMessage.PersistentSubscriptionStreamEventAppeared msg)
         {
-            var dto = new TcpClientMessageDto.PersistentSubscriptionStreamEventAppeared(new TcpClientMessageDto.ResolvedIndexedEvent(msg.Event.OriginalEvent, msg.Event.Link));
+            var dto = new TcpClientMessageDto.PersistentSubscriptionStreamEventAppeared(new TcpClientMessageDto.ResolvedIndexedEvent(msg.Event.Event, msg.Event.Link));
             return new TcpPackage(TcpCommand.PersistentSubscriptionStreamEventAppeared, msg.CorrelationId, dto.Serialize());
         }
 


### PR DESCRIPTION
PersistentConnection would not resolve a linked event, it would only show the link. This fixes it for me, but I don't know what other effect it might have upstream.
