### PR TITLE
Fixes the flakey scavenge tests

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
@@ -1,104 +1,87 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.IO;
 using System.Threading;
-using EventStore.Core.Bus;
+using EventStore.Common.Log;
 using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Helpers;
-using EventStore.Core.Tests.TransactionLog;
-using EventStore.Core.TransactionLog.Checkpoint;
-using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Tests.ClientAPI.Helpers;
 using EventStore.Core.Services;
-using EventStore.Core.Services.Storage;
 using EventStore.Core.Services.UserManagement;
+using EventStore.ClientAPI;
 using NUnit.Framework;
+using ILogger = EventStore.Common.Log.ILogger;
+
 
 namespace EventStore.Core.Tests.Services.Storage.Scavenge
 {
     [TestFixture]
-	public class when_running_scavenge_from_storage_scavenger : TestFixtureWithExistingEvents
+	public class when_running_scavenge_from_storage_scavenger : SpecificationWithDirectoryPerTestFixture
     {
-        protected EventStore.Core.Services.Storage.StorageScavenger _scavenger;
-        private ManualResetEvent _hasCompletedScavenge = new ManualResetEvent(false);
+		private static readonly ILogger Log = LogManager.GetLoggerFor<when_running_scavenge_from_storage_scavenger>();
+		private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(60);
+		private MiniNode _node;
 
-        protected override void Given()
+		public override void TestFixtureSetUp()
         {
-            base.Given();
+			base.TestFixtureSetUp();
 
-			var typeName = GetType().Name.Length > 30 ? GetType().Name.Substring(0, 30) : GetType().Name;
-			var pathName = Path.Combine(Path.GetTempPath(), string.Format("{0}-{1}", Guid.NewGuid(), typeName));
-			Directory.CreateDirectory(pathName);
+			_node = new MiniNode(PathName, skipInitializeStandardUsersCheck: false);
+			_node.Start();
 
-        	var db = new TFChunkDb(new TFChunkDbConfig(pathName,
-			                                        new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
-			                                        16 * 1024,
-			                                        0,
-			                                        new InMemoryCheckpoint(),
-			                                        new InMemoryCheckpoint(),
-			                                        new InMemoryCheckpoint(-1),
-			                                        new InMemoryCheckpoint(-1)));
-			db.Open();
-			_scavenger = new StorageScavenger(db, _ioDispatcher, new FakeTableIndex(), new ByLengthHasher(),
-			                                  new FakeReadIndex(x => x == "es-to-scavenge"), true, "fakeNodeIp", true, 30);
-
-            var scavengeMessage = new ClientMessage.ScavengeDatabase(Envelope, Guid.NewGuid(), SystemAccount.Principal);
-            _bus.Subscribe<ClientMessage.ScavengeDatabaseCompleted>(new AdHocHandler<ClientMessage.ScavengeDatabaseCompleted>(
-                           x => {_hasCompletedScavenge.Set();}));
-            _scavenger.Handle(scavengeMessage);
+			var scavengeMessage = new ClientMessage.ScavengeDatabase(new NoopEnvelope(), Guid.NewGuid(), SystemAccount.Principal);
+			_node.Node.MainQueue.Publish(scavengeMessage);
         }
 
-        [Test]
-        public void creates_scavenge_started_events_in_both_streams()
-        {
-            Assert.IsTrue(_hasCompletedScavenge.WaitOne(TimeSpan.FromSeconds(5)));
+		[TearDown]
+		public void TearDown()
+		{
+			_node.Shutdown();
+		}
 
-            var scavengeInstanceStreamResults = GetMessagesFromScavengeInstanceStream();
-            var scavengeEventResults = GetMessagesFromScavengesStream();
+		[Test]
+		public void should_create_scavenge_started_and_completed_link_to_events_on_index_stream_which_resolves_to_scavenge_stream() 
+		{
+			using(var conn = TestConnection.Create(_node.TcpEndPoint, TcpType.Normal, DefaultData.AdminCredentials))
+			{
+				conn.ConnectAsync().Wait();
+				var countdown = new CountdownEvent(2);
+				var events = new List<ResolvedEvent>();
 
-        	Assert.AreEqual(1, scavengeInstanceStreamResults.Count(x => x.Events.Any(y => y.EventType == SystemEventTypes.ScavengeStarted)));
-            Assert.AreEqual(1, scavengeEventResults.Count(x => x.Events.Any(y => y.EventType == SystemEventTypes.ScavengeStarted)));
-        }
+				var subscription = conn.SubscribeToStreamFrom(
+					SystemStreams.ScavengesStream, null, true,
+                    (x, y) =>
+					{
+						events.Add(y);
+						countdown.Signal();
+					},
+					_ => Log.Info("Processing events started."),
+					(x, y, z) =>
+					{
+						Log.Info("Subscription dropped: {0}, {1}.", y, z);
+					}
+				);
 
-        [Test]
-        public void creates_scavenge_completed_events_in_both_streams()
-        {
-            Assert.IsTrue(_hasCompletedScavenge.WaitOne(TimeSpan.FromSeconds(5)));
+				if (!countdown.Wait(Timeout))
+				{
+					Assert.Fail("Timeout expired while waiting for events.");
+				}
 
-            var scavengeInstanceStreamResults = GetMessagesFromScavengeInstanceStream();
-            var scavengeEventResults = GetMessagesFromScavengesStream();
+				Assert.AreEqual(2, events.Count);
 
-        	Assert.AreEqual(1, scavengeInstanceStreamResults.Count(x => x.Events.Any(y => y.EventType == SystemEventTypes.ScavengeCompleted)));
-        	Assert.AreEqual(1, scavengeEventResults.Count(x => x.Events.Any(y => y.EventType == SystemEventTypes.ScavengeCompleted)));
-        }
+				var scavengeStartedEvent = events.FirstOrDefault(x=>x.Event.EventType == SystemEventTypes.ScavengeStarted);
+				var scavengeCompletedEvent = events.FirstOrDefault(x=>x.Event.EventType == SystemEventTypes.ScavengeCompleted);
 
-        [Test]
-        public void creates_a_metadata_stream()
-        {
-            Assert.IsTrue(_hasCompletedScavenge.WaitOne(TimeSpan.FromSeconds(5)));
+				Assert.IsNotNull(scavengeStartedEvent, "A scavenge started event was not written.");
+				Assert.IsNotNull(scavengeCompletedEvent, "A scavenge completed event was not written.");
 
-            var metadataMessages = HandledMessages.OfType<ClientMessage.WriteEvents>()
-                    .Where(v=>
-                            v.EventStreamId.StartsWith(
-                                Core.Services.SystemStreams.MetastreamOf(Core.Services.SystemStreams.ScavengesStream) + "-")
-                    ).ToList<ClientMessage.WriteEvents>();
+				Assert.AreEqual(scavengeStartedEvent.Event.EventStreamId, scavengeCompletedEvent.Event.EventStreamId, 
+					string.Format("Scavenge started and completed events are not in the same stream. ScavengeStartedEvent Stream Id: {0}, ScavengeCompletedEvent Stream Id: {1}", 
+				    	scavengeStartedEvent.Event.EventStreamId, scavengeCompletedEvent.Event.EventStreamId));
 
-            Assert.AreEqual(1, metadataMessages.Count());
-        }
-
-        protected List<ClientMessage.WriteEvents> GetMessagesFromScavengeInstanceStream() {
-            return HandledMessages.OfType<ClientMessage.WriteEvents>()
-    				.Where(v =>
-    				        v.EventStreamId.StartsWith(Core.Services.SystemStreams.ScavengesStream + "-")
-    		        ).ToList<ClientMessage.WriteEvents>();
-        }
-
-        protected List<ClientMessage.WriteEvents> GetMessagesFromScavengesStream() {
-            return HandledMessages.OfType<ClientMessage.WriteEvents>()
-                    .Where(v =>
-                           v.EventStreamId.StartsWith(Core.Services.SystemStreams.ScavengesStream))
-                    .ToList<ClientMessage.WriteEvents>();
-        }
+				subscription.Stop(Timeout);
+			}
+		}
     }
 }


### PR DESCRIPTION
These tests were relying on the scavenge complete client message to be published after the scavenge completed event was written. This wasn't always the case, causing the test to fail intermittently.

This PR changes the scavenge event tests to subscribe to the scavenge index stream and make its assertions on that rather than on the client messages.

It also refactors the StorageScavenger to make writing events more readable.