### PR TITLE
Fix the periodic tick in the PersistentSubscriptionService

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -91,9 +91,9 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         public void Handle(SystemMessage.BecomeMaster message)
         {
-            _handleTick = true;
             Log.Debug("Subscriptions Became Master so now handling subscriptions");
             InitToEmpty();
+            _handleTick = true;
             _bus.Publish(_tickRequestMessage); 
             LoadConfiguration(Start);
         }


### PR DESCRIPTION
There's functionality to check for old messages to retry in the persistent subscriptions. This isn't working as the flag to guard against early ticks was incorrectly cleared.

I'm assuming this wasn't on purpose.