### PR TITLE
Fix up location of /index

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -221,7 +221,6 @@ namespace EventStore.ClusterNode
             ChunksCacheSize = Opts.ChunksCacheSizeDefault;
 
             Db = Locations.DefaultDataDirectory;
-            Index = Locations.DefaultDataDirectory;
             MemDb = Opts.InMemDbDefault;
             SkipDbVerify = Opts.SkipDbVerifyDefault;
             RunProjections = Opts.RunProjectionsDefault;


### PR DESCRIPTION
When the db path is specified, the index should be db/index.