### PR TITLE
Add a plugin model for persistent subscription consumer strategies

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -22,6 +22,7 @@ using EventStore.Core.Util;
 using System.Net.NetworkInformation;
 using EventStore.Core.Data;
 using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.ClusterNode
 {

--- a/src/EventStore.Common/Utils/Locations.cs
+++ b/src/EventStore.Common/Utils/Locations.cs
@@ -10,6 +10,7 @@ namespace EventStore.Common.Utils
         public static readonly string WebContentDirectory;
         public static readonly string ProjectionsDirectory;
         public static readonly string PreludeDirectory;
+        public static readonly string PluginsDirectory;
         public static readonly string DefaultContentDirectory;
         public static readonly string DefaultConfigurationDirectory;
         public static readonly string DefaultDataDirectory;
@@ -20,6 +21,8 @@ namespace EventStore.Common.Utils
         {
             ApplicationDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ??
                                    Path.GetFullPath(".");
+
+            PluginsDirectory = Path.Combine(ApplicationDirectory, "plugins");
 
             switch (Platforms.GetPlatform())
             {
@@ -51,6 +54,7 @@ namespace EventStore.Common.Utils
                         Path.Combine(ApplicationDirectory, "Prelude"),
                         Path.Combine(DefaultContentDirectory, "Prelude")
                         );
+
         }
 
         /// <summary>

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/StreamBufferTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/StreamBufferTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Services.PersistentSubscription;
 using NUnit.Framework;
@@ -8,6 +9,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
     [TestFixture]
     public class StreamBufferTests
     {
+
         [Test]
         public void adding_read_message_in_correct_order()
         {
@@ -15,8 +17,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             var id = Guid.NewGuid();
             buffer.AddReadMessage(BuildMessageAt(id, 0));
             Assert.AreEqual(1, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
+            OutstandingMessage message = buffer.Scan().First().Message;
             Assert.AreEqual(id, message.EventId);
             Assert.IsFalse(buffer.Live);
         }
@@ -30,11 +31,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 0));
             buffer.AddReadMessage(BuildMessageAt(id2, 1));
             Assert.AreEqual(2, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
             Assert.IsFalse(buffer.Live);
         }
 
@@ -48,11 +52,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 1));
             buffer.AddReadMessage(BuildMessageAt(id2, 0));
             Assert.AreEqual(2, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
             Assert.IsFalse(buffer.Live);
         }
 
@@ -64,11 +71,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 0));
             buffer.AddReadMessage(BuildMessageAt(id1, 0));
             Assert.AreEqual(2, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
             Assert.IsFalse(buffer.Live);
         }
 
@@ -81,9 +91,10 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 0));
             Assert.IsTrue(buffer.Live);
             Assert.AreEqual(1, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
         }
 
         [Test]
@@ -96,9 +107,10 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id2, 0));
             Assert.IsFalse(buffer.Live);
             Assert.AreEqual(1, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
         }
 
         [Test]
@@ -111,11 +123,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddLiveMessage(BuildMessageAt(id2, 7));
             Assert.IsTrue(buffer.Live);
             Assert.AreEqual(2, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
         }
 
         [Test]
@@ -130,9 +145,103 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 7));
             Assert.IsTrue(buffer.Live);
             Assert.AreEqual(1, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
+        }
+
+        [Test]
+        public void skipped_messages_are_not_removed()
+        {
+            var buffer = new StreamBuffer(10, 10, -1, true);
+            var id1 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id1, 0));
+            var id2 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id2, 1));
+            var id3 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id3, 2));
+            Assert.AreEqual(3, buffer.BufferCount);
+            
+            var messagePointer2 = buffer.Scan().Skip(1).First(); // Skip the first message.
+            Assert.AreEqual(id2, messagePointer2.Message.EventId);
+            messagePointer2.MarkSent();
+            Assert.AreEqual(2, buffer.BufferCount);
+
+            var messagePointers = buffer.Scan().ToArray();
+            Assert.AreEqual(id1, messagePointers[0].Message.EventId);
+            Assert.AreEqual(id3, messagePointers[1].Message.EventId);
+        }
+
+        [Test]
+        public void retried_messages_appear_first()
+        {
+            var buffer = new StreamBuffer(10, 10, -1, true);
+            var id1 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id1, 0));
+            var id2 = Guid.NewGuid();
+            buffer.AddRetry(BuildMessageAt(id2, 2));
+            Assert.AreEqual(2, buffer.BufferCount);
+            Assert.AreEqual(1, buffer.RetryBufferCount);
+            Assert.AreEqual(1, buffer.ReadBufferCount);
+
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            Assert.AreEqual(0, buffer.RetryBufferCount);
+            Assert.AreEqual(1, buffer.ReadBufferCount);
+
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
+            Assert.AreEqual(0, buffer.RetryBufferCount);
+            Assert.AreEqual(0, buffer.ReadBufferCount);
+
+            Assert.IsFalse(buffer.Live);
+        }
+
+        [Test]
+        public void retried_messages_appear_in_version_order()
+        {
+            var buffer = new StreamBuffer(10, 10, -1, true);
+            var id1 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id1, 0));
+            var id2 = Guid.NewGuid();
+            var id3 = Guid.NewGuid();
+            var id4 = Guid.NewGuid();
+            var id5 = Guid.NewGuid();
+            buffer.AddRetry(BuildMessageAt(id2, 2));
+            buffer.AddRetry(BuildMessageAt(id3, 3));
+            buffer.AddRetry(BuildMessageAt(id4, 1));
+            buffer.AddRetry(BuildMessageAt(id5, 2));
+
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id4, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id5, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id3, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+
+        }
+
+        public void lowest_retry_doesnt_assume_order()
+        {
+            var buffer = new StreamBuffer(10, 10, -1, true);
+            buffer.AddRetry(BuildMessageAt(Guid.NewGuid(), 4));
+            buffer.AddRetry(BuildMessageAt(Guid.NewGuid(), 2));
+            buffer.AddRetry(BuildMessageAt(Guid.NewGuid(), 3));
+            Assert.AreEqual(2, buffer.GetLowestRetry());
         }
 
         private OutstandingMessage BuildMessageAt(Guid id,int version)

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
@@ -6,6 +7,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Authentication;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Monitoring;
+using EventStore.Core.Services.PersistentSubscription;
 
 namespace EventStore.Core.Cluster.Settings
 {
@@ -61,6 +63,8 @@ namespace EventStore.Core.Cluster.Settings
 
         public readonly string Index;
 
+        public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
+
         public ClusterVNodeSettings(Guid instanceId, int debugIndex,
                                     IPEndPoint internalTcpEndPoint,
                                     IPEndPoint internalSecureTcpEndPoint,
@@ -104,10 +108,9 @@ namespace EventStore.Core.Cluster.Settings
 				                    bool verifyDbHash,
 				                    int maxMemtableEntryCount,
                                     bool startStandardProjections,
-                                    bool disableHTTPCaching,
-                                    string index = null,
-                                    bool enableHistograms = false,
-                                    int indexCacheDepth = 16)
+                                    bool disableHTTPCaching, string index = null, bool enableHistograms = false,
+                                    int indexCacheDepth = 16,
+                                    IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -144,6 +147,7 @@ namespace EventStore.Core.Cluster.Settings
             WorkerThreads = workerThreads;
             StartStandardProjections = startStandardProjections;
             DisableHTTPCaching = disableHTTPCaching;
+            AdditionalConsumerStrategies = additionalConsumerStrategies ?? new IPersistentSubscriptionConsumerStrategyFactory[0];
 
             DiscoverViaDns = discoverViaDns;
             ClusterDns = clusterDns;
@@ -185,6 +189,8 @@ namespace EventStore.Core.Cluster.Settings
             IndexCacheDepth = indexCacheDepth;
             Index = index;
         }
+
+        
 
         public override string ToString()
         {

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -8,6 +8,7 @@ using EventStore.Core.Authentication;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Cluster.Settings
 {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -436,7 +436,8 @@ namespace EventStore.Core
             _mainBus.Subscribe(perSubscrQueue.WidenFrom<SubscriptionMessage.PersistentSubscriptionTimerTick, Message>());
 
             //TODO CC can have multiple threads working on subscription if partition
-            var persistentSubscription = new PersistentSubscriptionService(subscrQueue, readIndex, ioDispatcher, _mainQueue);
+            var consumerStrategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry(_mainQueue, _mainBus, vNodeSettings.AdditionalConsumerStrategies);
+            var persistentSubscription = new PersistentSubscriptionService(subscrQueue, readIndex, ioDispatcher, _mainQueue, consumerStrategyRegistry);
             perSubscrBus.Subscribe<SystemMessage.BecomeShuttingDown>(persistentSubscription);
             perSubscrBus.Subscribe<SystemMessage.BecomeMaster>(persistentSubscription);
             perSubscrBus.Subscribe<SystemMessage.StateChangeMessage>(persistentSubscription);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -34,6 +34,7 @@ using EventStore.Core.Helpers;
 using EventStore.Core.Services.PersistentSubscription;
 using System.Threading;
 using EventStore.Core.Services.Histograms;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core
 {

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -184,10 +184,15 @@
     <Compile Include="Services\Gossip\LoopbackDns.cs" />
     <Compile Include="Services\Gossip\NodeGossipService.cs" />
     <Compile Include="Services\Histograms\HistogramService.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\ConsumerPushResult.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\DelegatePersistentSubscriptionConsumerStrategyFactory.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\DispatchToSinglePersistentSubscriptionConsumerStrategy.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\IPersistentSubscriptionConsumerStrategy.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\IPersistentSubscriptionConsumerStrategyFactory.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\PersistentSubscriptionConsumerStrategyRegistry.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\RoundRobinPersistentSubscriptionConsumerStrategy.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointReader.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointWriter.cs" />
-    <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategy.cs" />
-    <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategyFactory.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionMessageParker.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionStreamReader.cs" />
     <Compile Include="Services\PersistentSubscription\NakAction.cs" />
@@ -199,7 +204,6 @@
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionClient.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionClientCollection.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionConfig.cs" />
-    <Compile Include="Services\PersistentSubscription\PersistentSubscriptionConsumerStrategyRegistry.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionMessageParker.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionParams.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionParamsBuilder.cs" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Messages\UserManagementMessage.cs" />
     <Compile Include="Messaging\RequestResponseDispatcher.cs" />
     <Compile Include="PluginModel\IAuthenticationPlugin.cs" />
+    <Compile Include="PluginModel\IPersistentSubscriptionConsumerStrategyPlugin.cs" />
     <Compile Include="Services\AwakeReaderService\AwakeService.cs" />
     <Compile Include="Services\AwakeReaderService\AwakeServiceMessage.cs" />
     <Compile Include="Services\ClusterStorageWriterService.cs" />
@@ -186,6 +187,7 @@
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointReader.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointWriter.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategy.cs" />
+    <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategyFactory.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionMessageParker.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionStreamReader.cs" />
     <Compile Include="Services\PersistentSubscription\NakAction.cs" />

--- a/src/EventStore.Core/PluginModel/IPersistentSubscriptionConsumerStrategyPlugin.cs
+++ b/src/EventStore.Core/PluginModel/IPersistentSubscriptionConsumerStrategyPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.PluginModel
 {

--- a/src/EventStore.Core/PluginModel/IPersistentSubscriptionConsumerStrategyPlugin.cs
+++ b/src/EventStore.Core/PluginModel/IPersistentSubscriptionConsumerStrategyPlugin.cs
@@ -1,0 +1,13 @@
+﻿using EventStore.Core.Services.PersistentSubscription;
+
+namespace EventStore.Core.PluginModel
+{
+    public interface IPersistentSubscriptionConsumerStrategyPlugin
+    {
+        string Name { get; }
+
+        string Version { get; }
+
+        IPersistentSubscriptionConsumerStrategyFactory GetConsumerStrategyFactory();
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/ConsumerPushResult.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/ConsumerPushResult.cs
@@ -1,0 +1,9 @@
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    public enum ConsumerPushResult
+    {
+        Sent,
+        Skipped,
+        NoMoreCapacity
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DelegatePersistentSubscriptionConsumerStrategyFactory.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DelegatePersistentSubscriptionConsumerStrategyFactory.cs
@@ -5,7 +5,7 @@ namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
     class DelegatePersistentSubscriptionConsumerStrategyFactory : IPersistentSubscriptionConsumerStrategyFactory
     {
-        public string StrategyName { get; }
+        public string StrategyName { get; private set; }
 
         private readonly Func<string, IPublisher, ISubscriber, IPersistentSubscriptionConsumerStrategy> _factory;
 

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DelegatePersistentSubscriptionConsumerStrategyFactory.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DelegatePersistentSubscriptionConsumerStrategyFactory.cs
@@ -1,15 +1,8 @@
 using System;
 using EventStore.Core.Bus;
 
-namespace EventStore.Core.Services.PersistentSubscription
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
-    public interface IPersistentSubscriptionConsumerStrategyFactory
-    {
-        string StrategyName { get; }
-
-        IPersistentSubscriptionConsumerStrategy Create(string subscriptionId, IPublisher mainQueue, ISubscriber mainBus);
-    }
-
     class DelegatePersistentSubscriptionConsumerStrategyFactory : IPersistentSubscriptionConsumerStrategyFactory
     {
         public string StrategyName { get; }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DispatchToSinglePersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DispatchToSinglePersistentSubscriptionConsumerStrategy.cs
@@ -1,0 +1,27 @@
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    class DispatchToSinglePersistentSubscriptionConsumerStrategy : RoundRobinPersistentSubscriptionConsumerStrategy
+    {
+        public override string Name
+        {
+            get { return SystemConsumerStrategies.DispatchToSingle; }
+        }
+
+        public override ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        {
+            for (int i = 0; i < Clients.Count; i++)
+            {
+                if (Clients.Peek().Push(ev))
+                {
+                    return ConsumerPushResult.Sent;
+                }
+                var c = Clients.Dequeue();
+                Clients.Enqueue(c);
+            }
+
+            return ConsumerPushResult.NoMoreCapacity;
+        }
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategy.cs
@@ -1,0 +1,15 @@
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    public interface IPersistentSubscriptionConsumerStrategy
+    {
+        string Name { get; }
+
+        void ClientAdded(PersistentSubscriptionClient client);
+
+        void ClientRemoved(PersistentSubscriptionClient client);
+
+        ConsumerPushResult PushMessageToClient(ResolvedEvent ev);
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategyFactory.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategyFactory.cs
@@ -1,0 +1,11 @@
+using EventStore.Core.Bus;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    public interface IPersistentSubscriptionConsumerStrategyFactory
+    {
+        string StrategyName { get; }
+
+        IPersistentSubscriptionConsumerStrategy Create(string subscriptionId, IPublisher mainQueue, ISubscriber mainBus);
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PersistentSubscriptionConsumerStrategyRegistry.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PersistentSubscriptionConsumerStrategyRegistry.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using EventStore.Core.Bus;
 
-namespace EventStore.Core.Services.PersistentSubscription
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
     public class PersistentSubscriptionConsumerStrategyRegistry
     {

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/RoundRobinPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/RoundRobinPersistentSubscriptionConsumerStrategy.cs
@@ -3,49 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Data;
 
-namespace EventStore.Core.Services.PersistentSubscription
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
-    public enum ConsumerPushResult
-    {
-        Sent,
-        Skipped,
-        NoMoreCapacity
-    }
-
-    public interface IPersistentSubscriptionConsumerStrategy
-    {
-        string Name { get; }
-
-        void ClientAdded(PersistentSubscriptionClient client);
-
-        void ClientRemoved(PersistentSubscriptionClient client);
-
-        ConsumerPushResult PushMessageToClient(ResolvedEvent ev);
-    }
-
-    class DispatchToSinglePersistentSubscriptionConsumerStrategy : RoundRobinPersistentSubscriptionConsumerStrategy
-    {
-        public override string Name
-        {
-            get { return SystemConsumerStrategies.DispatchToSingle; }
-        }
-
-        public override ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
-        {
-            for (int i = 0; i < Clients.Count; i++)
-            {
-                if (Clients.Peek().Push(ev))
-                {
-                    return ConsumerPushResult.Sent;
-                }
-                var c = Clients.Dequeue();
-                Clients.Enqueue(c);
-            }
-
-            return ConsumerPushResult.NoMoreCapacity;
-        }
-    }
-
     class RoundRobinPersistentSubscriptionConsumerStrategy : IPersistentSubscriptionConsumerStrategy
     {
         protected readonly Queue<PersistentSubscriptionClient> Clients = new Queue<PersistentSubscriptionClient>();
@@ -91,5 +50,4 @@ namespace EventStore.Core.Services.PersistentSubscription
             return ConsumerPushResult.NoMoreCapacity;
         }
     }
-
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategy.cs
@@ -8,6 +8,7 @@ namespace EventStore.Core.Services.PersistentSubscription
     public enum ConsumerPushResult
     {
         Sent,
+        Skipped,
         NoMoreCapacity
     }
 

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategyFactory.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategyFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using EventStore.Core.Bus;
+
+namespace EventStore.Core.Services.PersistentSubscription
+{
+    public interface IPersistentSubscriptionConsumerStrategyFactory
+    {
+        string StrategyName { get; }
+
+        IPersistentSubscriptionConsumerStrategy Create(string subscriptionId, IPublisher mainQueue, ISubscriber mainBus);
+    }
+
+    class DelegatePersistentSubscriptionConsumerStrategyFactory : IPersistentSubscriptionConsumerStrategyFactory
+    {
+        public string StrategyName { get; }
+
+        private readonly Func<string, IPublisher, ISubscriber, IPersistentSubscriptionConsumerStrategy> _factory;
+
+        public DelegatePersistentSubscriptionConsumerStrategyFactory(string strategyName, Func<string, IPublisher, ISubscriber, IPersistentSubscriptionConsumerStrategy> factory)
+        {
+            _factory = factory;
+            StrategyName = strategyName;
+        }
+
+        public IPersistentSubscriptionConsumerStrategy Create(string subscriptionId, IPublisher mainQueue, ISubscriber mainBus)
+        {
+            return _factory(subscriptionId, mainQueue, mainBus);
+        }
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -7,6 +7,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Data;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Common.Utils;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -8,6 +8,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         private readonly TimerMessage.Schedule _tickRequestMessage;
         private bool _handleTick;
 
-        public PersistentSubscriptionService(IQueuedHandler queuedHandler, IReadIndex readIndex, IODispatcher ioDispatcher, IPublisher bus)
+        internal PersistentSubscriptionService(IQueuedHandler queuedHandler, IReadIndex readIndex, IODispatcher ioDispatcher, IPublisher bus, PersistentSubscriptionConsumerStrategyRegistry consumerStrategyRegistry)
         {
             Ensure.NotNull(queuedHandler, "queuedHandler");
             Ensure.NotNull(readIndex, "readIndex");
@@ -64,7 +64,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             _readIndex = readIndex;
             _ioDispatcher = ioDispatcher;
             _bus = bus;
-            _consumerStrategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry();
+            _consumerStrategyRegistry = consumerStrategyRegistry;
             _checkpointReader = new PersistentSubscriptionCheckpointReader(_ioDispatcher);
             _streamReader = new PersistentSubscriptionStreamReader(_ioDispatcher, 100);
             //TODO CC configurable
@@ -325,7 +325,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                     minCheckPointCount,
                     maxCheckPointCount,
                     maxSubscriberCount,
-                    _consumerStrategyRegistry.GetInstance(namedConsumerStrategy),
+                    _consumerStrategyRegistry.GetInstance(namedConsumerStrategy, key),
                     _streamReader,
                     _checkpointReader,
                     new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),


### PR DESCRIPTION
This completes the consumer strategy work I started in May. The final piece adds a plugin interface following the same pattern as the IAuthenticationPlugin.

It also includes the concept of temporarily skipping messages in the queue to allow our pinned consumer strategy to work efficiently.