### PR TITLE
Client ordering

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -174,6 +174,9 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.UnsafeDisableFlushToDiskDescr, Opts.DbGroup)]
         public bool UnsafeDisableFlushToDisk { get; set; }
 
+        [ArgDescription(Opts.BetterOrderingDescr, Opts.DbGroup)]
+        public bool BetterOrdering { get; set; }
+
         [ArgDescription(Opts.UnsafeIgnoreHardDeleteDescr, Opts.DbGroup)]
         public bool UnsafeIgnoreHardDelete { get; set; }
 
@@ -236,6 +239,7 @@ namespace EventStore.ClusterNode
             RunProjections = Opts.RunProjectionsDefault;
             ProjectionThreads = Opts.ProjectionThreadsDefault;
             WorkerThreads = Opts.WorkerThreadsDefault;
+            BetterOrdering = Opts.BetterOrderingDefault;
 
             IntHttpPrefixes = Opts.IntHttpPrefixesDefault;
             ExtHttpPrefixes = Opts.ExtHttpPrefixesDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -283,7 +283,8 @@ namespace EventStore.ClusterNode
                     options.EnableHistograms,
                     options.IndexCacheDepth,
                     consumerStrategyFactories,
-                    options.UnsafeIgnoreHardDelete
+                    options.UnsafeIgnoreHardDelete,
+                    options.BetterOrdering
                     );
         }
 

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_creating_delete_stream_request_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_creating_delete_stream_request_manager.cs
@@ -14,21 +14,21 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
         [Test]
         public void null_publisher_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new DeleteStreamTwoPhaseRequestManager(null, 3, 3, PrepareTimeout, CommitTimeout));
+            Assert.Throws<ArgumentNullException>(() => new DeleteStreamTwoPhaseRequestManager(null, 3, 3, PrepareTimeout, CommitTimeout, false));
         }
 
         [Test]
         public void zero_prepare_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new DeleteStreamTwoPhaseRequestManager(new FakePublisher(), 0, 3, PrepareTimeout, CommitTimeout));
+                () => new DeleteStreamTwoPhaseRequestManager(new FakePublisher(), 0, 3, PrepareTimeout, CommitTimeout, false));
         }
 
         [Test]
         public void zero_commit_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new DeleteStreamTwoPhaseRequestManager(new FakePublisher(), 3, 0, PrepareTimeout, CommitTimeout));
+                () => new DeleteStreamTwoPhaseRequestManager(new FakePublisher(), 3, 0, PrepareTimeout, CommitTimeout, false));
         }
 
 
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
         public void negative_commit_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new DeleteStreamTwoPhaseRequestManager(new FakePublisher(), 3, -1, PrepareTimeout, CommitTimeout));
+                () => new DeleteStreamTwoPhaseRequestManager(new FakePublisher(), 3, -1, PrepareTimeout, CommitTimeout, false));
         }
 
 
@@ -44,7 +44,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
         public void negative_prepare_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new DeleteStreamTwoPhaseRequestManager(new FakePublisher(), -1, 3, PrepareTimeout, CommitTimeout));
+                () => new DeleteStreamTwoPhaseRequestManager(new FakePublisher(), -1, 3, PrepareTimeout, CommitTimeout, false));
         }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_completes_successfully.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_already_committed.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_already_committed.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_commit_timeout_after_commit.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_commit_timeout_after_commit.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_commit_timeout_before_commit_stage.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_commit_timeout_before_commit_stage.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_commit_timeout_before_final_commit.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_commit_timeout_before_final_commit.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_prepare_timeout_after_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_prepare_timeout_after_prepares.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_prepare_timeout_before_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_prepare_timeout_before_prepares.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/DeleteStream/when_delete_stream_gets_stream_deleted.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.DeleteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new DeleteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_creating_transaction_commit_request_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_creating_transaction_commit_request_manager.cs
@@ -14,21 +14,21 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
         [Test]
         public void null_publisher_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new TransactionCommitTwoPhaseRequestManager(null, 3, 3, PrepareTimeout, CommitTimeout));
+            Assert.Throws<ArgumentNullException>(() => new TransactionCommitTwoPhaseRequestManager(null, 3, 3, PrepareTimeout, CommitTimeout, false));
         }
 
         [Test]
         public void zero_prepare_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new TransactionCommitTwoPhaseRequestManager(new FakePublisher(), 0, 3, PrepareTimeout, CommitTimeout));
+                () => new TransactionCommitTwoPhaseRequestManager(new FakePublisher(), 0, 3, PrepareTimeout, CommitTimeout, false));
         }
 
         [Test]
         public void zero_commit_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new TransactionCommitTwoPhaseRequestManager(new FakePublisher(), 3, 0, PrepareTimeout, CommitTimeout));
+                () => new TransactionCommitTwoPhaseRequestManager(new FakePublisher(), 3, 0, PrepareTimeout, CommitTimeout, false));
         }
 
 
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
         public void negative_commit_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new TransactionCommitTwoPhaseRequestManager(new FakePublisher(), 3, -1, PrepareTimeout, CommitTimeout));
+                () => new TransactionCommitTwoPhaseRequestManager(new FakePublisher(), 3, -1, PrepareTimeout, CommitTimeout, false));
         }
 
 
@@ -44,7 +44,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
         public void negative_prepare_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new TransactionCommitTwoPhaseRequestManager(new FakePublisher(), -1, 3, PrepareTimeout, CommitTimeout));
+                () => new TransactionCommitTwoPhaseRequestManager(new FakePublisher(), -1, 3, PrepareTimeout, CommitTimeout, false));
         }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_completes_successfully.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_already_committed.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_already_committed.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_commit_timeout_before_commit_stage.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_commit_timeout_before_commit_stage.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_commit_timeout_before_final_commit.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_commit_timeout_before_final_commit.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_prepare_timeout_after_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_prepare_timeout_after_prepares.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_prepare_timeout_before_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_prepare_timeout_before_prepares.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/TransactionCommit/when_transaction_commit_gets_stream_deleted.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.Services.Replication.TransactionCommit
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new TransactionCommitTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_creating_write_stream_request_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_creating_write_stream_request_manager.cs
@@ -14,21 +14,21 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
         [Test]
         public void null_publisher_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new WriteStreamTwoPhaseRequestManager(null, 3, 3, PrepareTimeout, CommitTimeout));
+            Assert.Throws<ArgumentNullException>(() => new WriteStreamTwoPhaseRequestManager(null, 3, 3, PrepareTimeout, CommitTimeout, false));
         }
 
         [Test]
         public void zero_prepare_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new WriteStreamTwoPhaseRequestManager(new FakePublisher(), 0, 3, PrepareTimeout, CommitTimeout));
+                () => new WriteStreamTwoPhaseRequestManager(new FakePublisher(), 0, 3, PrepareTimeout, CommitTimeout, false));
         }
 
         [Test]
         public void zero_commit_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new WriteStreamTwoPhaseRequestManager(new FakePublisher(), 3, 0, PrepareTimeout, CommitTimeout));
+                () => new WriteStreamTwoPhaseRequestManager(new FakePublisher(), 3, 0, PrepareTimeout, CommitTimeout, false));
         }
 
 
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
         public void negative_commit_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new WriteStreamTwoPhaseRequestManager(new FakePublisher(), 3, -1, PrepareTimeout, CommitTimeout));
+                () => new WriteStreamTwoPhaseRequestManager(new FakePublisher(), 3, -1, PrepareTimeout, CommitTimeout, false));
         }
 
 
@@ -44,7 +44,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
         public void negative_prepare_ack_count_throws_argument_out_range()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
-                () => new WriteStreamTwoPhaseRequestManager(new FakePublisher(), -1, 3, PrepareTimeout, CommitTimeout));
+                () => new WriteStreamTwoPhaseRequestManager(new FakePublisher(), -1, 3, PrepareTimeout, CommitTimeout, false));
         }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_completes_successfully.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_already_committed.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_already_committed.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_commit_timeout_after_commit.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_commit_timeout_after_commit.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_commit_timeout_before_commit_stage.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_commit_timeout_before_commit_stage.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_commit_timeout_before_final_commit.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_commit_timeout_before_final_commit.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_prepare_timeout_after_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_prepare_timeout_after_prepares.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_prepare_timeout_before_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_prepare_timeout_before_prepares.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/WriteStream/when_write_stream_gets_stream_deleted.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Replication.WriteStream
     {
         protected override TwoPhaseRequestManagerBase OnManager(FakePublisher publisher)
         {
-            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout);
+            return new WriteStreamTwoPhaseRequestManager(publisher, 3, 3, PrepareTimeout, CommitTimeout, false);
         }
 
         protected override IEnumerable<Message> WithInitialMessages()

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -64,6 +64,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly int MaxMemtableEntryCount;
         public readonly int IndexCacheDepth;
 
+        public readonly bool BetterOrdering;
         public readonly string Index;
 
         public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
@@ -117,7 +118,8 @@ namespace EventStore.Core.Cluster.Settings
                                     string index = null, bool enableHistograms = false,
                                     int indexCacheDepth = 16,
                                     IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null,
-                                    bool unsafeIgnoreHardDeletes = false)
+                                    bool unsafeIgnoreHardDeletes = false,
+                                    bool betterOrdering = false)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -198,6 +200,7 @@ namespace EventStore.Core.Cluster.Settings
             IndexCacheDepth = indexCacheDepth;
             Index = index;
             UnsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
+            BetterOrdering = betterOrdering;
         }
 
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -368,7 +368,8 @@ namespace EventStore.Core
                                                                  vNodeSettings.PrepareAckCount,
                                                                  vNodeSettings.CommitAckCount,
                                                                  vNodeSettings.PrepareTimeout,
-                                                                 vNodeSettings.CommitTimeout);
+                                                                 vNodeSettings.CommitTimeout,
+                                                                 vNodeSettings.BetterOrdering);
             _mainBus.Subscribe<SystemMessage.SystemInit>(requestManagement);
             _mainBus.Subscribe<ClientMessage.WriteEvents>(requestManagement);
             _mainBus.Subscribe<ClientMessage.TransactionStart>(requestManagement);

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Messages
 
         public interface IMasterWriteMessage
         {
-             
+
         }
 
         public class WritePrepares : Message, IPreconditionedWriteMessage, IFlushableMessage, IMasterWriteMessage
@@ -358,21 +358,22 @@ namespace EventStore.Core.Messages
         {
             private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
             public override int MsgTypeId { get { return TypeId; } }
-
-            public int QueueId { get { return EventStreamId.GetHashCode(); } }
+            private readonly int _affinity;
+            public int QueueId { get { return _affinity; } }
             public readonly string EventStreamId;
             public readonly long? TransactionId;
             public readonly StreamAccessType AccessType;
 
-            public CheckStreamAccess(IEnvelope envelope, Guid correlationId, string eventStreamId, long? transactionId, 
-                                     StreamAccessType accessType, IPrincipal user)
+            public CheckStreamAccess(IEnvelope envelope, Guid correlationId, string eventStreamId, long? transactionId,
+                                     StreamAccessType accessType, IPrincipal user, bool singleAffinity = false)
                 : base(correlationId, correlationId, envelope, user)
             {
                 if (eventStreamId == null && transactionId == null)
                     throw new ArgumentException("Neither eventStreamId nor transactionId is specified.");
-
                 EventStreamId = eventStreamId;
                 TransactionId = transactionId;
+                var hash = String.IsNullOrEmpty(EventStreamId) ? TransactionId.GetHashCode() : EventStreamId.GetHashCode();
+                _affinity = singleAffinity ? 1 : hash;
                 AccessType = accessType;
             }
         }
@@ -388,7 +389,7 @@ namespace EventStore.Core.Messages
             public readonly StreamAccessType AccessType;
             public readonly StreamAccess AccessResult;
 
-            public CheckStreamAccessCompleted(Guid correlationId, string eventStreamId, long? transactionId, 
+            public CheckStreamAccessCompleted(Guid correlationId, string eventStreamId, long? transactionId,
                                               StreamAccessType accessType, StreamAccess accessResult)
             {
                 CorrelationId = correlationId;

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -354,11 +354,12 @@ namespace EventStore.Core.Messages
             }
         }
 
-        public class CheckStreamAccess: ClientMessage.ReadRequestMessage
+        public class CheckStreamAccess: ClientMessage.ReadRequestMessage, IQueueAffineMessage
         {
             private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
             public override int MsgTypeId { get { return TypeId; } }
 
+            public int QueueId { get { return EventStreamId.GetHashCode(); } }
             public readonly string EventStreamId;
             public readonly long? TransactionId;
             public readonly StreamAccessType AccessType;

--- a/src/EventStore.Core/Services/RequestManager/Managers/DeleteStreamTwoPhaseRequestManager.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/DeleteStreamTwoPhaseRequestManager.cs
@@ -2,22 +2,23 @@ using System;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
- 
+
 namespace EventStore.Core.Services.RequestManager.Managers
 {
-    public class DeleteStreamTwoPhaseRequestManager : TwoPhaseRequestManagerBase, 
+    public class DeleteStreamTwoPhaseRequestManager : TwoPhaseRequestManagerBase,
                                                       IHandle<ClientMessage.DeleteStream>
     {
         private string _eventStreamId;
         private int _expectedVersion;
         private bool _hardDelete;
 
-        public DeleteStreamTwoPhaseRequestManager(IPublisher publisher,  
-                                                  int prepareCount, 
-                                                  int commitCount, 
+        public DeleteStreamTwoPhaseRequestManager(IPublisher publisher,
+                                                  int prepareCount,
+                                                  int commitCount,
                                                   TimeSpan prepareTimeout,
-                                                  TimeSpan commitTimeout) 
-            : base(publisher, prepareCount, commitCount, prepareTimeout, commitTimeout)
+                                                  TimeSpan commitTimeout,
+                                                  bool betterOrdering)
+            : base(publisher, prepareCount, commitCount, prepareTimeout, commitTimeout, betterOrdering)
         {
         }
 

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommitTwoPhaseRequestManager.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommitTwoPhaseRequestManager.cs
@@ -6,17 +6,18 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.RequestManager.Managers
 {
-    public class TransactionCommitTwoPhaseRequestManager : TwoPhaseRequestManagerBase, 
+    public class TransactionCommitTwoPhaseRequestManager : TwoPhaseRequestManagerBase,
                                                            IHandle<ClientMessage.TransactionCommit>
     {
         private long _transactionId;
 
-        public TransactionCommitTwoPhaseRequestManager(IPublisher publisher, 
-                                                       int prepareCount, 
-                                                       int commitCount, 
-                                                       TimeSpan prepareTimeout, 
-                                                       TimeSpan commitTimeout)
-            : base(publisher, prepareCount, commitCount, prepareTimeout, commitTimeout)
+        public TransactionCommitTwoPhaseRequestManager(IPublisher publisher,
+                                                       int prepareCount,
+                                                       int commitCount,
+                                                       TimeSpan prepareTimeout,
+                                                       TimeSpan commitTimeout,
+                                                       bool betterOrdering)
+            : base(publisher, prepareCount, commitCount, prepareTimeout, commitTimeout, betterOrdering)
         {
         }
 

--- a/src/EventStore.Core/Services/RequestManager/Managers/WriteStreamTwoPhaseRequestManager.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/WriteStreamTwoPhaseRequestManager.cs
@@ -5,17 +5,18 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.RequestManager.Managers
 {
-    public class WriteStreamTwoPhaseRequestManager : TwoPhaseRequestManagerBase, 
+    public class WriteStreamTwoPhaseRequestManager : TwoPhaseRequestManagerBase,
                                                      IHandle<ClientMessage.WriteEvents>
     {
         private ClientMessage.WriteEvents _request;
 
-        public WriteStreamTwoPhaseRequestManager(IPublisher publisher, 
-                                                 int prepareCount, 
+        public WriteStreamTwoPhaseRequestManager(IPublisher publisher,
+                                                 int prepareCount,
                                                  int commitCount,
                                                  TimeSpan prepareTimeout,
-                                                 TimeSpan commitTimeout)
-                : base(publisher, prepareCount, commitCount, prepareTimeout, commitTimeout)
+                                                 TimeSpan commitTimeout,
+                                                 bool betterOrdering)
+                : base(publisher, prepareCount, commitCount, prepareTimeout, commitTimeout, betterOrdering)
         {
         }
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -131,6 +131,9 @@ namespace EventStore.Core.Util
         public const string CommitTimeoutMsDescr = "Commit timeout (in milliseconds).";
         public static readonly int CommitTimeoutMsDefault = 2000; // 2 seconds
 
+        public const string BetterOrderingDescr = "Enable Queue affinity on reads during write process to try to get better ordering.";
+        public static readonly bool BetterOrderingDefault = false;
+
         public const string LogHttpRequestsDescr = "Log Http Requests and Responses before processing them.";
         public static readonly bool LogHttpRequestsDefault = false;
 


### PR DESCRIPTION
Fixes scheduling in client and adds stream based affinity by default on server (for doing access checks).
Also adds option --better-ordering which will force global affinity