### PR TITLE
Trigger cluster replication immediately after flush to speed up writes.

### DIFF
--- a/src/EventStore.Core/TransactionLog/Checkpoint/ICheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/ICheckpoint.cs
@@ -8,10 +8,9 @@ namespace EventStore.Core.TransactionLog.Checkpoint
         void Write(long checkpoint);
         void Flush();
         void Close();
-
         long Read();
         long ReadNonFlushed();
 
-        bool WaitForFlush(TimeSpan timeout);
+        event Action<long> Flushed;
     }
 }

--- a/src/EventStore.Core/TransactionLog/Checkpoint/InMemoryCheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/InMemoryCheckpoint.cs
@@ -47,18 +47,16 @@ namespace EventStore.Core.TransactionLog.Checkpoint
 
             Interlocked.Exchange(ref _lastFlushed, last);
 
-            lock (_flushLocker)
-            {
-                Monitor.PulseAll(_flushLocker);
-            }
+            OnFlushed(last);
         }
+        
+        public event Action<long> Flushed;
 
-        public bool WaitForFlush(TimeSpan timeout)
+        protected virtual void OnFlushed(long obj)
         {
-            lock (_flushLocker)
-            {
-                return Monitor.Wait(_flushLocker, timeout);
-            }
+            var onFlushed = Flushed;
+            if (onFlushed != null)
+                onFlushed.Invoke(obj);
         }
 
         public void Close()

--- a/src/EventStore.Core/TransactionLog/Checkpoint/WriteThroughFileCheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/WriteThroughFileCheckpoint.cs
@@ -100,6 +100,8 @@ namespace EventStore.Core.TransactionLog.Checkpoint
             _stream.Write(buffer, 0, buffer.Length);
 
             Interlocked.Exchange(ref _lastFlushed, last);
+
+            OnFlushed(last);
             //FlushFileBuffers(_file.SafeMemoryMappedFileHandle.DangerousGetHandle());
         }
 
@@ -118,10 +120,14 @@ namespace EventStore.Core.TransactionLog.Checkpoint
         {
             return Interlocked.Read(ref _last);
         }
+        
+        public event Action<long> Flushed;
 
-        public bool WaitForFlush(TimeSpan timeout)
+        protected virtual void OnFlushed(long obj)
         {
-            throw new NotImplementedException();
+            var onFlushed = Flushed;
+            if (onFlushed != null)
+                onFlushed.Invoke(obj);
         }
 
         public void Dispose()


### PR DESCRIPTION
I think this may only be an issue on Windows. I don't have a Linux box available to test on. The Thread.Sleep(1) causes an average delay of (1/64)/2 seconds delay (8ms) in replication of a cluster. This results in irregular commits to a cluster to take in the region of 10 ms each.

I've removed the sleep and triggered replication from the checkpoint flush event. This reduces writes much closer to the raw flush costs at ~3ms.

I've replaced the existing WaitForFlush with an event as the Monitor.Pulse method has a race between the check for more data and the call to Wait. 

I also added a fake type so the queue monitoring on the dashboard shows the replication activity.