### PR TITLE
Remove not used WatchdogState option description and default value

### DIFF
--- a/src/EventStore.Common/Options/EventStoreOptions.cs
+++ b/src/EventStore.Common/Options/EventStoreOptions.cs
@@ -148,7 +148,8 @@ namespace EventStore.Common.Options
             var revived = new TOptions();
             foreach (var optionSource in optionSources)
             {
-                var property = properties.First(x => x.Name.Equals(optionSource.Name, StringComparison.OrdinalIgnoreCase));
+                var property = properties.FirstOrDefault(x => x.Name.Equals(optionSource.Name, StringComparison.OrdinalIgnoreCase));
+                if(property == null) continue;
                 try
                 {
                     if (optionSource.Value == null) continue;

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -280,14 +280,11 @@ namespace EventStore.Core.Util
         /*
          *  MANAGER OPTIONS 
          */
-        public const string EnableWatchdogDescr = null;
+        public const string EnableWatchdogDescr = "Enable the node supervisor";
         public const bool   EnableWatchdogDefault = true;
 
-        public const string WatchdogConfigDescr = null;
+        public const string WatchdogConfigDescr = "Location of the watchdog configuration";
         public static readonly string WatchdogConfigDefault = string.Empty;
-
-        public const string WatchdogStateDescr = null;
-        public static readonly string WatchdogStateDefault = string.Empty;
 
         public const string WatchdogFailureTimeWindowDescr = "The time window for which to track supervised node failures.";
         public static readonly int WatchdogFailureTimeWindowDefault = -1;


### PR DESCRIPTION
Check if the property isn't null inside `EnsureCorrectType` (https://github.com/EventStore/EventStore/blob/f3ba760187ab296a3e3035d71066b786c768c123/src/EventStore.Common/Options/EventStoreOptions.cs#L145)