### PR TITLE
make ps update/create/delete return task

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -405,20 +405,20 @@ namespace EventStore.ClientAPI.Embedded
             return catchUpSubscription;
         }
 
-        public Task<PersistentSubscriptionCreateResult> CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings,
+        public Task CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings,
             UserCredentials credentials)
         {
             throw new NotImplementedException();
         }
 
-        public Task<PersistentSubscriptionUpdateResult> UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings,
+        public Task UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings,
             UserCredentials credentials)
         {
             throw new NotImplementedException();
         }
 
 
-        public Task<PersistentSubscriptionDeleteResult> DeletePersistentSubscriptionAsync(string stream, string groupName, UserCredentials userCredentials = null)
+        public Task DeletePersistentSubscriptionAsync(string stream, string groupName, UserCredentials userCredentials = null)
         {
             throw new NotImplementedException();
         }

--- a/src/EventStore.ClientAPI/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreNodeConnection.cs
@@ -349,7 +349,7 @@ namespace EventStore.ClientAPI
 */
 
 
-        public Task<PersistentSubscriptionCreateResult> CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials userCredentials = null) {
+        public Task CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials userCredentials = null) {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
             Ensure.NotNull(settings, "settings");
@@ -358,7 +358,7 @@ namespace EventStore.ClientAPI
             return source.Task;
         }
 
-        public Task<PersistentSubscriptionUpdateResult> UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials userCredentials = null)
+        public Task UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials userCredentials = null)
         {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
@@ -379,12 +379,12 @@ namespace EventStore.ClientAPI
         }
 
 */
-        public Task<PersistentSubscriptionDeleteResult> DeletePersistentSubscriptionAsync(string stream, string groupName, UserCredentials userCredentials = null) {
+        public Task DeletePersistentSubscriptionAsync(string stream, string groupName, UserCredentials userCredentials = null) {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
             var source = new TaskCompletionSource<PersistentSubscriptionDeleteResult>();
             EnqueueOperation(new DeletePersistentSubscriptionOperation(_settings.Log, source, stream, groupName, userCredentials));
-            return source.Task;            
+            return source.Task;
         }
 /*
 

--- a/src/EventStore.ClientAPI/IEventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnection.cs
@@ -379,7 +379,7 @@ namespace EventStore.ClientAPI
         /// <param name="settings">The <see cref="PersistentSubscriptionSettings"></see> for the subscription</param>
         /// <param name="credentials">The credentials to be used for this operation.</param>
         /// <returns>A <see cref="PersistentSubscriptionCreateResult"/>.</returns>
-        Task<PersistentSubscriptionUpdateResult> UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials credentials);
+        Task UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials credentials);
 
 
         /// <summary>
@@ -390,7 +390,7 @@ namespace EventStore.ClientAPI
         /// <param name="settings">The <see cref="PersistentSubscriptionSettings"></see> for the subscription</param>
         /// <param name="credentials">The credentials to be used for this operation.</param>
         /// <returns>A <see cref="PersistentSubscriptionCreateResult"/>.</returns>
-        Task<PersistentSubscriptionCreateResult> CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials credentials);
+        Task CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials credentials);
 
 
         /// <summary>
@@ -400,7 +400,7 @@ namespace EventStore.ClientAPI
         /// <param name="groupName">The name of the group to delete</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
         /// <returns>A <see cref="PersistentSubscriptionDeleteResult"/>.</returns>
-        Task<PersistentSubscriptionDeleteResult> DeletePersistentSubscriptionAsync(string stream, string groupName, UserCredentials userCredentials = null);
+        Task DeletePersistentSubscriptionAsync(string stream, string groupName, UserCredentials userCredentials = null);
 
         /*
         /// <summary>

--- a/src/EventStore.ClientAPI/PersistentSubscriptionCreateResult.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionCreateResult.cs
@@ -4,7 +4,7 @@
     /// A Persistent Subscription Create Result is the result of a single operation creating a
     /// persistent subscription in the event store
     /// </summary>
-    public class PersistentSubscriptionCreateResult
+    class PersistentSubscriptionCreateResult
     {
         /// <summary>
         /// The <see cref="PersistentSubscriptionCreateStatus"/> representing the status of this create attempt

--- a/src/EventStore.ClientAPI/PersistentSubscriptionCreateStatus.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionCreateStatus.cs
@@ -3,7 +3,7 @@ namespace EventStore.ClientAPI
     /// <summary>
     /// Enumeration representing the status of a single subscription create message.
     /// </summary>
-    public enum PersistentSubscriptionCreateStatus
+    enum PersistentSubscriptionCreateStatus
     {
         /// <summary>
         /// The subscription was created successfully

--- a/src/EventStore.ClientAPI/PersistentSubscriptionDeleteResult.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionDeleteResult.cs
@@ -4,7 +4,7 @@ namespace EventStore.ClientAPI
     /// A Persistent Subscription Delete Result is the result of a single operation deleting a
     /// persistent subscription in the event store
     /// </summary>
-    public class PersistentSubscriptionDeleteResult
+    class PersistentSubscriptionDeleteResult
     {
         /// <summary>
         /// The <see cref="PersistentSubscriptionDeleteStatus"/> representing the status of this create attempt

--- a/src/EventStore.ClientAPI/PersistentSubscriptionDeleteStatus.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionDeleteStatus.cs
@@ -3,7 +3,7 @@ namespace EventStore.ClientAPI
     /// <summary>
     /// Enumeration representing the status of a single subscription delete message.
     /// </summary>
-    public enum PersistentSubscriptionDeleteStatus
+    enum PersistentSubscriptionDeleteStatus
     {
         /// <summary>
         /// The subscription was created successfully

--- a/src/EventStore.Core.Tests/ClientAPI/create_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/create_persistent_subscription.cs
@@ -10,43 +10,45 @@ namespace EventStore.Core.Tests.ClientAPI
     [TestFixture, Category("LongRunning")]
     public class create_persistent_subscription_on_existing_stream : SpecificationWithMiniNode
     {
-        private PersistentSubscriptionCreateResult _result;
         private readonly string _stream = Guid.NewGuid().ToString();
+
         private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
-                                                                .DoNotResolveLinkTos()
-                                                                .StartFromCurrent();
+            .DoNotResolveLinkTos()
+            .StartFromCurrent();
+
         protected override void When()
         {
             _conn.AppendToStreamAsync(_stream, ExpectedVersion.Any,
                 new EventData(Guid.NewGuid(), "whatever", true, Encoding.UTF8.GetBytes("{'foo' : 2}"), new Byte[0]));
-            _result = _conn.CreatePersistentSubscriptionAsync(_stream, "existing", _settings, DefaultData.AdminCredentials).Result;
         }
 
         [Test]
         public void the_completion_succeeds()
         {
-            Assert.AreEqual(PersistentSubscriptionCreateStatus.Success, _result.Status);
+            Assert.DoesNotThrow(
+                () =>
+                    _conn.CreatePersistentSubscriptionAsync(_stream, "existing", _settings, DefaultData.AdminCredentials)
+                        .Wait());
         }
     }
 
-    
+
     [TestFixture, Category("LongRunning")]
     public class create_persistent_subscription_on_non_existing_stream : SpecificationWithMiniNode
     {
-        private PersistentSubscriptionCreateResult _result;
         private readonly string _stream = Guid.NewGuid().ToString();
         private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
                                                                 .DoNotResolveLinkTos()
                                                                 .StartFromCurrent();
         protected override void When()
         {
-            _result = _conn.CreatePersistentSubscriptionAsync(_stream, "nonexistinggroup", _settings, DefaultData.AdminCredentials).Result;
+            
         }
 
         [Test]
         public void the_completion_succeeds()
         {
-            Assert.AreEqual(PersistentSubscriptionCreateStatus.Success, _result.Status);
+            Assert.DoesNotThrow(() => _conn.CreatePersistentSubscriptionAsync(_stream, "nonexistinggroup", _settings, DefaultData.AdminCredentials).Wait());
         }
     }
 
@@ -84,20 +86,19 @@ namespace EventStore.Core.Tests.ClientAPI
     public class can_create_duplicate_persistent_subscription_group_name_on_different_streams : SpecificationWithMiniNode
     {
         private readonly string _stream = Guid.NewGuid().ToString();
-        private PersistentSubscriptionCreateResult _result;
         private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
                                                                 .DoNotResolveLinkTos()
                                                                 .StartFromCurrent();
         protected override void When()
         {
             _conn.CreatePersistentSubscriptionAsync(_stream, "group3211", _settings, DefaultData.AdminCredentials).Wait();
-            _result = _conn.CreatePersistentSubscriptionAsync("someother" + _stream, "group3211", _settings, DefaultData.AdminCredentials).Result;
+            
         }
 
         [Test]
         public void the_completion_succeeds()
         {
-            Assert.AreEqual(PersistentSubscriptionCreateStatus.Success, _result.Status);
+            Assert.DoesNotThrow(() => _conn.CreatePersistentSubscriptionAsync("someother" + _stream, "group3211", _settings, DefaultData.AdminCredentials).Wait());
         }
     }
 

--- a/src/EventStore.Core.Tests/ClientAPI/deleting_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/deleting_persistent_subscription.cs
@@ -23,8 +23,7 @@ namespace EventStore.Core.Tests.ClientAPI
         [Test]
         public void the_delete_of_group_succeeds()
         {
-            var result = _conn.DeletePersistentSubscriptionAsync(_stream, "groupname123", DefaultData.AdminCredentials).Result;
-            Assert.AreEqual(PersistentSubscriptionDeleteStatus.Success, result.Status);
+             Assert.DoesNotThrow(() => _conn.DeletePersistentSubscriptionAsync(_stream, "groupname123", DefaultData.AdminCredentials).Wait());
         }
     }
 


### PR DESCRIPTION
Get rid of Task< Result > on Create/Update/Delete since it only ever returned an enum value of success.
