### PR TITLE
Failed resolved links handled differently in PersistentSubscriptionService

### DIFF
--- a/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
@@ -178,7 +178,7 @@ namespace EventStore.ClientAPI
                 ResolvedEvent e;
                 while (_queue.TryDequeue(out e))
                 {
-                    if (e.Event == null) // drop subscription artificial ResolvedEvent
+                    if (e.Equals(DropSubscriptionEvent)) // drop subscription artificial ResolvedEvent
                     {
                         if (_dropData == null) throw new Exception("Drop reason not specified.");
                         DropSubscription(_dropData.Reason, _dropData.Error);

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -336,14 +336,14 @@ namespace EventStore.Core.Tests.Helpers
                 var parts = Helper.UTF8NoBom.GetString(x.Data).Split(_linkToSeparator, 2);
                 List<EventRecord> list;
                 if (_deletedStreams.Contains(parts[1]) || !_streams.TryGetValue(parts[1], out list))
-                    return new ResolvedEvent(x, null);
+                    return ResolvedEvent.ForFailedResolvedLink(x, ReadEventResult.StreamDeleted);
                 var eventNumber = int.Parse(parts[0]);
                 var target = list[eventNumber];
 
-                return new ResolvedEvent(target, x);
+                return ResolvedEvent.ForResolvedLink(target, x);
             }
             else
-                return new ResolvedEvent(x, null);
+                return ResolvedEvent.ForUnresolvedEvent(x);
         }
 
         private ResolvedEvent BuildEvent(EventRecord x, bool resolveLinks, long commitPosition)
@@ -355,10 +355,10 @@ namespace EventStore.Core.Tests.Helpers
                 var eventNumber = int.Parse(parts[0]);
                 var target = list[eventNumber];
 
-                return new ResolvedEvent(target, x, commitPosition);
+                return ResolvedEvent.ForResolvedLink(target, x, commitPosition);
             }
             else
-                return new ResolvedEvent(x, commitPosition);
+                return ResolvedEvent.ForUnresolvedEvent(x, commitPosition);
         }
 
         public void Handle(ClientMessage.WriteEvents message)

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -1059,7 +1059,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
         public static ResolvedEvent BuildFakeEvent(Guid id, string type, string stream, int version)
         {
             return
-                new ResolvedEvent(new EventRecord(version, 1234567, Guid.NewGuid(), id, 1234567, 1234, stream, version,
+                ResolvedEvent.ForUnresolvedEvent(new EventRecord(version, 1234567, Guid.NewGuid(), id, 1234567, 1234, stream, version,
                     DateTime.Now, PrepareFlags.SingleWrite, type, new byte[0], new byte[0]));
         }
 
@@ -1067,9 +1067,9 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
         {
             var link = new EventRecord(version, 1234567, Guid.NewGuid(), id, 1234567, 1234, stream, version, DateTime.Now, PrepareFlags.SingleWrite, SystemEventTypes.LinkTo, Encoding.UTF8.GetBytes(string.Format("{0}@{1}", ev.OriginalEventNumber, ev.OriginalStreamId)), new byte[0]);
             if (resolved)
-                return new ResolvedEvent(ev.Event, link);
+                return ResolvedEvent.ForResolvedLink(ev.Event, link);
             else
-                return new ResolvedEvent(link, link);
+                return ResolvedEvent.ForUnresolvedEvent(link);
         }
     }
 

--- a/src/EventStore.Core.Tests/Services/Transport/Http/auto_convertion.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/auto_convertion.cs
@@ -503,7 +503,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
 
         private ResolvedEvent GenerateResolvedEvent(byte[] data, byte[] metadata)
         {
-            return new ResolvedEvent(new EventRecord(0, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "stream", 0, 
+            return ResolvedEvent.ForUnresolvedEvent(new EventRecord(0, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "stream", 0, 
                                      DateTime.MinValue, PrepareFlags.IsJson, "type", data, metadata));
         }
     }
@@ -625,7 +625,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
 
         private ResolvedEvent GenerateResolvedEvent(byte[] data, byte[] metadata)
         {
-            return new ResolvedEvent(new EventRecord(0, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "stream", 0,
+            return ResolvedEvent.ForUnresolvedEvent(new EventRecord(0, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "stream", 0,
                                      DateTime.MinValue, PrepareFlags.IsJson, "type", data, metadata));
         }
     }

--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -115,10 +115,7 @@ namespace EventStore.Core.Services.Transport.Http
             feed.AddLink("metadata", HostName.Combine(requestedUrl, "/streams/{0}/metadata", AllEscaped));
             for (int i = msg.Events.Length - 1; i >= 0; --i)
             {
-                feed.AddEntry(
-                    ToEntry(
-                        new ResolvedEvent(msg.Events[i].Event, msg.Events[i].Link, msg.Events[i].ResolveResult),
-                        requestedUrl, embedContent));
+                feed.AddEntry(ToEntry(msg.Events[i].WithoutPosition(), requestedUrl, embedContent));
             }
             return feed;
         }
@@ -143,10 +140,7 @@ namespace EventStore.Core.Services.Transport.Http
             feed.AddLink("metadata", HostName.Combine(requestedUrl, "/streams/{0}/metadata", AllEscaped));
             for (int i = 0; i < msg.Events.Length; ++i)
             {
-                feed.AddEntry(
-                    ToEntry(
-                        new ResolvedEvent(msg.Events[i].Event, msg.Events[i].Link, msg.Events[i].ResolveResult),
-                        requestedUrl, embedContent));
+                feed.AddEntry(ToEntry(msg.Events[i].WithoutPosition(),requestedUrl, embedContent));
             }
             return feed;
         }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_eof_for_all_streams_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_eof_for_all_streams_and_idle_eof.cs
@@ -51,22 +51,22 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any, _fakeTimeProvider.Now,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
+                            "event_type1", new byte[] {1}, new byte[] {2})),
                         }, null, false, "", 2, 1, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                     _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 100, Guid.NewGuid(), _secondEventId, 100, 0, "b", ExpectedVersion.Any, _fakeTimeProvider.Now,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
+                            "event_type1", new byte[] {1}, new byte[] {2})),
                         }, null, false, "", 3, 2, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed.cs
@@ -49,16 +49,16 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                     {
-                        new ResolvedEvent( 
+                        ResolvedEvent.ForUnresolvedEvent( 
                             new EventRecord(
                                 1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null),
-                        new ResolvedEvent( 
+                                "event_type1", new byte[] {1}, new byte[] {2})),
+                        ResolvedEvent.ForUnresolvedEvent( 
                             new EventRecord(
                                 2, 100, Guid.NewGuid(), _secondEventId, 100, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type2", new byte[] {3}, new byte[] {4}), null)
+                                "event_type2", new byte[] {3}, new byte[] {4}))
                     }, null, false, "", 3, 4, false, 200));
         }
 
@@ -101,11 +101,11 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                     {
-                        new ResolvedEvent( 
+                        ResolvedEvent.ForUnresolvedEvent( 
                             new EventRecord(
                         2, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                         PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                        "event_type", new byte[0], new byte[0]), null)
+                        "event_type", new byte[0], new byte[0]))
                     }, null, false, "", 3, 4, false, 100));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_and_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_and_no_stream.cs
@@ -48,16 +48,16 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 100, Guid.NewGuid(), _secondEventId, 100, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
@@ -139,11 +139,11 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             3, 250, Guid.NewGuid(), Guid.NewGuid(), 250, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type", new byte[0], new byte[0]), null)
+                            "event_type", new byte[0], new byte[0]))
                         }, null, false, "", 4, 3, true, 300));
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams.cs
@@ -51,32 +51,32 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                     _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 100, Guid.NewGuid(), _thirdEventId, 100, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             3, 200, Guid.NewGuid(), _fourthEventId, 200, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 4, 3, true, 200));
         }
 
@@ -152,12 +152,12 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             10, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type", new byte[0], new byte[0]), null)
+                            "event_type", new byte[0], new byte[0]))
                         }, null, false, "", 11, 10, true, 100));
         }
 
@@ -169,11 +169,11 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             3, 250, Guid.NewGuid(), Guid.NewGuid(), 250, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type", new byte[0], new byte[0]), null)
+                            "event_type", new byte[0], new byte[0]))
                         }, null, false, "", 4, 4, false, 300));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_after_pause_requested.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_after_pause_requested.cs
@@ -53,32 +53,32 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                     {
-                        new EventStore.Core.Data.ResolvedEvent(
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null),
-                        new EventStore.Core.Data.ResolvedEvent(
+                                "event_type1", new byte[] {1}, new byte[] {2})),
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type2", new byte[] {3}, new byte[] {4}), null)
+                                "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                     _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, 
                     new[]
                     {
-                        new EventStore.Core.Data.ResolvedEvent(
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 2, 100, Guid.NewGuid(), _thirdEventId, 100, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null),
-                        new EventStore.Core.Data.ResolvedEvent(
+                                "event_type1", new byte[] {1}, new byte[] {2})),
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 3, 200, Guid.NewGuid(), _fourthEventId, 200, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type2", new byte[] {3}, new byte[] {4}), null)
+                                "event_type2", new byte[] {3}, new byte[] {4}))
                     }, null, false, "", 4, 3, true, 200));
         }
 
@@ -109,11 +109,11 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                     {
-                        new EventStore.Core.Data.ResolvedEvent(
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 3, 250, Guid.NewGuid(), Guid.NewGuid(), 250, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type", new byte[0], new byte[0]), null)
+                                "event_type", new byte[0], new byte[0]))
                     }, null, false, "", 4, 4, false, 300));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_and_eofs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_and_eofs.cs
@@ -52,32 +52,32 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                     _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 100, Guid.NewGuid(), _thirdEventId, 100, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             3, 200, Guid.NewGuid(), _fourthEventId, 200, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 4, 3, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_then_pause_requested_then_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_then_pause_requested_then_eof.cs
@@ -53,32 +53,32 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 100, Guid.NewGuid(), _secondEventId, 100, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                     _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 150, Guid.NewGuid(), _thirdEventId, 150, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             3, 200, Guid.NewGuid(), _fourthEventId, 200, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 4, 3, true, 200));
             _edp.Pause();
             _edp.Handle(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_onetime_reader_handles_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_onetime_reader_handles_eof.cs
@@ -51,23 +51,23 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any, _fakeTimeProvider.Now,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
+                            "event_type1", new byte[] {1}, new byte[] {2})),
                         }, null, false, "", 2, 1, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                     _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             2, 100, Guid.NewGuid(), _secondEventId, 100, 0, "b", ExpectedVersion.Any,
                             _fakeTimeProvider.Now,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
+                            "event_type1", new byte[] {1}, new byte[] {2})),
                         }, null, false, "", 3, 2, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_resuming.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_resuming.cs
@@ -79,12 +79,12 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type", new byte[0], new byte[0]))
+                            "event_type", new byte[0], new byte[0]), 0)
                         }, null, false, "", 2, 4, false, 100));
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_eof_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_eof_and_idle_eof.cs
@@ -46,17 +46,17 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             10, 50, Guid.NewGuid(), _firstEventId, 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             11, 100, Guid.NewGuid(), _secondEventId, 100, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_and_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_and_eof.cs
@@ -40,17 +40,17 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             10, 50, Guid.NewGuid(), _firstEventId, 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             11, 100, Guid.NewGuid(), _secondEventId, 100, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_stream_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_stream_event_reader.cs
@@ -39,17 +39,17 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             10, 50, Guid.NewGuid(), _firstEventId, 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             11, 100, Guid.NewGuid(), _secondEventId, 100, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
         }
 
@@ -119,12 +119,12 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             10, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type", new byte[0], new byte[0]), null)
+                            "event_type", new byte[0], new byte[0]))
                         }, null, false, "", 11, 10, true, 100));
         }
 
@@ -136,12 +136,12 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             12, 250, Guid.NewGuid(), Guid.NewGuid(), 250, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type", new byte[0], new byte[0]), null)
+                            "event_type", new byte[0], new byte[0]))
                         }, null, false, "", 13, 11, true, 300));
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_then_pause_then_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_then_pause_then_eof.cs
@@ -39,17 +39,17 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
-                            new ResolvedEvent(
-                        new EventRecord(
-                            10, 50, Guid.NewGuid(), _firstEventId, 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
-                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
-                        new EventRecord(
-                            11, 100, Guid.NewGuid(), _secondEventId, 100, 0, "stream", ExpectedVersion.Any,
-                            DateTime.UtcNow,
-                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            ResolvedEvent.ForUnresolvedEvent(
+                                new EventRecord(
+                                    10, 50, Guid.NewGuid(), _firstEventId, 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
+                                    PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                    "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
+                                new EventRecord(
+                                    11, 100, Guid.NewGuid(), _secondEventId, 100, 0, "stream", ExpectedVersion.Any,
+                                    DateTime.UtcNow,
+                                    PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                    "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
             _edp.Pause();
             _edp.Handle(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_onetime_reader_handles_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_onetime_reader_handles_eof.cs
@@ -45,17 +45,17 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
-                            new ResolvedEvent(
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             10, 50, Guid.NewGuid(), _firstEventId, 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type1", new byte[] {1}, new byte[] {2}), null),
-                            new ResolvedEvent(
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
                             11, 100, Guid.NewGuid(), _secondEventId, 100, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type2", new byte[] {3}, new byte[] {4}), null)
+                            "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_resuming_stream_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_resuming_stream_event_reader.cs
@@ -58,10 +58,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success, 
                     new[]
                     {
-                        new ResolvedEvent(new EventRecord(
+                        ResolvedEvent.ForUnresolvedEvent(new EventRecord(
                             10, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                            "event_type", new byte[0], new byte[0]))
+                            "event_type", new byte[0], new byte[0]), 0)
                     }, null, false, "", 11, 10, true, 100));
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_eof_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_eof_and_idle_eof.cs
@@ -43,18 +43,18 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
                     _distibutionPointCorrelationId, ReadAllResult.Success, null,
                     new[]
                     {
-                        new EventStore.Core.Data.ResolvedEvent(
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
                                 _fakeTimeProvider.Now,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null, 100),
-                        new EventStore.Core.Data.ResolvedEvent(
+                                "event_type1", new byte[] {1}, new byte[] {2}), 100),
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "b", ExpectedVersion.Any,
                                 _fakeTimeProvider.Now,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null, 200),
+                                "event_type1", new byte[] {1}, new byte[] {2}), 200),
                     }, null, false, 100,
                     new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_hard_deleted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_hard_deleted.cs
@@ -43,18 +43,18 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
                     _distibutionPointCorrelationId, ReadAllResult.Success, null,
                     new[]
                     {
-                        new ResolvedEvent(
+                        ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
                                 _fakeTimeProvider.Now,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null, 100),
-                        new ResolvedEvent(
+                                "event_type1", new byte[] {1}, new byte[] {2}), 100),
+                        ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "a", ExpectedVersion.Any,
                                 _fakeTimeProvider.Now,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                SystemEventTypes.StreamDeleted, new byte[] {1}, new byte[] {2}), null, 200),
+                                SystemEventTypes.StreamDeleted, new byte[] {1}, new byte[] {2}), 200),
                     }, null, false, 100,
                     new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_soft_deleted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_soft_deleted.cs
@@ -44,20 +44,20 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
                     _distibutionPointCorrelationId, ReadAllResult.Success, null,
                     new[]
                     {
-                        new ResolvedEvent(
+                        ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
                                 _fakeTimeProvider.Now,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null, 100),
-                        new ResolvedEvent(
+                                "event_type1", new byte[] {1}, new byte[] {2}), 100),
+                        ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "$$a", ExpectedVersion.Any,
                                 _fakeTimeProvider.Now,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                                 SystemEventTypes.StreamMetadata,
                                 new StreamMetadata(truncateBefore: EventNumber.DeletedStream).ToJsonBytes(),
-                                new byte[] {2}), null, 200),
+                                new byte[] {2}), 200),
                     }, null, false, 100, new TFPos(200, 150), new TFPos(500, -1),
                     new TFPos(100, 50), 500));
         }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_onetime_reader_handles_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_onetime_reader_handles_eof.cs
@@ -42,18 +42,18 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
                     _distibutionPointCorrelationId, ReadAllResult.Success, null,
                     new[]
                     {
-                        new EventStore.Core.Data.ResolvedEvent(
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
                                 _fakeTimeProvider.Now,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null, 100),
-                        new EventStore.Core.Data.ResolvedEvent(
+                                "event_type1", new byte[] {1}, new byte[] {2}), 100),
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
                             new EventRecord(
                                 2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "b", ExpectedVersion.Any,
                                 _fakeTimeProvider.Now,
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
-                                "event_type1", new byte[] {1}, new byte[] {2}), null, 200),
+                                "event_type1", new byte[] {1}, new byte[] {2}), 200),
                     }, null, false, 100, new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));
 
             _edp.Handle(

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -587,7 +587,7 @@ namespace EventStore.Projections.Core.Services.Management
         public static EventStore.Core.Data.ResolvedEvent ResolveState(IGrouping<string, EventStore.Core.Data.ResolvedEvent> events)
         {
             var eventToReturn = events.OrderByDescending(x => x.Event.TimeStamp).First();
-            return eventToReturn.Event.EventType == "$ProjectionCreated" ? eventToReturn : new EventStore.Core.Data.ResolvedEvent(null);
+            return eventToReturn.Event.EventType == "$ProjectionCreated" ? eventToReturn : EventStore.Core.Data.ResolvedEvent.EmptyEvent;
         }
 
         private void LoadProjectionListCompleted(

--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
@@ -624,8 +624,7 @@ namespace EventStore.Projections.Core.Services.Processing
                                 { // ignore data just update positions
                                     _reader.UpdateNextStreamPosition(link.EventStreamId, link.EventNumber + 1);
                                     // recover unresolved link event
-                                    var unresolvedLinkEvent = new EventStore.Core.Data.ResolvedEvent(
-                                        link, originalTfPosition.CommitPosition);
+                                    var unresolvedLinkEvent = EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(link, originalTfPosition.CommitPosition);
                                     DeliverEventRetrievedFromTf(
                                         unresolvedLinkEvent, 100.0f*link.LogPosition/message.TfLastCommitPosition,
                                         originalTfPosition);


### PR DESCRIPTION
### Issue
In the PersistentSubscriptionService the failed resolve would create a resolved event with Event set to the link and Link as null. This is in contrast to all other areas where Link is set to the link and Event is null. This was most likely because the ClientAPI checks for Event = null to detect the unsubscribe request. With the Event set to null the ClientApi will throw an error when the event is received. 

This was working in the obvious case, but when a historical bad link is read via the storage reader and resolved (not via the PersistentSubscriptionService resolve) the other format is used and the error case is hit. This stops the client from being able to process the stream as it drops the subscription on every attempt.

### Solution
I've changed the ResolvedEvent class to have clear factory methods for the 3 scenarios it appears to support. The PersistentSubscriptionService now uses the correct format. I've then fixed the ClientAPI to handle the correct format of Link != null and Event == null.

This is a change to the public interface but as I think the original behaviour was unclear and maybe unintended it is probably better to make the break sooner rather than later.

### Tests
To get all tests running on this branch I had to change specification_with_standard_projections_runnning.cs to use the ExtHttpEndPoint instead of IntHttpEndPoint. I also had to apply the fix from PR #474 to get the urlacls to work on Windows again (can this be included in this release branch please?).

There are 2 tests which are failing still for me (before and after my changes):
- a_failed_projection.when_starting.the_projection_status_becomes_running_enabled()
- a_completed_projection.when_starting.the_projection_status_becomes_running_enabled()

They both look incorrect to my ignorant eye.