### PR TITLE
Fixes Access Denied errors when building from source on Linux

### DIFF
--- a/src/EventStore.Common/Utils/Locations.cs
+++ b/src/EventStore.Common/Utils/Locations.cs
@@ -16,6 +16,7 @@ namespace EventStore.Common.Utils
         public static readonly string DefaultDataDirectory;
         public static readonly string DefaultLogDirectory;
         public static readonly string DefaultTestClientLogDirectory;
+        public static readonly string FallbackDefaultDataDirectory;
 
         static Locations()
         {
@@ -23,6 +24,7 @@ namespace EventStore.Common.Utils
                                    Path.GetFullPath(".");
 
             PluginsDirectory = Path.Combine(ApplicationDirectory, "plugins");
+            FallbackDefaultDataDirectory = Path.Combine(ApplicationDirectory, "data");
 
             switch (Platforms.GetPlatform())
             {


### PR DESCRIPTION
Fixes an issue where access is denied to the default data directory on Linux machines when building ES from source.

This fix handles access denied errors on startup. 
If the db path is the same as the default data directory, then it is changed to ./data.
Otherwise if the db path has been set to a custom path, the error is still thrown.