### PR TITLE
Move -i"" to beginning for BSD sed compatibility

### DIFF
--- a/scripts/package-mono/package-osx.sh
+++ b/scripts/package-mono/package-osx.sh
@@ -126,8 +126,8 @@ mkbundle -c \
     --machine-config $MACHINECONFIG
 
 # Forcibly set MONO_GC_DEBUG to clear-at-gc unless it's already set
-sed -e 's/mono_mkbundle_init();/setenv("MONO_GC_DEBUG", "clear-at-gc", 0);\
-        mono_mkbundle_init();/' -i"" clusternode.c
+sed -i"" -e 's/mono_mkbundle_init();/setenv("MONO_GC_DEBUG", "clear-at-gc", 0);\
+        mono_mkbundle_init();/' clusternode.c
 
 gcc \
     -mmacosx-version-min=10.6 \
@@ -169,8 +169,8 @@ mkbundle -c \
     --machine-config $MACHINECONFIG
 
 # Forcibly set MONO_GC_DEBUG to clear-at-gc unless it's already set
-sed -e 's/mono_mkbundle_init();/setenv("MONO_GC_DEBUG", "clear-at-gc", 0);\
-        mono_mkbundle_init();/' -i"" testclient.c
+sed -i"" -e 's/mono_mkbundle_init();/setenv("MONO_GC_DEBUG", "clear-at-gc", 0);\
+        mono_mkbundle_init();/' testclient.c
 
 gcc \
     -o testclient \


### PR DESCRIPTION
MacOS has BSD sed which doesn't like having the -i"" after the edit
command as it takes - to be the end of the input and therefore reads
from standard in, which is an error with -i (at least I think that's
what's happening). Problem does not occur if the -i"" is before the edit
command and filename.

This has not been an issue as our build boxes have GNU sed installed via
homebrew with `--use-default-names`, as all Macs really should...