### PR TITLE
Use single hash in shebang

### DIFF
--- a/scripts/package-mono/run-mono-node.sh
+++ b/scripts/package-mono/run-mono-node.sh
@@ -1,4 +1,4 @@
-##!/usr/bin/env bash
+#!/usr/bin/env bash
 EVENTSTORE_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 MONO_PATH=`which mono`
 LD_LIBRARY_PATH=${EVENTSTORE_DIR}:$LD_LIBRARY_PATH MONO_GC_DEBUG=clear-at-gc $MONO_PATH ${EVENTSTORE_DIR}/EventStore.ClusterNode.exe $@

--- a/scripts/package-mono/run-node.sh
+++ b/scripts/package-mono/run-node.sh
@@ -1,3 +1,3 @@
-##!/usr/bin/env bash
+#!/usr/bin/env bash
 EVENTSTORE_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 LD_LIBRARY_PATH=${EVENTSTORE_DIR}:$LD_LIBRARY_PATH ${EVENTSTORE_DIR}/eventstored $@


### PR DESCRIPTION
When running an executable, the kernel (and other executors) looks at the first
few bytes to determine the type of the file.
Some get confused when met by double hash.