### PR TITLE
Add Trusted Writes to TCP

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -467,6 +467,7 @@
     <Compile Include="Services\Transport\Http\uri_router_should.cs" />
     <Compile Include="Services\Transport\Tcp\ssl_connection.cs" />
     <Compile Include="Services\Transport\Tcp\core_tcp_package.cs" />
+    <Compile Include="Services\Transport\Tcp\TcpConnectionManagerTests.cs" />
     <Compile Include="Services\UserManagementService\password_change_notification_reader.cs" />
     <Compile Include="Services\UserManagementService\user_management_service.cs" />
     <Compile Include="Services\VNode\vnode_fsm_should.cs" />

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -1,0 +1,138 @@
+﻿using EventStore.Core.Bus;
+using EventStore.Core.Services.Transport.Tcp;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using EventStore.Transport.Tcp;
+using System.Net.Sockets;
+using EventStore.Core.Authentication;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Authentication;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using System.Threading;
+
+namespace EventStore.Core.Tests.Services.Transport.Tcp
+{
+    [TestFixture]
+    public class TcpConnectionManagerTests
+    {
+        public void when_handling_trusted_write_on_external_service()
+        {
+            var package = new TcpPackage(TcpCommand.WriteEvents, TcpFlags.TrustedWrite, Guid.NewGuid(), null, null, new byte[] { });
+
+            var dummyConnection = new DummyTcpConnection();
+
+            var tcpConnectionManager = new TcpConnectionManager(
+                Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+                InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), new StubPasswordHashAlgorithm(), 1),
+                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { });
+
+            tcpConnectionManager.ProcessPackage(package);
+
+            var data = dummyConnection.ReceivedData.Last();
+            var receivedPackage = TcpPackage.FromArraySegment(data);
+           
+            Assert.AreEqual(receivedPackage.Command, TcpCommand.BadRequest, "Expected Bad Request but got {0}", receivedPackage.Command);
+        }
+
+        public void when_handling_trusted_write_on_internal_service()
+        {
+            ManualResetEvent waiter = new ManualResetEvent(false);
+            ClientMessage.WriteEvents publishedWrite = null;
+            var evnt = new Event(Guid.NewGuid(), "TestEventType", true, new byte[] { }, new byte[] { });
+            var write = new TcpClientMessageDto.WriteEvents(
+                Guid.NewGuid().ToString(),
+                ExpectedVersion.Any,
+                new[] { new TcpClientMessageDto.NewEvent(evnt.EventId.ToByteArray(), evnt.EventType, evnt.IsJson ? 1 : 0, 0, evnt.Data, evnt.Metadata) },
+                false);
+
+            var package = new TcpPackage(TcpCommand.WriteEvents, Guid.NewGuid(), write.Serialize());
+            var dummyConnection = new DummyTcpConnection();
+            var publisher = InMemoryBus.CreateTest();
+
+            publisher.Subscribe(new AdHocHandler<ClientMessage.WriteEvents>(x => {
+                publishedWrite = x;
+                waiter.Set();
+            }));
+
+            var tcpConnectionManager = new TcpConnectionManager(
+                Guid.NewGuid().ToString(), TcpServiceType.Internal, new ClientTcpDispatcher(),
+                publisher, dummyConnection, publisher, new InternalAuthenticationProvider(new Core.Helpers.IODispatcher(publisher, new NoopEnvelope()), new StubPasswordHashAlgorithm(), 1),
+                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { });
+
+            tcpConnectionManager.ProcessPackage(package);
+
+            if (!waiter.WaitOne(TimeSpan.FromSeconds(5)))
+            {
+                throw new Exception("Timed out waiting for events.");
+            }
+            Assert.AreEqual(evnt.EventId, publishedWrite.Events.First().EventId, "Expected the published write to be the event that was sent through the tcp connection manager to be the event {0} but got {1}", evnt.EventId, publishedWrite.Events.First().EventId);
+        }
+    }
+
+    internal class DummyTcpConnection : ITcpConnection
+    {
+        public Guid ConnectionId
+        {
+            get
+            {
+                return Guid.NewGuid();
+            }
+        }
+
+        public bool IsClosed
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public IPEndPoint LocalEndPoint
+        {
+            get
+            {
+                return new IPEndPoint(IPAddress.Loopback, 2); ;
+            }
+        }
+
+        public IPEndPoint RemoteEndPoint
+        {
+            get
+            {
+                return new IPEndPoint(IPAddress.Loopback, 1);
+            }
+        }
+
+        public int SendQueueSize
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public event Action<ITcpConnection, SocketError> ConnectionClosed;
+
+        public void Close(string reason)
+        {
+            var handler = ConnectionClosed;
+            if (handler != null)
+                handler(this, SocketError.Shutdown);
+        }
+
+        public IEnumerable<ArraySegment<byte>> ReceivedData;
+        public void EnqueueSend(IEnumerable<ArraySegment<byte>> data)
+        {
+            ReceivedData = data;
+        }
+
+        public void ReceiveAsync(Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> callback)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -134,6 +134,10 @@ namespace EventStore.Core.Services.Transport.Tcp
         private static TcpPackage CreateWriteRequestPackage(TcpCommand command, ClientMessage.WriteRequestMessage msg, object dto)
         {
             // we forwarding with InternalCorrId, not client's CorrelationId!!!
+            if (msg.User == UserManagement.SystemAccount.Principal)
+            {
+                return new TcpPackage(command, TcpFlags.TrustedWrite, msg.InternalCorrId, null, null, dto.Serialize());
+            }
             return msg.Login != null && msg.Password != null
                 ? new TcpPackage(command, TcpFlags.Authenticated, msg.InternalCorrId, msg.Login, msg.Password, dto.Serialize())
                 : new TcpPackage(command, TcpFlags.None, msg.InternalCorrId, null, null, dto.Serialize());

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpPackage.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpPackage.cs
@@ -9,6 +9,7 @@ namespace EventStore.Core.Services.Transport.Tcp
     {
         None = 0x00,
         Authenticated = 0x01,
+        TrustedWrite = 0x02
     }
 
     public struct TcpPackage

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpService.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpService.cs
@@ -111,15 +111,16 @@ namespace EventStore.Core.Services.Transport.Tcp
 
         private void OnConnectionAccepted(IPEndPoint endPoint, Socket socket)
         {
-            var conn = _securityType == TcpSecurityType.Secure 
+            var conn = _securityType == TcpSecurityType.Secure
                 ? TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, _certificate, verbose: true)
                 : TcpConnection.CreateAcceptedTcpConnection(Guid.NewGuid(), endPoint, socket, verbose: true);
-            Log.Info("{0} TCP connection accepted: [{1}, {2}, L{3}, {4:B}].", 
+            Log.Info("{0} TCP connection accepted: [{1}, {2}, L{3}, {4:B}].",
                      _serviceType, _securityType, conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId);
 
             var dispatcher = _dispatcherFactory(conn.ConnectionId, _serverEndPoint);
             var manager = new TcpConnectionManager(
                     string.Format("{0}-{1}", _serviceType.ToString().ToLower(), _securityType.ToString().ToLower()),
+                    _serviceType,
                     dispatcher,
                     _publisher,
                     conn,


### PR DESCRIPTION
Add a new flag to identify a trusted write

- For the TcpPackage being forwarded the trusted write flag is set if the user on the write message is the System Account.
- For the TcpPackage coming in, if the trusted write flag is set, the user is set on the write events message