### PR TITLE
Return empty on no metadata

### DIFF
--- a/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
@@ -448,6 +448,7 @@ namespace EventStore.ClientAPI.Internal
                     case EventReadStatus.Success:
                         if (res.Event == null) throw new Exception("Event is null while operation result is Success.");
                         var evnt = res.Event.Value.OriginalEvent;
+                        if (evnt == null) return new RawStreamMetadataResult(stream, false, -1, Empty.ByteArray);
                         return new RawStreamMetadataResult(stream, false, evnt.EventNumber, evnt.Data);
                     case EventReadStatus.NotFound:
                     case EventReadStatus.NoStream:

--- a/src/EventStore.Core.Tests/ClientAPI/when_working_with_metadata.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/when_working_with_metadata.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using EventStore.ClientAPI;
+using EventStore.ClientAPI.Exceptions;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+using ExpectedVersion = EventStore.ClientAPI.ExpectedVersion;
+using StreamMetadata = EventStore.ClientAPI.StreamMetadata;
+using Newtonsoft.Json.Linq;
+
+namespace EventStore.Core.Tests.ClientAPI
+{
+    [TestFixture, Category("LongRunning")]
+    public class when_working_with_metadata : SpecificationWithDirectoryPerTestFixture
+    {
+        private MiniNode _node;
+        private IEventStoreConnection _connection;
+
+        [TestFixtureSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            _node = new MiniNode(PathName);
+            _node.Start();
+
+            _connection = BuildConnection(_node);
+            _connection.ConnectAsync().Wait();
+        }
+
+        protected virtual IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return TestConnection.Create(node.TcpEndPoint);
+        }
+
+        [TestFixtureTearDown]
+        public override void TestFixtureTearDown()
+        {
+            _connection.Close();
+            _node.Shutdown();
+            base.TestFixtureTearDown();
+        }
+
+        [Test]
+        public void when_getting_metadata_for_an_existing_stream_and_no_metadata_exists()
+        {
+            const string stream = "when_getting_metadata_for_an_existing_stream_and_no_metadata_exists";
+
+            _connection.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+
+            var meta = _connection.GetStreamMetadataAsRawBytesAsync(stream).Result;
+            Assert.AreEqual(stream, meta.Stream);
+            Assert.AreEqual(false, meta.IsStreamDeleted);
+            Assert.AreEqual(-1, meta.MetastreamVersion);
+            Assert.AreEqual(Helper.UTF8NoBom.GetBytes(""), meta.StreamMetadata);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="ClientAPI\Embedded\create_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\deleting_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\update_persistent_subscription.cs" />
+    <Compile Include="ClientAPI\when_working_with_metadata.cs" />
     <Compile Include="ClientAPI\persistent_connect_integration_tests.cs" />
     <Compile Include="ClientAPI\read_allevents_backward_with_linkto_deleted_event.cs" />
     <Compile Include="ClientAPI\Embedded\appending_to_implicitly_created_stream.cs" />

--- a/src/EventStore.Core.Tests/Http/Streams/metadata.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/metadata.cs
@@ -82,5 +82,37 @@ namespace EventStore.Core.Tests.Http.Streams
         }
     }
 
+    [TestFixture]
+    public class when_getting_metadata_for_an_existing_stream_and_no_metadata_exists : HttpBehaviorSpecificationWithSingleEvent
+    {
+        protected override void Given()
+        {
+            _response = MakeArrayEventsPost(
+                TestStream,
+                new[] {new {EventId = Guid.NewGuid(), EventType = "event-type", Data = new {A = "1"}}});
+        }
 
+        protected override void When()
+        {
+            Get(TestStream + "/metadata", String.Empty, EventStore.Transport.Http.ContentType.Json, DefaultData.AdminNetworkCredentials);
+        }
+
+        [Test]
+        public void returns_ok_status_code()
+        {
+            Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+        }
+
+        [Test]
+        public void returns_empty_etag()
+        {
+            Assert.IsNullOrEmpty(_lastResponse.Headers["ETag"]);
+        }
+
+        [Test]
+        public void returns_empty_body()
+        {
+            Assert.AreEqual("{}", _lastResponseBody);
+        }
+    }
 }

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReadEventResult.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReadEventResult.cs
@@ -9,8 +9,9 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
         public readonly EventRecord Record;
         public readonly StreamMetadata Metadata;
         public readonly int LastEventNumber;
+        public readonly bool OriginalStreamExists;
 
-        public IndexReadEventResult(ReadEventResult result, StreamMetadata metadata, int lastEventNumber)
+        public IndexReadEventResult(ReadEventResult result, StreamMetadata metadata, int lastEventNumber, bool originalStreamExists)
         {
             if (result == ReadEventResult.Success)
                 throw new ArgumentException(string.Format("Wrong ReadEventResult provided for failure constructor: {0}.", result), "result");
@@ -19,14 +20,16 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
             Record = null;
             Metadata = metadata;
             LastEventNumber = lastEventNumber;
+            OriginalStreamExists = originalStreamExists;
         }
 
-        public IndexReadEventResult(ReadEventResult result, EventRecord record, StreamMetadata metadata, int lastEventNumber)
+        public IndexReadEventResult(ReadEventResult result, EventRecord record, StreamMetadata metadata, int lastEventNumber, bool originalStreamExists)
         {
             Result = result;
             Record = record;
             Metadata = metadata;
             LastEventNumber = lastEventNumber;
+            OriginalStreamExists = originalStreamExists;
         }
     }
 }

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -155,7 +155,13 @@ namespace EventStore.Core.Services.Storage
                                          : ResolvedEvent.ForUnresolvedEvent(result.Record);
                     if (record == null)
                         return NoData(msg, ReadEventResult.AccessDenied);
-
+                    if ((result.Result == ReadEventResult.NoStream || 
+                        result.Result == ReadEventResult.NotFound) && 
+                        result.OriginalStreamExists &&
+                        SystemStreams.IsSystemStream(msg.EventStreamId))
+                    {
+                        return NoData(msg, ReadEventResult.Success);
+                    }
                     return new ClientMessage.ReadEventCompleted(msg.CorrelationId, msg.EventStreamId, result.Result,
                                                                 record.Value, result.Metadata, access.Public, null);
                 }

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -128,7 +128,7 @@ namespace EventStore.Core.Services.Transport.Http
                         }
                         if (headEvent)
                         {
-                            var etag = GetPositionETag(msg.Record.OriginalEventNumber, codec.ContentType);
+                            var etag = msg.Record.OriginalEvent != null ? GetPositionETag(msg.Record.OriginalEventNumber, codec.ContentType) : String.Empty;
                             var cacheSeconds = GetCacheSeconds(msg.StreamMetadata);
                             return Ok(codec.ContentType, codec.Encoding, etag, cacheSeconds, msg.IsCachePublic);
                         }

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Services.Transport.Http
         {
             var msg = message as ClientMessage.ReadEventCompleted;
             if (msg == null || msg.Result != ReadEventResult.Success || msg.Record.Event == null)
-                return string.Empty;
+                return entity.ResponseCodec.To(new {});
 
             switch (entity.ResponseCodec.ContentType)
             {


### PR DESCRIPTION
Fixes #498
Return an empty result when Metadata does not exist but the original stream does.
- If the result of reading the metastream event is `NoStream` or `NotFound` and the original stream exists, we return a success with an empty event.
- Format has been changed to return a new object that will be formatted according to the Accept header