### PR TITLE
Fix non-deterministic ordering issue

### DIFF
--- a/src/EventStore.Common/Options/EventStoreOptions.cs
+++ b/src/EventStore.Common/Options/EventStoreOptions.cs
@@ -71,12 +71,15 @@ namespace EventStore.Common.Options
             }
 
             optionSources = optionSources
-                                .Select(x => new OptionSource("Config File", x.Name, x.IsTyped, x.Value));
+                                .Select(x => new OptionSource("Update", x.Name, x.IsTyped, x.Value));
 
             var optionsToSave = Yaml.FromFile(configFile)
                                 .Concat(optionSources)
                                 .ToLookup(x => x.Name.ToLower())
                                 .Select(ResolveUpdatingPrecedence);
+
+            optionSources = optionSources
+                                .Select(x => new OptionSource("Config File", x.Name, x.IsTyped, x.Value));
 
             var conflictedOptions = effectiveOptions.DeterminePotentialPrecedenceIssues(optionSources);
 


### PR DESCRIPTION
When the options come in to be saved, we set it as "Update" in the source. After we determine which options are to be saved, we can set it to "Config File" to determine any conflicts due to our options precedence.
