### PR TITLE
Split Ext and Int HTTP Prefixes

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -106,8 +106,10 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.WorkerThreadsDescr, Opts.AppGroup)]
         public int WorkerThreads { get; set; }
 
-        [ArgDescription(Opts.HttpPrefixesDescr, Opts.InterfacesGroup)]
-        public string[] HttpPrefixes { get; set; }
+        [ArgDescription(Opts.IntHttpPrefixesDescr, Opts.InterfacesGroup)]
+        public string[] IntHttpPrefixes { get; set; }
+        [ArgDescription(Opts.ExtHttpPrefixesDescr, Opts.InterfacesGroup)]
+        public string[] ExtHttpPrefixes { get; set; }
         [ArgDescription(Opts.EnableTrustedAuthDescr, Opts.InterfacesGroup)]
         public bool EnableTrustedAuth { get; set; }
         [ArgDescription(Opts.AddInterfacePrefixesDescr, Opts.InterfacesGroup)]
@@ -197,7 +199,8 @@ namespace EventStore.ClusterNode
             ProjectionThreads = Opts.ProjectionThreadsDefault;
             WorkerThreads = Opts.WorkerThreadsDefault;
 
-            HttpPrefixes = Opts.HttpPrefixesDefault;
+            IntHttpPrefixes = Opts.IntHttpPrefixesDefault;
+            ExtHttpPrefixes = Opts.ExtHttpPrefixesDefault;
             EnableTrustedAuth = Opts.EnableTrustedAuthDefault;
             AddInterfacePrefixes = Opts.AddInterfacePrefixesDefault;
 

--- a/src/EventStore.Core.Tests/ClientAPI/SpecificationWithMiniNode.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/SpecificationWithMiniNode.cs
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.ClientAPI
             base.TestFixtureSetUp();
             _node = new MiniNode(PathName, skipInitializeStandardUsersCheck: false);
             _node.Start();
-            _HttpEndPoint = _node.HttpEndPoint;
+            _HttpEndPoint = _node.ExtHttpEndPoint;
             _conn = BuildConnection(_node);
             _conn.ConnectAsync().Wait();
             Given();

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -79,7 +79,7 @@ namespace EventStore.Core.Tests.Helpers
             var singleVNodeSettings = new ClusterVNodeSettings(
                 Guid.NewGuid(), debugIndex, InternalTcpEndPoint, InternalTcpSecEndPoint, ExternalTcpEndPoint,
                 ExternalTcpSecEndPoint, InternalHttpEndPoint, ExternalHttpEndPoint,
-                new[] {ExternalHttpEndPoint.ToHttpUrl()}, enableTrustedAuth, ssl_connections.GetCertificate(), 1, false,
+                new[] {InternalHttpEndPoint.ToHttpUrl()}, new[]{ExternalHttpEndPoint.ToHttpUrl()}, enableTrustedAuth, ssl_connections.GetCertificate(), 1, false,
                 "", gossipSeeds, TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2),
                 false, "", false, TimeSpan.FromHours(1), StatsStorage.None, 0,
                 new InternalAuthenticationProviderFactory(), disableScavengeMerging: true, adminOnPublic: true,

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -40,10 +40,10 @@ namespace EventStore.Core.Tests.Helpers
 
         public IPEndPoint TcpEndPoint { get; private set; }
         public IPEndPoint TcpSecEndPoint { get; private set; }
-        public IPEndPoint HttpEndPoint { get; private set; }
+        public IPEndPoint IntHttpEndPoint { get; private set; }
         public IPEndPoint IntTcpEndPoint { get; private set;}
         public IPEndPoint IntSecTcpEndPoint { get; private set; }
-        public IPEndPoint IntHttpEndPoint { get; private set; }
+        public IPEndPoint ExtHttpEndPoint { get; private set; }
         public readonly ClusterVNode Node;
         public readonly TFChunkDb Db;
         private readonly string _dbPath;
@@ -76,10 +76,10 @@ namespace EventStore.Core.Tests.Helpers
             
             TcpEndPoint = new IPEndPoint(ip, extTcpPort);
             TcpSecEndPoint = new IPEndPoint(ip, extSecTcpPort);
-            HttpEndPoint = new IPEndPoint(ip, extHttpPort);
             IntTcpEndPoint = new IPEndPoint(ip,intTcpPort);
             IntSecTcpEndPoint = new IPEndPoint(ip, intSecTcpPort);
             IntHttpEndPoint = new IPEndPoint(ip, intHttpPort);
+            ExtHttpEndPoint = new IPEndPoint(ip, extHttpPort);
             var vNodeSettings = new ClusterVNodeSettings(Guid.NewGuid(),
                                                          0,
                                                          IntTcpEndPoint,
@@ -87,8 +87,9 @@ namespace EventStore.Core.Tests.Helpers
                                                          TcpEndPoint,
                                                          TcpSecEndPoint,
                                                          IntHttpEndPoint,
-                                                         HttpEndPoint,
-                                                         new [] {HttpEndPoint.ToHttpUrl()},
+                                                         ExtHttpEndPoint,
+                                                         new [] {IntHttpEndPoint.ToHttpUrl()},
+                                                         new [] {ExtHttpEndPoint.ToHttpUrl()},
                                                          enableTrustedAuth,
                                                          ssl_connections.GetCertificate(),
                                                          1,
@@ -137,8 +138,8 @@ namespace EventStore.Core.Tests.Helpers
                      "DBPATH:", _dbPath,
                      "TCP ENDPOINT:", TcpEndPoint,
                      "TCP SECURE ENDPOINT:", TcpSecEndPoint,
-                     "HTTP ENDPOINT:", HttpEndPoint);
-            Node = new ClusterVNode(Db, vNodeSettings, new KnownEndpointGossipSeedSource(new [] {HttpEndPoint}), new InfoController(null), subsystems);
+                     "HTTP ENDPOINT:", ExtHttpEndPoint);
+            Node = new ClusterVNode(Db, vNodeSettings, new KnownEndpointGossipSeedSource(new [] {ExtHttpEndPoint}), new InfoController(null), subsystems);
 
             Node.ExternalHttpService.SetupController(new TestController(Node.MainQueue));
         }
@@ -175,7 +176,7 @@ namespace EventStore.Core.Tests.Helpers
             {
                 PortsHelper.ReturnPort(TcpEndPoint.Port);
                 PortsHelper.ReturnPort(TcpSecEndPoint.Port);
-                PortsHelper.ReturnPort(HttpEndPoint.Port);
+                PortsHelper.ReturnPort(IntHttpEndPoint.Port);
                 PortsHelper.ReturnPort(IntHttpEndPoint.Port);
                 PortsHelper.ReturnPort(IntTcpEndPoint.Port);
                 PortsHelper.ReturnPort(IntSecTcpEndPoint.Port);

--- a/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
+++ b/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
@@ -175,7 +175,7 @@ namespace EventStore.Core.Tests.Http
             if (supplied.IsAbsoluteUri && !supplied.IsFile) // NOTE: is file imporant for mono
                 return supplied;
 
-            var httpEndPoint = _node.HttpEndPoint;
+            var httpEndPoint = _node.ExtHttpEndPoint;
             var x =  new UriBuilder("http", httpEndPoint.Address.ToString(), httpEndPoint.Port, path);
             x.Query = extra;
 	    Console.WriteLine(new string('*', 50) + Environment.NewLine + path + Environment.NewLine + extra + Environment.NewLine + x.Uri + Environment.NewLine + new string('*', 50));

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -26,6 +26,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService
                 GetLoopbackForPort(tcpIntPort), null,
                 GetLoopbackForPort(tcpExtPort), null,
                 GetLoopbackForPort(httpIntPort), GetLoopbackForPort(httpExtPort),
+                new[] { GetLoopbackForPort(httpIntPort).ToHttpUrl() },
                 new[] { GetLoopbackForPort(httpExtPort).ToHttpUrl() },
                 false, null, 1, false, "dns", new[] { GetLoopbackForPort(ManagerPort) },
                 TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(2),

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_database.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
             var tcpPort = miniNode.TcpEndPoint.Port;
             var tcpSecPort = miniNode.TcpSecEndPoint.Port;
-            var httpPort = miniNode.HttpEndPoint.Port;
+            var httpPort = miniNode.ExtHttpEndPoint.Port;
             const int cnt = 50;
             var countdown = new CountdownEvent(cnt);
 
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
             var tcpPort = miniNode.TcpEndPoint.Port;
             var tcpSecPort = miniNode.TcpSecEndPoint.Port;
-            var httpPort = miniNode.HttpEndPoint.Port;
+            var httpPort = miniNode.ExtHttpEndPoint.Port;
             const int cnt = 1;
             var countdown = new CountdownEvent(cnt);
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -12,7 +12,8 @@ namespace EventStore.Core.Cluster.Settings
     public class ClusterVNodeSettings
     {
         public readonly VNodeInfo NodeInfo;
-        public readonly string[] HttpPrefixes;
+        public readonly string[] IntHttpPrefixes;
+        public readonly string[] ExtHttpPrefixes;
         public readonly bool EnableTrustedAuth;
         public readonly X509Certificate2 Certificate;
         public readonly int WorkerThreads;
@@ -62,7 +63,8 @@ namespace EventStore.Core.Cluster.Settings
                                     IPEndPoint externalSecureTcpEndPoint,
                                     IPEndPoint internalHttpEndPoint,
                                     IPEndPoint externalHttpEndPoint,
-                                    string[] httpPrefixes,
+                                    string[] intHttpPrefixes,
+                                    string[] extHttpPrefixes,
                                     bool enableTrustedAuth,
                                     X509Certificate2 certificate,
                                     int workerThreads,
@@ -102,7 +104,8 @@ namespace EventStore.Core.Cluster.Settings
             Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
             Ensure.NotNull(internalHttpEndPoint, "internalHttpEndPoint");
             Ensure.NotNull(externalHttpEndPoint, "externalHttpEndPoint");
-            Ensure.NotNull(httpPrefixes, "httpPrefixes");
+            Ensure.NotNull(intHttpPrefixes, "intHttpPrefixes");
+            Ensure.NotNull(extHttpPrefixes, "extHttpPrefixes");
             if (internalSecureTcpEndPoint != null || externalSecureTcpEndPoint != null)
                 Ensure.NotNull(certificate, "certificate");
             Ensure.Positive(workerThreads, "workerThreads");
@@ -122,7 +125,8 @@ namespace EventStore.Core.Cluster.Settings
                                      internalTcpEndPoint, internalSecureTcpEndPoint,
                                      externalTcpEndPoint, externalSecureTcpEndPoint,
                                      internalHttpEndPoint, externalHttpEndPoint);
-            HttpPrefixes = httpPrefixes;
+            IntHttpPrefixes = intHttpPrefixes;
+            ExtHttpPrefixes = extHttpPrefixes;
             EnableTrustedAuth = enableTrustedAuth;
             Certificate = certificate;
             WorkerThreads = workerThreads;
@@ -174,34 +178,36 @@ namespace EventStore.Core.Cluster.Settings
                                  + "ExternalSecureTcp: {4}\n"
                                  + "InternalHttp: {5}\n"
                                  + "ExternalHttp: {6}\n"
-                                 + "HttpPrefixes: {7}\n"
-                                 + "EnableTrustedAuth: {8}\n"
-                                 + "Certificate: {9}\n"
-                                 + "WorkerThreads: {10}\n"
-                                 + "DiscoverViaDns: {11}\n"
-                                 + "ClusterDns: {12}\n"
-                                 + "GossipSeeds: {13}\n"
-                                 + "ClusterNodeCount: {14}\n"
-                                 + "MinFlushDelay: {15}\n"
-                                 + "PrepareAckCount: {16}\n"
-                                 + "CommitAckCount: {17}\n"
-                                 + "PrepareTimeout: {18}\n"
-                                 + "CommitTimeout: {19}\n"
-                                 + "UseSsl: {20}\n"
-                                 + "SslTargetHost: {21}\n"
-                                 + "SslValidateServer: {22}\n"
-                                 + "StatsPeriod: {23}\n"
-                                 + "StatsStorage: {24}\n"
-                                 + "AuthenticationProviderFactory Type: {25}\n"
-                                 + "NodePriority: {26}"
-                                 + "GossipInterval: {27}\n"
-                                 + "GossipAllowedTimeDifference: {28}\n"
-                                 + "GossipTimeout: {29}\n",
+                                 + "IntHttpPrefixes: {7}\n"
+                                 + "ExtHttpPrefixes: {8}\n"
+                                 + "EnableTrustedAuth: {9}\n"
+                                 + "Certificate: {10}\n"
+                                 + "WorkerThreads: {12}\n"
+                                 + "DiscoverViaDns: {13}\n"
+                                 + "ClusterDns: {14}\n"
+                                 + "GossipSeeds: {15}\n"
+                                 + "ClusterNodeCount: {16}\n"
+                                 + "MinFlushDelay: {17}\n"
+                                 + "PrepareAckCount: {18}\n"
+                                 + "CommitAckCount: {19}\n"
+                                 + "PrepareTimeout: {20}\n"
+                                 + "CommitTimeout: {21}\n"
+                                 + "UseSsl: {22}\n"
+                                 + "SslTargetHost: {23}\n"
+                                 + "SslValidateServer: {24}\n"
+                                 + "StatsPeriod: {25}\n"
+                                 + "StatsStorage: {26}\n"
+                                 + "AuthenticationProviderFactory Type: {27}\n"
+                                 + "NodePriority: {28}"
+                                 + "GossipInterval: {29}\n"
+                                 + "GossipAllowedTimeDifference: {30}\n"
+                                 + "GossipTimeout: {31}\n",
                                  NodeInfo.InstanceId,
                                  NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
                                  NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
                                  NodeInfo.InternalHttp, NodeInfo.ExternalHttp,
-                                 string.Join(", ", HttpPrefixes),
+                                 string.Join(", ", IntHttpPrefixes),
+                                 string.Join(", ", ExtHttpPrefixes),
                                  EnableTrustedAuth,
                                  Certificate == null ? "n/a" : Certificate.ToString(true),
                                  WorkerThreads, DiscoverViaDns, ClusterDns,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -291,7 +291,9 @@ namespace EventStore.Core
 
             // EXTERNAL HTTP
             _externalHttpService = new HttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
-                                                    _workersHandler, vNodeSettings.HttpPrefixes);
+                                                    _workersHandler, 
+                                                    !isSingleNode ? vNodeSettings.ExtHttpPrefixes : 
+                                                                   vNodeSettings.ExtHttpPrefixes.Concat(vNodeSettings.IntHttpPrefixes).ToArray());
             if(vNodeSettings.AdminOnPublic)
                 _externalHttpService.SetupController(adminController);
             _externalHttpService.SetupController(pingController);
@@ -308,7 +310,7 @@ namespace EventStore.Core
             // INTERNAL HTTP
             if(!isSingleNode) {
                 _internalHttpService = new HttpService(ServiceAccessibility.Private, _mainQueue, new TrieUriRouter(),
-                                                       _workersHandler, _nodeInfo.InternalHttp.ToHttpUrl());
+                                                       _workersHandler, vNodeSettings.IntHttpPrefixes);
                 _internalHttpService.SetupController(adminController);
                 _internalHttpService.SetupController(pingController);
                 _internalHttpService.SetupController(infoController);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -292,8 +292,9 @@ namespace EventStore.Core
             // EXTERNAL HTTP
             _externalHttpService = new HttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
                                                     _workersHandler, 
-                                                    !isSingleNode ? vNodeSettings.ExtHttpPrefixes : 
-                                                                   vNodeSettings.ExtHttpPrefixes.Concat(vNodeSettings.IntHttpPrefixes).ToArray());
+                                                    isSingleNode ? vNodeSettings.ExtHttpPrefixes.Concat(vNodeSettings.IntHttpPrefixes).ToArray()) :
+                                                                   vNodeSettings.ExtHttpPrefixes;
+
             if(vNodeSettings.AdminOnPublic)
                 _externalHttpService.SetupController(adminController);
             _externalHttpService.SetupController(pingController);

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -107,8 +107,11 @@ namespace EventStore.Core.Util
         public const string WorkerThreadsDescr = "The number of threads to use for pool of worker services.";
         public const int    WorkerThreadsDefault = 5;
 
-        public const string HttpPrefixesDescr = "The prefixes that the http server should respond to.";
-        public static readonly string[] HttpPrefixesDefault = new string[0];
+        public const string IntHttpPrefixesDescr = "The prefixes that the internal http server should respond to.";
+        public static readonly string[] IntHttpPrefixesDefault = new string[0];
+
+        public const string ExtHttpPrefixesDescr = "The prefixes that the external http server should respond to.";
+        public static readonly string[] ExtHttpPrefixesDefault = new string[0];
 
         public const string UnsafeDisableFlushToDiskDescr = "Disable flushing to disk.  (UNSAFE: on power off)";
         public static readonly bool UnsafeDisableFlushToDiskDefault = false; 

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -41,7 +41,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
 
                 _manager = new ProjectionsManager(
                     new ConsoleLogger(),
-                    _node.HttpEndPoint,
+                    _node.IntHttpEndPoint,
                     TimeSpan.FromMilliseconds(10000));
                 WaitIdle();
                 if (GivenStandardProjectionsRunning())


### PR DESCRIPTION
This should reduce confusion when configuring HTTP prefixes, especially with cloud providers.