### PR TITLE
Introduce a System Ready message

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -155,13 +155,7 @@ namespace EventStore.Core.Tests.Helpers
         {
             StartingTime.Start();
 
-            var startedEvent = new ManualResetEventSlim(false);
-            Node.MainBus.Subscribe(
-                new AdHocHandler<UserManagementMessage.UserManagementServiceInitialized>(m => startedEvent.Set()));
-
-            Node.Start();
-
-            if (!startedEvent.Wait(60000))
+            if (!Node.StartAndWaitUntilReady().Wait(60000))
                 throw new TimeoutException("MiniNode has not started in 60 seconds.");
 
             StartingTime.Stop();

--- a/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_replica_stats_from_stat_controller.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_replica_stats_from_stat_controller.cs
@@ -75,7 +75,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
             // Wait for user management service to initialize
             var managementInitialised = new ManualResetEvent(false);
             masterNode.Node.MainBus.Subscribe(
-                new AdHocHandler<UserManagementMessage.UserManagementServiceInitialized>(msg => managementInitialised.Set()));
+                new AdHocHandler<SystemMessage.SystemReady>(msg => managementInitialised.Set()));
             if(!managementInitialised.WaitOne(Timeout))
             {
                 Assert.Fail("Timed out while waiting for User Management Service to initialize.");

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -21,6 +21,12 @@ namespace EventStore.Core.Messages
             public override int MsgTypeId { get { return TypeId; } }
         }
 
+        public class SystemReady : Message
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+        }
+
         public class ServiceInitialized: Message
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);

--- a/src/EventStore.Projections.Core.Tests/Integration/parallel_query/when_running_from_catalog_stream_query_twice.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/parallel_query/when_running_from_catalog_stream_query_twice.cs
@@ -39,7 +39,7 @@ fromStreamCatalog('catalog').foreachStream().when({
         protected override IEnumerable<WhenStep> When()
         {
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), _projectionMode, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
@@ -86,7 +86,7 @@ namespace EventStore.Projections.Core.Tests.Integration
         protected override IEnumerable<WhenStep> When()
         {
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             if (_startSystemProjections)
             {
                 yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -100,14 +100,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<SystemMessage.StateChangeMessage>(_manager);
-            _bus.Subscribe<UserManagementMessage.UserManagementServiceInitialized>(_manager);
+            _bus.Subscribe<SystemMessage.SystemReady>(_manager);
             _bus.Subscribe<ProjectionManagementMessage.ReaderReady>(_manager);
             _bus.Subscribe(
                 CallbackSubscriber.Create<ProjectionManagementMessage.Starting>(
                     starting => _queue.Publish(new ProjectionManagementMessage.ReaderReady())));
 
             _bus.Subscribe<SystemMessage.StateChangeMessage>(_coordinator);
-            _bus.Subscribe<UserManagementMessage.UserManagementServiceInitialized>(_coordinator);
+            _bus.Subscribe<SystemMessage.SystemReady>(_coordinator);
 
             if (GetInputQueue() != _processingQueues.First().Item2)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
             protected override IEnumerable<WhenStep> When()
             {
                 yield return(new SystemMessage.BecomeMaster(Guid.NewGuid()));
-                yield return(new UserManagementMessage.UserManagementServiceInitialized());
+                yield return(new SystemMessage.SystemReady());
                 yield return
                     (new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
@@ -45,7 +45,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
             protected override IEnumerable<WhenStep> When()
             {
                 yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-                yield return (new UserManagementMessage.UserManagementServiceInitialized());
+                yield return (new SystemMessage.SystemReady());
                 yield return (
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName, ProjectionManagementMessage.RunAs.System,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
@@ -38,7 +38,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
             protected override IEnumerable<WhenStep> When()
             {
                 yield return(new SystemMessage.BecomeMaster(Guid.NewGuid()));
-                yield return(new UserManagementMessage.UserManagementServiceInitialized());
+                yield return(new SystemMessage.SystemReady());
                 yield return
                     (new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
@@ -35,7 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> When()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new UserManagementMessage.UserManagementServiceInitialized();
+                yield return new SystemMessage.SystemReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
@@ -90,7 +90,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> When()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new UserManagementMessage.UserManagementServiceInitialized();
+                yield return new SystemMessage.SystemReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
@@ -133,7 +133,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> PreWhen()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new UserManagementMessage.UserManagementServiceInitialized();
+                yield return new SystemMessage.SystemReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -36,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> When()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new UserManagementMessage.UserManagementServiceInitialized();
+                yield return new SystemMessage.SystemReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Transient, _projectionName,
@@ -91,7 +91,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> When()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new UserManagementMessage.UserManagementServiceInitialized();
+                yield return new SystemMessage.SystemReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.slave_p
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new UserManagementMessage.UserManagementServiceInitialized();
+            yield return new SystemMessage.SystemReady();
             yield return
                 new CoreProjectionManagementMessage.CreateAndPrepareSlave(
                     _coreProjectionCorrelationId,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_a_dsiabled_projection_has_been_loaded.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_a_dsiabled_projection_has_been_loaded.cs
@@ -41,7 +41,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new UserManagementMessage.UserManagementServiceInitialized();
+            yield return new SystemMessage.SystemReady();
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new UserManagementMessage.UserManagementServiceInitialized();
+            yield return new SystemMessage.SystemReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new UserManagementMessage.UserManagementServiceInitialized();
+            yield return new SystemMessage.SystemReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new UserManagementMessage.UserManagementServiceInitialized();
+            yield return new SystemMessage.SystemReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new UserManagementMessage.UserManagementServiceInitialized();
+            yield return new SystemMessage.SystemReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new UserManagementMessage.UserManagementServiceInitialized();
+            yield return new SystemMessage.SystemReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_an_onetime_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_an_onetime_projection.cs
@@ -19,7 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionManagementMessage.RunAs.Anonymous,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new UserManagementMessage.UserManagementServiceInitialized();
+            yield return new SystemMessage.SystemReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_requesting_partition_state_from_a_stopped_foreach_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_requesting_partition_state_from_a_stopped_foreach_projection.cs
@@ -39,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _projectionName = "test-projection";
             // when
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_onetime_projection_has_been_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_onetime_projection_has_been_posted.cs
@@ -23,7 +23,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionQuery = @"fromAll(); on_any(function(){});log(1);";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionManagementMessage.RunAs.Anonymous, _projectionQuery,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
@@ -30,7 +30,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
@@ -31,7 +31,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
@@ -32,7 +32,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _projectionName = "test-projection";
             _source = @"fromAll(); on_any(function(){});log(1);";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
@@ -30,7 +30,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
@@ -72,7 +72,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Transient, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projections_subsystem.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projections_subsystem.cs
@@ -34,7 +34,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
         protected override IEnumerable<WhenStep> PreWhen()
         {
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new UserManagementMessage.UserManagementServiceInitialized());
+            yield return (new SystemMessage.SystemReady());
             yield return Yield;
             if (_startSystemProjections)
             {

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -77,7 +77,7 @@ namespace EventStore.Projections.Core
             ProjectionManagerCommandWriter projectionManagerCommandWriter)
         {
             mainBus.Subscribe<SystemMessage.StateChangeMessage>(projectionManager);
-            mainBus.Subscribe<UserManagementMessage.UserManagementServiceInitialized>(projectionManager);
+            mainBus.Subscribe<SystemMessage.SystemReady>(projectionManager);
             if (runProjections >= ProjectionType.System)
             {
                 mainBus.Subscribe<ProjectionManagementMessage.Command.Post>(projectionManager);
@@ -158,7 +158,7 @@ namespace EventStore.Projections.Core
             standardComponents.MainBus.Subscribe(
                 Forwarder.Create<SystemMessage.StateChangeMessage>(projectionsStandardComponents.MasterInputQueue));
             standardComponents.MainBus.Subscribe(
-                Forwarder.Create<UserManagementMessage.UserManagementServiceInitialized>(projectionsStandardComponents.MasterInputQueue));
+                Forwarder.Create<SystemMessage.SystemReady>(projectionsStandardComponents.MasterInputQueue));
             projectionsStandardComponents.MasterMainBus.Subscribe(new UnwrapEnvelopeHandler());
         }
     }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionCoreCoordinator.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionCoreCoordinator.cs
@@ -13,7 +13,7 @@ namespace EventStore.Projections.Core.Services.Management
     public class ProjectionCoreCoordinator
         : IHandle<ProjectionManagementMessage.Internal.RegularTimeout>,
         IHandle<SystemMessage.StateChangeMessage>,
-        IHandle<UserManagementMessage.UserManagementServiceInitialized>
+        IHandle<SystemMessage.SystemReady>
     {
         private readonly ILogger Log = LogManager.GetLoggerFor<ProjectionCoreCoordinator>();
         private readonly ProjectionType _runProjections;
@@ -47,7 +47,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         private bool _systemReady = false;
         private VNodeState _currentState = VNodeState.Unknown;
-        public void Handle(UserManagementMessage.UserManagementServiceInitialized message)
+        public void Handle(SystemMessage.SystemReady message)
         {
             _systemReady = true;
             StartWhenConditionsAreMet();
@@ -121,7 +121,7 @@ namespace EventStore.Projections.Core.Services.Management
         public void SetupMessaging(IBus bus)
         {
             bus.Subscribe<SystemMessage.StateChangeMessage>(this);
-            bus.Subscribe<UserManagementMessage.UserManagementServiceInitialized>(this);
+            bus.Subscribe<SystemMessage.SystemReady>(this);
             if (_runProjections >= ProjectionType.System)
             {
                 bus.Subscribe<ProjectionManagementMessage.Internal.RegularTimeout>(this);

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -19,7 +19,7 @@ namespace EventStore.Projections.Core.Services.Management
     public class ProjectionManager
         : IDisposable,
             IHandle<SystemMessage.StateChangeMessage>,
-            IHandle<UserManagementMessage.UserManagementServiceInitialized>,
+            IHandle<SystemMessage.SystemReady>,
             IHandle<ClientMessage.ReadStreamEventsBackwardCompleted>,
             IHandle<ClientMessage.WriteEventsCompleted>,
             IHandle<ClientMessage.DeleteStreamCompleted>,
@@ -533,7 +533,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         private VNodeState _currentState = VNodeState.Unknown;
         private bool _systemIsReady = false;
-        public void Handle(UserManagementMessage.UserManagementServiceInitialized message)
+        public void Handle(SystemMessage.SystemReady message)
         {
             _systemIsReady = true;
             StartWhenConditionsAreMet();


### PR DESCRIPTION
Fixes https://github.com/EventStore/EventStore/issues/784
Keep track of the number of standard users that needs to be created and only send a
single user management service initlized message.

When skipping the standard users check, send the user management service
initialised message

When the user management service has been initialized, start the sub
systems and then send a system ready message.

The system ready message can be used by subscribers to know when a node
is ready to start handling requests