### PR TITLE
Pinned consumer strategy

### DIFF
--- a/src/EventStore.ClientAPI/Common/SystemNames.cs
+++ b/src/EventStore.ClientAPI/Common/SystemNames.cs
@@ -139,6 +139,12 @@
         /// Distribute events to each client in a round robin fashion.
         /// </summary>
         public const string RoundRobin = "RoundRobin";
+
+        /// <summary>
+        /// Distribute events of the same streamId to the same client until it disconnects on a best efforts basis. 
+        /// Designed to be used with indexes such as the category projection.
+        /// </summary>
+        public const string Pinned = "Pinned";
     }
 
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -22,6 +22,7 @@ using EventStore.Core.Util;
 using System.Net.NetworkInformation;
 using EventStore.Core.Data;
 using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.ClusterNode
 {

--- a/src/EventStore.Common/Utils/Locations.cs
+++ b/src/EventStore.Common/Utils/Locations.cs
@@ -10,6 +10,7 @@ namespace EventStore.Common.Utils
         public static readonly string WebContentDirectory;
         public static readonly string ProjectionsDirectory;
         public static readonly string PreludeDirectory;
+        public static readonly string PluginsDirectory;
         public static readonly string DefaultContentDirectory;
         public static readonly string DefaultConfigurationDirectory;
         public static readonly string DefaultDataDirectory;
@@ -20,6 +21,8 @@ namespace EventStore.Common.Utils
         {
             ApplicationDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ??
                                    Path.GetFullPath(".");
+
+            PluginsDirectory = Path.Combine(ApplicationDirectory, "plugins");
 
             switch (Platforms.GetPlatform())
             {
@@ -51,6 +54,7 @@ namespace EventStore.Common.Utils
                         Path.Combine(ApplicationDirectory, "Prelude"),
                         Path.Combine(DefaultContentDirectory, "Prelude")
                         );
+
         }
 
         /// <summary>

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -331,6 +331,7 @@
     <Compile Include="Services\PersistentSubscription\OutstandingMessageCacheTests.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionConfigPersistence.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionTests.cs" />
+    <Compile Include="Services\PersistentSubscription\PinnedConsumerStrategyTests.cs" />
     <Compile Include="Services\PersistentSubscription\StreamBufferTests.cs" />
     <Compile Include="Services\Replication\DeleteStream\when_delete_stream_gets_commit_timeout_after_commit.cs" />
     <Compile Include="Authentication\when_handling_multiple_requests_with_reset_password_cache_in_between.cs" />

--- a/src/EventStore.Core.Tests/Helpers/PortsHelper.cs
+++ b/src/EventStore.Core.Tests/Helpers/PortsHelper.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Tests.Helpers
                 try
                 {
                     var httpListener = new HttpListener();
-                    httpListener.Prefixes.Add(string.Format("http://+:{0}/", port));
+                    httpListener.Prefixes.Add(string.Format("http://127.0.0.1:{0}/", port));
                     httpListener.Start();
 
                     Exception httpListenerError = null;

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -1,0 +1,497 @@
+﻿using System;
+using EventStore.Core.Index.Hashes;
+using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.Tests.Services.Replication;
+using EventStore.Core.Tests.Services.Storage;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.PersistentSubscription
+{
+    [TestFixture]
+    public class PinnedConsumerStrategyTests
+    {
+        [Test]
+        public void live_subscription_with_pinned_pushes_events_to_same_client_for_stream_id()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+                PersistentSubscriptionParamsBuilder.CreateFor("$ce-streamName", "groupName")
+                    .WithEventLoader(new FakeStreamReader(x => { }))
+                    .WithCheckpointReader(reader)
+                    .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                    .WithMessageParker(new FakeMessageParker())
+                    .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                    .StartFromCurrent());
+            reader.Load(null);
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 1));
+
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(0, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 2));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 3));
+
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(2, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 4));
+
+            Assert.AreEqual(3, client1Envelope.Replies.Count);
+            Assert.AreEqual(2, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-3", 5));
+
+            Assert.AreEqual(4, client1Envelope.Replies.Count);
+            Assert.AreEqual(2, client2Envelope.Replies.Count);
+        }
+
+        [Test]
+        public void new_stream_is_round_robinned_to_next_consumer()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+                PersistentSubscriptionParamsBuilder.CreateFor("$ce-streamName", "groupName")
+                    .WithEventLoader(new FakeStreamReader(x => { }))
+                    .WithCheckpointReader(reader)
+                    .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                    .WithMessageParker(new FakeMessageParker())
+                    .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                    .StartFromCurrent());
+            reader.Load(null);
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0));
+
+            Assert.AreEqual(1, client1Envelope.Replies.Count);
+            Assert.AreEqual(0, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 1));
+
+            Assert.AreEqual(1, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-3", 2));
+
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-4", 4));
+
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(2, client2Envelope.Replies.Count);
+        }
+
+        [Test]
+        public void resolved_link_events_use_event_stream_id()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+                PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                    .WithEventLoader(new FakeStreamReader(x => { }))
+                    .WithCheckpointReader(reader)
+                    .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                    .WithMessageParker(new FakeMessageParker())
+                    .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                    .StartFromCurrent());
+            reader.Load(null);
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0)));
+
+            Assert.AreEqual(1, client1Envelope.Replies.Count);
+            Assert.AreEqual(0, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0)));
+
+            Assert.AreEqual(1, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 2, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-3", 0)));
+
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 3, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-4", 0)));
+
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(2, client2Envelope.Replies.Count);
+        }
+
+        [Test]
+        public void link_events_use_data_to_detect_stream_id()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+                PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                    .WithEventLoader(new FakeStreamReader(x => { }))
+                    .WithCheckpointReader(reader)
+                    .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                    .WithMessageParker(new FakeMessageParker())
+                    .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                    .StartFromCurrent());
+            reader.Load(null);
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+
+            Assert.AreEqual(1, client1Envelope.Replies.Count);
+            Assert.AreEqual(0, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+
+            Assert.AreEqual(1, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 2, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-3", 0), false));
+
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 3, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-4", 0), false));
+
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(2, client2Envelope.Replies.Count);
+        }
+
+        [Test]
+        public void unsubscribed_client_has_assigned_streams_sent_to_another_client()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+                PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                    .WithEventLoader(new FakeStreamReader(x => { }))
+                    .WithCheckpointReader(reader)
+                    .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                    .WithMessageParker(new FakeMessageParker())
+                    .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                    .StartFromCurrent());
+            reader.Load(null);
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+            var client2Id = Guid.NewGuid();
+            sub.AddClient(client2Id, Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+
+            Assert.AreEqual(1, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+            sub.RemoveClientByCorrelationId(client2Id, false);
+
+            // Message 2 should be retried on client 1 as it wasn't acked.
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+        }
+
+        [Test]
+        public void new_subscription_gets_work()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var client3Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+                PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                    .WithEventLoader(new FakeStreamReader(x => { }))
+                    .WithCheckpointReader(reader)
+                    .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                    .WithMessageParker(new FakeMessageParker())
+                    .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new ByLengthHasher()))
+                    .StartFromCurrent());
+            reader.Load(null);
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1", 0));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11", 1));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "111", 2));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1111", 3));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11111", 4));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "111111", 5));
+
+            Assert.AreEqual(3, client1Envelope.Replies.Count);
+            Assert.AreEqual(3, client2Envelope.Replies.Count);
+
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client3Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1", 6));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11", 7));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "111", 8));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1111", 9));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11111", 10));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "111111", 11));
+
+            Assert.AreEqual(5, client1Envelope.Replies.Count);
+            Assert.AreEqual(5, client2Envelope.Replies.Count);
+            Assert.AreEqual(2, client3Envelope.Replies.Count);
+        }
+
+        [Test]
+        public void bad_availablecapacity_scneanrio_causing_null_reference()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+                PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                    .WithEventLoader(new FakeStreamReader(x => { }))
+                    .WithCheckpointReader(reader)
+                    .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                    .WithMessageParker(new FakeMessageParker())
+                    .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new ByLengthHasher()))
+                    .StartFromCurrent());
+            reader.Load(null);
+            var conn1Id = Guid.NewGuid();
+            sub.AddClient(Guid.NewGuid(), conn1Id, client1Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1", 0));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11", 1));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "111", 2));
+
+            Assert.AreEqual(3, client1Envelope.Replies.Count);
+
+            var conn2Id = Guid.NewGuid();
+            sub.AddClient(Guid.NewGuid(), conn2Id, client2Envelope, 10, "foo", "bar");
+
+            Assert.AreEqual(3, client1Envelope.Replies.Count);
+            Assert.AreEqual(0, client2Envelope.Replies.Count);
+
+            sub.RemoveClientByConnectionId(conn1Id);
+
+            // Used to throw a null reference exception.
+            Assert.That(() => sub.RemoveClientByConnectionId(conn2Id), Throws.Nothing);
+        }
+
+        [Test]
+        public void disconnected_client_has_assigned_streams_sent_to_another_client()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(
+                PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                    .WithEventLoader(new FakeStreamReader(x => { }))
+                    .WithCheckpointReader(reader)
+                    .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                    .WithMessageParker(new FakeMessageParker())
+                    .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                    .StartFromCurrent());
+            reader.Load(null);
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+            var client2Id = Guid.NewGuid();
+            sub.AddClient(Guid.NewGuid(), client2Id, client2Envelope, 10, "foo", "bar");
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+
+            Assert.AreEqual(1, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+            sub.RemoveClientByConnectionId(client2Id);
+
+            // Message 2 should be retried on client 1 as it wasn't acked.
+            Assert.AreEqual(2, client1Envelope.Replies.Count);
+            Assert.AreEqual(1, client2Envelope.Replies.Count);
+        }
+
+        [Test]
+        public void available_capacity_is_tracked()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            PersistentSubscriptionParams settings = PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                .WithEventLoader(new FakeStreamReader(x => { }))
+                .WithCheckpointReader(reader)
+                .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                .WithMessageParker(new FakeMessageParker())
+                .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                .StartFromCurrent();
+            var consumerStrategy = (PinnedPersistentSubscriptionConsumerStrategy)settings.ConsumerStrategy;
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(settings);
+            reader.Load(null);
+            var client1Id = Guid.NewGuid();
+            sub.AddClient(Guid.NewGuid(), client1Id, client1Envelope, 14, "foo", "bar");
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
+
+            var client2Id = Guid.NewGuid();
+            sub.AddClient(Guid.NewGuid(), client2Id, client2Envelope, 10, "foo", "bar");
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
+
+            sub.RemoveClientByConnectionId(client2Id);
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
+
+            sub.RemoveClientByConnectionId(client1Id);
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void available_capacity_is_tracked_with_inflight_messages()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            PersistentSubscriptionParams settings = PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                .WithEventLoader(new FakeStreamReader(x => { }))
+                .WithCheckpointReader(reader)
+                .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                .WithMessageParker(new FakeMessageParker())
+                .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                .StartFromCurrent();
+            var consumerStrategy = (PinnedPersistentSubscriptionConsumerStrategy)settings.ConsumerStrategy;
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(settings);
+            reader.Load(null);
+            var client1Id = Guid.NewGuid();
+            sub.AddClient(Guid.NewGuid(), client1Id, client1Envelope, 14, "foo", "bar");
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
+
+            var client2Id = Guid.NewGuid();
+            sub.AddClient(Guid.NewGuid(), client2Id, client2Envelope, 10, "foo", "bar");
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(23));
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(22));
+
+            sub.RemoveClientByConnectionId(client2Id);
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(12));
+
+            sub.RemoveClientByConnectionId(client1Id);
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void available_capacity_is_tracked_with_acked_messages()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            PersistentSubscriptionParams settings = PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                .WithEventLoader(new FakeStreamReader(x => { }))
+                .WithCheckpointReader(reader)
+                .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                .WithMessageParker(new FakeMessageParker())
+                .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                .StartFromCurrent();
+            var consumerStrategy = (PinnedPersistentSubscriptionConsumerStrategy)settings.ConsumerStrategy;
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(settings);
+            reader.Load(null);
+            var correlationId1 = Guid.NewGuid();
+            sub.AddClient(correlationId1, Guid.NewGuid(), client1Envelope, 14, "foo", "bar");
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
+
+            var correlationId2 = Guid.NewGuid();
+            sub.AddClient(correlationId2, Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
+
+            var message1 = Guid.NewGuid();
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(message1, subsctiptionStream, 0, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(23));
+
+            var message2 = Guid.NewGuid();
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(message2, subsctiptionStream, 1, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(22));
+
+            sub.AcknowledgeMessagesProcessed(correlationId1, new[] { message1 });
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(23));
+
+            sub.AcknowledgeMessagesProcessed(correlationId2, new[] { message2 });
+
+            Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
+
+        }
+
+        [Test]
+        public void events_are_skipped_if_assigned_client_full()
+        {
+            var client1Envelope = new FakeEnvelope();
+            var client2Envelope = new FakeEnvelope();
+            var reader = new FakeCheckpointReader();
+            const string subsctiptionStream = "$ce-streamName";
+            var sub = new Core.Services.PersistentSubscription.PersistentSubscription(PersistentSubscriptionParamsBuilder.CreateFor(subsctiptionStream, "groupName")
+                .WithEventLoader(new FakeStreamReader(x => { }))
+                .WithCheckpointReader(reader)
+                .WithCheckpointWriter(new FakeCheckpointWriter(x => { }))
+                .WithMessageParker(new FakeMessageParker())
+                .CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
+                .StartFromCurrent());
+            reader.Load(null);
+
+            var correlationId = Guid.NewGuid();
+            sub.AddClient(correlationId, Guid.NewGuid(), client1Envelope, 1, "foo", "bar");
+
+            sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 1, "foo", "bar");
+
+
+            var message1 = Guid.NewGuid();
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(message1, subsctiptionStream, 0, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+
+            Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
+            Assert.That(client2Envelope.Replies.Count, Is.EqualTo(0));
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 1, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
+
+            Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
+            Assert.That(client2Envelope.Replies.Count, Is.EqualTo(0));
+            Assert.That(sub._streamBuffer.BufferCount, Is.EqualTo(1));
+
+            sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 2, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
+
+            Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
+            Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));
+
+            Assert.That(sub._streamBuffer.BufferCount, Is.EqualTo(1));
+
+            sub.AcknowledgeMessagesProcessed(correlationId, new[] { message1 });
+
+            Assert.That(client1Envelope.Replies.Count, Is.EqualTo(2));
+            Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));
+
+            Assert.That(sub._streamBuffer.BufferCount, Is.EqualTo(0));
+        }
+
+    }
+}

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/StreamBufferTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/StreamBufferTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Services.PersistentSubscription;
 using NUnit.Framework;
@@ -8,6 +9,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
     [TestFixture]
     public class StreamBufferTests
     {
+
         [Test]
         public void adding_read_message_in_correct_order()
         {
@@ -15,8 +17,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             var id = Guid.NewGuid();
             buffer.AddReadMessage(BuildMessageAt(id, 0));
             Assert.AreEqual(1, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
+            OutstandingMessage message = buffer.Scan().First().Message;
             Assert.AreEqual(id, message.EventId);
             Assert.IsFalse(buffer.Live);
         }
@@ -30,11 +31,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 0));
             buffer.AddReadMessage(BuildMessageAt(id2, 1));
             Assert.AreEqual(2, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
             Assert.IsFalse(buffer.Live);
         }
 
@@ -48,11 +52,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 1));
             buffer.AddReadMessage(BuildMessageAt(id2, 0));
             Assert.AreEqual(2, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
             Assert.IsFalse(buffer.Live);
         }
 
@@ -64,11 +71,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 0));
             buffer.AddReadMessage(BuildMessageAt(id1, 0));
             Assert.AreEqual(2, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
             Assert.IsFalse(buffer.Live);
         }
 
@@ -81,9 +91,10 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 0));
             Assert.IsTrue(buffer.Live);
             Assert.AreEqual(1, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
         }
 
         [Test]
@@ -96,9 +107,10 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id2, 0));
             Assert.IsFalse(buffer.Live);
             Assert.AreEqual(1, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
         }
 
         [Test]
@@ -111,11 +123,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddLiveMessage(BuildMessageAt(id2, 7));
             Assert.IsTrue(buffer.Live);
             Assert.AreEqual(2, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id1, message.EventId);
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
         }
 
         [Test]
@@ -130,9 +145,103 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             buffer.AddReadMessage(BuildMessageAt(id1, 7));
             Assert.IsTrue(buffer.Live);
             Assert.AreEqual(1, buffer.BufferCount);
-            OutstandingMessage message;
-            Assert.IsTrue(buffer.TryDequeue(out message));
-            Assert.AreEqual(id2, message.EventId);
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
+        }
+
+        [Test]
+        public void skipped_messages_are_not_removed()
+        {
+            var buffer = new StreamBuffer(10, 10, -1, true);
+            var id1 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id1, 0));
+            var id2 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id2, 1));
+            var id3 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id3, 2));
+            Assert.AreEqual(3, buffer.BufferCount);
+            
+            var messagePointer2 = buffer.Scan().Skip(1).First(); // Skip the first message.
+            Assert.AreEqual(id2, messagePointer2.Message.EventId);
+            messagePointer2.MarkSent();
+            Assert.AreEqual(2, buffer.BufferCount);
+
+            var messagePointers = buffer.Scan().ToArray();
+            Assert.AreEqual(id1, messagePointers[0].Message.EventId);
+            Assert.AreEqual(id3, messagePointers[1].Message.EventId);
+        }
+
+        [Test]
+        public void retried_messages_appear_first()
+        {
+            var buffer = new StreamBuffer(10, 10, -1, true);
+            var id1 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id1, 0));
+            var id2 = Guid.NewGuid();
+            buffer.AddRetry(BuildMessageAt(id2, 2));
+            Assert.AreEqual(2, buffer.BufferCount);
+            Assert.AreEqual(1, buffer.RetryBufferCount);
+            Assert.AreEqual(1, buffer.ReadBufferCount);
+
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(1, buffer.BufferCount);
+            Assert.AreEqual(0, buffer.RetryBufferCount);
+            Assert.AreEqual(1, buffer.ReadBufferCount);
+
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id1, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+            Assert.AreEqual(0, buffer.BufferCount);
+            Assert.AreEqual(0, buffer.RetryBufferCount);
+            Assert.AreEqual(0, buffer.ReadBufferCount);
+
+            Assert.IsFalse(buffer.Live);
+        }
+
+        [Test]
+        public void retried_messages_appear_in_version_order()
+        {
+            var buffer = new StreamBuffer(10, 10, -1, true);
+            var id1 = Guid.NewGuid();
+            buffer.AddReadMessage(BuildMessageAt(id1, 0));
+            var id2 = Guid.NewGuid();
+            var id3 = Guid.NewGuid();
+            var id4 = Guid.NewGuid();
+            var id5 = Guid.NewGuid();
+            buffer.AddRetry(BuildMessageAt(id2, 2));
+            buffer.AddRetry(BuildMessageAt(id3, 3));
+            buffer.AddRetry(BuildMessageAt(id4, 1));
+            buffer.AddRetry(BuildMessageAt(id5, 2));
+
+            var messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id4, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id2, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id5, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+
+            messagePointer = buffer.Scan().First();
+            Assert.AreEqual(id3, messagePointer.Message.EventId);
+            messagePointer.MarkSent();
+
+        }
+
+        public void lowest_retry_doesnt_assume_order()
+        {
+            var buffer = new StreamBuffer(10, 10, -1, true);
+            buffer.AddRetry(BuildMessageAt(Guid.NewGuid(), 4));
+            buffer.AddRetry(BuildMessageAt(Guid.NewGuid(), 2));
+            buffer.AddRetry(BuildMessageAt(Guid.NewGuid(), 3));
+            Assert.AreEqual(2, buffer.GetLowestRetry());
         }
 
         private OutstandingMessage BuildMessageAt(Guid id,int version)

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
@@ -6,6 +7,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Authentication;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Monitoring;
+using EventStore.Core.Services.PersistentSubscription;
 
 namespace EventStore.Core.Cluster.Settings
 {
@@ -61,6 +63,8 @@ namespace EventStore.Core.Cluster.Settings
 
         public readonly string Index;
 
+        public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
+
         public ClusterVNodeSettings(Guid instanceId, int debugIndex,
                                     IPEndPoint internalTcpEndPoint,
                                     IPEndPoint internalSecureTcpEndPoint,
@@ -104,10 +108,9 @@ namespace EventStore.Core.Cluster.Settings
 				                    bool verifyDbHash,
 				                    int maxMemtableEntryCount,
                                     bool startStandardProjections,
-                                    bool disableHTTPCaching,
-                                    string index = null,
-                                    bool enableHistograms = false,
-                                    int indexCacheDepth = 16)
+                                    bool disableHTTPCaching, string index = null, bool enableHistograms = false,
+                                    int indexCacheDepth = 16,
+                                    IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -144,6 +147,7 @@ namespace EventStore.Core.Cluster.Settings
             WorkerThreads = workerThreads;
             StartStandardProjections = startStandardProjections;
             DisableHTTPCaching = disableHTTPCaching;
+            AdditionalConsumerStrategies = additionalConsumerStrategies ?? new IPersistentSubscriptionConsumerStrategyFactory[0];
 
             DiscoverViaDns = discoverViaDns;
             ClusterDns = clusterDns;
@@ -185,6 +189,8 @@ namespace EventStore.Core.Cluster.Settings
             IndexCacheDepth = indexCacheDepth;
             Index = index;
         }
+
+        
 
         public override string ToString()
         {

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -8,6 +8,7 @@ using EventStore.Core.Authentication;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Cluster.Settings
 {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -436,7 +436,8 @@ namespace EventStore.Core
             _mainBus.Subscribe(perSubscrQueue.WidenFrom<SubscriptionMessage.PersistentSubscriptionTimerTick, Message>());
 
             //TODO CC can have multiple threads working on subscription if partition
-            var persistentSubscription = new PersistentSubscriptionService(subscrQueue, readIndex, ioDispatcher, _mainQueue);
+            var consumerStrategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry(_mainQueue, _mainBus, vNodeSettings.AdditionalConsumerStrategies);
+            var persistentSubscription = new PersistentSubscriptionService(subscrQueue, readIndex, ioDispatcher, _mainQueue, consumerStrategyRegistry);
             perSubscrBus.Subscribe<SystemMessage.BecomeShuttingDown>(persistentSubscription);
             perSubscrBus.Subscribe<SystemMessage.BecomeMaster>(persistentSubscription);
             perSubscrBus.Subscribe<SystemMessage.StateChangeMessage>(persistentSubscription);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -34,6 +34,7 @@ using EventStore.Core.Helpers;
 using EventStore.Core.Services.PersistentSubscription;
 using System.Threading;
 using EventStore.Core.Services.Histograms;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core
 {

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -190,6 +190,10 @@
     <Compile Include="Services\PersistentSubscription\ConsumerStrategy\IPersistentSubscriptionConsumerStrategy.cs" />
     <Compile Include="Services\PersistentSubscription\ConsumerStrategy\IPersistentSubscriptionConsumerStrategyFactory.cs" />
     <Compile Include="Services\PersistentSubscription\ConsumerStrategy\PersistentSubscriptionConsumerStrategyRegistry.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\PinnedPersistentSubscriptionConsumerStrategy.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\PinnedState\BucketAssignment.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\PinnedState\Node.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\PinnedState\PinnedConsumerState.cs" />
     <Compile Include="Services\PersistentSubscription\ConsumerStrategy\RoundRobinPersistentSubscriptionConsumerStrategy.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointReader.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointWriter.cs" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -184,10 +184,15 @@
     <Compile Include="Services\Gossip\LoopbackDns.cs" />
     <Compile Include="Services\Gossip\NodeGossipService.cs" />
     <Compile Include="Services\Histograms\HistogramService.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\ConsumerPushResult.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\DelegatePersistentSubscriptionConsumerStrategyFactory.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\DispatchToSinglePersistentSubscriptionConsumerStrategy.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\IPersistentSubscriptionConsumerStrategy.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\IPersistentSubscriptionConsumerStrategyFactory.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\PersistentSubscriptionConsumerStrategyRegistry.cs" />
+    <Compile Include="Services\PersistentSubscription\ConsumerStrategy\RoundRobinPersistentSubscriptionConsumerStrategy.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointReader.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointWriter.cs" />
-    <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategy.cs" />
-    <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategyFactory.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionMessageParker.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionStreamReader.cs" />
     <Compile Include="Services\PersistentSubscription\NakAction.cs" />
@@ -199,7 +204,6 @@
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionClient.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionClientCollection.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionConfig.cs" />
-    <Compile Include="Services\PersistentSubscription\PersistentSubscriptionConsumerStrategyRegistry.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionMessageParker.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionParams.cs" />
     <Compile Include="Services\PersistentSubscription\PersistentSubscriptionParamsBuilder.cs" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Messages\UserManagementMessage.cs" />
     <Compile Include="Messaging\RequestResponseDispatcher.cs" />
     <Compile Include="PluginModel\IAuthenticationPlugin.cs" />
+    <Compile Include="PluginModel\IPersistentSubscriptionConsumerStrategyPlugin.cs" />
     <Compile Include="Services\AwakeReaderService\AwakeService.cs" />
     <Compile Include="Services\AwakeReaderService\AwakeServiceMessage.cs" />
     <Compile Include="Services\ClusterStorageWriterService.cs" />
@@ -186,6 +187,7 @@
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointReader.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionCheckpointWriter.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategy.cs" />
+    <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionConsumerStrategyFactory.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionMessageParker.cs" />
     <Compile Include="Services\PersistentSubscription\IPersistentSubscriptionStreamReader.cs" />
     <Compile Include="Services\PersistentSubscription\NakAction.cs" />

--- a/src/EventStore.Core/PluginModel/IPersistentSubscriptionConsumerStrategyPlugin.cs
+++ b/src/EventStore.Core/PluginModel/IPersistentSubscriptionConsumerStrategyPlugin.cs
@@ -1,4 +1,5 @@
 ﻿using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.PluginModel
 {

--- a/src/EventStore.Core/PluginModel/IPersistentSubscriptionConsumerStrategyPlugin.cs
+++ b/src/EventStore.Core/PluginModel/IPersistentSubscriptionConsumerStrategyPlugin.cs
@@ -1,0 +1,13 @@
+﻿using EventStore.Core.Services.PersistentSubscription;
+
+namespace EventStore.Core.PluginModel
+{
+    public interface IPersistentSubscriptionConsumerStrategyPlugin
+    {
+        string Name { get; }
+
+        string Version { get; }
+
+        IPersistentSubscriptionConsumerStrategyFactory GetConsumerStrategyFactory();
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/ConsumerPushResult.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/ConsumerPushResult.cs
@@ -1,0 +1,9 @@
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    public enum ConsumerPushResult
+    {
+        Sent,
+        Skipped,
+        NoMoreCapacity
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DelegatePersistentSubscriptionConsumerStrategyFactory.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DelegatePersistentSubscriptionConsumerStrategyFactory.cs
@@ -5,7 +5,7 @@ namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
     class DelegatePersistentSubscriptionConsumerStrategyFactory : IPersistentSubscriptionConsumerStrategyFactory
     {
-        public string StrategyName { get; }
+        public string StrategyName { get; private set; }
 
         private readonly Func<string, IPublisher, ISubscriber, IPersistentSubscriptionConsumerStrategy> _factory;
 

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DelegatePersistentSubscriptionConsumerStrategyFactory.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DelegatePersistentSubscriptionConsumerStrategyFactory.cs
@@ -1,15 +1,8 @@
 using System;
 using EventStore.Core.Bus;
 
-namespace EventStore.Core.Services.PersistentSubscription
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
-    public interface IPersistentSubscriptionConsumerStrategyFactory
-    {
-        string StrategyName { get; }
-
-        IPersistentSubscriptionConsumerStrategy Create(string subscriptionId, IPublisher mainQueue, ISubscriber mainBus);
-    }
-
     class DelegatePersistentSubscriptionConsumerStrategyFactory : IPersistentSubscriptionConsumerStrategyFactory
     {
         public string StrategyName { get; }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DispatchToSinglePersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DispatchToSinglePersistentSubscriptionConsumerStrategy.cs
@@ -1,0 +1,27 @@
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    class DispatchToSinglePersistentSubscriptionConsumerStrategy : RoundRobinPersistentSubscriptionConsumerStrategy
+    {
+        public override string Name
+        {
+            get { return SystemConsumerStrategies.DispatchToSingle; }
+        }
+
+        public override ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        {
+            for (int i = 0; i < Clients.Count; i++)
+            {
+                if (Clients.Peek().Push(ev))
+                {
+                    return ConsumerPushResult.Sent;
+                }
+                var c = Clients.Dequeue();
+                Clients.Enqueue(c);
+            }
+
+            return ConsumerPushResult.NoMoreCapacity;
+        }
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategy.cs
@@ -1,0 +1,15 @@
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    public interface IPersistentSubscriptionConsumerStrategy
+    {
+        string Name { get; }
+
+        void ClientAdded(PersistentSubscriptionClient client);
+
+        void ClientRemoved(PersistentSubscriptionClient client);
+
+        ConsumerPushResult PushMessageToClient(ResolvedEvent ev);
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategyFactory.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategyFactory.cs
@@ -1,0 +1,11 @@
+using EventStore.Core.Bus;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    public interface IPersistentSubscriptionConsumerStrategyFactory
+    {
+        string StrategyName { get; }
+
+        IPersistentSubscriptionConsumerStrategy Create(string subscriptionId, IPublisher mainQueue, ISubscriber mainBus);
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PersistentSubscriptionConsumerStrategyRegistry.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PersistentSubscriptionConsumerStrategyRegistry.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using EventStore.Core.Bus;
+using EventStore.Core.Index.Hashes;
 
 namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
@@ -18,6 +19,7 @@ namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
             _mainBus = mainBus;
             Register(new DelegatePersistentSubscriptionConsumerStrategyFactory(SystemConsumerStrategies.RoundRobin, (subId, queue, bus) => new RoundRobinPersistentSubscriptionConsumerStrategy()));
             Register(new DelegatePersistentSubscriptionConsumerStrategyFactory(SystemConsumerStrategies.DispatchToSingle, (subId, queue, bus) => new DispatchToSinglePersistentSubscriptionConsumerStrategy()));
+            Register(new DelegatePersistentSubscriptionConsumerStrategyFactory(SystemConsumerStrategies.Pinned, (subId, queue, bus) => new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe())));
 
             foreach (var consumerStrategyFactory in additionalConsumerStrategies)
             {

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PersistentSubscriptionConsumerStrategyRegistry.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PersistentSubscriptionConsumerStrategyRegistry.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using EventStore.Core.Bus;
 
-namespace EventStore.Core.Services.PersistentSubscription
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
     public class PersistentSubscriptionConsumerStrategyRegistry
     {

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedPersistentSubscriptionConsumerStrategy.cs
@@ -1,0 +1,118 @@
+﻿using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Index.Hashes;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy.PinnedState;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
+{
+    class PinnedPersistentSubscriptionConsumerStrategy : IPersistentSubscriptionConsumerStrategy
+    {
+        private readonly IHasher _hash;
+        private static readonly char LinkToSeparator = '@';
+        private readonly PinnedConsumerState _state = new PinnedConsumerState();
+        private readonly object _stateLock = new object();
+
+        public PinnedPersistentSubscriptionConsumerStrategy(IHasher streamHasher)
+        {
+            _hash = streamHasher;
+        }
+
+        public string Name
+        {
+            get { return SystemConsumerStrategies.Pinned; }
+        }
+
+        public int AvailableCapacity
+        {
+            get
+            {
+                if (_state == null)
+                    return 0;
+
+                return _state.AvailableCapacity;
+            }
+        }
+
+        public void ClientAdded(PersistentSubscriptionClient client)
+        {
+            lock (_stateLock)
+            {
+                var newNode = new Node(client);
+
+                _state.AddNode(newNode);
+
+                client.EventConfirmed += OnEventRemoved;
+            }
+        }
+
+        public void ClientRemoved(PersistentSubscriptionClient client)
+        {
+            var nodeId = client.CorrelationId;
+
+            client.EventConfirmed -= OnEventRemoved;
+
+            _state.DisconnectNode(nodeId);
+        }
+
+        public ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        {
+            if (_state == null)
+            {
+                return ConsumerPushResult.NoMoreCapacity;
+            }
+
+            if (_state.AvailableCapacity == 0)
+            {
+                return ConsumerPushResult.NoMoreCapacity;
+            }
+
+
+            uint bucket = GetAssignmentId(ev);
+
+            if (_state.Assignments[bucket].State != BucketAssignment.BucketState.Assigned)
+            {
+                _state.AssignBucket(bucket);
+            }
+
+            if (!_state.Assignments[bucket].Node.Client.Push(ev))
+            {
+                return ConsumerPushResult.Skipped;
+            }
+
+            _state.RecordEventSent(bucket);
+            return ConsumerPushResult.Sent;
+        }
+
+        private void OnEventRemoved(PersistentSubscriptionClient client, ResolvedEvent ev)
+        {
+            var assignmentId = GetAssignmentId(ev);
+            _state.EventRemoved(client.CorrelationId, assignmentId);
+        }
+
+        private uint GetAssignmentId(ResolvedEvent ev)
+        {
+            string sourceStreamId = GetSourceStreamId(ev);
+
+            return _hash.Hash(sourceStreamId) % (uint)_state.Assignments.Length;
+        }
+
+        private static string GetSourceStreamId(ResolvedEvent ev)
+        {
+            var eventRecord = ev.Event ?? ev.Link; // Unresolved link just use the link
+
+            string sourceStreamId = eventRecord.EventStreamId;
+
+            if (eventRecord.EventType == SystemEventTypes.LinkTo) // Unresolved link.
+            {
+                sourceStreamId = Helper.UTF8NoBom.GetString(eventRecord.Data);
+                int separatorIndex = sourceStreamId.IndexOf(LinkToSeparator);
+                if (separatorIndex != -1)
+                {
+                    sourceStreamId = sourceStreamId.Substring(separatorIndex + 1);
+                }
+            }
+            return sourceStreamId;
+        }
+
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/BucketAssignment.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/BucketAssignment.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy.PinnedState
+{
+    internal struct BucketAssignment
+    {
+        internal enum BucketState
+        {
+            Unassigned,
+            Assigned,
+            Disconnected
+        }
+
+        public Guid NodeId { get; set; }
+
+        public BucketState State { get; set; }
+
+        public int InFlightCount { get; set; }
+
+        public Node Node { get; set; }
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/Node.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/Node.cs
@@ -1,0 +1,67 @@
+using System;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy.PinnedState
+{
+    internal class Node
+    {
+        internal enum NodeState
+        {
+            Connected,
+            Disconnected
+        }
+
+        public Node()
+        {
+        }
+
+        public Node(Guid connectionId, Guid nodeId, string host, int port, NodeState state, PersistentSubscriptionClient client, int maximumInFlightMessages, int assignmentCount)
+        {
+            ConnectionId = connectionId;
+            NodeId = nodeId;
+            Host = host;
+            Port = port;
+            State = state;
+            Client = client;
+            MaximumInFlightMessages = maximumInFlightMessages;
+            AssignmentCount = assignmentCount;
+        }
+
+        public Node(PersistentSubscriptionClient client)
+        {
+            Client = client;
+            ConnectionId = client.ConnectionId;
+            NodeId = client.CorrelationId;
+
+            var portSplit = client.From.IndexOf(':');
+            if (portSplit == -1)
+            {
+                Host = client.From;
+            }
+            else
+            {
+                Host = client.From.Substring(0, portSplit);
+                Port = Int32.Parse(client.From.Substring(portSplit + 1));
+            }
+
+            State = NodeState.Connected;
+            MaximumInFlightMessages = client.MaximumInFlightMessages;
+        }
+
+        public Guid ConnectionId { get; set; }
+
+        public Guid NodeId { get; set; }
+
+        public string Host { get; set; }
+
+        public int Port { get; set; }
+
+        public NodeState State { get; set; }
+
+        public PersistentSubscriptionClient Client { get; set; }
+
+        public int MaximumInFlightMessages { get; set; }
+
+        public int AssignmentCount { get; set; }
+
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/PinnedConsumerState.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedState/PinnedConsumerState.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy.PinnedState
+{
+    class PinnedConsumerState
+    {
+        private const int MaxBucketCount = 1024;
+
+        public PinnedConsumerState()
+        {
+            Version = -1;
+            Assignments = new BucketAssignment[MaxBucketCount];
+            Nodes = new List<Node>();
+        }
+
+        public int Version { get; set; }
+
+        public BucketAssignment[] Assignments { get; set; }
+
+        public IList<Node> Nodes { get; set; }
+
+        public int AssignmentCount { get; set; }
+
+        public int TotalCapacity { get; set; }
+
+        public int AvailableCapacity
+        {
+            get
+            {
+                var cap = 0;
+                for (int index = 0; index < Nodes.Count; index++)
+                {
+
+                    var node = Nodes[index];
+                    if (node.State == Node.NodeState.Connected)
+                    {
+                        cap += node.MaximumInFlightMessages - node.Client.InflightMessages;
+                    }
+                }
+                return cap;
+            }
+        }
+
+        public void DisconnectNode(Guid nodeId)
+        {
+            var node = Nodes.FirstOrDefault(_ => _.NodeId == nodeId);
+
+            if (node == null)
+            {
+                throw new ApplicationException("ClientRemoved was called for a client the consumer strategy didn't have.");
+            }
+
+            if (node.State == Node.NodeState.Disconnected)
+                throw new InvalidOperationException();
+
+            node.State = Node.NodeState.Disconnected;
+
+            AssignmentCount -= node.AssignmentCount;
+            if (AssignmentCount < 0)
+                throw new InvalidOperationException();
+
+            TotalCapacity -= node.MaximumInFlightMessages;
+            if (TotalCapacity < 0)
+                throw new InvalidOperationException();
+
+            for (int i = 0; i < Assignments.Length; i++)
+            {
+                if (Assignments[i].NodeId == nodeId)
+                {
+                    Assignments[i].State = BucketAssignment.BucketState.Disconnected;
+                    Assignments[i].InFlightCount = 0;
+                }
+            }
+        }
+
+        public void AddNode(Node newNode)
+        {
+            Nodes.Add(newNode);
+            TotalCapacity += newNode.MaximumInFlightMessages;
+
+            var clientCount = Nodes.Count(_ => _.State == Node.NodeState.Connected);
+
+            var maxBalancedClientAssignmentCount = (int)Math.Ceiling(AssignmentCount / (decimal)clientCount);
+
+            var reassignments = new List<uint>();
+
+            foreach (var existingClient in Nodes)
+            {
+                if (existingClient == newNode || existingClient.State == Node.NodeState.Disconnected)
+                {
+                    continue;
+                }
+
+                if (existingClient.AssignmentCount > maxBalancedClientAssignmentCount)
+                {
+                    var assignmentsToMove = Assignments
+                        .Select((node, bucket) => Tuple.Create(node, bucket))
+                        .Where(_ => _.Item1.NodeId == existingClient.NodeId && _.Item1.State == BucketAssignment.BucketState.Assigned)
+                        .OrderBy(_ => _.Item1.InFlightCount) // Take buckets without inflight messages first.
+                        .Take(existingClient.AssignmentCount - maxBalancedClientAssignmentCount);
+
+                    foreach (var assignment in assignmentsToMove)
+                    {
+                        reassignments.Add((uint)assignment.Item2);
+                    }
+                }
+            }
+
+            foreach (var reassignment in reassignments)
+            {
+                ApplyBucketAssigned(reassignment, newNode.NodeId);
+            }
+                
+            Clean();
+        }
+
+        public void EventRemoved(Guid nodeId, uint assignmentId)
+        {
+            if (Assignments[assignmentId].NodeId == nodeId)
+            {
+                Assignments[assignmentId].InFlightCount--;
+            }
+        }
+
+        public void RecordEventSent(uint bucket)
+        {
+            Assignments[bucket].InFlightCount++;
+        }
+
+        public void AssignBucket(uint bucket)
+        {
+            var node = ChooseClient();
+            ApplyBucketAssigned(bucket, node.NodeId);
+        }
+
+        private void Clean()
+        {
+            var oldNodes = Nodes.Where(_ => _.AssignmentCount == 0 && _.State == Node.NodeState.Disconnected).ToList();
+            foreach (var oldNode in oldNodes)
+            {
+                Nodes.Remove(oldNode);
+            }
+        }
+
+        private void ApplyBucketAssigned(uint bucketId, Guid newNodeId)
+        {
+            if (Assignments[bucketId].State != BucketAssignment.BucketState.Assigned)
+            {
+                AssignmentCount++;
+            }
+
+            if (Assignments[bucketId].State != BucketAssignment.BucketState.Unassigned)
+            {
+                Assignments[bucketId].Node.AssignmentCount--;
+            }
+
+            Assignments[bucketId].State = BucketAssignment.BucketState.Assigned;
+            Assignments[bucketId].NodeId = newNodeId;
+            Assignments[bucketId].Node = Nodes.First(_ => _.NodeId == newNodeId);
+            Assignments[bucketId].Node.AssignmentCount++;
+        }
+
+        private Node ChooseClient()
+        {
+            Node minAssignedNode = null;
+            foreach (var node in Nodes.Where(_ => _.State == Node.NodeState.Connected))
+            {
+                if (minAssignedNode == null || node.AssignmentCount < minAssignedNode.AssignmentCount)
+                {
+                    minAssignedNode = node;
+                }
+            }
+            return minAssignedNode;
+        }
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/RoundRobinPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/RoundRobinPersistentSubscriptionConsumerStrategy.cs
@@ -3,49 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Data;
 
-namespace EventStore.Core.Services.PersistentSubscription
+namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
-    public enum ConsumerPushResult
-    {
-        Sent,
-        Skipped,
-        NoMoreCapacity
-    }
-
-    public interface IPersistentSubscriptionConsumerStrategy
-    {
-        string Name { get; }
-
-        void ClientAdded(PersistentSubscriptionClient client);
-
-        void ClientRemoved(PersistentSubscriptionClient client);
-
-        ConsumerPushResult PushMessageToClient(ResolvedEvent ev);
-    }
-
-    class DispatchToSinglePersistentSubscriptionConsumerStrategy : RoundRobinPersistentSubscriptionConsumerStrategy
-    {
-        public override string Name
-        {
-            get { return SystemConsumerStrategies.DispatchToSingle; }
-        }
-
-        public override ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
-        {
-            for (int i = 0; i < Clients.Count; i++)
-            {
-                if (Clients.Peek().Push(ev))
-                {
-                    return ConsumerPushResult.Sent;
-                }
-                var c = Clients.Dequeue();
-                Clients.Enqueue(c);
-            }
-
-            return ConsumerPushResult.NoMoreCapacity;
-        }
-    }
-
     class RoundRobinPersistentSubscriptionConsumerStrategy : IPersistentSubscriptionConsumerStrategy
     {
         protected readonly Queue<PersistentSubscriptionClient> Clients = new Queue<PersistentSubscriptionClient>();
@@ -91,5 +50,4 @@ namespace EventStore.Core.Services.PersistentSubscription
             return ConsumerPushResult.NoMoreCapacity;
         }
     }
-
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategy.cs
@@ -8,6 +8,7 @@ namespace EventStore.Core.Services.PersistentSubscription
     public enum ConsumerPushResult
     {
         Sent,
+        Skipped,
         NoMoreCapacity
     }
 

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategyFactory.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionConsumerStrategyFactory.cs
@@ -1,0 +1,30 @@
+using System;
+using EventStore.Core.Bus;
+
+namespace EventStore.Core.Services.PersistentSubscription
+{
+    public interface IPersistentSubscriptionConsumerStrategyFactory
+    {
+        string StrategyName { get; }
+
+        IPersistentSubscriptionConsumerStrategy Create(string subscriptionId, IPublisher mainQueue, ISubscriber mainBus);
+    }
+
+    class DelegatePersistentSubscriptionConsumerStrategyFactory : IPersistentSubscriptionConsumerStrategyFactory
+    {
+        public string StrategyName { get; }
+
+        private readonly Func<string, IPublisher, ISubscriber, IPersistentSubscriptionConsumerStrategy> _factory;
+
+        public DelegatePersistentSubscriptionConsumerStrategyFactory(string strategyName, Func<string, IPublisher, ISubscriber, IPersistentSubscriptionConsumerStrategy> factory)
+        {
+            _factory = factory;
+            StrategyName = strategyName;
+        }
+
+        public IPersistentSubscriptionConsumerStrategy Create(string subscriptionId, IPublisher mainQueue, ISubscriber mainBus)
+        {
+            return _factory(subscriptionId, mainQueue, mainBus);
+        }
+    }
+}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -7,6 +7,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Data;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Common.Utils;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParamsBuilder.cs
@@ -178,6 +178,18 @@ namespace EventStore.Core.Services.PersistentSubscription
         }
 
         /// <summary>
+        /// Sets the consumer strategy to the one provided.
+        /// </summary>
+        /// <param name="consumerStrategy"></param>
+        /// <returns></returns>
+        public PersistentSubscriptionParamsBuilder CustomConsumerStrategy(IPersistentSubscriptionConsumerStrategy consumerStrategy)
+        {
+            _consumerStrategy = consumerStrategy;
+            return this;
+        }
+
+
+        /// <summary>
         /// Sets that the subscription should start from the beginning of the stream.
         /// </summary>
         /// <returns>A new <see cref="PersistentSubscriptionParamsBuilder"></see></returns>

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -8,6 +8,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         private readonly TimerMessage.Schedule _tickRequestMessage;
         private bool _handleTick;
 
-        public PersistentSubscriptionService(IQueuedHandler queuedHandler, IReadIndex readIndex, IODispatcher ioDispatcher, IPublisher bus)
+        internal PersistentSubscriptionService(IQueuedHandler queuedHandler, IReadIndex readIndex, IODispatcher ioDispatcher, IPublisher bus, PersistentSubscriptionConsumerStrategyRegistry consumerStrategyRegistry)
         {
             Ensure.NotNull(queuedHandler, "queuedHandler");
             Ensure.NotNull(readIndex, "readIndex");
@@ -64,7 +64,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             _readIndex = readIndex;
             _ioDispatcher = ioDispatcher;
             _bus = bus;
-            _consumerStrategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry();
+            _consumerStrategyRegistry = consumerStrategyRegistry;
             _checkpointReader = new PersistentSubscriptionCheckpointReader(_ioDispatcher);
             _streamReader = new PersistentSubscriptionStreamReader(_ioDispatcher, 100);
             //TODO CC configurable
@@ -325,7 +325,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                     minCheckPointCount,
                     maxCheckPointCount,
                     maxSubscriberCount,
-                    _consumerStrategyRegistry.GetInstance(namedConsumerStrategy),
+                    _consumerStrategyRegistry.GetInstance(namedConsumerStrategy, key),
                     _streamReader,
                     _checkpointReader,
                     new PersistentSubscriptionCheckpointWriter(key, _ioDispatcher),

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -161,5 +161,11 @@ namespace EventStore.Core.Services
         /// Distribute events to each client in a round robin fashion.
         /// </summary>
         public const string RoundRobin = "RoundRobin";
+
+        /// <summary>
+        /// Distribute events of the same streamId to the same client until it disconnects on a best efforts basis. 
+        /// Designed to be used with indexes such as the category projection.
+        /// </summary>
+        public const string Pinned = "Pinned";
     }
 }


### PR DESCRIPTION
This is the same as #776 but with the pinned consumer strategy that initiated the consumer strategy work.

I'm opening the PR as a courtesy for accepting the changes for the consumer strategy plugin. However, I'm not sure this strategy is suitable for general use. As we can use the plugin framework it's entirely up to you if you want to include this consumer strategy in the main release.

Some information on how it works:
- The underlying stream id of the resolved link event is extracted.
- A bucketed hash map of stream id to PersistentSubscriptionClient is kept.
- When a new event arrives it is sent to the client which it is already assigned to (or the new bucket gets assigned.)
- The strategy attempts to keep the number of buckets per client balanced at all time.
- If a client disconnects the buckets are reassigned.

This allows fairly good load balancing but *attempts* to ensure serial ordered processing of a sub-stream. Therefore processing is more efficient as concurrency clashes are reduced.
