### PR TITLE
Connections

### DIFF
--- a/src/EventStore.ClientAPI/ClusterSettings.cs
+++ b/src/EventStore.ClientAPI/ClusterSettings.cs
@@ -12,6 +12,7 @@ namespace EventStore.ClientAPI
         /// Creates a new set of <see cref="ClusterSettings"/>
         /// </summary>
         /// <returns>A <see cref="ClusterSettingsBuilder"/> that can be used to build up a <see cref="ClusterSettings"/></returns>
+        [Obsolete("This class will be obsoleted, use ConnectionSettings and/or connection strings instead.")]
         public static ClusterSettingsBuilder Create()
         {
             return new ClusterSettingsBuilder();

--- a/src/EventStore.ClientAPI/ClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ClusterSettingsBuilder.cs
@@ -1,4 +1,6 @@
-﻿namespace EventStore.ClientAPI
+﻿using System;
+
+namespace EventStore.ClientAPI
 {
     /// <summary>
     /// Builder used for creating instances of ClusterSettings.
@@ -9,6 +11,7 @@
         /// Sets the client to discover nodes using a DNS name and a well-known port.
         /// </summary>
         /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        [Obsolete("This class will be obsoleted, use ConnectionSettings and/or connection strings instead.")]
         public DnsClusterSettingsBuilder DiscoverClusterViaDns()
         {
             return new DnsClusterSettingsBuilder();
@@ -19,6 +22,7 @@
         /// one or more of the nodes.
         /// </summary>
         /// <returns></returns>
+        [Obsolete("This class will be obsoleted, use ConnectionSettings and/or connection strings instead.")]
         public GossipSeedClusterSettingsBuilder DiscoverClusterViaGossipSeeds()
         {
             return new GossipSeedClusterSettingsBuilder();

--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -98,6 +98,28 @@ namespace EventStore.ClientAPI
         /// </summary>
         public readonly TimeSpan HeartbeatTimeout;
 
+        /// <summary>
+        /// The DNS name to use for discovering endpoints.
+        /// </summary>
+        public readonly string ClusterDns;
+        /// <summary>
+        /// The maximum number of attempts for discovering endpoints.
+        /// </summary>
+        public readonly int MaxDiscoverAttempts;
+        /// <summary>
+        /// The well-known endpoint on which cluster managers are running.
+        /// </summary>
+        public readonly int ExternalGossipPort;
+
+        /// <summary>
+        /// Endpoints for seeding gossip if not using DNS.
+        /// </summary>
+        public readonly GossipSeed[] GossipSeeds;
+
+        /// <summary>
+        /// Timeout for cluster gossip.
+        /// </summary>
+        public readonly TimeSpan GossipTimeout;
 
         /// <summary>
         /// The interval after which a client will time out during connection.
@@ -121,7 +143,12 @@ namespace EventStore.ClientAPI
                                     bool failOnNoServerResponse,
                                     TimeSpan heartbeatInterval,
                                     TimeSpan heartbeatTimeout,
-                                    TimeSpan clientConnectionTimeout)
+                                    TimeSpan clientConnectionTimeout,
+                                    string clusterDns,
+                                    GossipSeed[] gossipSeeds,
+                                    int maxDiscoverAttempts, 
+                                    int externalGossipPort, 
+                                    TimeSpan gossipTimeout)
         {
             Ensure.NotNull(log, "log");
             Ensure.Positive(maxQueueSize, "maxQueueSize");
@@ -132,7 +159,6 @@ namespace EventStore.ClientAPI
                 throw new ArgumentOutOfRangeException("maxReconnections", string.Format("maxReconnections value is out of range: {0}. Allowed range: [-1, infinity].", maxRetries));
             if (useSslConnection)
                 Ensure.NotNullOrEmpty(targetHost, "targetHost");
-
             Log = log;
             VerboseLogging = verboseLogging;
             MaxQueueSize = maxQueueSize;
@@ -152,6 +178,11 @@ namespace EventStore.ClientAPI
             FailOnNoServerResponse = failOnNoServerResponse;
             HeartbeatInterval = heartbeatInterval;
             HeartbeatTimeout = heartbeatTimeout;
+            ClusterDns = clusterDns;
+            GossipSeeds = gossipSeeds;
+            MaxDiscoverAttempts = maxDiscoverAttempts;
+            ExternalGossipPort = externalGossipPort;
+            GossipTimeout = gossipTimeout;
         }
     }
 }

--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
 
@@ -31,72 +32,87 @@ namespace EventStore.ClientAPI
         /// <summary>
         /// The <see cref="ILogger"/> that this connection will use
         /// </summary>
-        public readonly ILogger Log;
+        public ILogger Log { get; private set; }
+
         /// <summary>
         /// Whether or not do excessive logging of <see cref="EventStoreConnection"/> internal logic.
         /// </summary>
-        public readonly bool VerboseLogging;
+        public bool VerboseLogging { get; private set; }
+
         /// <summary>
         /// The maximum number of outstanding items allowed in the queue
         /// </summary>
-        public readonly int MaxQueueSize;
+        public int MaxQueueSize { get; private set; }
+
         /// <summary>
         /// The maximum number of allowed asynchronous operations to be in process
         /// </summary>
-        public readonly int MaxConcurrentItems;
+        public int MaxConcurrentItems { get; private set; }
+
         /// <summary>
         /// The maximum number of retry attempts
         /// </summary>
-        public readonly int MaxRetries;
+        public int MaxRetries { get; private set; }
+
         /// <summary>
         /// The maximum number of times to allow for reconnection
         /// </summary>
-        public readonly int MaxReconnections;
+        public int MaxReconnections { get; private set; }
+
         /// <summary>
         /// Whether or not to require EventStore to refuse serving read or write request if it is not master
         /// </summary>
-        public readonly bool RequireMaster;
+        public bool RequireMaster { get; private set; }
+        
         /// <summary>
         /// The amount of time to delay before attempting to reconnect
         /// </summary>
-        public readonly TimeSpan ReconnectionDelay;
+        public TimeSpan ReconnectionDelay { get; private set; }
+
         /// <summary>
         /// The amount of time before an operation is considered to have timed out
         /// </summary>
-        public readonly TimeSpan OperationTimeout;
+        public TimeSpan OperationTimeout { get; private set; }
+
         /// <summary>
         /// The amount of time that timeouts are checked in the system.
         /// </summary>
-        public readonly TimeSpan OperationTimeoutCheckPeriod;
+        public TimeSpan OperationTimeoutCheckPeriod { get; private set; }
+
         /// <summary>
         /// The <see cref="UserCredentials"/> to use for operations where other <see cref="UserCredentials"/> are not explicitly supplied.
         /// </summary>
-        public readonly UserCredentials DefaultUserCredentials;
+        public UserCredentials DefaultUserCredentials { get; private set; }
+
         /// <summary>
         /// Whether or not the connection is encrypted using SSL.
         /// </summary>
-        public readonly bool UseSslConnection;
+        public bool UseSslConnection { get; private set; }
+
         /// <summary>
         /// The host name of the server expected on the SSL certificate.
         /// </summary>
-        public readonly string TargetHost;
+        public string TargetHost { get; private set; }
+
         /// <summary>
         /// Whether or not to validate the server SSL certificate.
         /// </summary>
-        public readonly bool ValidateServer;
+        public bool ValidateServer { get; private set; }
 
         /// <summary>
         /// Whether or not to raise an error if no response is received from the server for an operation.
         /// </summary>
-        public readonly bool FailOnNoServerResponse;
+        public bool FailOnNoServerResponse { get; private set; }
+
         /// <summary>
         /// The interval at which to send heartbeat messages.
         /// </summary>
-        public readonly TimeSpan HeartbeatInterval;
+        public TimeSpan HeartbeatInterval { get; private set; }
+
         /// <summary>
         /// The interval after which an unacknowledged heartbeat will cause the connection to be considered faulted and disconnect.
         /// </summary>
-        public readonly TimeSpan HeartbeatTimeout;
+        public TimeSpan HeartbeatTimeout { get; private set; }
 
 
         /// <summary>

--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
 
@@ -32,87 +31,72 @@ namespace EventStore.ClientAPI
         /// <summary>
         /// The <see cref="ILogger"/> that this connection will use
         /// </summary>
-        public ILogger Log { get; private set; }
-
+        public readonly ILogger Log;
         /// <summary>
         /// Whether or not do excessive logging of <see cref="EventStoreConnection"/> internal logic.
         /// </summary>
-        public bool VerboseLogging { get; private set; }
-
+        public readonly bool VerboseLogging;
         /// <summary>
         /// The maximum number of outstanding items allowed in the queue
         /// </summary>
-        public int MaxQueueSize { get; private set; }
-
+        public readonly int MaxQueueSize;
         /// <summary>
         /// The maximum number of allowed asynchronous operations to be in process
         /// </summary>
-        public int MaxConcurrentItems { get; private set; }
-
+        public readonly int MaxConcurrentItems;
         /// <summary>
         /// The maximum number of retry attempts
         /// </summary>
-        public int MaxRetries { get; private set; }
-
+        public readonly int MaxRetries;
         /// <summary>
         /// The maximum number of times to allow for reconnection
         /// </summary>
-        public int MaxReconnections { get; private set; }
-
+        public readonly int MaxReconnections;
         /// <summary>
         /// Whether or not to require EventStore to refuse serving read or write request if it is not master
         /// </summary>
-        public bool RequireMaster { get; private set; }
-        
+        public readonly bool RequireMaster;
         /// <summary>
         /// The amount of time to delay before attempting to reconnect
         /// </summary>
-        public TimeSpan ReconnectionDelay { get; private set; }
-
+        public readonly TimeSpan ReconnectionDelay;
         /// <summary>
         /// The amount of time before an operation is considered to have timed out
         /// </summary>
-        public TimeSpan OperationTimeout { get; private set; }
-
+        public readonly TimeSpan OperationTimeout;
         /// <summary>
         /// The amount of time that timeouts are checked in the system.
         /// </summary>
-        public TimeSpan OperationTimeoutCheckPeriod { get; private set; }
-
+        public readonly TimeSpan OperationTimeoutCheckPeriod;
         /// <summary>
         /// The <see cref="UserCredentials"/> to use for operations where other <see cref="UserCredentials"/> are not explicitly supplied.
         /// </summary>
-        public UserCredentials DefaultUserCredentials { get; private set; }
-
+        public readonly UserCredentials DefaultUserCredentials;
         /// <summary>
         /// Whether or not the connection is encrypted using SSL.
         /// </summary>
-        public bool UseSslConnection { get; private set; }
-
+        public readonly bool UseSslConnection;
         /// <summary>
         /// The host name of the server expected on the SSL certificate.
         /// </summary>
-        public string TargetHost { get; private set; }
-
+        public readonly string TargetHost;
         /// <summary>
         /// Whether or not to validate the server SSL certificate.
         /// </summary>
-        public bool ValidateServer { get; private set; }
+        public readonly bool ValidateServer;
 
         /// <summary>
         /// Whether or not to raise an error if no response is received from the server for an operation.
         /// </summary>
-        public bool FailOnNoServerResponse { get; private set; }
-
+        public readonly bool FailOnNoServerResponse;
         /// <summary>
         /// The interval at which to send heartbeat messages.
         /// </summary>
-        public TimeSpan HeartbeatInterval { get; private set; }
-
+        public readonly TimeSpan HeartbeatInterval;
         /// <summary>
         /// The interval after which an unacknowledged heartbeat will cause the connection to be considered faulted and disconnect.
         /// </summary>
-        public TimeSpan HeartbeatTimeout { get; private set; }
+        public readonly TimeSpan HeartbeatTimeout;
 
 
         /// <summary>

--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -2,7 +2,9 @@
 using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
+using System.Net;
 using System.Reflection;
+using System.Runtime.Remoting.Messaging;
 
 namespace EventStore.ClientAPI
 {
@@ -26,7 +28,22 @@ namespace EventStore.ClientAPI
                 {typeof(byte), x=>byte.Parse(x)},
                 {typeof(double), x=>double.Parse(x)},
                 {typeof(float), x=>float.Parse(x)},
-                {typeof(TimeSpan), x => TimeSpan.FromMilliseconds(int.Parse(x))}
+                {typeof(TimeSpan), x => TimeSpan.FromMilliseconds(int.Parse(x))},
+                {typeof(GossipSeed[]), x => x.Split(',').Select(q =>
+                {
+                    try
+                    {
+                        var pieces = q.Trim().Split(':');
+                        if (pieces.Length != 2) throw new Exception("could not split ip address from port.");
+                            
+                        return new GossipSeed(new IPEndPoint(IPAddress.Parse(pieces[0]), int.Parse(pieces[1])));
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception(string.Format("Gossip seed {0} is not in correct format", q), ex);
+                    }
+                }).ToArray()
+                }
             };
         }
 

--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EventStore.ClientAPI
+{
+    /// <summary>
+    /// Methods for dealing with connection strings.
+    /// </summary>
+    public class ConnectionString
+    {
+
+        private static Dictionary<Type, Func<string, object>> translators;
+
+        static ConnectionString()
+        {
+            translators = new Dictionary<Type, Func<string, object>>()
+            {
+                {typeof(int), x => int.Parse(x)},
+                {typeof(decimal), x=>double.Parse(x)},
+                {typeof(string), x => x},
+                {typeof(bool), x=>bool.Parse(x)},
+                {typeof(long), x=>long.Parse(x)},
+                {typeof(byte), x=>byte.Parse(x)},
+                {typeof(double), x=>double.Parse(x)},
+                {typeof(float), x=>float.Parse(x)}
+            };
+        }
+
+        /// <summary>
+        /// Parses a connection string into its pieces represented as kv pairs
+        /// </summary>
+        /// <param name="connectionString">the connection string to parse</param>
+        /// <returns></returns>
+        private static IEnumerable<KeyValuePair<string, string>> GetConnectionStringInfo(string connectionString)
+        {
+            var builder = new DbConnectionStringBuilder(false) { ConnectionString = connectionString };
+            //can someome mutate this builder before the enumerable is closed sure but thats the fun!
+            return from object key in builder.Keys
+                select new KeyValuePair<string, string>(key.ToString(), builder[key.ToString()].ToString());
+        }
+
+ 
+        /// <summary>
+        /// Returns a <see cref="ConnectionSettings"></see> for a given connection string.
+        /// </summary>
+        /// <param name="connectionString"></param>
+        /// <returns>a <see cref="ConnectionSettings"/> from the connection string</returns>
+        public static ConnectionSettings GetForConnectionString(string connectionString)
+        {
+            var settings = ConnectionSettings.Default;
+            var items = GetConnectionStringInfo(connectionString).ToArray();
+            return Apply(items, settings);
+        }
+
+        private static T Apply<T>(IEnumerable<KeyValuePair<string , string>> items, T obj)
+        {
+            var fields = typeof (T).GetFields(BindingFlags.Instance & BindingFlags.Public).ToDictionary(x => x.Name.ToLower(), x=>x);
+            foreach (var item in items)
+            {
+                FieldInfo fi = null;
+                if (!fields.TryGetValue(item.Key, out fi)) continue;
+                Func<string, object> func = null;
+                if (!translators.TryGetValue(fi.FieldType, out func))
+                {
+                    throw new Exception(string.Format("Can not map field named {0} as type {1} has no translator", item, fi.FieldType.Name));
+                }
+                fi.SetValue(obj, func(item.Value));
+            }
+            return obj;
+        }
+    }
+}

--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -12,7 +12,7 @@ namespace EventStore.ClientAPI
     public class ConnectionString
     {
 
-        private static Dictionary<Type, Func<string, object>> translators;
+        private static readonly Dictionary<Type, Func<string, object>> translators;
 
         static ConnectionString()
         {
@@ -25,7 +25,8 @@ namespace EventStore.ClientAPI
                 {typeof(long), x=>long.Parse(x)},
                 {typeof(byte), x=>byte.Parse(x)},
                 {typeof(double), x=>double.Parse(x)},
-                {typeof(float), x=>float.Parse(x)}
+                {typeof(float), x=>float.Parse(x)},
+                {typeof(TimeSpan), x => TimeSpan.FromMilliseconds(int.Parse(x))}
             };
         }
 

--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Reflection;
-using System.Security.Cryptography.X509Certificates;
 
 namespace EventStore.ClientAPI
 {
@@ -49,7 +48,7 @@ namespace EventStore.ClientAPI
         /// </summary>
         /// <param name="connectionString"></param>
         /// <returns>a <see cref="ConnectionSettings"/> from the connection string</returns>
-        public static ConnectionSettings GetForConnectionString(string connectionString)
+        public static ConnectionSettings GetConnectionSettings(string connectionString)
         {
             var settings = ConnectionSettings.Default;
             var items = GetConnectionStringInfo(connectionString).ToArray();
@@ -58,7 +57,7 @@ namespace EventStore.ClientAPI
 
         private static T Apply<T>(IEnumerable<KeyValuePair<string , string>> items, T obj)
         {
-            var fields = typeof (T).GetFields(BindingFlags.Instance & BindingFlags.Public).ToDictionary(x => x.Name.ToLower(), x=>x);
+            var fields = typeof (T).GetFields().Where(x=>x.IsPublic).ToDictionary(x => x.Name.ToLower(), x=>x);
             foreach (var item in items)
             {
                 FieldInfo fi = null;

--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -35,14 +35,13 @@ namespace EventStore.ClientAPI
         /// </summary>
         /// <param name="connectionString">the connection string to parse</param>
         /// <returns></returns>
-        private static IEnumerable<KeyValuePair<string, string>> GetConnectionStringInfo(string connectionString)
+        internal static IEnumerable<KeyValuePair<string, string>> GetConnectionStringInfo(string connectionString)
         {
             var builder = new DbConnectionStringBuilder(false) { ConnectionString = connectionString };
             //can someome mutate this builder before the enumerable is closed sure but thats the fun!
             return from object key in builder.Keys
                 select new KeyValuePair<string, string>(key.ToString(), builder[key.ToString()].ToString());
         }
-
  
         /// <summary>
         /// Returns a <see cref="ConnectionSettings"></see> for a given connection string.

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="AllCheckpoint.cs" />
     <Compile Include="AllEventsSlice.cs" />
+    <Compile Include="IPEndPointExtensions.cs" />
     <Compile Include="UserManagement\ResetPasswordDetails.cs" />
     <Compile Include="UserManagement\ChangePasswordDetails.cs" />
     <Compile Include="EventStorePersistentSubscription.cs" />

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="AllCheckpoint.cs" />
     <Compile Include="AllEventsSlice.cs" />
+    <Compile Include="ConnectionString.cs" />
     <Compile Include="IPEndPointExtensions.cs" />
     <Compile Include="UserManagement\ResetPasswordDetails.cs" />
     <Compile Include="UserManagement\ChangePasswordDetails.cs" />

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -72,6 +72,7 @@ namespace EventStore.ClientAPI
 
         private static IPEndPoint GetSingleNodeIPEndPointFrom(Uri uri)
         {
+            //TODO GFY move this all the way back into the connection so it can be done on connect not on create
             var ipaddress = IPAddress.Any;
             if (!IPAddress.TryParse(uri.Host, out ipaddress))
             {

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -40,32 +40,42 @@ namespace EventStore.ClientAPI
         /// Creates a new <see cref="IEventStoreConnection"/> to single node using default <see cref="ConnectionSettings"/>
         /// </summary>
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
-        /// <param name="settings">The <see cref="ConnectionSettings"/> to apply to the new connection</param>
+        /// <param name="connectionSettings">The <see cref="ConnectionSettings"/> to apply to the new connection</param>
         /// <param name="uri">The Uri to connect to. It can be tcp:// to point to a single node or discover:// to discover nodes</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        public static IEventStoreConnection Create(ConnectionSettings settings, Uri uri, string connectionName = null)
+        public static IEventStoreConnection Create(ConnectionSettings connectionSettings, Uri uri, string connectionName = null)
         {
             var scheme = uri.Scheme.ToLower();
 
-            settings = settings ?? ConnectionSettings.Default;
+            connectionSettings = connectionSettings ?? ConnectionSettings.Default;
             var credential = GetCredentialFromUri(uri);
             if (credential != null)
             {
-                settings = new ConnectionSettings(settings.Log,settings.VerboseLogging,settings.MaxQueueSize,settings.MaxConcurrentItems,
-                settings.MaxRetries,settings.MaxReconnections,settings.RequireMaster,settings.ReconnectionDelay,settings.OperationTimeout,
-                settings.OperationTimeoutCheckPeriod,credential,settings.UseSslConnection,settings.TargetHost, 
-                settings.ValidateServer, settings.FailOnNoServerResponse, settings.HeartbeatInterval, settings.HeartbeatTimeout,
-                settings.ClientConnectionTimeout);
+                connectionSettings = new ConnectionSettings(connectionSettings.Log,connectionSettings.VerboseLogging,connectionSettings.MaxQueueSize,connectionSettings.MaxConcurrentItems,
+                connectionSettings.MaxRetries,connectionSettings.MaxReconnections,connectionSettings.RequireMaster,connectionSettings.ReconnectionDelay,connectionSettings.OperationTimeout,
+                connectionSettings.OperationTimeoutCheckPeriod,credential,connectionSettings.UseSslConnection,connectionSettings.TargetHost, 
+                connectionSettings.ValidateServer, connectionSettings.FailOnNoServerResponse, connectionSettings.HeartbeatInterval, connectionSettings.HeartbeatTimeout,
+                connectionSettings.ClientConnectionTimeout);
             }
             if (scheme == "discover://")
             {
-                var cluster = new ClusterSettings(null, 1, TimeSpan.Zero);
-                return Create(settings, cluster, connectionName);
+                var clusterSettings = new ClusterSettings(null, 1, TimeSpan.Zero);
+                Ensure.NotNull(connectionSettings, "connectionSettings");
+                Ensure.NotNull(clusterSettings, "clusterSettings");
+
+                var endPointDiscoverer = new ClusterDnsEndPointDiscoverer(connectionSettings.Log,
+                                                                          clusterSettings.ClusterDns,
+                                                                          clusterSettings.MaxDiscoverAttempts,
+                                                                          clusterSettings.ExternalGossipPort,
+                                                                          clusterSettings.GossipSeeds,
+                                                                          clusterSettings.GossipTimeout);
+
+                return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer, connectionName);
             }
             if (scheme == "tcp://")
             {
-                var endPoint = GetSingleNodeIPEndPointFrom(uri);
-                return Create(settings, endPoint, connectionName);
+                var tcpEndPoint = GetSingleNodeIPEndPointFrom(uri);
+                return new EventStoreNodeConnection(connectionSettings, null, new StaticEndPointDiscoverer(tcpEndPoint, connectionSettings.UseSslConnection), connectionName);
             }
             throw new Exception(string.Format("Unknown scheme for connection '{0}'", scheme));
         }
@@ -108,7 +118,7 @@ namespace EventStore.ClientAPI
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <param name="tcpEndPoint">The <see cref="IPEndPoint"/> to connect to.</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        //[Obsolete("Use Create with connectionstring or a uri instead")]
+        [Obsolete("Use Create with connectionstring or a uri instead")]
         public static IEventStoreConnection Create(IPEndPoint tcpEndPoint, string connectionName = null)
         {
             return Create(ConnectionSettings.Default, tcpEndPoint, connectionName);
@@ -117,16 +127,16 @@ namespace EventStore.ClientAPI
         /// <summary>
         /// Creates a new <see cref="IEventStoreConnection"/> to single node using specific <see cref="ConnectionSettings"/>
         /// </summary>
-        /// <param name="settings">The <see cref="ConnectionSettings"/> to apply to the new connection</param>
+        /// <param name="connectionSettings">The <see cref="ConnectionSettings"/> to apply to the new connection</param>
         /// <param name="tcpEndPoint">The <see cref="IPEndPoint"/> to connect to.</param>
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        //[Obsolete("Use Create with connectionstring or a uri instead")]
-        public static IEventStoreConnection Create(ConnectionSettings settings, IPEndPoint tcpEndPoint, string connectionName = null)
+        [Obsolete("Use Create with connectionstring or a uri instead")]
+        public static IEventStoreConnection Create(ConnectionSettings connectionSettings, IPEndPoint tcpEndPoint, string connectionName = null)
         {
-            Ensure.NotNull(settings, "settings");
+            Ensure.NotNull(connectionSettings, "settings");
             Ensure.NotNull(tcpEndPoint, "tcpEndPoint");
-            return new EventStoreNodeConnection(settings, null, new StaticEndPointDiscoverer(tcpEndPoint, settings.UseSslConnection), connectionName);
+            return new EventStoreNodeConnection(connectionSettings, null, new StaticEndPointDiscoverer(tcpEndPoint, connectionSettings.UseSslConnection), connectionName);
         }
         
         /// <summary>
@@ -137,7 +147,7 @@ namespace EventStore.ClientAPI
         /// <param name="clusterSettings">The <see cref="ClusterSettings"/> that determine cluster behavior.</param>
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        //[Obsolete("Use Create with connectionstring or a uri instead")]
+        [Obsolete("Use Create with connectionstring or a uri instead")]
         public static IEventStoreConnection Create(ConnectionSettings connectionSettings, ClusterSettings clusterSettings, string connectionName = null)
         {
             Ensure.NotNull(connectionSettings, "connectionSettings");

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Core;
 
@@ -9,12 +10,62 @@ namespace EventStore.ClientAPI
     /// </summary>
     public static class EventStoreConnection
     {
+
+        /// <summary>
+        /// Creates a new <see cref="IEventStoreConnection"/> to single node using default <see cref="ConnectionSettings"/>
+        /// </summary>
+        /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
+        /// <param name="uri">The Uri to connect to. It can be tcp:// to point to a single node or discover:// to discover nodes</param>
+        /// <returns>a new <see cref="IEventStoreConnection"/></returns>
+        public static IEventStoreConnection Create(Uri uri, string connectionName = null)
+        {
+            return Create(ConnectionSettings.Default, uri, connectionName);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="IEventStoreConnection"/> to single node using default <see cref="ConnectionSettings"/>
+        /// </summary>
+        /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
+        /// <param name="connectionString">The connection string to for this connection.</param>
+        /// <returns>a new <see cref="IEventStoreConnection"/></returns>
+        public static IEventStoreConnection Create(string connectionString, string connectionName = null)
+        {
+            var settings = GetSettingsFromConnectionString(connectionString);
+            var uri = GetUriFromConnectionString(connectionString);
+            return Create(settings, uri, connectionName);
+        }
+
+        private static ConnectionSettings GetSettingsFromConnectionString(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+        private static Uri GetUriFromConnectionString(string connectionString)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="IEventStoreConnection"/> to single node using default <see cref="ConnectionSettings"/>
+        /// </summary>
+        /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
+        /// <param name="settings">The <see cref="ConnectionSettings"/> to apply to the new connection</param>
+        /// <param name="uri">The Uri to connect to. It can be tcp:// to point to a single node or discover:// to discover nodes</param>
+        /// <returns>a new <see cref="IEventStoreConnection"/></returns>
+        public static IEventStoreConnection Create(ConnectionSettings settings, Uri uri, string connectionName = null)
+        {
+            //create connection
+            return null;
+        }
+
         /// <summary>
         /// Creates a new <see cref="IEventStoreConnection"/> to single node using default <see cref="ConnectionSettings"/>
         /// </summary>
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <param name="tcpEndPoint">The <see cref="IPEndPoint"/> to connect to.</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
+        //[Obsolete("Use Create with connectionstring or a uri instead")]
         public static IEventStoreConnection Create(IPEndPoint tcpEndPoint, string connectionName = null)
         {
             return Create(ConnectionSettings.Default, tcpEndPoint, connectionName);
@@ -27,6 +78,7 @@ namespace EventStore.ClientAPI
         /// <param name="tcpEndPoint">The <see cref="IPEndPoint"/> to connect to.</param>
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
+        //[Obsolete("Use Create with connectionstring or a uri instead")]
         public static IEventStoreConnection Create(ConnectionSettings settings, IPEndPoint tcpEndPoint, string connectionName = null)
         {
             Ensure.NotNull(settings, "settings");
@@ -42,6 +94,7 @@ namespace EventStore.ClientAPI
         /// <param name="clusterSettings">The <see cref="ClusterSettings"/> that determine cluster behavior.</param>
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
+        //[Obsolete("Use Create with connectionstring or a uri instead")]
         public static IEventStoreConnection Create(ConnectionSettings connectionSettings, ClusterSettings clusterSettings, string connectionName = null)
         {
             Ensure.NotNull(connectionSettings, "connectionSettings");

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -57,7 +57,7 @@ namespace EventStore.ClientAPI
                 connectionSettings.ValidateServer, connectionSettings.FailOnNoServerResponse, connectionSettings.HeartbeatInterval, connectionSettings.HeartbeatTimeout,
                 connectionSettings.ClientConnectionTimeout);
             }
-            if (scheme == "discover://")
+            if (scheme == "disc")
             {
                 var clusterSettings = new ClusterSettings(null, 1, TimeSpan.Zero);
                 Ensure.NotNull(connectionSettings, "connectionSettings");
@@ -72,7 +72,7 @@ namespace EventStore.ClientAPI
 
                 return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer, connectionName);
             }
-            if (scheme == "tcp://")
+            if (scheme == "tcp")
             {
                 var tcpEndPoint = GetSingleNodeIPEndPointFrom(uri);
                 return new EventStoreNodeConnection(connectionSettings, null, new StaticEndPointDiscoverer(tcpEndPoint, connectionSettings.UseSslConnection), connectionName);

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -43,11 +43,8 @@ namespace EventStore.ClientAPI
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <param name="connectionSettings">The <see cref="ConnectionSettings"/> to apply to the new connection</param>
         /// <param name="uri">The Uri to connect to. It can be tcp:// to point to a single node or discover:// to discover nodes</param>
-        /// <param name="gossipTimeout">The timeout to set for gossip if using discovery</param>
-        /// <param name="maxDiscoverRetries">The maximum number of times to try to discover if using discovery</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        public static IEventStoreConnection Create(ConnectionSettings connectionSettings, Uri uri, string connectionName = null, 
-                                                   TimeSpan? gossipTimeout=null, int maxDiscoverRetries=int.MaxValue) //TODO CONN move to connection settings
+        public static IEventStoreConnection Create(ConnectionSettings connectionSettings, Uri uri, string connectionName = null) 
         {
             var scheme = uri.Scheme.ToLower();
             
@@ -59,11 +56,12 @@ namespace EventStore.ClientAPI
                 connectionSettings.MaxRetries,connectionSettings.MaxReconnections,connectionSettings.RequireMaster,connectionSettings.ReconnectionDelay,connectionSettings.OperationTimeout,
                 connectionSettings.OperationTimeoutCheckPeriod,credential,connectionSettings.UseSslConnection,connectionSettings.TargetHost, 
                 connectionSettings.ValidateServer, connectionSettings.FailOnNoServerResponse, connectionSettings.HeartbeatInterval, connectionSettings.HeartbeatTimeout,
-                connectionSettings.ClientConnectionTimeout);
+                connectionSettings.ClientConnectionTimeout, connectionSettings.ClusterDns, connectionSettings.GossipSeeds, connectionSettings.MaxDiscoverAttempts,
+                connectionSettings.ExternalGossipPort, connectionSettings.GossipTimeout);
             }
             if (scheme == "disc")
             {
-                var clusterSettings = new ClusterSettings(uri.Host, maxDiscoverRetries, uri.Port, gossipTimeout ?? TimeSpan.FromSeconds(5));
+                var clusterSettings = new ClusterSettings(uri.Host, connectionSettings.MaxDiscoverAttempts, uri.Port, connectionSettings.GossipTimeout);
                 Ensure.NotNull(connectionSettings, "connectionSettings");
                 Ensure.NotNull(clusterSettings, "clusterSettings");
 

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -74,6 +74,24 @@ namespace EventStore.ClientAPI
 
                 return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer, connectionName);
             }
+            if (scheme == "gossipseeds")
+            {
+                var clusterSettings = new ClusterSettings(connectionSettings.GossipSeeds,
+                                                          connectionSettings.MaxDiscoverAttempts, 
+                                                          connectionSettings.GossipTimeout);
+                Ensure.NotNull(connectionSettings, "connectionSettings");
+                Ensure.NotNull(clusterSettings, "clusterSettings");
+
+                var endPointDiscoverer = new ClusterDnsEndPointDiscoverer(connectionSettings.Log,
+                                                                          clusterSettings.ClusterDns,
+                                                                          clusterSettings.MaxDiscoverAttempts,
+                                                                          clusterSettings.ExternalGossipPort,
+                                                                          clusterSettings.GossipSeeds,
+                                                                          clusterSettings.GossipTimeout);
+
+                return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer, connectionName);
+            }
+
             if (scheme == "tcp")
             {
                 var tcpEndPoint = GetSingleNodeIPEndPointFrom(uri);

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -47,7 +47,7 @@ namespace EventStore.ClientAPI
         /// <param name="maxDiscoverRetries">The maximum number of times to try to discover if using discovery</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
         public static IEventStoreConnection Create(ConnectionSettings connectionSettings, Uri uri, string connectionName = null, 
-                                                   TimeSpan? gossipTimeout=null, int maxDiscoverRetries=int.MaxValue)
+                                                   TimeSpan? gossipTimeout=null, int maxDiscoverRetries=int.MaxValue) //TODO CONN move to connection settings
         {
             var scheme = uri.Scheme.ToLower();
             

--- a/src/EventStore.ClientAPI/IPEndPointExtensions.cs
+++ b/src/EventStore.ClientAPI/IPEndPointExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Net;
+
+namespace EventStore.ClientAPI
+{
+    static class IPEndPointExtensions
+    {
+        public static Uri ToESTcpUri(this IPEndPoint ipEndPoint)
+        {
+            return new Uri(string.Format("tcp://{0}:{1}",ipEndPoint.Address, ipEndPoint.Port));
+        }
+
+        public static Uri ToESTcpUri(this IPEndPoint ipEndPoint, string username, string password)
+        {
+            return new Uri(string.Format("tcp://{0}:{1}@{2}:{3}", username, password, ipEndPoint.Address, ipEndPoint.Port));
+        }    
+    }
+}

--- a/src/EventStore.Core.Tests/ClientAPI/Helpers/TestConnection.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Helpers/TestConnection.cs
@@ -15,14 +15,14 @@ namespace EventStore.Core.Tests.ClientAPI.Helpers
         public static IEventStoreConnection Create(IPEndPoint endPoint, TcpType tcpType = TcpType.Normal, UserCredentials userCredentials = null)
         {
             return EventStoreConnection.Create(Settings(tcpType, userCredentials),
-                                               endPoint,
+                                               endPoint.ToESTcpUri(),
                                                string.Format("ESC-{0}", Interlocked.Increment(ref _nextConnId)));
         }
 
         public static IEventStoreConnection To(MiniNode miniNode, TcpType tcpType, UserCredentials userCredentials = null)
         {
             return EventStoreConnection.Create(Settings(tcpType, userCredentials),
-                                               tcpType == TcpType.Ssl ? miniNode.TcpSecEndPoint : miniNode.TcpEndPoint,
+                                               tcpType == TcpType.Ssl ? miniNode.TcpSecEndPoint.ToESTcpUri() : miniNode.TcpEndPoint.ToESTcpUri(),
                                                string.Format("ESC-{0}", Interlocked.Increment(ref _nextConnId)));
         }
 

--- a/src/EventStore.Core.Tests/ClientAPI/connect.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connect.cs
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.ClientAPI
             int port = PortsHelper.GetAvailablePort(ip);
             try
             {
-                using (var connection = EventStoreConnection.Create(settings, new IPEndPoint(ip, port)))
+                using (var connection = EventStoreConnection.Create(settings, new IPEndPoint(ip, port).ToESTcpUri()))
                 {
                     connection.Closed += (s, e) => closed.Set();
 
@@ -97,7 +97,7 @@ namespace EventStore.Core.Tests.ClientAPI
             int port = PortsHelper.GetAvailablePort(ip);
             try
             {
-                using (var connection = EventStoreConnection.Create(settings, new IPEndPoint(ip, port)))
+                using (var connection = EventStoreConnection.Create(settings, new IPEndPoint(ip, port).ToESTcpUri()))
                 {
                     connection.Closed += (s, e) => closed.Set();
                     connection.Connected += (s, e) => Console.WriteLine("EventStoreConnection '{0}': connected to [{1}]...", e.Connection.ConnectionName, e.RemoteEndPoint);
@@ -147,7 +147,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
             var ip = new IPAddress(new byte[] {8, 8, 8, 8}); //NOTE: This relies on Google DNS server being configured to swallow nonsense traffic
             const int port = 4567;
-            using (var connection = EventStoreConnection.Create(settings, new IPEndPoint(ip, port)))
+            using (var connection = EventStoreConnection.Create(settings, new IPEndPoint(ip, port).ToESTcpUri()))
             {
                 connection.Closed += (s, e) => closed.Set();
                 connection.Connected += (s, e) => Console.WriteLine("EventStoreConnection '{0}': connected to [{1}]...", e.Connection.ConnectionName, e.RemoteEndPoint);

--- a/src/EventStore.Core.Tests/ClientAPI/connection_string.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connection_string.cs
@@ -1,0 +1,53 @@
+﻿using EventStore.ClientAPI;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientAPI
+{
+    [TestFixture]
+    public class connection_string
+    {
+        [Test]
+        public void can_set_string_value()
+        {
+            var settings = ConnectionString.GetConnectionSettings("targethost=testtest");
+            Assert.AreEqual("testtest", settings.TargetHost);
+        }
+
+        [Test]
+        public void can_set_bool_value_with_string()
+        {
+            var settings = ConnectionString.GetConnectionSettings("verboselogging=true");
+            Assert.AreEqual(true, settings.VerboseLogging);
+        }
+
+        [Test]
+        public void can_set_int()
+        {
+            var settings = ConnectionString.GetConnectionSettings("maxretries=55");
+            Assert.AreEqual(55, settings.MaxRetries);
+        }
+
+        [Test]
+        public void can_set_timespan()
+        {
+            var settings = ConnectionString.GetConnectionSettings("heartbeattimeout=5555");
+            Assert.AreEqual(5555, settings.HeartbeatTimeout.TotalMilliseconds);
+        }
+
+        [Test]
+        public void can_set_multiple_values()
+        {
+            var settings = ConnectionString.GetConnectionSettings("heartbeattimeout=5555;maxretries=55");
+            Assert.AreEqual(5555, settings.HeartbeatTimeout.TotalMilliseconds);
+            Assert.AreEqual(55, settings.MaxRetries);
+        }
+
+        [Test]
+        public void can_set_mixed_case()
+        {
+            var settings = ConnectionString.GetConnectionSettings("heArtbeAtTimeout=5555");
+            Assert.AreEqual(5555, settings.HeartbeatTimeout.TotalMilliseconds);
+        }
+
+    }
+}

--- a/src/EventStore.Core.Tests/ClientAPI/connection_string.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connection_string.cs
@@ -49,5 +49,11 @@ namespace EventStore.Core.Tests.ClientAPI
             Assert.AreEqual(5555, settings.HeartbeatTimeout.TotalMilliseconds);
         }
 
+        [Test]
+        public void can_set_gossip_seeds()
+        {
+            var settings = ConnectionString.GetConnectionSettings("gossipseeds=111.222.222.111:1111,111.222.222.111:1112,111.222.222.111:1113");
+            Assert.AreEqual(3, settings.GossipSeeds.Length);
+        }
     }
 }

--- a/src/EventStore.Core.Tests/ClientAPI/soft_delete.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/soft_delete.cs
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
         protected virtual IEventStoreConnection BuildConnection(MiniNode node)
         {
-            return EventStoreConnection.Create(node.TcpEndPoint);
+            return EventStoreConnection.Create(node.TcpEndPoint.ToESTcpUri());
         }
 
         [Test, Category("LongRunning"), Category("Network")]

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="ClientAPI\appending_to_implicitly_created_stream.cs" />
     <Compile Include="ClientAPI\appending_to_implicitly_created_stream_using_transaction.cs" />
     <Compile Include="ClientAPI\connecting_to_a_persistent_subscription.cs" />
+    <Compile Include="ClientAPI\connection_string.cs" />
     <Compile Include="ClientAPI\create_persistent_subscription.cs" />
     <Compile Include="ClientAPI\deleting_persistent_subscription.cs" />
     <Compile Include="ClientAPI\read_allevents_backward_with_linkto_deleted_event.cs" />

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -464,7 +464,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
 
         protected override void Given()
         {
-            _conn = EventStoreConnection.Create(_node.TcpEndPoint);
+            _conn = EventStoreConnection.Create(_node.TcpEndPoint.ToESTcpUri());
             _conn.ConnectAsync().Wait();
             _conn.CreatePersistentSubscriptionAsync(_streamName, _groupName, _settings,
                     DefaultData.AdminCredentials).Wait();

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -91,7 +91,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
 
             WaitHandle.WaitAll(new[] { _nodes[0].StartedEvent, _nodes[1].StartedEvent, _nodes[2].StartedEvent });
             QueueStatsCollector.WaitIdle(waitForNonEmptyTf: true);
-            _conn = EventStoreConnection.Create(_nodes[0].ExternalTcpEndPoint);
+            _conn = EventStoreConnection.Create(_nodes[0].ExternalTcpEndPoint.ToESTcpUri());
             _conn.ConnectAsync().Wait();
 
             _manager = new ProjectionsManager(

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -36,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
             CreateNode();
             try
             {
-                _conn = EventStoreConnection.Create(_node.TcpEndPoint);
+                _conn = EventStoreConnection.Create(new Uri("tcp://" + _node.TcpEndPoint.Address + ":" + _node.TcpEndPoint.Port));
                 _conn.ConnectAsync().Wait();
 
                 _manager = new ProjectionsManager(

--- a/src/EventStore.TestClient/Commands/RunTestScenarios/ScenarioBase.cs
+++ b/src/EventStore.TestClient/Commands/RunTestScenarios/ScenarioBase.cs
@@ -136,7 +136,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
                                         .LimitRetriesForOperationTo(maxReconnections)
                                         .LimitReconnectionsTo(maxOperationRetries)
                                         .FailOnNoServerResponse(),
-                    new IPEndPoint(_nodeConnection.IpAddress, _nodeConnection.TcpPort),
+                    new Uri(string.Format("tcp://{0}:{1}", _nodeConnection.IpAddress, _nodeConnection.TcpPort)),
                     string.Format("ESConn-{0}", i));
                 _connections[i].Closed += (s, e) => Log.Debug("[SCENARIO] {0} closed.", e.Connection.ConnectionName);
                 _connections[i].Connected += (s, e) => Log.Debug("[SCENARIO] {0} connected to [{1}].", e.Connection.ConnectionName, e.RemoteEndPoint);

--- a/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
+++ b/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
@@ -26,8 +26,8 @@ namespace EventStore.TestClient.Commands
             var conn = EventStoreConnection.Create(ConnectionSettings.Create()
                                                                      .UseCustomLogger(new ClientApiLoggerBridge(context.Log))
                                                                      .FailOnNoServerResponse()
-                                                                     /*.EnableVerboseLogging()*/, 
-                                                                     context.Client.TcpEndpoint);
+                                                                     /*.EnableVerboseLogging()*/,
+                                                                     new Uri(string.Format("tcp://{0}:{1}", context.Client.TcpEndpoint.Address, context.Client.TcpEndpoint.Port)));
             conn.ConnectAsync().Wait();
 
             long appearedCnt = 0;

--- a/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
+++ b/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
@@ -12,7 +12,7 @@ namespace EventStore.TestClient.Commands
 
         public bool Execute(CommandProcessorContext context, string[] args)
         {
-            int subscriptionCount = 5000;
+            var subscriptionCount = 5000;
 
             if (args.Length > 0)
             {

--- a/src/EventStore.TestClient/Commands/WriteFloodClientApiProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodClientApiProcessor.cs
@@ -71,7 +71,7 @@ namespace EventStore.TestClient.Commands
                     .LimitConcurrentOperationsTo(context.Client.Options.WriteWindow/clientsCnt)
                     .FailOnNoServerResponse();
 
-                var client = EventStoreConnection.Create(settings, context.Client.TcpEndpoint);
+                var client = EventStoreConnection.Create(settings, new Uri(string.Format("tcp://{0}:{1}", context.Client.TcpEndpoint.Address, context.Client.TcpEndpoint.Port)));
                 clients.Add(client);
 
                 threads.Add(new Thread(_ =>


### PR DESCRIPTION
This PR supports connection strings for client api.

There is some weirdness in this commit due to not wanting to introduce a breaking change and should be reviewed. 

There are still overloads of create that work with connectionsettings/clustersettings. The clustersettings type and the overloads that use it have been marked as depreceated though. Likely docs need updating here...

For the new overloads there are 3 primary cases that are handled

Connect to single node:
     Create(new Uri("tcp://user:password@145.33.22.11:44"))

Connect to dns cluster
     Create(new Uri("discovery://whatevername:3030"))

Both also can take ConnectionSettings. If you put things in the uri they override the connection settings

Connect to gossip seeds (or either of the above)
    Create(ConnectionSettings) and Create("Connection String")

either of these will take the information from the settings/string. either of the previous examples can also be done in this way. Ideally we will remove the things on the connectionsettings that exist as well on the uri (default credentials) as its less confusing. Again this is worth discussing before accepting