### PR TITLE
Write projection streams using the system principal instead of the current user

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/QueryProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/QueryProcessingStrategy.cs
@@ -2,6 +2,7 @@ using System;
 using EventStore.Common.Log;
 using EventStore.Core.Bus;
 using EventStore.Core.Helpers;
+using EventStore.Core.Services.UserManagement;
 using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core.Services.Processing
@@ -53,7 +54,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 new CoreProjectionCheckpointWriter(
                     namingBuilder.MakeCheckpointStreamName(), ioDispatcher, _projectionVersion, _name);
             var checkpointManager2 = new DefaultCheckpointManager(
-                publisher, projectionCorrelationId, _projectionVersion, _projectionConfig.RunAs, ioDispatcher,
+                publisher, projectionCorrelationId, _projectionVersion, SystemAccount.Principal, ioDispatcher,
                 _projectionConfig, _name, new PhasePositionTagger(1), namingBuilder, GetUseCheckpoints(), false,
                 _sourceDefinition.DefinesFold, coreProjectionCheckpointWriter);
 


### PR DESCRIPTION
Fixes https://github.com/EventStore/EventStore/issues/873
The UI part of this is https://github.com/EventStore/EventStore.UI/pull/122

Queries were failing for non-admin users because they do not have access to write to system streams (including projection streams).

This fix uses the system principal to write to the projection streams instead of the current user. This only applies to once-off projections and queries, and happens after we ensure that the user has access to the stream he's trying to query.