### PR TITLE
Wait for subsystems to initialise before sending system ready

### DIFF
--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -21,6 +21,12 @@ namespace EventStore.Core.Messages
             public override int MsgTypeId { get { return TypeId; } }
         }
 
+        public class SystemCoreReady : Message
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+        }
+
         public class SystemReady : Message
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
@@ -38,6 +44,20 @@ namespace EventStore.Core.Messages
             {
                 Ensure.NotNullOrEmpty(serviceName, "serviceName");
                 ServiceName = serviceName;
+            }
+        }
+
+        public class SubSystemInitialized: Message
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly string SubSystemName;
+
+            public SubSystemInitialized(string subSystemName)
+            {
+                Ensure.NotNullOrEmpty(subSystemName, "subSystemName");
+                SubSystemName = subSystemName;
             }
         }
 

--- a/src/EventStore.Projections.Core.Tests/Integration/parallel_query/when_running_from_catalog_stream_query_twice.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/parallel_query/when_running_from_catalog_stream_query_twice.cs
@@ -39,7 +39,7 @@ fromStreamCatalog('catalog').foreachStream().when({
         protected override IEnumerable<WhenStep> When()
         {
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), _projectionMode, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
@@ -86,7 +86,7 @@ namespace EventStore.Projections.Core.Tests.Integration
         protected override IEnumerable<WhenStep> When()
         {
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             if (_startSystemProjections)
             {
                 yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -100,14 +100,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<SystemMessage.StateChangeMessage>(_manager);
-            _bus.Subscribe<SystemMessage.SystemReady>(_manager);
+            _bus.Subscribe<SystemMessage.SystemCoreReady>(_manager);
             _bus.Subscribe<ProjectionManagementMessage.ReaderReady>(_manager);
             _bus.Subscribe(
                 CallbackSubscriber.Create<ProjectionManagementMessage.Starting>(
                     starting => _queue.Publish(new ProjectionManagementMessage.ReaderReady())));
 
             _bus.Subscribe<SystemMessage.StateChangeMessage>(_coordinator);
-            _bus.Subscribe<SystemMessage.SystemReady>(_coordinator);
+            _bus.Subscribe<SystemMessage.SystemCoreReady>(_coordinator);
 
             if (GetInputQueue() != _processingQueues.First().Item2)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
             protected override IEnumerable<WhenStep> When()
             {
                 yield return(new SystemMessage.BecomeMaster(Guid.NewGuid()));
-                yield return(new SystemMessage.SystemReady());
+                yield return(new SystemMessage.SystemCoreReady());
                 yield return
                     (new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
@@ -45,7 +45,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
             protected override IEnumerable<WhenStep> When()
             {
                 yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-                yield return (new SystemMessage.SystemReady());
+                yield return (new SystemMessage.SystemCoreReady());
                 yield return (
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName, ProjectionManagementMessage.RunAs.System,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
@@ -38,7 +38,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
             protected override IEnumerable<WhenStep> When()
             {
                 yield return(new SystemMessage.BecomeMaster(Guid.NewGuid()));
-                yield return(new SystemMessage.SystemReady());
+                yield return(new SystemMessage.SystemCoreReady());
                 yield return
                     (new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
@@ -35,7 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> When()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new SystemMessage.SystemReady();
+                yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
@@ -90,7 +90,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> When()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new SystemMessage.SystemReady();
+                yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
@@ -133,7 +133,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> PreWhen()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new SystemMessage.SystemReady();
+                yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -36,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> When()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new SystemMessage.SystemReady();
+                yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Transient, _projectionName,
@@ -91,7 +91,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
             protected override IEnumerable<WhenStep> When()
             {
                 yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-                yield return new SystemMessage.SystemReady();
+                yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.slave_p
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
             yield return
                 new CoreProjectionManagementMessage.CreateAndPrepareSlave(
                     _coreProjectionCorrelationId,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_a_dsiabled_projection_has_been_loaded.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_a_dsiabled_projection_has_been_loaded.cs
@@ -41,7 +41,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_an_onetime_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_an_onetime_projection.cs
@@ -19,7 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionManagementMessage.RunAs.Anonymous,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
-            yield return new SystemMessage.SystemReady();
+            yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_requesting_partition_state_from_a_stopped_foreach_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_requesting_partition_state_from_a_stopped_foreach_projection.cs
@@ -39,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _projectionName = "test-projection";
             // when
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_onetime_projection_has_been_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_onetime_projection_has_been_posted.cs
@@ -23,7 +23,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionQuery = @"fromAll(); on_any(function(){});log(1);";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionManagementMessage.RunAs.Anonymous, _projectionQuery,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
@@ -30,7 +30,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
@@ -31,7 +31,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
@@ -32,7 +32,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _projectionName = "test-projection";
             _source = @"fromAll(); on_any(function(){});log(1);";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
@@ -30,7 +30,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
@@ -72,7 +72,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Transient, _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projections_subsystem.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projections_subsystem.cs
@@ -34,7 +34,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
         protected override IEnumerable<WhenStep> PreWhen()
         {
             yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
-            yield return (new SystemMessage.SystemReady());
+            yield return (new SystemMessage.SystemCoreReady());
             yield return Yield;
             if (_startSystemProjections)
             {

--- a/src/EventStore.Projections.Core/Prelude/1Prelude.js
+++ b/src/EventStore.Projections.Core/Prelude/1Prelude.js
@@ -33,7 +33,7 @@ var _log = $log;
 var _load_module = $load_module;
 
 function log(message) {
-    _log("P: " + message);
+    _log("PROJECTIONS (JS): " + message);
 }
 
 function initializeModules() {

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -77,7 +77,7 @@ namespace EventStore.Projections.Core
             ProjectionManagerCommandWriter projectionManagerCommandWriter)
         {
             mainBus.Subscribe<SystemMessage.StateChangeMessage>(projectionManager);
-            mainBus.Subscribe<SystemMessage.SystemReady>(projectionManager);
+            mainBus.Subscribe<SystemMessage.SystemCoreReady>(projectionManager);
             if (runProjections >= ProjectionType.System)
             {
                 mainBus.Subscribe<ProjectionManagementMessage.Command.Post>(projectionManager);
@@ -153,12 +153,13 @@ namespace EventStore.Projections.Core
             managerOutput.Subscribe(Forwarder.Create<AwakeServiceMessage.SubscribeAwake>(standardComponents.MainQueue));
             managerOutput.Subscribe(
                 Forwarder.Create<AwakeServiceMessage.UnsubscribeAwake>(standardComponents.MainQueue));
+            managerOutput.Subscribe<SystemMessage.SubSystemInitialized>(forwarder);
 
             // self forward all
             standardComponents.MainBus.Subscribe(
                 Forwarder.Create<SystemMessage.StateChangeMessage>(projectionsStandardComponents.MasterInputQueue));
             standardComponents.MainBus.Subscribe(
-                Forwarder.Create<SystemMessage.SystemReady>(projectionsStandardComponents.MasterInputQueue));
+                Forwarder.Create<SystemMessage.SystemCoreReady>(projectionsStandardComponents.MasterInputQueue));
             projectionsStandardComponents.MasterMainBus.Subscribe(new UnwrapEnvelopeHandler());
         }
     }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionCoreResponseWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionCoreResponseWriter.cs
@@ -1,4 +1,5 @@
 ﻿using EventStore.Common.Log;
+using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Messages.Persisted.Responses;

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -19,7 +19,7 @@ namespace EventStore.Projections.Core.Services.Management
     public class ProjectionManager
         : IDisposable,
             IHandle<SystemMessage.StateChangeMessage>,
-            IHandle<SystemMessage.SystemReady>,
+            IHandle<SystemMessage.SystemCoreReady>,
             IHandle<ClientMessage.ReadStreamEventsBackwardCompleted>,
             IHandle<ClientMessage.WriteEventsCompleted>,
             IHandle<ClientMessage.DeleteStreamCompleted>,
@@ -166,6 +166,7 @@ namespace EventStore.Projections.Core.Services.Management
                     {
                         _started = true;
                         ScheduleExpire();
+                        _publisher.Publish(new SystemMessage.SubSystemInitialized("Projections"));
                     });
         }
 
@@ -539,7 +540,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         private VNodeState _currentState = VNodeState.Unknown;
         private bool _systemIsReady = false;
-        public void Handle(SystemMessage.SystemReady message)
+        public void Handle(SystemMessage.SystemCoreReady message)
         {
             _systemIsReady = true;
             StartWhenConditionsAreMet();

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -8,6 +8,7 @@ using EventStore.Core.Services.TimerService;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Messages.ParallelQueryProcessingMessages;
 using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Utils;
 
 namespace EventStore.Projections.Core.Services.Processing
 {
@@ -123,6 +124,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
                 string name = message.Name;
                 var sourceDefinition = ProjectionSourceDefinition.From(stateHandler.GetSourceDefinition());
+
                 var projectionVersion = message.Version;
                 var projectionConfig = message.Config;
                 var namesBuilder = new ProjectionNamesBuilder(name, sourceDefinition);

--- a/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -9,7 +9,8 @@ namespace EventStore.Projections.Core.Services.Processing
                                                  IHandle<ClientMessage.ReadStreamEventsForward>,
                                                  IHandle<ClientMessage.ReadAllEventsForward>,
                                                  IHandle<ClientMessage.WriteEvents>,
-                                                 IHandle<ClientMessage.DeleteStream>
+                                                 IHandle<ClientMessage.DeleteStream>,
+                                                 IHandle<SystemMessage.SubSystemInitialized>
     {
         private readonly IPublisher _externalRequestQueue;
         private readonly IPublisher _inputQueue;
@@ -69,6 +70,12 @@ namespace EventStore.Projections.Core.Services.Processing
                     msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
                     msg.CommitPosition, msg.PreparePosition, msg.MaxCount, msg.ResolveLinkTos, msg.RequireMaster,
                     msg.ValidationTfLastCommitPosition, msg.User));
+        }
+
+        public void Handle(SystemMessage.SubSystemInitialized msg)
+        {
+            _externalRequestQueue.Publish(
+                new SystemMessage.SubSystemInitialized(msg.SubSystemName));
         }
     }
 }


### PR DESCRIPTION
Fixes #922
Introducing a new step in the process and that is to wait for all the sub systems to indicate via `SystemMessage.SubSystemInitialized` that they have completed their initialisation. 
Upon receiving a `SystemMessage.SubSystemInitialized` for each of the sub systems, the `SystemMessage.SystemReady` message will be sent.

For users using `StartAndWaitUntilReady` the task will only be completed once the sub systems have been initialised which helps with users that want to test with projections for example. 