### PR TITLE
Key was not present in dictionary

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
@@ -129,6 +129,7 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             if (!_pausedSubscriptions.Contains(message.SubscriptionId))
                 Handle(new ReaderSubscriptionManagement.Pause(message.SubscriptionId));
+            if(!_subscriptionEventReaders.ContainsKey(message.SubscriptionId)) return;
             var eventReaderId = _subscriptionEventReaders[message.SubscriptionId];
             if (eventReaderId != Guid.Empty)
             {


### PR DESCRIPTION
Fixes #515

To cut a long story short, 2 messages are being publish on shutdown (further explanation about the series of events is part of the commit message). One that clears out the list of subscriptions and another for each projection to ensure that they have UnSubscribed.

https://github.com/EventStore/EventStore/blob/dev/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs#L269-L273

https://github.com/EventStore/EventStore/blob/dev/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs#L132
