### PR TITLE
Backport upate check for mono 4

### DIFF
--- a/src/EventStore.Core/ProgramBase.cs
+++ b/src/EventStore.Core/ProgramBase.cs
@@ -102,7 +102,7 @@ namespace EventStore.Core
                     Application.Exit(3, "Appears that we are running in mono with boehm GC this is generally not a good idea, please run with sgen instead." + 
                         "to run with sgen use mono --gc=sgen. If you really want to run with boehm GC you can use --force to override this error.");
                 }
-                if(OS.IsUnix && !OS.GetRuntimeVersion().StartsWith("3"))
+                if(OS.IsUnix && !(OS.GetRuntimeVersion().StartsWith("3") || OS.GetRuntimeVersion().StartsWith("4")) )
                 {
                     Application.Exit(4, "Appears that we are running in linux with a version 2 build of mono. This is generally not a good idea." +
                         "We recommend running with 3.0 or higher (3.2 especially). If you really want to run with this version of mono use --force to override this error.");


### PR DESCRIPTION
Backport the Mono Runtime Version check to the next release. Fixes #522

(cherry picked from commit 9a0987f19935178df143a3cf876becaa1b11ffae)