### PR TITLE
Swap around version and platform in Windows packages

### DIFF
--- a/scripts/package-windows/package-windows.ps1
+++ b/scripts/package-windows/package-windows.ps1
@@ -4,7 +4,7 @@ Param(
     [string]$Version
 )
 
-$packageName = "EventStore-OSS-v$Version-Windows.zip"
+$packageName = "EventStore-OSS-Win-v$Version.zip"
 
 $baseDirectory = Resolve-Path (Join-Path $PSScriptRoot "..\..\")
 $binDirectory = Join-Path $baseDirectory "bin"


### PR DESCRIPTION
Change `EventStore-OSS-v3.1.0-Windows.zip` to be `EventStore-OSS-Win-v3.1.0.zip` as per other platforms.