### PR TITLE
flip args on connect to match others.

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -380,7 +380,7 @@ namespace EventStore.ClientAPI.Embedded
             return source.Task;
         }
 
-        public EventStorePersistentSubscription ConnectToPersistentSubscription(string groupName, string stream, Action<EventStorePersistentSubscription, ResolvedEvent> eventAppeared,
+        public EventStorePersistentSubscription ConnectToPersistentSubscription(string stream, string groupName, Action<EventStorePersistentSubscription, ResolvedEvent> eventAppeared,
             Action<EventStorePersistentSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null, int bufferSize = 10,
             bool autoAck = true)
         {

--- a/src/EventStore.ClientAPI/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreNodeConnection.cs
@@ -308,8 +308,8 @@ namespace EventStore.ClientAPI
         }
 
         public EventStorePersistentSubscription ConnectToPersistentSubscription(
-            string groupName, 
-            string stream, 
+            string stream,
+            string groupName,
             Action<EventStorePersistentSubscription, ResolvedEvent> eventAppeared, 
             Action<EventStorePersistentSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null, 

--- a/src/EventStore.ClientAPI/IEventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnection.cs
@@ -288,8 +288,8 @@ namespace EventStore.ClientAPI
         /// </remarks>
         /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
         EventStorePersistentSubscription ConnectToPersistentSubscription(
-            string groupName, 
-            string stream, 
+            string stream,
+            string groupName,
             Action<EventStorePersistentSubscription, ResolvedEvent> eventAppeared,
             Action<EventStorePersistentSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
@@ -18,8 +18,9 @@ namespace EventStore.Core.Tests.ClientAPI
         {
             try
             {
-                _conn.ConnectToPersistentSubscription("foo",
+                _conn.ConnectToPersistentSubscription(
                     "nonexisting2",
+                    "foo",
                     (sub, e) => Console.Write("appeared"),
                     (sub, reason, ex) =>
                     {
@@ -56,7 +57,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
         protected override void When()
         {
-            _conn.CreatePersistentSubscriptionAsync("agroupname17", _stream , _settings, DefaultData.AdminCredentials).Wait();
+            _conn.CreatePersistentSubscriptionAsync(_stream, "agroupname17", _settings, DefaultData.AdminCredentials).Wait();
             _sub = _conn.ConnectToPersistentSubscription(_stream,
                 "agroupname17",
                 (sub, e) => Console.Write("appeared"),
@@ -88,8 +89,9 @@ namespace EventStore.Core.Tests.ClientAPI
         {
             try
             {
-                _conn.ConnectToPersistentSubscription("agroupname55", 
+                _conn.ConnectToPersistentSubscription( 
                     _stream,
+                    "agroupname55",
                     (sub, e) => Console.Write("appeared"),
                     (sub, reason, ex) => {Console.WriteLine("dropped.");});
                 throw new Exception("should have thrown.");
@@ -138,8 +140,9 @@ namespace EventStore.Core.Tests.ClientAPI
 
         protected override void When()
         {
-            _conn.ConnectToPersistentSubscription(_group,
+            _conn.ConnectToPersistentSubscription(
                 _stream,
+                _group,
                 HandleEvent,
                 (sub, reason, ex) => { },
                 DefaultData.AdminCredentials);
@@ -194,8 +197,9 @@ namespace EventStore.Core.Tests.ClientAPI
 
         protected override void When()
         {
-            _conn.ConnectToPersistentSubscription(_group,
+            _conn.ConnectToPersistentSubscription(
                 _stream,
+                _group,
                 HandleEvent,
                 (sub, reason, ex) => { },
                 DefaultData.AdminCredentials);
@@ -231,8 +235,9 @@ namespace EventStore.Core.Tests.ClientAPI
             WriteEvents(_conn);
             _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
                 DefaultData.AdminCredentials).Wait();
-            _conn.ConnectToPersistentSubscription(_group,
+            _conn.ConnectToPersistentSubscription(
                 _stream,
+                _group,
                 HandleEvent,
                 (sub, reason, ex) => { },
                 DefaultData.AdminCredentials);
@@ -292,8 +297,9 @@ namespace EventStore.Core.Tests.ClientAPI
             WriteEvents(_conn);
             _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
                 DefaultData.AdminCredentials).Wait();
-            _conn.ConnectToPersistentSubscription(_group,
+            _conn.ConnectToPersistentSubscription(
                 _stream,
+                _group,
                 HandleEvent,
                 (sub, reason, ex) => { },
                 DefaultData.AdminCredentials);
@@ -355,8 +361,9 @@ namespace EventStore.Core.Tests.ClientAPI
             WriteEvents(_conn);
             _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
                 DefaultData.AdminCredentials).Wait();
-            _conn.ConnectToPersistentSubscription(_group,
+            _conn.ConnectToPersistentSubscription(
                 _stream,
+                _group,
                 HandleEvent,
                 (sub, reason, ex) => { },
                 DefaultData.AdminCredentials);
@@ -416,8 +423,9 @@ namespace EventStore.Core.Tests.ClientAPI
             WriteEvents(_conn);
             _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
                 DefaultData.AdminCredentials).Wait();
-            _conn.ConnectToPersistentSubscription(_group,
+            _conn.ConnectToPersistentSubscription(
                 _stream,
+                _group,
                 HandleEvent,
                 (sub, reason, ex) => { },
                 DefaultData.AdminCredentials);

--- a/src/EventStore.Core.Tests/ClientAPI/update_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/update_persistent_subscription.cs
@@ -53,7 +53,7 @@ namespace EventStore.Core.Tests.ClientAPI
             _conn.AppendToStreamAsync(_stream, ExpectedVersion.Any,
                 new EventData(Guid.NewGuid(), "whatever", true, Encoding.UTF8.GetBytes("{'foo' : 2}"), new Byte[0]));
             _conn.CreatePersistentSubscriptionAsync(_stream, "existing", _settings, DefaultData.AdminCredentials).Wait();
-            _conn.ConnectToPersistentSubscription("existing", _stream, (x, y) => { },
+            _conn.ConnectToPersistentSubscription(_stream, "existing" , (x, y) => { },
                 (sub, reason, ex) =>
                 {
                     _dropped.Set();

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/deleting.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/deleting.cs
@@ -53,7 +53,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
                 {
                     ResolveLinkTos = true
                 }, _admin);
-            _connection.ConnectToPersistentSubscription(_groupName, _stream, (x, y) => { },
+            _connection.ConnectToPersistentSubscription(_stream, _groupName, (x, y) => { },
                 (sub, reason, e) =>
                 {
                     _dropped.Set();

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -205,14 +205,14 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             base.Given();
             _conn.CreatePersistentSubscriptionAsync(_streamName, "secondgroup", _settings,
                         DefaultData.AdminCredentials).Wait();
-            _sub3 = _conn.ConnectToPersistentSubscription("secondgroup", _streamName,
+            _sub3 = _conn.ConnectToPersistentSubscription(_streamName,"secondgroup",
                         (subscription, @event) => Console.WriteLine(),
                         (subscription, reason, arg3) => Console.WriteLine());
-            _sub4 = _conn.ConnectToPersistentSubscription("secondgroup", _streamName,
+            _sub4 = _conn.ConnectToPersistentSubscription(_streamName,"secondgroup",
                         (subscription, @event) => Console.WriteLine(),
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
-            _sub5 = _conn.ConnectToPersistentSubscription("secondgroup", _streamName,
+            _sub5 = _conn.ConnectToPersistentSubscription(_streamName,"secondgroup",
                         (subscription, @event) => Console.WriteLine(),
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
@@ -352,14 +352,14 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             base.Given();
             _conn.CreatePersistentSubscriptionAsync(_streamName, "secondgroup", _settings,
                         DefaultData.AdminCredentials).Wait();
-            _sub3 = _conn.ConnectToPersistentSubscription("secondgroup", _streamName,
+            _sub3 = _conn.ConnectToPersistentSubscription(_streamName,"secondgroup",
                         (subscription, @event) => Console.WriteLine(),
                         (subscription, reason, arg3) => Console.WriteLine());
-            _sub4 = _conn.ConnectToPersistentSubscription("secondgroup", _streamName,
+            _sub4 = _conn.ConnectToPersistentSubscription(_streamName,"secondgroup",
                         (subscription, @event) => Console.WriteLine(),
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
-            _sub5 = _conn.ConnectToPersistentSubscription("secondgroup", _streamName,
+            _sub5 = _conn.ConnectToPersistentSubscription(_streamName,"secondgroup",
                         (subscription, @event) => Console.WriteLine(),
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
@@ -468,10 +468,10 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             _conn.ConnectAsync().Wait();
             _conn.CreatePersistentSubscriptionAsync(_streamName, _groupName, _settings,
                     DefaultData.AdminCredentials).Wait();
-            _sub1 = _conn.ConnectToPersistentSubscription(_groupName, _streamName,
+            _sub1 = _conn.ConnectToPersistentSubscription(_streamName,_groupName,
                         (subscription, @event) => Console.WriteLine(), 
                         (subscription, reason, arg3) => Console.WriteLine());
-            _sub2 = _conn.ConnectToPersistentSubscription(_groupName, _streamName,
+            _sub2 = _conn.ConnectToPersistentSubscription(_streamName, _groupName,
                         (subscription, @event) => Console.WriteLine(),
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/updating.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/updating.cs
@@ -84,7 +84,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
 
         private void SetupSubscription()
         {
-            _connection.ConnectToPersistentSubscription(_groupName, _stream, (x, y) => { },
+            _connection.ConnectToPersistentSubscription(_stream,_groupName, (x, y) => { },
                 (sub, reason, ex) =>
                 {
                     _droppedReason = reason;


### PR DESCRIPTION
@jen20 you need to see this PR. As it may affect a certain company

This PR fixes arguments being flipped on the Connect method of persistent subscriptions (all others were stream/group it was group/stream). This is a breaking change in pre-release stuff.
