### PR TITLE
Fix issues that were causing tests to fail

### DIFF
--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -128,9 +128,9 @@ namespace EventStore.Core.Tests.Http.Streams
             }
 
             [Test]
-            public void returns_ok_status_code()
+            public void returns_not_acceptable_status_code()
             {
-                Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+                Assert.AreEqual(HttpStatusCode.NotAcceptable, _lastResponse.StatusCode);
             }
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -7,7 +7,7 @@ namespace EventStore.Core.Tests.TransactionLog
     [TestFixture]
     public class when_reading_physical_bytes_bulk_from_a_chunk : SpecificationWithDirectory
     {
-        
+
         [Test]
         public void the_file_will_not_be_deleted_until_reader_released()
         {
@@ -27,7 +27,7 @@ namespace EventStore.Core.Tests.TransactionLog
             }
             finally
             {
-                if(chunk !=null)
+                if (chunk != null)
                     chunk.WaitForDestroy(5000);
             }
         }
@@ -66,13 +66,13 @@ namespace EventStore.Core.Tests.TransactionLog
             try
             {
                 chunk = TFChunk.CreateNew(GetFilePathFor("afile"), 200, 0, 0, true, false, false, false);
-                chunk.CompleteScavenge(new[] {new PosMap(0, 0), new PosMap(1, 1)});
+                chunk.CompleteScavenge(new[] { new PosMap(0, 0), new PosMap(1, 1) });
                 using (var reader = chunk.AcquireReader())
                 {
                     var buffer = new byte[1024];
                     var result = reader.ReadNextRawBytes(1024, buffer);
                     Assert.IsTrue(result.IsEOF);
-                    Assert.AreEqual(ChunkHeader.Size + ChunkHeader.Size + 2*PosMap.FullSize, result.BytesRead);
+                    Assert.AreEqual(ChunkHeader.Size + ChunkHeader.Size + 2 * PosMap.FullSize, result.BytesRead);
                 }
             }
             finally
@@ -88,7 +88,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_read_past_end_of_completed_chunk_does_include_header_or_footer()
         {
-             TFChunk chunk = null;
+            TFChunk chunk = null;
             //TODO GFY NEEDS REWORK
             try
             {
@@ -112,8 +112,8 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void if_asked_for_more_than_buffer_size_will_only_read_buffer_size()
         {
-            TFChunk chunk = null; 
-                
+            TFChunk chunk = null;
+
             try
             {
                 chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 3000, 0, 0, false, false, false, false);
@@ -136,7 +136,7 @@ namespace EventStore.Core.Tests.TransactionLog
         }
 
         [Test]
-        public void a_read_past_eof_returns_eof_and_no_footer()
+        public void a_read_past_eof_returns_eof()
         {
             TFChunk chunk = null;
 
@@ -148,7 +148,7 @@ namespace EventStore.Core.Tests.TransactionLog
                     var buffer = new byte[1024];
                     var result = reader.ReadNextRawBytes(1024, buffer);
                     Assert.IsTrue(result.IsEOF);
-                    Assert.AreEqual(556, result.BytesRead); //does not includes header and footer space
+                    Assert.AreEqual(ChunkHeader.Size + ChunkFooter.Size + 300, result.BytesRead);
                 }
             }
             finally

--- a/src/EventStore.Core/Services/Histograms/HistogramService.cs
+++ b/src/EventStore.Core/Services/Histograms/HistogramService.cs
@@ -24,7 +24,10 @@ namespace EventStore.Core.Services.Histograms
 
         public static void CreateHistogram(string name)
         {
-            Histograms.Add(name, new Histogram(NUMBEROFNS, 3));
+            if (!Histograms.ContainsKey(name))
+            {
+                Histograms.Add(name, new Histogram(NUMBEROFNS, 3));
+            }
         }
 
         public static void CreateHistograms()


### PR DESCRIPTION
1. Check before creating histogram
2. Incorrect assertion and expectancy.