### PR TITLE
add expiring of messages to reads (can be improved)

### DIFF
--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -81,6 +81,8 @@ namespace EventStore.Core.Messages
 
             public readonly IPrincipal User;
 
+            public DateTime Expires = DateTime.Now.AddSeconds(10);
+
             protected ReadRequestMessage(Guid internalCorrId, Guid correlationId, IEnvelope envelope, IPrincipal user)
             {
                 Ensure.NotEmptyGuid(internalCorrId, "internalCorrId");

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -44,11 +44,13 @@ namespace EventStore.Core.Services.Storage
 
         void IHandle<ClientMessage.ReadEvent>.Handle(ClientMessage.ReadEvent msg)
         {
+            if (msg.Expires < DateTime.Now) return;
             msg.Envelope.ReplyWith(ReadEvent(msg));
         }
 
         void IHandle<ClientMessage.ReadStreamEventsForward>.Handle(ClientMessage.ReadStreamEventsForward msg)
         {
+            if (msg.Expires < DateTime.Now) return;
             using (HistogramService.Measure(_readerStreamRangeHistogram))
             {
                 var res = ReadStreamEventsForward(msg);
@@ -81,11 +83,13 @@ namespace EventStore.Core.Services.Storage
 
         void IHandle<ClientMessage.ReadStreamEventsBackward>.Handle(ClientMessage.ReadStreamEventsBackward msg)
         {
+            if (msg.Expires < DateTime.Now) return;
             msg.Envelope.ReplyWith(ReadStreamEventsBackward(msg));
         }
 
         void IHandle<ClientMessage.ReadAllEventsForward>.Handle(ClientMessage.ReadAllEventsForward msg)
         {
+            if (msg.Expires < DateTime.Now) return;
             using (HistogramService.Measure(_readerAllRangeHistogram))
             {
                 var res = ReadAllEventsForward(msg);
@@ -124,11 +128,13 @@ namespace EventStore.Core.Services.Storage
 
         void IHandle<ClientMessage.ReadAllEventsBackward>.Handle(ClientMessage.ReadAllEventsBackward msg)
         {
+            if (msg.Expires < DateTime.Now) return;
             msg.Envelope.ReplyWith(ReadAllEventsBackward(msg));
         }
 
         void IHandle<StorageMessage.CheckStreamAccess>.Handle(StorageMessage.CheckStreamAccess msg)
         {
+            if (msg.Expires < DateTime.Now) return;
             msg.Envelope.ReplyWith(CheckStreamAccess(msg));
         }
 


### PR DESCRIPTION
Limits the reader workers in situations where storage may get very very slow (such as remote storage taking 1 minute/read)