### PR TITLE
Fixes for aligned chunk verification

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -481,11 +481,13 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                     // hash header and data
                     MD5Hash.ContinuousHashFor(md5, stream, 0, ChunkHeader.Size + footer.PhysicalDataSize);
                     // hash mapping and footer except MD5 hash sum which should always be last
-                    
+
+                    MD5Hash.ContinuousHashFor(md5, stream, ChunkHeader.Size + footer.PhysicalDataSize, footer.MapSize);
+
                     MD5Hash.ContinuousHashFor(md5, 
                                               stream,
                                               (int) stream.Length - ChunkHeader.Size,
-                                              footer.MapSize + ChunkFooter.Size - ChunkFooter.ChecksumSize);
+                                              ChunkFooter.Size - ChunkFooter.ChecksumSize);
                     md5.TransformFinalBlock(Empty.ByteArray, 0, 0);
                     hash = md5.Hash;
                 }


### PR DESCRIPTION
Correct hash verification for scavenged chunks.
Update the chunk hash when the chunk version is downgraded by the unaligner tool.

I've provided these in case anybody else needs to unalign a v3 chunk to v2.