### PR TITLE
Add TTL for http send

### DIFF
--- a/src/EventStore.Core/Messages/HttpMessage.cs
+++ b/src/EventStore.Core/Messages/HttpMessage.cs
@@ -62,7 +62,7 @@ namespace EventStore.Core.Messages
 
             public readonly ResponseConfiguration Configuration;
 
-            public HttpBeginSend(Guid correlationId, IEnvelope envelope, 
+            public HttpBeginSend(Guid correlationId, IEnvelope envelope,
                 HttpEntityManager httpEntityManager, ResponseConfiguration configuration)
                 : base(correlationId, envelope, httpEntityManager)
             {
@@ -132,11 +132,13 @@ namespace EventStore.Core.Messages
 
             public readonly IPEndPoint EndPoint;
             public readonly Message Message;
+            public readonly DateTime LiveUntil;
 
-            public SendOverHttp(IPEndPoint endPoint, Message message)
+            public SendOverHttp(IPEndPoint endPoint, Message message, DateTime liveUntil)
             {
                 EndPoint = endPoint;
                 Message = message;
+                LiveUntil = liveUntil;
             }
         }
 

--- a/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
@@ -43,7 +43,7 @@ namespace EventStore.Core.Services.Gossip
         private ClusterInfo _cluster;
         private readonly Random _rnd = new Random(Math.Abs(Environment.TickCount));
 
-        protected GossipServiceBase(IPublisher bus, 
+        protected GossipServiceBase(IPublisher bus,
                                     IGossipSeedSource gossipSeedSource,
                                     VNodeInfo nodeInfo,
                                     TimeSpan gossipInterval,
@@ -124,7 +124,7 @@ namespace EventStore.Core.Services.Gossip
             if (node != null)
             {
                 _cluster = UpdateCluster(_cluster, x => x.InstanceId == NodeInfo.InstanceId ? GetUpdatedMe(x) : x);
-                _bus.Publish(new HttpMessage.SendOverHttp(node.InternalHttpEndPoint, new GossipMessage.SendGossip(_cluster, NodeInfo.InternalHttp)));
+                _bus.Publish(new HttpMessage.SendOverHttp(node.InternalHttpEndPoint, new GossipMessage.SendGossip(_cluster, NodeInfo.InternalHttp),  DateTime.Now.Add(GossipInterval)));
             }
 
             var interval = message.GossipRound < 20 ? GossipStartupInterval : GossipInterval;
@@ -151,7 +151,7 @@ namespace EventStore.Core.Services.Gossip
                 return;
 
             var oldCluster = _cluster;
-            _cluster = MergeClusters(_cluster, 
+            _cluster = MergeClusters(_cluster,
                                      message.ClusterInfo,
                                      message.Server,
                                      x => x.InstanceId == NodeInfo.InstanceId ? GetUpdatedMe(x) : x);
@@ -220,7 +220,7 @@ namespace EventStore.Core.Services.Gossip
             _bus.Publish(new GossipMessage.GossipUpdated(_cluster));
         }
 
-        private ClusterInfo MergeClusters(ClusterInfo myCluster, ClusterInfo othersCluster, 
+        private ClusterInfo MergeClusters(ClusterInfo myCluster, ClusterInfo othersCluster,
                                           IPEndPoint peerEndPoint, Func<MemberInfo, MemberInfo> update)
         {
             var mems = myCluster.Members.ToDictionary(member => member.InternalHttpEndPoint);

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -65,7 +65,11 @@ namespace EventStore.Core.Services
 
         public void Handle(HttpMessage.SendOverHttp message)
         {
-            _httpPipe.Push(message.Message, message.EndPoint);
+            if(message.LiveUntil > DateTime.Now) {
+                _httpPipe.Push(message.Message, message.EndPoint);
+            } else {
+                Log.Debug("Dropping HTTP send message due to TTL being over. {1} To : {0}", message.EndPoint, message.Message.GetType().Name.ToString());
+            }
         }
 
         public void Handle(HttpMessage.HttpSend message)


### PR DESCRIPTION
Right now messages can get backed up due to a blocking operation DNS etc. This allows us to at least set a TTL on messages so they will be dropped on the floor if they are older than we care about.