### PR TITLE
Show TCP stats in the UI

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -460,6 +460,7 @@
     <Compile Include="Services\Transport\Http\PortableServer.cs" />
     <Compile Include="Services\Transport\Http\ping_controller_should.cs" />
     <Compile Include="Services\Transport\Http\when_getting_replica_stats_from_stat_controller.cs" />
+    <Compile Include="Services\Transport\Http\when_getting_tcp_stats_from_stat_controller.cs" />
     <Compile Include="MightyMooseIgnoreAttribute.cs" />
     <Compile Include="Services\Transport\Http\proxy_headers.cs" />
     <Compile Include="Services\Transport\Http\speed_test.cs" />

--- a/src/EventStore.Core.Tests/Services/Transport/Http/HttpBootstrap.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/HttpBootstrap.cs
@@ -2,6 +2,7 @@
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Core.Services.Transport.Http.Controllers;
+using EventStore.Core.Tests.Fakes;
 
 namespace EventStore.Core.Tests.Services.Transport.Http
 {
@@ -24,6 +25,11 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         public static void RegisterPing(HttpService service)
         {
             service.SetupController(new PingController());
+        }
+
+        public static void RegisterStat(HttpService service)
+        {
+            service.SetupController(new StatController(new FakePublisher(), new FakePublisher()));
         }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_tcp_stats_from_stat_controller.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_tcp_stats_from_stat_controller.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using EventStore.ClientAPI;
+using EventStore.Common.Utils;
+using EventStore.Core.Messages;
+using EventStore.Transport.Http;
+using EventStore.Transport.Http.Codecs;
+using NUnit.Framework;
+using EventStore.Core.Tests.ClientAPI;
+using EventStore.Core.Tests.Helpers;
+
+namespace EventStore.Core.Tests.Services.Transport.Http
+{
+    [TestFixture]
+    public class when_getting_tcp_stats_from_stat_controller : SpecificationWithMiniNode
+    {
+        private PortableServer _portableServer;
+        private IPEndPoint _serverEndPoint;
+        private IEventStoreConnection _connection;
+        private string _url;
+        
+        private List<MonitoringMessage.TcpConnectionStats> _results = new List<MonitoringMessage.TcpConnectionStats>();
+        
+        protected override void Given()
+        {
+            _serverEndPoint = new IPEndPoint(IPAddress.Loopback, PortsHelper.GetAvailablePort(IPAddress.Loopback));
+            _url = _HttpEndPoint.ToHttpUrl("/stats/tcp");
+            
+            var settings = ConnectionSettings.Create();
+            _connection = EventStoreConnection.Create(settings, _node.TcpEndPoint);
+            _connection.ConnectAsync().Wait();
+            
+            var testEvent = new EventData(Guid.NewGuid(),"TestEvent",true,Encoding.ASCII.GetBytes("{'Test' : 'OneTwoThree'}"),null);
+            _connection.AppendToStreamAsync("tests",ExpectedVersion.Any,testEvent).Wait();
+            
+            _portableServer = new PortableServer(_serverEndPoint);
+            _portableServer.SetUp();
+        }
+        
+        protected override void When()
+        {
+            Func<HttpResponse, bool> verifier = response => {
+                _results = Codec.Json.From<List<MonitoringMessage.TcpConnectionStats>>(response.Body);
+                return true;
+            };
+            
+            _portableServer.StartServiceAndSendRequest(y => {}, _url, verifier);
+        }
+
+        [Test]
+        public void should_return_the_external_connections()
+        {
+            Assert.AreEqual(2, _results.Count(r => r.IsExternalConnection));
+        }
+        
+        [Test]
+        public void should_return_the_total_number_of_bytes_sent_for_external_connections()
+        {
+            Assert.Greater(_results.Sum(r=> r.IsExternalConnection ? r.TotalBytesSent : 0), 0);
+        }
+        
+        [Test]
+        public void should_return_the_total_number_of_bytes_received_from_external_connections()
+        {
+            Assert.Greater(_results.Sum(r => r.IsExternalConnection ? r.TotalBytesReceived : 0), 0);
+        }
+        
+        [TestFixtureTearDown]
+        public override void TestFixtureTearDown()
+        {
+            _portableServer.TearDown();
+            _connection.Dispose();
+            base.TestFixtureTearDown();
+        }
+    }
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -131,7 +131,8 @@ namespace EventStore.Core
                                                    db.Config.Path,
                                                    vNodeSettings.StatsPeriod,
                                                    _nodeInfo.ExternalHttp,
-                                                   vNodeSettings.StatsStorage);
+                                                   vNodeSettings.StatsStorage,
+                                                   _nodeInfo.ExternalTcp);
             _mainBus.Subscribe(monitoringQueue.WidenFrom<SystemMessage.SystemInit, Message>());
             _mainBus.Subscribe(monitoringQueue.WidenFrom<SystemMessage.StateChangeMessage, Message>());
             _mainBus.Subscribe(monitoringQueue.WidenFrom<SystemMessage.BecomeShuttingDown, Message>());
@@ -143,6 +144,7 @@ namespace EventStore.Core
             monitoringInnerBus.Subscribe<SystemMessage.BecomeShutdown>(monitoring);
             monitoringInnerBus.Subscribe<ClientMessage.WriteEventsCompleted>(monitoring);
             monitoringInnerBus.Subscribe<MonitoringMessage.GetFreshStats>(monitoring);
+            monitoringInnerBus.Subscribe<MonitoringMessage.GetFreshTcpConnectionStats>(monitoring);
 
             var truncPos = db.Config.TruncateCheckpoint.Read();
             if (truncPos != -1)

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -167,6 +167,46 @@ namespace EventStore.Core.Messages
             }
         }
 
+        public class GetFreshTcpConnectionStats : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly IEnvelope Envelope;
+
+            public GetFreshTcpConnectionStats(IEnvelope envelope)
+            {
+                Ensure.NotNull(envelope, "envelope");
+
+                Envelope = envelope;
+            }
+        }
+
+        public class GetFreshTcpConnectionStatsCompleted : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly List<TcpConnectionStats> ConnectionStats;
+
+            public GetFreshTcpConnectionStatsCompleted(List<TcpConnectionStats> connectionStats)
+            {
+                ConnectionStats = connectionStats;
+            }
+        }
+
+        public class TcpConnectionStats
+        {
+            public string RemoteEndPoint { get; set; }
+            public string LocalEndPoint { get; set; }
+            public Guid ConnectionId { get; set; }
+            public long TotalBytesSent { get; set; }
+            public long TotalBytesReceived { get; set; }
+            public int PendingSendBytes { get; set; }
+            public int PendingReceivedBytes { get; set; }
+            public bool IsExternalConnection { get; set; }
+        }
+
         public class InternalStatsRequest : Message
         {
             private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);

--- a/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
@@ -154,12 +154,15 @@ namespace EventStore.Core.Services.Replication
             foreach (var conn in connections)
             {
                 var tcpConn = conn as TcpConnection;
-                var subscription = _subscriptions.FirstOrDefault(x => x.Value.ConnectionId == tcpConn.ConnectionId);
-                if (subscription.Value != null)
+                if (tcpConn != null)
                 {
-                    var stats = new ReplicationMessage.ReplicationStats(subscription.Key, tcpConn.ConnectionId, subscription.Value.ReplicaEndPoint.ToString(), tcpConn.SendQueueSize,
-                                        (int)conn.TotalBytesSent, (int)conn.TotalBytesReceived, conn.PendingSendBytes, conn.PendingReceivedBytes);
-                    replicaStats.Add(stats);
+                    var subscription = _subscriptions.FirstOrDefault(x => x.Value.ConnectionId == tcpConn.ConnectionId);
+                    if (subscription.Value != null)
+                    {
+                        var stats = new ReplicationMessage.ReplicationStats(subscription.Key, tcpConn.ConnectionId, subscription.Value.ReplicaEndPoint.ToString(), tcpConn.SendQueueSize,
+                                            (int)conn.TotalBytesSent, (int)conn.TotalBytesReceived, conn.PendingSendBytes, conn.PendingReceivedBytes);
+                        replicaStats.Add(stats);
+                    }
                 }
             }
             message.Envelope.ReplyWith(new ReplicationMessage.GetReplicationStatsCompleted(replicaStats));

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -402,5 +402,17 @@ namespace EventStore.Core.Services.Transport.Http
 
             var cacheSeconds = (int)MonitoringService.MemoizePeriod.TotalSeconds;
             return Ok(entity.ResponseCodec.ContentType, Helper.UTF8NoBom, null, cacheSeconds, isCachePublic: true);
-        }}
+        }
+
+        public static ResponseConfiguration GetFreshTcpConnectionStatsCompleted(HttpResponseConfiguratorArgs entity, Message message)
+        {
+            var completed = message as MonitoringMessage.GetFreshTcpConnectionStatsCompleted;
+            if (completed == null)
+                return InternalServerError();
+
+            var cacheSeconds = (int)MonitoringService.MemoizePeriod.TotalSeconds;
+            return Ok(entity.ResponseCodec.ContentType, Helper.UTF8NoBom, null, cacheSeconds, isCachePublic: true);
+        }
+    }
 }
+

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
@@ -27,7 +27,17 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
             service.RegisterAction(new ControllerAction("/stats", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs), OnGetFreshStats);
             service.RegisterAction(new ControllerAction("/stats/replication", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs), OnGetReplicationStats);
+            service.RegisterAction(new ControllerAction("/stats/tcp", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs), OnGetTcpConnectionStats);
             service.RegisterAction(new ControllerAction("/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs), OnGetFreshStats);
+        }
+
+        private void OnGetTcpConnectionStats(HttpEntityManager entity, UriTemplateMatch match)
+        {
+            var envelope = new SendToHttpEnvelope(_networkSendQueue,
+                                                  entity,
+                                                  Format.GetFreshTcpConnectionStatsCompleted,
+                                                  Configure.GetFreshTcpConnectionStatsCompleted);
+            Publish(new MonitoringMessage.GetFreshTcpConnectionStats(envelope));
         }
 
         private void OnGetFreshStats(HttpEntityManager entity, UriTemplateMatch match)

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -99,6 +99,15 @@ namespace EventStore.Core.Services.Transport.Http
             return entity.ResponseCodec.To(completed.ReplicationStats);
         }
 
+        public static string GetFreshTcpConnectionStatsCompleted(HttpResponseFormatterArgs entity, Message message)
+        {
+            var completed = message as MonitoringMessage.GetFreshTcpConnectionStatsCompleted;
+            if (completed == null)
+                return String.Empty;
+
+            return entity.ResponseCodec.To(completed.ConnectionStats);
+        }
+
 		public static string SendGossip(HttpResponseFormatterArgs entity, Message message)
 		{
 			if (message.GetType() != typeof(GossipMessage.SendGossip))


### PR DESCRIPTION
Creates a new route, /stats/tcp, on the StatController. This exposes the stats that TcpConnectionMonitor was collecting about each Tcp Connection.

The UI polls this route and displays the tcp stats on the dashboard, which looks like this:

![image](https://cloud.githubusercontent.com/assets/5140165/12514054/ea77c3c6-c129-11e5-821b-c8877097a0eb.png)
