### PR TITLE
Fix incorrect multi-thread access to the main InMemoryBus

### DIFF
--- a/src/EventStore.Core/Authentication/IAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core/Authentication/IAuthenticationProviderFactory.cs
@@ -6,7 +6,7 @@ namespace EventStore.Core.Authentication
 {
 	public interface IAuthenticationProviderFactory
 	{
-		IAuthenticationProvider BuildAuthenticationProvider(IPublisher mainQueue, IBus mainBus, IPublisher workersQueue, InMemoryBus[] workerBusses);
+        IAuthenticationProvider BuildAuthenticationProvider(IPublisher mainQueue, ISubscriber mainBus, IPublisher workersQueue, InMemoryBus[] workerBusses);
 		void RegisterHttpControllers(HttpService externalHttpService, HttpService internalHttpService, HttpSendService httpSendService, IPublisher mainQueue, IPublisher networkSendQueue);
 	}
 }

--- a/src/EventStore.Core/Authentication/InternalAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthenticationProviderFactory.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Authentication
 {
 	public class InternalAuthenticationProviderFactory : IAuthenticationProviderFactory
 	{
-		public IAuthenticationProvider BuildAuthenticationProvider(IPublisher mainQueue, IBus mainBus, IPublisher workersQueue, InMemoryBus[] workerBusses)
+		public IAuthenticationProvider BuildAuthenticationProvider(IPublisher mainQueue, ISubscriber mainBus, IPublisher workersQueue, InMemoryBus[] workerBusses)
 		{
 			var passwordHashAlgorithm = new Rfc2898PasswordHashAlgorithm();
 			var dispatcher = new IODispatcher(mainQueue, new PublishEnvelope(workersQueue, crossThread: true));

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -53,7 +53,7 @@ namespace EventStore.Core
 
         private readonly VNodeInfo _nodeInfo;
         private readonly QueuedHandler _mainQueue;
-        private readonly InMemoryBus _mainBus;
+        private readonly ISubscriber _mainBus;
 
         private readonly ClusterVNodeController _controller;
         private readonly TimerService _timerService;
@@ -110,7 +110,7 @@ namespace EventStore.Core
                                                             watchSlowMsg: true,
                                                             slowMsgThreshold: TimeSpan.FromMilliseconds(200)));
 
-            _controller = new ClusterVNodeController(_mainBus, _nodeInfo, db, vNodeSettings, this, forwardingProxy);
+            _controller = new ClusterVNodeController((IPublisher)_mainBus, _nodeInfo, db, vNodeSettings, this, forwardingProxy);
             _mainQueue = new QueuedHandler(_controller, "MainQueue");
             
             _controller.SetMainQueue(_mainQueue);
@@ -405,7 +405,7 @@ namespace EventStore.Core
 
             // PERSISTENT SUBSCRIPTIONS
             // IO DISPATCHER
-            var ioDispatcher = new IODispatcher(_mainBus, new PublishEnvelope(_mainQueue));
+            var ioDispatcher = new IODispatcher(_mainQueue, new PublishEnvelope(_mainQueue));
             _mainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
             _mainBus.Subscribe<ClientMessage.WriteEventsCompleted>(ioDispatcher.Writer);
             _mainBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(ioDispatcher.ForwardReader);


### PR DESCRIPTION
Replaces #505.

Seems the only incorrect access was from the IODispatcher. This seems to only be used by the PersistentSubscription code.

I've changed the code slightly to try and prevent further misuse.