### PR TITLE
Honour default credentials set on connection

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
@@ -43,7 +43,7 @@ namespace EventStore.ClientAPI.Embedded
             CorrelationId = correlationId;
 
             Publisher.PublishWithAuthentication(_authenticationProvider, _userCredentials, 
-                _ => DropSubscription(EventStore.Core.Services.SubscriptionDropReason.AccessDenied),
+                ex => DropSubscription(EventStore.Core.Services.SubscriptionDropReason.AccessDenied, ex),
                 user => new ClientMessage.ConnectToPersistentSubscription(correlationId, correlationId,
                     new PublishEnvelope(Publisher, true), ConnectionId, _subscriptionId, StreamId, _bufferSize,
                     String.Empty,
@@ -65,7 +65,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNull(reason, "reason");
 
             Publisher.PublishWithAuthentication(_authenticationProvider, _userCredentials,
-                _ => DropSubscription(EventStore.Core.Services.SubscriptionDropReason.AccessDenied),
+                ex => DropSubscription(EventStore.Core.Services.SubscriptionDropReason.AccessDenied, ex),
                 user => new ClientMessage.PersistentSubscriptionNackEvents(CorrelationId, CorrelationId,
                     new PublishEnvelope(Publisher, true), _subscriptionId, reason,
                     (ClientMessage.PersistentSubscriptionNackEvents.NakAction) action, processedEvents,

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscription.cs
@@ -40,8 +40,8 @@ namespace EventStore.ClientAPI.Embedded
         {
             CorrelationId = correlationId;
 
-            Publisher.PublishWithAuthentication(_authenticationProvider, _userCredentials, 
-                _ => DropSubscription(EventStore.Core.Services.SubscriptionDropReason.AccessDenied), 
+            Publisher.PublishWithAuthentication(_authenticationProvider, _userCredentials,
+                ex => DropSubscription(EventStore.Core.Services.SubscriptionDropReason.AccessDenied, ex), 
                 user => new ClientMessage.SubscribeToStream(
                     correlationId,
                     correlationId,

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriptionBase.cs
@@ -47,13 +47,13 @@ namespace EventStore.ClientAPI.Embedded
             _actionQueue = new ConcurrentQueue<Action>();
         }
 
-        public void DropSubscription(Core.Services.SubscriptionDropReason reason)
+        public void DropSubscription(Core.Services.SubscriptionDropReason reason, Exception ex)
         {
             switch (reason)
             {
                 case Core.Services.SubscriptionDropReason.AccessDenied:
                     DropSubscription(SubscriptionDropReason.AccessDenied,
-                        new AccessDeniedException(string.Format("Subscription to '{0}' failed due to access denied.",
+                        ex ?? new AccessDeniedException(string.Format("Subscription to '{0}' failed due to access denied.",
                             StreamId == string.Empty ? "<all>" : StreamId)));
                     break;
                 case Core.Services.SubscriptionDropReason.Unsubscribed:

--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -125,7 +125,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public Task<DeleteResult> DeleteStreamAsync(string stream, int expectedVersion, UserCredentials userCredentials = null)
         {
-            return DeleteStreamAsync(stream, expectedVersion, false, userCredentials);
+            return DeleteStreamAsync(stream, expectedVersion, false, GetUserCredentials(_settings, userCredentials));
         }
 
         public Task<DeleteResult> DeleteStreamAsync(string stream, int expectedVersion, bool hardDelete, UserCredentials userCredentials = null)
@@ -138,7 +138,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.DeleteStream(corrId, corrId, envelope, false,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.DeleteStream(corrId, corrId, envelope, false,
                 stream, expectedVersion, hardDelete, user));
 
             return source.Task;
@@ -156,7 +156,7 @@ namespace EventStore.ClientAPI.Embedded
         public Task<WriteResult> AppendToStreamAsync(string stream, int expectedVersion, UserCredentials userCredentials, params EventData[] events)
         {
             // ReSharper disable RedundantCast
-            return AppendToStreamAsync(stream, expectedVersion, (IEnumerable<EventData>)events, userCredentials);
+            return AppendToStreamAsync(stream, expectedVersion, (IEnumerable<EventData>)events, GetUserCredentials(_settings, userCredentials));
             // ReSharper restore RedundantCast
         }
 
@@ -172,7 +172,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.WriteEvents(corrId, corrId, envelope, false,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.WriteEvents(corrId, corrId, envelope, false,
                 stream, expectedVersion, events.ConvertToEvents(), user));
 
             return source.Task;
@@ -189,7 +189,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.TransactionStart(corrId, corrId, envelope,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.TransactionStart(corrId, corrId, envelope,
                 false, stream, expectedVersion, user));
 
             return source.Task;
@@ -198,7 +198,7 @@ namespace EventStore.ClientAPI.Embedded
         public EventStoreTransaction ContinueTransaction(long transactionId, UserCredentials userCredentials = null)
         {
             Ensure.Nonnegative(transactionId, "transactionId");
-            return new EventStoreTransaction(transactionId, userCredentials, this);
+            return new EventStoreTransaction(transactionId, GetUserCredentials(_settings, userCredentials), this);
         }
 
         Task IEventStoreTransactionConnection.TransactionalWriteAsync(EventStoreTransaction transaction, IEnumerable<EventData> events, UserCredentials userCredentials)
@@ -213,7 +213,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.TransactionWrite(corrId, corrId, envelope,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.TransactionWrite(corrId, corrId, envelope,
                 false, transaction.TransactionId, events.ConvertToEvents(), user));
 
             return source.Task;
@@ -231,7 +231,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.TransactionCommit(corrId, corrId, envelope,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.TransactionCommit(corrId, corrId, envelope,
                 false, transaction.TransactionId, user));
 
             return source.Task;
@@ -248,7 +248,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.ReadEvent(corrId, corrId, envelope,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.ReadEvent(corrId, corrId, envelope,
                 stream, eventNumber, resolveLinkTos, false, user));
 
             return source.Task;
@@ -266,7 +266,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.ReadStreamEventsForward(corrId, corrId, envelope,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.ReadStreamEventsForward(corrId, corrId, envelope,
                 stream, start, count, resolveLinkTos, false, null, user));
 
             return source.Task;
@@ -283,7 +283,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.ReadStreamEventsBackward(corrId, corrId, envelope,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.ReadStreamEventsBackward(corrId, corrId, envelope,
                 stream, start, count, resolveLinkTos, false, null, user));
 
             return source.Task;
@@ -299,13 +299,12 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.ReadAllEventsForward(corrId, corrId, envelope,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.ReadAllEventsForward(corrId, corrId, envelope,
                 position.CommitPosition,
                 position.PreparePosition, maxCount, resolveLinkTos, false, null, user));
 
             return source.Task;
         }
-
 
         public Task<AllEventsSlice> ReadAllEventsBackwardAsync(Position position, int maxCount, bool resolveLinkTos, UserCredentials userCredentials = null)
         {
@@ -317,7 +316,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.ReadAllEventsBackward(corrId, corrId, envelope,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.ReadAllEventsBackward(corrId, corrId, envelope,
                 position.CommitPosition,
                 position.PreparePosition, maxCount, resolveLinkTos, false, null, user));
 
@@ -337,7 +336,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _subscriptions.StartSubscription(corrId, source, stream, userCredentials, resolveLinkTos, eventAppeared, subscriptionDropped);
+            _subscriptions.StartSubscription(corrId, source, stream, GetUserCredentials(_settings, userCredentials), resolveLinkTos, eventAppeared, subscriptionDropped);
             
             return source.Task;
         }
@@ -355,7 +354,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNull(eventAppeared, "eventAppeared");
             var catchUpSubscription =
                 new EventStoreStreamCatchUpSubscription(this, _settings.Log, stream, lastCheckpoint,
-                    resolveLinkTos, userCredentials, eventAppeared,
+                    resolveLinkTos, GetUserCredentials(_settings, userCredentials), eventAppeared,
                     liveProcessingStarted, subscriptionDropped, _settings.VerboseLogging, readBatchSize);
             catchUpSubscription.Start();
             return catchUpSubscription;
@@ -373,7 +372,7 @@ namespace EventStore.ClientAPI.Embedded
         
             Guid corrId = Guid.NewGuid();
 
-            _subscriptions.StartSubscription(corrId, source, string.Empty, userCredentials, resolveLinkTos,  eventAppeared, subscriptionDropped);
+            _subscriptions.StartSubscription(corrId, source, string.Empty, GetUserCredentials(_settings, userCredentials), resolveLinkTos, eventAppeared, subscriptionDropped);
 
             return source.Task;
         }
@@ -390,7 +389,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNull(eventAppeared, "eventAppeared");
 
             var subscription = new EmbeddedEventStorePersistentSubscription(groupName, stream, eventAppeared, subscriptionDropped,
-                userCredentials, _settings.Log, _settings.VerboseLogging, _settings, _subscriptions, bufferSize,
+                GetUserCredentials(_settings, userCredentials), _settings.Log, _settings.VerboseLogging, _settings, _subscriptions, bufferSize,
                 autoAck);
 
             subscription.Start();
@@ -410,14 +409,14 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNull(eventAppeared, "eventAppeared");
             var catchUpSubscription =
                 new EventStoreAllCatchUpSubscription(this, _settings.Log, lastCheckpoint, resolveLinkTos,
-                    userCredentials, eventAppeared, liveProcessingStarted,
+                    GetUserCredentials(_settings, userCredentials), eventAppeared, liveProcessingStarted,
                     subscriptionDropped, _settings.VerboseLogging, readBatchSize);
             catchUpSubscription.Start();
             return catchUpSubscription;
         }
 
         public Task CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings,
-            UserCredentials credentials)
+            UserCredentials userCredentials)
         {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
@@ -430,7 +429,7 @@ namespace EventStore.ClientAPI.Embedded
             var corrId = Guid.NewGuid();
 
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, credentials, source.SetException, user => new ClientMessage.CreatePersistentSubscription(
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.CreatePersistentSubscription(
                 corrId, 
                 corrId,
                 envelope,
@@ -450,14 +449,14 @@ namespace EventStore.ClientAPI.Embedded
                 settings.MaxSubscriberCount,
                 settings.NamedConsumerStrategy,
                 user,
-                credentials == null ? null : credentials.Username,
-                credentials == null ? null : credentials.Password));
+                userCredentials == null ? null : userCredentials.Username,
+                userCredentials == null ? null : userCredentials.Password));
 
             return source.Task;
         }
 
         public Task UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings,
-            UserCredentials credentials)
+            UserCredentials userCredentials)
         {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
@@ -468,7 +467,7 @@ namespace EventStore.ClientAPI.Embedded
 
             var corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, credentials, source.SetException, user => new ClientMessage.UpdatePersistentSubscription(
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.UpdatePersistentSubscription(
                 corrId,
                 corrId,
                 envelope,
@@ -488,8 +487,8 @@ namespace EventStore.ClientAPI.Embedded
                 settings.MaxSubscriberCount,
                 settings.NamedConsumerStrategy,
                 user,
-                credentials == null ? null : credentials.Username,
-                credentials == null ? null : credentials.Password));
+                userCredentials == null ? null : userCredentials.Username,
+                userCredentials == null ? null : userCredentials.Password));
 
             return source.Task;
         }
@@ -508,7 +507,7 @@ namespace EventStore.ClientAPI.Embedded
 
             var corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.DeletePersistentSubscription(
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.DeletePersistentSubscription(
                 corrId,
                 corrId,
                 envelope,
@@ -521,7 +520,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVersion, StreamMetadata metadata, UserCredentials userCredentials = null)
         {
-            return SetStreamMetadataAsync(stream, expectedMetastreamVersion, metadata.AsJsonBytes(), userCredentials);
+            return SetStreamMetadataAsync(stream, expectedMetastreamVersion, metadata.AsJsonBytes(), GetUserCredentials(_settings, userCredentials));
         }
 
         public Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVersion, byte[] metadata, UserCredentials userCredentials = null)
@@ -540,7 +539,7 @@ namespace EventStore.ClientAPI.Embedded
 
             var corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user => new ClientMessage.WriteEvents(corrId, corrId, envelope, false, metastream,
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.WriteEvents(corrId, corrId, envelope, false, metastream,
                 expectedMetastreamVersion, metaevent.ConvertToEvent(), user));
 
             return source.Task;
@@ -548,7 +547,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public Task<StreamMetadataResult> GetStreamMetadataAsync(string stream, UserCredentials userCredentials = null)
         {
-            return GetStreamMetadataAsRawBytesAsync(stream, userCredentials).ContinueWith(t =>
+            return GetStreamMetadataAsRawBytesAsync(stream, GetUserCredentials(_settings, userCredentials)).ContinueWith(t =>
             {
                 if (t.Exception != null)
                     throw t.Exception.InnerException;
@@ -562,7 +561,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public Task<RawStreamMetadataResult> GetStreamMetadataAsRawBytesAsync(string stream, UserCredentials userCredentials = null)
         {
-            return ReadEventAsync(SystemStreams.MetastreamOf(stream), -1, false, userCredentials).ContinueWith(t =>
+            return ReadEventAsync(SystemStreams.MetastreamOf(stream), -1, false, GetUserCredentials(_settings, userCredentials)).ContinueWith(t =>
             {
                 if (t.Exception != null)
                     throw t.Exception.InnerException;
@@ -587,7 +586,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public Task SetSystemSettingsAsync(SystemSettings settings, UserCredentials userCredentials = null)
         {
-            return AppendToStreamAsync(SystemStreams.SettingsStream, ExpectedVersion.Any, userCredentials,
+            return AppendToStreamAsync(SystemStreams.SettingsStream, ExpectedVersion.Any, GetUserCredentials(_settings, userCredentials),
                 new EventData(Guid.NewGuid(), SystemEventTypes.Settings, true, settings.ToJsonBytes(), null));
         }
 
@@ -625,7 +624,7 @@ namespace EventStore.ClientAPI.Embedded
 
             Guid corrId = Guid.NewGuid();
 
-            _publisher.PublishWithAuthentication(_authenticationProvider, userCredentials, source.SetException, user =>  new ClientMessage.TransactionWrite(corrId, corrId, envelope,false, 
+            _publisher.PublishWithAuthentication(_authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException, user => new ClientMessage.TransactionWrite(corrId, corrId, envelope, false, 
                 transaction.TransactionId, events.ConvertToEvents(), user));
             
             return source.Task;
@@ -641,11 +640,16 @@ namespace EventStore.ClientAPI.Embedded
             Guid corrId = Guid.NewGuid();
 
             _publisher.PublishWithAuthentication(
-                _authenticationProvider, userCredentials, source.SetException,
+                _authenticationProvider, GetUserCredentials(_settings, userCredentials), source.SetException,
                 user => new ClientMessage.TransactionCommit(corrId, corrId, envelope, false,
                     transaction.TransactionId, user));
 
             return source.Task;
+        }
+
+        private UserCredentials GetUserCredentials(ConnectionSettings settings, UserCredentials givenCredentials)
+        {
+            return givenCredentials ?? settings.DefaultUserCredentials;
         }
     }
 }

--- a/src/EventStore.ClientAPI.Embedded/IEmbeddedSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/IEmbeddedSubscription.cs
@@ -4,7 +4,7 @@ namespace EventStore.ClientAPI.Embedded
 {
     internal interface IEmbeddedSubscription
     {
-        void DropSubscription(EventStore.Core.Services.SubscriptionDropReason reason);
+        void DropSubscription(EventStore.Core.Services.SubscriptionDropReason reason, Exception ex = null);
         void EventAppeared(EventStore.Core.Data.ResolvedEvent resolvedEvent);
         void ConfirmSubscription(long lastCommitPosition, int? lastEventNumber);
         void Unsubscribe();

--- a/src/EventStore.Core.Tests/ClientAPI/Embedded/Security/authorized_default_credentials_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Embedded/Security/authorized_default_credentials_security.cs
@@ -1,0 +1,16 @@
+﻿using EventStore.ClientAPI.Exceptions;
+using EventStore.ClientAPI.SystemData;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientAPI.Embedded.Security
+{
+    [TestFixture, Category("LongRunning"), Category("Network")]
+    public class authorized_default_credentials_security : EventStore.Core.Tests.ClientAPI.Security.authorized_default_credentials_security
+    {
+        public override EventStore.ClientAPI.IEventStoreConnection SetupConnection(Tests.Helpers.MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node, DefaultData.AdminCredentials);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/ClientAPI/Helpers/TestConnection.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Helpers/TestConnection.cs
@@ -49,15 +49,16 @@ namespace EventStore.Core.Tests.ClientAPI.Helpers
     {
         private static int _nextConnId = -1;
 
-        public static IEventStoreConnection To(MiniNode miniNode)
+        public static IEventStoreConnection To(MiniNode miniNode, UserCredentials credentials = null)
         {
-            return EmbeddedEventStoreConnection.Create(miniNode.Node, Settings(),
+            return EmbeddedEventStoreConnection.Create(miniNode.Node, Settings(credentials),
                                                string.Format("ESC-{0}", Interlocked.Increment(ref _nextConnId)));
         }
 
-        private static ConnectionSettingsBuilder Settings()
+        private static ConnectionSettingsBuilder Settings(UserCredentials credentials = null)
         {
             var settings = ConnectionSettings.Create()
+                                             .SetDefaultUserCredentials(credentials)
                                              .UseCustomLogger(ClientApiLoggerBridge.Default)
                                              .EnableVerboseLogging()
                                              .LimitReconnectionsTo(10)

--- a/src/EventStore.Core.Tests/ClientAPI/Security/AuthenticationTestBase.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/AuthenticationTestBase.cs
@@ -23,6 +23,11 @@ namespace EventStore.Core.Tests.ClientAPI.Security
             _userCredentials = userCredentials;
         }
 
+        public virtual IEventStoreConnection SetupConnection(MiniNode node)
+        {
+            return TestConnection.Create(node.TcpEndPoint, TcpType.Normal, _userCredentials);
+        }
+
         [TestFixtureSetUp]
         public override void TestFixtureSetUp()
         {
@@ -39,7 +44,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security
                             m =>
                             {
                                 Assert.IsTrue(m is UserManagementMessage.UpdateResult);
-                                var msg = (UserManagementMessage.UpdateResult) m;
+                                var msg = (UserManagementMessage.UpdateResult)m;
                                 Assert.IsTrue(msg.Success);
 
                                 userCreateEvent1.Set();
@@ -57,7 +62,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security
                             m =>
                             {
                                 Assert.IsTrue(m is UserManagementMessage.UpdateResult);
-                                var msg = (UserManagementMessage.UpdateResult) m;
+                                var msg = (UserManagementMessage.UpdateResult)m;
                                 Assert.IsTrue(msg.Success);
 
                                 userCreateEvent2.Set();
@@ -75,7 +80,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security
                             m =>
                             {
                                 Assert.IsTrue(m is UserManagementMessage.UpdateResult);
-                                var msg = (UserManagementMessage.UpdateResult) m;
+                                var msg = (UserManagementMessage.UpdateResult)m;
                                 Assert.IsTrue(msg.Success);
 
                                 adminCreateEvent2.Set();
@@ -83,14 +88,14 @@ namespace EventStore.Core.Tests.ClientAPI.Security
                         SystemAccount.Principal,
                         "adm",
                         "Administrator User",
-                        new[] {SystemRoles.Admins},
+                        new[] { SystemRoles.Admins },
                         "admpa$$"));
 
                 Assert.IsTrue(userCreateEvent1.Wait(10000), "User 1 creation failed");
                 Assert.IsTrue(userCreateEvent2.Wait(10000), "User 2 creation failed");
                 Assert.IsTrue(adminCreateEvent2.Wait(10000), "Administrator User creation failed");
 
-                Connection = TestConnection.Create(_node.TcpEndPoint, TcpType.Normal, _userCredentials);
+                Connection = SetupConnection(_node);
                 Connection.ConnectAsync().Wait();
 
                 Connection.SetStreamMetadataAsync("noacl-stream", ExpectedVersion.NoStream, StreamMetadata.Build())
@@ -207,7 +212,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
         protected EventStoreTransaction TransStart(string streamId, string login, string password)
         {
-            return  Connection.StartTransactionAsync(streamId, ExpectedVersion.Any,
+            return Connection.StartTransactionAsync(streamId, ExpectedVersion.Any,
                                                 login == null && password == null ? null : new UserCredentials(login, password))
             .Result;
         }
@@ -270,7 +275,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
         protected void DeleteStream(string streamId, string login, string password)
         {
-            Connection.DeleteStreamAsync(streamId, ExpectedVersion.Any, true, 
+            Connection.DeleteStreamAsync(streamId, ExpectedVersion.Any, true,
                                     login == null && password == null ? null : new UserCredentials(login, password)).Wait();
         }
 
@@ -286,7 +291,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
         protected EventData[] CreateEvents()
         {
-            return new[] { new EventData(Guid.NewGuid(), "some-type", false, new byte[] {1, 2, 3}, null) };
+            return new[] { new EventData(Guid.NewGuid(), "some-type", false, new byte[] { 1, 2, 3 }, null) };
         }
     }
 }

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="ClientAPI\Embedded\connecting_to_a_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\create_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\deleting_persistent_subscription.cs" />
+    <Compile Include="ClientAPI\Embedded\Security\authorized_default_credentials_security.cs" />
     <Compile Include="ClientAPI\Embedded\update_persistent_subscription.cs" />
     <Compile Include="ClientAPI\when_working_with_metadata.cs" />
     <Compile Include="ClientAPI\persistent_connect_integration_tests.cs" />


### PR DESCRIPTION
- Make use of the Exception that gets set when dropping the connection. 
  - This ensures consistency between EventStoreConnection and EmbeddedEventStore connection on authentication when subscribing where the **EventStoreConnection** was throwing a **NotAuthenticatedException** and **EmbeddedEventStoreConnection** an **AccessDeniedException**. 
- Add tests to validate default credentials. This uses the existing https://github.com/EventStore/EventStore/blob/release-v3.3.1/src/EventStore.Core.Tests/ClientAPI/Security/authorized_default_credentials_security.cs but replaces the connection with an **EmbeddedEventStoreConnection**