### PR TITLE
make system metadata definitions and event types public

### DIFF
--- a/src/EventStore.ClientAPI/Common/SystemNames.cs
+++ b/src/EventStore.ClientAPI/Common/SystemNames.cs
@@ -1,6 +1,6 @@
 ﻿namespace EventStore.ClientAPI.Common
 {
-    internal static class SystemStreams
+    static class SystemStreams
     {
         public const string StreamsStream = "$streams";
         public const string SettingsStream = "$settings";
@@ -22,30 +22,106 @@
         }
     }
 
-    static class SystemMetadata
+    ///<summary>
+    ///Constants for information in stream metadata
+    ///</summary>
+    public static class SystemMetadata
     {
+        ///<summary>
+        ///The definition of the MaxAge value assigned to stream metadata
+        ///Setting this allows all events older than the limit to be deleted
+        ///</summary>
         public const string MaxAge = "$maxAge";
+
+        ///<summary>
+        ///The definition of the MaxCount value assigned to stream metadata
+        ///setting this allows all events with a sequence less than current -maxcount to be deleted
+        ///</summary>
         public const string MaxCount = "$maxCount";
+        ///<summary>
+        ///The definition of the Truncate Before value assigned to stream metadata
+        ///setting this allows all events prior to the integer value to be deleted
+        ///</summary>
         public const string TruncateBefore = "$tb";
+
+        ///<summary>
+        /// Sets the cache control in seconds for the head of the stream.
+        ///</summary>
         public const string CacheControl = "$cacheControl";
         
+
+        ///<summary>
+        /// The acl definition in metadata
+        ///</summary>
         public const string Acl = "$acl";
+
+        ///<summary>
+        /// to read from a stream
+        ///</summary>
         public const string AclRead = "$r";
+
+        ///<summary>
+        /// to write to a stream
+        ///</summary>
         public const string AclWrite = "$w";
+
+        ///<summary>
+        /// to delete a stream
+        ///</summary>
         public const string AclDelete = "$d";
+        
+        ///<summary>
+        /// to read metadata 
+        ///</summary>
         public const string AclMetaRead = "$mr";
+        
+        ///<summary>
+        /// to write metadata 
+        ///</summary>
         public const string AclMetaWrite = "$mw";
 
+
+        ///<summary>
+        /// The user default acl stream 
+        ///</summary>
         public const string UserStreamAcl = "$userStreamAcl";
+
+        ///<summary>
+        /// the system stream defaults acl stream 
+        ///</summary>
         public const string SystemStreamAcl = "$systemStreamAcl";
     }
 
-    internal static class SystemEventTypes
+
+    ///<summary>
+    ///Constants for System event types
+    ///</summary>
+    public static class SystemEventTypes
     {
+
+        ///<summary>
+        /// event type for stream deleted
+        ///</summary>
         public const string StreamDeleted = "$streamDeleted";
+
+        ///<summary>
+        /// event type for statistics
+        ///</summary>
         public const string StatsCollection = "$statsCollected";
+
+        ///<summary>
+        /// event type for linkTo 
+        ///</summary>
         public const string LinkTo = "$>";
+
+        ///<summary>
+        /// event type for stream metadata 
+        ///</summary>
         public const string StreamMetadata = "$metadata";
+
+        ///<summary>
+        /// event type for the system settings 
+        ///</summary>
         public const string Settings = "$settings";
     }
 }

--- a/src/EventStore.Core/Services/Histograms/HistogramService.cs
+++ b/src/EventStore.Core/Services/Histograms/HistogramService.cs
@@ -64,7 +64,6 @@ namespace EventStore.Core.Services.Histograms
         public static void StartJitterMonitor()
         {
             CreateHistogram("jitter");
-            var hist = GetHistogram("jitter");
             Task.Factory.StartNew(x =>
             {
                 var watch = new Stopwatch();


### PR DESCRIPTION
also fix compile error.


Things like SystemEventTypes.LinkTo can be useful in outside code.

Also added xml docs.