### PR TITLE
Use correct method for constructing the MediaTypeHeaderValue

### DIFF
--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -197,7 +197,7 @@ namespace EventStore.Core.Services
                 && srcReq.ContentLength64 > 0)
             {
                 var streamContent = new StreamContent(srcReq.InputStream);
-                streamContent.Headers.ContentType = new MediaTypeHeaderValue(srcReq.ContentType);
+                streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse(srcReq.ContentType);
                 streamContent.Headers.ContentLength = srcReq.ContentLength64;
                 request.Content = streamContent;
 


### PR DESCRIPTION
The `MediaTypeHeaderValue`'s constructor accepts the media type as a constructor argument. In cases where the request's content type is `application/json;charset=utf-8`, the constructor throws. The correct
method to use here would be `MediaTypeHeaderValue.Parse`