### PR TITLE
Update README instructions for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ Event Store is written in a mixture of C#, C++ and JavaScript. It can run either
 
 Binaries are available from http://geteventstore.com, however if you want to build it from source, instructions for Windows and Linux are below.
 
+**Note: We include a precompiled js1 (We include builds of js1 for osx, ubunty-trusty as well as windows). This means that for the majority of cases, v8 does not need to be built from source.**
+
 ###Debug Builds on Windows / .NET
 
 ####Prerequisites
 
 - .NET Framework v4.0+
-- Windows platform SDK with compilers (v7.1) or Visual C++ installed
+- Windows platform SDK with compilers (v7.1) or Visual C++ installed *(Only required for a full build)*
 - git on PATH
-- svn on PATH
+- svn on PATH *(Only required for a full build)*
 
 ####Building the Event Store
-
-*Important note: if you have previously built from source, it's possible you have V8 checked out via git instead of Subversion. If this is the case, you should use the `clean-all` target noted below before building again.*
 
 From a command prompt:
 
@@ -42,32 +42,19 @@ Optional parameters (Specified using `-ParameterName value`)
 
 ####Building the Event Store from Visual Studio
 
-If you want to build from Visual Studio, it's necessary to first build from the
-command line in order to build `js1.dll` which incorporates V8. When this is
-available in the `src\EventStore\Libs\` directory, it is possible to build the
-`src\EventStore\EventStore.sln` solution from within Visual Studio.
-
 When building through Visual Studio, there are PowerShell scripts which run as
 pre- and post-build tasks on the EventStore.Common project, which set the
 informational version attribute of the EventStore.Common.dll assembly to the
 current commit hash on each build and then revert it.
 
-Unfortunately Visual Studio runs these scripts in 32-bit PowerShell. Since it's
-most likely that you're running 64-bit PowerShell under normal circumstances,
-the execution policy of 32-bit PowerShell will probably prohibit running
-scripts. *There is a batch file in the root of the repository named
-`RunMeElevatedFirst.cmd` which will set the execution policy for 32-bit
-PowerShell if you run it as Administrator. Obviously you may want to audit what
-the script does before executing it on your machine!*
-
-###Debug Builds on Linux (Ubuntu 12.04) or MacOS X / Mono
+###Debug Builds on Linux (Ubuntu 14.04) or MacOS X / Mono
 
 ####Prerequisites
 
 - git on `PATH`
-- Mono version 3.2.3 or greater on PATH
-- svn on `PATH`
-- gcc installed
+- Mono version 3.12.1 or greater on PATH
+- svn on `PATH` *(Only required for a full build)*
+- gcc installed *(Only required for a full build)*
 
 ####Building the Event Store
 


### PR DESCRIPTION
We now include the precompiled js1 as part of the source. This reduces the complexity/process around building Event Store from source in the majority of cases.

Removed script (RunMeElevatedFirst.cmd) that was removed in bc2d462fadec1d7a8e00260936e70bd73185c568
gcc only needed for performing a full build