### PR TITLE
release http socket properly

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/HttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/HttpService.cs
@@ -84,8 +84,7 @@ namespace EventStore.Core.Services.Transport.Http
 
         public void Handle(SystemMessage.BecomeShuttingDown message)
         {
-            if (message.ExitProcess)
-                Shutdown();
+            Shutdown();
             _inputBus.Publish(
                 new SystemMessage.ServiceShutdown(
                     string.Format("HttpServer [{0}]", string.Join(", ", _server._listenPrefixes))));


### PR DESCRIPTION
fixes #312 #322 

This should now release the socket before it was not getting released as exitprocess was false. We should look in a bit more about how we handle exitProcess.
