### PR TITLE
Exit the application when the Db or Log directories starts with a tilde

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -51,6 +51,13 @@ namespace EventStore.ClusterNode
         {
             base.PreInit(options);
 
+            if (options.Db.StartsWith("~") && !options.Force){
+                throw new ApplicationInitializationException("The given database path starts with a '~'. We don't expand '~'. You can use --force to override this error.");
+            }
+            if (options.Log.StartsWith("~") && !options.Force){
+                throw new ApplicationInitializationException("The given log path starts with a '~'. We don't expand '~'. You can use --force to override this error.");
+            }
+
             //Never seen this problem occur on the .NET framework
             if (!Runtime.IsMono)
                 return;


### PR DESCRIPTION
Fixes #693
When the Db or Log paths starts with a tilde, the application will exit.
The error can be overridden using the --force option.