### PR TITLE
Add ability to fetch partition state and result to the ProjectionManager in the .Net client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ bin
 *.cache
 *.ncrunchsolution
 *.ncrunchproject
+src/.vs/
 
 .idea
 
@@ -95,3 +96,4 @@ test_results
 
 # Mac
 .DS_Store
+

--- a/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
@@ -117,6 +117,21 @@ namespace EventStore.ClientAPI.Projections
             return SendGet(endPoint.ToHttpUrl("/projection/{0}/state", name), userCredentials, HttpStatusCode.OK);
         }
 
+        public Task<string> GetPartitionStateAsync(IPEndPoint endPoint, string name, string partition, UserCredentials userCredentials = null)
+        {
+            return SendGet(endPoint.ToHttpUrl("/projection/{0}/state?partition={1}", name, partition), userCredentials, HttpStatusCode.OK);
+        }
+
+        public Task<string> GetResult(IPEndPoint endPoint, string name, UserCredentials userCredentials = null)
+        {
+            return SendGet(endPoint.ToHttpUrl("/projection/{0}/result", name), userCredentials, HttpStatusCode.OK);
+        }
+
+        public Task<string> GetPartitionResultAsync(IPEndPoint endPoint, string name, string partition, UserCredentials userCredentials = null)
+        {
+            return SendGet(endPoint.ToHttpUrl("/projection/{0}/result?partition={1}", name, partition), userCredentials, HttpStatusCode.OK);
+        }
+
         public Task<string> GetStatistics(IPEndPoint endPoint, string name, UserCredentials userCredentials = null)
         {
             return SendGet(endPoint.ToHttpUrl("/projection/{0}/statistics", name), userCredentials, HttpStatusCode.OK);

--- a/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
@@ -193,6 +193,46 @@ namespace EventStore.ClientAPI.Projections
         }
 
         /// <summary>
+        /// Asynchronously gets the state of a projection for a specified partition.
+        /// </summary>
+        /// <param name="name">The name of the projection.</param>
+        /// <param name="partitionId">The id of the partition.</param>
+        /// <param name="userCredentials">Credentials for the operation.</param>
+        /// <returns>String of JSON containing projection state.</returns>
+        public Task<string> GetPartitionStateAsync(string name, string partitionId, UserCredentials userCredentials = null)
+        {
+            Ensure.NotNullOrEmpty(name, "name");
+            Ensure.NotNullOrEmpty(partitionId, "partitionId");
+            return _client.GetPartitionStateAsync(_httpEndPoint, name, partitionId, userCredentials);
+        }
+
+        /// <summary>
+        /// Asynchronously gets the state of a projection.
+        /// </summary>
+        /// <param name="name">The name of the projection.</param>
+        /// <param name="userCredentials">Credentials for the operation.</param>
+        /// <returns>String of JSON containing projection state.</returns>
+        public Task<string> GetResultAsync(string name, UserCredentials userCredentials = null)
+        {
+            Ensure.NotNullOrEmpty(name, "name");
+            return _client.GetState(_httpEndPoint, name, userCredentials);
+        }
+
+        /// <summary>
+        /// Asynchronously gets the state of a projection for a specified partition.
+        /// </summary>
+        /// <param name="name">The name of the projection.</param>
+        /// <param name="partitionId">The id of the partition.</param>
+        /// <param name="userCredentials">Credentials for the operation.</param>
+        /// <returns>String of JSON containing projection state.</returns>
+        public Task<string> GetPartitionResultAsync(string name, string partitionId, UserCredentials userCredentials = null)
+        {
+            Ensure.NotNullOrEmpty(name, "name");
+            Ensure.NotNullOrEmpty(partitionId, "partitionId");
+            return _client.GetPartitionStateAsync(_httpEndPoint, name, partitionId, userCredentials);
+        }
+
+        /// <summary>
         /// Asynchronously gets the statistics of a projection.
         /// </summary>
         /// <param name="name">The name of the projection.</param>


### PR DESCRIPTION
I haven't URI escaped the partition id as the query name is not escaped either. This keeps the input criteria consistent.

I've tagged on a .gitignore update for VS2015. If this isn't appropriate I'm happy to remove it.