### PR TITLE
Add support to run the run-node.sh script via absolute path

### DIFF
--- a/scripts/package-mono/run-node.sh
+++ b/scripts/package-mono/run-node.sh
@@ -1,3 +1,4 @@
 ##!/usr/bin/env bash
+EVENTSTORE_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-LD_LIBRARY_PATH=.:$LD_LIBRARY_PATH ./clusternode $@
+LD_LIBRARY_PATH=${EVENTSTORE_DIR}:$LD_LIBRARY_PATH ${EVENTSTORE_DIR}/clusternode $@


### PR DESCRIPTION
This small change add support to run the run-node.sh script via absolute path. Currently it is only possible to cd into the EventStore directory and call ```./run-node.sh``` otherwise ```LD_LIBRARY_PATH```was wrong and the ```clusternode``` binary was not found.

No you can use the ```run-node.sh```script in environments where you're not allowed to change path before executing the script.