### PR TITLE
Omit the metadata json field if there is no metadata on a feed entry

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -276,6 +276,10 @@ namespace EventStore.Core.Services.Transport.Http
                             {
                                 richEntry.MetaData = FormatJson(richEntry.MetaData);
                             }
+                            if (string.IsNullOrEmpty(richEntry.MetaData))
+                            {
+                                richEntry.MetaData = null;
+                            }
                         }
                         catch
                         {


### PR DESCRIPTION
Fixes #736 

Sets the metadata on a feed entry to null if the parsed metadata is an empty string.
This way, when the entry is converted to json, the metadata field is omitted.