### PR TITLE
Split development mode

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
@@ -31,7 +31,8 @@ namespace EventStore.ClientAPI.Embedded
         private string _dbPath;
         private long _chunksCacheSize;
         private bool _inMemoryDb;
-        private bool _developmentMode;
+        private bool _startStandardProjections;
+        private bool _disableHTTPCaching;
 
         private IPEndPoint _internalTcp;
         private IPEndPoint _internalSecureTcp;
@@ -150,6 +151,9 @@ namespace EventStore.ClientAPI.Embedded
             _maxMemtableSize = Opts.MaxMemtableSizeDefault;
             _subsystems = new List<ISubsystem>();
             _clusterGossipPort = Opts.ClusterGossipPortDefault;
+
+            _startStandardProjections = Opts.StartStandardProjectionsDefault;
+            _disableHTTPCaching = Opts.DisableHttpCachingDefault;
         }
 
         /// <summary>
@@ -184,15 +188,24 @@ namespace EventStore.ClientAPI.Embedded
         }
 
         /// <summary>
-        /// Enable development mode. This disables caching for events over HTTP.
+        /// Start standard projections.
         /// </summary>
         /// <returns></returns>
-        public EmbeddedVNodeBuilder EnableDevelopmentMode()
+        public EmbeddedVNodeBuilder StartStandardProjections()
         {
-            _developmentMode = true;
+            _startStandardProjections = true;
             return this;
         }
 
+        /// <summary>
+        /// Disable HTTP Caching.
+        /// </summary>
+        /// <returns></returns>
+        public EmbeddedVNodeBuilder DisableHTTPCaching()
+        {
+            _disableHTTPCaching = true;
+            return this;
+        }
 
         /// <summary>
         /// Sets the mode and the number of threads on which to run projections.
@@ -627,7 +640,7 @@ namespace EventStore.ClientAPI.Embedded
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType, _developmentMode));
+            _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType, _startStandardProjections));
         }
 
         /// <summary>
@@ -695,7 +708,8 @@ namespace EventStore.ClientAPI.Embedded
                     _extTcpHeartbeatInterval,
                     !_skipVerifyDbHashes,
                     _maxMemtableSize,
-                    _developmentMode);
+                    _startStandardProjections,
+                    _disableHTTPCaching);
             var infoController = new InfoController(null, _projectionType);
             return new ClusterVNode(db, vNodeSettings, GetGossipSource(), infoController, _subsystems.ToArray());
         }

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -20,8 +20,10 @@ namespace EventStore.ClusterNode
         public string[] Defines { get; set; }
         [ArgDescription(Opts.WhatIfDescr, Opts.AppGroup)]
         public bool WhatIf { get; set; }
-        [ArgDescription(Opts.DevelopmentModeDescr, Opts.AppGroup)]
-        public bool DevelopmentMode { get; set; }
+        [ArgDescription(Opts.StartStandardProjectionsDescr, Opts.AppGroup)]
+        public bool StartStandardProjections { get; set; }
+        [ArgDescription(Opts.DisableHttpCachingDescr, Opts.AppGroup)]
+        public bool DisableHTTPCaching { get; set; }
 
         [ArgDescription(Opts.MonoMinThreadpoolSizeDescr, Opts.AppGroup)]
         public int MonoMinThreadpoolSize { get; set; }
@@ -264,6 +266,9 @@ namespace EventStore.ClusterNode
             GossipTimeoutMs = Opts.GossipTimeoutMsDefault;
             IndexCacheDepth = Opts.IndexCacheDepthDefault;
             EnableHistograms = Opts.HistogramEnabledDefault;
+
+            StartStandardProjections = Opts.StartStandardProjectionsDefault;
+            DisableHTTPCaching = Opts.DisableHttpCachingDefault;
         }
     }
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -140,7 +140,7 @@ namespace EventStore.ClusterNode
             var enabledNodeSubsystems = runProjections >= ProjectionType.System
                 ? new[] { NodeSubsystems.Projections }
             : new NodeSubsystems[0];
-            _projections = new Projections.Core.ProjectionsSubsystem(opts.ProjectionThreads, opts.RunProjections, opts.DevelopmentMode);
+            _projections = new Projections.Core.ProjectionsSubsystem(opts.ProjectionThreads, opts.RunProjections, opts.StartStandardProjections);
             var infoController = new InfoController(opts, opts.RunProjections);
             _node = new ClusterVNode(db, vNodeSettings, gossipSeedSource, infoController, _projections);
             RegisterWebControllers(enabledNodeSubsystems, vNodeSettings);
@@ -276,7 +276,8 @@ namespace EventStore.ClusterNode
                     TimeSpan.FromMilliseconds(options.IntTcpHeartbeatTimeout),
                     TimeSpan.FromMilliseconds(options.IntTcpHeartbeatInterval),
                     !options.SkipDbVerify, options.MaxMemTableSize,
-                    options.DevelopmentMode,
+                    options.StartStandardProjections,
+                    options.DisableHTTPCaching,
                     options.EnableHistograms,
                     options.IndexCacheDepth);
         }

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -91,7 +91,7 @@ namespace EventStore.Core.Tests.Helpers
                 gossipAllowedTimeDifference: TimeSpan.FromSeconds(1), gossipTimeout: TimeSpan.FromSeconds(1),
                 extTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), extTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
                 intTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), intTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
-                verifyDbHash: false, maxMemtableEntryCount: memTableSize, developmentMode: false);
+                verifyDbHash: false, maxMemtableEntryCount: memTableSize, startStandardProjections: false, disableHTTPCaching: false);
 
             Log.Info(
                 "\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -126,6 +126,7 @@ namespace EventStore.Core.Tests.Helpers
                                                          TimeSpan.FromSeconds(10),
                                                          false,
                                                          memTableSize,
+                                                         false,
                                                          false);
             Log.Info("\n{0,-25} {1} ({2}/{3}, {4})\n"
                      + "{5,-25} {6} ({7})\n"

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
-                TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, false);
+                TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, false, false);
 
             return vnode;
         }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -18,7 +18,8 @@ namespace EventStore.Core.Cluster.Settings
         public readonly bool EnableTrustedAuth;
         public readonly X509Certificate2 Certificate;
         public readonly int WorkerThreads;
-        public readonly bool DevelopmentMode;
+        public readonly bool StartStandardProjections;
+        public readonly bool DisableHTTPCaching;
 
         public readonly bool DiscoverViaDns;
         public readonly string ClusterDns;
@@ -100,7 +101,8 @@ namespace EventStore.Core.Cluster.Settings
                                     TimeSpan extTcpHeartbeatInterval,
 				                    bool verifyDbHash,
 				                    int maxMemtableEntryCount,
-                                    bool developmentMode,
+                                    bool startStandardProjections,
+                                    bool disableHTTPCaching,
                                     bool enableHistograms = false,
                                     int indexCacheDepth = 16)
         {
@@ -137,7 +139,8 @@ namespace EventStore.Core.Cluster.Settings
             EnableTrustedAuth = enableTrustedAuth;
             Certificate = certificate;
             WorkerThreads = workerThreads;
-            DevelopmentMode = developmentMode;
+            StartStandardProjections = startStandardProjections;
+            DisableHTTPCaching = disableHTTPCaching;
 
             DiscoverViaDns = discoverViaDns;
             ClusterDns = clusterDns;
@@ -212,7 +215,8 @@ namespace EventStore.Core.Cluster.Settings
                                  + "GossipInterval: {29}\n"
                                  + "GossipAllowedTimeDifference: {30}\n"
                                  + "GossipTimeout: {31}\n"
-                                 + "HistogramEnabled: {32}\n",
+                                 + "HistogramEnabled: {32}\n"
+                                 + "HTTPCachingDisabled: {33}\n",
                                  NodeInfo.InstanceId,
                                  NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
                                  NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -227,7 +231,7 @@ namespace EventStore.Core.Cluster.Settings
                                  PrepareAckCount, CommitAckCount, PrepareTimeout, CommitTimeout,
                                  UseSsl, SslTargetHost, SslValidateServer,
                                  StatsPeriod, StatsStorage, AuthenticationProviderFactory.GetType(),
-                                 NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout, EnableHistograms);
+                                 NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout, EnableHistograms, DisableHTTPCaching);
         }
     }
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -298,7 +298,7 @@ namespace EventStore.Core
             var pingController = new PingController();
             var histogramController = new HistogramController();
             var statController = new StatController(monitoringQueue, _workersHandler);
-            var atomController = new AtomController(httpSendService, _mainQueue, _workersHandler, vNodeSettings.DevelopmentMode);
+            var atomController = new AtomController(httpSendService, _mainQueue, _workersHandler, vNodeSettings.DisableHTTPCaching);
             var gossipController = new GossipController(_mainQueue, _workersHandler, vNodeSettings.GossipTimeout);
             var persistentSubscriptionController = new PersistentSubscriptionController(httpSendService, _mainQueue, _workersHandler);
             var electController = new ElectController(_mainQueue);

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Services.Transport.Http
     public static class Configure
     {
         private const int MaxPossibleAge = 31536000;
-        public static bool DevelopmentMode = false;
+        public static bool DisableHTTPCaching = false;
 
         public static ResponseConfiguration Ok(string contentType)
         {
@@ -30,7 +30,7 @@ namespace EventStore.Core.Services.Transport.Http
                                                params KeyValuePair<string, string>[] headers)
         {
             var headrs = new List<KeyValuePair<string, string>>(headers);
-            if (DevelopmentMode)
+            if (DisableHTTPCaching)
             {
                 headrs.Add(new KeyValuePair<string, string>(
                     "Cache-Control",

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -74,15 +74,15 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         private readonly IHttpForwarder _httpForwarder;
         private readonly IPublisher _networkSendQueue;
 
-        public AtomController(IHttpForwarder httpForwarder, IPublisher publisher, IPublisher networkSendQueue, bool developmentMode = false): base(publisher)
+        public AtomController(IHttpForwarder httpForwarder, IPublisher publisher, IPublisher networkSendQueue, bool disableHTTPCaching = false): base(publisher)
         {
             _httpForwarder = httpForwarder;
             _networkSendQueue = networkSendQueue;
 
-            if (developmentMode)
+            if (disableHTTPCaching)
             {
                 // ReSharper disable once RedundantNameQualifier
-                Transport.Http.Configure.DevelopmentMode = true;
+                Transport.Http.Configure.DisableHTTPCaching = true;
             }
         }
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -30,8 +30,10 @@ namespace EventStore.Core.Util
         public const string WhatIfDescr = "Print effective configuration to console and then exit.";
         public const bool WhatIfDefault = false;
 
-        public const string DevelopmentModeDescr = "Enable development mode. This disables caching on events over HTTP.";
-        public const bool DevelopmentModeDefault = false;
+        public const string StartStandardProjectionsDescr = "Enable development mode. This disables caching on events over HTTP.";
+        public const bool StartStandardProjectionsDefault = false;
+        public const string DisableHttpCachingDescr = "Disable HTTP caching.";
+        public const bool DisableHttpCachingDefault = false;
 
         public const string LogsDescr = "Path where to keep log files.";
 

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -110,7 +110,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
 
         private MiniClusterNode CreateNode(int index, Endpoints endpoints, IPEndPoint[] gossipSeeds)
         {
-            _projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All, developmentMode: false);
+            _projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All, startStandardProjections: false);
             var node = new MiniClusterNode(
                 PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp, endpoints.ExternalTcp,
                 endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false,

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -78,7 +78,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
         private void CreateNode()
         {
             var projectionWorkerThreadCount = GivenWorkerThreadCount();
-            _projections = new ProjectionsSubsystem(projectionWorkerThreadCount, runProjections: ProjectionType.All, developmentMode: false);
+            _projections = new ProjectionsSubsystem(projectionWorkerThreadCount, runProjections: ProjectionType.All, startStandardProjections: false);
             _node = new MiniNode(
                 PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { _projections });
             _node.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_response_writer/when_handling_stopped_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_response_writer/when_handling_stopped_message.cs
@@ -11,16 +11,18 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
     {
         private Guid _projectionId;
         private bool _completed;
+        private string _projectionName;
 
         protected override void Given()
         {
             _projectionId = Guid.NewGuid();
             _completed = true;
+            _projectionName = Guid.NewGuid().ToString();
         }
 
         protected override void When()
         {
-            _sut.Handle(new CoreProjectionStatusMessage.Stopped(_projectionId, _completed));
+            _sut.Handle(new CoreProjectionStatusMessage.Stopped(_projectionId, _projectionName, _completed));
         }
 
         [Test]

--- a/src/EventStore.Projections.Core/Messages/CoreProjectionStatusMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/CoreProjectionStatusMessage.cs
@@ -241,16 +241,22 @@ namespace EventStore.Projections.Core.Messages
             }
 
             private readonly bool _completed;
+            private readonly string _name;
 
-            public Stopped(Guid projectionId, bool completed)
+            public Stopped(Guid projectionId, string name, bool completed)
                 : base(projectionId)
             {
                 _completed = completed;
+                _name = name;
             }
 
             public bool Completed
             {
                 get { return _completed; }
+            }
+            public string Name
+            {
+                get { return _name; }
             }
         }
     }

--- a/src/EventStore.Projections.Core/Messages/Persisted/Responses/Stopped.cs
+++ b/src/EventStore.Projections.Core/Messages/Persisted/Responses/Stopped.cs
@@ -3,6 +3,7 @@ namespace EventStore.Projections.Core.Messages.Persisted.Responses
     public class Stopped
     {
         public string Id { get; set; }
+        public string Name { get; set; }
         public bool Completed { get; set; }
     }
 }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionCoreResponseWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionCoreResponseWriter.cs
@@ -78,7 +78,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(CoreProjectionStatusMessage.Stopped message)
         {
-            var command = new Stopped {Id = message.ProjectionId.ToString("N"), Completed = message.Completed,};
+            var command = new Stopped {Id = message.ProjectionId.ToString("N"), Completed = message.Completed, Name = message.Name};
             _writer.PublishCommand("$stopped", command);
         }
 

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManagerResponseReader.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManagerResponseReader.cs
@@ -198,6 +198,7 @@ namespace EventStore.Projections.Core.Services.Management
                     _publisher.Publish(
                         new CoreProjectionStatusMessage.Stopped(
                             Guid.ParseExact(commandBody.Id, "N"),
+                            commandBody.Name,
                             commandBody.Completed));
                     break;
                 }

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
@@ -571,7 +571,7 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             EnsureUnsubscribed();
             StopSlaveProjections(); 
-            _publisher.Publish(new CoreProjectionStatusMessage.Stopped(_projectionCorrelationId, _completed));
+            _publisher.Publish(new CoreProjectionStatusMessage.Stopped(_projectionCorrelationId, _name, _completed));
         }
 
         private void EnterFaultedStopping()


### PR DESCRIPTION
Fixes #706

- Development mode is now 2 separate flags, one for disabling http cache and
  another for starting standard projections
- Wait for the individual projections to be at the stopped state before
  attempting to enable them when the "StartStandardProjections" flag has
  been set to true
- Embedded Client also contains a **breaking** change where the **EnableDevelopmentMode** method has been replaced by 2 new methods, **StartStandardProjections** and **DisableHTTPCaching**. We could leave the EnableDevelopmentMode in there and just set the appropriate settings in there? thoughts @gregoryyoung and @jen20 