### PR TITLE
Set index path via options

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -116,6 +116,8 @@ namespace EventStore.ClusterNode
 
         [ArgDescription(Opts.DbPathDescr, Opts.DbGroup)]
         public string Db { get; set; }
+        [ArgDescription(Opts.IndexPathDescr, Opts.DbGroup)]
+        public string Index { get; set; }
         [ArgDescription(Opts.InMemDbDescr, Opts.DbGroup)]
         public bool MemDb { get; set; }
         [ArgDescription(Opts.SkipDbVerifyDescr, Opts.DbGroup)]
@@ -219,6 +221,7 @@ namespace EventStore.ClusterNode
             ChunksCacheSize = Opts.ChunksCacheSizeDefault;
 
             Db = Locations.DefaultDataDirectory;
+            Index = Locations.DefaultDataDirectory;
             MemDb = Opts.InMemDbDefault;
             SkipDbVerify = Opts.SkipDbVerifyDefault;
             RunProjections = Opts.RunProjectionsDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -274,6 +274,7 @@ namespace EventStore.ClusterNode
                     !options.SkipDbVerify, options.MaxMemTableSize,
                     options.StartStandardProjections,
                     options.DisableHTTPCaching,
+                    options.Index,
                     options.EnableHistograms,
                     options.IndexCacheDepth);
         }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -59,6 +59,8 @@ namespace EventStore.Core.Cluster.Settings
         public readonly int MaxMemtableEntryCount;
         public readonly int IndexCacheDepth;
 
+        public readonly string Index;
+
         public ClusterVNodeSettings(Guid instanceId, int debugIndex,
                                     IPEndPoint internalTcpEndPoint,
                                     IPEndPoint internalSecureTcpEndPoint,
@@ -103,6 +105,7 @@ namespace EventStore.Core.Cluster.Settings
 				                    int maxMemtableEntryCount,
                                     bool startStandardProjections,
                                     bool disableHTTPCaching,
+                                    string index = null,
                                     bool enableHistograms = false,
                                     int indexCacheDepth = 16)
         {
@@ -180,6 +183,7 @@ namespace EventStore.Core.Cluster.Settings
 
             EnableHistograms = enableHistograms;
             IndexCacheDepth = indexCacheDepth;
+            Index = index;
         }
 
         public override string ToString()
@@ -216,7 +220,8 @@ namespace EventStore.Core.Cluster.Settings
                                  + "GossipAllowedTimeDifference: {30}\n"
                                  + "GossipTimeout: {31}\n"
                                  + "HistogramEnabled: {32}\n"
-                                 + "HTTPCachingDisabled: {33}\n",
+                                 + "HTTPCachingDisabled: {33}\n"
+                                 + "IndexPath: {34}\n",
                                  NodeInfo.InstanceId,
                                  NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
                                  NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -231,7 +236,7 @@ namespace EventStore.Core.Cluster.Settings
                                  PrepareAckCount, CommitAckCount, PrepareTimeout, CommitTimeout,
                                  UseSsl, SslTargetHost, SslValidateServer,
                                  StatsPeriod, StatsStorage, AuthenticationProviderFactory.GetType(),
-                                 NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout, EnableHistograms, DisableHTTPCaching);
+                                 NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout, EnableHistograms, DisableHTTPCaching, Index);
         }
     }
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -154,7 +154,7 @@ namespace EventStore.Core
 
             // STORAGE SUBSYSTEM
             db.Open(vNodeSettings.VerifyDbHash);
-            var indexPath = Path.Combine(db.Config.Path, "index");
+            var indexPath = vNodeSettings.Index ?? Path.Combine(db.Config.Path, "index");
             var readerPool = new ObjectPool<ITransactionFileReader>(
                 "ReadIndex readers pool", ESConsts.PTableInitialReaderCount, ESConsts.PTableMaxReaderCount,
                 () => new TFChunkReader(db, db.Config.WriterCheckpoint));

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -84,6 +84,7 @@ namespace EventStore.Core.Util
         public static readonly bool DisableScavengeMergeDefault = false;
 
         public const string DbPathDescr = "The path the db should be loaded/saved to.";
+        public const string IndexPathDescr = "The path the index should be loaded/saved to.";
 
         public const string InMemDbDescr = "Keep everything in memory, no directories or files are created.";
         public const bool   InMemDbDefault = false;


### PR DESCRIPTION
Gives the user the option of specifying where the Index is stored
```
./clusternode --index ~/EventStoreDb/index
```
**PS: It does not append `index` to the given path**