### PR TITLE
Change prelude js files to embedded resources

### DIFF
--- a/src/EventStore.Common/Utils/Locations.cs
+++ b/src/EventStore.Common/Utils/Locations.cs
@@ -10,6 +10,7 @@ namespace EventStore.Common.Utils
         public static readonly string WebContentDirectory;
         public static readonly string ProjectionsDirectory;
         public static readonly string PreludeDirectory;
+        public static readonly string PreludeResourcesPath;
         public static readonly string PluginsDirectory;
         public static readonly string DefaultContentDirectory;
         public static readonly string DefaultConfigurationDirectory;
@@ -56,6 +57,7 @@ namespace EventStore.Common.Utils
                         Path.Combine(ApplicationDirectory, "Prelude"),
                         Path.Combine(DefaultContentDirectory, "Prelude")
                         );
+            PreludeResourcesPath = "EventStore.Projections.Core.Prelude";
 
         }
 

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -384,18 +384,18 @@
     <Folder Include="Prelude\Modules\" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Prelude\1Prelude.js">
+    <EmbeddedResource Include="Prelude\1Prelude.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Prelude\Modules.js">
+    </EmbeddedResource>
+    <EmbeddedResource Include="Prelude\Modules.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Prelude\ModulesExecuted.js">
+    </EmbeddedResource>
+    <EmbeddedResource Include="Prelude\ModulesExecuted.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Prelude\Projections.js">
+    </EmbeddedResource>
+    <EmbeddedResource Include="Prelude\Projections.js">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
     <Content Include="Services\Management\TODO.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Fixes #752 by changing the prelude js files from content files to embedded resources.
Also updates the V8 projections handler to get the prelude files from the embedded resources instead of the file system.