### PR TITLE
Create ClusterVNode using a builder rather than its constructor

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -250,7 +250,7 @@ namespace EventStore.ClusterNode
             IntTcpHeartbeatTimeout = Opts.IntTcpHeartbeatTimeoutDefault;
 
             ExtTcpHeartbeatInterval = Opts.ExtTcpHeartbeatIntervalDefault;
-            IntTcpHeartbeatInterval = Opts.IntTcpHeartbeatInvervalDefault;
+            IntTcpHeartbeatInterval = Opts.IntTcpHeartbeatIntervalDefault;
 
             ExtIpAdvertiseAs = Opts.ExternalIpAdvertiseAsDefault;
             ExtTcpPortAdvertiseAs = Opts.ExternalTcpPortAdvertiseAsDefault;

--- a/src/EventStore.ClusterNode/ClusterVNodeBuilder.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeBuilder.cs
@@ -1,15 +1,15 @@
-﻿using EventStore.Core;
+using EventStore.Core;
 using EventStore.Projections.Core;
 
-namespace EventStore.ClientAPI.Embedded
+namespace EventStore.ClusterNode
 {
     /// <summary>
-    /// Allows a client to build a <see cref="ClusterVNode" /> for use with the Embedded client API by specifying
+    /// Allows a client to build a <see cref="ClusterVNode" /> for use in EventStore.ClusterNode by specifying
     /// high level options rather than using the constructor of <see cref="ClusterVNode"/> directly.
     /// </summary>
-    public class EmbeddedVNodeBuilder : VNodeBuilder
+    public class ClusterVNodeBuilder : VNodeBuilder
     {
-        private EmbeddedVNodeBuilder()
+        protected ClusterVNodeBuilder()
         {
         }
 
@@ -17,25 +17,22 @@ namespace EventStore.ClientAPI.Embedded
         /// Returns a builder set to construct options for a single node instance
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-        public static EmbeddedVNodeBuilder AsSingleNode()
+        public static ClusterVNodeBuilder AsSingleNode()
         {
-            var ret = new EmbeddedVNodeBuilder().WithSingleNodeSettings();
-            return (EmbeddedVNodeBuilder)ret;
+            var ret = new ClusterVNodeBuilder().WithSingleNodeSettings();
+            return (ClusterVNodeBuilder)ret;
         }
 
         /// <summary>
         /// Returns a builder set to construct options for a cluster node instance with a cluster size 
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-        public static EmbeddedVNodeBuilder AsClusterMember(int clusterSize)
+        public static ClusterVNodeBuilder AsClusterMember(int clusterSize)
         {
-            var ret = new EmbeddedVNodeBuilder().WithClusterNodeSettings(clusterSize);
-            return (EmbeddedVNodeBuilder)ret;
+            var ret = new ClusterVNodeBuilder().WithClusterNodeSettings(clusterSize);
+            return (ClusterVNodeBuilder)ret;
         }
-
-        /// <summary>
-        /// Sets up the projections subsystem
-        /// </summary>
+        
         protected override void SetUpProjectionsIfNeeded()
         {
             _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType, _startStandardProjections));

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ClusterNodeOptions.cs" />
+    <Compile Include="ClusterVNodeBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClusterNode.Web\EventStore.ClusterNode.Web.csproj">

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -29,7 +29,6 @@ namespace EventStore.ClusterNode
     public class Program : ProgramBase<ClusterNodeOptions>
     {
         private ClusterVNode _node;
-        private Projections.Core.ProjectionsSubsystem _projections;
         private ExclusiveDbLock _dbLock;
         private ClusterNodeMutex _clusterNodeMutex;
 
@@ -97,61 +96,31 @@ namespace EventStore.ClusterNode
             if (!_clusterNodeMutex.Acquire())
                 throw new Exception(string.Format("Couldn't acquire exclusive Cluster Node mutex '{0}'.", _clusterNodeMutex.MutexName));
 
-            var dbConfig = CreateDbConfig(dbPath, opts.CachedChunks, opts.ChunksCacheSize, opts.MemDb);
-            FileStreamExtensions.ConfigureFlush(disableFlushToDisk: opts.UnsafeDisableFlushToDisk);
-            var db = new TFChunkDb(dbConfig);
-            var vNodeSettings = GetClusterVNodeSettings(opts);
-
-            IGossipSeedSource gossipSeedSource;
-            if (opts.DiscoverViaDns)
+            if (!opts.DiscoverViaDns && opts.GossipSeed.Length == 0)
             {
-                gossipSeedSource = new DnsGossipSeedSource(opts.ClusterDns, opts.ClusterGossipPort);
-            }
-            else
-            {
-                if (opts.GossipSeed.Length == 0)
+                if (opts.ClusterSize == 1)
                 {
-                    if (opts.ClusterSize > 1)
-                    {
-                        Log.Error("DNS discovery is disabled, but no gossip seed endpoints have been specified. "
-                                + "Specify gossip seeds using the --gossip-seed command line option.");
-                    }
-                    else
-                    {
-                        Log.Info("DNS discovery is disabled, but no gossip seed endpoints have been specified. Since"
-                                + "the cluster size is set to 1, this may be intentional. Gossip seeds can be specified"
-                                + "seeds using the --gossip-seed command line option.");
-                    }
+                    Log.Info("DNS discovery is disabled, but no gossip seed endpoints have been specified. Since"
+                            + "the cluster size is set to 1, this may be intentional. Gossip seeds can be specified"
+                            + "using the --gossip-seed command line option.");
                 }
-
-                gossipSeedSource = new KnownEndpointGossipSeedSource(opts.GossipSeed);
             }
 
             var runProjections = opts.RunProjections;
-
-            Log.Info("{0,-25} {1}", "INSTANCE ID:", vNodeSettings.NodeInfo.InstanceId);
-            Log.Info("{0,-25} {1}", "DATABASE:", db.Config.Path);
-            Log.Info("{0,-25} {1} (0x{1:X})", "WRITER CHECKPOINT:", db.Config.WriterCheckpoint.Read());
-            Log.Info("{0,-25} {1} (0x{1:X})", "CHASER CHECKPOINT:", db.Config.ChaserCheckpoint.Read());
-            Log.Info("{0,-25} {1} (0x{1:X})", "EPOCH CHECKPOINT:", db.Config.EpochCheckpoint.Read());
-            Log.Info("{0,-25} {1} (0x{1:X})", "TRUNCATE CHECKPOINT:", db.Config.TruncateCheckpoint.Read());
-
             var enabledNodeSubsystems = runProjections >= ProjectionType.System
                 ? new[] { NodeSubsystems.Projections }
             : new NodeSubsystems[0];
-            _projections = new Projections.Core.ProjectionsSubsystem(opts.ProjectionThreads, opts.RunProjections, opts.StartStandardProjections);
-            var infoController = new InfoController(opts, opts.RunProjections);
-            _node = new ClusterVNode(db, vNodeSettings, gossipSeedSource, infoController, _projections);
-            RegisterWebControllers(enabledNodeSubsystems, vNodeSettings);
+            _node = BuildNode(opts);
+            RegisterWebControllers(enabledNodeSubsystems, opts);
         }
 
-        private void RegisterWebControllers(NodeSubsystems[] enabledNodeSubsystems, ClusterVNodeSettings settings)
+        private void RegisterWebControllers(NodeSubsystems[] enabledNodeSubsystems, ClusterNodeOptions options)
         {
             if (_node.InternalHttpService != null)
             {
                 _node.InternalHttpService.SetupController(new ClusterWebUiController(_node.MainQueue, enabledNodeSubsystems));
             }
-            if (settings.AdminOnPublic)
+            if (options.AdminOnExt)
             {
                 _node.ExternalHttpService.SetupController(new ClusterWebUiController(_node.MainQueue, enabledNodeSubsystems));
             }
@@ -163,36 +132,20 @@ namespace EventStore.ClusterNode
             return clusterSize / 2 + 1;
         }
 
-        private static ClusterVNodeSettings GetClusterVNodeSettings(ClusterNodeOptions options)
+        private static ClusterVNode BuildNode(ClusterNodeOptions options)
         {
-            X509Certificate2 certificate = null;
-            if (options.IntSecureTcpPort > 0 || options.ExtSecureTcpPort > 0)
+            if (options.UseInternalSsl)
             {
-                if (options.CertificateStoreName.IsNotEmptyString())
-                    certificate = LoadCertificateFromStore(options.CertificateStoreLocation, options.CertificateStoreName, options.CertificateSubjectName, options.CertificateThumbprint);
-                else if (options.CertificateFile.IsNotEmptyString())
-                    certificate = LoadCertificateFromFile(options.CertificateFile, options.CertificatePassword);
-                else
-                    throw new Exception("No server certificate specified.");
+                if (ReferenceEquals(options.SslTargetHost, Opts.SslTargetHostDefault)) throw new Exception("No SSL target host specified.");
+                if (options.IntSecureTcpPort > 0) throw new Exception("Usage of internal secure communication is specified, but no internal secure endpoint is specified!");
             }
-
-            var intHttp = new IPEndPoint(options.IntIp, options.IntHttpPort);
-            var extHttp = new IPEndPoint(options.ExtIp, options.ExtHttpPort);
-            var intTcp = new IPEndPoint(options.IntIp, options.IntTcpPort);
-            var intSecTcp = options.IntSecureTcpPort > 0 ? new IPEndPoint(options.IntIp, options.IntSecureTcpPort) : null;
-            var extTcp = new IPEndPoint(options.ExtIp, options.ExtTcpPort);
-            var extSecTcp = options.ExtSecureTcpPort > 0 ? new IPEndPoint(options.ExtIp, options.ExtSecureTcpPort) : null;
-            var intHttpPrefixes = options.IntHttpPrefixes.IsNotEmpty() ? options.IntHttpPrefixes : new string[0];
-            var extHttpPrefixes = options.ExtHttpPrefixes.IsNotEmpty() ? options.ExtHttpPrefixes : new string[0];
             var quorumSize = GetQuorumSize(options.ClusterSize);
-
-            GossipAdvertiseInfo gossipAdvertiseInfo;
 
             IPAddress intIpAddressToAdvertise = options.IntIpAdvertiseAs ?? options.IntIp;
             IPAddress extIpAddressToAdvertise = options.ExtIpAdvertiseAs ?? options.ExtIp;
 
-            var additionalIntHttpPrefixes = new List<string>(intHttpPrefixes);
-            var additionalExtHttpPrefixes = new List<string>(extHttpPrefixes);
+            var additionalIntHttpPrefixes = new List<string>(options.IntHttpPrefixes);
+            var additionalExtHttpPrefixes = new List<string>(options.ExtHttpPrefixes);
 
             if ((options.IntIp.Equals(IPAddress.Parse("0.0.0.0")) ||
                 options.ExtIp.Equals(IPAddress.Parse("0.0.0.0"))) && options.AddInterfacePrefixes)
@@ -202,11 +155,11 @@ namespace EventStore.ClusterNode
 
                 if(options.IntIp.Equals(IPAddress.Parse("0.0.0.0"))){
                     intIpAddressToAdvertise = options.IntIpAdvertiseAs ?? addressToAdvertise;
-                    additionalIntHttpPrefixes.Add(String.Format("http://*:{0}/", intHttp.Port));
+                    additionalIntHttpPrefixes.Add(String.Format("http://*:{0}/", options.IntHttpPort));
                 }
                 if(options.ExtIp.Equals(IPAddress.Parse("0.0.0.0"))){
                     extIpAddressToAdvertise = options.ExtIpAdvertiseAs ?? addressToAdvertise;
-                    additionalExtHttpPrefixes.Add(String.Format("http://*:{0}/", extHttp.Port));
+                    additionalExtHttpPrefixes.Add(String.Format("http://*:{0}/", options.ExtHttpPort));
                 }
             }
             else if (options.AddInterfacePrefixes)
@@ -221,18 +174,16 @@ namespace EventStore.ClusterNode
                 }
             }
 
-            intHttpPrefixes = additionalIntHttpPrefixes.ToArray();
-            extHttpPrefixes = additionalExtHttpPrefixes.ToArray();
+            var intHttpPrefixes = additionalIntHttpPrefixes.ToArray();
+            var extHttpPrefixes = additionalExtHttpPrefixes.ToArray();
 
             var intTcpPort = options.IntTcpPortAdvertiseAs > 0 ? options.IntTcpPortAdvertiseAs : options.IntTcpPort;
             var intTcpEndPoint = new IPEndPoint(intIpAddressToAdvertise, intTcpPort);
-            var intSecureTcpPort = options.IntSecureTcpPortAdvertiseAs > 0 ? options.IntSecureTcpPortAdvertiseAs : options.IntSecureTcpPort;
-            var intSecureTcpEndPoint = new IPEndPoint(intIpAddressToAdvertise, intSecureTcpPort);
+            var intSecureTcpEndPoint = options.IntSecureTcpPort > 0 ? new IPEndPoint(intIpAddressToAdvertise, options.IntSecureTcpPort) : null;
 
             var extTcpPort = options.ExtTcpPortAdvertiseAs > 0 ? options.ExtTcpPortAdvertiseAs : options.ExtTcpPort;
             var extTcpEndPoint = new IPEndPoint(extIpAddressToAdvertise, extTcpPort);
-            var extSecureTcpPort = options.ExtSecureTcpPortAdvertiseAs > 0 ? options.ExtSecureTcpPortAdvertiseAs : options.ExtSecureTcpPort;
-            var extSecureTcpEndPoint = new IPEndPoint(extIpAddressToAdvertise, extSecureTcpPort);
+            var extSecureTcpEndPoint = options.ExtSecureTcpPort > 0 ? new IPEndPoint(extIpAddressToAdvertise, options.ExtSecureTcpPort) : null;
 
             var intHttpPort = options.IntHttpPortAdvertiseAs > 0 ? options.IntHttpPortAdvertiseAs : options.IntHttpPort;
             var extHttpPort = options.ExtHttpPortAdvertiseAs > 0 ? options.ExtHttpPortAdvertiseAs : options.ExtHttpPort;
@@ -240,55 +191,127 @@ namespace EventStore.ClusterNode
             var intHttpEndPoint = new IPEndPoint(intIpAddressToAdvertise, intHttpPort);
             var extHttpEndPoint = new IPEndPoint(extIpAddressToAdvertise, extHttpPort);
 
-            gossipAdvertiseInfo = new GossipAdvertiseInfo(intTcpEndPoint, intSecureTcpEndPoint,
-                                                          extTcpEndPoint, extSecureTcpEndPoint,
-                                                          intHttpEndPoint, extHttpEndPoint);
-
             var prepareCount = options.PrepareCount > quorumSize ? options.PrepareCount : quorumSize;
-            var commitCount = options.CommitCount > quorumSize ? options.CommitCount : quorumSize;
             Log.Info("Quorum size set to " + prepareCount);
-            if (options.UseInternalSsl)
+
+            VNodeBuilder builder;
+            if(options.ClusterSize > 1) {
+                builder = ClusterVNodeBuilder.AsClusterMember(options.ClusterSize);
+            } else {
+                builder = ClusterVNodeBuilder.AsSingleNode();
+            }
+            if(options.MemDb) {
+                builder = builder.RunInMemory();
+            } else {
+                builder = builder.RunOnDisk(options.Db);
+            }
+
+            builder.WithInternalTcpOn(intTcpEndPoint)
+                        .WithInternalSecureTcpOn(intSecureTcpEndPoint)
+                        .WithExternalTcpOn(extTcpEndPoint)
+                        .WithExternalSecureTcpOn(extSecureTcpEndPoint)
+                        .WithInternalHttpOn(intHttpEndPoint)
+                        .WithExternalHttpOn(extHttpEndPoint)
+                        .WithWorkerThreads(options.WorkerThreads)
+                        .WithInternalHeartbeatTimeout(TimeSpan.FromMilliseconds(options.IntTcpHeartbeatTimeout))
+                        .WithInternalHeartbeatInterval(TimeSpan.FromMilliseconds(options.IntTcpHeartbeatInterval))
+                        .WithExternalHeartbeatTimeout(TimeSpan.FromMilliseconds(options.ExtTcpHeartbeatTimeout))
+                        .WithExternalHeartbeatInterval(TimeSpan.FromMilliseconds(options.ExtTcpHeartbeatInterval))
+                        .MaximumMemoryTableSizeOf(options.MaxMemTableSize)
+                        .WithGossipInterval(TimeSpan.FromMilliseconds(options.GossipIntervalMs))
+                        .WithGossipAllowedTimeDifference(TimeSpan.FromMilliseconds(options.GossipAllowedDifferenceMs))
+                        .WithGossipTimeout(TimeSpan.FromMilliseconds(options.GossipTimeoutMs))
+                        .WithClusterGossipPort(options.ClusterGossipPort)
+                        .WithMinFlushDelay(TimeSpan.FromMilliseconds(options.MinFlushDelayMs))
+                        .WithPrepareTimeout(TimeSpan.FromMilliseconds(options.PrepareTimeoutMs))
+                        .WithCommitTimeout(TimeSpan.FromMilliseconds(options.CommitTimeoutMs))
+                        .WithStatsPeriod(TimeSpan.FromSeconds(options.StatsPeriodSec))
+                        .WithPrepareCount(options.PrepareCount)
+                        .WithCommitCount(options.CommitCount)
+                        .WithNodePriority(options.NodePriority)
+                        .WithScavengeHistoryMaxAge(options.ScavengeHistoryMaxAge)
+                        .WithIndexPath(options.Index)
+                        .WithIndexCacheDepth(options.IndexCacheDepth)
+                        .WithSslTargetHost(options.SslTargetHost)
+                        .RunProjections(options.RunProjections, options.ProjectionThreads)
+                        .WithTfCachedChunks(options.CachedChunks)
+                        .WithTfChunksCacheSize(options.ChunksCacheSize)
+                        .WithStatsStorage(StatsStorage.StreamAndCsv);
+
+            if(options.GossipSeed.Length > 0)
+                builder.WithGossipSeeds(options.GossipSeed);
+
+            if(options.DiscoverViaDns)
+                builder.WithClusterDnsName(options.ClusterDns);
+            else
+                builder.DisableDnsDiscovery();
+
+            foreach(var prefix in intHttpPrefixes) {
+                builder.AddInternalHttpPrefix(prefix);
+            }
+            foreach(var prefix in extHttpPrefixes) {
+                builder.AddExternalHttpPrefix(prefix);
+            }
+            
+            if(options.EnableTrustedAuth)
+                builder.EnableTrustedAuth();
+            if(options.StartStandardProjections)
+                builder.StartStandardProjections();
+            if(options.DisableHTTPCaching)
+                builder.DisableHTTPCaching();
+            if(options.DisableScavengeMerging)
+                builder.DisableScavengeMerging();
+            if(options.LogHttpRequests)
+                builder.EnableLoggingOfHttpRequests();
+            if(options.EnableHistograms)
+                builder.EnableHistograms();
+            if(options.UnsafeIgnoreHardDelete)
+                builder.WithUnsafeIgnoreHardDelete();
+            if(options.UnsafeDisableFlushToDisk)
+                builder.WithUnsafeDisableFlushToDisk();
+            if(options.BetterOrdering)
+                builder.WithBetterOrdering();
+            if(options.SslValidateServer)
+                builder.ValidateSslServer();
+            if(options.UseInternalSsl)
+                builder.EnableSsl();
+            if(!options.AdminOnExt)
+                builder.NoAdminOnPublicInterface();
+            if(!options.StatsOnExt)
+                builder.NoStatsOnPublicInterface();
+            if(!options.GossipOnExt)
+                builder.NoGossipOnPublicInterface();
+            if(options.SkipDbVerify)
+                builder.DoNotVerifyDbHashes();
+
+            if (options.IntSecureTcpPort > 0 || options.ExtSecureTcpPort > 0)
             {
-                if (ReferenceEquals(options.SslTargetHost, Opts.SslTargetHostDefault)) throw new Exception("No SSL target host specified.");
-                if (intSecTcp == null) throw new Exception("Usage of internal secure communication is specified, but no internal secure endpoint is specified!");
+                if (!string.IsNullOrWhiteSpace(options.CertificateStoreLocation))
+                {
+                    var location = GetCertificateStoreLocation(options.CertificateStoreLocation);
+                    var name = GetCertificateStoreName(options.CertificateStoreName);
+                    builder.WithServerCertificateFromStore(location,name, options.CertificateSubjectName, options.CertificateThumbprint);
+                }
+                else if (!string.IsNullOrWhiteSpace(options.CertificateStoreName))
+                {
+                    var name = GetCertificateStoreName(options.CertificateStoreName);
+                    builder.WithServerCertificateFromStore(name, options.CertificateSubjectName, options.CertificateThumbprint);
+                }
+                else if (options.CertificateFile.IsNotEmptyString())
+                {
+                    builder.WithServerCertificateFromFile(options.CertificateFile, options.CertificatePassword);
+                }
+                else
+                    throw new Exception("No server certificate specified.");
             }
 
             var authenticationConfig = String.IsNullOrEmpty(options.AuthenticationConfig) ? options.Config : options.AuthenticationConfig;
             var plugInContainer = FindPlugins();
             var authenticationProviderFactory = GetAuthenticationProviderFactory(options.AuthenticationType, authenticationConfig, plugInContainer);
             var consumerStrategyFactories = GetPlugInConsumerStrategyFactories(plugInContainer);
-            return new ClusterVNodeSettings(Guid.NewGuid(), 0,
-                    intTcp, intSecTcp, extTcp, extSecTcp, intHttp, extHttp, gossipAdvertiseInfo,
-                    intHttpPrefixes, extHttpPrefixes, options.EnableTrustedAuth,
-                    certificate,
-                    options.WorkerThreads, options.DiscoverViaDns,
-                    options.ClusterDns, options.GossipSeed,
-                    TimeSpan.FromMilliseconds(options.MinFlushDelayMs), options.ClusterSize,
-                    prepareCount, commitCount,
-                    TimeSpan.FromMilliseconds(options.PrepareTimeoutMs),
-                    TimeSpan.FromMilliseconds(options.CommitTimeoutMs),
-                    options.UseInternalSsl, options.SslTargetHost, options.SslValidateServer,
-                    TimeSpan.FromSeconds(options.StatsPeriodSec), StatsStorage.StreamAndCsv,
-                    options.NodePriority, authenticationProviderFactory, options.DisableScavengeMerging,
-                    options.ScavengeHistoryMaxAge, options.AdminOnExt, options.StatsOnExt, options.GossipOnExt,
-                    TimeSpan.FromMilliseconds(options.GossipIntervalMs),
-                    TimeSpan.FromMilliseconds(options.GossipAllowedDifferenceMs),
-                    TimeSpan.FromMilliseconds(options.GossipTimeoutMs),
-                    TimeSpan.FromMilliseconds(options.IntTcpHeartbeatTimeout),
-                    TimeSpan.FromMilliseconds(options.IntTcpHeartbeatInterval),
-                    TimeSpan.FromMilliseconds(options.ExtTcpHeartbeatTimeout),
-                    TimeSpan.FromMilliseconds(options.ExtTcpHeartbeatInterval),
-                    !options.SkipDbVerify, options.MaxMemTableSize,
-                    options.StartStandardProjections,
-                    options.DisableHTTPCaching,
-                    options.LogHttpRequests,
-                    options.Index,
-                    options.EnableHistograms,
-                    options.IndexCacheDepth,
-                    consumerStrategyFactories,
-                    options.UnsafeIgnoreHardDelete,
-                    options.BetterOrdering
-                    );
+            builder.WithAuthenticationProvider(authenticationProviderFactory);
+            
+            return builder.Build(options, consumerStrategyFactories);
         }
 
         private static IPAddress GetNonLoopbackAddress(){

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthentictaionProviderFactory.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthentictaionProviderFactory.cs
@@ -1,0 +1,26 @@
+using EventStore.Core.Authentication;
+using EventStore.Core.Bus;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Transport.Http;
+
+namespace EventStore.Core.Tests.Common.VNodeBuilderTests
+{
+    public class TestAuthenticationProviderFactory : IAuthenticationProviderFactory
+    {
+        public IAuthenticationProvider BuildAuthenticationProvider(IPublisher mainQueue, ISubscriber mainBus, IPublisher workersQueue, InMemoryBus[] workerBusses)
+        {
+            return new TestAuthenticationProvider();
+        }
+        
+        public void RegisterHttpControllers(HttpService externalHttpService, HttpService internalHttpService, HttpSendService httpSendService, IPublisher mainQueue, IPublisher networkSendQueue)
+        {
+        }
+    }
+
+    public class TestAuthenticationProvider : IAuthenticationProvider
+    {
+        public void Authenticate(AuthenticationRequest authenticationRequest)
+        {
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestVNodeBuilder.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestVNodeBuilder.cs
@@ -1,0 +1,43 @@
+using EventStore.Core.Cluster.Settings;
+using EventStore.Core.TransactionLog.Chunks;
+
+namespace EventStore.Core.Tests.Common.VNodeBuilderTests
+{
+    public class TestVNodeBuilder : VNodeBuilder
+    {
+        protected TestVNodeBuilder()
+        {
+        }
+
+        public static TestVNodeBuilder AsSingleNode()
+        {
+            var ret = new TestVNodeBuilder().WithSingleNodeSettings();
+            return (TestVNodeBuilder)ret;
+        }
+
+        public static TestVNodeBuilder AsClusterMember(int clusterSize)
+        {
+            var ret = new TestVNodeBuilder().WithClusterNodeSettings(clusterSize);
+            return (TestVNodeBuilder)ret;
+        }
+        
+        protected override void SetUpProjectionsIfNeeded()
+        {
+        }
+
+        public ClusterVNodeSettings GetSettings()
+        {
+            return _vNodeSettings;
+        }
+
+        public TFChunkDb GetDb()
+        {
+            return _db;
+        }
+
+        public TFChunkDbConfig GetDbConfig()
+        {
+            return _dbConfig;
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
@@ -1,0 +1,65 @@
+using EventStore.Core.Cluster.Settings;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Common.VNodeBuilderTests
+{
+    [TestFixture]
+    public abstract class SingleNodeScenario
+    {
+        protected VNodeBuilder _builder;
+        protected ClusterVNode _node;
+        protected ClusterVNodeSettings _settings;
+        protected TFChunkDbConfig _dbConfig;
+
+        [TestFixtureSetUp]
+        public virtual void TestFixtureSetUp()
+        {
+            _builder = TestVNodeBuilder.AsSingleNode()
+                                       .RunInMemory();
+            Given();
+            _node = _builder.Build();
+            _settings = ((TestVNodeBuilder)_builder).GetSettings();
+            _dbConfig = ((TestVNodeBuilder)_builder).GetDbConfig();
+        }
+
+        [TestFixtureTearDown]
+        public virtual void TestFixtureTearDown()
+        {
+            _node.Stop();
+        }
+
+        public abstract void Given();
+    }
+
+    [TestFixture]
+    public abstract class ClusterMemberScenario
+    {
+        protected VNodeBuilder _builder;
+        protected ClusterVNode _node;
+        protected ClusterVNodeSettings _settings;
+        protected TFChunkDbConfig _dbConfig;
+        protected int _clusterSize = 3;
+        protected int _quorumSize;
+
+        [TestFixtureSetUp]
+        public virtual void TestFixtureSetUp()
+        {
+            _builder = TestVNodeBuilder.AsClusterMember(_clusterSize)
+                                       .RunInMemory();
+            _quorumSize = _clusterSize / 2 + 1;
+            Given();
+            _node = _builder.Build();
+            _settings = ((TestVNodeBuilder)_builder).GetSettings();
+            _dbConfig = ((TestVNodeBuilder)_builder).GetDbConfig();
+        }
+        
+        [TestFixtureTearDown]
+        public virtual void TestFixtureTearDown()
+        {
+            _node.Stop();
+        }
+
+        public abstract void Given();
+    }
+}

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_cluster_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_cluster_node_and_custom_settings.cs
@@ -1,0 +1,230 @@
+using NUnit.Framework;
+using System;
+using System.Net;
+
+namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
+{
+    [TestFixture]
+    public class with_cluster_dns_name : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithClusterDnsName("ClusterDns");
+        }
+
+        [Test]
+        public void should_set_discover_via_dns_to_true()
+        {
+            Assert.IsTrue(_settings.DiscoverViaDns);
+        }
+
+        [Test]
+        public void should_set_cluster_dns_name()
+        {
+            Assert.AreEqual("ClusterDns", _settings.ClusterDns);
+        }
+    }
+
+    [TestFixture]
+    public class with_dns_discovery_disabled_and_no_gossip_seeds
+    {
+        private Exception _caughtException;
+        protected VNodeBuilder _builder;
+
+        [TestFixtureSetUp]
+        public void TestFixtureSetUp()
+        {
+            _builder = TestVNodeBuilder.AsClusterMember(3)
+                                       .RunInMemory()
+                                       .OnDefaultEndpoints()
+                                       .DisableDnsDiscovery();
+            try 
+            {
+                _builder.Build();
+            } 
+            catch(Exception e) 
+            {
+                _caughtException = e;
+            }
+        }
+
+        [Test]
+        public void should_throw_an_exception()
+        {
+            Assert.IsNotNull(_caughtException);
+        }
+    }
+
+    [TestFixture]
+    public class with_dns_discovery_disabled_and_gossip_seeds_defined : ClusterMemberScenario
+    {
+        private IPEndPoint[] _gossipSeeds;
+
+        public override void Given()
+        {
+            var baseAddress = IPAddress.Parse("192.168.1.10");
+            _gossipSeeds = new IPEndPoint[] {
+                new IPEndPoint(baseAddress, 1111),
+                new IPEndPoint(baseAddress, 1112)
+            };
+            _builder.DisableDnsDiscovery()
+                    .WithGossipSeeds(_gossipSeeds);
+        }
+
+        [Test]
+        public void should_set_discover_via_dns_to_false()
+        {
+            Assert.IsFalse(_settings.DiscoverViaDns);
+        }
+
+        [Test]
+        public void should_set_the_gossip_seeds()
+        {
+            CollectionAssert.AreEqual(_gossipSeeds, _settings.GossipSeeds);
+        }
+    }
+
+    [TestFixture]
+    public class with_prepare_ack_count_set_higher_than_the_quorum : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithPrepareCount(_quorumSize + 1);
+        }
+
+        [Test]
+        public void should_set_prepare_count_to_the_given_value()
+        {
+            Assert.AreEqual(_quorumSize + 1, _settings.PrepareAckCount);
+        }
+    }
+
+    [TestFixture]
+    public class with_commit_ack_count_set_higher_than_the_quorum : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithCommitCount(_quorumSize + 1);
+        }
+
+        [Test]
+        public void should_set_commit_count_to_the_given_value()
+        {
+            Assert.AreEqual(_quorumSize + 1, _settings.CommitAckCount);
+        }
+    }
+
+    [TestFixture]
+    public class with_prepare_ack_count_set_lower_than_the_quorum : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithPrepareCount(_quorumSize - 1);
+        }
+
+        [Test]
+        public void should_set_prepare_count_to_the_quorum_size()
+        {
+            Assert.AreEqual(_quorumSize, _settings.PrepareAckCount);
+        }
+    }
+
+    [TestFixture]
+    public class with_commit_ack_count_set_lower_than_the_quorum : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithCommitCount(_quorumSize - 1);
+        }
+
+        [Test]
+        public void should_set_commit_count_to_the_quorum_size()
+        {
+            Assert.AreEqual(_quorumSize, _settings.CommitAckCount);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_node_priority : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithNodePriority(5);
+        }
+
+        [Test]
+        public void should_set_the_node_priority()
+        {
+            Assert.AreEqual(5, _settings.NodePriority);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_gossip_seeds : ClusterMemberScenario
+    {
+        private IPEndPoint[] _gossipSeeds;
+        public override void Given()
+        {
+            var baseIpAddress = IPAddress.Parse("192.168.1.15");
+            _gossipSeeds = new IPEndPoint[] { new IPEndPoint(baseIpAddress, 2112), new IPEndPoint(baseIpAddress, 3112)};
+            _builder.WithGossipSeeds(_gossipSeeds);
+        }
+
+        [Test]
+        public void should_turn_off_discovery_by_dns()
+        {
+            Assert.IsFalse(_settings.DiscoverViaDns);
+        }
+
+        [Test]
+        public void should_set_the_gossip_seeds()
+        {
+            CollectionAssert.AreEqual(_gossipSeeds, _settings.GossipSeeds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_gossip_interval : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithGossipInterval(TimeSpan.FromMilliseconds(1300));
+        }
+
+        [Test]
+        public void should_set_the_gossip_interval()
+        {
+            Assert.AreEqual(1300, _settings.GossipInterval.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_gossip_allowed_time_difference : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithGossipAllowedTimeDifference(TimeSpan.FromMilliseconds(1300));
+        }
+
+        [Test]
+        public void should_set_the_allowed_gossip_time_difference()
+        {
+            Assert.AreEqual(1300, _settings.GossipAllowedTimeDifference.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_gossip_timeout : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+            _builder.WithGossipTimeout(TimeSpan.FromMilliseconds(1300));
+        }
+
+        [Test]
+        public void should_set_the_gossip_timeout()
+        {
+            Assert.AreEqual(1300, _settings.GossipTimeout.TotalMilliseconds);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
@@ -1,0 +1,189 @@
+using EventStore.Core.Authentication;
+using EventStore.Common.Options;
+using EventStore.Common.Utils;
+using EventStore.Core.Services.Monitoring;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Util;
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Collections.Generic;
+
+namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
+{
+    [TestFixture]
+    public class with_default_settings_as_single_node : SingleNodeScenario
+    {
+        public override void Given()
+        {
+        }
+
+        [Test]
+        public void should_create_single_cluster_node()
+        {
+            Assert.IsNotNull(_node);
+            Assert.AreEqual(1, _settings.ClusterNodeCount, "ClusterNodeCount");
+            Assert.IsInstanceOf<InternalAuthenticationProviderFactory>(_settings.AuthenticationProviderFactory);
+            Assert.AreEqual(StatsStorage.Stream, _settings.StatsStorage);
+        }
+
+        [Test]
+        public void should_have_default_endpoints()
+        {
+            Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 1112), _settings.NodeInfo.InternalTcp);
+            Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 1113), _settings.NodeInfo.ExternalTcp);
+            Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 2112), _settings.NodeInfo.InternalHttp);
+            Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 2113), _settings.NodeInfo.ExternalHttp);
+
+            var intHttpPrefixes = new List<string> { "http://127.0.0.1:2112/" };
+            var extHttpPrefixes = new List<string> { "http://127.0.0.1:2113/" };
+            if (Runtime.IsMono)
+            {
+                intHttpPrefixes.Add("http://localhost:2112/");
+                extHttpPrefixes.Add("http://localhost:2113/");
+            }
+            CollectionAssert.AreEqual(intHttpPrefixes, _settings.IntHttpPrefixes);
+            CollectionAssert.AreEqual(extHttpPrefixes, _settings.ExtHttpPrefixes);
+        }
+
+        [Test]
+        public void should_not_use_ssl()
+        {
+            Assert.AreEqual("n/a", _settings.Certificate == null ? "n/a" : _settings.Certificate.ToString());
+            Assert.IsFalse(_settings.UseSsl);
+            Assert.AreEqual("n/a", _settings.SslTargetHost == null ? "n/a" : _settings.SslTargetHost);
+        }
+
+        [Test]
+        public void should_set_command_line_args_to_default_values()
+        {
+            Assert.AreEqual(Opts.EnableTrustedAuthDefault, _settings.EnableTrustedAuth, "EnableTrustedAuth");
+            Assert.AreEqual(Opts.LogHttpRequestsDefault, _settings.LogHttpRequests, "LogHttpRequests");
+            Assert.AreEqual(Opts.WorkerThreadsDefault, _settings.WorkerThreads, "WorkerThreads");
+            Assert.AreEqual(Opts.DiscoverViaDnsDefault, _settings.DiscoverViaDns, "DiscoverViaDns");
+            Assert.AreEqual(Opts.StatsPeriodDefault, _settings.StatsPeriod.Seconds, "StatsPeriod");
+            Assert.AreEqual(Opts.HistogramEnabledDefault, _settings.EnableHistograms, "EnableHistograms");
+            Assert.AreEqual(Opts.DisableHttpCachingDefault, _settings.DisableHTTPCaching, "DisableHTTPCaching");
+            Assert.AreEqual(Opts.SkipDbVerifyDefault, !_settings.VerifyDbHash, "VerifyDbHash");
+            Assert.AreEqual(Opts.MinFlushDelayMsDefault, _settings.MinFlushDelay.TotalMilliseconds, "MinFlushDelay");
+            Assert.AreEqual(Opts.ScavengeHistoryMaxAgeDefault, _settings.ScavengeHistoryMaxAge, "ScavengeHistoryMaxAge");
+            Assert.AreEqual(Opts.DisableScavengeMergeDefault, _settings.DisableScavengeMerging, "DisableScavengeMerging");
+            Assert.AreEqual(Opts.AdminOnExtDefault, _settings.AdminOnPublic, "AdminOnPublic");
+            Assert.AreEqual(Opts.StatsOnExtDefault, _settings.StatsOnPublic, "StatsOnPublic");
+            Assert.AreEqual(Opts.GossipOnExtDefault, _settings.GossipOnPublic, "GossipOnPublic");
+            Assert.AreEqual(Opts.MaxMemtableSizeDefault, _settings.MaxMemtableEntryCount, "MaxMemtableEntryCount");
+            Assert.AreEqual(Opts.StartStandardProjectionsDefault, _settings.StartStandardProjections, "StartStandardProjections");
+            Assert.AreEqual(Opts.UnsafeIgnoreHardDeleteDefault, _settings.UnsafeIgnoreHardDeletes, "UnsafeIgnoreHardDeletes");
+            Assert.AreEqual(Opts.BetterOrderingDefault, _settings.BetterOrdering, "BetterOrdering");
+            Assert.IsNullOrEmpty(_settings.Index, "IndexPath");
+            Assert.AreEqual(1, _settings.PrepareAckCount, "PrepareAckCount");
+            Assert.AreEqual(1, _settings.CommitAckCount, "CommitAckCount");
+            Assert.AreEqual(Opts.PrepareTimeoutMsDefault, _settings.PrepareTimeout.TotalMilliseconds, "PrepareTimeout");
+            Assert.AreEqual(Opts.CommitTimeoutMsDefault, _settings.CommitTimeout.TotalMilliseconds, "CommitTimeout");
+
+            Assert.AreEqual(Opts.IntTcpHeartbeatIntervalDefault, _settings.IntTcpHeartbeatInterval.TotalMilliseconds, "IntTcpHeartbeatInterval");
+            Assert.AreEqual(Opts.IntTcpHeartbeatTimeoutDefault, _settings.IntTcpHeartbeatTimeout.TotalMilliseconds, "IntTcpHeartbeatTimeout");
+            Assert.AreEqual(Opts.ExtTcpHeartbeatIntervalDefault, _settings.ExtTcpHeartbeatInterval.TotalMilliseconds, "ExtTcpHeartbeatInterval");
+            Assert.AreEqual(Opts.ExtTcpHeartbeatTimeoutDefault, _settings.ExtTcpHeartbeatTimeout.TotalMilliseconds, "ExtTcpHeartbeatTimeout");
+
+            Assert.AreEqual(TFConsts.ChunkSize, _dbConfig.ChunkSize, "ChunkSize");
+            Assert.AreEqual(Opts.ChunksCacheSizeDefault, _dbConfig.MaxChunksCacheSize, "MaxChunksCacheSize");
+        }
+    }
+
+    [TestFixture]
+    public class with_default_settings_as_node_in_a_cluster : ClusterMemberScenario
+    {
+        public override void Given()
+        {
+        }
+
+        [Test]
+        public void should_create_single_cluster_node()
+        {
+            Assert.IsNotNull(_node);
+            Assert.AreEqual(_clusterSize, _settings.ClusterNodeCount, "ClusterNodeCount");
+            Assert.IsInstanceOf<InternalAuthenticationProviderFactory>(_settings.AuthenticationProviderFactory);
+            Assert.AreEqual(StatsStorage.Stream, _settings.StatsStorage);
+        }
+
+        [Test]
+        public void should_have_default_endpoints()
+        {
+            var internalTcp = new IPEndPoint(IPAddress.Loopback, 1112); 
+            var externalTcp = new IPEndPoint(IPAddress.Loopback, 1113);
+            var internalHttp = new IPEndPoint(IPAddress.Loopback, 2112);
+            var externalHttp = new IPEndPoint(IPAddress.Loopback, 2113); 
+
+            Assert.AreEqual(internalTcp, _settings.NodeInfo.InternalTcp);
+            Assert.AreEqual(externalTcp, _settings.NodeInfo.ExternalTcp);
+            Assert.AreEqual(internalHttp, _settings.NodeInfo.InternalHttp);
+            Assert.AreEqual(externalHttp, _settings.NodeInfo.ExternalHttp);
+
+            var intHttpPrefixes = new List<string> { "http://127.0.0.1:2112/" };
+            var extHttpPrefixes = new List<string> { "http://127.0.0.1:2113/" };
+            if (Runtime.IsMono)
+            {
+                intHttpPrefixes.Add("http://localhost:2112/");
+                extHttpPrefixes.Add("http://localhost:2113/");
+            }
+            CollectionAssert.AreEqual(intHttpPrefixes, _settings.IntHttpPrefixes);
+            CollectionAssert.AreEqual(extHttpPrefixes, _settings.ExtHttpPrefixes);
+
+            Assert.AreEqual(internalTcp, _settings.GossipAdvertiseInfo.InternalTcp);
+            Assert.AreEqual(externalTcp, _settings.GossipAdvertiseInfo.ExternalTcp);
+            Assert.AreEqual(internalHttp, _settings.GossipAdvertiseInfo.InternalHttp);
+            Assert.AreEqual(externalHttp, _settings.GossipAdvertiseInfo.ExternalHttp);
+        }
+
+        [Test]
+        public void should_not_use_ssl()
+        {
+            Assert.AreEqual("n/a", _settings.Certificate == null ? "n/a" : _settings.Certificate.ToString());
+            Assert.IsFalse(_settings.UseSsl);
+            Assert.AreEqual("n/a", _settings.SslTargetHost == null ? "n/a" : _settings.SslTargetHost.ToString());
+        }
+
+        [Test]
+        public void should_set_command_line_args_to_default_values()
+        {
+            Assert.AreEqual(Opts.EnableTrustedAuthDefault, _settings.EnableTrustedAuth, "EnableTrustedAuth");
+            Assert.AreEqual(Opts.LogHttpRequestsDefault, _settings.LogHttpRequests, "LogHttpRequests");
+            Assert.AreEqual(Opts.WorkerThreadsDefault, _settings.WorkerThreads, "WorkerThreads");
+            Assert.AreEqual(Opts.DiscoverViaDnsDefault, _settings.DiscoverViaDns, "DiscoverViaDns");
+            Assert.AreEqual(Opts.StatsPeriodDefault, _settings.StatsPeriod.Seconds, "StatsPeriod");
+            Assert.AreEqual(Opts.HistogramEnabledDefault, _settings.EnableHistograms, "EnableHistograms");
+            Assert.AreEqual(Opts.DisableHttpCachingDefault, _settings.DisableHTTPCaching, "DisableHTTPCaching");
+            Assert.AreEqual(Opts.SkipDbVerifyDefault, !_settings.VerifyDbHash, "VerifyDbHash");
+            Assert.AreEqual(Opts.MinFlushDelayMsDefault, _settings.MinFlushDelay.TotalMilliseconds, "MinFlushDelay");
+            Assert.AreEqual(Opts.ScavengeHistoryMaxAgeDefault, _settings.ScavengeHistoryMaxAge, "ScavengeHistoryMaxAge");
+            Assert.AreEqual(Opts.DisableScavengeMergeDefault, _settings.DisableScavengeMerging, "DisableScavengeMerging");
+            Assert.AreEqual(Opts.AdminOnExtDefault, _settings.AdminOnPublic, "AdminOnPublic");
+            Assert.AreEqual(Opts.StatsOnExtDefault, _settings.StatsOnPublic, "StatsOnPublic");
+            Assert.AreEqual(Opts.GossipOnExtDefault, _settings.GossipOnPublic, "GossipOnPublic");
+            Assert.AreEqual(Opts.MaxMemtableSizeDefault, _settings.MaxMemtableEntryCount, "MaxMemtableEntryCount");
+            Assert.AreEqual(Opts.StartStandardProjectionsDefault, _settings.StartStandardProjections, "StartStandardProjections");
+            Assert.AreEqual(Opts.UnsafeIgnoreHardDeleteDefault, _settings.UnsafeIgnoreHardDeletes, "UnsafeIgnoreHardDeletes");
+            Assert.AreEqual(Opts.BetterOrderingDefault, _settings.BetterOrdering, "BetterOrdering");
+            Assert.IsNullOrEmpty(_settings.Index, "IndexPath");
+            Assert.AreEqual(Opts.PrepareTimeoutMsDefault, _settings.PrepareTimeout.TotalMilliseconds, "PrepareTimeout");
+            Assert.AreEqual(Opts.CommitTimeoutMsDefault, _settings.CommitTimeout.TotalMilliseconds, "CommitTimeout");
+
+            Assert.AreEqual(Opts.IntTcpHeartbeatIntervalDefault, _settings.IntTcpHeartbeatInterval.TotalMilliseconds, "IntTcpHeartbeatInterval");
+            Assert.AreEqual(Opts.IntTcpHeartbeatTimeoutDefault, _settings.IntTcpHeartbeatTimeout.TotalMilliseconds, "IntTcpHeartbeatTimeout");
+            Assert.AreEqual(Opts.ExtTcpHeartbeatIntervalDefault, _settings.ExtTcpHeartbeatInterval.TotalMilliseconds, "ExtTcpHeartbeatInterval");
+            Assert.AreEqual(Opts.ExtTcpHeartbeatTimeoutDefault, _settings.ExtTcpHeartbeatTimeout.TotalMilliseconds, "ExtTcpHeartbeatTimeout");
+
+            Assert.AreEqual(TFConsts.ChunkSize, _dbConfig.ChunkSize, "ChunkSize");
+            Assert.AreEqual(Opts.ChunksCacheSizeDefault, _dbConfig.MaxChunksCacheSize, "MaxChunksCacheSize");
+        }
+
+        [Test]
+        public void should_set_commit_and_prepare_counts_to_quorum_size()
+        {
+            var quorumSize = _clusterSize / 2 + 1;
+            Assert.AreEqual(quorumSize, _settings.PrepareAckCount, "PrepareAckCount");
+            Assert.AreEqual(quorumSize, _settings.CommitAckCount, "CommitAckCount");
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_secure_tcp.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_secure_tcp.cs
@@ -1,0 +1,170 @@
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using System.IO;
+using System.Reflection;
+using EventStore.Core.Tests.Services.Transport.Tcp;
+
+namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
+{
+    [TestFixture]
+    [Category("LongRunning")]
+    public class with_ssl_enabled_and_using_a_security_certificate_from_file : SingleNodeScenario
+    {
+        private IPEndPoint _internalSecTcp;
+        private IPEndPoint _externalSecTcp;
+        public override void Given()
+        {
+            var certPath = GetCertificatePath();
+            var baseIpAddress = IPAddress.Parse("192.168.1.15");
+            _internalSecTcp = new IPEndPoint(baseIpAddress, 1114);
+            _externalSecTcp = new IPEndPoint(baseIpAddress, 1115);
+            _builder.WithInternalSecureTcpOn(_internalSecTcp)
+                    .WithExternalSecureTcpOn(_externalSecTcp)
+            		.EnableSsl()
+            		.WithSslTargetHost("Host")
+            		.ValidateSslServer()
+            		.WithServerCertificateFromFile(certPath, "1111");
+        }
+        
+        [Test]
+        public void should_set_ssl_to_enabled()
+        {
+            Assert.IsTrue(_settings.UseSsl);
+        }
+
+        [Test]
+        public void should_set_certificate()
+        {
+            Assert.AreNotEqual("n/a", _settings.Certificate == null ? "n/a" : _settings.Certificate.ToString());
+        }
+
+        [Test]
+        public void should_set_internal_secure_tcp_endpoint()
+        {
+            Assert.AreEqual(_internalSecTcp, _settings.NodeInfo.InternalSecureTcp);
+        }
+
+        [Test]
+        public void should_set_external_secure_tcp_endpoint()
+        {
+            Assert.AreEqual(_externalSecTcp, _settings.NodeInfo.ExternalSecureTcp);
+        }
+
+        [Test]
+        public void should_set_ssl_target_host()
+        {
+            Assert.AreEqual("Host", _settings.SslTargetHost);
+        }
+
+		[Test]
+        public void should_enable_validating_ssl_server()
+        {
+            Assert.IsTrue(_settings.SslValidateServer);
+        }
+
+        private string GetCertificatePath()
+        {
+            var filePath = Path.Combine(Path.GetTempPath(), string.Format("cert-{0}.p12", Guid.NewGuid()));
+            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("EventStore.Core.Tests.server.p12"))
+            using (var fileStream = File.Create(filePath))
+            {
+                stream.Seek(0, SeekOrigin.Begin);
+                stream.CopyTo(fileStream);
+                return filePath;
+            }
+        }
+    }
+
+    [TestFixture]
+    public class with_ssl_enabled_and_using_a_security_certificate : SingleNodeScenario
+    {
+        private IPEndPoint _internalSecTcp;
+        private IPEndPoint _externalSecTcp;
+        private X509Certificate2 _certificate;
+        public override void Given()
+        {
+            _certificate = ssl_connections.GetCertificate();
+            var baseIpAddress = IPAddress.Parse("192.168.1.15");
+            _internalSecTcp = new IPEndPoint(baseIpAddress, 1114);
+            _externalSecTcp = new IPEndPoint(baseIpAddress, 1115);
+            _builder.WithInternalSecureTcpOn(_internalSecTcp)
+                    .WithExternalSecureTcpOn(_externalSecTcp)
+                    .EnableSsl()
+                    .WithSslTargetHost("Host")
+                    .ValidateSslServer()
+                    .WithServerCertificate(_certificate);
+        }
+        
+        [Test]
+        public void should_set_ssl_to_enabled()
+        {
+            Assert.IsTrue(_settings.UseSsl);
+        }
+
+        [Test]
+        public void should_set_certificate()
+        {
+            Assert.AreNotEqual("n/a", _settings.Certificate == null ? "n/a" : _settings.Certificate.ToString());
+        }
+
+        [Test]
+        public void should_set_internal_secure_tcp_endpoint()
+        {
+            Assert.AreEqual(_internalSecTcp, _settings.NodeInfo.InternalSecureTcp);
+        }
+
+        [Test]
+        public void should_set_external_secure_tcp_endpoint()
+        {
+            Assert.AreEqual(_externalSecTcp, _settings.NodeInfo.ExternalSecureTcp);
+        }
+
+        [Test]
+        public void should_set_ssl_target_host()
+        {
+            Assert.AreEqual("Host", _settings.SslTargetHost);
+        }
+
+        [Test]
+        public void should_enable_validating_ssl_server()
+        {
+            Assert.IsTrue(_settings.SslValidateServer);
+        }
+    }
+
+
+    [TestFixture]
+    public class with_secure_tcp_endpoints_and_no_certificates
+    {
+        private VNodeBuilder _builder;
+        private Exception _caughtException;
+
+        [TestFixtureSetUp]
+        public void SetUp()
+        {
+            var baseIpAddress = IPAddress.Parse("192.168.1.15");
+            var internalSecTcp = new IPEndPoint(baseIpAddress, 1114);
+            var externalSecTcp = new IPEndPoint(baseIpAddress, 1115);
+            _builder = TestVNodeBuilder.AsSingleNode()
+                                       .RunInMemory()
+                                       .OnDefaultEndpoints()
+                                       .WithInternalSecureTcpOn(internalSecTcp)
+                                       .WithExternalSecureTcpOn(externalSecTcp);
+            try
+            {
+                _builder.Build();
+            }
+            catch(Exception ex)
+            {
+                _caughtException = ex;
+            }
+        }
+        [Test]
+        public void should_throw_an_exception()
+        {
+            Assert.IsNotNull(_caughtException);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
@@ -1,0 +1,660 @@
+using NUnit.Framework;
+using System;
+using System.Net;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Services.Monitoring;
+
+namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
+{
+    [TestFixture]
+    public class with_run_on_disk : SingleNodeScenario
+    {
+        private string _dbPath;
+        public override void Given()
+        {
+            _dbPath =string.Format("Test-{0}", Guid.NewGuid());
+            _builder.RunOnDisk(_dbPath);
+        }
+
+        [Test]
+        public void should_set_memdb_to_false()
+        {
+            Assert.IsFalse(_dbConfig.InMemDb);
+        }
+        
+        [Test]
+        public void should_set_the_db_path()
+        {
+            Assert.AreEqual(_dbPath, _dbConfig.Path);
+        }
+    }
+
+    [TestFixture]
+    public class with_default_endpoints_option : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            var noEndpoint = new IPEndPoint(IPAddress.None, 0);
+            _builder.WithInternalHttpOn(noEndpoint)
+                    .WithExternalHttpOn(noEndpoint)
+                    .WithInternalTcpOn(noEndpoint)
+                    .WithExternalTcpOn(noEndpoint);
+
+            _builder.OnDefaultEndpoints();
+        }
+
+        [Test]
+        public void should_set_internal_tcp()
+        {
+            Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 1112), _settings.NodeInfo.InternalTcp);
+        }
+
+        [Test]
+        public void should_set_external_tcp()
+        {
+            Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 1113), _settings.NodeInfo.ExternalTcp);
+        }
+
+        [Test]
+        public void should_set_internal_http()
+        {
+            Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 2112), _settings.NodeInfo.InternalHttp);
+        }
+        
+        [Test]
+        public void should_set_external_http()
+        {
+            Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 2113), _settings.NodeInfo.ExternalHttp);
+        }
+    }
+
+    [TestFixture]
+    public class with_run_in_memory : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.RunInMemory();
+        }
+
+        [Test]
+        public void should_set_memdb_to_true()
+        {
+            Assert.IsTrue(_dbConfig.InMemDb);
+        }
+    }
+
+    [TestFixture]
+    public class with_log_http_requests_enabled : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.EnableLoggingOfHttpRequests();
+        }
+
+        [Test]
+        public void should_set_http_logging_to_true()
+        {
+            Assert.IsTrue(_settings.LogHttpRequests);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_number_of_worker_threads : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithWorkerThreads(10);
+        }
+
+        [Test]
+        public void should_set_the_number_of_worker_threads()
+        {
+            Assert.AreEqual(10, _settings.WorkerThreads);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_stats_period : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithStatsPeriod(TimeSpan.FromSeconds(1));
+        }
+
+        [Test]
+        public void should_set_the_stats_period()
+        {
+            Assert.AreEqual(1, _settings.StatsPeriod.TotalSeconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_stats_storage : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithStatsStorage(StatsStorage.None);
+        }
+
+        [Test]
+        public void should_set_the_stats_storage()
+        {
+            Assert.AreEqual(StatsStorage.None, _settings.StatsStorage);
+        }
+    }
+
+    [TestFixture]
+    public class with_histograms_enabled : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.EnableHistograms();
+        }
+
+        [Test]
+        public void should_enable_histograms()
+        {
+            Assert.IsTrue(_settings.EnableHistograms);
+        }
+    }
+
+    [TestFixture]
+    public class with_trusted_auth_enabled : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.EnableTrustedAuth();
+        }
+
+        [Test]
+        public void should_enable_trusted_authentication()
+        {
+            Assert.IsTrue(_settings.EnableTrustedAuth);
+        }
+    }
+
+    [TestFixture]
+    public class with_http_caching_disabled : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.DisableHTTPCaching();
+        }
+
+        [Test]
+        public void should_disable_http_caching()
+        {
+            Assert.IsTrue(_settings.DisableHTTPCaching);
+        }
+    }
+
+    [TestFixture]
+    public class without_verifying_db_hashes : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.DoNotVerifyDbHashes();
+        }
+
+        [Test]
+        public void should_set_verify_db_hashes_to_false()
+        {
+            Assert.IsFalse(_settings.VerifyDbHash);
+        }
+    }
+
+    [TestFixture]
+    public class with_verifying_db_hashes : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.DoNotVerifyDbHashes() // Turn off verification before turning it back on
+                    .VerifyDbHashes();
+        }
+
+        [Test]
+        public void should_set_verify_db_hashes_to_true()
+        {
+            Assert.IsTrue(_settings.VerifyDbHash);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_min_flush_delay : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithMinFlushDelay(TimeSpan.FromMilliseconds(1200));
+        }
+
+        [Test]
+        public void should_set_the_min_flush_delay()
+        {
+            Assert.AreEqual(1200, _settings.MinFlushDelay.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_scavenge_history_max_age : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithScavengeHistoryMaxAge(2);
+        }
+
+        [Test]
+        public void should_set_the_scavenge_history_max_age()
+        {
+            Assert.AreEqual(2, _settings.ScavengeHistoryMaxAge);
+        }
+    }
+
+    [TestFixture]
+    public class with_scavenge_merging_disabled : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.DisableScavengeMerging();
+        }
+
+        [Test]
+        public void should_disable_scavenge_merging()
+        {
+            Assert.IsTrue(_settings.DisableScavengeMerging);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_max_memtable_size : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.MaximumMemoryTableSizeOf(200);
+        }
+
+        [Test]
+        public void should_set_the_max_memtable_size()
+        {
+            Assert.AreEqual(200, _settings.MaxMemtableEntryCount);
+        }
+    }
+
+    [TestFixture]
+    public class with_standard_projections_started : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.StartStandardProjections();
+        }
+
+        [Test]
+        public void should_set_start_standard_projections_to_true()
+        {
+            Assert.IsTrue(_settings.StartStandardProjections);
+        }
+    }
+
+    [TestFixture]
+    public class with_ignore_hard_delete_enabled : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithUnsafeIgnoreHardDelete();
+        }
+
+        [Test]
+        public void should_set_ignore_hard_deletes()
+        {
+            Assert.IsTrue(_settings.UnsafeIgnoreHardDeletes);
+        }
+    }
+
+    [TestFixture]
+    public class with_better_ordering_enabled : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithBetterOrdering();
+        }
+
+        [Test]
+        public void should_set_better_ordering()
+        {
+            Assert.IsTrue(_settings.BetterOrdering);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_index_path : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithIndexPath("index");
+        }
+
+        [Test]
+        public void should_set_the_index_path()
+        {
+            Assert.AreEqual("index", _settings.Index);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_prepare_timeout : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithPrepareTimeout(TimeSpan.FromMilliseconds(1234));
+        }
+
+        [Test]
+        public void should_set_the_prepare_timeout()
+        {
+            Assert.AreEqual(1234, _settings.PrepareTimeout.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_commit_timeout : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithCommitTimeout(TimeSpan.FromMilliseconds(1234));
+        }
+
+        [Test]
+        public void should_set_the_commit_timeout()
+        {
+            Assert.AreEqual(1234, _settings.CommitTimeout.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_internal_heartbeat_interval : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithInternalHeartbeatInterval(TimeSpan.FromMilliseconds(1234));
+        }
+
+        [Test]
+        public void should_set_the_internal_heartbeat_interval()
+        {
+            Assert.AreEqual(1234, _settings.IntTcpHeartbeatInterval.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_internal_heartbeat_timeout : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithInternalHeartbeatTimeout(TimeSpan.FromMilliseconds(1234));
+        }
+
+        [Test]
+        public void should_set_the_internal_heartbeat_timeout()
+        {
+            Assert.AreEqual(1234, _settings.IntTcpHeartbeatTimeout.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_external_heartbeat_interval : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithExternalHeartbeatInterval(TimeSpan.FromMilliseconds(1234));
+        }
+
+        [Test]
+        public void should_set_the_external_heartbeat_interval()
+        {
+            Assert.AreEqual(1234, _settings.ExtTcpHeartbeatInterval.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_external_heartbeat_timeout : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithExternalHeartbeatTimeout(TimeSpan.FromMilliseconds(1234));
+        }
+
+        [Test]
+        public void should_set_the_external_heartbeat_timeout()
+        {
+            Assert.AreEqual(1234, _settings.ExtTcpHeartbeatTimeout.TotalMilliseconds);
+        }
+    }
+
+    [TestFixture]
+    public class with_no_admin_on_public_interface : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.NoAdminOnPublicInterface();
+        }
+
+        [Test]
+        public void should_disable_admin_on_public()
+        {
+            Assert.IsFalse(_settings.AdminOnPublic);
+        }
+    }
+
+    [TestFixture]
+    public class with_no_gossip_on_public_interface : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.NoGossipOnPublicInterface();
+        }
+
+        [Test]
+        public void should_disable_gossip_on_public()
+        {
+            Assert.IsFalse(_settings.GossipOnPublic);
+        }
+    }
+
+    [TestFixture]
+    public class with_no_stats_on_public_interface : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.NoStatsOnPublicInterface();
+        }
+
+        [Test]
+        public void should_disable_stats_on_public()
+        {
+            Assert.IsFalse(_settings.StatsOnPublic);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_ip_endpoints : SingleNodeScenario
+    {
+        private IPEndPoint _internalHttp;
+        private IPEndPoint _externalHttp;
+        private IPEndPoint _internalTcp;
+        private IPEndPoint _externalTcp;
+        public override void Given()
+        {
+            var baseIpAddress = IPAddress.Parse("192.168.1.15");
+            _internalHttp = new IPEndPoint(baseIpAddress, 1112);
+            _externalHttp = new IPEndPoint(baseIpAddress, 1113);
+            _internalTcp = new IPEndPoint(baseIpAddress, 1114);
+            _externalTcp = new IPEndPoint(baseIpAddress, 1115);
+            _builder.WithInternalHttpOn(_internalHttp)
+                    .WithExternalHttpOn(_externalHttp)
+                    .WithExternalTcpOn(_externalTcp)
+                    .WithInternalTcpOn(_internalTcp);
+        }
+
+        [Test]
+        public void should_set_internal_http_endpoint()
+        {
+            Assert.AreEqual(_internalHttp, _settings.NodeInfo.InternalHttp);
+        }
+
+        [Test]
+        public void should_set_external_http_endpoint()
+        {
+            Assert.AreEqual(_externalHttp, _settings.NodeInfo.ExternalHttp);
+        }
+
+        [Test]
+        public void should_set_internal_tcp_endpoint()
+        {
+            Assert.AreEqual(_internalTcp, _settings.NodeInfo.InternalTcp);
+        }
+
+        [Test]
+        public void should_set_external_tcp_endpoint()
+        {
+            Assert.AreEqual(_externalTcp, _settings.NodeInfo.ExternalTcp);
+        }
+
+        [Test]
+        public void should_set_internal_http_prefixes()
+        {
+            var internalHttpPrefix = string.Format("http://{0}/", _internalHttp);
+            CollectionAssert.AreEqual(new string[] {internalHttpPrefix}, _settings.IntHttpPrefixes);
+        }
+
+        [Test]
+        public void should_set_external_http_prefixes()
+        {
+            var externalHttpPrefix = string.Format("http://{0}/", _externalHttp);
+            CollectionAssert.AreEqual(new string[] {externalHttpPrefix}, _settings.ExtHttpPrefixes);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_http_prefixes : SingleNodeScenario
+    {
+
+        private string _intPrefix;
+        private string _intLoopbackPrefix;
+        private string _extPrefix;
+        private string _extLoopbackPrefix;
+
+        public override void Given()
+        {
+            var baseIpAddress = IPAddress.Parse("192.168.1.15");
+            int intPort = 1112;
+            int extPort = 1113;
+
+            var internalHttp = new IPEndPoint(baseIpAddress, intPort);
+            var externalHttp = new IPEndPoint(baseIpAddress, extPort);
+
+            _intPrefix = string.Format("http://{0}/", internalHttp);
+            _intLoopbackPrefix = string.Format("http://{0}/", new IPEndPoint(IPAddress.Loopback, intPort));
+            _extPrefix = string.Format("http://{0}/", externalHttp);
+            _extLoopbackPrefix = string.Format("http://{0}/", new IPEndPoint(IPAddress.Loopback, extPort));
+
+            _builder.WithInternalHttpOn(internalHttp)
+                    .WithExternalHttpOn(externalHttp)
+                    .AddInternalHttpPrefix(_intPrefix)
+                    .AddInternalHttpPrefix(_intLoopbackPrefix)
+                    .AddExternalHttpPrefix(_extPrefix)
+                    .AddExternalHttpPrefix(_extLoopbackPrefix);
+        }
+
+        [Test]
+        public void should_set_internal_http_prefixes()
+        {
+            CollectionAssert.AreEqual(new string[] {_intPrefix, _intLoopbackPrefix}, _settings.IntHttpPrefixes);
+        }
+
+        [Test]
+        public void should_set_external_http_prefixes()
+        {
+            CollectionAssert.AreEqual(new string[] {_extPrefix, _extLoopbackPrefix}, _settings.ExtHttpPrefixes);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_index_cache_depth : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithIndexCacheDepth(8);
+        }
+
+        [Test]
+        public void should_set_index_cache_depth()
+        {
+            Assert.AreEqual(8, _settings.IndexCacheDepth);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_authentication_provider_factory : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithAuthenticationProvider(new TestAuthenticationProviderFactory());
+        }
+
+        [Test]
+        public void should_set_authentication_provider_factory()
+        {
+            Assert.IsInstanceOf(typeof(TestAuthenticationProviderFactory), _settings.AuthenticationProviderFactory);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_chunk_size : SingleNodeScenario
+    {
+        private int _chunkSize;
+        public override void Given()
+        {
+            _chunkSize = 268435712;
+            _builder.WithTfChunkSize(_chunkSize);
+        }
+
+        [Test]
+        public void should_set_chunk_size()
+        {
+            Assert.AreEqual(_chunkSize, _dbConfig.ChunkSize);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_chunk_cache_size : SingleNodeScenario
+    {
+        private long _chunkCacheSize;
+        public override void Given()
+        {
+            _chunkCacheSize = 268435712;
+            _builder.WithTfChunksCacheSize(_chunkCacheSize);
+        }
+
+        [Test]
+        public void should_set_max_chunk_cache_size()
+        {
+            Assert.AreEqual(_chunkCacheSize, _dbConfig.MaxChunksCacheSize);
+        }
+    }
+
+    [TestFixture]
+    public class with_custom_number_of_cached_chunks : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithTfCachedChunks(10);
+        }
+
+        [Test]
+        public void should_set_max_chunk_size_to_the_size_of_the_number_of_cached_chunks()
+        {
+            var chunkSizeResult = 10*(long)(TFConsts.ChunkSize + ChunkHeader.Size + ChunkFooter.Size);
+            Assert.AreEqual(chunkSizeResult, _dbConfig.MaxChunksCacheSize);
+        }
+    }
+
+}

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -204,6 +204,12 @@
     <Compile Include="Common\EventStoreOptionsTests\when_parsing\with_arguments.cs" />
     <Compile Include="Common\EventStoreOptionsTests\when_parsing\with_no_arguments.cs" />
     <Compile Include="Common\EventStoreOptionsTests\when_parsing\with_unknown_options.cs" />
+    <Compile Include="Common\VNodeBuilderTests\when_building\with_default_settings.cs" />
+    <Compile Include="Common\VNodeBuilderTests\VNodeBuilderScenarios.cs" />
+    <Compile Include="Common\VNodeBuilderTests\TestVNodeBuilder.cs" />
+    <Compile Include="Common\VNodeBuilderTests\when_building\with_single_node_and_custom_settings.cs" />
+    <Compile Include="Common\VNodeBuilderTests\when_building\with_cluster_node_and_custom_settings.cs" />
+    <Compile Include="Common\VNodeBuilderTests\TestAuthentictaionProviderFactory.cs" />
     <Compile Include="DefaultData.cs" />
     <Compile Include="Fakes\FakeTfReader.cs" />
     <Compile Include="Helpers\CollectionsExtensions.cs" />
@@ -566,6 +572,7 @@
     <Compile Include="TransactionLog\when_writing_prepare_record_to_file.cs" />
     <Compile Include="mono_filestream_bug.cs" />
     <Compile Include="ClientAPI\connecting_with_connection_string.cs" />
+    <Compile Include="Common\VNodeBuilderTests\when_building\with_secure_tcp.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj">

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -417,6 +417,7 @@
     <Compile Include="Util\Opts.cs" />
     <Compile Include="VNodeStatusChangeArgs.cs" />
     <Compile Include="Util\DefaultFiles.cs" />
+    <Compile Include="VNodeBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj">

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -62,7 +62,7 @@ namespace EventStore.Core.Util
         public const int ExtTcpHeartbeatIntervalDefault = 2000;
 
         public const string IntTcpHeartbeatIntervalDescr = "Heartbeat interval for internal TCP sockets";
-        public const int IntTcpHeartbeatInvervalDefault = 700;
+        public const int IntTcpHeartbeatIntervalDefault = 700;
 
 
         public const string StatsPeriodDescr = "The number of seconds between statistics gathers.";

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1,0 +1,1143 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Common.Log;
+using EventStore.Common.Options;
+using EventStore.Common.Utils;
+using EventStore.Core;
+using EventStore.Core.Authentication;
+using EventStore.Core.Cluster.Settings;
+using EventStore.Core.Services.Gossip;
+using EventStore.Core.Services.Monitoring;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Util;
+using EventStore.Core.Services.Transport.Http.Controllers;
+using EventStore.Core.Data;
+using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+
+namespace EventStore.Core
+{
+    /// <summary>
+    /// Allows a client to build a <see cref="ClusterVNode" /> for use with the Embedded client API by specifying
+    /// high level options rather than using the constructor of <see cref="ClusterVNode"/> directly.
+    /// </summary>
+    public abstract class VNodeBuilder
+    {
+        // ReSharper disable FieldCanBeMadeReadOnly.Local - as more options are added
+        protected ILogger _log;
+
+        protected int _chunkSize;
+        protected string _dbPath;
+        protected long _chunksCacheSize;
+        protected int _cachedChunks;
+        protected bool _inMemoryDb;
+        protected bool _startStandardProjections;
+        protected bool _disableHTTPCaching;
+        protected bool _logHttpRequests;
+        protected bool _enableHistograms;
+
+        protected IPEndPoint _internalTcp;
+        protected IPEndPoint _internalSecureTcp;
+        protected IPEndPoint _externalTcp;
+        protected IPEndPoint _externalSecureTcp;
+        protected IPEndPoint _internalHttp;
+        protected IPEndPoint _externalHttp;
+
+        protected List<string> _intHttpPrefixes;
+        protected List<string> _extHttpPrefixes;
+        protected bool _enableTrustedAuth;
+        protected X509Certificate2 _certificate;
+        protected int _workerThreads;
+
+        protected bool _discoverViaDns;
+        protected string _clusterDns;
+        protected List<IPEndPoint> _gossipSeeds;
+
+        protected TimeSpan _minFlushDelay;
+
+        protected int _clusterNodeCount;
+        protected int _prepareAckCount;
+        protected int _commitAckCount;
+        protected TimeSpan _prepareTimeout;
+        protected TimeSpan _commitTimeout;
+
+        protected int _nodePriority;
+
+        protected bool _useSsl;
+        protected string _sslTargetHost;
+        protected bool _sslValidateServer;
+
+        protected TimeSpan _statsPeriod;
+        protected StatsStorage _statsStorage;
+
+        protected IAuthenticationProviderFactory _authenticationProviderFactory;
+        protected bool _disableScavengeMerging;
+        protected int _scavengeHistoryMaxAge;
+        protected bool _adminOnPublic;
+        protected bool _statsOnPublic;
+        protected bool _gossipOnPublic;
+        protected TimeSpan _gossipInterval;
+        protected TimeSpan _gossipAllowedTimeDifference;
+        protected TimeSpan _gossipTimeout;
+
+        protected TimeSpan _intTcpHeartbeatTimeout;
+        protected TimeSpan _intTcpHeartbeatInterval;
+        protected TimeSpan _extTcpHeartbeatTimeout;
+        protected TimeSpan _extTcpHeartbeatInterval;
+
+        protected bool _skipVerifyDbHashes;
+        protected int _maxMemtableSize;
+        protected List<ISubsystem> _subsystems;
+        protected int _clusterGossipPort;
+
+        protected string _index;
+        protected int _indexCacheDepth;
+        protected bool _unsafeIgnoreHardDelete;
+        protected bool _unsafeDisableFlushToDisk;
+        protected bool _betterOrdering;
+        protected ProjectionType _projectionType;
+        protected int _projectionsThreads;
+
+        protected TFChunkDb _db;
+        protected ClusterVNodeSettings _vNodeSettings;
+        protected TFChunkDbConfig _dbConfig;
+        // ReSharper restore FieldCanBeMadeReadOnly.Local
+
+        protected VNodeBuilder()
+        {
+            _log = LogManager.GetLoggerFor<VNodeBuilder>();
+            _statsStorage = StatsStorage.Stream;
+
+            _chunkSize = TFConsts.ChunkSize;
+            _dbPath = Path.Combine(Path.GetTempPath(), "EmbeddedEventStore", string.Format("{0:yyyy-MM-dd_HH.mm.ss.ffffff}-EmbeddedNode", DateTime.UtcNow));
+            _chunksCacheSize = TFConsts.ChunksCacheSize;
+            _cachedChunks = Opts.CachedChunksDefault;
+            _inMemoryDb = true;
+            _projectionType = ProjectionType.None;
+
+            _externalTcp = new IPEndPoint(Opts.ExternalIpDefault, Opts.ExternalTcpPortDefault);
+            _externalSecureTcp = null;
+            _internalTcp = new IPEndPoint(Opts.InternalIpDefault, Opts.InternalTcpPortDefault);
+            _internalSecureTcp = null;
+            _externalHttp = new IPEndPoint(Opts.ExternalIpDefault, Opts.ExternalHttpPortDefault);
+            _internalHttp = new IPEndPoint(Opts.InternalIpDefault, Opts.InternalHttpPortDefault);
+
+            _intHttpPrefixes = new List<string>();
+            _extHttpPrefixes = new List<string>();
+            _enableTrustedAuth = Opts.EnableTrustedAuthDefault;
+            _certificate = null;
+            _workerThreads = Opts.WorkerThreadsDefault;
+
+            _discoverViaDns = Opts.DiscoverViaDnsDefault;
+            _clusterDns = Opts.ClusterDnsDefault;
+            _gossipSeeds = new List<IPEndPoint>();
+
+            _minFlushDelay = TimeSpan.FromMilliseconds(Opts.MinFlushDelayMsDefault);
+
+            _clusterNodeCount = 1;
+            _prepareAckCount = 1;
+            _commitAckCount = 1;
+            _prepareTimeout = TimeSpan.FromMilliseconds(Opts.PrepareTimeoutMsDefault);
+            _commitTimeout = TimeSpan.FromMilliseconds(Opts.CommitTimeoutMsDefault);
+
+            _nodePriority = Opts.NodePriorityDefault;
+
+            _useSsl = Opts.UseInternalSslDefault;
+            _sslTargetHost = Opts.SslTargetHostDefault;
+            _sslValidateServer = Opts.SslValidateServerDefault;
+
+            _statsPeriod = TimeSpan.FromSeconds(Opts.StatsPeriodDefault);
+
+            _authenticationProviderFactory = new InternalAuthenticationProviderFactory();
+            _disableScavengeMerging = Opts.DisableScavengeMergeDefault;
+            _scavengeHistoryMaxAge = Opts.ScavengeHistoryMaxAgeDefault;
+            _adminOnPublic = Opts.AdminOnExtDefault;
+            _statsOnPublic = Opts.StatsOnExtDefault;
+            _gossipOnPublic = Opts.GossipOnExtDefault;
+            _gossipInterval = TimeSpan.FromMilliseconds(Opts.GossipIntervalMsDefault);
+            _gossipAllowedTimeDifference = TimeSpan.FromMilliseconds(Opts.GossipAllowedDifferenceMsDefault);
+            _gossipTimeout = TimeSpan.FromMilliseconds(Opts.GossipTimeoutMsDefault);
+
+            _intTcpHeartbeatInterval = TimeSpan.FromMilliseconds(Opts.IntTcpHeartbeatIntervalDefault);
+            _intTcpHeartbeatTimeout = TimeSpan.FromMilliseconds(Opts.IntTcpHeartbeatTimeoutDefault);
+            _extTcpHeartbeatInterval = TimeSpan.FromMilliseconds(Opts.ExtTcpHeartbeatIntervalDefault);
+            _extTcpHeartbeatTimeout = TimeSpan.FromMilliseconds(Opts.ExtTcpHeartbeatTimeoutDefault);
+
+            _skipVerifyDbHashes = Opts.SkipDbVerifyDefault;
+            _maxMemtableSize = Opts.MaxMemtableSizeDefault;
+            _subsystems = new List<ISubsystem>();
+            _clusterGossipPort = Opts.ClusterGossipPortDefault;
+
+            _startStandardProjections = Opts.StartStandardProjectionsDefault;
+            _disableHTTPCaching = Opts.DisableHttpCachingDefault;
+            _logHttpRequests = Opts.LogHttpRequestsDefault;
+            _enableHistograms = Opts.LogHttpRequestsDefault;
+            _index = null;
+            _indexCacheDepth = Opts.IndexCacheDepthDefault;
+            _unsafeIgnoreHardDelete = Opts.UnsafeIgnoreHardDeleteDefault;
+            _betterOrdering = Opts.BetterOrderingDefault;
+            _unsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
+        }
+
+        protected VNodeBuilder WithSingleNodeSettings()
+        {
+            _clusterNodeCount = 1;
+            _prepareAckCount = 1;
+            _commitAckCount = 1;
+            return this;
+        }
+
+        protected VNodeBuilder WithClusterNodeSettings(int clusterNodeCount)
+        {
+            int quorumSize = clusterNodeCount / 2 + 1;
+            _clusterNodeCount = clusterNodeCount;
+            _prepareAckCount = quorumSize;
+            _commitAckCount = quorumSize;
+            return this;
+        }
+
+        /// <summary>
+        /// Start standard projections.
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder StartStandardProjections()
+        {
+            _startStandardProjections = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Disable HTTP Caching.
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder DisableHTTPCaching()
+        {
+            _disableHTTPCaching = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the mode and the number of threads on which to run projections.
+        /// </summary>
+        /// <param name="projectionType">The mode in which to run the projections system</param>
+        /// <param name="numberOfThreads">The number of threads to use for projections. Defaults to 3.</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder RunProjections(ProjectionType projectionType, int numberOfThreads = Opts.ProjectionThreadsDefault)
+        {
+            _projectionType = projectionType;
+            _projectionsThreads = numberOfThreads;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a custom subsystem to the builder. NOTE: This is an advanced use case that most people will never need!
+        /// </summary>
+        /// <param name="subsystem">The subsystem to add</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder AddCustomSubsystem(ISubsystem subsystem)
+        {
+            _subsystems.Add(subsystem);
+            return this;
+        }
+
+        /// <summary>
+        /// Returns a builder set to run in memory only
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder RunInMemory()
+        {
+            _inMemoryDb = true;
+            _dbPath = Path.Combine(Path.GetTempPath(), "EmbeddedEventStore", string.Format("{0:yyyy-MM-dd_HH.mm.ss.ffffff}-EmbeddedNode", DateTime.UtcNow));
+            return this;
+        }
+
+        /// <summary>
+        /// Returns a builder set to write database files to the specified path
+        /// </summary>
+        /// <param name="path">The path on disk in which to write the database files</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder RunOnDisk(string path)
+        {
+            _inMemoryDb = false;
+            _dbPath = path;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the default endpoints on localhost (1113 tcp, 2113 http)
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder OnDefaultEndpoints()
+        {
+            _internalHttp = new IPEndPoint(Opts.InternalIpDefault, 2112);
+            _internalTcp = new IPEndPoint(Opts.InternalIpDefault, 1112);
+            _externalHttp = new IPEndPoint(Opts.ExternalIpDefault, 2113);
+            _externalTcp = new IPEndPoint(Opts.InternalIpDefault, 1113);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the internal gossip port (used when using cluster dns, this should point to a known port gossip will be running on)
+        /// </summary>
+        /// <param name="port">The cluster gossip to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithClusterGossipPort(int port)
+        {
+            _clusterGossipPort = port;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the internal http endpoint to the specified value
+        /// </summary>
+        /// <param name="endpoint">The internal endpoint to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithInternalHttpOn(IPEndPoint endpoint)
+        {
+            _internalHttp = endpoint;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the external http endpoint to the specified value
+        /// </summary>
+        /// <param name="endpoint">The external endpoint to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithExternalHttpOn(IPEndPoint endpoint)
+        {
+            _externalHttp = endpoint;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the internal tcp endpoint to the specified value
+        /// </summary>
+        /// <param name="endpoint">The internal endpoint to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithInternalTcpOn(IPEndPoint endpoint)
+        {
+            _internalTcp = endpoint;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the internal secure tcp endpoint to the specified value
+        /// </summary>
+        /// <param name="endpoint">The internal secure endpoint to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithInternalSecureTcpOn(IPEndPoint endpoint)
+        {
+            _internalSecureTcp = endpoint;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the external tcp endpoint to the specified value
+        /// </summary>
+        /// <param name="endpoint">The external endpoint to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithExternalTcpOn(IPEndPoint endpoint)
+        {
+            _externalTcp = endpoint;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the external secure tcp endpoint to the specified value
+        /// </summary>
+        /// <param name="endpoint">The external secure endpoint to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithExternalSecureTcpOn(IPEndPoint endpoint)
+        {
+            _externalSecureTcp = endpoint;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets that SSL should be used on connections
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder EnableSsl()
+        {
+            _useSsl = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the target host of the server's SSL certificate. 
+        /// </summary>
+        /// <param name="targetHost">The target host of the server's SSL certificate</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithSslTargetHost(string targetHost)
+        {
+            _sslTargetHost = targetHost;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets whether to validate that the server's certificate is trusted.  
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder ValidateSslServer()
+        {
+            _sslValidateServer = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the gossip seeds this node should talk to
+        /// </summary>
+        /// <param name="endpoints">The gossip seeds this node should try to talk to</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithGossipSeeds(params IPEndPoint[] endpoints)
+        {
+            _gossipSeeds.Clear();
+            _gossipSeeds.AddRange(endpoints);
+            _discoverViaDns = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum size a memtable is allowed to reach (in count) before being moved to be a ptable
+        /// </summary>
+        /// <param name="size">The maximum count</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder MaximumMemoryTableSizeOf(int size)
+        {
+            _maxMemtableSize = size;
+            return this;
+        }
+
+        /// <summary>
+        /// Marks that the existing database files should not be checked for checksums on startup.
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder DoNotVerifyDbHashes()
+        {
+            _skipVerifyDbHashes = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables gossip on the public (client) interface
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder NoGossipOnPublicInterface()
+        {
+            _gossipOnPublic = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables the admin interface on the public (client) interface
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder NoAdminOnPublicInterface()
+        {
+            _adminOnPublic = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables statistics screens on the public (client) interface
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder NoStatsOnPublicInterface()
+        {
+            _statsOnPublic = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Marks that the existing database files should be checked for checksums on startup.
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder VerifyDbHashes()
+        {
+            _skipVerifyDbHashes = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the dns name used for the discovery of other cluster nodes
+        /// </summary>
+        /// <param name="name">The dns name the node should use to discover gossip partners</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithClusterDnsName(string name)
+        {
+            _clusterDns = name;
+            _discoverViaDns = true;
+            return this;
+        }
+
+
+        /// <summary>
+        /// Disable dns discovery for the cluster
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder DisableDnsDiscovery()
+        {
+            _discoverViaDns = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the number of worker threads to use in shared threadpool
+        /// </summary>
+        /// <param name="count">The number of worker threads</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithWorkerThreads(int count)
+        {
+            _workerThreads = count;
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a http prefix for the internal http endpoint
+        /// </summary>
+        /// <param name="prefix">The prefix to add</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder AddInternalHttpPrefix(string prefix)
+        {
+            _intHttpPrefixes.Add(prefix);
+            return this;
+        }
+
+        /// <summary>
+        /// Adds a http prefix for the external http endpoint
+        /// </summary>
+        /// <param name="prefix">The prefix to add</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder AddExternalHttpPrefix(string prefix)
+        {
+            _extHttpPrefixes.Add(prefix);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the Server SSL Certificate to be loaded from a file
+        /// </summary>
+        /// <param name="path">The path to the certificate file</param>
+        /// <param name="password">The password for the certificate</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithServerCertificateFromFile(string path, string password)
+        {
+            var cert = new X509Certificate2(path, password);
+
+            _certificate = cert;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the heartbeat interval for the internal network interface.
+        /// </summary>
+        /// <param name="heartbeatInterval">The heartbeat interval</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithInternalHeartbeatInterval(TimeSpan heartbeatInterval)
+        {
+            _intTcpHeartbeatInterval = heartbeatInterval;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the heartbeat interval for the external network interface.
+        /// </summary>
+        /// <param name="heartbeatInterval">The heartbeat interval</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithExternalHeartbeatInterval(TimeSpan heartbeatInterval)
+        {
+            _extTcpHeartbeatInterval = heartbeatInterval;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the heartbeat timeout for the internal network interface.
+        /// </summary>
+        /// <param name="heartbeatTimeout">The heartbeat timeout</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithInternalHeartbeatTimeout(TimeSpan heartbeatTimeout)
+        {
+            _intTcpHeartbeatTimeout = heartbeatTimeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the heartbeat timeout for the external network interface.
+        /// </summary>
+        /// <param name="heartbeatTimeout">The heartbeat timeout</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithExternalHeartbeatTimeout(TimeSpan heartbeatTimeout)
+        {
+            _extTcpHeartbeatTimeout = heartbeatTimeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the gossip interval
+        /// </summary>
+        /// <param name="gossipInterval">The gossip interval</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithGossipInterval(TimeSpan gossipInterval)
+        {
+            _gossipInterval = gossipInterval;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the allowed gossip time difference
+        /// </summary>
+        /// <param name="gossipAllowedDifference">The allowed gossip time difference</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithGossipAllowedTimeDifference(TimeSpan gossipAllowedDifference)
+        {
+            _gossipAllowedTimeDifference = gossipAllowedDifference;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the gossip timeout
+        /// </summary>
+        /// <param name="gossipTimeout">The gossip timeout</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithGossipTimeout(TimeSpan gossipTimeout)
+        {
+            _gossipTimeout = gossipTimeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the minimum flush delay 
+        /// </summary>
+        /// <param name="minFlushDelay">The minimum flush delay</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithMinFlushDelay(TimeSpan minFlushDelay)
+        {
+            _minFlushDelay = minFlushDelay;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the prepare timeout 
+        /// </summary>
+        /// <param name="prepareTimeout">The prepare timeout</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithPrepareTimeout(TimeSpan prepareTimeout)
+        {
+            _prepareTimeout = prepareTimeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the commit timeout 
+        /// </summary>
+        /// <param name="commitTimeout">The commit timeout</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithCommitTimeout(TimeSpan commitTimeout)
+        {
+            _commitTimeout = commitTimeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the period between statistics gathers
+        /// </summary>
+        /// <param name="statsPeriod">The period between statistics gathers</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithStatsPeriod(TimeSpan statsPeriod)
+        {
+            _statsPeriod = statsPeriod;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets how stats are stored. Default is Stream
+        /// </summary>
+        /// <param name="statsStorage">The storage method to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithStatsStorage(StatsStorage statsStorage)
+        {
+            _statsStorage = statsStorage;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the number of nodes which must acknowledge prepares. 
+        /// The minimum allowed value is one greater than half the cluster size.
+        /// </summary>
+        /// <param name="prepareCount">The number of nodes which must acknowledge prepares</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithPrepareCount(int prepareCount)
+        {
+            _prepareAckCount = prepareCount > _prepareAckCount ? prepareCount : _prepareAckCount;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the number of nodes which must acknowledge commits before acknowledging to a client.  
+        /// The minimum allowed value is one greater than half the cluster size.
+        /// </summary>
+        /// <param name="commitCount">The number of nodes which must acknowledge commits</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithCommitCount(int commitCount)
+        {
+            _commitAckCount = commitCount > _commitAckCount ? commitCount : _commitAckCount;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the node priority used during master election
+        /// </summary>
+        /// <param name="nodePriority">The node priority used during master election</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithNodePriority(int nodePriority)
+        {
+            _nodePriority = nodePriority;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables the merging of chunks when scavenge is running 
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder DisableScavengeMerging()
+        {
+            _disableScavengeMerging = true;
+            return this;
+        }
+
+        /// <summary>
+        /// The number of days to keep scavenge history (Default: 30)
+        /// </summary>
+        /// <param name="scavengeHistoryMaxAge">The number of days to keep scavenge history</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithScavengeHistoryMaxAge(int scavengeHistoryMaxAge)
+        {
+            _scavengeHistoryMaxAge = scavengeHistoryMaxAge;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the path the index should be loaded/saved to
+        /// </summary>
+        /// <param name="indexPath">The index path</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithIndexPath(string indexPath)
+        {
+            _index = indexPath;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable logging of Http Requests and Responses before they are processed
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder EnableLoggingOfHttpRequests()
+        {
+            _logHttpRequests = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable the tracking of various histograms in the backend, typically only used for debugging
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder EnableHistograms()
+        {
+            _enableHistograms = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the depth to cache for the mid point cache in index
+        /// </summary>
+        /// <param name="indexCacheDepth">The index cache depth</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithIndexCacheDepth(int indexCacheDepth)
+        {
+            _indexCacheDepth = indexCacheDepth;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables Hard Deletes (UNSAFE: use to remove hard deletes)
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithUnsafeIgnoreHardDelete()
+        {
+            _unsafeIgnoreHardDelete = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Disables Hard Deletes (UNSAFE: use to remove hard deletes)
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithUnsafeDisableFlushToDisk()
+        {
+            _unsafeDisableFlushToDisk = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable Queue affinity on reads during write process to try to get better ordering.
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithBetterOrdering()
+        {
+            _betterOrdering = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Enable trusted authentication by an intermediary in the HTTP
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder EnableTrustedAuth()
+        {
+            _enableTrustedAuth = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the authentication provider factory to use
+        /// </summary>
+        /// <param name="authenticationProviderFactory">The authentication provider factory to use </param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithAuthenticationProvider(IAuthenticationProviderFactory authenticationProviderFactory)
+        {
+            _authenticationProviderFactory = authenticationProviderFactory;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the Server SSL Certificate
+        /// </summary>
+        /// <param name="sslCertificate">The server SSL certificate to use</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithServerCertificate(X509Certificate2 sslCertificate)
+        {
+            _certificate = sslCertificate;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the Server SSL Certificate to be loaded from a certificate store
+        /// </summary>
+        /// <param name="storeLocation">The location of the certificate store</param>
+        /// <param name="storeName">The name of the certificate store</param>
+        /// <param name="certificateSubjectName">The subject name of the certificate</param>
+        /// <param name="certificateThumbprint">The thumbpreint of the certificate</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithServerCertificateFromStore(StoreLocation storeLocation, StoreName storeName, string certificateSubjectName, string certificateThumbprint)
+        {
+            var store = new X509Store(storeName, storeLocation);
+            _certificate = GetCertificateFromStore(store, certificateSubjectName, certificateThumbprint);
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the Server SSL Certificate to be loaded from a certificate store
+        /// </summary>
+        /// <param name="storeName">The name of the certificate store</param>
+        /// <param name="certificateSubjectName">The subject name of the certificate</param>
+        /// <param name="certificateThumbprint">The thumbpreint of the certificate</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithServerCertificateFromStore(StoreName storeName, string certificateSubjectName, string certificateThumbprint)
+        {
+            var store = new X509Store(storeName);
+            _certificate = GetCertificateFromStore(store, certificateSubjectName, certificateThumbprint);
+            return this;
+        }
+
+        private X509Certificate2 GetCertificateFromStore(X509Store store, string certificateSubjectName, string certificateThumbprint)
+        {
+            try
+            {
+                store.Open(OpenFlags.OpenExistingOnly);
+            }
+            catch (Exception exc)
+            {
+                throw new Exception(string.Format("Could not open certificate store '{0}' in location {1}'.", store.Name, store.Location), exc);
+            }
+
+            if (!string.IsNullOrWhiteSpace(certificateThumbprint))
+            {
+                var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, true);
+                if (certificates.Count == 0)
+                    throw new Exception(string.Format("Could not find valid certificate with thumbprint '{0}'.", certificateThumbprint));
+
+                //Can this even happen?
+                if (certificates.Count > 1)
+                    throw new Exception(string.Format("Could not determine a unique certificate from thumbprint '{0}'.", certificateThumbprint));
+
+                return certificates[0];
+            }
+
+            if (!string.IsNullOrWhiteSpace(certificateSubjectName))
+            {
+                var certificates = store.Certificates.Find(X509FindType.FindBySubjectName, certificateSubjectName, true);
+                if (certificates.Count == 0)
+                    throw new Exception(string.Format("Could not find valid certificate with subject name '{0}'.", certificateSubjectName));
+
+                //Can this even happen?
+                if (certificates.Count > 1)
+                    throw new Exception(string.Format("Could not determine a unique certificate from subject name '{0}'.", certificateSubjectName));
+
+                return certificates[0];
+            }
+
+            throw new ArgumentException("No thumbprint or subject name was specified for a certificate, but a certificate store was specified.");
+        }
+
+
+        /// <summary>
+        /// Sets the transaction file chunk size. Default is <see cref="TFConsts.ChunkSize"/>
+        /// </summary>
+        /// <param name="chunkSize">The size of the chunk, in bytes</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithTfChunkSize(int chunkSize)
+        {
+            _chunkSize = chunkSize;
+
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the transaction file chunk cache size. Default is <see cref="TFConsts.ChunksCacheSize"/>
+        /// </summary>
+        /// <param name="chunksCacheSize">The size of the cache</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithTfChunksCacheSize(long chunksCacheSize)
+        {
+            _chunksCacheSize = chunksCacheSize;
+            _cachedChunks = -1;
+
+            return this;
+        }
+
+        /// <summary>
+        /// The number of chunks to cache in unmanaged memory.        
+        /// </summary>
+        /// <param name="cachedChunks">The number of chunks to cache</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithTfCachedChunks(int cachedChunks)
+        {
+            _cachedChunks = cachedChunks;
+
+            return this;
+        }
+
+        private void EnsureHttpPrefixes()
+        {
+            if (_intHttpPrefixes == null || _intHttpPrefixes.IsEmpty())
+                _intHttpPrefixes = new List<string>(new[] { _internalHttp.ToHttpUrl() });
+            if (_extHttpPrefixes == null || _extHttpPrefixes.IsEmpty())
+                _extHttpPrefixes = new List<string>(new[] { _externalHttp.ToHttpUrl() });
+
+            if (!Runtime.IsMono)
+                return;
+
+            if (!_intHttpPrefixes.Contains(x => x.Contains("localhost")) && Equals(_internalHttp.Address, IPAddress.Loopback))
+            {
+                _intHttpPrefixes.Add(string.Format("http://localhost:{0}/", _internalHttp.Port));
+            }
+            if (!_extHttpPrefixes.Contains(x => x.Contains("localhost")) && Equals(_externalHttp.Address, IPAddress.Loopback))
+            {
+                _extHttpPrefixes.Add(string.Format("http://localhost:{0}/", _externalHttp.Port));
+            }
+        }
+
+        protected abstract void SetUpProjectionsIfNeeded();
+
+        /// <summary>
+        /// Converts an <see cref="VNodeBuilder"/> to a <see cref="ClusterVNode"/>.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <returns>A <see cref="ClusterVNode"/> built with the options that were set on the <see cref="VNodeBuilder"/></returns>
+        public static implicit operator ClusterVNode(VNodeBuilder builder)
+        {
+            return builder.Build();
+        }
+
+        /// <summary>
+        /// Converts an <see cref="VNodeBuilder"/> to a <see cref="ClusterVNode"/>.
+        /// </summary>
+        /// <param name="options">The options with which to build the infoController</param>
+        /// <param name="consumerStrategies">The consumer strategies with which to build the node</param>
+        /// <returns>A <see cref="ClusterVNode"/> built with the options that were set on the <see cref="VNodeBuilder"/></returns>
+        public ClusterVNode Build(IOptions options = null, IPersistentSubscriptionConsumerStrategyFactory[] consumerStrategies = null)
+        {
+            EnsureHttpPrefixes();
+            SetUpProjectionsIfNeeded();
+
+            _dbConfig = CreateDbConfig(_chunkSize, _cachedChunks, _dbPath, _chunksCacheSize,
+                    _inMemoryDb, _log);
+            FileStreamExtensions.ConfigureFlush(disableFlushToDisk: _unsafeDisableFlushToDisk);
+
+            _db = new TFChunkDb(_dbConfig);
+
+            _vNodeSettings = new ClusterVNodeSettings(Guid.NewGuid(),
+                    0,
+                    _internalTcp,
+                    _internalSecureTcp,
+                    _externalTcp,
+                    _externalSecureTcp,
+                    _internalHttp,
+                    _externalHttp,
+                    new GossipAdvertiseInfo(_internalTcp, _internalSecureTcp, _externalTcp, _externalSecureTcp, _internalHttp, _externalHttp),
+                    _intHttpPrefixes.ToArray(),
+                    _extHttpPrefixes.ToArray(),
+                    _enableTrustedAuth,
+                    _certificate,
+                    _workerThreads,
+                    _discoverViaDns,
+                    _clusterDns,
+                    _gossipSeeds.ToArray(),
+                    _minFlushDelay,
+                    _clusterNodeCount,
+                    _prepareAckCount,
+                    _commitAckCount,
+                    _prepareTimeout,
+                    _commitTimeout,
+                    _useSsl,
+                    _sslTargetHost,
+                    _sslValidateServer,
+                    _statsPeriod,
+                    _statsStorage,
+                    _nodePriority,
+                    _authenticationProviderFactory,
+                    _disableScavengeMerging,
+                    _scavengeHistoryMaxAge,
+                    _adminOnPublic,
+                    _statsOnPublic,
+                    _gossipOnPublic,
+                    _gossipInterval,
+                    _gossipAllowedTimeDifference,
+                    _gossipTimeout,
+                    _intTcpHeartbeatTimeout,
+                    _intTcpHeartbeatInterval,
+                    _extTcpHeartbeatTimeout,
+                    _extTcpHeartbeatInterval,
+                    !_skipVerifyDbHashes,
+                    _maxMemtableSize,
+                    _startStandardProjections,
+                    _disableHTTPCaching,
+                    _logHttpRequests,
+                    _index,
+                    _enableHistograms,
+                    _indexCacheDepth,
+                    consumerStrategies,
+                    _unsafeIgnoreHardDelete,
+                    _betterOrdering);
+            var infoController = new InfoController(options, _projectionType);
+
+            _log.Info("{0,-25} {1}", "INSTANCE ID:", _vNodeSettings.NodeInfo.InstanceId);
+            _log.Info("{0,-25} {1}", "DATABASE:", _db.Config.Path);
+            _log.Info("{0,-25} {1} (0x{1:X})", "WRITER CHECKPOINT:", _db.Config.WriterCheckpoint.Read());
+            _log.Info("{0,-25} {1} (0x{1:X})", "CHASER CHECKPOINT:", _db.Config.ChaserCheckpoint.Read());
+            _log.Info("{0,-25} {1} (0x{1:X})", "EPOCH CHECKPOINT:", _db.Config.EpochCheckpoint.Read());
+            _log.Info("{0,-25} {1} (0x{1:X})", "TRUNCATE CHECKPOINT:", _db.Config.TruncateCheckpoint.Read());
+
+            return new ClusterVNode(_db, _vNodeSettings, GetGossipSource(), infoController, _subsystems.ToArray());
+        }
+
+
+        private IGossipSeedSource GetGossipSource()
+        {
+            IGossipSeedSource gossipSeedSource;
+            if (_discoverViaDns)
+            {
+                gossipSeedSource = new DnsGossipSeedSource(_clusterDns, _clusterGossipPort);
+            }
+            else
+            {
+                if ((_gossipSeeds == null || _gossipSeeds.Count == 0) && _clusterNodeCount > 1)
+                {
+                    throw new Exception("DNS discovery is disabled, but no gossip seed endpoints have been specified. "
+                            + "Specify gossip seeds");
+                }
+
+                if (_gossipSeeds == null)
+                    throw new ApplicationException("Gossip seeds cannot be null");
+                gossipSeedSource = new KnownEndpointGossipSeedSource(_gossipSeeds.ToArray());
+            }
+            return gossipSeedSource;
+        }
+
+        private static TFChunkDbConfig CreateDbConfig(int chunkSize, int cachedChunks, string dbPath, long chunksCacheSize, bool inMemDb, ILogger log)
+        {
+            ICheckpoint writerChk;
+            ICheckpoint chaserChk;
+            ICheckpoint epochChk;
+            ICheckpoint truncateChk;
+            if (inMemDb)
+            {
+                writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
+                chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
+                epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
+                truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
+            }
+            else
+            {
+                try
+                {
+                    if (!Directory.Exists(dbPath)) // mono crashes without this check
+                        Directory.CreateDirectory(dbPath);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    if (dbPath == Locations.DefaultDataDirectory)
+                    {
+                        log.Info("Access to path {0} denied. The Event Store database will be created in {1}", dbPath, Locations.FallbackDefaultDataDirectory);
+                        dbPath = Locations.FallbackDefaultDataDirectory;
+                        log.Info("Defaulting DB Path to {0}", dbPath);
+
+                        if (!Directory.Exists(dbPath)) // mono crashes without this check
+                            Directory.CreateDirectory(dbPath);
+                    }
+                    else {
+                        throw;
+                    }
+                }
+                var writerCheckFilename = Path.Combine(dbPath, Checkpoint.Writer + ".chk");
+                var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
+                var epochCheckFilename = Path.Combine(dbPath, Checkpoint.Epoch + ".chk");
+                var truncateCheckFilename = Path.Combine(dbPath, Checkpoint.Truncate + ".chk");
+                if (Runtime.IsMono)
+                {
+                    writerChk = new FileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
+                    chaserChk = new FileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
+                    epochChk = new FileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true, initValue: -1);
+                    truncateChk = new FileCheckpoint(truncateCheckFilename, Checkpoint.Truncate, cached: true, initValue: -1);
+                }
+                else
+                {
+                    writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
+                    chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
+                    epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true, initValue: -1);
+                    truncateChk = new MemoryMappedFileCheckpoint(truncateCheckFilename, Checkpoint.Truncate, cached: true, initValue: -1);
+                }
+            }
+
+            var cache = cachedChunks >= 0
+                                ? cachedChunks*(long)(TFConsts.ChunkSize + ChunkHeader.Size + ChunkFooter.Size)
+                                : chunksCacheSize;
+
+            var nodeConfig = new TFChunkDbConfig(dbPath,
+                    new VersionedPatternFileNamingStrategy(dbPath, "chunk-"),
+                    chunkSize,
+                    cache,
+                    writerChk,
+                    chaserChk,
+                    epochChk,
+                    truncateChk,
+                    inMemDb);
+
+            return nodeConfig;
+        }
+    }
+}


### PR DESCRIPTION
Add VNodeBuilder, which can be used to create a ClusterVNode using methods instead of the ClusterVNode constructor. It contains the same logic as was in EmbeddedVNodeBuilder, but updated to cater for any command line arguments that weren't available in the EmbeddedVNode, and with additional checks and options from ClusterNode.Program.cs.

ClusterNode, EmbeddedVNode and MiniNode now make use of the VNodeBuilder, instead of building their own nodes separately.