### PR TITLE
remove check for first/last on AlreadyCommitted for case where

### DIFF
--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -195,7 +195,7 @@ namespace EventStore.Core.Messages
                     throw new ArgumentOutOfRangeException("firstEventNumber", String.Format("FirstEventNumber: {0}", firstEventNumber));
                 if (lastEventNumber - firstEventNumber + 1 < 0)
                     throw new ArgumentOutOfRangeException("lastEventNumber", String.Format("LastEventNumber {0}, FirstEventNumber {1}.", lastEventNumber, firstEventNumber));
-
+ 
                 CorrelationId = correlationId;
                 Result = OperationResult.Success;
                 Message = null;

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -267,6 +267,7 @@ namespace EventStore.Core.Messages
                 if (lastEventNumber < firstEventNumber)
                     throw new ArgumentOutOfRangeException("lastEventNumber", "LastEventNumber is less than FirstEventNumber");
 
+
                 CorrelationId = correlationId;
                 EventStreamId = eventStreamId;
                 FirstEventNumber = firstEventNumber;


### PR DESCRIPTION
many events with same ids are used

Should fix #758 worth adding a test (can't run tests here now)