### PR TITLE
Return a task when starting a persistent subscription

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -412,9 +412,21 @@ namespace EventStore.ClientAPI.Embedded
                 GetUserCredentials(_settings, userCredentials), _settings.Log, _settings.VerboseLogging, _settings, _subscriptions, bufferSize,
                 autoAck);
 
-            subscription.Start();
+            subscription.Start().Wait();
 
             return subscription;
+        }
+
+        public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
+            string stream, string groupName, Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared, 
+            Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null, 
+            UserCredentials userCredentials = null, int bufferSize = 10, bool autoAck = true)
+        {
+            var subscription = new EmbeddedEventStorePersistentSubscription(groupName, stream, eventAppeared, subscriptionDropped,
+                GetUserCredentials(_settings, userCredentials), _settings.Log, _settings.VerboseLogging, _settings, _subscriptions, bufferSize,
+                autoAck);
+
+            return subscription.Start();
         }
 
         public EventStoreAllCatchUpSubscription SubscribeToAllFrom(

--- a/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
@@ -62,16 +62,18 @@ namespace EventStore.ClientAPI
             _autoAck = autoAck;
         }
 
-        internal void Start()
+        internal Task<EventStorePersistentSubscriptionBase> Start()
         {
             _stopped.Reset();
 
             var task = StartSubscription(_subscriptionId, _streamId, _bufferSize, _userCredentials, OnEventAppeared,
-                OnSubscriptionDropped, _settings);
-            
-            task.Wait();
-            
-            _subscription = task.Result;
+                OnSubscriptionDropped, _settings).ContinueWith(t =>
+                {
+                    _subscription = t.Result;
+                    return this;
+                });
+
+            return task;
         }
 
         internal abstract Task<PersistentEventStoreSubscription> StartSubscription(

--- a/src/EventStore.ClientAPI/IEventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnection.cs
@@ -312,7 +312,7 @@ namespace EventStore.ClientAPI
                 UserCredentials userCredentials = null);
 
         /// <summary>
-        /// Subscribes a persistent subscription (competing consumer) to the event store
+        /// Subscribes to a persistent subscription(competing consumer) on event store
         /// </summary>
         /// <param name="groupName">The subscription group to connect to</param>
         /// <param name="stream">The stream to subscribe to</param>
@@ -328,8 +328,35 @@ namespace EventStore.ClientAPI
         /// If one connection dies work will be balanced across the rest of the consumers in the group. If
         /// you attempt to connect to a group that does not exist you will be given an exception.
         /// </remarks>
-        /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
+        /// <returns>An <see cref="EventStorePersistentSubscriptionBase"/> representing the subscription</returns>
         EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(
+            string stream,
+            string groupName,
+            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+            Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
+            UserCredentials userCredentials = null,
+            int bufferSize = 10,
+            bool autoAck = true);
+
+        /// <summary>
+        /// Asynchronously subscribes to a persistent subscription(competing consumer) on event store
+        /// </summary>
+        /// <param name="groupName">The subscription group to connect to</param>
+        /// <param name="stream">The stream to subscribe to</param>
+        /// <param name="eventAppeared">An action invoked when an event appears</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="bufferSize">The buffer size to use for the persistent subscription</param>
+        /// <param name="autoAck">Whether the subscription should automatically acknowledge messages processed.
+        /// If not set the receiver is required to explicitly acknowledge messages through the subscription.</param>
+        /// <remarks>This will connect you to a persistent subscription group for a stream. The subscription group
+        /// must first be created with CreatePersistentSubscriptionAsync many connections
+        /// can connect to the same group and they will be treated as competing consumers within the group.
+        /// If one connection dies work will be balanced across the rest of the consumers in the group. If
+        /// you attempt to connect to a group that does not exist you will be given an exception.
+        /// </remarks>
+        /// <returns>An <see cref="EventStorePersistentSubscriptionBase"/> representing the subscription</returns>
+        Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
             string stream,
             string groupName,
             Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,

--- a/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
@@ -352,29 +352,48 @@ namespace EventStore.ClientAPI.Internal
                 groupName, stream, eventAppeared, subscriptionDropped, userCredentials, _settings.Log,
                 _settings.VerboseLogging, _settings, _handler, bufferSize, autoAck);
 
-            subscription.Start();
-
+            subscription.Start().Wait();
             return subscription;
         }
-/*
 
-        public EventStorePersistentSubscription ConnectToPersistentSubscriptionForAll(
+        public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
+            string stream,
             string groupName,
-            Action<EventStorePersistentSubscription, ResolvedEvent> eventAppeared,
-            Action<EventStorePersistentSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+            Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
-            int? bufferSize = null,
+            int bufferSize = 10,
             bool autoAck = true)
         {
-            return ConnectToPersistentSubscription(groupName,
-                SystemStreams.AllStream,
-                eventAppeared,
-                subscriptionDropped,
-                userCredentials,
-                bufferSize,
-                autoAck);
+            Ensure.NotNullOrEmpty(groupName, "groupName");
+            Ensure.NotNullOrEmpty(stream, "stream");
+            Ensure.NotNull(eventAppeared, "eventAppeared");
+
+            var subscription = new EventStorePersistentSubscription(
+                groupName, stream, eventAppeared, subscriptionDropped, userCredentials, _settings.Log,
+                _settings.VerboseLogging, _settings, _handler, bufferSize, autoAck);
+
+            return subscription.Start();
         }
-*/
+        /*
+
+                public EventStorePersistentSubscription ConnectToPersistentSubscriptionForAll(
+                    string groupName,
+                    Action<EventStorePersistentSubscription, ResolvedEvent> eventAppeared,
+                    Action<EventStorePersistentSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                    UserCredentials userCredentials = null,
+                    int? bufferSize = null,
+                    bool autoAck = true)
+                {
+                    return ConnectToPersistentSubscription(groupName,
+                        SystemStreams.AllStream,
+                        eventAppeared,
+                        subscriptionDropped,
+                        userCredentials,
+                        bufferSize,
+                        autoAck);
+                }
+        */
 
 
         public Task CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials userCredentials = null) {

--- a/src/EventStore.Core.Tests/ClientAPI/Embedded/connecting_to_a_persistent_subscription_async.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Embedded/connecting_to_a_persistent_subscription_async.cs
@@ -1,0 +1,57 @@
+﻿using EventStore.ClientAPI;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientAPI.Embedded
+{
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_non_existing_persistent_subscription_with_permissions_async :
+        ClientAPI.connect_to_non_existing_persistent_subscription_with_permissions_async
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_permissions_async :
+        ClientAPI.connect_to_existing_persistent_subscription_with_permissions_async
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_without_permissions_async :
+        ClientAPI.connect_to_existing_persistent_subscription_without_permissions_async
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_start_from_beginning_and_events_in_it_async :
+        ClientAPI.connect_to_existing_persistent_subscription_with_start_from_beginning_and_events_in_it_async
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_start_from_beginning_not_set_and_events_in_it_async :
+        ClientAPI.connect_to_existing_persistent_subscription_with_start_from_beginning_not_set_and_events_in_it_async
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
@@ -678,5 +678,10 @@ namespace EventStore.Core.Tests.ClientAPI
             var handler = Connected;
             if (handler != null) handler(this, e);
         }
+
+        public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(string stream, string groupName, Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared, Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null, int bufferSize = 10, bool autoAck = true)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
         protected override void When()
         {
-            try
+            _caught = Assert.Throws<AggregateException>(() =>
             {
                 _conn.ConnectToPersistentSubscription(
                     "nonexisting2",
@@ -27,11 +27,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     {
                     });
                 throw new Exception("should have thrown");
-            }
-            catch (Exception ex)
-            {
-                _caught = ex;
-            }
+            }).InnerException;
         }
 
         [Test]
@@ -99,8 +95,9 @@ namespace EventStore.Core.Tests.ClientAPI
             }
             catch (Exception ex)
             {
-                Assert.IsInstanceOf<AggregateException>(ex);
-                Assert.IsInstanceOf<AccessDeniedException>(ex.InnerException);
+                var innerEx = ex.InnerException;
+                Assert.IsInstanceOf<AggregateException>(innerEx);
+                Assert.IsInstanceOf<AccessDeniedException>(innerEx.InnerException);
             }
         }
     }
@@ -133,9 +130,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
         protected override void When()
         {
-            //TODO GFY FIND TESTS USING THIS PATTERN AND REPLACE WITH HELPER THROWS METHOD
-            try
-            {
+            _exception = Assert.Throws<AggregateException>(() => {
                 _conn.ConnectToPersistentSubscription(
                     _stream,
                     _group,
@@ -143,11 +138,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     (sub, reason, ex) => { },
                     DefaultData.AdminCredentials);
                 throw new Exception("should have thrown.");
-            }
-            catch (Exception ex)
-            {
-                _exception = ex;
-            }
+            }).InnerException;
         }
 
         [Test]
@@ -685,6 +676,7 @@ namespace EventStore.Core.Tests.ClientAPI
             Assert.AreEqual(_id, _firstEvent.Event.EventId);
         }
     }
+
     //ALL
 
 /*

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription_async.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription_async.cs
@@ -1,0 +1,373 @@
+﻿using EventStore.ClientAPI;
+using EventStore.ClientAPI.ClientOperations;
+using EventStore.ClientAPI.Exceptions;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace EventStore.Core.Tests.ClientAPI
+{
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_non_existing_persistent_subscription_with_permissions_async : SpecificationWithMiniNode
+    {
+        private Exception _innerEx;
+
+        protected override void When()
+        {
+            _innerEx = Assert.Throws<AggregateException>(() =>
+            {
+                _conn.ConnectToPersistentSubscriptionAsync(
+                     "nonexisting2",
+                     "foo",
+                     (sub, e) => Console.Write("appeared"),
+                     (sub, reason, ex) =>
+                     {
+                     }).Wait();
+            }).InnerException;
+        }
+
+        [Test]
+        public void the_subscription_fails_to_connect_with_argument_exception()
+        {
+            Assert.IsInstanceOf<AggregateException>(_innerEx);
+            Assert.IsInstanceOf<ArgumentException>(_innerEx.InnerException);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_permissions_async : SpecificationWithMiniNode
+    {
+        private EventStorePersistentSubscriptionBase _sub;
+        private readonly string _stream = Guid.NewGuid().ToString();
+
+        private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
+                                                                .DoNotResolveLinkTos()
+                                                                .StartFromCurrent();
+
+        protected override void When()
+        {
+            _conn.CreatePersistentSubscriptionAsync(_stream, "agroupname17", _settings, DefaultData.AdminCredentials).Wait();
+            _sub = _conn.ConnectToPersistentSubscriptionAsync(_stream,
+                "agroupname17",
+                (sub, e) => Console.Write("appeared"),
+                (sub, reason, ex) => { }).Result;
+        }
+
+        [Test]
+        public void the_subscription_suceeds()
+        {
+            Assert.IsNotNull(_sub);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_without_permissions_async : SpecificationWithMiniNode
+    {
+        private readonly string _stream = "$" + Guid.NewGuid();
+
+        private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
+                                                                .DoNotResolveLinkTos()
+                                                                .StartFromCurrent();
+
+        private Exception _innerEx;
+
+        protected override void When()
+        {
+            _conn.CreatePersistentSubscriptionAsync(_stream, "agroupname55", _settings,
+                DefaultData.AdminCredentials).Wait();
+            _innerEx = Assert.Throws<AggregateException>(() =>
+            {
+                _conn.ConnectToPersistentSubscriptionAsync(
+                   _stream,
+                   "agroupname55",
+                   (sub, e) => Console.Write("appeared"),
+                   (sub, reason, ex) => Console.WriteLine("dropped.")).Wait();
+            }).InnerException;
+        }
+
+        [Test]
+        public void the_subscription_fails_to_connect_with_access_denied_exception()
+        {
+            Assert.IsInstanceOf<AggregateException>(_innerEx);
+            Assert.IsInstanceOf<AccessDeniedException>(_innerEx.InnerException);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_max_one_client_async : SpecificationWithMiniNode
+    {
+        private readonly string _stream = "$" + Guid.NewGuid();
+
+        private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
+                                                                .DoNotResolveLinkTos()
+                                                                .StartFromCurrent()
+                                                                .WithMaxSubscriberCountOf(1);
+
+        private Exception _innerEx;
+
+        private const string _group = "startinbeginning1";
+        private EventStorePersistentSubscriptionBase _firstConn;
+
+        protected override void Given()
+        {
+            base.Given();
+            _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
+                DefaultData.AdminCredentials).Wait();
+            // First connection
+            _firstConn = _conn.ConnectToPersistentSubscriptionAsync(
+                _stream,
+                _group,
+                (s, e) => s.Acknowledge(e),
+                (sub, reason, ex) => { },
+                DefaultData.AdminCredentials).Result;
+        }
+
+        protected override void When()
+        {
+            _innerEx = Assert.Throws<AggregateException>(() =>
+            {
+                // Second connection
+                _conn.ConnectToPersistentSubscriptionAsync(
+                    _stream,
+                    _group,
+                    (s, e) => s.Acknowledge(e),
+                    (sub, reason, ex) => { },
+                    DefaultData.AdminCredentials).Wait();
+            }).InnerException;
+        }
+
+        [Test]
+        public void the_first_subscription_connects_successfully()
+        {
+            Assert.IsNotNull(_firstConn);
+        }
+
+        [Test]
+        public void the_second_subscription_throws_maximum_subscribers_reached_exception()
+        {
+            Assert.IsInstanceOf<AggregateException>(_innerEx);
+            Assert.IsInstanceOf<MaximumSubscribersReachedException>(_innerEx.InnerException);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_start_from_beginning_and_no_stream_async : SpecificationWithMiniNode
+    {
+        private readonly string _stream = "$" + Guid.NewGuid();
+
+        private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
+                                                                .DoNotResolveLinkTos()
+                                                                .StartFromBeginning();
+
+        private readonly AutoResetEvent _resetEvent = new AutoResetEvent(false);
+        private ResolvedEvent _firstEvent;
+        private readonly Guid _id = Guid.NewGuid();
+        private bool _set = false;
+
+        private const string _group = "startinbeginning1";
+
+        protected override void Given()
+        {
+            _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
+                DefaultData.AdminCredentials).Wait();
+            _conn.ConnectToPersistentSubscriptionAsync(
+             _stream,
+             _group,
+             HandleEvent,
+             (sub, reason, ex) => { },
+             DefaultData.AdminCredentials).Wait();
+        }
+
+        protected override void When()
+        {
+            _conn.AppendToStreamAsync(_stream, ExpectedVersion.Any, DefaultData.AdminCredentials,
+                new EventData(_id, "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
+        }
+
+        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        {
+            if (_set) return;
+            _set = true;
+            _firstEvent = resolvedEvent;
+            _resetEvent.Set();
+        }
+
+        [Test]
+        public void the_subscription_gets_event_zero_as_its_first_event()
+        {
+            Assert.IsTrue(_resetEvent.WaitOne(TimeSpan.FromSeconds(10)));
+            Assert.AreEqual(0, _firstEvent.Event.EventNumber);
+            Assert.AreEqual(_id, _firstEvent.Event.EventId);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_start_from_two_and_no_stream_async : SpecificationWithMiniNode
+    {
+        private readonly string _stream = "$" + Guid.NewGuid();
+
+        private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
+                                                                .DoNotResolveLinkTos()
+                                                                .StartFrom(2);
+
+        private readonly AutoResetEvent _resetEvent = new AutoResetEvent(false);
+        private ResolvedEvent _firstEvent;
+        private readonly Guid _id = Guid.NewGuid();
+        private bool _set = false;
+
+        private const string _group = "startinbeginning1";
+
+        protected override void Given()
+        {
+            _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
+                DefaultData.AdminCredentials).Wait();
+            _conn.ConnectToPersistentSubscriptionAsync(
+             _stream,
+             _group,
+             HandleEvent,
+             (sub, reason, ex) => { },
+             DefaultData.AdminCredentials).Wait();
+        }
+
+        protected override void When()
+        {
+            _conn.AppendToStreamAsync(_stream, ExpectedVersion.Any, DefaultData.AdminCredentials,
+                new EventData(Guid.NewGuid(), "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
+            _conn.AppendToStreamAsync(_stream, ExpectedVersion.Any, DefaultData.AdminCredentials,
+                new EventData(Guid.NewGuid(), "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
+            _conn.AppendToStreamAsync(_stream, ExpectedVersion.Any, DefaultData.AdminCredentials,
+                new EventData(_id, "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
+        }
+
+        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        {
+            if (_set) return;
+            _set = true;
+            _firstEvent = resolvedEvent;
+            _resetEvent.Set();
+        }
+
+        [Test]
+        public void the_subscription_gets_event_two_as_its_first_event()
+        {
+            Assert.IsTrue(_resetEvent.WaitOne(TimeSpan.FromSeconds(10)));
+            Assert.AreEqual(2, _firstEvent.Event.EventNumber);
+            Assert.AreEqual(_id, _firstEvent.Event.EventId);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_start_from_beginning_and_events_in_it_async : SpecificationWithMiniNode
+    {
+        private readonly string _stream = "$" + Guid.NewGuid();
+
+        private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
+                                                                .DoNotResolveLinkTos()
+                                                                .StartFromBeginning();
+
+        private readonly AutoResetEvent _resetEvent = new AutoResetEvent(false);
+        private ResolvedEvent _firstEvent;
+        private List<Guid> _ids = new List<Guid>();
+        private bool _set = false;
+
+        private const string _group = "startinbeginning1";
+
+        protected override void Given()
+        {
+            WriteEvents(_conn);
+            _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
+                DefaultData.AdminCredentials).Wait();
+        }
+
+        private void WriteEvents(IEventStoreConnection connection)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                _ids.Add(Guid.NewGuid());
+                connection.AppendToStreamAsync(_stream, ExpectedVersion.Any, DefaultData.AdminCredentials,
+                    new EventData(_ids[i], "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
+            }
+        }
+
+        protected override void When()
+        {
+            _conn.ConnectToPersistentSubscriptionAsync(
+                _stream,
+                _group,
+                HandleEvent,
+                (sub, reason, ex) => { },
+                DefaultData.AdminCredentials).Wait();
+        }
+
+        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        {
+            if (!_set)
+            {
+                _set = true;
+                _firstEvent = resolvedEvent;
+                _resetEvent.Set();
+            }
+        }
+
+        [Test]
+        public void the_subscription_gets_event_zero_as_its_first_event()
+        {
+            Assert.IsTrue(_resetEvent.WaitOne(TimeSpan.FromSeconds(10)));
+            Assert.AreEqual(0, _firstEvent.Event.EventNumber);
+            Assert.AreEqual(_ids[0], _firstEvent.Event.EventId);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_existing_persistent_subscription_with_start_from_beginning_not_set_and_events_in_it_async : SpecificationWithMiniNode
+    {
+        private readonly string _stream = "$" + Guid.NewGuid();
+
+        private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
+                                                                .DoNotResolveLinkTos()
+                                                                .StartFromCurrent();
+
+        private readonly AutoResetEvent _resetEvent = new AutoResetEvent(false);
+
+        private const string _group = "startinbeginning1";
+
+        protected override void Given()
+        {
+            WriteEvents(_conn);
+            _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
+                DefaultData.AdminCredentials).Wait();
+        }
+
+        private void WriteEvents(IEventStoreConnection connection)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                connection.AppendToStreamAsync(_stream, ExpectedVersion.Any, DefaultData.AdminCredentials,
+                    new EventData(Guid.NewGuid(), "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
+            }
+        }
+
+        protected override void When()
+        {
+            _conn.ConnectToPersistentSubscriptionAsync(
+                _stream,
+                _group,
+                HandleEvent,
+                (sub, reason, ex) => { },
+                DefaultData.AdminCredentials).Wait();
+        }
+
+        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        {
+            _resetEvent.Set();
+        }
+
+        [Test]
+        public void the_subscription_gets_no_events()
+        {
+            Assert.IsFalse(_resetEvent.WaitOne(TimeSpan.FromSeconds(1)));
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -85,10 +85,12 @@
     <Compile Include="ClientAPI\appending_to_implicitly_created_stream.cs" />
     <Compile Include="ClientAPI\appending_to_implicitly_created_stream_using_transaction.cs" />
     <Compile Include="ClientAPI\catch_up_subscription_handles_errors.cs" />
+    <Compile Include="ClientAPI\connecting_to_a_persistent_subscription_async.cs" />
     <Compile Include="ClientAPI\connecting_to_a_persistent_subscription.cs" />
     <Compile Include="ClientAPI\connection_string.cs" />
     <Compile Include="ClientAPI\create_persistent_subscription.cs" />
     <Compile Include="ClientAPI\deleting_persistent_subscription.cs" />
+    <Compile Include="ClientAPI\Embedded\connecting_to_a_persistent_subscription_async.cs" />
     <Compile Include="ClientAPI\Embedded\connecting_to_a_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\create_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\deleting_persistent_subscription.cs" />


### PR DESCRIPTION
Fixes #881 

The start method on persistent subscriptions now returns a task rather than calling task.Wait(), which used to cause deadlocks.

There is a new async method on EventStoreConnection for connecting to persistent connections that returns the subscription task, and the existing methods now wait on the subscription task before returning the subscription.