### PR TITLE
Fix race condition in EventStorePersistentSubscription

### DIFF
--- a/src/EventStore.ClientAPI/Common/Utils/Threading/ManualResetEventSlimExtensions.cs
+++ b/src/EventStore.ClientAPI/Common/Utils/Threading/ManualResetEventSlimExtensions.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.ClientAPI.Common.Utils.Threading
+{
+    internal static class ManualResetEventSlimExtensions
+    {
+        public static Task AsTask(this ManualResetEventSlim resetEvent)
+        {
+            return AsTask(resetEvent, Timeout.Infinite);
+        }
+
+        public static Task AsTask(this ManualResetEventSlim resetEvent, int timeoutMs)
+        {
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+
+            RegisteredWaitHandle registration = ThreadPool.RegisterWaitForSingleObject(resetEvent.WaitHandle, (state, timedOut) =>
+            {
+                if (timedOut)
+                {
+                    tcs.SetCanceled();
+                }
+                else
+                {
+                    tcs.SetResult(null);
+                }
+            }, null, timeoutMs, true);
+
+            tcs.Task.ContinueWith(_ => registration.Unregister(null));
+
+            return tcs.Task;
+        }
+    }
+}

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -52,6 +52,7 @@
   <ItemGroup>
     <Compile Include="AllCheckpoint.cs" />
     <Compile Include="AllEventsSlice.cs" />
+    <Compile Include="Common\Utils\Threading\ManualResetEventSlimExtensions.cs" />
     <Compile Include="ConnectionString.cs" />
     <Compile Include="Internal\IPEndPointExtensions.cs" />
     <Compile Include="UserManagement\RelLink.cs" />


### PR DESCRIPTION
Queue processing (ProcessQueue) may be triggered before _subscription has been set i.e. ProcessQueue may be called whilst _subscription is still null. The fix delays queue processing until _subscription has been set and tries to do this in a way that does not add performance overhead to the normal path (i.e. _subscription has been set). If the subscription has not been initialized, the first attempt to process the queue will result in a single callback being registered to start processing the queue without any blocking.