### PR TITLE
Adds logging for http requests and responses

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
@@ -33,6 +33,7 @@ namespace EventStore.ClientAPI.Embedded
         private bool _inMemoryDb;
         private bool _startStandardProjections;
         private bool _disableHTTPCaching;
+        private bool _logHttpRequests;
 
         private IPEndPoint _internalTcp;
         private IPEndPoint _internalSecureTcp;
@@ -156,6 +157,7 @@ namespace EventStore.ClientAPI.Embedded
 
             _startStandardProjections = Opts.StartStandardProjectionsDefault;
             _disableHTTPCaching = Opts.DisableHttpCachingDefault;
+            _logHttpRequests = Opts.LogHttpRequestsDefault;
         }
 
         /// <summary>
@@ -712,7 +714,8 @@ namespace EventStore.ClientAPI.Embedded
                     !_skipVerifyDbHashes,
                     _maxMemtableSize,
                     _startStandardProjections,
-                    _disableHTTPCaching);
+                    _disableHTTPCaching,
+                    _logHttpRequests);
             var infoController = new InfoController(null, _projectionType);
             return new ClusterVNode(db, vNodeSettings, GetGossipSource(), infoController, _subsystems.ToArray());
         }

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -186,6 +186,9 @@ namespace EventStore.ClusterNode
 
         [ArgDescription(Opts.HistogramDescr, Opts.AppGroup)]
         public bool EnableHistograms { get; set; }
+
+        [ArgDescription(Opts.LogHttpRequestsDescr, Opts.AppGroup)]
+        public bool LogHttpRequests { get; set; }
         public ClusterNodeOptions()
         {
             Config = "";
@@ -283,6 +286,7 @@ namespace EventStore.ClusterNode
 
             StartStandardProjections = Opts.StartStandardProjectionsDefault;
             DisableHTTPCaching = Opts.DisableHttpCachingDefault;
+            LogHttpRequests = Opts.LogHttpRequestsDefault;
         }
     }
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -278,6 +278,7 @@ namespace EventStore.ClusterNode
                     !options.SkipDbVerify, options.MaxMemTableSize,
                     options.StartStandardProjections,
                     options.DisableHTTPCaching,
+                    options.LogHttpRequests,
                     options.Index,
                     options.EnableHistograms,
                     options.IndexCacheDepth,

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -91,7 +91,7 @@ namespace EventStore.Core.Tests.Helpers
                 gossipAllowedTimeDifference: TimeSpan.FromSeconds(1), gossipTimeout: TimeSpan.FromSeconds(1),
                 extTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), extTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
                 intTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), intTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
-                verifyDbHash: false, maxMemtableEntryCount: memTableSize, startStandardProjections: false, disableHTTPCaching: false);
+                verifyDbHash: false, maxMemtableEntryCount: memTableSize, startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false);
 
             Log.Info(
                 "\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -128,6 +128,7 @@ namespace EventStore.Core.Tests.Helpers
                                                          false,
                                                          memTableSize,
                                                          false,
+                                                         false,
                                                          false);
             Log.Info("\n{0,-25} {1} ({2}/{3}, {4})\n"
                      + "{5,-25} {6} ({7})\n"

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
-                TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, false, false);
+                TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, false, false, false);
 
             return vnode;
         }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -55,7 +55,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
                 var httpAuthenticationProviders = new HttpAuthenticationProvider[] {new AnonymousHttpAuthenticationProvider()};
 
                 _service = new HttpService(ServiceAccessibility.Private, _bus, new NaiveUriRouter(),
-                                           _multiQueuedHandler, _serverEndPoint.ToHttpUrl());
+                                           _multiQueuedHandler, false, _serverEndPoint.ToHttpUrl());
                 HttpService.CreateAndSubscribePipeline(pipelineBus, httpAuthenticationProviders);
                 _client = new HttpAsyncClient();
             }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
@@ -138,8 +138,8 @@ namespace EventStore.Core.Tests.Services.Transport.Http
             var queue = new QueuedHandlerThreadPool(bus, "Test", true, TimeSpan.FromMilliseconds(50));
             var multiQueuedHandler = new MultiQueuedHandler(new IQueuedHandler[]{queue}, null);
             var providers = new HttpAuthenticationProvider[] {new AnonymousHttpAuthenticationProvider()};
-            var httpService = new HttpService(ServiceAccessibility.Public, inputBus, 
-                                              new TrieUriRouter(), multiQueuedHandler, "http://localhost:12345/");
+            var httpService = new HttpService(ServiceAccessibility.Public, inputBus,
+                                              new TrieUriRouter(), multiQueuedHandler, false, "http://localhost:12345/");
             HttpService.CreateAndSubscribePipeline(bus, providers);
 
             var fakeController = new FakeController(iterations, null);

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -23,6 +23,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly int WorkerThreads;
         public readonly bool StartStandardProjections;
         public readonly bool DisableHTTPCaching;
+        public readonly bool LogHttpRequests;
 
         public readonly bool DiscoverViaDns;
         public readonly string ClusterDns;
@@ -111,7 +112,9 @@ namespace EventStore.Core.Cluster.Settings
 				                    bool verifyDbHash,
 				                    int maxMemtableEntryCount,
                                     bool startStandardProjections,
-                                    bool disableHTTPCaching, string index = null, bool enableHistograms = false,
+                                    bool disableHTTPCaching,
+                                    bool logHttpRequests,
+                                    string index = null, bool enableHistograms = false,
                                     int indexCacheDepth = 16,
                                     IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null)
         {
@@ -150,6 +153,7 @@ namespace EventStore.Core.Cluster.Settings
             WorkerThreads = workerThreads;
             StartStandardProjections = startStandardProjections;
             DisableHTTPCaching = disableHTTPCaching;
+            LogHttpRequests = logHttpRequests;
             AdditionalConsumerStrategies = additionalConsumerStrategies ?? new IPersistentSubscriptionConsumerStrategyFactory[0];
 
             DiscoverViaDns = discoverViaDns;
@@ -209,6 +213,7 @@ namespace EventStore.Core.Cluster.Settings
                                  + "ExtHttpPrefixes: {8}\n"
                                  + "EnableTrustedAuth: {9}\n"
                                  + "Certificate: {10}\n"
+                                 + "LogHttpRequests: {11}\n"
                                  + "WorkerThreads: {12}\n"
                                  + "DiscoverViaDns: {13}\n"
                                  + "ClusterDns: {14}\n"
@@ -241,6 +246,7 @@ namespace EventStore.Core.Cluster.Settings
                                  string.Join(", ", ExtHttpPrefixes),
                                  EnableTrustedAuth,
                                  Certificate == null ? "n/a" : Certificate.ToString(true),
+                                 LogHttpRequests,
                                  WorkerThreads, DiscoverViaDns, ClusterDns,
                                  string.Join(",", GossipSeeds.Select(x => x.ToString())),
                                  ClusterNodeCount, MinFlushDelay,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -302,7 +302,7 @@ namespace EventStore.Core
 
             // EXTERNAL HTTP
             _externalHttpService = new HttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
-                                                    _workersHandler, vNodeSettings.ExtHttpPrefixes);
+                                                    _workersHandler, vNodeSettings.LogHttpRequests, vNodeSettings.ExtHttpPrefixes);
             _externalHttpService.SetupController(persistentSubscriptionController);
             if(vNodeSettings.AdminOnPublic)
                 _externalHttpService.SetupController(adminController);
@@ -321,7 +321,7 @@ namespace EventStore.Core
             // INTERNAL HTTP
             if(!isSingleNode) {
                 _internalHttpService = new HttpService(ServiceAccessibility.Private, _mainQueue, new TrieUriRouter(),
-                                                       _workersHandler, vNodeSettings.IntHttpPrefixes);
+                                                       _workersHandler, vNodeSettings.LogHttpRequests, vNodeSettings.IntHttpPrefixes);
                 _internalHttpService.SetupController(adminController);
                 _internalHttpService.SetupController(pingController);
                 _internalHttpService.SetupController(infoController);

--- a/src/EventStore.Core/Services/Transport/Http/HttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/HttpService.cs
@@ -29,12 +29,13 @@ namespace EventStore.Core.Services.Transport.Http
         private readonly IPublisher _inputBus;
         private readonly IUriRouter _uriRouter;
         private readonly IEnvelope _publishEnvelope;
+        private readonly bool _logHttpRequests;
 
         private readonly HttpAsyncServer _server;
         private readonly MultiQueuedHandler _requestsMultiHandler;
 
         public HttpService(ServiceAccessibility accessibility, IPublisher inputBus, IUriRouter uriRouter,
-                           MultiQueuedHandler multiQueuedHandler, params string[] prefixes)
+                           MultiQueuedHandler multiQueuedHandler, bool logHttpRequests, params string[] prefixes)
         {
             Ensure.NotNull(inputBus, "inputBus");
             Ensure.NotNull(uriRouter, "uriRouter");
@@ -46,6 +47,7 @@ namespace EventStore.Core.Services.Transport.Http
             _publishEnvelope = new PublishEnvelope(inputBus);
 
             _requestsMultiHandler = multiQueuedHandler;
+            _logHttpRequests = logHttpRequests;
 
             _server = new HttpAsyncServer(prefixes);
             _server.RequestReceived += RequestReceived;
@@ -93,7 +95,7 @@ namespace EventStore.Core.Services.Transport.Http
 
         private void RequestReceived(HttpAsyncServer sender, HttpListenerContext context)
         {
-            var entity = new HttpEntity(context.Request, context.Response, context.User);
+            var entity = new HttpEntity(context.Request, context.Response, context.User, _logHttpRequests);
             _requestsMultiHandler.Handle(new IncomingHttpRequestMessage(this, entity, _requestsMultiHandler));
         }
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -128,6 +128,9 @@ namespace EventStore.Core.Util
         public const string CommitTimeoutMsDescr = "Commit timeout (in milliseconds).";
         public static readonly int CommitTimeoutMsDefault = 2000; // 2 seconds
 
+        public const string LogHttpRequestsDescr = "Log Http Requests and Responses before processing them.";
+        public static readonly bool LogHttpRequestsDefault = false;
+
         //Loading certificates from files
         public const string CertificateFileDescr = "The path to certificate file.";
         public static readonly string CertificateFileDefault = string.Empty;


### PR DESCRIPTION
Fixes #484 

Adds a new command line option, --log-http-requests, which turns on debug logging for http requests and responses.

The logged output looks like this:

![loghttpsample](https://cloud.githubusercontent.com/assets/5140165/12675740/10b4eab2-c695-11e5-9aa6-aafe67ea9ead.png)

