### PR TITLE
Use ClientResolvedEvent if OriginalPosition not null

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriptionBase.cs
@@ -68,7 +68,9 @@ namespace EventStore.ClientAPI.Embedded
 
         public void EventAppeared(Core.Data.ResolvedEvent resolvedEvent)
         {
-            _eventAppeared(_subscription, new ResolvedEvent(resolvedEvent.ConvertToClientResolvedIndexEvent()));
+            _eventAppeared(_subscription, resolvedEvent.OriginalPosition == null
+                ? new ResolvedEvent(resolvedEvent.ConvertToClientResolvedIndexEvent())
+                : new ResolvedEvent(resolvedEvent.ConvertToClientResolvedEvent()));
         }
 
         public void ConfirmSubscription(long lastCommitPosition, int? lastEventNumber)


### PR DESCRIPTION
fixes #823, event not appearing in catchupsubscriptons on embedded
connection