### PR TITLE
Shows stats about replicas in a cluster

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -459,6 +459,7 @@
     <Compile Include="Services\Transport\Http\http_service_should.cs" />
     <Compile Include="Services\Transport\Http\PortableServer.cs" />
     <Compile Include="Services\Transport\Http\ping_controller_should.cs" />
+    <Compile Include="Services\Transport\Http\when_getting_replica_stats_from_stat_controller.cs" />
     <Compile Include="MightyMooseIgnoreAttribute.cs" />
     <Compile Include="Services\Transport\Http\proxy_headers.cs" />
     <Compile Include="Services\Transport\Http\speed_test.cs" />

--- a/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_replica_stats_from_stat_controller.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_replica_stats_from_stat_controller.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Transport.Http;
+using EventStore.Transport.Http.Client;
+using EventStore.Transport.Http.Codecs;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Http
+{
+    [TestFixture]
+    public class when_getting_replica_stats_from_stat_controller : SpecificationWithDirectoryPerTestFixture
+    {
+        private readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+        protected MiniClusterNode[] _nodes = new MiniClusterNode[2];
+        protected Endpoints[] _nodeEndpoints = new Endpoints[3];
+        protected HttpAsyncClient _client;
+        
+		private string _replicationUrl = "/stats/replication";
+        private string[] _urls = new string[2];
+        
+        private List<List<ReplicationMessage.ReplicationStats>> _responses;
+        
+        [TestFixtureSetUp]
+        protected void SetUp()
+        {
+            _client = new HttpAsyncClient();
+            
+            _nodeEndpoints[0] = new Endpoints(
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback),
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback),
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback));
+            _nodeEndpoints[1] = new Endpoints(
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback),
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback),
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback));
+            _nodeEndpoints[2] = new Endpoints(
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback),
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback),
+				PortsHelper.GetAvailablePort(IPAddress.Loopback), PortsHelper.GetAvailablePort(IPAddress.Loopback));
+            
+            // We only need two nodes running
+            _nodes[0] = CreateNode(0,
+                _nodeEndpoints[0], new IPEndPoint[] { _nodeEndpoints[1].InternalHttp, _nodeEndpoints[2].InternalHttp });
+            _nodes[1] = CreateNode(1,
+                _nodeEndpoints[1], new IPEndPoint[] { _nodeEndpoints[0].InternalHttp, _nodeEndpoints[2].InternalHttp });
+
+            _nodes[0].Start();
+            _nodes[1].Start();
+            
+            var nodesStarted = new CountdownEvent(2);
+            _nodes[0].Node.MainBus.Subscribe(
+                new AdHocHandler<SystemMessage.SystemStart>(m => nodesStarted.Signal()));
+            _nodes[1].Node.MainBus.Subscribe(
+                new AdHocHandler<SystemMessage.SystemStart>(m => nodesStarted.Signal()));
+
+            if(!nodesStarted.Wait(Timeout))
+            {
+                Assert.Fail("Timed out while waiting for the nodes to start");
+            }
+            
+            var replicasSubscribed = new CountdownEvent(1);
+            _nodes[0].Node.MainBus.Subscribe(
+                new AdHocHandler<ReplicationMessage.ReplicaSubscribed>(m => replicasSubscribed.Signal()));
+            _nodes[1].Node.MainBus.Subscribe(
+                new AdHocHandler<ReplicationMessage.ReplicaSubscribed>(m => replicasSubscribed.Signal()));
+
+            if(!replicasSubscribed.Wait(Timeout)) 
+            {
+                Assert.Fail("Timed out while waiting for replicas to subscribe to master");
+            }
+            
+            _urls[0] = string.Format("http://{0}{1}", _nodeEndpoints[0].ExternalHttp.ToString(), _replicationUrl);
+            _urls[1] = string.Format("http://{0}{1}", _nodeEndpoints[1].ExternalHttp.ToString(), _replicationUrl);
+
+            When();
+        }
+        
+        protected void When() 
+        {
+            var signal = new CountdownEvent(2);
+            _responses = new List<List<ReplicationMessage.ReplicationStats>>();
+            
+            var handleResponse = new Action<HttpResponse>(response => {
+                _responses.Add(Codec.Json.From<List<ReplicationMessage.ReplicationStats>>(response.Body));
+                signal.Signal();
+            });
+            var handleException = new Action<Exception>(exception => {
+                Assert.Fail("Exception when getting replica stats, {0}", exception.ToString());
+                signal.Signal();
+            });
+            
+			_client.Get(_urls[0], Timeout, handleResponse, handleException);
+			_client.Get(_urls[1], Timeout, handleResponse, handleException);
+			
+            if(!signal.Wait(Timeout)) 
+            {
+                Assert.Fail("Timed out while waiting for replica stats");
+            }
+        }
+        
+        [Test]
+        public void should_have_a_response_from_each_running_node() 
+        {
+            Assert.AreEqual(2, _responses.Count());
+        }
+        
+        [Test]
+        public void should_return_empty_list_from_replica_node() 
+        {
+			Assert.AreEqual(1, _responses.Count(res => res != null && res.Count() == 0));
+        }
+        
+        [Test]
+        public void should_return_replica_stats_from_the_master_node()
+        {
+            var masterStats = _responses.FirstOrDefault(res => res != null && res.Count() > 0);
+        		Assert.IsNotNull(masterStats, "No replication stats were returned from master.");
+			Assert.AreEqual(1, masterStats.Count(),
+                string.Format("Expected master to have 1 set of replication stats. Got {0}", masterStats.Count()));
+        }
+        
+        [TestFixtureTearDown]
+        protected void TearDown()
+        {
+            _nodes[0].Shutdown();
+            _nodes[1].Shutdown();
+        }
+        
+        private MiniClusterNode CreateNode(int index, Endpoints endpoints, IPEndPoint[] gossipSeeds)
+		{
+			return new MiniClusterNode(
+				PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp, endpoints.ExternalTcp,
+				endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false, gossipSeeds: gossipSeeds);
+		}
+        
+        protected class Endpoints
+		{
+			public readonly IPEndPoint InternalTcp;
+			public readonly IPEndPoint InternalTcpSec;
+			public readonly IPEndPoint InternalHttp;
+			public readonly IPEndPoint ExternalTcp;
+			public readonly IPEndPoint ExternalTcpSec;
+			public readonly IPEndPoint ExternalHttp;
+			
+			public Endpoints(
+				int internalTcp, int internalTcpSec, int internalHttp, int externalTcp,
+				int externalTcpSec, int externalHttp)
+			{
+				var testIp = Environment.GetEnvironmentVariable("ES-TESTIP");
+				
+				var address = string.IsNullOrEmpty(testIp) ? IPAddress.Loopback : IPAddress.Parse(testIp);
+				InternalTcp = new IPEndPoint(address, internalTcp);
+				InternalTcpSec = new IPEndPoint(address, internalTcpSec);
+				InternalHttp = new IPEndPoint(address, internalHttp);
+				ExternalTcp = new IPEndPoint(address, externalTcp);
+				ExternalTcpSec = new IPEndPoint(address, externalTcpSec);
+				ExternalHttp = new IPEndPoint(address, externalHttp);
+			}
+		}
+    }
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -482,6 +482,7 @@ namespace EventStore.Core
                 _mainBus.Subscribe<SystemMessage.StateChangeMessage>(masterReplicationService);
                 _mainBus.Subscribe<ReplicationMessage.ReplicaSubscriptionRequest>(masterReplicationService);
                 _mainBus.Subscribe<ReplicationMessage.ReplicaLogPositionAck>(masterReplicationService);
+                monitoringInnerBus.Subscribe<ReplicationMessage.GetReplicationStats>(masterReplicationService);
 
                 // REPLICA REPLICATION
                 var replicaService = new ReplicaService(_mainQueue, db, epochManager, _workersHandler, _internalAuthenticationProvider,

--- a/src/EventStore.Core/Messages/ReplicationMessage.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessage.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
@@ -396,6 +397,56 @@ namespace EventStore.Core.Messages
                 return string.Format("DataChunkBulk message: MasterId: {0}, SubscriptionId: {1}, ChunkStartNumber: {2}, ChunkEndNumber: {3}, SubscriptionPosition: {4}, DataBytes length: {5}, CompleteChunk: {6}",
                                      MasterId, SubscriptionId, ChunkStartNumber, ChunkEndNumber, 
                                      SubscriptionPosition, DataBytes.Length, CompleteChunk);
+            }
+        }
+
+        public class GetReplicationStats : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+            public IEnvelope Envelope;
+
+            public GetReplicationStats(IEnvelope envelope)
+            {
+                Envelope = envelope;
+            }
+        }
+
+        public class GetReplicationStatsCompleted : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public List<ReplicationMessage.ReplicationStats> ReplicationStats;
+
+            public GetReplicationStatsCompleted(List<ReplicationMessage.ReplicationStats> replicationStats)
+            {
+                ReplicationStats = replicationStats;
+            }
+        }
+
+        public class ReplicationStats
+        {
+            public Guid SubscriptionId { get; private set; }
+            public Guid ConnectionId { get; private set; }
+            public string SubscriptionEndpoint { get; private set; }
+            public int TotalBytesSent { get; private set; }
+            public int TotalBytesReceived { get; private set; }
+            public int PendingSendBytes { get; private set; }
+            public int PendingReceivedBytes { get; private set; }
+            public int SendQueueSize { get; private set; }
+
+            public ReplicationStats(Guid subscriptionId, Guid connectionId, string subscriptionEndpoint, int sendQueueSize,
+                                int totalBytesSent, int totalBytesReceived, int pendingSendBytes, int pendingReceivedBytes)
+            {
+                SubscriptionId = subscriptionId;
+                ConnectionId = connectionId;
+                SubscriptionEndpoint = subscriptionEndpoint;
+                SendQueueSize = sendQueueSize;
+                TotalBytesSent = totalBytesSent;
+                TotalBytesReceived = totalBytesReceived;
+                PendingSendBytes = pendingSendBytes;
+                PendingReceivedBytes = pendingReceivedBytes;
             }
         }
     }

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -393,5 +393,14 @@ namespace EventStore.Core.Services.Transport.Http
                 ? Ok(entity.ResponseCodec.ContentType, Helper.UTF8NoBom, null, cacheSeconds, isCachePublic: true)
                 : NotFound();
         }
-    }
+
+        public static ResponseConfiguration GetReplicationStatsCompleted(HttpResponseConfiguratorArgs entity, Message message)
+        {
+            var completed = message as ReplicationMessage.GetReplicationStatsCompleted;
+            if (completed == null)
+                return InternalServerError();
+
+            var cacheSeconds = (int)MonitoringService.MemoizePeriod.TotalSeconds;
+            return Ok(entity.ResponseCodec.ContentType, Helper.UTF8NoBom, null, cacheSeconds, isCachePublic: true);
+        }}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
@@ -26,6 +26,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             Ensure.NotNull(service, "service");
 
             service.RegisterAction(new ControllerAction("/stats", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs), OnGetFreshStats);
+            service.RegisterAction(new ControllerAction("/stats/replication", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs), OnGetReplicationStats);
             service.RegisterAction(new ControllerAction("/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs), OnGetFreshStats);
         }
 
@@ -90,6 +91,15 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
                 return dict;
             };
+        }
+
+        private void OnGetReplicationStats(HttpEntityManager entity, UriTemplateMatch match)
+        {
+            var envelope = new SendToHttpEnvelope(_networkSendQueue,
+                                                  entity,
+                                                  Format.GetReplicationStatsCompleted,
+                                                  Configure.GetReplicationStatsCompleted);
+            Publish(new ReplicationMessage.GetReplicationStats(envelope));
         }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -89,6 +89,16 @@ namespace EventStore.Core.Services.Transport.Http
             return entity.ResponseCodec.To(completed.Stats);
         }
 
+        public static string GetReplicationStatsCompleted(HttpResponseFormatterArgs entity, Message message)
+        {
+            if (message.GetType() != typeof(ReplicationMessage.GetReplicationStatsCompleted))
+                throw new Exception(string.Format("Unexpected type of Response message: {0}, expected: {1}",
+                                                    message.GetType().Name,
+                                                    typeof(ReplicationMessage.GetReplicationStatsCompleted).Name));
+            var completed = message as ReplicationMessage.GetReplicationStatsCompleted;
+            return entity.ResponseCodec.To(completed.ReplicationStats);
+        }
+
 		public static string SendGossip(HttpResponseFormatterArgs entity, Message message)
 		{
 			if (message.GetType() != typeof(GossipMessage.SendGossip))

--- a/src/EventStore.Transport.Tcp/TcpConnectionMonitor.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionMonitor.cs
@@ -51,6 +51,13 @@ namespace EventStore.Transport.Tcp
                 return stats;
             }
         }
+        
+        public IMonitoredTcpConnection[] GetTcpConnectionStats()
+        {
+            GetTcpStats();
+            var monitoredConnections = _connections.Values.Select(conn => conn.Connection).ToArray();
+            return monitoredConnections;
+        }
 
         private TcpStats AnalyzeConnections(ConnectionData[] connections, TimeSpan measurePeriod)
         {


### PR DESCRIPTION
Fixes #732 

Adds a new route, /stats/replication, which returns the connection stats about subscription on the master node. 
The UI polls this route and uses it to calculate how far back a node is, and about how long it will take to catch up with the master. This information is then displayed at the bottom of the Cluster Status page.

The result looks like this: 
![replicastatus](https://cloud.githubusercontent.com/assets/5140165/12751062/a0f47fd0-c9c3-11e5-97c2-b1375055405c.png)

One thing to note: these stats are only available from the master node, accessing /stats/replication on a slave will return an empty array.