### PR TITLE
Allow using a connection string with only gossipSeeds

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -68,7 +68,7 @@ namespace EventStore.ClientAPI
         /// <returns>a <see cref="ConnectionSettings"/> from the connection string</returns>
         public static ConnectionSettings GetConnectionSettings(string connectionString)
         {
-            var settings = ConnectionSettings.Default;
+            var settings = ConnectionSettings.Create().Build();
             var items = GetConnectionStringInfo(connectionString).ToArray();
             return Apply(items, settings);
         }

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_with_connection_string.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_with_connection_string.cs
@@ -1,0 +1,66 @@
+using EventStore.ClientAPI;
+using NUnit.Framework;
+using EventStore.Core.Tests.Helpers;
+using System;
+using System.Linq;
+
+namespace EventStore.Core.Tests.ClientAPI
+{
+    public class when_connecting_with_connection_string: SpecificationWithDirectoryPerTestFixture
+    {
+        private MiniNode _node;
+
+        [TestFixtureSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            _node = new MiniNode(PathName);
+            _node.Start();
+        }
+
+        [TestFixtureTearDown]
+        public override void TestFixtureTearDown()
+        {
+            _node.Shutdown();
+            base.TestFixtureTearDown();
+        }
+
+        [Test]
+        [Category("Network")]
+        public void should_not_throw_when_connect_to_is_set()
+        {
+            string connectionString = string.Format("ConnectTo=tcp://{0};", _node.TcpEndPoint);
+            using(var connection = EventStoreConnection.Create(connectionString))
+            {
+                Assert.DoesNotThrow(connection.ConnectAsync().Wait);
+                connection.Close();
+            }
+        }
+
+        [Test]
+        public void should_not_throw_when_only_gossip_seeds_is_set()
+        {
+            string connectionString = string.Format("GossipSeeds={0};", _node.IntHttpEndPoint);
+            IEventStoreConnection connection = null;
+
+            Assert.DoesNotThrow(() => connection = EventStoreConnection.Create(connectionString));
+            Assert.AreEqual(_node.IntHttpEndPoint, connection.Settings.GossipSeeds.First().EndPoint);
+
+            connection.Dispose();
+        }
+
+        [Test]
+        public void should_throw_when_gossip_seeds_and_connect_to_is_set()
+        {
+            string connectionString = string.Format("ConnectTo=tcp://{0};GossipSeeds={1}", _node.TcpEndPoint, _node.IntHttpEndPoint);
+            Assert.Throws<NotSupportedException>(() => EventStoreConnection.Create(connectionString));
+        }
+
+        [Test]
+        public void should_throw_when_neither_gossip_seeds_nor_connect_to_is_set()
+        {
+            string connectionString = string.Format("HeartBeatTimeout=2000");
+            Assert.Throws<Exception>(() => EventStoreConnection.Create(connectionString));
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -564,6 +564,7 @@
     <Compile Include="TransactionLog\when_writing_commit_record_to_file.cs" />
     <Compile Include="TransactionLog\when_writing_prepare_record_to_file.cs" />
     <Compile Include="mono_filestream_bug.cs" />
+    <Compile Include="ClientAPI\connecting_with_connection_string.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj">


### PR DESCRIPTION
Fixes #917 

Allow creating an connection with a connection string if gossipSeeds is set, but connectTo is not.
If neither connectTo nor gossipSeeds is set, an exception is thrown.
If both connectTo and gossipSeeds are set, a NotSupportedException is thrown.