### PR TITLE
Add new cluster node stat "proc_cpuScaled" which is "proc-cpu" but scaled by number of logical processors

### DIFF
--- a/src/EventStore.Core/Services/Monitoring/SystemStatsHelper.cs
+++ b/src/EventStore.Core/Services/Monitoring/SystemStatsHelper.cs
@@ -117,10 +117,13 @@ namespace EventStore.Core.Services.Monitoring
             var process = Process.GetCurrentProcess();
             try
             {
+                var procCpuUsage = _perfCounter.GetProcCpuUsage(); 
+                
                 stats["proc-startTime"] = process.StartTime.ToUniversalTime().ToString("O");
                 stats["proc-id"] = process.Id;
                 stats["proc-mem"] = new StatMetadata(process.WorkingSet64, "Process", "Process Virtual Memory");
-                stats["proc-cpu"] = new StatMetadata(_perfCounter.GetProcCpuUsage(), "Process", "Process Cpu Usage");
+                stats["proc-cpu"] = new StatMetadata(procCpuUsage, "Process", "Process Cpu Usage");
+                stats["proc-cpuScaled"] = new StatMetadata(procCpuUsage / Environment.ProcessorCount, "Process", "Process Cpu Usage Scaled by Logical Processor Count");
                 stats["proc-threadsCount"] = _perfCounter.GetProcThreadsCount();
                 stats["proc-contentionsRate"] = _perfCounter.GetContentionsRateCount();
                 stats["proc-thrownExceptionsRate"] = _perfCounter.GetThrownExceptionsRate();


### PR DESCRIPTION
Add new cluster node stat "proc_cpuScaled" which is "proc-cpu" but scaled by number of logical processors to give a value which bounded to 0-100%. The current "proc-cpu" figure has a range of 100% * number of logical processors which makes it tricky where downstream users may not know the number of logical processors or if the number of processors changes e.g. VM environment or hardware changes.

See the following discussion: https://github.com/EventStore/EventStore/issues/521
