### PR TITLE
Mark Obsolete in favor of URI and ConnectionStrings

### DIFF
--- a/src/EventStore.ClientAPI/ClusterSettings.cs
+++ b/src/EventStore.ClientAPI/ClusterSettings.cs
@@ -12,6 +12,7 @@ namespace EventStore.ClientAPI
         /// Creates a new set of <see cref="ClusterSettings"/>
         /// </summary>
         /// <returns>A <see cref="ClusterSettingsBuilder"/> that can be used to build up a <see cref="ClusterSettings"/></returns>
+        [Obsolete("Use ConnectionSettings and/or Connection Strings instead.")]
         public static ClusterSettingsBuilder Create()
         {
             return new ClusterSettingsBuilder();

--- a/src/EventStore.ClientAPI/ClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ClusterSettingsBuilder.cs
@@ -1,4 +1,5 @@
-﻿namespace EventStore.ClientAPI
+﻿using System;
+namespace EventStore.ClientAPI
 {
     /// <summary>
     /// Builder used for creating instances of ClusterSettings.
@@ -9,6 +10,7 @@
         /// Sets the client to discover nodes using a DNS name and a well-known port.
         /// </summary>
         /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        [Obsolete("Use ConnectionSettings and/or Connection Strings instead.")]
         public DnsClusterSettingsBuilder DiscoverClusterViaDns()
         {
             return new DnsClusterSettingsBuilder();
@@ -19,6 +21,7 @@
         /// one or more of the nodes.
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Use ConnectionSettings and/or Connection Strings instead.")]
         public GossipSeedClusterSettingsBuilder DiscoverClusterViaGossipSeeds()
         {
             return new GossipSeedClusterSettingsBuilder();

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -146,7 +146,7 @@ namespace EventStore.ClientAPI
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <param name="tcpEndPoint">The <see cref="IPEndPoint"/> to connect to.</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        [Obsolete("Use Create with connectionstring or a uri instead")]
+        [Obsolete("Use Create with ConnectionString or a URI instead")]
         public static IEventStoreConnection Create(IPEndPoint tcpEndPoint, string connectionName = null)
         {
             return Create(ConnectionSettings.Default, tcpEndPoint, connectionName);
@@ -159,7 +159,7 @@ namespace EventStore.ClientAPI
         /// <param name="tcpEndPoint">The <see cref="IPEndPoint"/> to connect to.</param>
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        [Obsolete("Use Create with connectionstring or a uri instead")]
+        [Obsolete("Use Create with ConnectionString or a URI instead")]
         public static IEventStoreConnection Create(ConnectionSettings connectionSettings, IPEndPoint tcpEndPoint, string connectionName = null)
         {
             Ensure.NotNull(connectionSettings, "settings");
@@ -175,7 +175,7 @@ namespace EventStore.ClientAPI
         /// <param name="clusterSettings">The <see cref="ClusterSettings"/> that determine cluster behavior.</param>
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        [Obsolete("Use Create with connectionstring or a uri instead")]
+        [Obsolete("Use Create with ConnectionString or a URI instead")]
         public static IEventStoreConnection Create(ConnectionSettings connectionSettings, ClusterSettings clusterSettings, string connectionName = null)
         {
             Ensure.NotNull(connectionSettings, "connectionSettings");

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
             CreateNode();
             try
             {
-                _conn = EventStoreConnection.Create(_node.TcpEndPoint);
+                _conn = EventStoreConnection.Create(new Uri("tcp://" + _node.TcpEndPoint.Address + ":" + _node.TcpEndPoint.Port));
                 _conn.ConnectAsync().Wait();
 
                 _manager = new ProjectionsManager(


### PR DESCRIPTION
Use non-Obsolete Create method in Projections Tests

Manual merge of https://github.com/EventStore/EventStore/commit/d58dc42efa998348ed20a27f847701966b506a11
