### PR TITLE
Introduce a subset of codecs

### DIFF
--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -93,9 +93,7 @@
     <None Include="Log\log.config">
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Locks\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <PreBuildEvent>powershell.exe $(MSBuildProjectDirectory)\..\Scripts\version\updateCommitHash.ps1 $(MSBuildProjectDirectory)\Properties\AssemblyInfo.cs</PreBuildEvent>

--- a/src/EventStore.Common/Utils/Empty.cs
+++ b/src/EventStore.Common/Utils/Empty.cs
@@ -9,5 +9,8 @@ namespace EventStore.Common.Utils
         public static readonly object[] ObjectArray = new object[0];
 
         public static readonly Action Action = () => { };
+        public static readonly object Result = new object();
+        public static readonly string Xml = String.Empty;
+        public static readonly string Json = "{}";
     }
 }

--- a/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
+++ b/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
@@ -337,11 +337,13 @@ namespace EventStore.Core.Tests.Http
                 return default(T);
             }
         }
-
-        protected void Get(string path, string extra, string accept = null, ICredentials credentials = null)
+			
+		protected void Get(string path, string extra, string accept = null, ICredentials credentials = null, bool setAcceptHeader = true)
         {
             var request = CreateRequest(path, extra, "GET", null, credentials);
-            request.Accept = accept ?? "application/json";
+			if (setAcceptHeader) {
+				request.Accept = accept ?? "application/json";
+			}
             _lastResponse = GetRequestResponse(request);
             var memoryStream = new MemoryStream();
             _lastResponse.GetResponseStream().CopyTo(memoryStream);

--- a/src/EventStore.Core.Tests/Http/Streams/metadata.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/metadata.cs
@@ -4,6 +4,8 @@ using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.Http.Streams.basic;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using System.Xml.Linq;
+using EventStore.Common.Utils;
 
 namespace EventStore.Core.Tests.Http.Streams
 {
@@ -83,6 +85,27 @@ namespace EventStore.Core.Tests.Http.Streams
     }
 
     [TestFixture]
+    public class when_getting_metadata_for_an_existing_stream_without_an_accept_header : HttpBehaviorSpecificationWithSingleEvent
+    {
+        protected override void When()
+        {
+			Get(TestStream + "/metadata", null, null, DefaultData.AdminNetworkCredentials, false);
+        }
+
+        [Test]
+        public void returns_ok_status_code()
+        {
+            Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+        }
+
+        [Test]
+        public void returns_empty_body()
+        {
+            Assert.AreEqual(Empty.Xml, _lastResponseBody);
+        }
+    }
+
+    [TestFixture]
     public class when_getting_metadata_for_an_existing_stream_and_no_metadata_exists : HttpBehaviorSpecificationWithSingleEvent
     {
         protected override void Given()
@@ -112,7 +135,7 @@ namespace EventStore.Core.Tests.Http.Streams
         [Test]
         public void returns_empty_body()
         {
-            Assert.AreEqual("{}", _lastResponseBody);
+            Assert.AreEqual(Empty.Json, _lastResponseBody);
         }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -73,6 +73,16 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                                                                   HtmlFeedCodec // initialization order matters
                                                               };
 
+        private static readonly ICodec[] DefaultCodecs =
+                                                              {
+                                                                  Codec.Xml,
+                                                                  Codec.ApplicationXml,
+                                                                  Codec.Json,
+                                                                  Codec.EventXml,
+                                                                  Codec.EventJson,
+                                                                  HtmlFeedCodec // initialization order matters
+                                                              };
+
         private readonly IHttpForwarder _httpForwarder;
         private readonly IPublisher _networkSendQueue;
 
@@ -102,7 +112,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
             Register(http, "/streams/{stream}?embed={embed}", HttpMethod.Get, GetStreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
 
-            Register(http, "/streams/{stream}/{event}?embed={embed}", HttpMethod.Get, GetStreamEvent, Codec.NoCodecs, AtomWithHtmlCodecs);
+            Register(http, "/streams/{stream}/{event}?embed={embed}", HttpMethod.Get, GetStreamEvent, Codec.NoCodecs, DefaultCodecs);
             Register(http, "/streams/{stream}/{event}/{count}?embed={embed}", HttpMethod.Get, GetStreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
             Register(http, "/streams/{stream}/{event}/backward/{count}?embed={embed}", HttpMethod.Get, GetStreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
             RegisterCustom(http, "/streams/{stream}/{event}/forward/{count}?embed={embed}", HttpMethod.Get, GetStreamEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs);
@@ -111,9 +121,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             Register(http, "/streams/{stream}/metadata", HttpMethod.Post, PostMetastreamEvent, AtomCodecs, AtomCodecs);
             Register(http, "/streams/{stream}/metadata/", HttpMethod.Post, RedirectKeepVerb, AtomCodecs, AtomCodecs);
 
-            Register(http, "/streams/{stream}/metadata?embed={embed}", HttpMethod.Get, GetMetastreamEvent, Codec.NoCodecs, AtomWithHtmlCodecs);
-            Register(http, "/streams/{stream}/metadata/?embed={embed}", HttpMethod.Get, RedirectKeepVerb, Codec.NoCodecs, AtomCodecs);
-            Register(http, "/streams/{stream}/metadata/{event}?embed={embed}", HttpMethod.Get, GetMetastreamEvent, Codec.NoCodecs, AtomWithHtmlCodecs);
+            Register(http, "/streams/{stream}/metadata?embed={embed}", HttpMethod.Get, GetMetastreamEvent, Codec.NoCodecs, DefaultCodecs);
+            Register(http, "/streams/{stream}/metadata/?embed={embed}", HttpMethod.Get, RedirectKeepVerb, Codec.NoCodecs, DefaultCodecs);
+            Register(http, "/streams/{stream}/metadata/{event}?embed={embed}", HttpMethod.Get, GetMetastreamEvent, Codec.NoCodecs, DefaultCodecs);
 
             Register(http, "/streams/{stream}/metadata/{event}/{count}?embed={embed}", HttpMethod.Get, GetMetastreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
             Register(http, "/streams/{stream}/metadata/{event}/backward/{count}?embed={embed}", HttpMethod.Get, GetMetastreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -5,7 +5,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Services.Transport.Http.Controllers;
 using EventStore.Transport.Http;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
-using EventStore.Transport.Http.Atom;
+using EventStore.Common.Utils;
 
 namespace EventStore.Core.Services.Transport.Http
 {
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.Transport.Http
         {
             var msg = message as ClientMessage.ReadEventCompleted;
             if (msg == null || msg.Result != ReadEventResult.Success || msg.Record.Event == null)
-                return entity.ResponseCodec.To(new {});
+                return entity.ResponseCodec.To(Empty.Result);
 
             switch (entity.ResponseCodec.ContentType)
             {

--- a/src/EventStore.Transport.Http/Codecs/JsonCodec.cs
+++ b/src/EventStore.Transport.Http/Codecs/JsonCodec.cs
@@ -72,7 +72,12 @@ namespace EventStore.Transport.Http.Codecs
 
         public string To<T>(T value)
         {
-            if (value == null) return "";
+            if (value == null)
+                return "";
+
+            if ((object)value == Empty.Result)
+                return Empty.Json;
+
             try
             {
                 return JsonConvert.SerializeObject(value, Formatting, ToSettings);

--- a/src/EventStore.Transport.Http/Codecs/XmlCodec.cs
+++ b/src/EventStore.Transport.Http/Codecs/XmlCodec.cs
@@ -54,6 +54,9 @@ namespace EventStore.Transport.Http.Codecs
             if ((object)value == null)
                 return null;
 
+            if((object)value == Empty.Result)
+                return Empty.Xml;
+
             try
             {
                 using (var memory = new MemoryStream())


### PR DESCRIPTION
When reading a single event (event/metadata), only a subset of the usual codecs are needed.
For instance, the atom codecs nor the stream description codecs are relevant.

Introduce an `Empty.Result` and return an `Empty.Xml` or `Empty.Json` result when this result is encountered in the codecs.

The change only impacts reading a single event.

Remove the tests that are no longer relevant and include a new set of tests for requests without accept headers.
Remove empty locks directory.