### PR TITLE
Consumer Strategy

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -429,6 +429,7 @@ namespace EventStore.ClientAPI.Embedded
 
             var corrId = Guid.NewGuid();
 
+
             _publisher.PublishWithAuthentication(_authenticationProvider, credentials, source.SetException, user => new ClientMessage.CreatePersistentSubscription(
                 corrId, 
                 corrId,
@@ -443,11 +444,11 @@ namespace EventStore.ClientAPI.Embedded
                 settings.HistoryBufferSize,
                 settings.LiveBufferSize,
                 settings.ReadBatchSize,
-                settings.PreferRoundRobin,
                 (int)settings.CheckPointAfter.TotalMilliseconds,
                 settings.MinCheckPointCount,
                 settings.MaxCheckPointCount,
                 settings.MaxSubscriberCount,
+                settings.NamedConsumerStrategy,
                 user,
                 credentials == null ? null : credentials.Username,
                 credentials == null ? null : credentials.Password));
@@ -481,11 +482,11 @@ namespace EventStore.ClientAPI.Embedded
                 settings.HistoryBufferSize,
                 settings.LiveBufferSize,
                 settings.ReadBatchSize,
-                settings.PreferRoundRobin,
                 (int) settings.CheckPointAfter.TotalMilliseconds,
                 settings.MinCheckPointCount,
                 settings.MaxCheckPointCount,
                 settings.MaxSubscriberCount,
+                settings.NamedConsumerStrategy,
                 user,
                 credentials == null ? null : credentials.Username,
                 credentials == null ? null : credentials.Password));

--- a/src/EventStore.ClientAPI/ClientOperations/CreatePersistentSubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/CreatePersistentSubscriptionOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using EventStore.ClientAPI.Common;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.Internal;
@@ -20,11 +21,11 @@ namespace EventStore.ClientAPI.ClientOperations
         private readonly int _liveBufferSize;
         private readonly int _readBatchSize;
         private readonly int _bufferSize;
-        private readonly bool _preferRoundRobin;
         private readonly int _checkPointAfter;
         private readonly int _minCheckPointCount;
         private readonly int _maxCheckPointCount;
         private readonly int _maxSubscriberCount;
+        private readonly string _namedConsumerStrategy;
 
         public CreatePersistentSubscriptionOperation(ILogger log,
                                        TaskCompletionSource<PersistentSubscriptionCreateResult> source,
@@ -44,19 +45,19 @@ namespace EventStore.ClientAPI.ClientOperations
             _readBatchSize = settings.ReadBatchSize;
             _bufferSize = settings.HistoryBufferSize;
             _recordStatistics = settings.ExtraStatistics;
-            _preferRoundRobin = settings.PreferRoundRobin;
             _messageTimeoutMilliseconds = (int) settings.MessageTimeout.TotalMilliseconds;
             _checkPointAfter = (int) settings.CheckPointAfter.TotalMilliseconds;
             _minCheckPointCount = settings.MinCheckPointCount;
             _maxCheckPointCount = settings.MaxCheckPointCount;
             _maxSubscriberCount = settings.MaxSubscriberCount;
+            _namedConsumerStrategy = settings.NamedConsumerStrategy;
         }
 
         protected override object CreateRequestDto()
         {
             return new ClientMessage.CreatePersistentSubscription(_groupName, _stream, _resolveLinkTos, _startFromBeginning, _messageTimeoutMilliseconds,
-                                    _recordStatistics, _liveBufferSize, _readBatchSize, _bufferSize, _maxRetryCount, _preferRoundRobin, _checkPointAfter,
-                                    _maxCheckPointCount, _minCheckPointCount, _maxSubscriberCount);
+                                    _recordStatistics, _liveBufferSize, _readBatchSize, _bufferSize, _maxRetryCount, _namedConsumerStrategy == SystemConsumerStrategies.RoundRobin, _checkPointAfter,
+                                    _maxCheckPointCount, _minCheckPointCount, _maxSubscriberCount, _namedConsumerStrategy);
         }
 
         protected override InspectionResult InspectResponse(ClientMessage.CreatePersistentSubscriptionCompleted response)

--- a/src/EventStore.ClientAPI/ClientOperations/UpdatePersistentSubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/UpdatePersistentSubscriptionOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using EventStore.ClientAPI.Common;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.Internal;
@@ -20,10 +21,11 @@ namespace EventStore.ClientAPI.ClientOperations
         private readonly int _liveBufferSize;
         private readonly int _readBatchSize;
         private readonly int _bufferSize;
-        private readonly bool _preferRoundRobin;
         private readonly int _checkPointAfter;
         private readonly int _minCheckPointCount;
         private readonly int _maxCheckPointCount;
+        private readonly string _namedConsumerStrategy;
+        private readonly int _maxSubscriberCount;
 
         public UpdatePersistentSubscriptionOperation(ILogger log,
             TaskCompletionSource<PersistentSubscriptionUpdateResult> source,
@@ -43,18 +45,19 @@ namespace EventStore.ClientAPI.ClientOperations
             _readBatchSize = settings.ReadBatchSize;
             _bufferSize = settings.HistoryBufferSize;
             _recordStatistics = settings.ExtraStatistics;
-            _preferRoundRobin = settings.PreferRoundRobin;
             _messageTimeoutMilliseconds = (int)settings.MessageTimeout.TotalMilliseconds;
             _checkPointAfter = (int)settings.CheckPointAfter.TotalMilliseconds;
             _minCheckPointCount = settings.MinCheckPointCount;
             _maxCheckPointCount = settings.MaxCheckPointCount;
+            _maxSubscriberCount = settings.MaxSubscriberCount;
+            _namedConsumerStrategy = settings.NamedConsumerStrategy;
         }
 
         protected override object CreateRequestDto()
         {
             return new ClientMessage.UpdatePersistentSubscription(_groupName, _stream, _resolveLinkTos, _startFromBeginning, _messageTimeoutMilliseconds,
-                _recordStatistics, _liveBufferSize, _readBatchSize, _bufferSize, _maxRetryCount, _preferRoundRobin, _checkPointAfter,
-                _maxCheckPointCount, _minCheckPointCount);
+                _recordStatistics, _liveBufferSize, _readBatchSize, _bufferSize, _maxRetryCount, _namedConsumerStrategy == SystemConsumerStrategies.RoundRobin, _checkPointAfter,
+                _maxCheckPointCount, _minCheckPointCount, _maxSubscriberCount, _namedConsumerStrategy);
         }
 
         protected override InspectionResult InspectResponse(ClientMessage.UpdatePersistentSubscriptionCompleted response)

--- a/src/EventStore.ClientAPI/Common/SystemNames.cs
+++ b/src/EventStore.ClientAPI/Common/SystemNames.cs
@@ -124,4 +124,21 @@
         ///</summary>
         public const string Settings = "$settings";
     }
+
+    /// <summary>
+    /// System supported consumer strategies for use with persistent subscriptions.
+    /// </summary>
+    public static class SystemConsumerStrategies
+    {
+        /// <summary>
+        /// Distributes events to a single client until it is full. Then round robin to the next client.
+        /// </summary>
+        public const string DispatchToSingle = "DispatchToSingle";
+
+        /// <summary>
+        /// Distribute events to each client in a round robin fashion.
+        /// </summary>
+        public const string RoundRobin = "RoundRobin";
+    }
+
 }

--- a/src/EventStore.ClientAPI/Messages/ClientMessage.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessage.cs
@@ -692,13 +692,16 @@ namespace EventStore.ClientAPI.Messages
   
     [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int CheckpointMinCount;
-
-    [ProtoMember(15, IsRequired = true, Name = @"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+  
+    [ProtoMember(15, IsRequired = true, Name=@"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int SubscriberMaxCount;
+  
+    [ProtoMember(16, IsRequired = false, Name=@"named_consumer_strategy", DataFormat = DataFormat.Default)]
+    public readonly string NamedConsumerStrategy;
   
     private CreatePersistentSubscription() {}
   
-    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount)
+    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount, string namedConsumerStrategy)
     {
         SubscriptionGroupName = subscriptionGroupName;
         EventStreamId = eventStreamId;
@@ -715,6 +718,7 @@ namespace EventStore.ClientAPI.Messages
         CheckpointMaxCount = checkpointMaxCount;
         CheckpointMinCount = checkpointMinCount;
         SubscriberMaxCount = subscriberMaxCount;
+        NamedConsumerStrategy = namedConsumerStrategy;
     }
   }
   
@@ -781,9 +785,15 @@ namespace EventStore.ClientAPI.Messages
     [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int CheckpointMinCount;
   
+    [ProtoMember(15, IsRequired = true, Name=@"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int SubscriberMaxCount;
+  
+    [ProtoMember(16, IsRequired = false, Name=@"named_consumer_strategy", DataFormat = DataFormat.Default)]
+    public readonly string NamedConsumerStrategy;
+  
     private UpdatePersistentSubscription() {}
   
-    public UpdatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount)
+    public UpdatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount, string namedConsumerStrategy)
     {
         SubscriptionGroupName = subscriptionGroupName;
         EventStreamId = eventStreamId;
@@ -799,6 +809,8 @@ namespace EventStore.ClientAPI.Messages
         CheckpointAfterTime = checkpointAfterTime;
         CheckpointMaxCount = checkpointMaxCount;
         CheckpointMinCount = checkpointMinCount;
+        SubscriberMaxCount = subscriberMaxCount;
+        NamedConsumerStrategy = namedConsumerStrategy;
     }
   }
   
@@ -1108,8 +1120,8 @@ namespace EventStore.ClientAPI.Messages
             
       [ProtoEnum(Name=@"PersistentSubscriptionDeleted", Value=3)]
       PersistentSubscriptionDeleted = 3,
-
-      [ProtoEnum(Name = @"SubscriberMaxCountReached", Value=4)]
+            
+      [ProtoEnum(Name=@"SubscriberMaxCountReached", Value=4)]
       SubscriberMaxCountReached = 4
     }
   

--- a/src/EventStore.ClientAPI/PersistentSubscriptionSettings.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using EventStore.ClientAPI.Common;
 
 namespace EventStore.ClientAPI
 {
@@ -22,11 +23,11 @@ namespace EventStore.ClientAPI
                                                              500,
                                                              10,
                                                              20,
-                                                             true,
                                                              TimeSpan.FromSeconds(2),
                                                              10,
                                                              1000,
-                                                             0);
+                                                             0,
+                                                             SystemConsumerStrategies.RoundRobin);
         }
 
 
@@ -71,12 +72,6 @@ namespace EventStore.ClientAPI
         public int HistoryBufferSize;
 
         /// <summary>
-        /// Whether the subscription should prefer round robin between clients of
-        /// sending to a single client if possible.
-        /// </summary>
-        public bool PreferRoundRobin;
-
-        /// <summary>
         /// The amount of time to try to checkpoint after 
         /// </summary>
         public readonly TimeSpan CheckPointAfter;
@@ -97,12 +92,17 @@ namespace EventStore.ClientAPI
         public readonly int MaxSubscriberCount;
 
         /// <summary>
+        /// The strategy to use for distributing events to client consumers. See <see cref="SystemConsumerStrategies"/> for system supported strategies.
+        /// </summary>
+        public string NamedConsumerStrategy;
+
+        /// <summary>
         /// Constructs a new <see cref="PersistentSubscriptionSettings"></see>
         /// </summary>
         internal PersistentSubscriptionSettings(bool resolveLinkTos, int startFrom, bool extraStatistics, TimeSpan messageTimeout,
                                                 int maxRetryCount, int liveBufferSize, int readBatchSize, int historyBufferSize,
-                                                bool preferRoundRobin, TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount, 
-                                                int maxSubscriberCount)
+                                                TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount, 
+                                                int maxSubscriberCount, string namedConsumerStrategy)
         {
             MessageTimeout = messageTimeout;
             ResolveLinkTos = resolveLinkTos;
@@ -112,11 +112,11 @@ namespace EventStore.ClientAPI
             LiveBufferSize = liveBufferSize;
             ReadBatchSize = readBatchSize;
             HistoryBufferSize = historyBufferSize;
-            PreferRoundRobin = preferRoundRobin;
             CheckPointAfter = checkPointAfter;
             MinCheckPointCount = minCheckPointCount;
             MaxCheckPointCount = maxCheckPointCount;
             MaxSubscriberCount = maxSubscriberCount;
+            NamedConsumerStrategy = namedConsumerStrategy;
         }
 
     }

--- a/src/EventStore.ClientAPI/PersistentSubscriptionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionSettingsBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using EventStore.ClientAPI.Common;
 using EventStore.ClientAPI.Common.Utils;
 
 namespace EventStore.ClientAPI
@@ -15,17 +16,17 @@ namespace EventStore.ClientAPI
         private int _readBatchSize;
         private int _maxRetryCount;
         private int _liveBufferSize;
-        private bool _preferRoundRobin;
         private int _bufferSize;
         private TimeSpan _checkPointAfter;
         private int _minCheckPointCount;
         private int _maxCheckPointCount;
         private int _maxSubscriberCount;
+        private string _namedConsumerStrategies;
 
         internal PersistentSubscriptionSettingsBuilder(bool resolveLinkTos, int startFrom, bool timingStatistics, TimeSpan timeout,
-                                                      int bufferSize, int liveBufferSize, int maxRetryCount, int readBatchSize, 
-                                                      bool preferRoundRobin, TimeSpan checkPointAfter, int minCheckPointCount,
-                                                      int maxCheckPointCount, int maxSubscriberCount)
+                                                      int bufferSize, int liveBufferSize, int maxRetryCount, int readBatchSize,
+                                                      TimeSpan checkPointAfter, int minCheckPointCount,
+                                                      int maxCheckPointCount, int maxSubscriberCount, string namedConsumerStrategies)
         {
             _resolveLinkTos = resolveLinkTos;
             _startFrom = startFrom;
@@ -35,11 +36,11 @@ namespace EventStore.ClientAPI
             _liveBufferSize = liveBufferSize;
             _maxRetryCount = maxRetryCount;
             _readBatchSize = readBatchSize;
-            _preferRoundRobin = preferRoundRobin;
             _checkPointAfter = checkPointAfter;
             _minCheckPointCount = minCheckPointCount;
             _maxCheckPointCount = maxCheckPointCount;
             _maxSubscriberCount = maxSubscriberCount;
+            _namedConsumerStrategies = namedConsumerStrategies;
         }
 
 
@@ -81,7 +82,7 @@ namespace EventStore.ClientAPI
         /// <returns>A new <see cref="PersistentSubscriptionSettingsBuilder"></see></returns>
         public PersistentSubscriptionSettingsBuilder PreferRoundRobin()
         {
-            _preferRoundRobin = true;
+            _namedConsumerStrategies = SystemConsumerStrategies.RoundRobin;
             return this;
         }
 
@@ -93,7 +94,7 @@ namespace EventStore.ClientAPI
         /// <returns>A new <see cref="PersistentSubscriptionSettingsBuilder"></see></returns>
         public PersistentSubscriptionSettingsBuilder PreferDispatchToSingle()
         {
-            _preferRoundRobin = false;
+            _namedConsumerStrategies = SystemConsumerStrategies.DispatchToSingle;
             return this;
         }
 
@@ -267,6 +268,18 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
+        /// Sets the consumer strategy for distributing event to clients. See <see cref="SystemConsumerStrategies"/> for system supported strategies.
+        /// </summary>
+        /// <returns>A new <see cref="PersistentSubscriptionSettingsBuilder"></see></returns>
+        public PersistentSubscriptionSettingsBuilder WithNamedConsumerStrategy(string namedConsumerStrategy)
+        {
+            Ensure.NotNullOrEmpty(namedConsumerStrategy, "namedConsumerStrategy");
+            _namedConsumerStrategies = namedConsumerStrategy;
+            return this;
+        }
+
+
+        /// <summary>
         /// Builds a <see cref="PersistentSubscriptionSettings"/> object from a <see cref="PersistentSubscriptionSettingsBuilder"/>.
         /// </summary>
         /// <param name="builder"><see cref="PersistentSubscriptionSettingsBuilder"/> from which to build a <see cref="PersistentSubscriptionSettingsBuilder"/></param>
@@ -290,11 +303,11 @@ namespace EventStore.ClientAPI
                 _liveBufferSize,
                 _readBatchSize,
                 _bufferSize,
-                _preferRoundRobin,
                 _checkPointAfter,
                 _minCheckPointCount,
                 _maxCheckPointCount,
-                _maxSubscriberCount);
+                _maxSubscriberCount,
+                _namedConsumerStrategies);
         }
     }
 }

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -182,6 +182,7 @@
     <Compile Include="Services\Gossip\LoopbackDns.cs" />
     <Compile Include="Services\Gossip\NodeGossipService.cs" />
     <Compile Include="Services\Histograms\HistogramService.cs" />
+    <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategy.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointReader.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointWriter.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionMessageParker.cs" />
@@ -195,6 +196,7 @@
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionClient.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionClientCollection.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionConfig.cs" />
+    <Compile Include="Services\PersistentSubscription\PersistentSubscriptionConsumerStrategyRegistry.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionMessageParker.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionParams.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionParamsBuilder.cs" />

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -868,7 +868,6 @@ namespace EventStore.Core.Messages
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
             public override int MsgTypeId { get { return TypeId; } }
-            public bool PreferRoundRobin { get; set; }
 
             public readonly int StartFrom;
             public readonly int MessageTimeoutMilliseconds;
@@ -883,6 +882,7 @@ namespace EventStore.Core.Messages
             public readonly string GroupName;
             public readonly string EventStreamId;
             public int MaxSubscriberCount;
+            public string NamedConsumerStrategy;
             public int MaxCheckPointCount;
             public int MinCheckPointCount;
             public int CheckPointAfterMilliseconds;
@@ -890,8 +890,9 @@ namespace EventStore.Core.Messages
             public CreatePersistentSubscription(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
                 string eventStreamId, string groupName, bool resolveLinkTos, int startFrom,
                 int messageTimeoutMilliseconds, bool recordStatistics, int maxRetryCount, int bufferSize,
-                int liveBufferSize, int readbatchSize, bool preferRoundRobin,
-                int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount, int maxSubscriberCount,
+                int liveBufferSize, int readbatchSize,
+                int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount,
+                int maxSubscriberCount, string namedConsumerStrategy,
                 IPrincipal user, string username, string password)
                 : base(internalCorrId, correlationId, envelope, user)
             {
@@ -905,11 +906,11 @@ namespace EventStore.Core.Messages
                 BufferSize = bufferSize;
                 LiveBufferSize = liveBufferSize;
                 ReadBatchSize = readbatchSize;
-                PreferRoundRobin = preferRoundRobin;
                 MaxCheckPointCount = maxCheckPointCount;
                 MinCheckPointCount = minCheckPointCount;
                 CheckPointAfterMilliseconds = checkPointAfterMilliseconds;
                 MaxSubscriberCount = maxSubscriberCount;
+                NamedConsumerStrategy = namedConsumerStrategy;
             }
 
         }
@@ -943,7 +944,6 @@ namespace EventStore.Core.Messages
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
             public override int MsgTypeId { get { return TypeId; } }
-            public bool PreferRoundRobin { get; set; }
 
             public readonly int StartFrom;
             public readonly int MessageTimeoutMilliseconds;
@@ -958,15 +958,18 @@ namespace EventStore.Core.Messages
             public readonly string GroupName;
             public readonly string EventStreamId;
             public int MaxSubscriberCount;
+            
             public int MaxCheckPointCount;
             public int MinCheckPointCount;
             public int CheckPointAfterMilliseconds;
+            public string NamedConsumerStrategy;
 
             public UpdatePersistentSubscription(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
                 string eventStreamId, string groupName, bool resolveLinkTos, int startFrom,
                 int messageTimeoutMilliseconds, bool recordStatistics, int maxRetryCount, int bufferSize,
-                int liveBufferSize, int readbatchSize, bool preferRoundRobin,
-                int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount, int maxSubscriberCount,
+                int liveBufferSize, int readbatchSize,
+                int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount,
+                int maxSubscriberCount, string namedConsumerStrategy,
                 IPrincipal user, string username, string password)
                 : base(internalCorrId, correlationId, envelope, user)
             {
@@ -980,11 +983,11 @@ namespace EventStore.Core.Messages
                 BufferSize = bufferSize;
                 LiveBufferSize = liveBufferSize;
                 ReadBatchSize = readbatchSize;
-                PreferRoundRobin = preferRoundRobin;
                 MaxCheckPointCount = maxCheckPointCount;
                 MinCheckPointCount = minCheckPointCount;
                 CheckPointAfterMilliseconds = checkPointAfterMilliseconds;
                 MaxSubscriberCount = maxSubscriberCount;
+                NamedConsumerStrategy = namedConsumerStrategy;
             }
 
         }

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -104,7 +104,6 @@ namespace EventStore.Core.Messages
             public int LiveBufferSize { get; set; }
             public int BufferSize { get; set; }
             public int ReadBatchSize { get; set; }
-            public bool PreferRoundRobin { get; set; }
             public int CheckPointAfterMilliseconds { get; set; }
             public int MinCheckPointCount { get; set; }
             public int MaxCheckPointCount { get; set; }
@@ -112,6 +111,7 @@ namespace EventStore.Core.Messages
             public int LiveBufferCount { get; set; }
             public int RetryBufferCount { get; set; }
             public int TotalInFlightMessages { get; set; }
+            public string NamedConsumerStrategy { get; set; }
         }
 
         public class ConnectionInfo

--- a/src/EventStore.Core/Messages/TcpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDto.cs
@@ -692,13 +692,16 @@ namespace EventStore.Core.Messages
   
     [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int CheckpointMinCount;
-
-    [ProtoMember(15, IsRequired = true, Name = @"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+  
+    [ProtoMember(15, IsRequired = true, Name=@"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int SubscriberMaxCount;
+  
+    [ProtoMember(16, IsRequired = false, Name=@"named_consumer_strategy", DataFormat = DataFormat.Default)]
+    public readonly string NamedConsumerStrategy;
   
     private CreatePersistentSubscription() {}
   
-    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount)
+    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount, string namedConsumerStrategy)
     {
         SubscriptionGroupName = subscriptionGroupName;
         EventStreamId = eventStreamId;
@@ -715,6 +718,7 @@ namespace EventStore.Core.Messages
         CheckpointMaxCount = checkpointMaxCount;
         CheckpointMinCount = checkpointMinCount;
         SubscriberMaxCount = subscriberMaxCount;
+        NamedConsumerStrategy = namedConsumerStrategy;
     }
   }
   
@@ -780,13 +784,16 @@ namespace EventStore.Core.Messages
   
     [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int CheckpointMinCount;
-
-    [ProtoMember(15, IsRequired = true, Name = @"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+  
+    [ProtoMember(15, IsRequired = true, Name=@"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
     public readonly int SubscriberMaxCount;
+  
+    [ProtoMember(16, IsRequired = false, Name=@"named_consumer_strategy", DataFormat = DataFormat.Default)]
+    public readonly string NamedConsumerStrategy;
   
     private UpdatePersistentSubscription() {}
   
-    public UpdatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount)
+    public UpdatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, int startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount, string namedConsumerStrategy)
     {
         SubscriptionGroupName = subscriptionGroupName;
         EventStreamId = eventStreamId;
@@ -803,6 +810,7 @@ namespace EventStore.Core.Messages
         CheckpointMaxCount = checkpointMaxCount;
         CheckpointMinCount = checkpointMinCount;
         SubscriberMaxCount = subscriberMaxCount;
+        NamedConsumerStrategy = namedConsumerStrategy;
     }
   }
   
@@ -1112,8 +1120,8 @@ namespace EventStore.Core.Messages
             
       [ProtoEnum(Name=@"PersistentSubscriptionDeleted", Value=3)]
       PersistentSubscriptionDeleted = 3,
-
-      [ProtoEnum(Name = @"SubscriberMaxCountReached", Value = 4)]
+            
+      [ProtoEnum(Name=@"SubscriberMaxCountReached", Value=4)]
       SubscriberMaxCountReached = 4
     }
   

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategy.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Services.PersistentSubscription
+{
+    public enum ConsumerPushResult
+    {
+        Sent,
+        NoMoreCapacity
+    }
+
+    public interface IPersistentSubscriptionConsumerStrategy
+    {
+        string Name { get; }
+
+        void ClientAdded(PersistentSubscriptionClient client);
+
+        void ClientRemoved(PersistentSubscriptionClient client);
+
+        ConsumerPushResult PushMessageToClient(ResolvedEvent ev);
+    }
+
+    class DispatchToSinglePersistentSubscriptionConsumerStrategy : RoundRobinPersistentSubscriptionConsumerStrategy
+    {
+        public override string Name
+        {
+            get { return SystemConsumerStrategies.DispatchToSingle; }
+        }
+
+        public override ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        {
+            for (int i = 0; i < Clients.Count; i++)
+            {
+                if(CurrentClient.Push(ev))
+                {
+                    return ConsumerPushResult.Sent;
+                }
+                else
+                {
+                    MoveToNextClient();
+                }
+            }
+
+            return ConsumerPushResult.NoMoreCapacity;
+        }
+    }
+
+    class RoundRobinPersistentSubscriptionConsumerStrategy : IPersistentSubscriptionConsumerStrategy
+    {
+        protected readonly IList<PersistentSubscriptionClient> Clients = new List<PersistentSubscriptionClient>();
+        private int _currentClientIndex;
+
+        public virtual string Name
+        {
+            get { return SystemConsumerStrategies.RoundRobin; }
+        }
+
+        public PersistentSubscriptionClient CurrentClient
+        {
+            get { return Clients[_currentClientIndex]; }
+        }
+
+        public void ClientAdded(PersistentSubscriptionClient client)
+        {
+            Clients.Add(client);
+        }
+
+        public void ClientRemoved(PersistentSubscriptionClient client)
+        {
+            int indexOf = Clients.IndexOf(client);
+            if (indexOf == -1)
+            {
+                throw new InvalidOperationException("Only added clients can be removed.");
+            }
+
+            Clients.RemoveAt(indexOf);
+            if (_currentClientIndex > indexOf)
+            {
+                _currentClientIndex--;
+            }
+
+            if (_currentClientIndex >= Clients.Count)
+            {
+                _currentClientIndex = 0;
+            }
+        }
+
+        public virtual ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        {
+            for (int i = 0; i < Clients.Count; i++)
+            {
+                bool pushed = Clients[_currentClientIndex].Push(ev);
+
+                MoveToNextClient();
+
+                if (pushed)
+                {
+                    return ConsumerPushResult.Sent;
+                }
+            }
+
+            return ConsumerPushResult.NoMoreCapacity;
+        }
+
+        protected void MoveToNextClient()
+        {
+            _currentClientIndex = (_currentClientIndex + 1) % Clients.Count;
+        }
+    }
+
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -73,7 +73,8 @@ namespace EventStore.Core.Services.PersistentSubscription
             _lastCheckPoint = -1;
             _statistics.SetLastKnownEventNumber(-1);
             _settings.CheckpointReader.BeginLoadState(SubscriptionId, OnCheckpointLoaded);
-            _pushClients = new PersistentSubscriptionClientCollection(_settings.PreferRoundRobin);
+
+            _pushClients = new PersistentSubscriptionClientCollection(_settings.NamedConsumerStrategy);
         }
 
         private void OnCheckpointLoaded(int? checkpoint)

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -74,7 +74,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             _statistics.SetLastKnownEventNumber(-1);
             _settings.CheckpointReader.BeginLoadState(SubscriptionId, OnCheckpointLoaded);
 
-            _pushClients = new PersistentSubscriptionClientCollection(_settings.NamedConsumerStrategy);
+            _pushClients = new PersistentSubscriptionClientCollection(_settings.ConsumerStrategy);
         }
 
         private void OnCheckpointLoaded(int? checkpoint)
@@ -168,11 +168,12 @@ namespace EventStore.Core.Services.PersistentSubscription
             lock (_lock)
             {
                 if (_state == PersistentSubscriptionState.NotReady) return;
+
                 while (true)
                 {
                     OutstandingMessage message;
                     if (!_streamBuffer.TryPeek(out message)) return;
-                    if (!_pushClients.PushMessageToClient(message.ResolvedEvent)) return;
+                    if (_pushClients.PushMessageToClient(message.ResolvedEvent) == ConsumerPushResult.NoMoreCapacity) return;
                     if (!_streamBuffer.TryDequeue(out message))
                     {
                         throw new WTFException(
@@ -182,6 +183,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                         _lastKnownMessage = message.ResolvedEvent.OriginalEventNumber;
                     MarkBeginProcessing(message);
                 }
+                
             }
         }
 
@@ -377,7 +379,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 lock (_lock)
                 {
                     _outstandingMessages.Remove(e.OriginalEvent.EventId);
-                    _pushClients.RemoveProcessingMessage(e); 
+                    _pushClients.RemoveProcessingMessage(e.OriginalEvent.EventId); 
                     TryPushingMessagesToClients();
                 }
             });
@@ -493,7 +495,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         {
             Log.Debug("Retrying message {0} {1}/{2}", SubscriptionId, @event.OriginalStreamId, @event.OriginalPosition);
             _outstandingMessages.Remove(@event.Event.EventId);
-            _pushClients.RemoveProcessingMessage(@event);
+            _pushClients.RemoveProcessingMessage(@event.Event.EventId);
             _streamBuffer.AddRetry(new OutstandingMessage(@event.OriginalEvent.EventId, null, @event, count + 1));
         }
 
@@ -516,7 +518,8 @@ namespace EventStore.Core.Services.PersistentSubscription
 
     public class WTFException : Exception
     {
-        public WTFException(string message) : base(message)
+        public WTFException(string message)
+            : base(message)
         {
         }
     }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConfig.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConfig.cs
@@ -22,11 +22,34 @@ namespace EventStore.Core.Services.PersistentSubscription
             {
                 var ret = data.ParseJson<PersistentSubscriptionConfig>();
                 if(ret.Version == null) throw new BadConfigDataException("Deserialized but no version present, invalid configuration data.", null);
+
+                UpdateIfRequired(ret);
+
                 return ret;
             }
             catch (Exception ex)
             {
                 throw new BadConfigDataException("The config data appears to be invalid", ex);
+            }
+        }
+
+        private static void UpdateIfRequired(PersistentSubscriptionConfig ret)
+        {
+            if (ret.Version == "1")
+            {
+                if (ret.Entries != null)
+                {
+                    foreach (var persistentSubscriptionEntry in ret.Entries)
+                    {
+                        if (string.IsNullOrEmpty(persistentSubscriptionEntry.NamedConsumerStrategy))
+                        {
+                            persistentSubscriptionEntry.NamedConsumerStrategy = persistentSubscriptionEntry.PreferRoundRobin
+                                ? SystemConsumerStrategies.RoundRobin
+                                : SystemConsumerStrategies.DispatchToSingle;
+                        }
+                    }
+                }
+                ret.Version = "2";
             }
         }
     }
@@ -56,5 +79,6 @@ namespace EventStore.Core.Services.PersistentSubscription
         public int MinCheckPointCount { get; set; }
         public int MaxCheckPointCount { get; set; }
         public int MaxSubscriberCount { get; set; }
+        public string NamedConsumerStrategy { get; set; }
     }
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConsumerStrategyRegistry.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConsumerStrategyRegistry.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+
+namespace EventStore.Core.Services.PersistentSubscription
+{
+    internal class PersistentSubscriptionConsumerStrategyRegistry
+    {
+        private readonly IDictionary<string, Func<IPersistentSubscriptionConsumerStrategy>> _factoryLookup = new Dictionary<string, Func<IPersistentSubscriptionConsumerStrategy>>()
+        {
+            {SystemConsumerStrategies.RoundRobin, () => new RoundRobinPersistentSubscriptionConsumerStrategy()},
+            {SystemConsumerStrategies.DispatchToSingle, () => new DispatchToSinglePersistentSubscriptionConsumerStrategy()}
+        };
+
+        public IPersistentSubscriptionConsumerStrategy GetInstance(string namedConsumerStrategy)
+        {
+            if (!ValidateStrategy(namedConsumerStrategy))
+            {
+                throw new ArgumentException("The named consumer strategy is unknown.", "namedConsumerStrategy");
+            }
+
+            return _factoryLookup[namedConsumerStrategy]();
+        }
+
+        public bool ValidateStrategy(string name)
+        {
+            return _factoryLookup.ContainsKey(name);
+        }
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -15,8 +15,8 @@ namespace EventStore.Core.Services.PersistentSubscription
         private readonly int _minCheckPointCount;
         private readonly int _maxCheckPointCount;
         private readonly int _maxSubscriberCount;
+        private readonly string _namedConsumerStrategy;
 
-        private readonly bool _preferRoundRobin;
         private readonly int _maxRetryCount;
         private readonly int _liveBufferSize;
         private readonly int _bufferSize;
@@ -27,9 +27,10 @@ namespace EventStore.Core.Services.PersistentSubscription
         private IPersistentSubscriptionMessageParker _messageParker;
 
         public PersistentSubscriptionParams(bool resolveLinkTos, string subscriptionId, string eventStreamId, string groupName, 
-                                           int startFrom, bool extraStatistics, TimeSpan messageTimeout, bool preferRoundRobin, 
+                                           int startFrom, bool extraStatistics, TimeSpan messageTimeout, 
                                            int maxRetryCount, int liveBufferSize, int bufferSize, int readBatchSize,
-                                           TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount, int maxSubscriberCount,
+                                           TimeSpan checkPointAfter, int minCheckPointCount,
+                                           int maxCheckPointCount, int maxSubscriberCount, string namedConsumerStrategy,
                                            IPersistentSubscriptionStreamReader streamReader, 
                                            IPersistentSubscriptionCheckpointReader checkpointReader, 
                                            IPersistentSubscriptionCheckpointWriter checkpointWriter,
@@ -42,7 +43,6 @@ namespace EventStore.Core.Services.PersistentSubscription
             _startFrom = startFrom;
             _extraStatistics = extraStatistics;
             _messageTimeout = messageTimeout;
-            _preferRoundRobin = preferRoundRobin;
             _maxRetryCount = maxRetryCount;
             _liveBufferSize = liveBufferSize;
             _bufferSize = bufferSize;
@@ -50,6 +50,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             _minCheckPointCount = minCheckPointCount;
             _maxCheckPointCount = maxCheckPointCount;
             _maxSubscriberCount = maxSubscriberCount;
+            _namedConsumerStrategy = namedConsumerStrategy;
             _readBatchSize = readBatchSize;
             _streamReader = streamReader;
             _checkpointReader = checkpointReader;
@@ -112,11 +113,6 @@ namespace EventStore.Core.Services.PersistentSubscription
             get { return _messageParker; }
         }
 
-        public bool PreferRoundRobin
-        {
-            get { return _preferRoundRobin; }
-        }
-
         public int MaxRetryCount
         {
             get { return _maxRetryCount; }
@@ -155,6 +151,11 @@ namespace EventStore.Core.Services.PersistentSubscription
         public int MaxSubscriberCount
         {
             get { return _maxSubscriberCount; }
+        }
+
+        public string NamedConsumerStrategy
+        {
+            get { return _namedConsumerStrategy; }
         }
 
         public string ParkedMessageStream

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         private readonly int _minCheckPointCount;
         private readonly int _maxCheckPointCount;
         private readonly int _maxSubscriberCount;
-        private readonly string _namedConsumerStrategy;
+        private readonly IPersistentSubscriptionConsumerStrategy _consumerStrategy;
 
         private readonly int _maxRetryCount;
         private readonly int _liveBufferSize;
@@ -30,7 +30,8 @@ namespace EventStore.Core.Services.PersistentSubscription
                                            int startFrom, bool extraStatistics, TimeSpan messageTimeout, 
                                            int maxRetryCount, int liveBufferSize, int bufferSize, int readBatchSize,
                                            TimeSpan checkPointAfter, int minCheckPointCount,
-                                           int maxCheckPointCount, int maxSubscriberCount, string namedConsumerStrategy,
+                                           int maxCheckPointCount, int maxSubscriberCount, 
+                                           IPersistentSubscriptionConsumerStrategy consumerStrategy,
                                            IPersistentSubscriptionStreamReader streamReader, 
                                            IPersistentSubscriptionCheckpointReader checkpointReader, 
                                            IPersistentSubscriptionCheckpointWriter checkpointWriter,
@@ -50,7 +51,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             _minCheckPointCount = minCheckPointCount;
             _maxCheckPointCount = maxCheckPointCount;
             _maxSubscriberCount = maxSubscriberCount;
-            _namedConsumerStrategy = namedConsumerStrategy;
+            _consumerStrategy = consumerStrategy;
             _readBatchSize = readBatchSize;
             _streamReader = streamReader;
             _checkpointReader = checkpointReader;
@@ -153,9 +154,9 @@ namespace EventStore.Core.Services.PersistentSubscription
             get { return _maxSubscriberCount; }
         }
 
-        public string NamedConsumerStrategy
+        public IPersistentSubscriptionConsumerStrategy ConsumerStrategy
         {
-            get { return _namedConsumerStrategy; }
+            get { return _consumerStrategy; }
         }
 
         public string ParkedMessageStream

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -160,17 +160,17 @@ namespace EventStore.Core.Services.PersistentSubscription
                                     message.LiveBufferSize,
                                     message.BufferSize,
                                     message.ReadBatchSize,
-                                    message.PreferRoundRobin,
                                     TimeSpan.FromMilliseconds(message.CheckPointAfterMilliseconds),
                                     message.MinCheckPointCount,
                                     message.MaxCheckPointCount,
                                     message.MaxSubscriberCount,
+                                    message.NamedConsumerStrategy,
                                     TimeSpan.FromMilliseconds(message.MessageTimeoutMilliseconds)
                                     );
             Log.Debug("New persistent subscription {0}.", message.GroupName);
             _config.Updated = DateTime.Now;
             _config.UpdatedBy = message.User.Identity.Name;
-            _config.Entries.Add(new PersistentSubscriptionEntry()
+            _config.Entries.Add(new PersistentSubscriptionEntry
             {
                 Stream=message.EventStreamId, 
                 Group = message.GroupName, 
@@ -183,7 +183,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 MinCheckPointCount = message.MinCheckPointCount,
                 MaxRetryCount = message.MaxRetryCount,
                 MessageTimeout = message.MessageTimeoutMilliseconds,
-                PreferRoundRobin = message.PreferRoundRobin
+                NamedConsumerStrategy =  message.NamedConsumerStrategy
             });            
             SaveConfiguration(() => message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionCompleted(message.CorrelationId,
                 ClientMessage.CreatePersistentSubscriptionCompleted.CreatePersistentSubscriptionResult.Success, "")));
@@ -223,11 +223,11 @@ namespace EventStore.Core.Services.PersistentSubscription
                                     message.LiveBufferSize,
                                     message.BufferSize,
                                     message.ReadBatchSize,
-                                    message.PreferRoundRobin,
                                     TimeSpan.FromMilliseconds(message.CheckPointAfterMilliseconds),
                                     message.MinCheckPointCount,
                                     message.MaxCheckPointCount,
                                     message.MaxSubscriberCount,
+                                    message.NamedConsumerStrategy,
                                     TimeSpan.FromMilliseconds(message.MessageTimeoutMilliseconds)
                                     );
             _config.Updated = DateTime.Now;
@@ -245,7 +245,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 MinCheckPointCount = message.MinCheckPointCount,
                 MaxRetryCount = message.MaxRetryCount,
                 MessageTimeout = message.MessageTimeoutMilliseconds,
-                PreferRoundRobin = message.PreferRoundRobin
+                NamedConsumerStrategy = message.NamedConsumerStrategy
             });
             SaveConfiguration(() => message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionCompleted(message.CorrelationId,
     ClientMessage.UpdatePersistentSubscriptionCompleted.UpdatePersistentSubscriptionResult.Success, "")));
@@ -260,11 +260,11 @@ namespace EventStore.Core.Services.PersistentSubscription
                                              int liveBufferSize,
                                              int historyBufferSize,
                                              int readBatchSize,
-                                             bool preferRoundRobin,
                                              TimeSpan checkPointAfter,
                                              int minCheckPointCount,
                                              int maxCheckPointCount,
                                              int maxSubscriberCount,
+                                             string namedConsumerStrategy,
                                              TimeSpan messageTimeout)
         {
             var key = BuildSubscriptionGroupKey(eventStreamId, groupName);
@@ -284,7 +284,6 @@ namespace EventStore.Core.Services.PersistentSubscription
                     startFrom,
                     extraStatistics,
                     messageTimeout,
-                    preferRoundRobin,
                     maxRetryCount,
                     liveBufferSize,
                     historyBufferSize,
@@ -293,6 +292,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                     minCheckPointCount,
                     maxCheckPointCount,
                     maxSubscriberCount,
+                    namedConsumerStrategy,
                     _streamReader,
                     _checkpointReader,
                     new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),
@@ -575,11 +575,11 @@ namespace EventStore.Core.Services.PersistentSubscription
                                                     entry.LiveBufferSize,
                                                     entry.HistoryBufferSize,
                                                     entry.ReadBatchSize,
-                                                    entry.PreferRoundRobin,
                                                     TimeSpan.FromMilliseconds(entry.CheckPointAfter),
                                                     entry.MinCheckPointCount,
                                                     entry.MaxCheckPointCount,
                                                     entry.MaxSubscriberCount,
+                                                    entry.NamedConsumerStrategy,
                                                     TimeSpan.FromMilliseconds(entry.MessageTimeout)); 
                         }
                         continueWith();
@@ -590,7 +590,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                     }
                     break;
                 case ReadStreamResult.NoStream:
-                    _config = new PersistentSubscriptionConfig {Version = "1"};
+                    _config = new PersistentSubscriptionConfig {Version = "2"};
                     continueWith();
                     break;
                 default:
@@ -639,11 +639,11 @@ namespace EventStore.Core.Services.PersistentSubscription
                                         sub.LiveBufferSize,
                                         sub.HistoryBufferSize,
                                         sub.ReadBatchSize,
-                                        sub.PreferRoundRobin,
                                         TimeSpan.FromMilliseconds(sub.CheckPointAfter),
                                         sub.MinCheckPointCount,
                                         sub.MaxCheckPointCount,
                                         sub.MaxSubscriberCount,
+                                        sub.NamedConsumerStrategy,
                                         TimeSpan.FromMilliseconds(sub.MessageTimeout));
             }
         }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -101,7 +101,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 LiveBufferCount = _parent._streamBuffer.LiveBufferCount,
                 ExtraStatistics = _settings.ExtraStatistics,
                 TotalInFlightMessages = _parent.OutstandingMessageCount,
-                NamedConsumerStrategy = _settings.NamedConsumerStrategy
+                NamedConsumerStrategy = _settings.ConsumerStrategy.Name
             };
         }
     }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -93,7 +93,6 @@ namespace EventStore.Core.Services.PersistentSubscription
                 MaxRetryCount = _settings.MaxRetryCount,
                 MessageTimeoutMilliseconds = (int) _settings.MessageTimeout.TotalMilliseconds,
                 MinCheckPointCount = _settings.MinCheckPointCount,
-                PreferRoundRobin = _settings.PreferRoundRobin,
                 ReadBatchSize = _settings.ReadBatchSize,
                 ResolveLinktos = _settings.ResolveLinkTos,
                 StartFrom = _settings.StartFrom,
@@ -102,6 +101,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 LiveBufferCount = _parent._streamBuffer.LiveBufferCount,
                 ExtraStatistics = _settings.ExtraStatistics,
                 TotalInFlightMessages = _parent.OutstandingMessageCount,
+                NamedConsumerStrategy = _settings.NamedConsumerStrategy
             };
         }
     }

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -144,4 +144,20 @@ namespace EventStore.Core.Services
         public const string Admins = "$admins";
         public const string All = "$all";
     }
+
+    /// <summary>
+    /// System supported consumer strategies for use with persistent subscriptions.
+    /// </summary>
+    public static class SystemConsumerStrategies
+    {
+        /// <summary>
+        /// Distributes events to a single client until it is full. Then round robin to the next client.
+        /// </summary>
+        public const string DispatchToSingle = "DispatchToSingle";
+
+        /// <summary>
+        /// Distribute events to each client in a round robin fashion.
+        /// </summary>
+        public const string RoundRobin = "RoundRobin";
+    }
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -110,6 +110,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                 (o, s) =>
                 {
                     var data = http.RequestCodec.From<SubscriptionConfigData>(s);
+
+                    var namedConsumerStrategy = CalculateNamedConsumerStrategyForOldClients(data);
+
                     //TODO competing validate data?
                     var message = new ClientMessage.CreatePersistentSubscription(Guid.NewGuid(), 
                         Guid.NewGuid(),
@@ -124,11 +127,11 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                         data == null ? 500 : data.BufferSize,
                         data == null ? 500 : data.LiveBufferSize,
                         data == null ? 20 : data.ReadBatchSize,
-                        data == null || data.PreferRoundRobin, 
                         data == null ? 1000 : data.CheckPointAfterMilliseconds,
                         data == null ? 10 : data.MinCheckPointCount,
                         data == null ? 500 : data.MaxCheckPointCount,
                         data == null ? 0 : data.MaxSubscriberCount,
+                        namedConsumerStrategy,
                         http.User,
                         "",
                         "");
@@ -174,6 +177,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                 (o, s) =>
                 {
                     var data = http.RequestCodec.From<SubscriptionConfigData>(s);
+
+                    var namedConsumerStrategy = CalculateNamedConsumerStrategyForOldClients(data);
+
                     //TODO competing validate data?
                     var message = new ClientMessage.UpdatePersistentSubscription(Guid.NewGuid(),
                         Guid.NewGuid(),
@@ -188,16 +194,29 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                         data == null ? 500 : data.BufferSize,
                         data == null ? 500 : data.LiveBufferSize,
                         data == null ? 20 : data.ReadBatchSize,
-                        data == null || data.PreferRoundRobin,
                         data == null ? 1000 : data.CheckPointAfterMilliseconds,
                         data == null ? 10 : data.MinCheckPointCount,
                         data == null ? 500 : data.MaxCheckPointCount,
                         data == null ? 0 : data.MaxSubscriberCount,
+                        namedConsumerStrategy,
                         http.User,
                         "",
                         "");
                     Publish(message);
                 }, x => Log.DebugException(x, "Reply Text Content Failed."));
+        }
+
+        private static string CalculateNamedConsumerStrategyForOldClients(SubscriptionConfigData data)
+        {
+            var namedConsumerStrategy = data == null ? null : data.NamedConsumerStrategy;
+            if (string.IsNullOrEmpty(namedConsumerStrategy))
+            {
+                var preferRoundRobin = data == null || data.PreferRoundRobin;
+                namedConsumerStrategy = preferRoundRobin
+                    ? SystemConsumerStrategies.RoundRobin
+                    : SystemConsumerStrategies.DispatchToSingle;
+            }
+            return namedConsumerStrategy;
         }
 
 
@@ -338,7 +357,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                         MaxRetryCount = stat.MaxRetryCount,
                         MessageTimeoutMilliseconds = stat.MessageTimeoutMilliseconds,
                         MinCheckPointCount = stat.MinCheckPointCount,
-                        PreferRoundRobin = stat.PreferRoundRobin,
+                        NamedConsumerStrategy = stat.NamedConsumerStrategy,
+                        PreferRoundRobin = stat.NamedConsumerStrategy == SystemConsumerStrategies.RoundRobin,
                         ReadBatchSize = stat.ReadBatchSize,
                         ResolveLinktos = stat.ResolveLinktos,
                         StartFrom = stat.StartFrom,
@@ -411,6 +431,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             public int MinCheckPointCount { get; set; }
             public int MaxCheckPointCount { get; set; }
             public int MaxSubscriberCount { get; set; }
+            public string NamedConsumerStrategy { get; set; }
         }
 
         private class SubscriptionSummary

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -438,10 +438,20 @@ namespace EventStore.Core.Services.Transport.Tcp
             TcpConnectionManager connection) {
             var dto = package.Data.Deserialize<TcpClientMessageDto.CreatePersistentSubscription>();
             if(dto == null) return null;
+
+            var namedConsumerStrategy = dto.NamedConsumerStrategy;
+            if (string.IsNullOrEmpty(namedConsumerStrategy))
+            {
+                  namedConsumerStrategy = dto.PreferRoundRobin
+                    ? SystemConsumerStrategies.RoundRobin
+                    : SystemConsumerStrategies.DispatchToSingle;
+            }
+
             return new ClientMessage.CreatePersistentSubscription(Guid.NewGuid(), package.CorrelationId, envelope,
                             dto.EventStreamId, dto.SubscriptionGroupName, dto.ResolveLinkTos, dto.StartFrom, dto.MessageTimeoutMilliseconds, 
                             dto.RecordStatistics, dto.MaxRetryCount, dto.BufferSize, dto.LiveBufferSize,
-                            dto.ReadBatchSize,dto.PreferRoundRobin, dto.CheckpointAfterTime, dto.CheckpointMinCount, dto.CheckpointMaxCount, dto.SubscriberMaxCount,
+                            dto.ReadBatchSize, dto.CheckpointAfterTime, dto.CheckpointMinCount,
+                            dto.CheckpointMaxCount, dto.SubscriberMaxCount, namedConsumerStrategy,
                             user, username, password);
         }
 
@@ -449,14 +459,24 @@ namespace EventStore.Core.Services.Transport.Tcp
             TcpPackage package, IEnvelope envelope, IPrincipal user, string username, string password,
             TcpConnectionManager connection)
         {
+
             var dto = package.Data.Deserialize<TcpClientMessageDto.UpdatePersistentSubscription>();
             if (dto == null) return null;
+
+            var namedConsumerStrategy = dto.NamedConsumerStrategy;
+            if (string.IsNullOrEmpty(namedConsumerStrategy))
+            {
+                namedConsumerStrategy = dto.PreferRoundRobin
+                  ? SystemConsumerStrategies.RoundRobin
+                  : SystemConsumerStrategies.DispatchToSingle;
+            }
+
             return new ClientMessage.UpdatePersistentSubscription(Guid.NewGuid(), package.CorrelationId, envelope,
                 dto.EventStreamId, dto.SubscriptionGroupName, dto.ResolveLinkTos, dto.StartFrom,
                 dto.MessageTimeoutMilliseconds,
                 dto.RecordStatistics, dto.MaxRetryCount, dto.BufferSize, dto.LiveBufferSize,
-                dto.ReadBatchSize, dto.PreferRoundRobin, dto.CheckpointAfterTime, dto.CheckpointMinCount,
-                dto.CheckpointMaxCount, dto.SubscriberMaxCount,
+                dto.ReadBatchSize, dto.CheckpointAfterTime, dto.CheckpointMinCount,
+                dto.CheckpointMaxCount, dto.SubscriberMaxCount, namedConsumerStrategy,
                 user, username, password);
         }
 

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -211,6 +211,7 @@ message CreatePersistentSubscription {
 	required int32 checkpoint_max_count = 13;
 	required int32 checkpoint_min_count = 14;
 	required int32 subscriber_max_count = 15;
+	optional string named_consumer_strategy = 16;
 }
 
 message DeletePersistentSubscription {
@@ -234,6 +235,7 @@ message UpdatePersistentSubscription {
 	required int32 checkpoint_max_count = 13;
 	required int32 checkpoint_min_count = 14;
 	required int32 subscriber_max_count = 15;
+	optional string named_consumer_strategy = 16;
 }
 
 message UpdatePersistentSubscriptionCompleted {


### PR DESCRIPTION
## Quick Background

We have an aggregate hosting platform built on top of ActiveMQ and MySQL that we're migrating to EventStore for it's much better fit and impressive performance. One of our requirements is high availability which we support through active/active operation where aggregate instances can be run on any host. We want to avoid aggregate instances moving randomly between hosts, which incurs a large overhead through concurrency retries and state loading. We currently take advantage of the JMS spec for message groups to pin an instance to a consumer until the consumer dies. (See http://activemq.apache.org/message-groups.html for more info.) This avoids unnecessary overhead but maintains excellent resilience!

The new persistent subscription feature in EventStore provides the foundations for everything we need. However, the current round robin and prefer single strategies will lead to a non-optimal distribution of load for this fairly common usage. Therefore, our plan is to take this excellent platform and contribute a new event distribution strategy that behaves similarly to JMS message groups. 

## The Changes

This pull request contains a refactor of the existing 2 strategies into a framework that will allow us to complete the design. The framework takes a named consumer strategy from the persistent subscription settings. The name is then used to construct the correct strategy as an IPersistentSubscriptionConsumerStrategy.

## Technical details
* The ClientApi interface is backwards and forwards compatible via the protobuf contracts. 
* Where the EventStore does not support a named strategy an error is returned.
* On EventStore upgrade the existing settings are updated to use the new named strategy.
* There are tests covering the round robin and single strategies already. All tests pass.
* **Bug Fix**: The UpdatePersistentSubscriptionOperation wasn't updating the max subscriber count. I'm not sure if this was on purpose, but it seemed more like an incomplete change.
