### PR TITLE
Failed resolved link issues part 2

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -276,7 +276,7 @@ namespace EventStore.ClientAPI
                 ResolvedEvent e;
                 while (_liveQueue.TryDequeue(out e))
                 {
-                    if (e.Event == null) // drop subscription artificial ResolvedEvent
+                    if (e.Equals(DropSubscriptionEvent)) // drop subscription artificial ResolvedEvent
                     {
                         if (_dropData == null) _dropData = new DropData(SubscriptionDropReason.Unknown, new Exception("Drop reason not specified."));
                         DropSubscription(_dropData.Reason, _dropData.Error);

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -54,6 +54,11 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         private string GetLinkToFor(ResolvedEvent ev)
         {
+            if (ev.Event == null) // Unresolved link so just use the bad/deleted link data.
+            {
+                return Encoding.UTF8.GetString(ev.Link.Data);
+            }
+
             return string.Format("{0}@{1}", ev.Event.EventNumber, ev.Event.EventStreamId);
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Services;
@@ -73,18 +72,28 @@ namespace EventStore.Projections.Core.Services.Processing
                             positionEvent.Metadata.ParseCheckpointTagVersionExtraJson(default(ProjectionVersion));
                         tag = checkpointTagJson.Tag;
                         extraMetadata = checkpointTagJson.ExtraMetadata;
+
+                        var parsedPosition = tag.Position;
+
+                        eventOrLinkTargetPosition = parsedPosition != new TFPos(long.MinValue, long.MinValue)
+                            ? parsedPosition
+                            : new TFPos(-1, positionEvent.LogPosition);
                     }
                     else
                     {
                         tag = positionEvent.Metadata.ParseCheckpointTagJson();
+
+                        var parsedPosition = tag.Position;
+                        eventOrLinkTargetPosition = parsedPosition != new TFPos(long.MinValue, long.MinValue)
+                            ? parsedPosition
+                            : new TFPos(-1, resolvedEvent.Event.LogPosition);
                     }
-                    var parsedPosition = tag.Position;
-                    eventOrLinkTargetPosition = parsedPosition != new TFPos(long.MinValue, long.MinValue)
-                        ? parsedPosition
-                        : new TFPos(-1, resolvedEvent.Event.LogPosition);
+
                 }
                 else
-                    eventOrLinkTargetPosition = new TFPos(-1, resolvedEvent.Event.LogPosition);
+                {
+                    eventOrLinkTargetPosition = @event != null ? new TFPos(-1, @event.LogPosition) : new TFPos(-1, positionEvent.LogPosition); 
+                }
 
                 JToken deletedValue;
                 IsLinkToDeletedStreamTombstone = extraMetadata != null


### PR DESCRIPTION
I came across a new scenario which causes null reference exceptions from bad assumptions:

- A failed resolved link is found (in our case truncated old metadata)
- The client can cause the event to be parked.
- The message parker tries to to access the null ResolvedEvent.Event value.

Once I fixed this I found an issue in the projection system:
- The parked event gets picked up by the projection system.
- It correctly identifies it as failed resolved but assumes that the metadata contains a TF position.
- This results in it still accessing the null ResolvedEvent.Event.

My fix for this is to return the bad link TFPos. This seems like it should be safe but the projection system is large and I'm not very familiar.

Finally I noticed the issue I fixed in the ClientApi for failed resolved links causing dropped subscriptions also applies to the catch up subscription.