### PR TITLE
Encode URIs consistently across APIs

### DIFF
--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -287,13 +287,13 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
         [Test]
         public void the_first_parked_message_queue_uri_is_correct()
         {
-            Assert.AreEqual(string.Format("http://{0}/streams/$persistentsubscription-{1}::{2}-parked", _node.ExtHttpEndPoint, _streamName, _groupName), _json[0]["parkedMessageUri"].Value<string>());
+            Assert.AreEqual(string.Format("http://{0}/streams/%24persistentsubscription-{1}::{2}-parked", _node.ExtHttpEndPoint, _streamName, _groupName), _json[0]["parkedMessageUri"].Value<string>());
         }
 
         [Test]
         public void the_second_parked_message_queue_uri_is_correct()
         {
-            Assert.AreEqual(string.Format("http://{0}/streams/$persistentsubscription-{1}::{2}-parked", _node.ExtHttpEndPoint, _streamName, "secondgroup"), _json[1]["parkedMessageUri"].Value<string>());
+            Assert.AreEqual(string.Format("http://{0}/streams/%24persistentsubscription-{1}::{2}-parked", _node.ExtHttpEndPoint, _streamName, "secondgroup"), _json[1]["parkedMessageUri"].Value<string>());
         }
 
         [Test]
@@ -402,13 +402,13 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
         [Test]
         public void the_first_parked_message_queue_uri_is_correct()
         {
-            Assert.AreEqual(string.Format("http://{0}/streams/$persistentsubscription-{1}::{2}-parked", _node.ExtHttpEndPoint, _streamName, _groupName), _json[0]["parkedMessageUri"].Value<string>());
+            Assert.AreEqual(string.Format("http://{0}/streams/%24persistentsubscription-{1}::{2}-parked", _node.ExtHttpEndPoint, _streamName, _groupName), _json[0]["parkedMessageUri"].Value<string>());
         }
 
         [Test]
         public void the_second_parked_message_queue_uri_is_correct()
         {
-            Assert.AreEqual(string.Format("http://{0}/streams/$persistentsubscription-{1}::{2}-parked", _node.ExtHttpEndPoint, _streamName, "secondgroup"), _json[1]["parkedMessageUri"].Value<string>());
+            Assert.AreEqual(string.Format("http://{0}/streams/%24persistentsubscription-{1}::{2}-parked", _node.ExtHttpEndPoint, _streamName, "secondgroup"), _json[1]["parkedMessageUri"].Value<string>());
         }
 
         [Test]

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -220,6 +220,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 {
                     messagePointer.MarkSent();
                     MarkBeginProcessing(messagePointer.Message);
+                    _lastKnownMessage = Math.Max(_lastKnownMessage, messagePointer.Message.ResolvedEvent.OriginalEventNumber);
                     yield return messagePointer.Message.ResolvedEvent;
                 }
             }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -593,19 +593,22 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                 default: return EmbedLevel.None;
             }
         }
-
+        string parkedMessageUriTemplate = "/streams/" + Uri.EscapeDataString("$persistentsubscription") + "-{0}::{1}-parked";
         private IEnumerable<SubscriptionInfo> ToDto(HttpEntityManager manager, MonitoringMessage.GetPersistentSubscriptionStatsCompleted message)
         {
             if (message == null) yield break;
             if (message.SubscriptionStats == null) yield break;
+
             foreach (var stat in message.SubscriptionStats)
             {
+                string escapedStreamId = Uri.EscapeDataString(stat.EventStreamId);
+                string escapedGroupName = Uri.EscapeDataString(stat.GroupName);
                 var info = new SubscriptionInfo
                 {
                     Links = new List<RelLink>()
                     {
-                        new RelLink(MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/info", stat.EventStreamId,stat.GroupName)), "detail"),
-                        new RelLink(MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/replayParked", stat.EventStreamId,stat.GroupName)), "replayParked")
+                        new RelLink(MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/info", escapedStreamId, escapedGroupName)), "detail"),
+                        new RelLink(MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/replayParked", escapedStreamId, escapedGroupName)), "replayParked")
                     },
                     EventStreamId = stat.EventStreamId,
                     GroupName = stat.GroupName,
@@ -619,8 +622,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                     LiveBufferCount = stat.LiveBufferCount,
                     RetryBufferCount = stat.RetryBufferCount,
                     TotalInFlightMessages = stat.TotalInFlightMessages,
-                    ParkedMessageUri = MakeUrl(manager, string.Format("/streams/$persistentsubscription-{0}::{1}-parked", stat.EventStreamId, stat.GroupName)),
-                    GetMessagesUri = MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/{2}", stat.EventStreamId, stat.GroupName, DefaultNumberOfMessagesToGet)),
+                    ParkedMessageUri = MakeUrl(manager, string.Format(parkedMessageUriTemplate, escapedStreamId, escapedGroupName)),
+                    GetMessagesUri = MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/{2}", escapedStreamId, escapedGroupName, DefaultNumberOfMessagesToGet)),
                     Config = new SubscriptionConfigData
                     {
                         CheckPointAfterMilliseconds = stat.CheckPointAfterMilliseconds,
@@ -664,13 +667,16 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         {
             if (message == null) yield break;
             if (message.SubscriptionStats == null) yield break;
+
             foreach (var stat in message.SubscriptionStats)
             {
+                string escapedStreamId = Uri.EscapeDataString(stat.EventStreamId);
+                string escapedGroupName = Uri.EscapeDataString(stat.GroupName);
                 var info = new SubscriptionSummary
                 {
                     Links = new List<RelLink>()
                     {
-                        new RelLink(MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/info", stat.EventStreamId,stat.GroupName)), "detail"),
+                        new RelLink(MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/info", escapedStreamId, escapedGroupName)), "detail"),
                     },
                     EventStreamId = stat.EventStreamId,
                     GroupName = stat.GroupName,
@@ -679,8 +685,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                     TotalItemsProcessed = stat.TotalItems,
                     LastKnownEventNumber = stat.LastKnownMessage,
                     LastProcessedEventNumber = stat.LastProcessedEventNumber,
-                    ParkedMessageUri = MakeUrl(manager, string.Format("/streams/$persistentsubscription-{0}::{1}-parked", stat.EventStreamId, stat.GroupName)),
-                    GetMessagesUri = MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/{2}", stat.EventStreamId, stat.GroupName, DefaultNumberOfMessagesToGet)),
+                    ParkedMessageUri = MakeUrl(manager, string.Format(parkedMessageUriTemplate, escapedStreamId, escapedGroupName)),
+                    GetMessagesUri = MakeUrl(manager, string.Format("/subscriptions/{0}/{1}/{2}", escapedStreamId, escapedGroupName, DefaultNumberOfMessagesToGet)),
                     TotalInFlightMessages = stat.TotalInFlightMessages,
                 };
                 if (stat.Connections != null)

--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -156,7 +156,7 @@ namespace EventStore.Core.Services.Transport.Http
             string escapedGroupName = Uri.EscapeDataString(groupName);
             var self = HostName.Combine(requestedUrl, "/subscriptions/{0}/{1}", escapedStreamId, escapedGroupName);
             var feed = new FeedElement();
-            feed.SetTitle(String.Format("Messages for {0}/{1}", escapedStreamId, escapedGroupName));
+            feed.SetTitle(string.Format("Messages for '{0}/{1}'", streamId, groupName));
             feed.SetId(self);
             feed.SetUpdated(msg.Events.Length > 0 && msg.Events[0].Event != null ? msg.Events[msg.Events.Length - 1].Event.TimeStamp : DateTime.MinValue.ToUniversalTime());
             feed.SetAuthor(AtomSpecs.Author);
@@ -190,20 +190,21 @@ namespace EventStore.Core.Services.Transport.Http
 
         public static DescriptionDocument ToDescriptionDocument(Uri requestedUrl, string streamId, string[] subscriptions)
         {
+            string escapedStreamId = Uri.EscapeDataString(streamId);
             var descriptionDocument = new DescriptionDocument();
-            descriptionDocument.SetTitle("description document for " + streamId);
-            descriptionDocument.SetDescription(@"The description document will be presented when no accept header is present or it was requested)");
+            descriptionDocument.SetTitle(string.Format("Description document for '{0}'", streamId));
+            descriptionDocument.SetDescription(@"The description document will be presented when no accept header is present or it was requested");
 
-            descriptionDocument.SetSelf("/streams/" + streamId,
+            descriptionDocument.SetSelf("/streams/" + escapedStreamId,
                                     Codec.DescriptionJson.ContentType);
 
-            descriptionDocument.SetStream("/streams/" + streamId,
+            descriptionDocument.SetStream("/streams/" + escapedStreamId,
                                     Codec.EventStoreXmlCodec.ContentType,
                                     Codec.EventStoreJsonCodec.ContentType);
 
             if (subscriptions != null) {
                 foreach (var group in subscriptions) {
-                    descriptionDocument.AddStreamSubscription(String.Format("/subscriptions/{0}/{1}", streamId, group),
+                    descriptionDocument.AddStreamSubscription(String.Format("/subscriptions/{0}/{1}", escapedStreamId, group),
                                     Codec.CompetingXml.ContentType,
                                     Codec.CompetingJson.ContentType);
                 }


### PR DESCRIPTION
- When URIs get sent to the client, there needs to be consistency across
the APIs (Atom, Competing Consumers, etc).

- Last Known Message gets used as the checkpoint in case there are no outstanding messages and affects the statistical information that gets used to display information to the user in the administration UI.
It gets set as part of pushing messages to the clients which only applies to TCP for now. This is now set as part of reading messages which specifically applies to HTTP Competing Consumers.