### PR TITLE
Show scavenge status in the UI

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
@@ -70,6 +70,7 @@ namespace EventStore.ClientAPI.Embedded
 
         private IAuthenticationProviderFactory _authenticationProviderFactory;
         private bool _disableScavengeMerging;
+        private int _scavengeHistoryMaxAge;
         private bool _adminOnPublic;
         private bool _statsOnPublic;
         private bool _gossipOnPublic;
@@ -135,6 +136,7 @@ namespace EventStore.ClientAPI.Embedded
 
             _authenticationProviderFactory = new InternalAuthenticationProviderFactory();
             _disableScavengeMerging = Opts.DisableScavengeMergeDefault;
+            _scavengeHistoryMaxAge = Opts.ScavengeHistoryMaxAgeDefault;
             _adminOnPublic = Opts.AdminOnExtDefault;
             _statsOnPublic = Opts.StatsOnExtDefault;
             _gossipOnPublic = Opts.GossipOnExtDefault;
@@ -696,6 +698,7 @@ namespace EventStore.ClientAPI.Embedded
                     _nodePriority,
                     _authenticationProviderFactory,
                     _disableScavengeMerging,
+                    _scavengeHistoryMaxAge,
                     _adminOnPublic,
                     _statsOnPublic,
                     _gossipOnPublic,

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -95,6 +95,8 @@ namespace EventStore.ClusterNode
         public bool GossipOnExt { get; set; }
         [ArgDescription(Opts.DisableScavengeMergeDescr, Opts.DbGroup)]
         public bool DisableScavengeMerging { get; set; }
+        [ArgDescription(Opts.ScavengeHistoryMaxAgeDescr, Opts.DbGroup)]
+        public int ScavengeHistoryMaxAge { get; set; }
 
         [ArgDescription(Opts.DiscoverViaDnsDescr, Opts.ClusterGroup)]
         public bool DiscoverViaDns { get; set; }
@@ -269,6 +271,7 @@ namespace EventStore.ClusterNode
             PrepareTimeoutMs = Opts.PrepareTimeoutMsDefault;
             CommitTimeoutMs = Opts.CommitTimeoutMsDefault;
             DisableScavengeMerging = Opts.DisableScavengeMergeDefault;
+            ScavengeHistoryMaxAge = Opts.ScavengeHistoryMaxAgeDefault;
             GossipOnExt = Opts.GossipOnExtDefault;
             StatsOnExt = Opts.StatsOnExtDefault;
             AdminOnExt = Opts.AdminOnExtDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -267,7 +267,7 @@ namespace EventStore.ClusterNode
                     options.UseInternalSsl, options.SslTargetHost, options.SslValidateServer,
                     TimeSpan.FromSeconds(options.StatsPeriodSec), StatsStorage.StreamAndCsv,
                     options.NodePriority, authenticationProviderFactory, options.DisableScavengeMerging,
-                    options.AdminOnExt, options.StatsOnExt, options.GossipOnExt,
+                    options.ScavengeHistoryMaxAge, options.AdminOnExt, options.StatsOnExt, options.GossipOnExt,
                     TimeSpan.FromMilliseconds(options.GossipIntervalMs),
                     TimeSpan.FromMilliseconds(options.GossipAllowedDifferenceMs),
                     TimeSpan.FromMilliseconds(options.GossipTimeoutMs),

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -398,6 +398,7 @@
     <Compile Include="Services\Storage\Scavenge\when_writing_delete_prepare_without_commit_on_stream_spanning_through_2_chunks_in_db_with_2_chunks.cs" />
     <Compile Include="Services\Storage\Scavenge\when_deleting_single_stream_spanning_through_2_chunks_in_db_with_3_chunks.cs" />
     <Compile Include="Services\Storage\Scavenge\when_deleting_single_stream_spanning_through_2_chunks_in_db_with_2_chunks.cs" />
+    <Compile Include="Services\Storage\Scavenge\when_running_a_scavenge_from_storage_scavenger.cs" />
     <Compile Include="Services\Storage\DeletingStream\when_deleting_stream_spanning_through_multiple_chunks_in_db_with_other_streams_read_index_should.cs" />
     <Compile Include="Services\Storage\DeletingStream\deleting_stream_tests_2.cs" />
     <Compile Include="Services\Storage\DeletingStream\deleting_stream_tests_3.cs" />

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -86,7 +86,7 @@ namespace EventStore.Core.Tests.Helpers
                 new[] {InternalHttpEndPoint.ToHttpUrl()}, new[]{ExternalHttpEndPoint.ToHttpUrl()}, enableTrustedAuth, ssl_connections.GetCertificate(), 1, false,
                 "", gossipSeeds, TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2),
                 false, "", false, TimeSpan.FromHours(1), StatsStorage.None, 0,
-                new InternalAuthenticationProviderFactory(), disableScavengeMerging: true, adminOnPublic: true,
+                new InternalAuthenticationProviderFactory(), disableScavengeMerging: true, scavengeHistoryMaxAge: 30, adminOnPublic: true,
                 statsOnPublic: true, gossipOnPublic: true, gossipInterval: TimeSpan.FromSeconds(1),
                 gossipAllowedTimeDifference: TimeSpan.FromSeconds(1), gossipTimeout: TimeSpan.FromSeconds(1),
                 extTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), extTcpHeartbeatInterval: TimeSpan.FromSeconds(10),

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -114,6 +114,7 @@ namespace EventStore.Core.Tests.Helpers
                                                          1,
                                                          new InternalAuthenticationProviderFactory(),
                                                          true,
+                                                         30,
                                                          true,
                                                          true,
                                                          false,

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService
                 false, null, 1, false, "dns", new[] { GetLoopbackForPort(ManagerPort) },
                 TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(2),
                 TimeSpan.FromSeconds(2), false, null, false, TimeSpan.FromHours(1),
-                StatsStorage.StreamAndCsv, 0, new InternalAuthenticationProviderFactory(), false, true, true, true,
+                StatsStorage.StreamAndCsv, 0, new InternalAuthenticationProviderFactory(), false, 30, true, true, true,
                 TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1),
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Storage;
+using EventStore.Core.Services.UserManagement;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.Scavenge
+{
+    [TestFixture]
+	public class when_running_scavenge_from_storage_scavenger : TestFixtureWithExistingEvents
+    {
+        protected EventStore.Core.Services.Storage.StorageScavenger _scavenger;
+        private ManualResetEvent _hasCompletedScavenge = new ManualResetEvent(false);
+
+        protected override void Given()
+        {
+            base.Given();
+
+			var typeName = GetType().Name.Length > 30 ? GetType().Name.Substring(0, 30) : GetType().Name;
+			var pathName = Path.Combine(Path.GetTempPath(), string.Format("{0}-{1}", Guid.NewGuid(), typeName));
+			Directory.CreateDirectory(pathName);
+
+        	var db = new TFChunkDb(new TFChunkDbConfig(pathName,
+			                                        new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
+			                                        16 * 1024,
+			                                        0,
+			                                        new InMemoryCheckpoint(),
+			                                        new InMemoryCheckpoint(),
+			                                        new InMemoryCheckpoint(-1),
+			                                        new InMemoryCheckpoint(-1)));
+			db.Open();
+			_scavenger = new StorageScavenger(db, _ioDispatcher, new FakeTableIndex(), new ByLengthHasher(),
+			                                  new FakeReadIndex(x => x == "es-to-scavenge"), true, "fakeNodeIp", true, 30);
+
+            var scavengeMessage = new ClientMessage.ScavengeDatabase(Envelope, Guid.NewGuid(), SystemAccount.Principal);
+            _bus.Subscribe<ClientMessage.ScavengeDatabaseCompleted>(new AdHocHandler<ClientMessage.ScavengeDatabaseCompleted>(
+                           x => {_hasCompletedScavenge.Set();}));
+            _scavenger.Handle(scavengeMessage);
+        }
+
+        [Test]
+        public void creates_scavenge_started_events_in_both_streams()
+        {
+            Assert.IsTrue(_hasCompletedScavenge.WaitOne(TimeSpan.FromSeconds(5)));
+
+            var scavengeInstanceStreamResults = GetMessagesFromScavengeInstanceStream();
+            var scavengeEventResults = GetMessagesFromScavengesStream();
+
+        	Assert.AreEqual(1, scavengeInstanceStreamResults.Count(x => x.Events.Any(y => y.EventType == SystemEventTypes.ScavengeStarted)));
+            Assert.AreEqual(1, scavengeEventResults.Count(x => x.Events.Any(y => y.EventType == SystemEventTypes.ScavengeStarted)));
+        }
+
+        [Test]
+        public void creates_scavenge_completed_events_in_both_streams()
+        {
+            Assert.IsTrue(_hasCompletedScavenge.WaitOne(TimeSpan.FromSeconds(5)));
+
+            var scavengeInstanceStreamResults = GetMessagesFromScavengeInstanceStream();
+            var scavengeEventResults = GetMessagesFromScavengesStream();
+
+        	Assert.AreEqual(1, scavengeInstanceStreamResults.Count(x => x.Events.Any(y => y.EventType == SystemEventTypes.ScavengeCompleted)));
+        	Assert.AreEqual(1, scavengeEventResults.Count(x => x.Events.Any(y => y.EventType == SystemEventTypes.ScavengeCompleted)));
+        }
+
+        [Test]
+        public void creates_a_metadata_stream()
+        {
+            Assert.IsTrue(_hasCompletedScavenge.WaitOne(TimeSpan.FromSeconds(5)));
+
+            var metadataMessages = HandledMessages.OfType<ClientMessage.WriteEvents>()
+                    .Where(v=>
+                            v.EventStreamId.StartsWith(
+                                Core.Services.SystemStreams.MetastreamOf(Core.Services.SystemStreams.ScavengesStream) + "-")
+                    ).ToList<ClientMessage.WriteEvents>();
+
+            Assert.AreEqual(1, metadataMessages.Count());
+        }
+
+        protected List<ClientMessage.WriteEvents> GetMessagesFromScavengeInstanceStream() {
+            return HandledMessages.OfType<ClientMessage.WriteEvents>()
+    				.Where(v =>
+    				        v.EventStreamId.StartsWith(Core.Services.SystemStreams.ScavengesStream + "-")
+    		        ).ToList<ClientMessage.WriteEvents>();
+        }
+
+        protected List<ClientMessage.WriteEvents> GetMessagesFromScavengesStream() {
+            return HandledMessages.OfType<ClientMessage.WriteEvents>()
+                    .Where(v =>
+                           v.EventStreamId.StartsWith(Core.Services.SystemStreams.ScavengesStream))
+                    .ToList<ClientMessage.WriteEvents>();
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using EventStore.Core.Bus;
 using EventStore.Core.DataStructures;
+using EventStore.Core.Helpers;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
+using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Settings;
 using EventStore.Core.Tests.Fakes;
@@ -66,7 +69,9 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
             ReadIndex.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 
             //var scavengeReadIndex = new ScavengeReadIndex(_dbResult.Streams, _metastreamMaxCount);
-            var scavenger = new TFChunkScavenger(_dbResult.Db, tableIndex, hasher, ReadIndex);
+            var bus = new InMemoryBus("Bus");
+            var ioDispatcher = new IODispatcher(bus, new PublishEnvelope(bus));
+            var scavenger = new TFChunkScavenger(_dbResult.Db, ioDispatcher, tableIndex, hasher, ReadIndex, Guid.NewGuid(), "fakeNodeIp");
             scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);
         }
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -47,6 +47,7 @@ namespace EventStore.Core.Cluster.Settings
 
         public readonly IAuthenticationProviderFactory AuthenticationProviderFactory;
         public readonly bool DisableScavengeMerging;
+        public readonly int ScavengeHistoryMaxAge;
         public bool AdminOnPublic;
         public bool StatsOnPublic;
         public bool GossipOnPublic;
@@ -96,6 +97,7 @@ namespace EventStore.Core.Cluster.Settings
                                     int nodePriority,
                                     IAuthenticationProviderFactory authenticationProviderFactory,
                                     bool disableScavengeMerging,
+                                    int scavengeHistoryMaxAge,
                                     bool adminOnPublic,
                                     bool statsOnPublic,
                                     bool gossipOnPublic,
@@ -172,6 +174,7 @@ namespace EventStore.Core.Cluster.Settings
 
             NodePriority = nodePriority;
             DisableScavengeMerging = disableScavengeMerging;
+            ScavengeHistoryMaxAge = scavengeHistoryMaxAge;
             AdminOnPublic = adminOnPublic;
             StatsOnPublic = statsOnPublic;
             GossipOnPublic = gossipOnPublic;
@@ -228,7 +231,8 @@ namespace EventStore.Core.Cluster.Settings
                                  + "GossipTimeout: {31}\n"
                                  + "HistogramEnabled: {32}\n"
                                  + "HTTPCachingDisabled: {33}\n"
-                                 + "IndexPath: {34}\n",
+                                 + "IndexPath: {34}\n"
+                                 + "ScavengeHistoryMaxAge: {35}\n",
                                  NodeInfo.InstanceId,
                                  NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
                                  NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -243,7 +247,8 @@ namespace EventStore.Core.Cluster.Settings
                                  PrepareAckCount, CommitAckCount, PrepareTimeout, CommitTimeout,
                                  UseSsl, SslTargetHost, SslValidateServer,
                                  StatsPeriod, StatsStorage, AuthenticationProviderFactory.GetType(),
-                                 NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout, EnableHistograms, DisableHTTPCaching, Index);
+                                 NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout,
+                                 EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge);
         }
     }
 }

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -1,13 +1,17 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Services.Storage
@@ -17,28 +21,36 @@ namespace EventStore.Core.Services.Storage
         private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
 
         private readonly TFChunkDb _db;
+        private readonly IODispatcher _ioDispatcher;
         private readonly ITableIndex _tableIndex;
         private readonly IHasher _hasher;
         private readonly IReadIndex _readIndex;
         private readonly bool _alwaysKeepScavenged;
         private readonly bool _mergeChunks;
+        private readonly string _nodeEndpoint;
+        private readonly int _scavengeHistoryMaxAge;
 
         private int _isScavengingRunning;
 
-        public StorageScavenger(TFChunkDb db, ITableIndex tableIndex, IHasher hasher, 
-                                IReadIndex readIndex, bool alwaysKeepScavenged, bool mergeChunks)
+        public StorageScavenger(TFChunkDb db, IODispatcher ioDispatcher, ITableIndex tableIndex, IHasher hasher,
+                                IReadIndex readIndex, bool alwaysKeepScavenged, string nodeEndpoint, bool mergeChunks, int scavengeHistoryMaxAge)
         {
             Ensure.NotNull(db, "db");
+            Ensure.NotNull(ioDispatcher, "ioDispatcher");
             Ensure.NotNull(tableIndex, "tableIndex");
             Ensure.NotNull(hasher, "hasher");
             Ensure.NotNull(readIndex, "readIndex");
+            Ensure.NotNull(nodeEndpoint, "nodeEndpoint");
 
             _db = db;
+            _ioDispatcher = ioDispatcher;
             _tableIndex = tableIndex;
             _hasher = hasher;
             _readIndex = readIndex;
             _alwaysKeepScavenged = alwaysKeepScavenged;
             _mergeChunks = mergeChunks;
+            _nodeEndpoint = nodeEndpoint;
+            _scavengeHistoryMaxAge = scavengeHistoryMaxAge;
         }
 
         public void Handle(ClientMessage.ScavengeDatabase message)
@@ -47,21 +59,21 @@ namespace EventStore.Core.Services.Storage
             {
                 ThreadPool.QueueUserWorkItem(_ => Scavenge(message));
             }
-            else 
+            else
             {
-                message.Envelope.ReplyWith(
-                    new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId, 
-                                                                ClientMessage.ScavengeDatabase.ScavengeResult.InProgress,
-                                                                "Scavenge already in progress.", 
-                                                                TimeSpan.FromMilliseconds(0),
-                                                                0)
-                    );
+                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId,
+                                                            ClientMessage.ScavengeDatabase.ScavengeResult.InProgress,
+                                                            "Scavenge already in progress.",
+                                                            TimeSpan.FromMilliseconds(0),
+                                                            0));
             }
         }
 
         private void Scavenge(ClientMessage.ScavengeDatabase message)
         {
             var sw = Stopwatch.StartNew();
+            Guid scavengeId = Guid.NewGuid();
+            var streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, scavengeId);
             ClientMessage.ScavengeDatabase.ScavengeResult result;
             string error = null;
             long spaceSaved = 0;
@@ -74,8 +86,10 @@ namespace EventStore.Core.Services.Storage
                 }
                 else
                 {
-                    var scavenger = new TFChunkScavenger(_db, _tableIndex, _hasher, _readIndex);
-                    spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
+                    PublishScavengeStartedEvent(streamName, scavengeId);
+                    
+                    var scavenger = new TFChunkScavenger(_db, _ioDispatcher, _tableIndex, _hasher, _readIndex, scavengeId, _nodeEndpoint);
+					spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
                     result = ClientMessage.ScavengeDatabase.ScavengeResult.Success;
                 }
             }
@@ -88,8 +102,42 @@ namespace EventStore.Core.Services.Storage
 
             Interlocked.Exchange(ref _isScavengingRunning, 0);
 
+            var evnt = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeCompleted, true, new Dictionary<string, object>{
+                    {"scavengeId", scavengeId},
+                    {"nodeEndpoint", _nodeEndpoint},
+                    {"result", result},
+                    {"error", error},
+                    {"timeTaken", sw.Elapsed},
+                    {"spaceSaved", spaceSaved}
+                }.ToJsonBytes(), null);
+
+            _ioDispatcher.WriteEvent(streamName, ExpectedVersion.Any, evnt, SystemAccount.Principal, x => WriteScavengeEventCompleted(x, streamName));
             message.Envelope.ReplyWith(
-                new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId, result, error, sw.Elapsed, spaceSaved));
+                new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId, result, error, sw.Elapsed, spaceSaved)
+            );
+        }
+
+        private void PublishScavengeStartedEvent(string streamName, Guid scavengeId)
+        {
+            var metadataEventId = Guid.NewGuid();
+            var metaStreamId = SystemStreams.MetastreamOf(streamName);
+            var metadata = new StreamMetadata(maxAge: TimeSpan.FromDays(_scavengeHistoryMaxAge));
+            var metaStreamEvent = new Event(metadataEventId, SystemEventTypes.StreamMetadata, isJson: true,
+                                            data: metadata.ToJsonBytes(), metadata: null);
+            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => { });
+
+            var scavengeStartEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeStarted, true, new Dictionary<string, object>{
+                    {"scavengeId", scavengeId},
+                    {"nodeEndpoint", _nodeEndpoint},
+                }.ToJsonBytes(), null);
+            _ioDispatcher.WriteEvent(streamName, ExpectedVersion.Any, scavengeStartEvent, SystemAccount.Principal, x => WriteScavengeEventCompleted(x, streamName));
+        }
+
+        private void WriteScavengeEventCompleted(ClientMessage.WriteEventsCompleted msg, string streamName)
+        {
+            string eventLinkTo = string.Format("{0}@{1}", msg.FirstEventNumber, streamName);
+            var scavengeCompleteEvent = new Event(Guid.NewGuid(), SystemEventTypes.LinkTo, false, eventLinkTo, null);
+            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.Any, scavengeCompleteEvent, SystemAccount.Principal, n => { });
         }
     }
 }

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -23,6 +23,7 @@ namespace EventStore.Core.Services
         public const string StreamsStream = "$streams";
         public const string SettingsStream = "$settings";
         public const string StatsStreamPrefix = "$stats";
+        public const string ScavengesStream = "$scavenges";
 
         public static bool IsSystemStream(string streamId)
         {
@@ -77,6 +78,10 @@ namespace EventStore.Core.Services
         public const string V2__StreamCreated_InIndex = "StreamCreated";
         public const string V1__StreamCreated__ = "$stream-created";
         public const string V1__StreamCreatedImplicit__ = "$stream-created-implicit";
+
+        public const string ScavengeStarted = "$scavengeStarted";
+        public const string ScavengeCompleted = "$scavengeCompleted";
+        public const string ScavengeChunksCompleted = "$scavengeChunksCompleted";
 
         public static string StreamReferenceEventToStreamId(string eventType, byte[] data)
         {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -14,7 +14,8 @@ using EventStore.Core.Messages;
 
 namespace EventStore.Core.Services.Transport.Http.Controllers
 {
-    public class InfoController : IHttpController, IHandle<SystemMessage.StateChangeMessage>
+    public class InfoController : IHttpController,
+                                  IHandle<SystemMessage.StateChangeMessage>
     {
         private static readonly ILogger Log = LogManager.GetLoggerFor<InfoController>();
         private static readonly ICodec[] SupportedCodecs = { Codec.Json, Codec.Xml, Codec.ApplicationXml, Codec.Text };
@@ -22,6 +23,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         private readonly IOptions _options;
         private readonly ProjectionType _projectionType;
         private VNodeState _currentState;
+
         public InfoController(IOptions options, ProjectionType projectionType)
         {
             _options = options;

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -83,6 +83,9 @@ namespace EventStore.Core.Util
         public const string DisableScavengeMergeDescr = "Disables the merging of chunks when scavenge is running";
         public static readonly bool DisableScavengeMergeDefault = false;
 
+        public const string ScavengeHistoryMaxAgeDescr = "The number of days to keep scavenge history";
+        public static readonly int ScavengeHistoryMaxAgeDefault = 30;
+
         public const string DbPathDescr = "The path the db should be loaded/saved to.";
         public const string IndexPathDescr = "The path the index should be loaded/saved to.";
 


### PR DESCRIPTION
Fixes #714 by showing the scavenge status in the UI. I updated the scavenger to publish a message when it finishes scavenging a chunk and used that to display the progress in the UI, which ends up looking like this :

![scavengestatus](https://cloud.githubusercontent.com/assets/5140165/11897220/8b012b48-a596-11e5-933c-5763acd2eb37.png)

On a related note: it doesn't look like there is any scavenge history being stored. Would it not be useful to create a stream called $scavenges and store the info in that stream?