### PR TITLE
Switch to binding to loopback by default instead of 0.0.0.0

### DIFF
--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -179,10 +179,10 @@ namespace EventStore.Core.Util
         public const bool StatsOnExtDefault = true;
 
         public const string InternalIpDescr = "Internal IP Address.";
-        public static readonly IPAddress InternalIpDefault = IPAddress.Parse("0.0.0.0");
+        public static readonly IPAddress InternalIpDefault = IPAddress.Loopback;
 
         public const string ExternalIpDescr = "External IP Address.";
-        public static readonly IPAddress ExternalIpDefault = IPAddress.Parse("0.0.0.0");
+        public static readonly IPAddress ExternalIpDefault = IPAddress.Loopback;
 
         public const string InternalHttpPortDescr = "Internal HTTP Port.";
         public const int    InternalHttpPortDefault = 2112;


### PR DESCRIPTION
In light of [articles such as this](http://securityintelligence.com/news/about-30000-instances-of-mongodb-exposed-on-web-security-researcher-says/#.Vb-5pnhhyuc) we decided it would be better to bind only to loopback by default.

This commit effects that change.