### PR TITLE
Set sane default for message timeout

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -449,7 +449,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             public string NamedConsumerStrategy { get; set; }
             public SubscriptionConfigData(){
                 StartFrom = 0;
-                MessageTimeoutMilliseconds = 0;
+                MessageTimeoutMilliseconds = 10000;
                 MaxRetryCount = 10;
                 BufferSize = 500;
                 LiveBufferSize = 500;


### PR DESCRIPTION
Fixes #748 along with the following PR from the UI (https://github.com/EventStore/EventStore.UI/pull/100)

Set to 10 seconds.

