### PR TITLE
Set head of stream when reading forward

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -39,7 +39,11 @@ namespace EventStore.Core.Services.Transport.Http
                 feed.AddLink("last", HostName.Combine(requestedUrl, "/streams/{0}/{1}/forward/{2}", escapedStreamId, 0, msg.MaxCount));
                 feed.AddLink("next", HostName.Combine(requestedUrl, "/streams/{0}/{1}/backward/{2}", escapedStreamId, nextEventNumber, msg.MaxCount));
             }
-            if (!msg.IsEndOfStream || msg.Events.Length > 0)
+            if (!msg.IsEndOfStream && msg.Events.Length == msg.MaxCount)
+            {
+                feed.SetHeadOfStream(true);
+            }
+            if (!msg.IsEndOfStream || msg.Events.Length > 0) { }
                 feed.AddLink("previous", HostName.Combine(requestedUrl, "/streams/{0}/{1}/forward/{2}", escapedStreamId, prevEventNumber, msg.MaxCount));
             if(!escapedStreamId.StartsWith("$$"))
                 feed.AddLink("metadata", HostName.Combine(requestedUrl, "/streams/{0}/metadata", escapedStreamId));


### PR DESCRIPTION
Fixes #548
When reading from the start of a stream. /stream_name/0/forward/20. and following the previous links to  /stream_name/20/forward/20 we never explicitly set the headOfStream. This should resolve that issue and correctly set the head of stream.