### PR TITLE
Handle special characters such as slashes in stream names

### DIFF
--- a/src/EventStore.Core.Tests/Http/ArgumentPassing/matching.cs
+++ b/src/EventStore.Core.Tests/Http/ArgumentPassing/matching.cs
@@ -36,6 +36,10 @@ namespace EventStore.Core.Tests.Http.ArgumentPassing
 //            [TestCase("%2F", "/", "2", "2")] // /
             [TestCase("%20", " ", "2", "2")] // space
             [TestCase("%25", "%", "2", "2")] // %
+            [TestCase("%2525", "%", "2", "2")] // %
+            [TestCase("%252F", "/", "2", "2")] // /
+            [TestCase("%253F", "?", "2", "2")] // ?
+            [TestCase("%2524", "$", "2", "2")] // $
             public void returns_ok_status_code(string _a, string _ra, string _b, string _rb)
             {
                 _response = GetJson2<JObject>("/test-encoding/" + _a, "b=" + _b);

--- a/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
+++ b/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
@@ -99,16 +99,18 @@ namespace EventStore.Core.Tests.Http
             }
         }
 
+        protected string _testStreamName = "test";
+        
         public string TestStream {
-            get { return "/streams/test" + Tag; }
+            get { return "/streams/" + _testStreamName + Tag; }
         }
 
         public string TestStreamName {
-            get { return "test" + Tag; }
+            get { return _testStreamName + Tag; }
         }
 
         public string TestMetadataStream {
-            get { return "/streams/$$test" + Tag; }
+            get { return "/streams/$$" + _testStreamName + Tag; }
         }
 
         public string Tag

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/getting.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/getting.cs
@@ -185,6 +185,44 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             Assert.AreEqual(Events.Count, count, "Expected {0} events, received {1}", Events.Count, count);
         }
     }
+    
+    [TestFixture]
+    class when_getting_messages_from_a_subscription_on_a_stream_with_containing_a_slash : with_subscription_having_events
+    {
+        private JObject _response;
+        private string _unencodedStreamName = "test/stream";
+        private string _doubleEncodedStreamName = "test%252Fstream";
+
+        [TestFixtureSetUp]
+        public override void TestFixtureSetUp() 
+        {
+            _testStreamName = _doubleEncodedStreamName;
+            base.TestFixtureSetUp();
+        }
+        
+        protected override void When()
+        {
+
+            _response = GetJson<JObject>(
+                                SubscriptionPath + "/" + Events.Count,
+                                ContentType.CompetingJson, //todo CLC sort out allowed content types
+                                _admin);
+        }
+        
+        [Test]
+        public void returns_title_containing_unencoded_stream_name() 
+        {
+            var title = _response["title"].ToString();
+            Assert.IsTrue(title.Contains(_unencodedStreamName));
+        }
+
+        [Test]
+        public void returns_links_with_double_encoded_stream_name()
+        {
+            var link = ((JObject)_response["links"].First())["uri"].ToString();
+            Assert.IsTrue(link.Contains(_doubleEncodedStreamName));
+        }
+    }
 
     class when_getting_messages_from_a_subscription_with_more_than_n_messages : with_subscription_having_events
     {

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -118,6 +118,94 @@ namespace EventStore.Core.Tests.Http.Streams
             }
         }
 
+        [TestFixture, Category("LongRunning")]
+        public class when_retrieving_feed_head_with_slash_in_stream_id : SpecificationWithLongFeed
+        {
+            private JObject _feed;
+            private string _encodedStreamName = "test%252Fstream";
+            private string _decodedStreamName = "test/stream";
+            
+            [TestFixtureSetUp]
+            public override void TestFixtureSetUp() 
+            {
+                _testStreamName = _encodedStreamName;
+                base.TestFixtureSetUp();
+            }
+            
+            protected override void When()
+            {
+                _feed = GetJson<JObject>(TestStream, ContentType.AtomJson);
+            }
+
+            [Test]
+            public void returns_ok_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+            }
+            
+            [Test]
+            public void contains_a_decoded_stream_id() 
+            {
+                var streamId = _feed["streamId"].ToString();
+                Assert.AreEqual(_decodedStreamName + Tag, streamId);
+            }
+
+            [Test]
+            public void contains_a_link_rel_previous_with_the_stream_id_double_encoded()
+            {
+                var rel = GetLink(_feed, "previous");
+                Assert.IsNotEmpty(rel);
+                Assert.IsTrue(rel.Contains(_encodedStreamName));
+            }
+
+            [Test]
+            public void contains_a_link_rel_next_with_the_stream_id_double_encoded()
+            {
+                var rel = GetLink(_feed, "next");
+                Assert.IsNotEmpty(rel);
+                Assert.IsTrue(rel.Contains(_encodedStreamName));
+            }
+
+            [Test]
+            public void contains_a_link_rel_self_with_the_stream_id_double_encoded()
+            {
+                var rel = GetLink(_feed, "self");
+                Assert.IsNotEmpty(rel);
+                Assert.IsTrue(rel.Contains(_encodedStreamName));
+            }
+
+            [Test]
+            public void contains_a_link_rel_first_with_the_stream_id_double_encoded()
+            {
+                var rel = GetLink(_feed, "first");
+                Assert.IsNotEmpty(rel);
+                Assert.IsTrue(rel.Contains(_encodedStreamName));
+            }
+
+            [Test]
+            public void contains_a_link_rel_last_with_the_stream_id_double_encoded()
+            {
+                var rel = GetLink(_feed, "last");
+                Assert.IsNotEmpty(rel);
+                Assert.IsTrue(rel.Contains(_encodedStreamName));
+            }
+            
+            [Test]
+            public void contains_events_with_titles_using_decoded_stream_id()
+            {
+                var entry = _feed["entries"].FirstOrDefault();
+                var title = entry["title"].ToString();
+                Assert.IsTrue(title.Contains(_decodedStreamName));
+            }
+            
+            [Test]
+            public void contains_events_with_link_using_double_encoded_stream_id()
+            {
+                var entry = _feed["entries"].FirstOrDefault();
+                var id = entry["id"].ToString();
+                Assert.IsTrue(id.Contains(_encodedStreamName));
+            }
+        }
 
         [TestFixture, Category("LongRunning")]
         public class when_retrieving_the_previous_link_of_the_feed_head: SpecificationWithLongFeed
@@ -332,7 +420,7 @@ namespace EventStore.Core.Tests.Http.Streams
                 //TODO GFY I really wish we were targeting 4.5 only so I could use Uri.EscapeDataString
                 //given the choice between this and a dependency on system.web well yeah. When we have 4.5
                 //only lets use Uri
-                Assert.AreEqual(MakeUrl("/streams/" + StreamName.Replace("@", "%40") + "/0"), foo["uri"].ToString());
+                Assert.AreEqual(MakeUrl("/streams/" + StreamName.Replace("@", "%2540") + "/0"), foo["uri"].ToString());
             }
 
             [Test]
@@ -340,7 +428,7 @@ namespace EventStore.Core.Tests.Http.Streams
             {
                 var foo = _entries[1]["links"][1];
                 Assert.AreEqual("alternate", foo["relation"].ToString());
-                Assert.AreEqual(MakeUrl("/streams/" + StreamName.Replace("@", "%40") + "/0"), foo["uri"].ToString());
+                Assert.AreEqual(MakeUrl("/streams/" + StreamName.Replace("@", "%2540") + "/0"), foo["uri"].ToString());
             }
 
             [Test]
@@ -348,7 +436,7 @@ namespace EventStore.Core.Tests.Http.Streams
             {
                 var foo = _entries[0]["links"][0];
                 Assert.AreEqual("edit", foo["relation"].ToString());
-                Assert.AreEqual(MakeUrl("/streams/" + StreamName.Replace("@", "%40") + "/1"), foo["uri"].ToString());
+                Assert.AreEqual(MakeUrl("/streams/" + StreamName.Replace("@", "%2540") + "/1"), foo["uri"].ToString());
             }
 
             [Test]
@@ -356,7 +444,7 @@ namespace EventStore.Core.Tests.Http.Streams
             {
                 var foo = _entries[0]["links"][1];
                 Assert.AreEqual("alternate", foo["relation"].ToString());
-                Assert.AreEqual(MakeUrl("/streams/" + StreamName.Replace("@", "%40") + "/1"), foo["uri"].ToString());
+                Assert.AreEqual(MakeUrl("/streams/" + StreamName.Replace("@", "%2540") + "/1"), foo["uri"].ToString());
             }
         }
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -601,7 +601,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
             foreach (var stat in message.SubscriptionStats)
             {
-                string escapedStreamId = Uri.EscapeDataString(stat.EventStreamId);
+                string escapedStreamId = DoubleEscapeDataString(stat.EventStreamId);
                 string escapedGroupName = Uri.EscapeDataString(stat.GroupName);
                 var info = new SubscriptionInfo
                 {
@@ -671,7 +671,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
             foreach (var stat in message.SubscriptionStats)
             {
-                string escapedStreamId = Uri.EscapeDataString(stat.EventStreamId);
+                string escapedStreamId = DoubleEscapeDataString(stat.EventStreamId);
                 string escapedGroupName = Uri.EscapeDataString(stat.GroupName);
                 var info = new SubscriptionSummary
                 {
@@ -696,6 +696,11 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                 }
                 yield return info;
             }
+        }
+        
+        private string DoubleEscapeDataString(string data) 
+        {
+            return Uri.EscapeDataString(Uri.EscapeDataString(data));
         }
 
         public class SubscriptionConfigData

--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Services.Transport.Http
         {
             Ensure.NotNull(msg, "msg");
 
-            string escapedStreamId = Uri.EscapeDataString(msg.EventStreamId);
+            string escapedStreamId = DoubleEscapeDataString(msg.EventStreamId);
             var self = HostName.Combine(requestedUrl, "/streams/{0}", escapedStreamId);
             var feed = new FeedElement();
             feed.SetTitle(string.Format("Event stream '{0}'", msg.EventStreamId));
@@ -61,7 +61,7 @@ namespace EventStore.Core.Services.Transport.Http
         {
             Ensure.NotNull(msg, "msg");
 
-            string escapedStreamId = Uri.EscapeDataString(msg.EventStreamId);
+            string escapedStreamId = DoubleEscapeDataString(msg.EventStreamId);
             var self = HostName.Combine(requestedUrl, "/streams/{0}", escapedStreamId);
             var feed = new FeedElement();
             feed.SetTitle(string.Format("Event stream '{0}'", msg.EventStreamId));
@@ -149,7 +149,7 @@ namespace EventStore.Core.Services.Transport.Http
 
         public static FeedElement ToNextNPersistentMessagesFeed(ClientMessage.ReadNextNPersistentMessagesCompleted msg, Uri requestedUrl, string streamId, string groupName, int count, EmbedLevel embedContent)
         {
-            string escapedStreamId = Uri.EscapeDataString(streamId);
+            string escapedStreamId = DoubleEscapeDataString(streamId);
             string escapedGroupName = Uri.EscapeDataString(groupName);
             var self = HostName.Combine(requestedUrl, "/subscriptions/{0}/{1}", escapedStreamId, escapedGroupName);
             var feed = new FeedElement();
@@ -187,7 +187,7 @@ namespace EventStore.Core.Services.Transport.Http
 
         public static DescriptionDocument ToDescriptionDocument(Uri requestedUrl, string streamId, string[] subscriptions)
         {
-            string escapedStreamId = Uri.EscapeDataString(streamId);
+            string escapedStreamId = DoubleEscapeDataString(streamId);
             var descriptionDocument = new DescriptionDocument();
             descriptionDocument.SetTitle(string.Format("Description document for '{0}'", streamId));
             descriptionDocument.SetDescription(@"The description document will be presented when no accept header is present or it was requested");
@@ -338,7 +338,7 @@ namespace EventStore.Core.Services.Transport.Http
 
         private static void SetEntryProperties(string stream, int eventNumber, DateTime timestamp, Uri requestedUrl, EntryElement entry)
         {
-            var escapedStreamId = Uri.EscapeDataString(stream);
+            var escapedStreamId = DoubleEscapeDataString(stream);
             entry.SetTitle(eventNumber + "@" + stream);
             entry.SetId(HostName.Combine(requestedUrl, "/streams/{0}/{1}", escapedStreamId, eventNumber));
             entry.SetUpdated(timestamp);
@@ -356,6 +356,11 @@ namespace EventStore.Core.Services.Transport.Http
             var jo = JObject.Parse(unformattedjson);
             var json = JsonConvert.SerializeObject(jo, Formatting.Indented);
             return json;
+        }
+
+        private static string DoubleEscapeDataString(string data)
+        {
+            return Uri.EscapeDataString(Uri.EscapeDataString(data));
         }
     }
 

--- a/src/EventStore.Core/Services/Transport/Http/HttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/HttpService.cs
@@ -144,7 +144,11 @@ namespace EventStore.Core.Services.Transport.Http
 
         public List<UriToActionMatch> GetAllUriMatches(Uri uri)
         {
-            return _uriRouter.GetAllUriMatches(uri);
+            var uriToMatch = uri;
+#if !__MonoCS__
+            uriToMatch = new Uri(Uri.EscapeUriString(uri.OriginalString));
+#endif
+            return _uriRouter.GetAllUriMatches(uriToMatch);
         }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/UriRouters.cs
+++ b/src/EventStore.Core/Services/Transport/Http/UriRouters.cs
@@ -90,7 +90,16 @@ namespace EventStore.Core.Services.Transport.Http
                 var route = routes[i];
                 var match = route.UriTemplate.Match(baseAddress, uri);
                 if (match != null)
+                {
+                    for(var j = 0; j < match.BoundVariables.Keys.Count; j++)
+                    {
+                        var key = match.BoundVariables.Keys[j];
+                        var boundVar = match.BoundVariables[key];
+                        if(boundVar != null)
+                            match.BoundVariables[key] = Uri.UnescapeDataString(boundVar);
+                    }
                     matches.Add(new UriToActionMatch(match, route.Action, route.Handler));
+                }
             }
         }
 
@@ -121,7 +130,16 @@ namespace EventStore.Core.Services.Transport.Http
                 var route = _actions[i];
                 var match = route.UriTemplate.Match(baseAddress, uri);
                 if (match != null)
+                {
+                    for(var j = 0; j < match.BoundVariables.Keys.Count; j++)
+                    {
+                        var key = match.BoundVariables.Keys[j];
+                        var boundVar = match.BoundVariables[key];
+                        if(boundVar != null)
+                            match.BoundVariables[key] = Uri.UnescapeDataString(boundVar);
+                    }
                     matches.Add(new UriToActionMatch(match, route.Action, route.Handler));
+                }
             }
             return matches;
         }


### PR DESCRIPTION
Fixes #804 

Double encode the stream names being sent from event store as part of the atom feeds and persistent subscription feeds, and double encode the stream names being sent to event store by the admin UI.
Update the url matching in the UriRouter to handle the double encoded stream ids by decoding them after they have been matched.

Also update the http service to escape the request uri before attempting to match it when running on .Net because .Net 4 decodes the whole url before we have a chance to match it.
