### PR TITLE
Fix replica stats test

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -53,7 +53,7 @@ namespace EventStore.Core.Tests.Helpers
             IPEndPoint externalTcp, IPEndPoint externalTcpSec, IPEndPoint externalHttp, IPEndPoint[] gossipSeeds,
             ISubsystem[] subsystems = null, int? chunkSize = null, int? cachedChunkSize = null,
             bool enableTrustedAuth = false, bool skipInitializeStandardUsersCheck = true, int memTableSize = 1000,
-            bool inMemDb = true, bool disableFlushToDisk = false)
+            bool inMemDb = true, bool disableFlushToDisk = false, int clusterCount = 3)
         {
             RunningTime.Start();
             RunCount += 1;
@@ -84,11 +84,11 @@ namespace EventStore.Core.Tests.Helpers
                                              ExternalTcpEndPoint, ExternalTcpSecEndPoint,
                                              InternalHttpEndPoint, ExternalHttpEndPoint),
                 new[] {InternalHttpEndPoint.ToHttpUrl()}, new[]{ExternalHttpEndPoint.ToHttpUrl()}, enableTrustedAuth, ssl_connections.GetCertificate(), 1, false,
-                "", gossipSeeds, TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2),
+                "", gossipSeeds, TFConsts.MinFlushDelayMs, clusterCount, 2, 2, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2),
                 false, "", false, TimeSpan.FromHours(1), StatsStorage.None, 0,
                 new InternalAuthenticationProviderFactory(), disableScavengeMerging: true, scavengeHistoryMaxAge: 30, adminOnPublic: true,
-                statsOnPublic: true, gossipOnPublic: true, gossipInterval: TimeSpan.FromSeconds(1),
-                gossipAllowedTimeDifference: TimeSpan.FromSeconds(1), gossipTimeout: TimeSpan.FromSeconds(1),
+                statsOnPublic: true, gossipOnPublic: true, gossipInterval: TimeSpan.FromSeconds(3),
+                gossipAllowedTimeDifference: TimeSpan.FromSeconds(10), gossipTimeout: TimeSpan.FromSeconds(3),
                 extTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), extTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
                 intTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), intTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
                 verifyDbHash: false, maxMemtableEntryCount: memTableSize, startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false);

--- a/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_replica_stats_from_stat_controller.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_replica_stats_from_stat_controller.cs
@@ -41,9 +41,9 @@ namespace EventStore.Core.Tests.Services.Transport.Http
                 _nodeEndpoints[1], new IPEndPoint[] { _nodeEndpoints[0].InternalHttp });
 
             _nodes[0].Start();
+            WaitHandle.WaitAll(new [] {_nodes[0].StartedEvent});
             _nodes[1].Start();
-            
-            WaitHandle.WaitAll(new[] { _nodes[0].StartedEvent, _nodes[1].StartedEvent });
+            WaitHandle.WaitAll(new [] {_nodes[1].StartedEvent});
         }
         
         [TestFixtureSetUp]
@@ -121,7 +121,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
 		{
 			return new MiniClusterNode(
 				PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp, endpoints.ExternalTcp,
-				endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false, gossipSeeds: gossipSeeds);
+				endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false, gossipSeeds: gossipSeeds, clusterCount: 2);
 		}
         
         protected class Endpoints


### PR DESCRIPTION
Change the cluster size being used for the replica stat test to 2 instead of 3 as there are only 2 nodes being brought up in the test.