### PR TITLE
Fix flapping truncation tests

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -75,7 +75,7 @@ namespace EventStore.Core.Tests.Services.Storage
             ChaserCheckpoint.Write(WriterCheckpoint.Read());
             ChaserCheckpoint.Flush();
 
-            var readers = new ObjectPool<ITransactionFileReader>("Readers", 2, 2, () => new TFChunkReader(Db, Db.Config.WriterCheckpoint));
+            var readers = new ObjectPool<ITransactionFileReader>("Readers", 2, 5, () => new TFChunkReader(Db, Db.Config.WriterCheckpoint));
             TableIndex = new TableIndex(GetFilePathFor("index"),
                                         () => new HashListMemTable(MaxEntriesInMemTable * 2),
                                         () => new TFReaderLease(readers),


### PR DESCRIPTION
Increase the number of readers available in the reader pool in the ReadIndexTestScenario.
This fixes the ObjectPoolMaxLimitReachedException that was occasionally being thrown by TableIndex, causing it to timeout.