### PR TITLE
Add ExpectedVersion.StreamExists

### DIFF
--- a/src/EventStore.ClientAPI/ExpectedVersion.cs
+++ b/src/EventStore.ClientAPI/ExpectedVersion.cs
@@ -6,18 +6,19 @@ namespace EventStore.ClientAPI
     /// <remarks>
     /// The use of expected version can be a bit tricky especially when discussing idempotency assurances given by the event store.
     /// 
-    /// There are four possible values that can be used for the passing of an expected version.
+    /// There are five possible values that can be used for the passing of an expected version.
     /// 
     /// ExpectedVersion.Any (-2) says that you should not conflict with anything.
     /// ExpectedVersion.NoStream (-1) says that the stream should not exist when doing your write.
     /// ExpectedVersion.EmptyStream (0) says the stream should exist but be empty when doing the write.
+    /// ExpectedVersion.StreamExists(-4) says the stream or a metadata stream should exist when doing your write.
     /// 
     /// Any other value states that the last event written to the stream should have a sequence number matching your 
     /// expected value.
     /// 
     /// The Event Store will assure idempotency for all operations using any value in ExpectedVersion except for
-    /// ExpectedVersion.Any. When using ExpectedVersion.Any the Event Store will do its best to assure idempotency but
-    /// will not guarantee idempotency.
+    /// ExpectedVersion.Any and ExpectedVersion.StreamExists. When using ExpectedVersion.Any or ExpectedVersion.StreamExists
+    /// the Event Store will do its best to assure idempotency but will not guarantee idempotency.
     /// </remarks>
     public static class ExpectedVersion
     {
@@ -33,5 +34,10 @@ namespace EventStore.ClientAPI
         /// The stream should exist and should be empty. If it does not exist or is not empty treat that as a concurrency problem.
         /// </summary>
         public const int EmptyStream = -1;
+
+        /// <summary>
+        /// The stream should exist. If it or a metadata stream does not exist treat that as a concurrency problem.
+        /// </summary>
+        public const int StreamExists = -4;
     }
 }

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -247,6 +247,7 @@
     <Compile Include="Http\Streams\idempotency.cs" />
     <Compile Include="Http\Streams\basic.cs" />
     <Compile Include="Http\Streams\feed.cs" />
+    <Compile Include="Http\Streams\append_to_stream.cs" />
     <Compile Include="Http\Streams\metadata.cs" />
     <Compile Include="Http\Streams\SetUpFixture.cs" />
     <Compile Include="Http\Streams\SpecificationWithLinkToToMaxCountDeletedEvents.cs" />

--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -1,0 +1,516 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using EventStore.ClientAPI;
+using EventStore.Transport.Http;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using HttpStatusCode = System.Net.HttpStatusCode;
+
+namespace EventStore.Core.Tests.Http.Streams
+{
+    namespace append_to_stream
+    {
+        public abstract class ExpectedVersionSpecification : HttpBehaviorSpecification 
+        {
+            public string WrongExpectedVersionDesc {get {return "Wrong expected EventNumber";} }
+            public string DeletedStreamDesc {get {return "Stream deleted"; } }
+
+            public HttpWebResponse PostEventWithExpectedVersion(int expectedVersion) 
+            {
+                var request = CreateRequest(TestStream, "", "POST", "application/json");
+                request.Headers.Add("ES-EventType", "SomeType");
+                request.Headers.Add("ES-ExpectedVersion", expectedVersion.ToString());
+                request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+                var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
+                request.ContentLength = data.Length;
+                request.GetRequestStream().Write(data, 0, data.Length);
+                return GetRequestResponse(request);
+            }
+
+            public void HardDeleteTestStream()
+            {
+                DeleteTestStream(true);
+            }
+
+            public void DeleteTestStream(bool hardDelete = false)
+            {
+                var deleteRequest = CreateRequest(TestStream, "", "DELETE", "application/json");
+                deleteRequest.Headers.Add("ES-ExpectedVersion", (ExpectedVersion.Any).ToString());
+                deleteRequest.Headers.Add("ES-HardDelete", hardDelete.ToString());
+                GetRequestResponse(deleteRequest);
+            }
+
+            public List<JToken> GetTestStream()
+            {
+                var stream = GetJson<JObject>(TestStream + "/0/forward/10", accept: ContentType.Json);
+                return stream != null ? stream["entries"].ToList() : new List<JToken>();
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_create_stream_with_no_stream_exp_ver_on_first_write_if_does_not_exist : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.NoStream);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_created_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+            }
+
+            [Test]
+            public void should_create_stream()
+            {
+                Assert.AreEqual(1, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_no_stream_exp_ver_to_existing_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+                PostEventWithExpectedVersion(ExpectedVersion.Any);
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.NoStream);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_bad_request_with_wrong_expected_version()
+            {
+                Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
+                Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
+            }
+
+            [Test]
+            public void should_not_append_to_stream()
+            {
+                Assert.AreEqual(1, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_create_stream_with_any_exp_ver_on_first_write_if_does_not_exist : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.Any);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_created_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+            }
+
+            [Test]
+            public void should_create_stream()
+            {
+                Assert.AreEqual(1, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_append_with_any_exp_ver_to_existing_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+                for(var i = 0; i < 3; i++)
+                {
+                    PostEventWithExpectedVersion(ExpectedVersion.Any);
+                }
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.Any);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_created_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+            }
+
+            [Test]
+            public void should_append_event_to_stream()
+            {
+                Assert.AreEqual(4, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_any_exp_ver_to_deleted_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+
+            protected override void Given()
+            {
+                HardDeleteTestStream();
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.Any);
+            }
+
+            [Test]
+            public void should_return_gone_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
+                Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_append_with_correct_exp_ver_to_existing_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+                for(var i = 0; i < 3; i++)
+                {
+                    PostEventWithExpectedVersion(ExpectedVersion.Any);
+                }
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(2);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_created_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+            }
+
+            [Test]
+            public void should_append_event_to_stream()
+            {
+                Assert.AreEqual(4, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_wrong_exp_ver_to_existing_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+                for(var i = 0; i < 2; i++)
+                {
+                    PostEventWithExpectedVersion(ExpectedVersion.Any);
+                }
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(4);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_bad_request_with_wrong_expected_version()
+            {
+                Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
+                Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
+            }
+            [Test]
+            public void should_not_append_event()
+            {
+                Assert.AreEqual(2, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_wrong_exp_ver_to_new_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(1);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_bad_request_with_wrong_expected_version()
+            {
+                Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
+                Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
+            }
+
+            [Test]
+            public void should_not_append_to_stream()
+            {
+                Assert.AreEqual(0, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_correct_exp_ver_to_deleted_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+
+            protected override void Given()
+            {
+                HardDeleteTestStream();
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.NoStream);
+            }
+
+            [Test]
+            public void should_return_gone_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
+                Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_invalid_exp_ver_to_deleted_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+
+            protected override void Given()
+            {
+                HardDeleteTestStream();
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(5);
+            }
+
+            [Test]
+            public void should_return_gone_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
+                Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_append_with_stream_exists_exp_ver_to_existing_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+                PostEventWithExpectedVersion(ExpectedVersion.Any);
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.StreamExists);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_created_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+            }
+
+            [Test]
+            public void should_append_event_to_stream()
+            {
+                Assert.AreEqual(2, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_append_with_stream_exists_exp_ver_to_stream_with_multiple_events : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+                for(var i = 0; i < 2; i++)
+                {
+                    PostEventWithExpectedVersion(ExpectedVersion.Any);
+                }
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.StreamExists);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_created_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+            }
+
+            [Test]
+            public void should_append_event_to_stream()
+            {
+                Assert.AreEqual(3, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_append_with_stream_exists_exp_ver_if_metadata_stream_exists : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+                var request = CreateRequest(TestMetadataStream, "", "POST", "application/json");
+                request.Headers.Add("ES-EventType", "$user-created");
+                request.Headers.Add("ES-ExpectedVersion", ((int)ExpectedVersion.Any).ToString());
+                request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+                var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
+                request.ContentLength = data.Length;
+                request.GetRequestStream().Write(data, 0, data.Length);
+                GetRequestResponse(request);
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.StreamExists);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_created_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+            }
+
+            [Test]
+            public void should_append_event_to_stream()
+            {
+                Assert.AreEqual(1, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_stream_exists_exp_ver_and_stream_does_not_exist : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+            private List<JToken> _read;
+
+            protected override void Given()
+            {
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.StreamExists);
+                _read = GetTestStream();
+            }
+
+            [Test]
+            public void should_return_bad_request_with_wrong_expected_version()
+            {
+                Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
+                Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
+            }
+
+            [Test]
+            public void should_not_append_event_to_stream()
+            {
+                Assert.AreEqual(0, _read.Count);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_stream_exists_exp_ver_to_hard_deleted_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+
+            protected override void Given()
+            {
+                HardDeleteTestStream();
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.StreamExists);
+            }
+
+            [Test]
+            public void should_return_gone_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
+                Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
+            }
+        }
+
+        [TestFixture, Category("LongRunning")]
+        public class should_fail_appending_with_stream_exists_exp_ver_to_soft_deleted_stream : ExpectedVersionSpecification
+        {
+            private HttpWebResponse _response;
+
+            protected override void Given()
+            {
+                DeleteTestStream();
+            }
+
+            protected override void When()
+            {
+                _response = PostEventWithExpectedVersion(ExpectedVersion.StreamExists);
+            }
+
+            [Test]
+            public void should_return_gone_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.Gone, _response.StatusCode);
+                Assert.AreEqual(DeletedStreamDesc, _response.StatusDescription);
+            }
+        }
+    }
+}

--- a/src/EventStore.Core/Data/ExpectedVersion.cs
+++ b/src/EventStore.Core/Data/ExpectedVersion.cs
@@ -6,5 +6,6 @@ namespace EventStore.Core.Data
         public const int NoStream = -1;
         //public const int EmptyStream = 0;
         public const int Invalid = -3;
+        public const int StreamExists = -4;
     }
 }

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -153,7 +153,7 @@ namespace EventStore.Core.Messages
                 : base(internalCorrId, correlationId, envelope, requireMaster, user, login, password)
             {
                 Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
-                if (expectedVersion < Data.ExpectedVersion.Any) throw new ArgumentOutOfRangeException("expectedVersion");
+                if (expectedVersion < Data.ExpectedVersion.StreamExists || expectedVersion == Data.ExpectedVersion.Invalid) throw new ArgumentOutOfRangeException("expectedVersion");
                 Ensure.NotNull(events, "events");
 
                 EventStreamId = eventStreamId;

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -648,7 +648,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                 expectedVersion = ExpectedVersion.Any;
                 return true;
             }
-            return int.TryParse(expVer, out expectedVersion) && expectedVersion >= ExpectedVersion.Any;
+            return int.TryParse(expVer, out expectedVersion) && expectedVersion >= ExpectedVersion.StreamExists;
         }
 
         private bool GetIncludedId(HttpEntityManager manager, out Guid includedId)


### PR DESCRIPTION
Fixes #901 

Add ExpectedVersion.StreamExists to the ExpectedVersions enum with a value of -4.
This will only allow events to be appended to a stream if it exists, or if a metadata stream exists for it.
If the stream does not exist, it returns WrongExpectedVersion.
If the stream has been deleted (hard or soft) it returns DeletedStream.
After ensuring that the stream exists, this will behave the same way as ExpectedVersion.Any.