### PR TITLE
Guard against null GossipSeeds

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -91,7 +91,7 @@ namespace EventStore.ClientAPI
                 var tcpEndPoint = GetSingleNodeIPEndPointFrom(uri);
                 return new EventStoreNodeConnection(connectionSettings, null, new StaticEndPointDiscoverer(tcpEndPoint, connectionSettings.UseSslConnection), connectionName);
             }
-            if (connectionSettings.GossipSeeds.Length > 0)
+            if (connectionSettings.GossipSeeds != null && connectionSettings.GossipSeeds.Length > 0)
             {
                 var clusterSettings = new ClusterSettings(connectionSettings.GossipSeeds,
                     connectionSettings.MaxDiscoverAttempts,


### PR DESCRIPTION
When creating a connection and no valid scheme is passed in the Uri and no
GossipSeeds, the GossipSeeds.Length will cause a NullRefException. We want
the consumer to be warned against a valid scheme, not a NRE.