### PR TITLE
Handle null Uri that gets passed when retrieving credentials

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -130,7 +130,7 @@ namespace EventStore.ClientAPI
 
         private static UserCredentials GetCredentialFromUri(Uri uri)
         {
-            if (string.IsNullOrEmpty(uri.UserInfo)) return null;
+            if (uri == null || string.IsNullOrEmpty(uri.UserInfo)) return null;
             var pieces = uri.UserInfo.Split(':');
             if (pieces.Length != 2) throw new Exception(string.Format("Unable to parse user information '{0}'", uri.UserInfo));
             return new UserCredentials(pieces[0], pieces[1]);


### PR DESCRIPTION
Fixes #684

When the following `Create` is called, a null Uri gets passed.
```
public static IEventStoreConnection Create(ConnectionSettings connectionSettings, string connectionName = null)
{
    return Create(connectionSettings, (Uri)null, connectionName);
}
```
A non-null Uri only get's used if the `scheme` is present. Therefor we can safely guard against a null Uri in the `GetCredentialFromUri`
e.g.
```
private static UserCredentials GetCredentialFromUri(Uri uri)
{
    if (uri == null || string.IsNullOrEmpty(uri.UserInfo)) return null;
    ...
}
```