### PR TITLE
Second PR for issue #454

### DIFF
--- a/src/EventStore.Common/Log/LogManager.cs
+++ b/src/EventStore.Common/Log/LogManager.cs
@@ -73,7 +73,7 @@ namespace EventStore.Common.Log
             }
             catch (Exception exc)
             {
-                GlobalLogger.ErrorException(exc, "Exception during flushing logs, ignoring...");
+                GlobalLogger.ErrorException(exc, "Exception while flushing logs, ignoring...");
             }
         }
 

--- a/src/EventStore.Common/Options/EventStoreOptions.cs
+++ b/src/EventStore.Common/Options/EventStoreOptions.cs
@@ -67,7 +67,7 @@ namespace EventStore.Common.Options
             var configFile = effectiveOptions.FirstOrDefault(x => x.Name.Equals(ConfigKey, StringComparison.OrdinalIgnoreCase)).Value as string;
             if (!File.Exists(configFile))
             {
-                throw new Exception("A configuration file must be available for use with updating of the options.");
+                throw new Exception("A configuration file must be available in order to update options.");
             }
 
             optionSources = optionSources

--- a/src/EventStore.Common/Utils/BytesFormatter.cs
+++ b/src/EventStore.Common/Utils/BytesFormatter.cs
@@ -17,7 +17,7 @@ namespace EventStore.Common.Utils
 
         public static string ToFriendlySizeString(this ulong bytes)
         {
-            return bytes > long.MaxValue ? "more then long.MaxValue" : ToFriendlySizeString((long) bytes);
+            return bytes > long.MaxValue ? "more than long.MaxValue" : ToFriendlySizeString((long) bytes);
         }
         public static string ToFriendlySizeString(this long bytes)
         {
@@ -26,7 +26,7 @@ namespace EventStore.Common.Utils
 
         public static string ToFriendlyNumberString(this ulong number)
         {
-            return number > long.MaxValue ? "more then long.MaxValue" : ToFriendlyNumberString((long)number);
+            return number > long.MaxValue ? "more than long.MaxValue" : ToFriendlyNumberString((long)number);
         }
         public static string ToFriendlyNumberString(this long number)
         {

--- a/src/EventStore.Common/Utils/Ensure.cs
+++ b/src/EventStore.Common/Utils/Ensure.cs
@@ -43,7 +43,7 @@ namespace EventStore.Common.Utils
         public static void NotEmptyGuid(Guid guid, string argumentName)
         {
             if (Guid.Empty == guid)
-                throw new ArgumentException(argumentName, argumentName + " shoud be non-empty GUID.");
+                throw new ArgumentException(argumentName, argumentName + " should be non-empty GUID.");
         }
 
         public static void Equal(int expected, int actual, string argumentName)

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_should.cs
@@ -46,7 +46,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 using (store.SubscribeToStreamAsync(stream, false, (s, x) => appeared.Signal(), (s, r, e) => dropped.Signal()).Result)
                 {
                     store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
-                    Assert.IsTrue(appeared.Wait(Timeout), "Event appeared countdown event timed out.");
+                    Assert.IsTrue(appeared.Wait(Timeout), "Appeared countdown event timed out.");
                 }
             }
         }

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_catching_up_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_catching_up_should.cs
@@ -93,7 +93,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 store.SubscribeToAllAsync(false, (s, x) => { }, (s, r, e) => { }).Wait();
                 Thread.Sleep(100);
 
-                Assert.IsFalse(appeared.Wait(0), "Some event appeared!");
+                Assert.IsFalse(appeared.Wait(0), "Some event appeared.");
                 Assert.IsFalse(dropped.Wait(0), "Subscription was dropped prematurely.");
                 subscription.Stop(Timeout);
                 Assert.IsTrue(dropped.Wait(Timeout));

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_stream_catching_up_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_stream_catching_up_should.cs
@@ -58,7 +58,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 Thread.Sleep(100); // give time for first pull phase
                 store.SubscribeToStreamAsync(stream, false, (s, x) => { }, (s, r, e) => { }).Wait();
                 Thread.Sleep(100);
-                Assert.IsFalse(appeared.Wait(0), "Some event appeared!");
+                Assert.IsFalse(appeared.Wait(0), "Some event appeared.");
                 Assert.IsFalse(dropped.Wait(0), "Subscription was dropped prematurely.");
                 subscription.Stop(Timeout);
                 Assert.IsTrue(dropped.Wait(Timeout));
@@ -87,7 +87,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 if (!appeared.Wait(Timeout))
                 {
                     Assert.IsFalse(dropped.Wait(0), "Subscription was dropped prematurely.");
-                    Assert.Fail("Event appeared countdown event timed out.");
+                    Assert.Fail("Appeared countdown event timed out.");
                 }
 
                 Assert.IsFalse(dropped.Wait(0));

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -155,7 +155,7 @@ namespace EventStore.Core.Tests.Helpers
             Node.Start();
 
             if (!startedEvent.Wait(60000))
-                throw new TimeoutException("MiniNode haven't started in 60 seconds.");
+                throw new TimeoutException("MiniNode has not started in 60 seconds.");
 
             StartingTime.Stop();
         }

--- a/src/EventStore.Core.Tests/Index/create_index_map_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/Index/create_index_map_from_non_existing_file.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Tests.Index
         [SetUp]
         public void Setup()
         {
-            _map = IndexMap.FromFile("shitbird");
+            _map = IndexMap.FromFile("thisfiledoesnotexist");
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/ElectionsLogger.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/ElectionsLogger.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
 
         public void LogMessages()
         {
-            Console.WriteLine("There were total {0} messages in this run.", ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", ProcessedItems.Count());
 
             foreach (var it in ProcessedItems)
             {

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
@@ -142,7 +142,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
 
             if (!isGood)
             {
-                Console.WriteLine("Unsuccessfull run. Parameters:\n"
+                Console.WriteLine("Unsuccessful run. Parameters:\n"
                                   + "rndSeed: {0}\n"
                                   + "maxIterCnt = {1}\n"
                                   + "instancesCnt = {2}\n"

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_3_nodes_full_gossip_no_http_loss_no_dup.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_3_nodes_full_gossip_no_http_loss_no_dup.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
 
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
     }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_3_nodes_full_gossip_some_http_loss_some_dup.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_3_nodes_full_gossip_some_http_loss_some_dup.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
 
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
     }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_4_nodes_full_gossip_no_http_loss_no_dup.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_4_nodes_full_gossip_no_http_loss_no_dup.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
 
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
     }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_4_nodes_full_gossip_some_http_loss_some_dup.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_4_nodes_full_gossip_some_http_loss_some_dup.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
 
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
     }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_4_nodes_full_gossip_some_http_loss_some_dup_rndseed_20676840.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_4_nodes_full_gossip_some_http_loss_some_dup_rndseed_20676840.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
     }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_full_gossip_no_http_loss_no_dup.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_full_gossip_no_http_loss_no_dup.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
 
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
     }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_full_gossip_some_http_loss_some_dup.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_full_gossip_some_http_loss_some_dup.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
 
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             var success = _randomCase.Run();
             if (!success)
                 _randomCase.Logger.LogMessages();
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Assert.True(success);
         }
     }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_with_1_known_when_started_and_set_full_imediately.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_with_1_known_when_started_and_set_full_imediately.cs
@@ -67,7 +67,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             if (!success)
                 _randomCase.Logger.LogMessages();
 
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Console.WriteLine("There were {0} GossipUpdated messages in this run.",
                               _randomCase.Logger.ProcessedItems.Count(x => x.Message is GossipMessage.GossipUpdated));
 
@@ -81,7 +81,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             if (!success)
                 _randomCase.Logger.LogMessages();
 
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Console.WriteLine("There were {0} GossipUpdated messages in this run.",
                               _randomCase.Logger.ProcessedItems.Count(x => x.Message is GossipMessage.GossipUpdated));
 

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_with_1_known_when_started_and_set_to_full_later.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_with_1_known_when_started_and_set_to_full_later.cs
@@ -70,7 +70,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             if (!success)
                 _randomCase.Logger.LogMessages();
 
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Console.WriteLine("There were {0} GossipUpdated messages in this run.",
                               _randomCase.Logger.ProcessedItems.Count(x => x.Message is GossipMessage.GossipUpdated));
 
@@ -84,7 +84,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized
             if (!success)
                 _randomCase.Logger.LogMessages();
 
-            Console.WriteLine("There were total {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
+            Console.WriteLine("There were a total of {0} messages in this run.", _randomCase.Logger.ProcessedItems.Count());
             Console.WriteLine("There were {0} GossipUpdated messages in this run.",
                               _randomCase.Logger.ProcessedItems.Count(x => x.Message is GossipMessage.GossipUpdated));
 

--- a/src/EventStore.Core.Tests/Services/Monitoring/FormatterTests.cs
+++ b/src/EventStore.Core.Tests/Services/Monitoring/FormatterTests.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.Services.Monitoring
         [TestCase(79725330432UL, Result = "74.25GiB")]
         [TestCase(1099511627776UL, Result = "1TiB")]
         [TestCase(1125899906842624UL, Result = "1024TiB")]
-        [TestCase(ulong.MaxValue, Result = "more then long.MaxValue")] //16777215TiB
+        [TestCase(ulong.MaxValue, Result = "more than long.MaxValue")] //16777215TiB
         public string test_size_multiple_cases_ulong(ulong bytes )
         {
             return bytes.ToFriendlySizeString();
@@ -103,7 +103,7 @@ namespace EventStore.Core.Tests.Services.Monitoring
         [TestCase(79725330432UL, Result = "74.25G")]
         [TestCase(1099511627776UL, Result = "1T")]
         [TestCase(1125899906842624UL, Result = "1024T")]
-        [TestCase(ulong.MaxValue, Result = "more then long.MaxValue")] //16777215TiB
+        [TestCase(ulong.MaxValue, Result = "more than long.MaxValue")] //16777215TiB
         public string test_number_multiple_cases_ulong(ulong number )
         {
             return number.ToFriendlyNumberString();

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionConfigPersistence.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionConfigPersistence.cs
@@ -26,14 +26,14 @@ namespace EventStore.Core.Tests.Services
         }
 
         [Test]
-        public void bunk_json_causes_bad_config_data_exception()
+        public void bad_json_causes_bad_config_data_exception()
         {
-            var bunkdata = Encoding.UTF8.GetBytes("{'some weird shit' : 'something'}");
+            var bunkdata = Encoding.UTF8.GetBytes("{'some weird stuff' : 'something'}");
             Assert.Throws<BadConfigDataException>(() => PersistentSubscriptionConfig.FromSerializedForm(bunkdata));
         }
 
         [Test]
-        public void random_crap_data_causes_bad_config_data_exception()
+        public void random_bad_data_causes_bad_config_data_exception()
         {
             var bunkdata = Encoding.UTF8.GetBytes("This ain't even valid json");
             Assert.Throws<BadConfigDataException>(() => PersistentSubscriptionConfig.FromSerializedForm(bunkdata));

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -948,7 +948,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             },
                 (sub, reason, ex) => { });
 
-            Assert.IsTrue(manualResetEventSlim.Wait(TimeSpan.FromSeconds(120)), "Failed to recieve all events in 2 minutes. Assume event store is deadlocked.");
+            Assert.IsTrue(manualResetEventSlim.Wait(TimeSpan.FromSeconds(120)), "Failed to receive all events in 2 minutes. Assume event store is deadlocked.");
             sub1.Stop(TimeSpan.FromSeconds(10));
             eventStoreConnection.Close();
 

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
@@ -83,7 +83,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
                 },
                 verbose: true);
 
-            Assert.IsTrue(done.Wait(20000), "Too long didn't receive completion.");
+            Assert.IsTrue(done.Wait(20000), "Took too long to receive completion.");
 
             Log.Info("Stopping listener...");
             listener.Stop();

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -78,7 +78,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
             base.TestFixtureTearDown();
 
             if (!_checked)
-                throw new Exception("Records weren't checked. Probably you forgot to call CheckRecords() method.");
+                throw new Exception("Records were not checked. Probably you forgot to call CheckRecords() method.");
         }
 
         protected abstract DbResult CreateDb(TFChunkDbCreationHelper dbCreator);

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
                     else
                     {
                         if (rec.Type == Rec.RecType.TransStart)
-                            throw new Exception(string.Format("Not expected record type: {0}.", rec.Type));
+                            throw new Exception(string.Format("Unexpected record type: {0}.", rec.Type));
                     }
 
                     if (transInfo.StreamId != rec.StreamId)

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_database.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
             // --- first part of events
             WriteEvents(cnt, miniNode, countdown);
-            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Too long writing first part of events.");
+            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Took too long writing first part of events.");
             countdown.Reset();
 
             // -- set up truncation
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
             // --- second part of events
             WriteEvents(cnt, miniNode, countdown);
-            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Too long writing second part of events.");
+            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Took too long writing second part of events.");
             countdown.Reset();
 
             miniNode.Shutdown(keepDb: true, keepPorts: true);
@@ -49,7 +49,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
             // -- third part of events
             WriteEvents(cnt, miniNode, countdown);
-            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Too long writing third part of events.");
+            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Took too long writing third part of events.");
             countdown.Reset();
 
             miniNode.Shutdown(keepDb: true, keepPorts: true);
@@ -80,7 +80,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
             // --- first part of events
             WriteEvents(cnt, miniNode, countdown, MiniNode.ChunkSize / 5 * 3);
-            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Too long writing first part of events.");
+            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Took too long writing first part of events.");
             countdown.Reset();
 
             // -- set up truncation
@@ -90,7 +90,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
             // --- second part of events
             WriteEvents(cnt, miniNode, countdown, MiniNode.ChunkSize / 2);
-            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Too long writing second part of events.");
+            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Took too long writing second part of events.");
             countdown.Reset();
 
             miniNode.Shutdown(keepDb: true, keepPorts: true);
@@ -104,7 +104,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
             // -- third part of events
             WriteEvents(cnt, miniNode, countdown, MiniNode.ChunkSize / 5);
-            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Too long writing third part of events.");
+            Assert.IsTrue(countdown.Wait(TimeSpan.FromSeconds(10)), "Took too long writing third part of events.");
             countdown.Reset();
 
             // -- if we get here -- then everything is ok

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
@@ -127,7 +127,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
                 fs.Position = ChunkHeader.Size + _config.WriterCheckpoint.Read()%_config.ChunkSize;
                 fs.Read(shouldBeZeros, 0, shouldBeZeros.Length);
 
-                Assert.IsTrue(shouldBeZeros.All(x => x == 0), "Chunk is not zeroed!");
+                Assert.IsTrue(shouldBeZeros.All(x => x == 0), "Chunk is not zeroed.");
             }
         }
     }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_scavenged_chunk_with_index_in_memory.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_scavenged_chunk_with_index_in_memory.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
         protected override void OnBeforeTruncating()
         {
-            // svacenged chunk names
+            // scavenged chunk names
             // TODO MM: avoid this complexity - try scavenging exactly at where its invoked and not wait for readIndex to rebuild
             chunk0 = GetChunkName(0);
             chunk1 = GetChunkName(1);

--- a/src/EventStore.Core/Data/StreamMetadata.cs
+++ b/src/EventStore.Core/Data/StreamMetadata.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.Data
                     "maxAge", string.Format("{0} should be positive time span.", SystemMetadata.MaxAge));
             if (truncateBefore < 0)
                 throw new ArgumentOutOfRangeException(
-                    "truncateBefore", string.Format("{0} should be non negative value.", SystemMetadata.TruncateBefore));
+                    "truncateBefore", string.Format("{0} should be non-negative value.", SystemMetadata.TruncateBefore));
             if (cacheControl <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(
                     "cacheControl", string.Format("{0} should be positive time span.", SystemMetadata.CacheControl));

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -110,7 +110,7 @@ namespace EventStore.Core.Index
             }
             catch (PossibleToHandleOutOfMemoryException)
             {
-                Log.Error("Was unable to create midpoints for PTable '{0}' ({1} entries, depth {2} requested). "
+                Log.Error("Unable to create midpoints for PTable '{0}' ({1} entries, depth {2} requested). "
                           + "Performance hit possible. OOM Exception.", Path.GetFileName(Filename), Count, depth);
             }
             Log.Trace("Loading PTable '{0}' ({1} entries, cache depth {2}) done in {3}.",

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -336,7 +336,7 @@ namespace EventStore.Core.Index
                     Log.Trace("File being deleted.");
                 }
             }
-            throw new InvalidOperationException("Something is wrong. Files are locked.");
+            throw new InvalidOperationException("Files are locked.");
         }
 
         private bool TryGetOneValueInternal(uint stream, int version, out long position)
@@ -377,7 +377,7 @@ namespace EventStore.Core.Index
                     Log.Trace("File being deleted.");
                 }
             }
-            throw new InvalidOperationException("Something is wrong. Files are locked.");
+            throw new InvalidOperationException("Files are locked.");
         }
 
         private bool TryGetLatestEntryInternal(uint stream, out IndexEntry entry)
@@ -415,7 +415,7 @@ namespace EventStore.Core.Index
                     Log.Trace("File being deleted.");
                 }
             }
-            throw new InvalidOperationException("Something is wrong. Files are locked.");
+            throw new InvalidOperationException("Files are locked.");
         }
 
         private bool TryGetOldestEntryInternal(uint stream, out IndexEntry entry)
@@ -453,7 +453,7 @@ namespace EventStore.Core.Index
                     Log.Trace("File being deleted.");
                 }
             }
-            throw new InvalidOperationException("Something is wrong. Files are locked.");
+            throw new InvalidOperationException("Files are locked.");
         }
 
         private IEnumerable<IndexEntry> GetRangeInternal(uint stream, int startVersion, int endVersion)

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1209,7 +1209,7 @@ namespace EventStore.Core.Messages
             }
         }
 
-        //End of persistens subscritions
+        //End of persistence subscriptions
 
 
         public class SubscribeToStream : ReadRequestMessage

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -89,13 +89,13 @@ namespace EventStore.Core.Services
             var writerCheck = Db.Config.WriterCheckpoint.ReadNonFlushed();
             if (message.SubscriptionPosition > writerCheck)
             {
-                ReplicationFail("Master [{0},{1:B}] subscribed us at {2} (0x{2:X}), which is greater than our writer checkpoint {3} (0x{3:X}). REPLICATION BUG!",
+                ReplicationFail("Master [{0},{1:B}] subscribed us at {2} (0x{2:X}), which is greater than our writer checkpoint {3} (0x{3:X}). REPLICATION BUG.",
                                 message.MasterEndPoint, message.MasterId, message.SubscriptionPosition, writerCheck);
             }
             
             if (message.SubscriptionPosition < writerCheck)
             {
-                Log.Info("Master [{0},{1:B}] subscribed us at {2} (0x{2:X}), which is less than our writer checkpoint {3} (0x{3:X}). TRUNCATION IS NEEDED!",
+                Log.Info("Master [{0},{1:B}] subscribed us at {2} (0x{2:X}), which is less than our writer checkpoint {3} (0x{3:X}). TRUNCATION IS NEEDED.",
                          message.MasterEndPoint, message.MasterId, message.SubscriptionPosition, writerCheck);
 
                 var lastCommitPosition = _getLastCommitPosition();
@@ -107,7 +107,7 @@ namespace EventStore.Core.Services
                 EpochRecord lastEpoch = EpochManager.GetLastEpoch();
                 if (AreAnyCommittedRecordsTruncatedWithLastEpoch(message.SubscriptionPosition, lastEpoch, lastCommitPosition))
                 {
-                    Log.Error("Master [{0},{1:B}] subscribed us at {2} (0x{2:X}), which is less than our last epoch and LastCommitPosition {3} (0x{3:X}) >= lastEpoch.EpochPosition {3} (0x{3:X})!!! "
+                    Log.Error("Master [{0},{1:B}] subscribed us at {2} (0x{2:X}), which is less than our last epoch and LastCommitPosition {3} (0x{3:X}) >= lastEpoch.EpochPosition {3} (0x{3:X}). "
                                 + "That might be bad, especially if the LastCommitPosition is way beyond EpochPosition.\n" 
                                 + "ATTEMPT TO TRUNCATE EPOCH WITH COMMITTED RECORDS. THIS MAY BE BAD, BUT IT IS OK IF JUST-ELECTED MASTER FAILS IMMEDIATELY AFTER ITS ELECTION.",
                                 message.MasterEndPoint, message.MasterId, message.SubscriptionPosition, lastCommitPosition, lastEpoch.EpochPosition);
@@ -235,7 +235,7 @@ namespace EventStore.Core.Services
                     Writer.CompleteChunk();
 
                     if (_framer.HasData) 
-                        ReplicationFail("There is some data left in framer when completing chunk!");
+                        ReplicationFail("There is some data left in framer when completing chunk.");
 
                     _subscriptionPos = chunk.ChunkHeader.ChunkEndPosition;
                     _framer.Reset();

--- a/src/EventStore.Core/Services/Monitoring/Stats/DiskIo.cs
+++ b/src/EventStore.Core/Services/Monitoring/Stats/DiskIo.cs
@@ -84,7 +84,7 @@ namespace EventStore.Core.Services.Monitoring.Stats
             }
             catch (Exception ex)
             {
-                log.InfoException(ex, "Error while reading disk io on Windows.");
+                log.InfoException(ex, "Error while reading disk IO on Windows.");
                 return null;
             }
             finally

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -370,7 +370,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                         ParkMessage(e, reason, count + 1);
                         return;
                     }
-                    Log.Error("Unable to park message {0}/{1} operation failed {2} after retries. possible message loss.", e.OriginalStreamId,
+                    Log.Error("Unable to park message {0}/{1} operation failed {2} after retries. Possible message loss.", e.OriginalStreamId,
                         e.OriginalEventNumber, result);
                 }
                 lock (_lock)

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         public PersistentSubscriptionService(IQueuedHandler queuedHandler, IReadIndex readIndex, IODispatcher ioDispatcher, IPublisher bus)
         {
-            Ensure.NotNull(queuedHandler, "queudHandler");
+            Ensure.NotNull(queuedHandler, "queuedHandler");
             Ensure.NotNull(readIndex, "readIndex");
             Ensure.NotNull(ioDispatcher, "ioDispatcher");
 
@@ -586,7 +586,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                     }
                     catch (Exception ex)
                     {
-                        Log.Error("There was an error loading configuration from storage something is wrong.", ex);
+                        Log.Error("There was an error loading configuration from storage.", ex);
                     }
                     break;
                 case ReadStreamResult.NoStream:
@@ -594,7 +594,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                     continueWith();
                     break;
                 default:
-                    throw new Exception(readStreamEventsBackwardCompleted.Result + " is an unexpected result writing subscription configuration. Something is wrong.");
+                    throw new Exception(readStreamEventsBackwardCompleted.Result + " is an unexpected result writing subscription configuration.");
             }
         }
 
@@ -619,7 +619,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                     SaveConfiguration(continueWith);
                     break;
                 default:
-                    throw new Exception(obj.Result + " is an unexpected result writing subscription configuration. Something is wrong.");
+                    throw new Exception(obj.Result + " is an unexpected result writing subscription configuration.");
             }
         }
 

--- a/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
@@ -129,7 +129,7 @@ namespace EventStore.Core.Services.Replication
                 {
                     ReplicaSubscription existingSubscr;
                     _subscriptions.TryGetValue(subscription.SubscriptionId, out existingSubscr);
-                    var msg = string.Format("There is already subscription with SubscriptionID {0:B}: {1}.\nSubscription we tried to add: {2}",
+                    var msg = string.Format("There is already a subscription with SubscriptionID {0:B}: {1}.\nSubscription we tried to add: {2}",
                                             subscription.SubscriptionId, existingSubscr, subscription);
                     Log.Error(msg);
                     subscription.SendBadRequestAndClose(message.CorrelationId, msg);
@@ -162,8 +162,8 @@ namespace EventStore.Core.Services.Replication
             }
             catch (Exception exc)
             {
-                Log.ErrorException(exc, "Exception during subscribing replica. Connection will be dropped.");
-                replica.SendBadRequestAndClose(correlationId, string.Format("Exception during subscribing replica. Connection will be dropped. Error: {0}", exc.Message));
+                Log.ErrorException(exc, "Exception while subscribing replica. Connection will be dropped.");
+                replica.SendBadRequestAndClose(correlationId, string.Format("Exception while subscribing replica. Connection will be dropped. Error: {0}", exc.Message));
                 return false;
             }
         }

--- a/src/EventStore.Core/Services/RequestManager/Managers/TwoPhaseRequestManagerBase.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TwoPhaseRequestManagerBase.cs
@@ -148,7 +148,7 @@ namespace EventStore.Core.Services.RequestManager.Managers
                 return;
 
             if (_transactionId == -1)
-                throw new Exception("Something is wrong, transactionId was not set, transactionId = -1.");
+                throw new Exception("TransactionId was not set, transactionId = -1.");
 
             if (message.Flags.HasAnyOf(PrepareFlags.TransactionEnd))
             {

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -112,10 +112,10 @@ namespace EventStore.Core.Services.Storage
             }
             catch (Exception exc)
             {
-                Log.FatalException(exc, "Error in StorageChaser. SOMETHING VERY BAD HAPPENED. Terminating...");
+                Log.FatalException(exc, "Error in StorageChaser. Terminating...");
                 _queueStats.EnterIdle();
                 _queueStats.ProcessingStarted<FaultedChaserState>(0);
-                Application.Exit(ExitCode.Error, "Error in StorageChaser. SOMETHING VERY BAD HAPPENED. Terminating...\nError: " + exc.Message);
+                Application.Exit(ExitCode.Error, "Error in StorageChaser. Terminating...\nError: " + exc.Message);
                 while (!_stop)
                 {
                     Thread.Sleep(100);

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -74,7 +74,7 @@ namespace EventStore.Core.Services.Storage
             }
             catch (Exception exc)
             {
-                Log.ErrorException(exc, "Error during stopping readers multi handler.");
+                Log.ErrorException(exc, "Error while stopping readers multi handler.");
             }
 
             _bus.Publish(new SystemMessage.ServiceShutdown("StorageReader"));

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -194,7 +194,7 @@ namespace EventStore.Core.Services.Storage
         void IHandle<SystemMessage.WriteEpoch>.Handle(SystemMessage.WriteEpoch message)
         {
             if (_vnodeState != VNodeState.Master)
-                throw new Exception(string.Format("New Epoch request came not in master state!!! State: {0}.", _vnodeState));
+                throw new Exception(string.Format("New Epoch request not in master state. State: {0}.", _vnodeState));
             EpochManager.WriteNewEpoch();
             PurgeNotProcessedInfo();
         }

--- a/src/EventStore.Core/Services/Transport/Http/AuthenticatedHttpRequestProcessor.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AuthenticatedHttpRequestProcessor.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Services.Transport.Http
                     {
                         req = _pending.DeleteMin();
                         req.Item2.ReplyStatus(HttpStatusCode.RequestTimeout, "Server was unable to handle request in time",
-                                              e => Log.Debug("Error occurred while closing timed out connection (http service core): {0}.", e.Message));
+                                              e => Log.Debug("Error occurred while closing timed out connection (HTTP service core): {0}.", e.Message));
                     }
                     else 
                         break;
@@ -123,7 +123,7 @@ namespace EventStore.Core.Services.Transport.Http
             }
             catch (Exception exc)
             {
-                Log.ErrorException(exc, "Unhandled exception while processing http request at [{0}].",
+                Log.ErrorException(exc, "Unhandled exception while processing HTTP request at [{0}].",
                                    string.Join(", ", httpService.ListenPrefixes));
                 InternalServerError(httpEntity);
             }
@@ -147,42 +147,42 @@ namespace EventStore.Core.Services.Transport.Http
         {
             var entity = httpEntity.CreateManager(Codec.NoCodec, Codec.NoCodec, allowed, _ => { });
             entity.ReplyStatus(HttpStatusCode.OK, "OK",
-                               e => Log.Debug("Error while closing http connection (http service core): {0}.", e.Message));
+                               e => Log.Debug("Error while closing HTTP connection (HTTP service core): {0}.", e.Message));
         }
 
         private void MethodNotAllowed(HttpEntity httpEntity, string[] allowed)
         {
             var entity = httpEntity.CreateManager(Codec.NoCodec, Codec.NoCodec, allowed, _ => { });
             entity.ReplyStatus(HttpStatusCode.MethodNotAllowed, "Method Not Allowed",
-                               e => Log.Debug("Error while closing http connection (http service core): {0}.", e.Message));
+                               e => Log.Debug("Error while closing HTTP connection (HTTP service core): {0}.", e.Message));
         }
 
         private void NotFound(HttpEntity httpEntity)
         {
             var entity = httpEntity.CreateManager();
             entity.ReplyStatus(HttpStatusCode.NotFound, "Not Found",
-                               e => Log.Debug("Error while closing http connection (http service core): {0}.", e.Message));
+                               e => Log.Debug("Error while closing HTTP connection (HTTP service core): {0}.", e.Message));
         }
 
         private void InternalServerError(HttpEntity httpEntity)
         {
             var entity = httpEntity.CreateManager();
             entity.ReplyStatus(HttpStatusCode.InternalServerError, "Internal Server Error",
-                               e => Log.Debug("Error while closing http connection (http service core): {0}.", e.Message));
+                               e => Log.Debug("Error while closing HTTP connection (HTTP service core): {0}.", e.Message));
         }
 
         private void BadCodec(HttpEntity httpEntity, string reason)
         {
             var entity = httpEntity.CreateManager();
             entity.ReplyStatus(HttpStatusCode.NotAcceptable, reason,
-                               e => Log.Debug("Error while closing http connection (http service core): {0}.", e.Message));
+                               e => Log.Debug("Error while closing HTTP connection (HTTP service core): {0}.", e.Message));
         }
 
         private void BadContentType(HttpEntity httpEntity, string reason)
         {
             var entity = httpEntity.CreateManager();
             entity.ReplyStatus(HttpStatusCode.UnsupportedMediaType, reason,
-                               e => Log.Debug("Error while closing http connection (http service core): {0}.", e.Message));
+                               e => Log.Debug("Error while closing HTTP connection (HTTP service core): {0}.", e.Message));
         }
 
         private ICodec SelectRequestCodec(string method, string contentType, ICodec[] supportedCodecs)

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -55,7 +55,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
         private void LogReplyError(Exception exc)
         {
-            Log.Debug("Error while closing http connection (admin controller): {0}.", exc.Message);
+            Log.Debug("Error while closing HTTP connection (admin controller): {0}.", exc.Message);
         }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -380,7 +380,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             string foo;
             GetIncludedType(manager, out foo);
             if(!(foo == null || foo == SystemEventTypes.StreamMetadata)) {
-                SendBadRequest(manager, "Bad Request you should not include a event type for metadata");
+                SendBadRequest(manager, "Bad Request. You should not include an event type for metadata.");
                 return;
             }
             const string includedType = SystemEventTypes.StreamMetadata;

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         {
             httpEntityManager.ReplyStatus(HttpStatusCode.BadRequest,
                                           reason,
-                                          e => Log.Debug("Error while closing http connection (bad request): {0}.", e.Message));
+                                          e => Log.Debug("Error while closing HTTP connection (bad request): {0}.", e.Message));
             return new RequestParams(done: true);
         }
 
@@ -49,7 +49,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         {
             httpEntityManager.ReplyStatus(HttpStatusCode.RequestEntityTooLarge,
                                           "Too large events received. Limit is 4mb",
-                                          e => Log.Debug("Too large events received over http"));
+                                          e => Log.Debug("Too large events received over HTTP"));
             return new RequestParams(done: true);
         }
 
@@ -57,7 +57,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         {
             httpEntityManager.ReplyStatus(HttpStatusCode.OK,
                                           "OK",
-                                          e => Log.Debug("Error while closing http connection (ok): {0}.", e.Message));
+                                          e => Log.Debug("Error while closing HTTP connection (ok): {0}.", e.Message));
             return new RequestParams(done: true);
         }
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -44,7 +44,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
              "OK",
              entity.ResponseCodec.ContentType,
              null,
-             e => Log.ErrorException(e, "Error while writing http response (info)"));
+             e => Log.ErrorException(e, "Error while writing HTTP response (info)"));
         }
 
         private void OnGetOptions(HttpEntityManager entity, UriTemplateMatch match)
@@ -56,7 +56,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                                         "OK",
                                         entity.ResponseCodec.ContentType,
                                         null,
-                                        e => Log.ErrorException(e, "error while writing http response (options)"));
+                                        e => Log.ErrorException(e, "error while writing HTTP response (options)"));
             }
             else
             {
@@ -86,7 +86,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                                             "OK",
                                             entity.ResponseCodec.ContentType,
                                             null,
-                                            e => Log.ErrorException(e, "error while writing http response (options)"));
+                                            e => Log.ErrorException(e, "error while writing HTTP response (options)"));
                                     }
                                     catch (Exception ex)
                                     {
@@ -108,7 +108,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                                     reason,
                                     httpEntityManager.ResponseCodec.ContentType,
                                     null,
-                                    e => Log.Debug("Error while closing http connection (bad request): {0}.", e.Message));
+                                    e => Log.Debug("Error while closing HTTP connection (bad request): {0}.", e.Message));
             return new RequestParams(done: true);
         }
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PingController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PingController.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                                     "OK",
                                     entity.ResponseCodec.ContentType,
                                     null,
-                                    e => Log.ErrorException(e, "Error while writing http response (ping)"));
+                                    e => Log.ErrorException(e, "Error while writing HTTP response (ping)"));
         }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/HttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/HttpService.cs
@@ -77,7 +77,7 @@ namespace EventStore.Core.Services.Transport.Http
             else
             {
                 Application.Exit(ExitCode.Error,
-                                 string.Format("Http async server failed to start listening at [{0}].", 
+                                 string.Format("HTTP async server failed to start listening at [{0}].", 
                                                string.Join(", ", _server._listenPrefixes)));
             }
         }

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -221,7 +221,7 @@ namespace EventStore.Core.Services.Transport.Tcp
             }
             catch (Exception e)
             {
-                SendBadRequestAndClose(package.CorrelationId, string.Format("Error during processing package. Error: {0}", e));
+                SendBadRequestAndClose(package.CorrelationId, string.Format("Error while processing package. Error: {0}", e));
             }
         }
 

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -396,7 +396,7 @@ namespace EventStore.Core.Services.VNode
                 {
                     Log.ErrorException(exc, "Error when stopping workers/main queue.");
                 }
-                Application.Exit(ExitCode.Success, "Shutdown with exiting from process was requested.");
+                Application.Exit(ExitCode.Success, "Shutdown and exit from process was requested.");
             }
         }
 

--- a/src/EventStore.Core/Services/VNode/MessageForwardingProxy.cs
+++ b/src/EventStore.Core/Services/VNode/MessageForwardingProxy.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Services.VNode
                 (x, y) =>
                 { 
                     throw new Exception(
-                        string.Format("Forwarding for InternalCorrId {0:B} (ClientCorrId {1:B}) already exists!",
+                        string.Format("Forwarding for InternalCorrId {0:B} (ClientCorrId {1:B}) already exists.",
                                       internalCorrId, clientCorrId));
                 });
         }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -296,7 +296,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 if (_writerWorkItem.StreamLength != expectedFileSize)
                 {
                     throw new CorruptDatabaseException(new BadChunkInDatabaseException(
-                        string.Format("Chunk file '{0}' should have file size {1} bytes, but instead has {2} bytes length.",
+                        string.Format("Chunk file '{0}' should have a file size of {1} bytes, but it has a size of {2} bytes.",
                                       _filename,
                                       expectedFileSize,
                                       _writerWorkItem.StreamLength)));
@@ -766,14 +766,14 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
         public void Complete()
         {
             if (ChunkHeader.IsScavenged)
-                throw new InvalidOperationException("CompleteScavenged should be used for scavenged chunks!");
+                throw new InvalidOperationException("CompleteScavenged should be used for scavenged chunks.");
             CompleteNonRaw(null);
         }
 
         public void CompleteScavenge(ICollection<PosMap> mapping)
         {
             if (!ChunkHeader.IsScavenged)
-                throw new InvalidOperationException("CompleteScavenged should not be used for non-scavenged chunks!");
+                throw new InvalidOperationException("CompleteScavenged should not be used for non-scavenged chunks.");
 
             CompleteNonRaw(mapping);
         }
@@ -816,9 +816,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
             {
                 if (!_inMem && _isCached != 0)
                 {
-                    throw new InvalidOperationException("Trying to write mapping while chunk is cached! "
+                    throw new InvalidOperationException("Trying to write mapping while chunk is cached. "
                                                       + "You probably are writing scavenged chunk as cached. "
-                                                      + "Do not do this!");
+                                                      + "Do not do this.");
                 }
                 mapSize = mapping.Count * PosMap.FullSize;
                 workItem.Buffer.SetLength(mapSize);
@@ -873,7 +873,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 workItem.WorkingStream.CopyTo(memStream);
 
                 if (!TryDestructMemStreams())
-                    throw new Exception("MemStream readers are in use when writing scavenged chunk!");
+                    throw new Exception("MemStream readers are in use when writing scavenged chunk.");
 
                 _cachedLength = newFileSize;
                 _cachedData = newCachedData;
@@ -926,7 +926,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
             }
 
             if (fileStreamCount < 0)
-                throw new Exception("Somehow we managed to decrease count of file streams below zero.");
+                throw new Exception("Count of file streams reduced below zero.");
             if (fileStreamCount == 0) // we are the last who should "turn the light off" for file streams
                 CleanUpFileStreamDestruction();
         }
@@ -963,7 +963,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 memStreamCount = Interlocked.Decrement(ref _memStreamCount);
             }
             if (memStreamCount < 0)
-                throw new Exception("Somehow we managed to decrease count of memory streams below zero.");
+                throw new Exception("Count of memory streams reduced below zero.");
             if (memStreamCount != 0) return false;
             FreeCachedData();
             return true;
@@ -1063,7 +1063,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
         {
             var fileStreamCount = Interlocked.Decrement(ref _fileStreamCount);
             if (fileStreamCount < 0)
-                throw new Exception("Somehow we managed to decrease count of file streams below zero.");
+                throw new Exception("Count of file streams reduced below zero.");
             if (_selfdestructin54321 && fileStreamCount == 0)
                 CleanUpFileStreamDestruction();
         }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -144,7 +144,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
             private Midpoint[] PopulateMidpoints(int depth)
             {
                 if (depth > 31)
-                    throw new ArgumentOutOfRangeException("depth", "Too large depth for midpoints.");
+                    throw new ArgumentOutOfRangeException("depth", "Depth too for midpoints.");
 
                 if (Chunk.ChunkFooter.MapCount == 0) // empty chunk
                     return null;
@@ -456,6 +456,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 length = workItem.Reader.ReadInt32();
                 if (length <= 0)
                 {
+                    // TODO - Is it intentional not to include the Chunk in the exception, like the ones below do?
                     throw new InvalidReadException(
                         string.Format("Log record at actual pos {0} has non-positive length: {1}. "
                                       + " in chunk.", actualPosition, length, Chunk));

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -103,7 +103,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                     if (!readOnly)
                     {
                         Log.Info("Moving WriterCheckpoint from {0} to {1}, as it points to the scavenged chunk. "
-                                 + "If that was not caused by replication of scavenged chunks, that could be bug!",
+                                 + "If that was not caused by replication of scavenged chunks, that could be a bug.",
                                  checkpoint, lastChunk.ChunkHeader.ChunkEndPosition);
                         Config.WriterCheckpoint.Write(lastChunk.ChunkHeader.ChunkEndPosition);
                         Config.WriterCheckpoint.Flush();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
@@ -127,7 +127,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 || truncateChk >= chunkHeader.ChunkEndPosition)
             {
                 throw new Exception(
-                    string.Format("Chunk #{0}-{1} ({2}) is not correct unscavenged chunk! TruncatePosition: {3}, ChunkHeader: {4}.",
+                    string.Format("Chunk #{0}-{1} ({2}) is not correct unscavenged chunk. TruncatePosition: {3}, ChunkHeader: {4}.",
                                   chunkHeader.ChunkStartNumber, chunkHeader.ChunkEndNumber, chunkFilename, truncateChk, chunkHeader));
             }
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -294,7 +294,7 @@ namespace EventStore.Core.TransactionLog.Chunks
         public TFChunk.TFChunk GetChunk(int chunkNum)
         {
             if (chunkNum < 0 || chunkNum >= _chunksCount)
-                throw new ArgumentOutOfRangeException("chunkNum", string.Format("Chunk #{0} isn't present in DB.", chunkNum));
+                throw new ArgumentOutOfRangeException("chunkNum", string.Format("Chunk #{0} is not present in DB.", chunkNum));
 
             var chunk = _chunks[chunkNum];
             if (chunk == null)

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -92,7 +92,7 @@ namespace EventStore.Core.Util
         public const string InMemDbDescr = "Keep everything in memory, no directories or files are created.";
         public const bool InMemDbDefault = false;
 
-        public const string EnableTrustedAuthDescr = "Enables trusted authentication by an intermediary in the Http";
+        public const string EnableTrustedAuthDescr = "Enables trusted authentication by an intermediary in the HTTP";
         public const bool EnableTrustedAuthDefault = false;
 
         public const string MaxMemTableSizeDescr = "Adjusts the maximum size of a mem table.";
@@ -112,7 +112,7 @@ namespace EventStore.Core.Util
         public const string WorkerThreadsDescr = "The number of threads to use for pool of worker services.";
         public const int WorkerThreadsDefault = 5;
 
-        public const string HttpPrefixesDescr = "The prefixes that the http server should respond to.";
+        public const string HttpPrefixesDescr = "The prefixes that the HTTP server should respond to.";
         public static readonly string[] HttpPrefixesDefault = new string[0];
 
         public const string UnsafeDisableFlushToDiskDescr = "Disable flushing to disk.  (UNSAFE: on power off)";
@@ -170,24 +170,24 @@ namespace EventStore.Core.Util
          */
 
         public const string GossipAllowedDifferenceMsDescr =
-            "The amount of drift between clocks on nodes allowed before gossip is rejected in ms.";
+            "The amount of drift, in ms, between clocks on nodes allowed before gossip is rejected.";
 
         public const int GossipAllowedDifferenceMsDefault = 60000;
 
-        public const string GossipIntervalMsDescr = "The interval nodes should try to gossip with each other in ms.";
+        public const string GossipIntervalMsDescr = "The interval, in ms, nodes should try to gossip with each other.";
         public const int GossipIntervalMsDefault = 1000;
 
-        public const string GossipTimeoutMsDescr = "The timeout on gossip to another node in ms.";
+        public const string GossipTimeoutMsDescr = "The timeout, in ms, on gossip to another node.";
         public const int GossipTimeoutMsDefault = 500;
 
-        public const string AdminOnExtDescr = "Whether or not to run the admin ui on the external http endpoint";
+        public const string AdminOnExtDescr = "Whether or not to run the admin ui on the external HTTP endpoint";
         public const bool AdminOnExtDefault = true;
 
-        public const string GossipOnExtDescr = "Whether or not to accept gossip requests on the external http endpoint";
+        public const string GossipOnExtDescr = "Whether or not to accept gossip requests on the external HTTP endpoint";
         public const bool GossipOnExtDefault = true;
 
         public const string StatsOnExtDescr =
-            "Whether or not to accept statistics requests on the external http endpoint, needed if you use admin ui";
+            "Whether or not to accept statistics requests on the external HTTP endpoint, needed if you use admin ui";
 
         public const bool StatsOnExtDefault = true;
 

--- a/src/EventStore.Projections.Core/Services/IProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/IProjectionStateHandler.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Services
             out string newSharedState, out EmittedEventEnvelope[] emittedEvents);
 
         /// <summary>
-        /// Processes partition created notificatiion and updates internal state if necessary.  
+        /// Processes partition created notification and updates internal state if necessary.  
         /// </summary>
         /// <param name="partition"></param>
         /// <param name="createPosition"></param>

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -278,7 +278,7 @@ namespace EventStore.Projections.Core.Services.Management
             var projection = GetProjection(message.Name);
             if (projection == null)
             {
-                _logger.Error("DBG: PROJECTION *{0}* NOT FOUND!!!", message.Name);
+                _logger.Error("DBG: PROJECTION *{0}* NOT FOUND.", message.Name);
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             }
             else
@@ -307,7 +307,7 @@ namespace EventStore.Projections.Core.Services.Management
             var projection = GetProjection(message.Name);
             if (projection == null)
             {
-                _logger.Error("DBG: PROJECTION *{0}* NOT FOUND!!!", message.Name);
+                _logger.Error("DBG: PROJECTION *{0}* NOT FOUND.", message.Name);
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             }
             else
@@ -323,7 +323,7 @@ namespace EventStore.Projections.Core.Services.Management
             var projection = GetProjection(message.Name);
             if (projection == null)
             {
-                _logger.Error("DBG: PROJECTION *{0}* NOT FOUND!!!", message.Name);
+                _logger.Error("DBG: PROJECTION *{0}* NOT FOUND.", message.Name);
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             }
             else

--- a/src/EventStore.Projections.Core/Services/Processing/AllStreamsCatalogEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/AllStreamsCatalogEventReader.cs
@@ -221,7 +221,7 @@ namespace EventStore.Projections.Core.Services.Processing
             if (_disposed)
                 return;
             if (!_eventsRequested)
-                throw new InvalidOperationException("Read events has not been requested");
+                throw new InvalidOperationException("Read events have not been requested");
             if (Paused)
                 throw new InvalidOperationException("Paused");
             _eventsRequested = false;
@@ -328,7 +328,7 @@ namespace EventStore.Projections.Core.Services.Processing
             }
 
             //NOTE: we do not throw exception if read operation is already in progress as we have
-            // a mix of read operations and allow multiple in progress. However, only one seauential read
+            // a mix of read operations and allow multiple in progress. However, only one sequential read
             // from the catalog is permitted at any time
             if (_eventsRequested)
                 return;

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
@@ -341,7 +341,7 @@ namespace EventStore.Projections.Core.Services.Processing
             {
                 SetFaulted(
                     string.Format(
-                        "A concurrency violation detected, but the projection is not running. Current state is: {0}.  The reason for the restart is: '{1}' ",
+                        "A concurrency violation was detected, but the projection is not running. Current state is: {0}.  The reason for the restart is: '{1}' ",
                         _state, message.Reason));
                 return;
             }

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointWriter.cs
@@ -60,7 +60,7 @@ namespace EventStore.Projections.Core.Services.Processing
             {
                 if (_logger != null)
                     _logger.Trace(
-                        "Checkpoint has be written for projection {0} at sequence number {1} (current)", _name,
+                        "Checkpoint has been written for projection {0} at sequence number {1} (current)", _name,
                         firstWrittenEventNumber);
                 _lastWrittenCheckpointEventNumber = firstWrittenEventNumber;
 

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -234,7 +234,7 @@ namespace EventStore.Projections.Core.Services.Processing
             switch (message.Result)
             {
                 case OperationResult.WrongExpectedVersion:
-                    RequestRestart(string.Format("The '{0}' stream has be written to from the outside", _streamId));
+                    RequestRestart(string.Format("The '{0}' stream has been written to from the outside", _streamId));
                     break;
                 case OperationResult.PrepareTimeout:
                 case OperationResult.ForwardTimeout:
@@ -444,7 +444,7 @@ namespace EventStore.Projections.Core.Services.Processing
             switch (message.Result)
             {
                 case OperationResult.WrongExpectedVersion:
-                    RequestRestart(string.Format("The '{0}' stream has be written to from the outside", _streamId));
+                    RequestRestart(string.Format("The '{0}' stream has been written to from the outside", _streamId));
                     break;
                 case OperationResult.PrepareTimeout:
                 case OperationResult.ForwardTimeout:
@@ -628,7 +628,7 @@ namespace EventStore.Projections.Core.Services.Processing
             if (failed)
                 throw new InvalidEmittedEventSequenceExceptioin(
                     string.Format(
-                        "An event emitted in recovery differ from the originally emitted event.  Existing('{0}', '{1}'). New('{2}', '{3}')",
+                        "An event emitted in recovery differs from the originally emitted event.  Existing('{0}', '{1}'). New('{2}', '{3}')",
                         topAlreadyCommitted.Item2, topAlreadyCommitted.Item1, eventsToWrite.EventType, eventsToWrite.CausedByTag));
             return topAlreadyCommitted;
         }

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderStrategy.cs
@@ -57,8 +57,10 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             if (!sources.AllStreams && !sources.HasCategories() && !sources.HasStreams()
                 && string.IsNullOrEmpty(sources.CatalogStream))
+                // TODO This exception message needs a translation.
                 throw new InvalidOperationException("None of streams and categories are included");
             if (!sources.AllEvents && !sources.HasEvents())
+                // TODO This exception message needs a translation.  I *think* it means to say, "No events are included".
                 throw new InvalidOperationException("None of events are included");
             if (sources.HasStreams() && sources.HasCategories())
                 throw new InvalidOperationException(


### PR DESCRIPTION
This is the remainder of my effort on issue #454.  I seem to have reached the end of the code, scanning any textual output/exception messages.  Summary of changes:
- Wording oddities
- Replaced exclamation points with periods in exception messages.
- Misspellings/grammar
-TODOs re: guards in ReaderStrategy.Create()
- Removed redundancies (e.g. "Something is wrong" in an exception)
- Capitalization (if only to keep consistent with existing code)
- Removed contractions
- Removed a few curse words, in strings and in a couple of test method names. Not a personal statement, but I figured they should be "normalized" :)
