### PR TITLE
correcting misleading comment

### DIFF
--- a/src/EventStore.ClientAPI/PersistentSubscriptionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionSettingsBuilder.cs
@@ -256,8 +256,7 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
-        /// Sets the size of the read batch used when paging in history for the subscription
-        /// sizes should not be too big ...
+        /// Sets the maximum number of subscribers allowed to connect.
         /// </summary>
         /// <returns>A new <see cref="PersistentSubscriptionSettingsBuilder"></see></returns>
         public PersistentSubscriptionSettingsBuilder WithMaxSubscriberCountOf(int count)

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -198,10 +198,10 @@ message ReadAllEventsCompleted {
 message CreatePersistentSubscription {
 	required string subscription_group_name = 1;
 	required string event_stream_id = 2;
-   	required bool resolve_link_tos = 3;
-   	required int32 start_from = 4;
-   	required int32 message_timeout_milliseconds = 5;
-  	required bool record_statistics = 6;
+	required bool resolve_link_tos = 3;
+	required int32 start_from = 4;
+	required int32 message_timeout_milliseconds = 5;
+	required bool record_statistics = 6;
 	required int32 live_buffer_size = 7;
 	required int32 read_batch_size = 8;
 	required int32 buffer_size = 9;
@@ -210,7 +210,7 @@ message CreatePersistentSubscription {
 	required int32 checkpoint_after_time = 12;
 	required int32 checkpoint_max_count = 13;
 	required int32 checkpoint_min_count = 14;
-    required int32 subscriber_max_count = 15;
+	required int32 subscriber_max_count = 15;
 }
 
 message DeletePersistentSubscription {
@@ -221,10 +221,10 @@ message DeletePersistentSubscription {
 message UpdatePersistentSubscription {
 	required string subscription_group_name = 1;
 	required string event_stream_id = 2;
-   	required bool resolve_link_tos = 3;
-   	required int32 start_from = 4;
-   	required int32 message_timeout_milliseconds = 5;
-  	required bool record_statistics = 6;
+	required bool resolve_link_tos = 3;
+	required int32 start_from = 4;
+	required int32 message_timeout_milliseconds = 5;
+	required bool record_statistics = 6;
 	required int32 live_buffer_size = 7;
 	required int32 read_batch_size = 8;
 	required int32 buffer_size = 9;
@@ -233,7 +233,7 @@ message UpdatePersistentSubscription {
 	required int32 checkpoint_after_time = 12;
 	required int32 checkpoint_max_count = 13;
 	required int32 checkpoint_min_count = 14;
-    required int32 subscriber_max_count = 15;
+	required int32 subscriber_max_count = 15;
 }
 
 message UpdatePersistentSubscriptionCompleted {
@@ -330,7 +330,7 @@ message SubscriptionDropped {
 		AccessDenied = 1;
 		NotFound=2;
 		PersistentSubscriptionDeleted=3;
-        SubscriberMaxCountReached=4;
+		SubscriberMaxCountReached=4;
 	}
 	
 	optional SubscriptionDropReason reason = 1 [default = Unsubscribed];


### PR DESCRIPTION
Just  a comment on configuration builder and cleaned ClientMessageDtos.proto from spaces.