### PR TITLE
Take a hard dependency on EventStore.Client of the same version

### DIFF
--- a/scripts/nuget-clientapi/EventStore.Client.Embedded.nuspec
+++ b/scripts/nuget-clientapi/EventStore.Client.Embedded.nuspec
@@ -14,7 +14,7 @@
     <copyright>Copyright 2012-2013 Event Store LLP</copyright>
     <tags>eventstore client embedded</tags>
     <dependencies>
-      <dependency id="EventStore.Client" version="3.0.0" />
+      <dependency id="EventStore.Client" version="[$version$]" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
As a result of #700 
Packaging of the EventStore.Client* packages are done via a single script. With this change, the EventStore.Client.Embedded will take a strict dependency on the same version of the EventStore.Client package.

This will eliminate the issue from #700 for future versions.