### PR TITLE
Compile again

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/UserManagement/updating_a_user.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/UserManagement/updating_a_user.cs
@@ -37,8 +37,8 @@ namespace EventStore.Core.Tests.ClientAPI.UserManagement
 
         [Test]
         public void updating_non_existing_user_throws()
-        {   
-            var ex = Assert.Throws<AggregateException>(() => _manager.UpdateUserAsync(Guid.NewGuid().ToString(), "bar", new []{"foo"}, new UserCredentials("admin", "changeit")).Wait());
+        {
+            Assert.Throws<AggregateException>(() => _manager.UpdateUserAsync(Guid.NewGuid().ToString(), "bar", new []{"foo"}, new UserCredentials("admin", "changeit")).Wait());
         }
 
         [Test]

--- a/src/EventStore.Core/Messages/UserManagementMessage.cs
+++ b/src/EventStore.Core/Messages/UserManagementMessage.cs
@@ -261,6 +261,7 @@ namespace EventStore.Core.Messages
         {
             public readonly UserDataHttpFormated Data;
             private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
 
             public UserDetailsResultHttpFormatted(UserDetailsResult msg, Func<string, string> makeAbsoluteUrl) :
                 base(msg.Success, msg.Error)
@@ -273,8 +274,9 @@ namespace EventStore.Core.Messages
 
         public class AllUserDetailsResultHttpFormatted : ResponseMessage
         {
-            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
             public readonly UserDataHttpFormated[] Data;
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
 
             public AllUserDetailsResultHttpFormatted(AllUserDetailsResult msg, Func<string, string> makeAbsoluteUrl) :
                 base(msg.Success, msg.Error)


### PR DESCRIPTION
This fixes compiler errors on Darwin.

On Mono 0.12.0 on CentOS, it still doesn't compile:

```
/home/builder/EventStore/src/EventStore.Core/EventStore.Core.csproj (default targets) ->
/usr/lib/mono/4.5/Microsoft.CSharp.targets (CoreCompile target) ->

	ClusterVNode.cs(159,118): error CS1525: Unexpected symbol `2'
```

I will try Mono 0.12.1 and it will surely work then, as that is what I have on OS X.