### PR TITLE
Stop PersistentSubscriptionService receiving duplicate messages.

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -413,8 +413,6 @@ namespace EventStore.Core
             _mainBus.Subscribe(ioDispatcher);
             var perSubscrBus = new InMemoryBus("PersistentSubscriptionsBus", true, TimeSpan.FromMilliseconds(50));
             var perSubscrQueue = new QueuedHandlerThreadPool(perSubscrBus, "PersistentSubscriptions", false);
-            _mainBus.Subscribe(perSubscrQueue.WidenFrom<SystemMessage.BecomeShuttingDown, Message>());
-            _mainBus.Subscribe(perSubscrQueue.WidenFrom<SystemMessage.BecomeMaster, Message>());
             _mainBus.Subscribe(perSubscrQueue.WidenFrom<SystemMessage.StateChangeMessage, Message>());
             _mainBus.Subscribe(perSubscrQueue.WidenFrom<TcpMessage.ConnectionClosed, Message>());
             _mainBus.Subscribe(perSubscrQueue.WidenFrom<ClientMessage.CreatePersistentSubscription, Message>());


### PR DESCRIPTION
I noticed this when fixing the UI listing of competing consumers. When starting up the BecomeMaster message is received twice causing the subscriptions to be loaded twice. A race results in duplicates.

It seems that the in memory bus is subscribed twice to the BecomeMaster message via a subscription to StateChangeMessage. This is because they are the same type id. I'm not sure of the design of the internal bus, but I've removed the subscription to the more specific types.

This might not be the correct approach though.
