### PR TITLE
Add VNodeState to cluster node stats

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -143,6 +143,8 @@ namespace EventStore.Core
             monitoringInnerBus.Subscribe<ClientMessage.WriteEventsCompleted>(monitoring);
             monitoringInnerBus.Subscribe<MonitoringMessage.GetFreshStats>(monitoring);
 
+            monitoringRequestBus.Subscribe<MonitoringMessage.InternalStatsRequest>(_controller);
+
             var truncPos = db.Config.TruncateCheckpoint.Read();
             if (truncPos != -1)
             {


### PR DESCRIPTION
To allow querying of the state of each node in a cluster via the stats http endpoint, add current value of VNodeState to node stats. This allows cluster master\slave status to be monitored by external tools.