### PR TITLE
Expose Authentication Config via Options

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -161,6 +161,8 @@ namespace EventStore.ClusterNode
 
         [ArgDescription(Opts.AuthenticationTypeDescr, Opts.AuthGroup)]
         public string AuthenticationType { get; set; }
+        [ArgDescription(Opts.AuthenticationConfigFileDescr, Opts.AuthGroup)]
+        public string AuthenticationConfig { get; set; }
 
         [ArgDescription(Opts.PrepareTimeoutMsDescr, Opts.DbGroup)]
         public int PrepareTimeoutMs { get; set; }
@@ -261,6 +263,7 @@ namespace EventStore.ClusterNode
             SslValidateServer = Opts.SslValidateServerDefault;
 
             AuthenticationType = Opts.AuthenticationTypeDefault;
+            AuthenticationConfig = Opts.AuthenticationConfigFileDefault;
 
             UnsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
             PrepareTimeoutMs = Opts.PrepareTimeoutMsDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -248,7 +248,8 @@ namespace EventStore.ClusterNode
                 if (intSecTcp == null) throw new Exception("Usage of internal secure communication is specified, but no internal secure endpoint is specified!");
             }
 
-            var authenticationProviderFactory = GetAuthenticationProviderFactory(options.AuthenticationType, options.Config);
+            var authenticationConfig = String.IsNullOrEmpty(options.AuthenticationConfig) ? options.Config : options.AuthenticationConfig;
+            var authenticationProviderFactory = GetAuthenticationProviderFactory(options.AuthenticationType, authenticationConfig);
 
             return new ClusterVNodeSettings(Guid.NewGuid(), 0,
                     intTcp, intSecTcp, extTcp, extSecTcp, intHttp, extHttp, gossipAdvertiseInfo,


### PR DESCRIPTION
If the authentication config has been specified, use it instead of the node's config file.