### PR TITLE
Make midpoints and validate at same time

### DIFF
--- a/src/EventStore.Core.Tests/Index/opening_a_ptable_with_more_than_32bits_of_records.cs
+++ b/src/EventStore.Core.Tests/Index/opening_a_ptable_with_more_than_32bits_of_records.cs
@@ -6,7 +6,7 @@ using EventStore.Core.Index;
 
 namespace EventStore.Core.Tests.Index
 {
-    [TestFixture]
+    [TestFixture, Explicit]
     public class opening_a_ptable_with_more_than_32bits_of_records: SpecificationWithFilePerTestFixture
     {
         private PTable _ptable;

--- a/src/EventStore.Core.Tests/Index/ptable_midpoint_cache_should.cs
+++ b/src/EventStore.Core.Tests/Index/ptable_midpoint_cache_should.cs
@@ -23,8 +23,7 @@ namespace EventStore.Core.Tests.Index
 
                     for (int depth = 0; depth < 15; ++depth)
                     {
-                        var cache = ptable.CacheMidpoints(depth);
-                        ValidateCache(cache, count, depth);
+                        ValidateCache(ptable.GetMidPoints(), count, depth);
                     }
                 }
                 finally

--- a/src/EventStore.Core.Tests/Index/when_a_ptable_header_is_corrupt_on_disk.cs
+++ b/src/EventStore.Core.Tests/Index/when_a_ptable_header_is_corrupt_on_disk.cs
@@ -30,13 +30,12 @@ namespace EventStore.Core.Tests.Index
                 f.Seek(22, SeekOrigin.Begin);
                 f.WriteByte(0x22);
             }
-            _table = PTable.FromFile(_copiedfilename, 16);
         }
 
-        [Test]          
+        [Test]
         public void the_hash_is_invalid()
         {
-            var exc = Assert.Throws<CorruptIndexException>(() => _table.VerifyFileHash());
+            var exc = Assert.Throws<CorruptIndexException>(() => _table = PTable.FromFile(_copiedfilename, 16));
             Assert.IsInstanceOf<HashValidationException>(exc.InnerException);
         }
 

--- a/src/EventStore.Core.Tests/Index/when_a_ptable_is_corrupt_on_disk.cs
+++ b/src/EventStore.Core.Tests/Index/when_a_ptable_is_corrupt_on_disk.cs
@@ -31,7 +31,6 @@ namespace EventStore.Core.Tests.Index
                 f.Seek(130, SeekOrigin.Begin);
                 f.WriteByte(0x22);
             }
-            _table = PTable.FromFile(_copiedfilename, 16);
         }
 
         [TearDown]
@@ -46,7 +45,7 @@ namespace EventStore.Core.Tests.Index
         [Test]
         public void the_hash_is_invalid()
         {
-            var exc = Assert.Throws<CorruptIndexException>(() => _table.VerifyFileHash());
+            var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(_copiedfilename, 16));
             Assert.IsInstanceOf<HashValidationException>(exc.InnerException);
         }
     }

--- a/src/EventStore.Core.Tests/Index/when_creating_ptable_from_memtable.cs
+++ b/src/EventStore.Core.Tests/Index/when_creating_ptable_from_memtable.cs
@@ -64,7 +64,7 @@ namespace EventStore.Core.Tests.Index
                 Assert.AreEqual(0x0102, items[2].Stream);
                 Assert.AreEqual(0x0001, items[2].Version);
                 Assert.AreEqual(0x0101, items[3].Stream);
-                Assert.AreEqual(0x0001, items[3].Version);        
+                Assert.AreEqual(0x0001, items[3].Version);
             }
         }
 
@@ -76,10 +76,7 @@ namespace EventStore.Core.Tests.Index
             table.Add(0x0105, 0x0001, 0x0002);
             table.Add(0x0102, 0x0001, 0x0003);
             table.Add(0x0102, 0x0002, 0x0003);
-            using (var sstable = PTable.FromMemtable(table, Filename))
-            {
-                Assert.DoesNotThrow(() => sstable.VerifyFileHash());
-            }
+            Assert.DoesNotThrow(() => {using (var sstable = PTable.FromMemtable(table, Filename)) {}});
         }
     }
 }

--- a/src/EventStore.Core.Tests/Index/when_merging_four_ptables.cs
+++ b/src/EventStore.Core.Tests/Index/when_merging_four_ptables.cs
@@ -59,11 +59,5 @@ namespace EventStore.Core.Tests.Index
                 last = item;
             }
         }
-
-        [Test]
-        public void the_hash_can_be_verified()
-        {
-            Assert.DoesNotThrow(() => _newtable.VerifyFileHash());
-        }
     }
 }

--- a/src/EventStore.Core.Tests/Index/when_merging_ptables_with_entries_to_nonexisting_record.cs
+++ b/src/EventStore.Core.Tests/Index/when_merging_ptables_with_entries_to_nonexisting_record.cs
@@ -48,12 +48,6 @@ namespace EventStore.Core.Tests.Index
         }
 
         [Test]
-        public void the_hash_can_be_verified()
-        {
-            Assert.DoesNotThrow(() => _newtable.VerifyFileHash());
-        }
-
-        [Test]
         public void the_items_are_sorted()
         {
             var last = new IndexEntry(ulong.MaxValue, long.MaxValue);

--- a/src/EventStore.Core.Tests/Index/when_merging_two_ptables.cs
+++ b/src/EventStore.Core.Tests/Index/when_merging_two_ptables.cs
@@ -60,11 +60,5 @@ namespace EventStore.Core.Tests.Index
                 last = item;
             }
         }
-
-        [Test]
-        public void the_hash_can_be_verified()
-        {
-            Assert.DoesNotThrow(() => _newtable.VerifyFileHash());
-        }
     }
 }

--- a/src/EventStore.Core/Index/IndexMap.cs
+++ b/src/EventStore.Core/Index/IndexMap.cs
@@ -38,7 +38,7 @@ namespace EventStore.Core.Index
 
             _map = CopyFrom(tables);
             _maxTablesPerLevel = maxTablesPerLevel;
-            
+
             VerifyStructure();
         }
 
@@ -231,7 +231,6 @@ namespace EventStore.Core.Index
                     var ptablePath = Path.Combine(path, file);
 
                     ptable = PTable.FromFile(ptablePath, cacheDepth);
-                    ptable.VerifyFileHash();
 
                     CreateIfNeeded(level, tables);
                     tables[level].Insert(position, ptable);
@@ -287,7 +286,7 @@ namespace EventStore.Core.Index
                 memWriter.Flush();
 
                 memStream.Position = 0;
-                using (var f = File.OpenWrite(tmpIndexMap)) 
+                using (var f = File.OpenWrite(tmpIndexMap))
                 {
                     f.Write(memStream.GetBuffer(), 0, (int)memStream.Length);
                     f.FlushToDisk();
@@ -312,9 +311,9 @@ namespace EventStore.Core.Index
             }
         }
 
-        public MergeResult AddPTable(PTable tableToAdd, 
-                                     long prepareCheckpoint, 
-                                     long commitCheckpoint, 
+        public MergeResult AddPTable(PTable tableToAdd,
+                                     long prepareCheckpoint,
+                                     long commitCheckpoint,
                                      Func<IndexEntry, bool> recordExistsAt,
                                      IIndexFilenameProvider filenameProvider,
                                      int indexCacheDepth = 16)

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading;
+using System.Security.Cryptography;
 using EventStore.Common.Log;
 using EventStore.Common.Streams;
 using EventStore.Common.Utils;
@@ -11,6 +12,7 @@ using EventStore.Core.DataStructures;
 using EventStore.Core.Exceptions;
 using EventStore.Core.Settings;
 using EventStore.Core.Util;
+using EventStore.Core.TransactionLog.Unbuffered;
 
 namespace EventStore.Core.Index
 {
@@ -44,6 +46,8 @@ namespace EventStore.Core.Index
         private readonly ManualResetEventSlim _destroyEvent = new ManualResetEventSlim(false);
         private volatile bool _deleteFile;
 
+        internal Midpoint[] GetMidPoints() {return _midpoints;}
+
         private PTable(string filename,
                        Guid id,
                        int initialReaders = ESConsts.PTableInitialReaderCount,
@@ -61,7 +65,7 @@ namespace EventStore.Core.Index
             _id = id;
             _filename = filename;
 
-            Log.Trace("Loading PTable '{0}' started...", Path.GetFileName(Filename));
+            Log.Trace("Loading and Verification of PTable '{0}' started...", Path.GetFileName(Filename));
             var sw = Stopwatch.StartNew();
 
             _count = ((new FileInfo(_filename).Length - PTableHeader.Size - MD5Size) / IndexEntrySize);
@@ -105,111 +109,81 @@ namespace EventStore.Core.Index
 
             try
             {
-                _midpoints = CacheMidpoints(depth);
+                _midpoints = CacheMidpointsAndVerifyHash(depth);
             }
             catch (PossibleToHandleOutOfMemoryException)
             {
                 Log.Error("Unable to create midpoints for PTable '{0}' ({1} entries, depth {2} requested). "
-                          + "Performance hit possible. OOM Exception.", Path.GetFileName(Filename), Count, depth);
+                          + "Performance hit will occur. OOM Exception.", Path.GetFileName(Filename), Count, depth);
             }
             Log.Trace("Loading PTable '{0}' ({1} entries, cache depth {2}) done in {3}.",
                       Path.GetFileName(Filename), Count, depth, sw.Elapsed);
         }
 
-        internal Midpoint[] CacheMidpoints(int depth)
+        internal Midpoint[] CacheMidpointsAndVerifyHash(int depth)
         {
+            var buffer = new byte[4096];
             if (depth < 0 || depth > 30)
                 throw new ArgumentOutOfRangeException("depth");
             var count = Count;
             if (count == 0 || depth == 0)
                 return null;
-
-            var workItem = GetWorkItem();
-            try
-            {
-                int midpointsCount;
-                Midpoint[] midpoints;
-                try
-                {
-                    midpointsCount = (int) Math.Max(2L, Math.Min((long) 1 << depth, count));
-                    midpoints = new Midpoint[midpointsCount];
-                }
-                catch (OutOfMemoryException exc)
-                {
-                    throw new PossibleToHandleOutOfMemoryException("Failed to allocate memory for Midpoint cache.", exc);
-                }
-                workItem.Stream.Position = PTableHeader.Size;
-                for (long k = 0; k < midpointsCount; ++k)
-                {
-                    var nextIndex = (long)k * (count - 1) / (midpointsCount - 1);
-                    ReadUntil(PTableHeader.Size + IndexEntrySize*nextIndex, workItem.Stream);
-                    midpoints[k] = new Midpoint(ReadNextNoSeek(workItem).Key, nextIndex);
-                }
-
-                return midpoints;
-            }
-            finally
-            {
-                ReturnWorkItem(workItem);
-            }
-        }
-
-        private static readonly byte[] TmpBuf = new byte[DefaultBufferSize];
-        private static void ReadUntil(long nextPos, FileStream fileStream)
-        {
-            long toRead = nextPos - fileStream.Position;
-            if (toRead < 0)
-            {
-                fileStream.Seek(nextPos, SeekOrigin.Begin);
-                return;
-            }
-            while (toRead > 0)
-            {
-                var localReadCount = Math.Min(toRead, TmpBuf.Length);
-                fileStream.Read(TmpBuf, 0, (int)localReadCount);
-                toRead -= localReadCount;
-            }
-        }
-
-        public void VerifyFileHash()
-        {
-            var sw = Stopwatch.StartNew();
-            Log.Trace("Verifying file hash of PTable '{0}' started...", Path.GetFileName(Filename));
 #if  __MonoCS__
             var workItem = GetWorkItem();
             var stream = workItem.Stream;
             try {
 #else
-            using (var stream = UnbufferedFileReadStream.Open(_filename))
+            using (var stream = UnbufferedFileStream.Create(_filename, FileMode.Open, FileAccess.Read, FileShare.Read, false, 4096, 4096, false, 4096))
             {
 #endif
-                //stream.Position = 0;
-                var hash = MD5Hash.GetHashFor(stream, 0, stream.Length - MD5Size);
+                try {
+                    int midpointsCount;
+                    Midpoint[] midpoints;
+                    using (MD5 md5 = MD5.Create())
+                    {
+                        try
+                        {
+                            midpointsCount = (int)Math.Max(2L, Math.Min((long)1 << depth, count));
+                            midpoints = new Midpoint[midpointsCount];
+                        }
+                        catch (OutOfMemoryException exc)
+                        {
+                            throw new PossibleToHandleOutOfMemoryException("Failed to allocate memory for Midpoint cache.", exc);
+                        }
+                        stream.Seek(0, SeekOrigin.Begin);
+                        stream.Read(buffer, 0, PTableHeader.Size);
+                        md5.TransformBlock(buffer, 0, PTableHeader.Size, null, 0);
+                        long previousNextIndex = long.MinValue;
+                        UInt64 previousKey = long.MaxValue;
+                        for (long k = 0; k < midpointsCount; ++k)
+                        {
+                            var nextIndex = (long)k * (count - 1) / (midpointsCount - 1);
+                            if (previousNextIndex != nextIndex) {
+                                ReadUntilWithMd5(PTableHeader.Size + IndexEntrySize * nextIndex, stream, md5);
+                                stream.Read(buffer, 0, 8);
+                                md5.TransformBlock(buffer, 0, 8, null, 0);
+                                var key = BitConverter.ToUInt64(buffer, 0);
+                                midpoints[k] = new Midpoint(key, nextIndex);
+                                previousNextIndex = nextIndex;
+                                previousKey = key;
+                            } else {
+                                midpoints[k] = new Midpoint(previousKey, previousNextIndex);
+                            }
+                        }
 
-                var fileHash = new byte[MD5Size];
-                stream.Read(fileHash, 0, MD5Size);
-
-                if (hash == null)
-                    throw new CorruptIndexException(new HashValidationException("Calculated MD5 hash is null!"));
-                if (fileHash.Length != hash.Length)
-                    throw new CorruptIndexException(
-                        new HashValidationException(
-                            string.Format(
-                                "Hash sizes differ! FileHash({0}): {1}, hash({2}): {3}.",
-                                fileHash.Length,
-                                BitConverter.ToString(fileHash),
-                                hash.Length,
-                                BitConverter.ToString(hash))));
-
-                for (int i = 0; i < fileHash.Length; i++)
+                        ReadUntilWithMd5(stream.Length - MD5Size, stream, md5);
+                        //verify hash (should be at stream.length - MD5Size)
+                        md5.TransformFinalBlock(Empty.ByteArray, 0, 0);
+                        var fileHash = new byte[MD5Size];
+                        stream.Read(fileHash, 0, MD5Size);
+                        ValidateHash(md5.Hash, fileHash);
+                        return midpoints;
+                    }
+                }
+                catch
                 {
-                    if (fileHash[i] != hash[i])
-                        throw new CorruptIndexException(
-                            new HashValidationException(
-                                string.Format(
-                                    "Hashes are different! FileHash: {0}, hash: {1}.",
-                                    BitConverter.ToString(fileHash),
-                                    BitConverter.ToString(hash))));
+                    Dispose();
+                    throw;
                 }
             }
 #if __MonoCS__
@@ -218,7 +192,49 @@ namespace EventStore.Core.Index
                 ReturnWorkItem(workItem);
             }
 #endif
-            Log.Trace("Verifying file hash of PTable '{0}' ({1} entries) done in {2}.", Path.GetFileName(Filename), Count, sw.Elapsed);
+        }
+
+
+        private readonly byte[] TmpReadBuf = new byte[DefaultBufferSize];
+        private void ReadUntilWithMd5(long nextPos, Stream fileStream, MD5 md5)
+        {
+            long toRead = nextPos - fileStream.Position;
+            if (toRead < 0) throw new Exception("should not do negative reads.");
+            while (toRead > 0)
+            {
+                var localReadCount = Math.Min(toRead, TmpReadBuf.Length);
+                int read = fileStream.Read(TmpReadBuf, 0, (int)localReadCount);
+                md5.TransformBlock(TmpReadBuf, 0, read, null, 0);
+                toRead -= read;
+            }
+        }
+        void ValidateHash(byte [] fromFile, byte[] computed)
+        {
+            if (computed == null)
+                throw new CorruptIndexException(new HashValidationException("Calculated MD5 hash is null!"));
+            if (fromFile == null)
+                throw new CorruptIndexException(new HashValidationException("Read from file MD5 hash is null!"));
+
+            if (computed.Length != fromFile.Length)
+                throw new CorruptIndexException(
+                    new HashValidationException(
+                        string.Format(
+                           "Hash sizes differ! FileHash({0}): {1}, hash({2}): {3}.",
+                           computed.Length,
+                           BitConverter.ToString(computed),
+                           fromFile.Length,
+                           BitConverter.ToString(fromFile))));
+
+            for (int i = 0; i < fromFile.Length; i++)
+            {
+                if (fromFile[i] != computed[i])
+                    throw new CorruptIndexException(
+                        new HashValidationException(
+                            string.Format(
+                                "Hashes are different! computed: {0}, hash: {1}.",
+                                BitConverter.ToString(computed),
+                                BitConverter.ToString(fromFile))));
+            }
         }
 
         public IEnumerable<IndexEntry> IterateAllInOrder()


### PR DESCRIPTION
Previously there were two steps involved one to load mid points
and the other to validate md5. This brings both of these scans
together.

Fixes #884