### PR TITLE
Fix deadlock from PersistentSubscription lock and RequestResponseDispatcher lock

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -282,6 +282,7 @@
     <Compile Include="Infrastructure\IRandTestFinishCondition.cs" />
     <Compile Include="Infrastructure\IRandTestItemProcessor.cs" />
     <Compile Include="Infrastructure\RandomTestRunner.cs" />
+    <Compile Include="Messaging\RequestResponseDispatcherTests.cs" />
     <Compile Include="Services\ElectionsService\ClusterSettings.cs" />
     <Compile Include="Services\ElectionsService\ClusterSettingsFactory.cs" />
     <Compile Include="Services\ElectionsService\ElectionServiceUnit.cs" />

--- a/src/EventStore.Core.Tests/Messaging/RequestResponseDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Messaging/RequestResponseDispatcherTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Messaging
+{
+
+    [TestFixture]
+    public class RequestResponseDispatcherTests
+    {
+        [Test]
+        public void lock_is_not_held_when_calling_unknown_callbacks()
+        {
+            var requestResponseDispatcher = new RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted>(
+                new FakePublisher(), _ => _.CorrelationId, _ => _.CorrelationId, new FakeEnvelope());
+            object aSecondLock = new object();
+
+            //Control flow events to simulate race condition
+            var lock1EnteredEvent = new ManualResetEventSlim();
+            var lock2EnteredEvent = new ManualResetEventSlim();
+
+            var request1 = new ClientMessage.WriteEvents(Guid.NewGuid(), Guid.NewGuid(), new FakeEnvelope(), false, "stream", 0, new Event[0], null);
+            var response1 = new ClientMessage.WriteEventsCompleted(request1.CorrelationId, OperationResult.AccessDenied, "Test");
+            var request2 = new ClientMessage.WriteEvents(Guid.NewGuid(), Guid.NewGuid(), new FakeEnvelope(), false, "stream", 0, new Event[0], null);
+
+            //Set up callback for first request.
+            requestResponseDispatcher.Publish(request1, _ =>
+            {
+                lock2EnteredEvent.Set();
+
+                lock (aSecondLock)
+                {
+
+                }
+            });
+
+            var theRequest1Handler = Task.Factory.StartNew(() =>
+            {
+                lock1EnteredEvent.Wait();
+                requestResponseDispatcher.Handle(response1);
+            });
+
+            var theRequest2Publisher = Task.Factory.StartNew(() =>
+            {
+                lock (aSecondLock)
+                {
+                    lock1EnteredEvent.Set();
+                    lock2EnteredEvent.Wait();
+
+                    requestResponseDispatcher.Publish(request2, _ => { });
+                }
+            });
+
+            Assert.IsTrue(Task.WaitAll(new[] { theRequest1Handler, theRequest2Publisher }, TimeSpan.FromSeconds(5)));
+        }
+    }
+}


### PR DESCRIPTION
This can occur if a persistent subscription client message comes in whilst a read is made via the IODispatcher (which uses the RequestResponseDispatcher). A lock in PersistentSubscription and RequestResponseDispatcher are taken in different orders resulting in deadlock.

For the fix I have moved the handler callback to outside the lock. The handler is unknown code so calling inside the lock is dangerous. I can't see a reason it needs to be locked.

No tests sorry as it's a race condition scenario.