### PR TITLE
Set head of stream when reading forward

### DIFF
--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.Http.Streams
     {
         public abstract class SpecificationWithLongFeed : HttpBehaviorSpecification
         {
-            private int _numberOfEvents;
+            protected int _numberOfEvents;
 
             protected override void Given()
             {
@@ -575,5 +575,52 @@ namespace EventStore.Core.Tests.Http.Streams
             }
         }
 
+        [TestFixture, Category("LongRunning")]
+        public class when_reading_a_stream_forward_from_beginning_asking_for_less_events_than_in_the_stream : SpecificationWithLongFeed
+        {
+            private JObject _feed;
+            protected override void When()
+            {
+                _feed = GetJson<JObject>(TestStream + "/0/forward/" + (_numberOfEvents - 1), accept: ContentType.AtomJson);
+            }
+
+            [Test]
+            public void the_head_of_stream_is_false()
+            {
+                Assert.AreEqual(false, _feed.Value<bool>("headOfStream"));
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class when_reading_a_stream_forward_from_beginning_asking_for_more_events_than_in_the_stream : SpecificationWithLongFeed
+        {
+            private JObject _feed;
+            protected override void When()
+            {
+                _feed = GetJson<JObject>(TestStream + "/0/forward/" + (_numberOfEvents + 1), accept: ContentType.AtomJson);
+            }
+
+            [Test]
+            public void the_head_of_stream_is_true()
+            {
+                Assert.AreEqual(true, _feed.Value<bool>("headOfStream"));
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class when_reading_a_stream_forward_from_beginning_asking_for_exactly_the_events_in_the_stream : SpecificationWithLongFeed
+        {
+            private JObject _feed;
+            protected override void When()
+            {
+                _feed = GetJson<JObject>(TestStream + "/0/forward/" + _numberOfEvents, accept: ContentType.AtomJson);
+            }
+
+            [Test]
+            public void the_head_of_stream_is_true()
+            {
+                Assert.AreEqual(true, _feed.Value<bool>("headOfStream"));
+            }
+        }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Services.Transport.Http
             feed.SetId(self);
             feed.SetUpdated(msg.Events.Length > 0 && msg.Events[0].Event != null ? msg.Events[0].Event.TimeStamp : DateTime.MinValue.ToUniversalTime());
             feed.SetAuthor(AtomSpecs.Author);
+            feed.SetHeadOfStream(msg.IsEndOfStream);
 
             var prevEventNumber = Math.Min(msg.FromEventNumber + msg.MaxCount - 1, msg.LastEventNumber) + 1;
             var nextEventNumber = msg.FromEventNumber - 1;
@@ -43,10 +44,6 @@ namespace EventStore.Core.Services.Transport.Http
             {
                 feed.AddLink("last", HostName.Combine(requestedUrl, "/streams/{0}/{1}/forward/{2}", escapedStreamId, 0, msg.MaxCount));
                 feed.AddLink("next", HostName.Combine(requestedUrl, "/streams/{0}/{1}/backward/{2}", escapedStreamId, nextEventNumber, msg.MaxCount));
-            }
-            if (!msg.IsEndOfStream && msg.Events.Length == msg.MaxCount)
-            {
-                feed.SetHeadOfStream(true);
             }
             if (!msg.IsEndOfStream || msg.Events.Length > 0)
                 feed.AddLink("previous", HostName.Combine(requestedUrl, "/streams/{0}/{1}/forward/{2}", escapedStreamId, prevEventNumber, msg.MaxCount));


### PR DESCRIPTION
While investigating this issue in the UI (https://github.com/EventStore/EventStore.UI/issues/85), i noticed that the head of stream is not correctly being set when reading forward and this results in the UI wanting to poll when it should not be.

The head of stream should be set to whatever was returned from the read. (https://github.com/EventStore/EventStore/blob/release-v3.4.0/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs#L198)

This is the case when reading backwards (https://github.com/EventStore/EventStore/blob/7b0cc4299bb5b2def5d1ea01e92c48af6681e480/src/EventStore.Core/Services/Transport/Http/Convert.cs#L72)
