### PR TITLE
Don't register the projection routes if projections aren't enabled

### DIFF
--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -37,9 +37,12 @@ namespace EventStore.Projections.Core
                 inputQueue: projectionsStandardComponents.MasterInputQueue,
                 externalRequestQueue: standardComponents.MainQueue);
 
-            foreach (var httpService in standardComponents.HttpServices)
+            if (projectionsStandardComponents.RunProjections != ProjectionType.None)
             {
-                httpService.SetupController(projectionsController);
+                foreach (var httpService in standardComponents.HttpServices)
+                {
+                    httpService.SetupController(projectionsController);
+                }
             }
 
             var commandWriter = new MultiStreamMessageWriter(ioDispatcher);


### PR DESCRIPTION
Fixes #797 

If projections are set to None, don't register the projections controller. 
This causes any http requests for projections to return a 404 instead of timing out.