### PR TITLE
Added Maximum Subscribers to persistant subscribtion

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/ConnectToPersistentSubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/ConnectToPersistentSubscriptionOperation.cs
@@ -71,6 +71,12 @@ namespace EventStore.ClientAPI.ClientOperations
                     result = new InspectionResult(InspectionDecision.EndOperation, "SubscriptionDropped");
                     return true;
                 }
+                if (dto.Reason == ClientMessage.SubscriptionDropped.SubscriptionDropReason.SubscriberMaxCountReached)
+                {
+                    DropSubscription(SubscriptionDropReason.NotFound, new Exception("Maximum subscribptions reached."));
+                    result = new InspectionResult(InspectionDecision.EndOperation, "SubscriptionDropped");
+                    return true;
+                }
                 DropSubscription((SubscriptionDropReason) dto.Reason, null, _getConnection());
                 result = new InspectionResult(InspectionDecision.EndOperation, "SubscriptionDropped");
                 return true;

--- a/src/EventStore.ClientAPI/ClientOperations/CreatePersistentSubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/CreatePersistentSubscriptionOperation.cs
@@ -23,6 +23,7 @@ namespace EventStore.ClientAPI.ClientOperations
         private readonly int _checkPointAfter;
         private readonly int _minCheckPointCount;
         private readonly int _maxCheckPointCount;
+        private readonly int _maxSubscriberCount;
 
         public CreatePersistentSubscriptionOperation(ILogger log,
                                        TaskCompletionSource<PersistentSubscriptionCreateResult> source,
@@ -47,13 +48,14 @@ namespace EventStore.ClientAPI.ClientOperations
             _checkPointAfter = (int) settings.CheckPointAfter.TotalMilliseconds;
             _minCheckPointCount = settings.MinCheckPointCount;
             _maxCheckPointCount = settings.MaxCheckPointCount;
+            _maxSubscriberCount = settings.MaxSubscriberCount;
         }
 
         protected override object CreateRequestDto()
         {
             return new ClientMessage.CreatePersistentSubscription(_groupName, _stream, _resolveLinkTos, _startFromBeginning, _messageTimeoutMilliseconds,
                                     _recordStatistics, _liveBufferSize, _readBatchSize, _bufferSize, _maxRetryCount, _preferRoundRobin, _checkPointAfter,
-                                    _maxCheckPointCount, _minCheckPointCount);
+                                    _maxCheckPointCount, _minCheckPointCount, _maxSubscriberCount);
         }
 
         protected override InspectionResult InspectResponse(ClientMessage.CreatePersistentSubscriptionCompleted response)

--- a/src/EventStore.ClientAPI/Messages/ClientMessage.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessage.cs
@@ -692,10 +692,13 @@ namespace EventStore.ClientAPI.Messages
   
     [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int CheckpointMinCount;
+
+    [ProtoMember(15, IsRequired = true, Name = @"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int SubscriberMaxCount;
   
     private CreatePersistentSubscription() {}
   
-    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount)
+    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount)
     {
         SubscriptionGroupName = subscriptionGroupName;
         EventStreamId = eventStreamId;
@@ -711,6 +714,7 @@ namespace EventStore.ClientAPI.Messages
         CheckpointAfterTime = checkpointAfterTime;
         CheckpointMaxCount = checkpointMaxCount;
         CheckpointMinCount = checkpointMinCount;
+        SubscriberMaxCount = subscriberMaxCount;
     }
   }
   
@@ -1103,7 +1107,10 @@ namespace EventStore.ClientAPI.Messages
       NotFound = 2,
             
       [ProtoEnum(Name=@"PersistentSubscriptionDeleted", Value=3)]
-      PersistentSubscriptionDeleted = 3
+      PersistentSubscriptionDeleted = 3,
+
+      [ProtoEnum(Name = @"SubscriberMaxCountReached", Value=4)]
+      SubscriberMaxCountReached = 4
     }
   
     private SubscriptionDropped() {}

--- a/src/EventStore.ClientAPI/PersistentSubscriptionSettings.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionSettings.cs
@@ -25,7 +25,8 @@ namespace EventStore.ClientAPI
                                                              true,
                                                              TimeSpan.FromSeconds(2),
                                                              10,
-                                                             1000);
+                                                             1000,
+                                                             0);
         }
 
 
@@ -91,11 +92,17 @@ namespace EventStore.ClientAPI
         public readonly int MaxCheckPointCount;
 
         /// <summary>
+        /// The maximum number of subscribers allowed.
+        /// </summary>
+        public readonly int MaxSubscriberCount;
+
+        /// <summary>
         /// Constructs a new <see cref="PersistentSubscriptionSettings"></see>
         /// </summary>
         internal PersistentSubscriptionSettings(bool resolveLinkTos, int startFrom, bool extraStatistics, TimeSpan messageTimeout,
                                                 int maxRetryCount, int liveBufferSize, int readBatchSize, int historyBufferSize,
-                                                bool preferRoundRobin, TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount)
+                                                bool preferRoundRobin, TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount, 
+                                                int maxSubscriberCount)
         {
             MessageTimeout = messageTimeout;
             ResolveLinkTos = resolveLinkTos;
@@ -109,6 +116,7 @@ namespace EventStore.ClientAPI
             CheckPointAfter = checkPointAfter;
             MinCheckPointCount = minCheckPointCount;
             MaxCheckPointCount = maxCheckPointCount;
+            MaxSubscriberCount = maxSubscriberCount;
         }
 
     }

--- a/src/EventStore.ClientAPI/PersistentSubscriptionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionSettingsBuilder.cs
@@ -20,11 +20,12 @@ namespace EventStore.ClientAPI
         private TimeSpan _checkPointAfter;
         private int _minCheckPointCount;
         private int _maxCheckPointCount;
+        private int _maxSubscriberCount;
 
         internal PersistentSubscriptionSettingsBuilder(bool resolveLinkTos, int startFrom, bool timingStatistics, TimeSpan timeout,
                                                       int bufferSize, int liveBufferSize, int maxRetryCount, int readBatchSize, 
                                                       bool preferRoundRobin, TimeSpan checkPointAfter, int minCheckPointCount,
-                                                      int maxCheckPointCount)
+                                                      int maxCheckPointCount, int maxSubscriberCount)
         {
             _resolveLinkTos = resolveLinkTos;
             _startFrom = startFrom;
@@ -38,6 +39,7 @@ namespace EventStore.ClientAPI
             _checkPointAfter = checkPointAfter;
             _minCheckPointCount = minCheckPointCount;
             _maxCheckPointCount = maxCheckPointCount;
+            _maxSubscriberCount = maxSubscriberCount;
         }
 
 
@@ -254,6 +256,18 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
+        /// Sets the size of the read batch used when paging in history for the subscription
+        /// sizes should not be too big ...
+        /// </summary>
+        /// <returns>A new <see cref="PersistentSubscriptionSettingsBuilder"></see></returns>
+        public PersistentSubscriptionSettingsBuilder WithMaxSubscriberCountOf(int count)
+        {
+            Ensure.Nonnegative(count, "count");
+            _maxSubscriberCount = count;
+            return this;
+        }
+
+        /// <summary>
         /// Builds a <see cref="PersistentSubscriptionSettings"/> object from a <see cref="PersistentSubscriptionSettingsBuilder"/>.
         /// </summary>
         /// <param name="builder"><see cref="PersistentSubscriptionSettingsBuilder"/> from which to build a <see cref="PersistentSubscriptionSettingsBuilder"/></param>
@@ -280,7 +294,8 @@ namespace EventStore.ClientAPI
                 _preferRoundRobin,
                 _checkPointAfter,
                 _minCheckPointCount,
-                _maxCheckPointCount);
+                _maxCheckPointCount,
+                _maxSubscriberCount);
         }
     }
 }

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -880,6 +880,7 @@ namespace EventStore.Core.Messages
             
             public readonly string GroupName;
             public readonly string EventStreamId;
+            public int MaxSubscriberCount;
             public int MaxCheckPointCount;
             public int MinCheckPointCount;
             public int CheckPointAfterMilliseconds;
@@ -888,7 +889,7 @@ namespace EventStore.Core.Messages
                 string eventStreamId, string groupName, bool resolveLinkTos, int startFrom,
                 int messageTimeoutMilliseconds, bool recordStatistics, int maxRetryCount, int bufferSize,
                 int liveBufferSize, int readbatchSize, bool preferRoundRobin,
-                int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount,
+                int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount, int maxSubscriberCount,
                 IPrincipal user, string username, string password)
                 : base(internalCorrId, correlationId, envelope, user)
             {
@@ -906,6 +907,7 @@ namespace EventStore.Core.Messages
                 MaxCheckPointCount = maxCheckPointCount;
                 MinCheckPointCount = minCheckPointCount;
                 CheckPointAfterMilliseconds = checkPointAfterMilliseconds;
+                MaxSubscriberCount = maxSubscriberCount;
             }
 
         }
@@ -953,6 +955,7 @@ namespace EventStore.Core.Messages
 
             public readonly string GroupName;
             public readonly string EventStreamId;
+            public int MaxSubscriberCount;
             public int MaxCheckPointCount;
             public int MinCheckPointCount;
             public int CheckPointAfterMilliseconds;
@@ -961,7 +964,7 @@ namespace EventStore.Core.Messages
                 string eventStreamId, string groupName, bool resolveLinkTos, int startFrom,
                 int messageTimeoutMilliseconds, bool recordStatistics, int maxRetryCount, int bufferSize,
                 int liveBufferSize, int readbatchSize, bool preferRoundRobin,
-                int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount,
+                int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount, int maxSubscriberCount,
                 IPrincipal user, string username, string password)
                 : base(internalCorrId, correlationId, envelope, user)
             {
@@ -979,6 +982,7 @@ namespace EventStore.Core.Messages
                 MaxCheckPointCount = maxCheckPointCount;
                 MinCheckPointCount = minCheckPointCount;
                 CheckPointAfterMilliseconds = checkPointAfterMilliseconds;
+                MaxSubscriberCount = maxSubscriberCount;
             }
 
         }

--- a/src/EventStore.Core/Messages/TcpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDto.cs
@@ -692,10 +692,13 @@ namespace EventStore.Core.Messages
   
     [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int CheckpointMinCount;
+
+    [ProtoMember(15, IsRequired = true, Name = @"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int SubscriberMaxCount;
   
     private CreatePersistentSubscription() {}
   
-    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount)
+    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount)
     {
         SubscriptionGroupName = subscriptionGroupName;
         EventStreamId = eventStreamId;
@@ -711,6 +714,7 @@ namespace EventStore.Core.Messages
         CheckpointAfterTime = checkpointAfterTime;
         CheckpointMaxCount = checkpointMaxCount;
         CheckpointMinCount = checkpointMinCount;
+        SubscriberMaxCount = subscriberMaxCount;
     }
   }
   
@@ -776,10 +780,13 @@ namespace EventStore.Core.Messages
   
     [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int CheckpointMinCount;
+
+    [ProtoMember(15, IsRequired = true, Name = @"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int SubscriberMaxCount;
   
     private UpdatePersistentSubscription() {}
   
-    public UpdatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount)
+    public UpdatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount)
     {
         SubscriptionGroupName = subscriptionGroupName;
         EventStreamId = eventStreamId;
@@ -795,6 +802,7 @@ namespace EventStore.Core.Messages
         CheckpointAfterTime = checkpointAfterTime;
         CheckpointMaxCount = checkpointMaxCount;
         CheckpointMinCount = checkpointMinCount;
+        SubscriberMaxCount = subscriberMaxCount;
     }
   }
   
@@ -1103,7 +1111,10 @@ namespace EventStore.Core.Messages
       NotFound = 2,
             
       [ProtoEnum(Name=@"PersistentSubscriptionDeleted", Value=3)]
-      PersistentSubscriptionDeleted = 3
+      PersistentSubscriptionDeleted = 3,
+
+      [ProtoEnum(Name = @"SubscriberMaxCountReached", Value = 4)]
+      SubscriberMaxCountReached = 4
     }
   
     private SubscriptionDropped() {}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -37,6 +37,8 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         public int ClientCount { get { return _pushClients.Count; } }
 
+        public bool HasReachedMaxClientCount { get { return _settings.MaxSubscriberCount == 0 ? false : _pushClients.Count >= _settings.MaxSubscriberCount; } }
+
         public PersistentSubscriptionState State
         {
             get { return _state; }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConfig.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConfig.cs
@@ -55,5 +55,6 @@ namespace EventStore.Core.Services.PersistentSubscription
         public int CheckPointAfter { get; set; }
         public int MinCheckPointCount { get; set; }
         public int MaxCheckPointCount { get; set; }
+        public int MaxSubscriberCount { get; set; }
     }
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -14,6 +14,8 @@ namespace EventStore.Core.Services.PersistentSubscription
         private readonly TimeSpan _checkPointAfter;
         private readonly int _minCheckPointCount;
         private readonly int _maxCheckPointCount;
+        private readonly int _maxSubscriberCount;
+
         private readonly bool _preferRoundRobin;
         private readonly int _maxRetryCount;
         private readonly int _liveBufferSize;
@@ -27,7 +29,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         public PersistentSubscriptionParams(bool resolveLinkTos, string subscriptionId, string eventStreamId, string groupName, 
                                            int startFrom, bool extraStatistics, TimeSpan messageTimeout, bool preferRoundRobin, 
                                            int maxRetryCount, int liveBufferSize, int bufferSize, int readBatchSize,
-                                           TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount,
+                                           TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount, int maxSubscriberCount,
                                            IPersistentSubscriptionStreamReader streamReader, 
                                            IPersistentSubscriptionCheckpointReader checkpointReader, 
                                            IPersistentSubscriptionCheckpointWriter checkpointWriter,
@@ -47,6 +49,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             _checkPointAfter = checkPointAfter;
             _minCheckPointCount = minCheckPointCount;
             _maxCheckPointCount = maxCheckPointCount;
+            _maxSubscriberCount = maxSubscriberCount;
             _readBatchSize = readBatchSize;
             _streamReader = streamReader;
             _checkpointReader = checkpointReader;
@@ -147,6 +150,11 @@ namespace EventStore.Core.Services.PersistentSubscription
         public int MaxCheckPointCount
         {
             get { return _maxCheckPointCount; }
+        }
+
+        public int MaxSubscriberCount
+        {
+            get { return _maxSubscriberCount; }
         }
 
         public string ParkedMessageStream

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
@@ -27,6 +27,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         private TimeSpan _checkPointAfter;
         private int _minCheckPointCount;
         private int _maxCheckPointCount;
+        private int _maxSubscriberCount;
 
         /// <summary>
         /// Creates a new <see cref="PersistentSubscriptionParamsBuilder"></see> object
@@ -50,13 +51,14 @@ namespace EventStore.Core.Services.PersistentSubscription
                 true,
                 TimeSpan.FromSeconds(1),
                 5,
-                1000);
+                1000,
+                0);
         }
 
 
         private PersistentSubscriptionParamsBuilder(string subscriptionId, string streamName, string groupName, bool resolveLinkTos, int startFrom, bool recordStatistics, TimeSpan timeout,
             int historyBufferSize, int liveBufferSize, int maxRetryCount, int readBatchSize, bool preferRoundRobin, TimeSpan checkPointAfter,
-            int minCheckPointCount, int maxCheckPointCount)
+            int minCheckPointCount, int maxCheckPointCount, int maxSubscriptionCount)
         {
             _resolveLinkTos = resolveLinkTos;
             _startFrom = startFrom;
@@ -73,6 +75,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             _checkPointAfter = checkPointAfter;
             _minCheckPointCount = minCheckPointCount;
             _maxCheckPointCount = maxCheckPointCount;
+            _maxSubscriberCount = maxSubscriptionCount;
         }
 
         /// <summary>
@@ -315,6 +318,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 builder._checkPointAfter,
                 builder._minCheckPointCount,
                 builder._maxCheckPointCount,
+                builder._maxSubscriberCount,
                 builder._streamReader,
                 builder._checkpointReader,
                 builder._checkpointWriter,

--- a/src/EventStore.Core/Services/SubscriptionsService.cs
+++ b/src/EventStore.Core/Services/SubscriptionsService.cs
@@ -15,7 +15,9 @@ namespace EventStore.Core.Services
     {
         Unsubscribed = 0,
         AccessDenied = 1,
-	NotFound = 2
+	    NotFound = 2,
+        PersistentSubscriptionDeleted = 3,
+        SubscriberMaxCountReached = 4
     }
 
     public class SubscriptionsService : IHandle<SystemMessage.SystemStart>, 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -128,6 +128,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                         data == null ? 1000 : data.CheckPointAfterMilliseconds,
                         data == null ? 10 : data.MinCheckPointCount,
                         data == null ? 500 : data.MaxCheckPointCount,
+                        data == null ? 0 : data.MaxSubscriberCount,
                         http.User,
                         "",
                         "");
@@ -191,6 +192,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                         data == null ? 1000 : data.CheckPointAfterMilliseconds,
                         data == null ? 10 : data.MinCheckPointCount,
                         data == null ? 500 : data.MaxCheckPointCount,
+                        data == null ? 0 : data.MaxSubscriberCount,
                         http.User,
                         "",
                         "");
@@ -408,6 +410,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             public int CheckPointAfterMilliseconds { get; set; }
             public int MinCheckPointCount { get; set; }
             public int MaxCheckPointCount { get; set; }
+            public int MaxSubscriberCount { get; set; }
         }
 
         private class SubscriptionSummary

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -441,7 +441,7 @@ namespace EventStore.Core.Services.Transport.Tcp
             return new ClientMessage.CreatePersistentSubscription(Guid.NewGuid(), package.CorrelationId, envelope,
                             dto.EventStreamId, dto.SubscriptionGroupName, dto.ResolveLinkTos, dto.StartFrom, dto.MessageTimeoutMilliseconds, 
                             dto.RecordStatistics, dto.MaxRetryCount, dto.BufferSize, dto.LiveBufferSize,
-                            dto.ReadBatchSize,dto.PreferRoundRobin, dto.CheckpointAfterTime, dto.CheckpointMinCount, dto.CheckpointMaxCount, 
+                            dto.ReadBatchSize,dto.PreferRoundRobin, dto.CheckpointAfterTime, dto.CheckpointMinCount, dto.CheckpointMaxCount, dto.SubscriberMaxCount,
                             user, username, password);
         }
 
@@ -456,7 +456,7 @@ namespace EventStore.Core.Services.Transport.Tcp
                 dto.MessageTimeoutMilliseconds,
                 dto.RecordStatistics, dto.MaxRetryCount, dto.BufferSize, dto.LiveBufferSize,
                 dto.ReadBatchSize, dto.PreferRoundRobin, dto.CheckpointAfterTime, dto.CheckpointMinCount,
-                dto.CheckpointMaxCount,
+                dto.CheckpointMaxCount, dto.SubscriberMaxCount,
                 user, username, password);
         }
 

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -210,6 +210,7 @@ message CreatePersistentSubscription {
 	required int32 checkpoint_after_time = 12;
 	required int32 checkpoint_max_count = 13;
 	required int32 checkpoint_min_count = 14;
+    required int32 subscriber_max_count = 15;
 }
 
 message DeletePersistentSubscription {
@@ -232,6 +233,7 @@ message UpdatePersistentSubscription {
 	required int32 checkpoint_after_time = 12;
 	required int32 checkpoint_max_count = 13;
 	required int32 checkpoint_min_count = 14;
+    required int32 subscriber_max_count = 15;
 }
 
 message UpdatePersistentSubscriptionCompleted {
@@ -328,6 +330,7 @@ message SubscriptionDropped {
 		AccessDenied = 1;
 		NotFound=2;
 		PersistentSubscriptionDeleted=3;
+        SubscriberMaxCountReached=4;
 	}
 	
 	optional SubscriptionDropReason reason = 1 [default = Unsubscribed];


### PR DESCRIPTION
I have a situation when I want to have only one subscriber for the group. The easiest way to do that is to check the subscriber count on the EventStore side.