### PR TITLE
Don't add prefixes when not asked to.

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -50,6 +50,13 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.ExternalHttpPortAdvertiseAsDescr, Opts.InterfacesGroup)]
         public int ExtHttpPortAdvertiseAs { get; set; }
 
+        [ArgDescription(Opts.InternalIpAdvertiseAsDescr, Opts.InterfacesGroup)]
+        public IPAddress IntIpAdvertiseAs { get; set; }
+        [ArgDescription(Opts.InternalTcpPortAdvertiseAsDescr, Opts.InterfacesGroup)]
+        public int IntTcpPortAdvertiseAs { get; set; }
+        [ArgDescription(Opts.InternalHttpPortAdvertiseAsDescr, Opts.InterfacesGroup)]
+        public int IntHttpPortAdvertiseAs { get; set; }
+
         [ArgDescription(Opts.IntTcpHeartbeatTimeoutDescr, Opts.InterfacesGroup)]
         public int IntTcpHeartbeatTimeout { get; set; }
         [ArgDescription(Opts.ExtTcpHeartbeatTimeoutDescr, Opts.InterfacesGroup)]
@@ -226,6 +233,10 @@ namespace EventStore.ClusterNode
             ExtIpAdvertiseAs = Opts.ExternalIpAdvertiseAsDefault;
             ExtTcpPortAdvertiseAs = Opts.ExternalTcpPortAdvertiseAsDefault;
             ExtHttpPortAdvertiseAs = Opts.ExternalHttpPortAdvertiseAsDefault;
+
+            IntIpAdvertiseAs = Opts.InternalIpAdvertiseAsDefault;
+            IntTcpPortAdvertiseAs = Opts.InternalTcpPortAdvertiseAsDefault;
+            IntHttpPortAdvertiseAs = Opts.InternalHttpPortAdvertiseAsDefault;
 
             CertificateStoreLocation = Opts.CertificateStoreLocationDefault;
             CertificateStoreName = Opts.CertificateStoreNameDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -206,13 +206,23 @@ namespace EventStore.ClusterNode
                 }
                 if (gossipAdvertiseInfo == null)
                 {
-                    IPAddress addressToGossip = options.ClusterSize > 1 ? nonLoopbackAddress : IPAddress.Loopback;
-                    gossipAdvertiseInfo = new GossipAdvertiseInfo(new IPEndPoint(addressToGossip, options.IntTcpPort),
-                                                                  options.IntSecureTcpPort > 0 ? new IPEndPoint(addressToGossip, options.IntSecureTcpPort) : null,
-                                                                  new IPEndPoint(options.ExtIpAdvertiseAs ?? addressToGossip, options.ExtTcpPortAdvertiseAs > 0 ? options.ExtTcpPortAdvertiseAs : options.ExtTcpPort),
-                                                                  options.ExtSecureTcpPort > 0 ? new IPEndPoint(addressToGossip, options.ExtSecureTcpPort) : null,
-                                                                  new IPEndPoint(addressToGossip, options.IntHttpPort),
-                                                                  new IPEndPoint(options.ExtIpAdvertiseAs ?? addressToGossip, options.ExtHttpPortAdvertiseAs > 0 ? options.ExtHttpPortAdvertiseAs : options.ExtHttpPort));
+                    IPAddress addressToAdvertise = options.ClusterSize > 1 ? nonLoopbackAddress : IPAddress.Loopback;
+                    gossipAdvertiseInfo = new GossipAdvertiseInfo(new IPEndPoint(options.IntIpAdvertiseAs ?? addressToAdvertise,
+                                                                      options.IntTcpPortAdvertiseAs > 0 ? 
+                                                                      options.IntTcpPortAdvertiseAs : options.IntTcpPort),
+                                                                  options.IntSecureTcpPort > 0 ? new IPEndPoint(addressToAdvertise,
+                                                                      options.IntSecureTcpPort) : null,
+                                                                  new IPEndPoint(options.ExtIpAdvertiseAs ?? addressToAdvertise,
+                                                                      options.ExtTcpPortAdvertiseAs > 0 ? 
+                                                                      options.ExtTcpPortAdvertiseAs : options.ExtTcpPort),
+                                                                  options.ExtSecureTcpPort > 0 ? new IPEndPoint(addressToAdvertise,
+                                                                      options.ExtSecureTcpPort) : null,
+                                                                  new IPEndPoint(options.IntIpAdvertiseAs ?? addressToAdvertise,
+                                                                      options.IntHttpPortAdvertiseAs > 0 ?
+                                                                      options.IntHttpPortAdvertiseAs : options.IntHttpPort),
+                                                                  new IPEndPoint(options.ExtIpAdvertiseAs ?? addressToAdvertise,
+                                                                      options.ExtHttpPortAdvertiseAs > 0 ?
+                                                                      options.ExtHttpPortAdvertiseAs : options.ExtHttpPort));
                 }
             }
             else if (options.AddInterfacePrefixes)
@@ -220,7 +230,7 @@ namespace EventStore.ClusterNode
                 additionalIntHttpPrefixes.Add(String.Format("http://{0}:{1}/", options.IntIp, options.IntHttpPort));
                 additionalExtHttpPrefixes.Add(String.Format("http://{0}:{1}/", options.ExtIp, options.ExtHttpPort));
             }
-            if (!intHttpPrefixes.Contains(x => x.Contains("localhost")))
+            if (!intHttpPrefixes.Contains(x => x.Contains("localhost")) && options.AddInterfacePrefixes)
             {
                 if (options.IntIp.Equals(IPAddress.Parse("0.0.0.0")) ||
                    Equals(intHttp.Address, IPAddress.Loopback))
@@ -228,7 +238,7 @@ namespace EventStore.ClusterNode
                     additionalIntHttpPrefixes.Add(string.Format("http://localhost:{0}/", intHttp.Port));
                 }
             }
-            if (!extHttpPrefixes.Contains(x => x.Contains("localhost")))
+            if (!extHttpPrefixes.Contains(x => x.Contains("localhost")) && options.AddInterfacePrefixes)
             {
                 if (options.ExtIp.Equals(IPAddress.Parse("0.0.0.0")) ||
                    Equals(extHttp.Address, IPAddress.Loopback))
@@ -241,12 +251,20 @@ namespace EventStore.ClusterNode
 
             if (gossipAdvertiseInfo == null)
             {
-                gossipAdvertiseInfo = new GossipAdvertiseInfo(intTcp,
+                gossipAdvertiseInfo = new GossipAdvertiseInfo(new IPEndPoint(options.IntIpAdvertiseAs ?? options.IntIp, 
+                                                                options.IntTcpPortAdvertiseAs > 0 ?
+                                                                options.IntTcpPortAdvertiseAs : options.IntTcpPort),
                                                               intSecTcp,
-                                                              new IPEndPoint(options.ExtIpAdvertiseAs ?? options.ExtIp, options.ExtTcpPortAdvertiseAs > 0 ? options.ExtTcpPortAdvertiseAs : options.ExtTcpPort),
+                                                              new IPEndPoint(options.ExtIpAdvertiseAs ?? options.ExtIp,
+                                                                  options.ExtTcpPortAdvertiseAs > 0 ?
+                                                                  options.ExtTcpPortAdvertiseAs : options.ExtTcpPort),
                                                               extSecTcp,
-                                                              intHttp,
-                                                              new IPEndPoint(options.ExtIpAdvertiseAs ?? options.ExtIp, options.ExtHttpPortAdvertiseAs > 0 ? options.ExtHttpPortAdvertiseAs : options.ExtHttpPort));
+                                                              new IPEndPoint(options.IntIpAdvertiseAs ?? options.IntIp,
+                                                                  options.IntHttpPortAdvertiseAs >0 ?
+                                                                  options.IntHttpPortAdvertiseAs : options.IntHttpPort),
+                                                              new IPEndPoint(options.ExtIpAdvertiseAs ?? options.ExtIp,
+                                                                  options.ExtHttpPortAdvertiseAs > 0 ?
+                                                                  options.ExtHttpPortAdvertiseAs : options.ExtHttpPort));
             }
 
             var prepareCount = options.PrepareCount > quorumSize ? options.PrepareCount : quorumSize;

--- a/src/EventStore.Core/Data/GossipAdvertiseInfo.cs
+++ b/src/EventStore.Core/Data/GossipAdvertiseInfo.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
+﻿using System.Net;
 
 namespace EventStore.Core.Data
 {
@@ -21,8 +17,14 @@ namespace EventStore.Core.Data
             InternalTcp = internalTcp;
             InternalSecureTcp = internalSecureTcp;
             ExternalTcp = externalTcp;
+            ExternalSecureTcp = externalSecureTcp;
             InternalHttp = internalHttp;
             ExternalHttp = externalHttp;
+        }
+        public override string ToString()
+        {
+            return string.Format("IntTcp: {0}, IntSecureTcp: {1}\nExtTcp: {2}, ExtSecureTcp: {3}\nIntHttp: {4}, ExtHttp: {5}", 
+                    InternalTcp, InternalSecureTcp, ExternalTcp, ExternalSecureTcp, InternalHttp, ExternalHttp);
         }
     }
 }

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -211,6 +211,15 @@ namespace EventStore.Core.Util
         public const string ExternalHttpPortAdvertiseAsDescr = "Advertise External Http Port As.";
         public static readonly int ExternalHttpPortAdvertiseAsDefault = 0;
 
+        public const string InternalIpAdvertiseAsDescr = "Advertise Internal Tcp Address As.";
+        public static readonly IPAddress InternalIpAdvertiseAsDefault = null;
+
+        public const string InternalTcpPortAdvertiseAsDescr = "Advertise Internal Tcp Port As.";
+        public static readonly int InternalTcpPortAdvertiseAsDefault = 0;
+
+        public const string InternalHttpPortAdvertiseAsDescr = "Advertise Internal Http Port As.";
+        public static readonly int InternalHttpPortAdvertiseAsDefault = 0;
+
 		public const string ClusterSizeDescr = "The number of nodes in the cluster.";
         public const int    ClusterSizeDefault = 1;
 


### PR DESCRIPTION
Fixes #620

1. Add configuration options for advertising the Internal IP, TCP port and HTTP port. This mirrors the options for the external interface.
2. Only setup prefixes when asked to. If you now set AddInterfacePrefixes to false, you need to set Int and Ext HTTP prefixes.

e.g.
```
---
ExtIp: 0.0.0.0
ExtIpAdvertiseAs: 192.168.1.103
ExtHttpPrefixes: http://*:2113/
IntIp: 0.0.0.0
IntIpAdvertiseAs: 192.168.1.103
IntHttpPrefixes: http://*:2112/
AddInterfacePrefixes: false
```