### PR TITLE
Honour projection authorisation

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_event_type_index_positions_when_updating.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_phase.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_catalog_stream.cs" />
+    <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection_and_not_authorised.cs" />
     <Compile Include="Services\projections_manager\when_recreating_a_deleted_projection.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EventStore.Common.Utils;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Management;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager
+{
+    [TestFixture]
+    public class when_deleting_a_persistent_projection_and_not_authorised : TestFixtureWithProjectionCoreAndManagementServices
+    {
+        private string _projectionName;
+
+        protected override void Given()
+        {
+            _projectionName = "test-projection";
+            AllWritesSucceed();
+            NoOtherStreams();
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return
+                new ProjectionManagementMessage.Command.Post(
+                    new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
+                    ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
+                    enabled: true, checkpointsEnabled: true, emitEnabled: false);
+            yield return
+                new ProjectionManagementMessage.Command.Disable(
+                    new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);
+            yield return
+                new ProjectionManagementMessage.Command.Delete(
+                    new PublishEnvelope(_bus), _projectionName,
+                    ProjectionManagementMessage.RunAs.Anonymous, false, false);
+        }
+
+        [Test, Category("v8")]
+        public void a_projection_deleted_event_is_not_written()
+        {
+            Assert.AreNotEqual(
+                "$ProjectionDeleted",
+                _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Last().Events[0].EventType, "$ProjectionDeleted event was not supposed to be written");
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -220,6 +220,11 @@ namespace EventStore.Projections.Core.Services.Management
             get { return _id; }
         }
 
+        public IPrincipal RunAs
+        {
+            get { return _runAs; }
+        }
+
         internal void SetState(ManagedProjectionState value)
         {
 //            _logger.Trace("MP: {0} {1} => {2}", _name, _state, value);
@@ -354,7 +359,6 @@ namespace EventStore.Projections.Core.Services.Management
         public void Handle(ProjectionManagementMessage.Command.GetQuery message)
         {
             _lastAccessed = _timeProvider.Now;
-            if (!ProjectionManagementMessage.RunAs.ValidateRunAs(Mode, ReadWrite.Read, _runAs, message)) return;
 
             var emitEnabled = _persistedState.EmitEnabled ?? false;
 
@@ -378,7 +382,6 @@ namespace EventStore.Projections.Core.Services.Management
         public void Handle(ProjectionManagementMessage.Command.UpdateQuery message)
         {
             _lastAccessed = _timeProvider.Now;
-            if (!ProjectionManagementMessage.RunAs.ValidateRunAs(Mode, ReadWrite.Write, _runAs, message)) return;
 
             _prepared = false;
             DoUpdateQuery1(message);
@@ -398,7 +401,6 @@ namespace EventStore.Projections.Core.Services.Management
         public void Handle(ProjectionManagementMessage.Command.Disable message)
         {
             _lastAccessed = _timeProvider.Now;
-            if (!ProjectionManagementMessage.RunAs.ValidateRunAs(Mode, ReadWrite.Write, _runAs, message)) return;
             SetLastReplyEnvelope(message.Envelope);
             Disable();
             UpdateProjectionVersion();
@@ -408,7 +410,6 @@ namespace EventStore.Projections.Core.Services.Management
         public void Handle(ProjectionManagementMessage.Command.Abort message)
         {
             _lastAccessed = _timeProvider.Now;
-            if (!ProjectionManagementMessage.RunAs.ValidateRunAs(Mode, ReadWrite.Write, _runAs, message)) return;
             UpdateProjectionVersion();
             SetLastReplyEnvelope(message.Envelope);
             Disable();
@@ -418,7 +419,6 @@ namespace EventStore.Projections.Core.Services.Management
         public void Handle(ProjectionManagementMessage.Command.Enable message)
         {
             _lastAccessed = _timeProvider.Now;
-            if (!ProjectionManagementMessage.RunAs.ValidateRunAs(Mode, ReadWrite.Write, _runAs, message)) return;
             if (Enabled
                 && !(_state == ManagedProjectionState.Completed || _state == ManagedProjectionState.Faulted
                      || _state == ManagedProjectionState.Aborted || _state == ManagedProjectionState.Loaded
@@ -438,12 +438,6 @@ namespace EventStore.Projections.Core.Services.Management
         public void Handle(ProjectionManagementMessage.Command.SetRunAs message)
         {
             _lastAccessed = _timeProvider.Now;
-            if (
-                !ProjectionManagementMessage.RunAs.ValidateRunAs(
-                    Mode, ReadWrite.Write, _runAs, message,
-                    message.Action == ProjectionManagementMessage.Command.SetRunAs.SetRemove.Set)) return;
-
-
             _prepared = false;
             DoSetRunAs1(message);
             UpdateProjectionVersion();
@@ -456,7 +450,6 @@ namespace EventStore.Projections.Core.Services.Management
             if (_state != ManagedProjectionState.Stopped)
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.OperationFailed("Cannot delete a projection that hasn't been stopped.")); 
             _lastAccessed = _timeProvider.Now;
-            if (!ProjectionManagementMessage.RunAs.ValidateRunAs(Mode, ReadWrite.Write, _runAs, message)) return;
             if (message.DeleteCheckpointStream)
             {
                 DeleteCheckpointStream();
@@ -470,7 +463,6 @@ namespace EventStore.Projections.Core.Services.Management
         public void Handle(ProjectionManagementMessage.Command.Reset message)
         {
             _lastAccessed = _timeProvider.Now;
-            if (!ProjectionManagementMessage.RunAs.ValidateRunAs(Mode, ReadWrite.Write, _runAs, message)) return;
             _prepared = false;
             DoReset1();
             UpdateProjectionVersion();

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -232,6 +232,7 @@ namespace EventStore.Projections.Core.Services.Management
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             else
             {
+                if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.GetMode(), ReadWrite.Write, projection.RunAs, message)) return;
                 projection.Handle(message);
                 _projections.Remove(message.Name);
                 _projectionsMap.Remove(projection.Id);
@@ -264,7 +265,10 @@ namespace EventStore.Projections.Core.Services.Management
             if (projection == null)
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             else
+            {
+                if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.GetMode(), ReadWrite.Read, projection.RunAs, message)) return;
                 projection.Handle(message);
+            }
         }
 
         public void Handle(ProjectionManagementMessage.Command.UpdateQuery message)
@@ -280,7 +284,10 @@ namespace EventStore.Projections.Core.Services.Management
             if (projection == null)
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             else
+            {
+                if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.GetMode(), ReadWrite.Write, projection.RunAs, message)) return;
                 projection.Handle(message); // update query text
+            }
         }
 
         public void Handle(ProjectionManagementMessage.Command.Disable message)
@@ -293,7 +300,10 @@ namespace EventStore.Projections.Core.Services.Management
             if (projection == null)
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             else
+            {
+                if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.GetMode(), ReadWrite.Write, projection.RunAs, message)) return;
                 projection.Handle(message);
+            }
         }
 
         public void Handle(ProjectionManagementMessage.Command.Enable message)
@@ -309,7 +319,10 @@ namespace EventStore.Projections.Core.Services.Management
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             }
             else
+            {
+                if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.GetMode(), ReadWrite.Write, projection.RunAs, message)) return;
                 projection.Handle(message);
+            }
         }
 
         public void Handle(ProjectionManagementMessage.Command.Abort message)
@@ -322,7 +335,10 @@ namespace EventStore.Projections.Core.Services.Management
             if (projection == null)
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             else
+            {
+                if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.GetMode(), ReadWrite.Write, projection.RunAs, message)) return;
                 projection.Handle(message);
+            }
         }
 
         public void Handle(ProjectionManagementMessage.Command.SetRunAs message)
@@ -338,7 +354,14 @@ namespace EventStore.Projections.Core.Services.Management
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             }
             else
+            {
+                if (
+                    !ProjectionManagementMessage.RunAs.ValidateRunAs(
+                        projection.GetMode(), ReadWrite.Write, projection.RunAs, message,
+                        message.Action == ProjectionManagementMessage.Command.SetRunAs.SetRemove.Set)) return;
+
                 projection.Handle(message);
+            }
         }
 
         public void Handle(ProjectionManagementMessage.Command.Reset message)
@@ -354,7 +377,10 @@ namespace EventStore.Projections.Core.Services.Management
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             }
             else
+            {
+                if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.GetMode(), ReadWrite.Write, projection.RunAs, message)) return;
                 projection.Handle(message);
+            }
         }
 
         public void Handle(ProjectionManagementMessage.Command.GetStatistics message)


### PR DESCRIPTION
Move the authorisation check out of the Projection and into the
Projection Manager.

The authorisation check is performed inside of the Managed Projection, and therefor
poses a problem when the Projection Manager needs to perform a series of
steps after the Projection has completed it's work.

The use case that exposed a problem is the deletion of a projection which
replied with a NotAuthorised message to the user, but the Projection Manager continued
deleting the projection as it had no idea that a check failed inside of
the Managed Projection.