### PR TITLE
Refactor HTTP Interface Prefixes

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -50,6 +50,13 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.ExternalHttpPortAdvertiseAsDescr, Opts.InterfacesGroup)]
         public int ExtHttpPortAdvertiseAs { get; set; }
 
+        [ArgDescription(Opts.InternalIpAdvertiseAsDescr, Opts.InterfacesGroup)]
+        public IPAddress IntIpAdvertiseAs { get; set; }
+        [ArgDescription(Opts.InternalTcpPortAdvertiseAsDescr, Opts.InterfacesGroup)]
+        public int IntTcpPortAdvertiseAs { get; set; }
+        [ArgDescription(Opts.InternalHttpPortAdvertiseAsDescr, Opts.InterfacesGroup)]
+        public int IntHttpPortAdvertiseAs { get; set; }
+
         [ArgDescription(Opts.IntTcpHeartbeatTimeoutDescr, Opts.InterfacesGroup)]
         public int IntTcpHeartbeatTimeout { get; set; }
         [ArgDescription(Opts.ExtTcpHeartbeatTimeoutDescr, Opts.InterfacesGroup)]
@@ -226,6 +233,10 @@ namespace EventStore.ClusterNode
             ExtIpAdvertiseAs = Opts.ExternalIpAdvertiseAsDefault;
             ExtTcpPortAdvertiseAs = Opts.ExternalTcpPortAdvertiseAsDefault;
             ExtHttpPortAdvertiseAs = Opts.ExternalHttpPortAdvertiseAsDefault;
+
+            IntIpAdvertiseAs = Opts.InternalIpAdvertiseAsDefault;
+            IntTcpPortAdvertiseAs = Opts.InternalTcpPortAdvertiseAsDefault;
+            IntHttpPortAdvertiseAs = Opts.InternalHttpPortAdvertiseAsDefault;
 
             CertificateStoreLocation = Opts.CertificateStoreLocationDefault;
             CertificateStoreName = Opts.CertificateStoreNameDefault;

--- a/src/EventStore.Core/Data/GossipAdvertiseInfo.cs
+++ b/src/EventStore.Core/Data/GossipAdvertiseInfo.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
+﻿using System.Net;
 
 namespace EventStore.Core.Data
 {
@@ -21,8 +17,14 @@ namespace EventStore.Core.Data
             InternalTcp = internalTcp;
             InternalSecureTcp = internalSecureTcp;
             ExternalTcp = externalTcp;
+            ExternalSecureTcp = externalSecureTcp;
             InternalHttp = internalHttp;
             ExternalHttp = externalHttp;
+        }
+        public override string ToString()
+        {
+            return string.Format("IntTcp: {0}, IntSecureTcp: {1}\nExtTcp: {2}, ExtSecureTcp: {3}\nIntHttp: {4}, ExtHttp: {5}", 
+                    InternalTcp, InternalSecureTcp, ExternalTcp, ExternalSecureTcp, InternalHttp, ExternalHttp);
         }
     }
 }

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -211,6 +211,15 @@ namespace EventStore.Core.Util
         public const string ExternalHttpPortAdvertiseAsDescr = "Advertise External Http Port As.";
         public static readonly int ExternalHttpPortAdvertiseAsDefault = 0;
 
+        public const string InternalIpAdvertiseAsDescr = "Advertise Internal Tcp Address As.";
+        public static readonly IPAddress InternalIpAdvertiseAsDefault = null;
+
+        public const string InternalTcpPortAdvertiseAsDescr = "Advertise Internal Tcp Port As.";
+        public static readonly int InternalTcpPortAdvertiseAsDefault = 0;
+
+        public const string InternalHttpPortAdvertiseAsDescr = "Advertise Internal Http Port As.";
+        public static readonly int InternalHttpPortAdvertiseAsDefault = 0;
+
 		public const string ClusterSizeDescr = "The number of nodes in the cluster.";
         public const int    ClusterSizeDefault = 1;
 


### PR DESCRIPTION
Fixes #620 

The result of the refactor is the following.

**Setting up HTTP Prefixes**

If AddInterfacePrefixes is set to true (Default: true) and External or Internal IP Address has been set to 0.0.0.0, we will.
- Set the Int/Ext HTTP Prefixes to http://*:{IntHTTPPort/ExtHTTPPort}/ respectively
- Use the first IPv4 Address that is not the loopback address and use that as the address to advertise.

If AddInterfacePrefixes is set to true but neither Internal or External IP Address has been set to 0.0.0.0, we will.
- Set the Int/Ext HTTP Prefixes to http://{IntIp}:{IntHTTPPort}/ and http://{ExtIp}:{ExtHTTPPort}/
- In addition, if the Int/Ext IP Addresses are set to the loopback, we will also add http://localhost:{IntHTTPPort/ExtHTTPPort}/ respectively

If the user has opted to set AddInterfacePrefixes to false, the user is required to setup the Internal and External HTTP Prefixes as we will in that case not do anything.
