### PR TITLE
Specify some linux build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Unfortunately Visual Studio runs these scripts in 32-bit PowerShell. Since it’
 
 - Git on `PATH`
 - Mono version 3.2.3 or greater on `PATH`
+  - Including ` mono-xbuild` and `mono-devel`
 - SVN on `PATH`
 - GCC installed
 


### PR DESCRIPTION
I had mono available on my path (via `mono-runtime` package, but got cryptic error messages until I also installed `mono-devel` and `mono-xbuild`.