### PR TITLE
Throw an exception when attempting to delete a non transient projection

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_null_streamId.cs" />
     <Compile Include="Services\event_reader\stream_reader\when_handling_soft_deleted_stream_with_a_single_event_event_reader.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection_and_not_authorised.cs" />
+    <Compile Include="Services\projections_manager\when_deleting_a_running_persistent_projection.cs" />
     <Compile Include="Services\projections_manager\when_recreating_a_deleted_projection.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager
+{
+    [TestFixture]
+    public class when_deleting_a_running_persistent_projection : TestFixtureWithProjectionCoreAndManagementServices
+    {
+        private string _projectionName;
+        private const string _projectionCheckpointStream = "$projections-test-projection-checkpoint";
+
+        protected override void Given()
+        {
+            _projectionName = "test-projection";
+            AllWritesSucceed();
+            NoOtherStreams();
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.SystemReady();
+            yield return
+                new ProjectionManagementMessage.Command.Post(
+                    new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
+                    ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
+                    enabled: true, checkpointsEnabled: true, emitEnabled: true);
+            yield return
+                new ProjectionManagementMessage.Command.Delete(
+                    new PublishEnvelope(_bus), _projectionName,
+                    ProjectionManagementMessage.RunAs.System, true, true);
+        }
+
+        [Test, Category("v8")]
+        public void a_projection_deleted_event_is_not_written()
+        {
+            var projectionDeletedEventExists = _consumer.HandledMessages.Any(x =>
+                           x.GetType() == typeof(ClientMessage.WriteEvents) &&
+                           ((ClientMessage.WriteEvents)x).Events[0].EventType == "$ProjectionDeleted");
+            Assert.IsFalse(projectionDeletedEventExists,
+                "Expected that the $ProjectionDeleted event not to have been written");
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -447,8 +447,8 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.Delete message)
         {
-            if (_state != ManagedProjectionState.Stopped)
-                message.Envelope.ReplyWith(new ProjectionManagementMessage.OperationFailed("Cannot delete a projection that hasn't been stopped.")); 
+            if (_state != ManagedProjectionState.Stopped && Mode != ProjectionMode.Transient)
+                throw new InvalidOperationException("Cannot delete a running projection");
             _lastAccessed = _timeProvider.Now;
             if (message.DeleteCheckpointStream)
             {
@@ -480,7 +480,6 @@ namespace EventStore.Projections.Core.Services.Management
                     // NOTE: workaround for stop not working on creating state (just ignore them)
                     return;
                 }
-
                 Handle(
                     new ProjectionManagementMessage.Command.Delete(
                         new NoopEnvelope(),

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -234,7 +234,13 @@ namespace EventStore.Projections.Core.Services.Management
             else
             {
                 if (!ProjectionManagementMessage.RunAs.ValidateRunAs(projection.GetMode(), ReadWrite.Write, projection.RunAs, message)) return;
-                projection.Handle(message);
+                try {
+                    projection.Handle(message);
+                }
+                catch (InvalidOperationException ex){
+                    message.Envelope.ReplyWith(new ProjectionManagementMessage.OperationFailed(ex.Message));
+                    return;
+                }
                 _projections.Remove(message.Name);
                 _projectionsMap.Remove(projection.Id);
                 const string eventStreamId = "$projections-$all";


### PR DESCRIPTION
that hasn't stopped