### PR TITLE
Change formatting in Subscription/Operation(Item)

### DIFF
--- a/src/EventStore.ClientAPI/Internal/OperationsManager.cs
+++ b/src/EventStore.ClientAPI/Internal/OperationsManager.cs
@@ -40,7 +40,7 @@ namespace EventStore.ClientAPI.Internal
 
         public override string ToString()
         {
-            return string.Format("Operation {0} ({1:B}): {2}, retry count: {3}, created: {4:HH:mm:ss.fff}, last updated: {5:HH:mm:ss.fff}",
+            return string.Format("Operation {0} ({1:D}): {2}, retry count: {3}, created: {4:HH:mm:ss.fff}, last updated: {5:HH:mm:ss.fff}",
                                  Operation.GetType().Name, CorrelationId, Operation, RetryCount, CreatedTime, LastUpdated);
         }
     }

--- a/src/EventStore.ClientAPI/Internal/SubscriptionsManager.cs
+++ b/src/EventStore.ClientAPI/Internal/SubscriptionsManager.cs
@@ -37,7 +37,7 @@ namespace EventStore.ClientAPI.Internal
 
         public override string ToString()
         {
-            return string.Format("Subscription {0} ({1:B}): {2}, is subscribed: {3}, retry count: {4}, "
+            return string.Format("Subscription {0} ({1:D}): {2}, is subscribed: {3}, retry count: {4}, "
                                  + "created: {5:HH:mm:ss.fff}, last updated: {6:HH:mm:ss.fff}",
                                  Operation.GetType().Name, CorrelationId, Operation, IsSubscribed, RetryCount, CreatedTime, LastUpdated);
         }


### PR DESCRIPTION
Fixes #716

Switch B (Includes braces) to use D (Doesnt include braces). This resolves an issue where the item would be passed to another call that will attempt to format it and the included braces will cause an format exception.