### PR TITLE
Implemented 494 story about mapping ClientApi queries to DTO objects

### DIFF
--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -84,6 +84,7 @@
     <Compile Include="PersistentSubscriptionNakEventAction.cs" />
     <Compile Include="PersistentSubscriptionSettings.cs" />
     <Compile Include="PersistentSubscriptionSettingsBuilder.cs" />
+    <Compile Include="Projections\ProjectionDetails.cs" />
     <Compile Include="StreamCheckpoint.cs" />
     <Compile Include="ClientAuthenticationFailedEventArgs.cs" />
     <Compile Include="ClientErrorEventArgs.cs" />

--- a/src/EventStore.ClientAPI/Projections/ProjectionDetails.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionDetails.cs
@@ -1,0 +1,217 @@
+﻿using System;
+
+namespace EventStore.ClientAPI.Projections
+{
+    /// <summary>
+    /// Provides the details for a projection.
+    /// </summary>
+    public sealed class ProjectionDetails
+    {
+        /// <summary>
+        /// The CoreProcessingTime
+        /// </summary>
+        public readonly int CoreProcessingTime;
+
+        /// <summary>
+        /// The projection version
+        /// </summary>
+        public readonly int Version;
+
+        /// <summary>
+        /// The Epoch
+        /// </summary>
+        public readonly int Epoch;
+
+        /// <summary>
+        /// The projection EffectiveName
+        /// </summary>
+        public readonly string EffectiveName;
+
+        /// <summary>
+        /// The projection WritesInProgress
+        /// </summary>
+        public readonly int WritesInProgress;
+
+        /// <summary>
+        /// The projection ReadsInProgress
+        /// </summary>
+        public readonly int ReadsInProgress;
+
+        /// <summary>
+        /// The projection PartitionsCached
+        /// </summary>
+        public readonly int PartitionsCached;
+
+        /// <summary>
+        /// The projection Status
+        /// </summary>
+        public readonly string Status;
+
+        /// <summary>
+        /// The projection StateReason
+        /// </summary>
+        public readonly string StateReason;
+
+        /// <summary>
+        /// The projection Name
+        /// </summary>
+        public readonly string Name;
+
+        /// <summary>
+        /// The projection Mode
+        /// </summary>
+        public readonly string Mode;
+
+        /// <summary>
+        /// The projection Position
+        /// </summary>
+        public readonly string Position;
+
+        /// <summary>
+        /// The projection Progress
+        /// </summary>
+        public readonly decimal Progress;
+
+        /// <summary>
+        /// LastCheckpoint
+        /// </summary>
+        public readonly string LastCheckpoint;
+
+        /// <summary>
+        /// The projection EventsProcessedAfterRestart
+        /// </summary>
+        public readonly int EventsProcessedAfterRestart;
+
+        /// <summary>
+        /// The projection StatusUrl
+        /// </summary>
+        public readonly Uri StatusUrl;
+
+        /// <summary>
+        /// The projection StateUrl
+        /// </summary>
+        public readonly Uri StateUrl;
+
+        /// <summary>
+        /// The projection ResultUrl
+        /// </summary>
+        public readonly Uri ResultUrl;
+
+        /// <summary>
+        /// The projection QueryUrl
+        /// </summary>
+        public readonly Uri QueryUrl;
+
+        /// <summary>
+        /// The projection EnableCommandUrl
+        /// </summary>
+        public readonly Uri EnableCommandUrl;
+
+        /// <summary>
+        /// The projection DisableCommandUrl
+        /// </summary>
+        public readonly Uri DisableCommandUrl;
+
+        /// <summary>
+        /// The projection CheckpointStatus
+        /// </summary>
+        public readonly string CheckpointStatus;
+
+        /// <summary>
+        /// The projection BufferedEvents
+        /// </summary>
+        public readonly int BufferedEvents;
+
+        /// <summary>
+        /// The projection WritePendingEventsBeforeCheckpoint
+        /// </summary>
+        public readonly int WritePendingEventsBeforeCheckpoint;
+
+        /// <summary>
+        /// The projection WritePendingEventsAfterCheckpoint
+        /// </summary>
+        public readonly int WritePendingEventsAfterCheckpoint;
+
+        /// <summary>
+        /// create a new <see cref="ProjectionDetails"/> class.
+        /// </summary>
+        /// <param name="coreProcessingTime"></param>
+        /// <param name="version"></param>
+        /// <param name="epoch"></param>
+        /// <param name="effectiveName"></param>
+        /// <param name="writesInProgress"></param>
+        /// <param name="readsInProgress"></param>
+        /// <param name="partitionsCached"></param>
+        /// <param name="status"></param>
+        /// <param name="stateReason"></param>
+        /// <param name="name"></param>
+        /// <param name="mode"></param>
+        /// <param name="position"></param>
+        /// <param name="progress"></param>
+        /// <param name="lastCheckpoint"></param>
+        /// <param name="eventsProcessedAfterRestart"></param>
+        /// <param name="statusUrl"></param>
+        /// <param name="stateUrl"></param>
+        /// <param name="resultUrl"></param>
+        /// <param name="queryUrl"></param>
+        /// <param name="enableCommandUrl"></param>
+        /// <param name="disableCommandUrl"></param>
+        /// <param name="checkpointStatus"></param>
+        /// <param name="bufferedEvents"></param>
+        /// <param name="writePendingEventsBeforeCheckpoint"></param>
+        /// <param name="writePendingEventsAfterCheckpoint"></param>
+        public ProjectionDetails(
+            int coreProcessingTime,
+            int version,
+            int epoch,
+            string effectiveName,
+            int writesInProgress,
+            int readsInProgress,
+            int partitionsCached,
+            string status,
+            string stateReason,
+            string name,
+            string mode,
+            string position,
+            decimal progress,
+            string lastCheckpoint,
+            int eventsProcessedAfterRestart,
+            Uri statusUrl,
+            Uri stateUrl,
+            Uri resultUrl,
+            Uri queryUrl,
+            Uri enableCommandUrl,
+            Uri disableCommandUrl,
+            string checkpointStatus,
+            int bufferedEvents,
+            int writePendingEventsBeforeCheckpoint,
+            int writePendingEventsAfterCheckpoint)
+        {
+            CoreProcessingTime = coreProcessingTime;
+            Version = version;
+            Epoch = epoch;
+            this.EffectiveName = effectiveName;
+            WritesInProgress = writesInProgress;
+            ReadsInProgress = readsInProgress;
+            PartitionsCached = partitionsCached;
+            Status = status;
+            StateReason = stateReason;
+            Name = name;
+            Mode = mode;
+            Position = position;
+            Progress = progress;
+            LastCheckpoint = lastCheckpoint;
+            EventsProcessedAfterRestart = eventsProcessedAfterRestart;
+            StatusUrl = statusUrl;
+            StateUrl = stateUrl;
+            ResultUrl = resultUrl;
+            QueryUrl = queryUrl;
+            EnableCommandUrl = enableCommandUrl;
+            DisableCommandUrl = disableCommandUrl;
+            CheckpointStatus = checkpointStatus;
+            BufferedEvents = bufferedEvents;
+            WritePendingEventsBeforeCheckpoint = writePendingEventsBeforeCheckpoint;
+            WritePendingEventsAfterCheckpoint = writePendingEventsAfterCheckpoint;
+        }
+    }
+}

--- a/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.SystemData;
 using EventStore.ClientAPI.Transport.Http;
+using Newtonsoft.Json.Linq;
 using HttpStatusCode = EventStore.ClientAPI.Transport.Http.HttpStatusCode;
 
 namespace EventStore.ClientAPI.Projections
@@ -50,23 +52,41 @@ namespace EventStore.ClientAPI.Projections
 
         public Task CreateContinuous(IPEndPoint endPoint, string name, string query, UserCredentials userCredentials = null)
         {
-            return SendPost(endPoint.ToHttpUrl("/projections/continuous?name={0}&type=JS&emit=1", name), 
+            return SendPost(endPoint.ToHttpUrl("/projections/continuous?name={0}&type=JS&emit=1", name),
                             query, userCredentials, HttpStatusCode.Created);
         }
 
-        public Task<string> ListAll(IPEndPoint endPoint, UserCredentials userCredentials = null)
+        public Task<List<ProjectionDetails>> ListAll(IPEndPoint endPoint, UserCredentials userCredentials = null)
         {
-            return SendGet(endPoint.ToHttpUrl("/projections/any"), userCredentials, HttpStatusCode.OK);
+            return SendGet(endPoint.ToHttpUrl("/projections/any"), userCredentials, HttpStatusCode.OK)
+                    .ContinueWith(x =>
+                    {
+                        if (x.IsFaulted) throw x.Exception;
+                        var r = JObject.Parse(x.Result);
+                        return r["projections"] != null ? r["projections"].ToObject<List<ProjectionDetails>>() : null;
+                    });
         }
 
-        public Task<string> ListOneTime(IPEndPoint endPoint, UserCredentials userCredentials = null)
+        public Task<List<ProjectionDetails>> ListOneTime(IPEndPoint endPoint, UserCredentials userCredentials = null)
         {
-            return SendGet(endPoint.ToHttpUrl("/projections/onetime"), userCredentials, HttpStatusCode.OK);
+            return SendGet(endPoint.ToHttpUrl("/projections/onetime"), userCredentials, HttpStatusCode.OK)
+                    .ContinueWith(x =>
+                    {
+                        if (x.IsFaulted) throw x.Exception;
+                        var r = JObject.Parse(x.Result);
+                        return r["projections"] != null ? r["projections"].ToObject<List<ProjectionDetails>>() : null;
+                    });
         }
 
-        public Task<string> ListContinuous(IPEndPoint endPoint, UserCredentials userCredentials = null)
+        public Task<List<ProjectionDetails>> ListContinuous(IPEndPoint endPoint, UserCredentials userCredentials = null)
         {
-            return SendGet(endPoint.ToHttpUrl("/projections/continuous"), userCredentials, HttpStatusCode.OK);
+            return SendGet(endPoint.ToHttpUrl("/projections/continuous"), userCredentials, HttpStatusCode.OK)
+                    .ContinueWith(x =>
+                    {
+                        if (x.IsFaulted) throw x.Exception;
+                        var r = JObject.Parse(x.Result);
+                        return r["projections"] != null ? r["projections"].ToObject<List<ProjectionDetails>>() : null;
+                    });
         }
 
         public Task<string> GetStatus(IPEndPoint endPoint, string name, UserCredentials userCredentials = null)

--- a/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Utils;
@@ -109,7 +110,7 @@ namespace EventStore.ClientAPI.Projections
         /// </summary>
         /// <param name="userCredentials">Credentials for the operation.</param>
         /// <returns>String of JSON containing projection statuses.</returns>
-        public Task<string> ListAllAsync(UserCredentials userCredentials = null)
+        public Task<List<ProjectionDetails>> ListAllAsync(UserCredentials userCredentials = null)
         {
             return _client.ListAll(_httpEndPoint, userCredentials);
         }
@@ -119,7 +120,7 @@ namespace EventStore.ClientAPI.Projections
         /// </summary>
         /// <param name="userCredentials">Credentials for the operation.</param>
         /// <returns>String of JSON containing projection statuses.</returns>
-        public Task<string> ListOneTimeAsync(UserCredentials userCredentials = null)
+        public Task<List<ProjectionDetails>> ListOneTimeAsync(UserCredentials userCredentials = null)
         {
             return _client.ListOneTime(_httpEndPoint, userCredentials);
         }
@@ -129,7 +130,7 @@ namespace EventStore.ClientAPI.Projections
         /// </summary>
         /// <param name="userCredentials">Credentials for the operation.</param>
         /// <returns>String of JSON containing projection statuses.</returns>
-        public Task<string> ListContinuousAsync(UserCredentials userCredentials = null)
+        public Task<List<ProjectionDetails>> ListContinuousAsync(UserCredentials userCredentials = null)
         {
             return _client.ListContinuous(_httpEndPoint, userCredentials);
         }

--- a/src/EventStore.Core.Tests/ClientAPI/Projections/TestWithNode.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Projections/TestWithNode.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using EventStore.ClientAPI;
+using EventStore.ClientAPI.Common.Log;
+using EventStore.ClientAPI.Projections;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientAPI.Projections
+{
+    [Category("LongRunning")]
+    public class TestWithNode : SpecificationWithDirectoryPerTestFixture
+    {
+        protected MiniNode _node;
+        protected ProjectionsManager _manager;
+
+        [TestFixtureSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            _node = new MiniNode(PathName);
+            _node.Start();
+            _manager = new ProjectionsManager(new NoopLogger(), _node.ExtHttpEndPoint, TimeSpan.FromSeconds(5));
+        }
+
+        [TestFixtureTearDown]
+        public override void TestFixtureTearDown()
+        {
+            _node.Shutdown();
+            base.TestFixtureTearDown();
+        }
+
+
+        protected virtual IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return TestConnection.Create(node.TcpEndPoint);
+        }
+
+    }
+}

--- a/src/EventStore.Core.Tests/ClientAPI/Projections/list_projections.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Projections/list_projections.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Linq;
+using EventStore.ClientAPI.SystemData;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientAPI.Projections
+{
+    public class list_projections : TestWithNode
+    {
+        const string TestProjection = "fromAll().when({$init: function (state, ev) {return {};},ConversationStarted: function (state, ev) {state.lastBatchSent = ev;return state;}});";
+
+        [Test]
+        public void list_all_projections_works()
+        {
+            var x = _manager.ListAllAsync(new UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(true, x.Any());
+            Assert.IsTrue(x.Any(p => p.Name == "$streams"));
+        }
+
+        [Test]
+        public void list_oneTime_projections_works()
+        {
+            _manager.CreateOneTimeAsync(TestProjection, new UserCredentials("admin", "changeit")).Wait();
+            var x = _manager.ListOneTimeAsync(new UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(true, x.Any(p => p.Mode == "OneTime"));
+        }
+
+        [Test]
+        public void list_continuous_projections_works()
+        {
+            var nameToTest = Guid.NewGuid().ToString();
+            _manager.CreateContinuousAsync(nameToTest, TestProjection, new UserCredentials("admin", "changeit")).Wait();
+            var x = _manager.ListContinuousAsync(new UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(true, x.Any(p => p.Name == nameToTest));
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -91,6 +91,8 @@
     <Compile Include="ClientAPI\Embedded\deleting_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\update_persistent_subscription.cs" />
     <Compile Include="ClientAPI\persistent_connect_integration_tests.cs" />
+    <Compile Include="ClientAPI\Projections\list_projections.cs" />
+    <Compile Include="ClientAPI\Projections\TestWithNode.cs" />
     <Compile Include="ClientAPI\read_allevents_backward_with_linkto_deleted_event.cs" />
     <Compile Include="ClientAPI\Embedded\appending_to_implicitly_created_stream.cs" />
     <Compile Include="ClientAPI\Embedded\appending_to_implicitly_created_stream_using_transaction.cs" />

--- a/src/EventStore.Padmin/Command.cs
+++ b/src/EventStore.Padmin/Command.cs
@@ -78,17 +78,17 @@ namespace EventStore.Padmin
             {
                 case "all":
                     Log("Listing all projections...");
-                    LogUnformatted(manager.ListAllAsync(userCredentials).Result);
+                    LogUnformatted(string.Join(" | ", manager.ListAllAsync(userCredentials).Result));
                     Log("All projections listed");
                     break;
                 case "onetime":
                     Log("Listing onetime projections...");
-                    LogUnformatted(manager.ListOneTimeAsync(userCredentials).Result);
+                    LogUnformatted(string.Join(" | ", manager.ListOneTimeAsync(userCredentials).Result));
                     Log("Onetime projections listed");
                     break;
                 case "continuous":
                     Log("Listing continuous projections...");
-                    LogUnformatted(manager.ListContinuousAsync(userCredentials).Result);
+                    LogUnformatted(string.Join(" | ", manager.ListContinuousAsync(userCredentials).Result));
                     Log("Continuous projections listed");
                     break;
                 default:

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -60,7 +60,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
             base.TestFixtureSetUp();
 #if (!DEBUG)
             throw new NotSupportedException("These tests require DEBUG conditional");
-#else 
+#else
             QueueStatsCollector.InitializeIdleDetection();
             _nodeEndpoints[0] = new Endpoints(
                 PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback),
@@ -77,14 +77,14 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
 
             PortsHelper.GetAvailablePort(IPAddress.Loopback);
 
-            _nodes[0] = CreateNode(0, 
-                _nodeEndpoints[0], new IPEndPoint[] {_nodeEndpoints[1].InternalHttp, _nodeEndpoints[2].InternalHttp});
-            _nodes[1] = CreateNode(1, 
+            _nodes[0] = CreateNode(0,
+                _nodeEndpoints[0], new IPEndPoint[] { _nodeEndpoints[1].InternalHttp, _nodeEndpoints[2].InternalHttp });
+            _nodes[1] = CreateNode(1,
                 _nodeEndpoints[1], new IPEndPoint[] { _nodeEndpoints[0].InternalHttp, _nodeEndpoints[2].InternalHttp });
-            
-            _nodes[2] = CreateNode(2, 
+
+            _nodes[2] = CreateNode(2,
                 _nodeEndpoints[2], new IPEndPoint[] { _nodeEndpoints[0].InternalHttp, _nodeEndpoints[1].InternalHttp });
-            
+
 
             _nodes[0].Start();
             _nodes[1].Start();
@@ -114,7 +114,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
             var node = new MiniClusterNode(
                 PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp, endpoints.ExternalTcp,
                 endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false,
-                subsystems: new ISubsystem[] {_projections}, gossipSeeds: gossipSeeds);
+                subsystems: new ISubsystem[] { _projections }, gossipSeeds: gossipSeeds);
             WaitIdle();
             return node;
         }
@@ -123,7 +123,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
         public void PostTestAsserts()
         {
             var all = _manager.ListAllAsync(_admin).Result;
-            if (all.Contains("Faulted"))
+            if (all.Any(p => p.Name == "Faulted"))
                 Assert.Fail("Projections faulted while running the test" + "\r\n" + all);
         }
 
@@ -181,7 +181,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
 
         protected void PostEvent(string stream, string eventType, string data)
         {
-            _conn.AppendToStreamAsync(stream, ExpectedVersion.Any, new[] {CreateEvent(eventType, data)}).Wait();
+            _conn.AppendToStreamAsync(stream, ExpectedVersion.Any, new[] { CreateEvent(eventType, data) }).Wait();
         }
 
         protected void HardDeleteStream(string stream)

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -32,7 +32,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
             base.TestFixtureSetUp();
 #if (!DEBUG)
             Assert.Ignore("These tests require DEBUG conditional");
-#else 
+#else
             QueueStatsCollector.InitializeIdleDetection();
             CreateNode();
             try
@@ -80,7 +80,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
             var projectionWorkerThreadCount = GivenWorkerThreadCount();
             _projections = new ProjectionsSubsystem(projectionWorkerThreadCount, runProjections: ProjectionType.All, developmentMode: false);
             _node = new MiniNode(
-                PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] {_projections});
+                PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { _projections });
             _node.Start();
         }
 
@@ -93,7 +93,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
         public void PostTestAsserts()
         {
             var all = _manager.ListAllAsync(_admin).Result;
-            if (all.Contains("Faulted"))
+            if (all.Any(p => p.Name == "Faulted"))
                 Assert.Fail("Projections faulted while running the test" + "\r\n" + all);
         }
 
@@ -131,11 +131,11 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
         [TestFixtureTearDown]
         public override void TestFixtureTearDown()
         {
-	    if (_conn != null)
-		_conn.Close();
+            if (_conn != null)
+                _conn.Close();
 
-	    if (_node != null)
-		_node.Shutdown();
+            if (_node != null)
+                _node.Shutdown();
 
             base.TestFixtureTearDown();
 #if DEBUG
@@ -153,7 +153,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
 
         protected void PostEvent(string stream, string eventType, string data)
         {
-            _conn.AppendToStreamAsync(stream, ExpectedVersion.Any, new[] {event_by_type_index.with_existing_events.CreateEvent(eventType, data)}).Wait();
+            _conn.AppendToStreamAsync(stream, ExpectedVersion.Any, new[] { event_by_type_index.with_existing_events.CreateEvent(eventType, data) }).Wait();
         }
 
         protected void HardDeleteStream(string stream)


### PR DESCRIPTION
I implemented the story following the already existent UserManager implementation. 
I created a DTO class called ProjectionDetails that reflect the JSon results that I found. I don't know exactly the meaning of each field so I was not able to describe it in the field comment.
I wrote some integration tests in the following class:
EventStore.Core.Tests/ClientAPI/Projections/list_projections.cs

The above changes break some tests that I fixed but I'm not able to run those tests right now because I don't have a test environment ready.
The tests are:
src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
and the fix that allow me to compile but probably need to be reviewd is:
all.Any(p => p.Name == "Faulted")

I also had to fix a problem with the EventStore.Padmin.Commands class that I end up fixing with the following code:
LogUnformatted(string.Join(" | ", manager.ListAllAsync(userCredentials).Result));
I did not found tests for this so I was not able to check properly this fix.

Cheers
Riccardo