### PR TITLE
Ensure an ipv4 address is used when resolving dns names for tcp #690

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using System.Linq;
+using System.Net.Sockets;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Internal;
 using System;
@@ -119,7 +120,9 @@ namespace EventStore.ClientAPI
             {
                 var entries = Dns.GetHostAddresses(uri.Host);
                 if (entries.Length == 0) throw new Exception(string.Format("Unable to parse IP address or lookup DNS host for '{0}'", uri.Host));
-                ipaddress = entries[0];
+                //pick an IPv4 address, if one exists
+                ipaddress = entries.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
+                if (ipaddress == null) throw new Exception(string.Format("Could not get an IPv4 address for host '{0}'", uri.Host));
             }
             var port = uri.IsDefaultPort ? 2113 : uri.Port;
             return new IPEndPoint(ipaddress, port);


### PR DESCRIPTION
I couldn't see an easy way to unit test this, since the IPaddress isn't exposed on the connection anywhere and I didn't want to go using reflection to call private methods in unit tests.
As such I've only manually tested it. 