### PR TITLE
Catch InvalidOperationException in ConnectAsync

### DIFF
--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpClientConnector.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpClientConnector.cs
@@ -92,6 +92,10 @@ namespace EventStore.ClientAPI.Transport.Tcp
             {
                 HandleBadConnect(socketArgs);
             }
+            catch (InvalidOperationException)
+            {
+                HandleBadConnect(socketArgs);
+            }
         }
 
         private void ConnectCompleted(object sender, SocketAsyncEventArgs e)


### PR DESCRIPTION
This commit attempts to resolve the issue described in #591. On balance this still looks like a bug in Mono.

Fixes #591.