### PR TITLE
Race condition when reconnecting to store

### DIFF
--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -230,7 +230,7 @@ namespace EventStore.ClientAPI.Transport.Tcp
         private void ProcessReceive(SocketAsyncEventArgs socketArgs)
         {
             // socket closed normally or some error occurred
-            if (socketArgs.BytesTransferred == 0 || socketArgs.SocketError != SocketError.Success)
+            if (socketArgs.BytesTransferred == 0 && socketArgs.SocketError != SocketError.Success)
             {
                 NotifyReceiveCompleted(0);
                 ReturnReceivingSocketArgs();

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -230,7 +230,7 @@ namespace EventStore.ClientAPI.Transport.Tcp
         private void ProcessReceive(SocketAsyncEventArgs socketArgs)
         {
             // socket closed normally or some error occurred
-            if (socketArgs.BytesTransferred == 0 && socketArgs.SocketError != SocketError.Success)
+            if (socketArgs.BytesTransferred == 0 || socketArgs.SocketError != SocketError.Success)
             {
                 NotifyReceiveCompleted(0);
                 ReturnReceivingSocketArgs();


### PR DESCRIPTION
Added _isProcessing flag check before running a new catchup subscription, prevents ProcessLiveQueue and catch up from running at the same time creating a race condition in which 1 or more events can be processed twice.

ProcessReceive is capable of receiving 0 length messages, so don't disconnect the socket simply because of that.
Fixed couple of log messages