### PR TITLE
Minor field correction

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
@@ -407,7 +407,7 @@ namespace EventStore.ClientAPI.Embedded
         /// <returns>A <see cref="EmbeddedVNodeBuilder"/> with the options set</returns>
         public EmbeddedVNodeBuilder NoStatsOnPublicInterface()
         {
-            _adminOnPublic = false;
+            _statsOnPublic = false;
             return this;
         }
 


### PR DESCRIPTION
It looks like `_adminOnPublic` was inadvertently reused here. Otherwise, there is no code path which would change `_statsOnPublic` from its default value before being passed on to build the cluster settings.