### PR TITLE
Fix 404 errors in the UI when polling the $scavenges stream

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -465,6 +465,7 @@ namespace EventStore.Core
 
 			// ReSharper disable RedundantTypeArgumentsOfMethod
             _mainBus.Subscribe<ClientMessage.ScavengeDatabase>(storageScavenger);
+            _mainBus.Subscribe<UserManagementMessage.UserManagementServiceInitialized>(storageScavenger);
             // ReSharper restore RedundantTypeArgumentsOfMethod
 
 

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -82,6 +82,7 @@ namespace EventStore.Core.Services
         public const string ScavengeStarted = "$scavengeStarted";
         public const string ScavengeCompleted = "$scavengeCompleted";
         public const string ScavengeChunksCompleted = "$scavengeChunksCompleted";
+        public const string ScavengeIndexInitialized = "$scavengeIndexInitialized";
 
         public static string StreamReferenceEventToStreamId(string eventType, byte[] data)
         {


### PR DESCRIPTION
Ensure the $scavenges stream always exists by writing a ScavengeIndexInitializedEvent to the it when the node starts up.

This is to fix an issue in the UI where it logs a constant stream of 404 errors when polling for the scavenge status and no scavenges have been run.