### PR TITLE
Projection Emit Null Stream #541

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_event_type_index_positions_when_updating.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_phase.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_catalog_stream.cs" />
+    <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_null_streamId.cs" />
     <Compile Include="Services\event_reader\stream_reader\when_handling_soft_deleted_stream_with_a_single_event_event_reader.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection_and_not_authorised.cs" />
     <Compile Include="Services\projections_manager\when_recreating_a_deleted_projection.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_null_streamId.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_null_streamId.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_checkpoint
+{
+    [TestFixture]
+    public class when_emitting_events_with_null_streamId : TestFixtureWithExistingEvents
+    {
+        private ProjectionCheckpoint _checkpoint;
+        private Exception _lastException;
+        private TestCheckpointManagerMessageHandler _readyHandler;
+
+        [SetUp]
+        public void setup()
+        {
+            _readyHandler = new TestCheckpointManagerMessageHandler();
+            _checkpoint = new ProjectionCheckpoint(
+                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+            try
+            {
+                _checkpoint.ValidateOrderAndEmitEvents(
+                    new[]
+                    {
+                        new EmittedEventEnvelope(
+                            new EmittedDataEvent(
+                                null, Guid.NewGuid(), "type", true, "data", null, CheckpointTag.FromPosition(0, 40, 30), null))
+                    });
+            }
+            catch (Exception ex)
+            {
+                _lastException = ex;
+            }
+        }
+
+        [Test, ExpectedException(typeof(ArgumentNullException))]
+        public void throws_invalid_operation_exception()
+        {
+            if (_lastException != null) throw _lastException;
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCheckpoint.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCheckpoint.cs
@@ -126,6 +126,8 @@ namespace EventStore.Projections.Core.Services.Processing
 
         private void EmitEventsToStream(string streamId, EmittedEventEnvelope[] emittedEvents)
         {
+            if (streamId == null)
+                throw new ArgumentNullException("streamId");
             EmittedStream stream;
             if (!_emittedStreams.TryGetValue(streamId, out stream))
             {


### PR DESCRIPTION
Added a null check in ProjectionCheckpoint class and throw an ArgumentNullException if the streamId is null; created a new test for it