### PR TITLE
Make EvenStoreCatchupSubscription Async

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -1,9 +1,10 @@
-using System;
-using System.Threading;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.SystemData;
+using System;
 using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.ClientAPI
 {
@@ -68,14 +69,15 @@ namespace EventStore.ClientAPI
         private readonly ManualResetEventSlim _stopped = new ManualResetEventSlim(true);
 
         /// <summary>
-        /// Read events until the given position or event number.
+        /// Read events until the given position or event number async.
         /// </summary>
         /// <param name="connection">The connection.</param>
         /// <param name="resolveLinkTos">Whether to resolve Link events.</param>
         /// <param name="userCredentials">User credentials for the operation.</param>
         /// <param name="lastCommitPosition">The commit position to read until.</param>
         /// <param name="lastEventNumber">The event number to read until.</param>
-        protected abstract void ReadEventsTill(IEventStoreConnection connection,
+        /// <returns></returns>
+        protected abstract Task ReadEventsTillAsync(IEventStoreConnection connection,
                                                bool resolveLinkTos,
                                                UserCredentials userCredentials,
                                                long? lastCommitPosition,
@@ -123,10 +125,10 @@ namespace EventStore.ClientAPI
             Verbose = settings.VerboseLogging;
         }
 
-        internal void Start()
+        internal Task Start()
         {
             if (Verbose) Log.Debug("Catch-up Subscription to {0}: starting...", IsSubscribedToAll ? "<all>" : StreamId);
-            RunSubscription();
+            return RunSubscription();
         }
 
         /// <summary>
@@ -164,57 +166,108 @@ namespace EventStore.ClientAPI
             RunSubscription();
         }
 
-        private void RunSubscription()
+        private Task RunSubscription()
         {
-            ThreadPool.QueueUserWorkItem(_ =>
-            {
-                if (Verbose) Log.Debug("Catch-up Subscription to {0}: running...", IsSubscribedToAll ? "<all>" : StreamId);
-
-                _stopped.Reset();
-                try
-                {
-                    if (!ShouldStop)
-                    {
-                        if (Verbose) Log.Debug("Catch-up Subscription to {0}: pulling events...", IsSubscribedToAll ? "<all>" : StreamId);
-                        ReadEventsTill(_connection, _resolveLinkTos, _userCredentials, null, null);
-                    }
-
-                    if (!ShouldStop)
-                    {
-                        if (Verbose) Log.Debug("Catch-up Subscription to {0}: subscribing...", IsSubscribedToAll ? "<all>" : StreamId);
-                        _subscription = _streamId == string.Empty
-                            ? _connection.SubscribeToAllAsync(_resolveLinkTos, EnqueuePushedEvent, ServerSubscriptionDropped, _userCredentials).Result
-                            : _connection.SubscribeToStreamAsync(_streamId, _resolveLinkTos, EnqueuePushedEvent, ServerSubscriptionDropped, _userCredentials).Result;
-
-                        if (Verbose) Log.Debug("Catch-up Subscription to {0}: pulling events (if left)...", IsSubscribedToAll ? "<all>" : StreamId);
-                        ReadEventsTill(_connection, _resolveLinkTos, _userCredentials, _subscription.LastCommitPosition, _subscription.LastEventNumber);
-                    }
-                }
-                catch (Exception exc)
-                {
-                    DropSubscription(SubscriptionDropReason.CatchUpError, exc);
-                    return;
-                }
-
-                if (ShouldStop)
-                {
-                    DropSubscription(SubscriptionDropReason.UserInitiated, null);
-                    return;
-                }
-
-                if (Verbose) Log.Debug("Catch-up Subscription to {0}: processing live events...", IsSubscribedToAll ? "<all>" : StreamId);
-
-                if (_liveProcessingStarted != null)
-                    _liveProcessingStarted(this);
-
-                if (Verbose) Log.Debug("Catch-up Subscription to {0}: hooking to connection.Connected", IsSubscribedToAll ? "<all>" : StreamId);
-                _connection.Connected += OnReconnect;
-
-                _allowProcessing = true;
-                EnsureProcessingPushQueue();
-            });
+            return Task.Factory.StartNew(LoadHistoricalEvents, TaskCreationOptions.AttachedToParent)
+                .ContinueWith(_ => HandleErrorOrContinue(_));
         }
-        
+
+        private void LoadHistoricalEvents()
+        {
+            if (Verbose) Log.Debug("Catch-up Subscription to {0}: running...", IsSubscribedToAll ? "<all>" : StreamId);
+
+            _stopped.Reset();
+            _allowProcessing = false;
+
+            if (!ShouldStop)
+            {
+                if (Verbose)
+                    Log.Debug("Catch-up Subscription to {0}: pulling events...", IsSubscribedToAll ? "<all>" : StreamId);
+
+                ReadEventsTillAsync(_connection, _resolveLinkTos, _userCredentials, null, null)
+                    .ContinueWith(_ => HandleErrorOrContinue(_, SubscribeToStream), TaskContinuationOptions.AttachedToParent);
+            }
+            else
+            {
+                DropSubscription(SubscriptionDropReason.UserInitiated, null);
+            }
+        }
+
+        private void SubscribeToStream()
+        {
+            if (!ShouldStop)
+            {
+                if (Verbose) Log.Debug("Catch-up Subscription to {0}: subscribing...", IsSubscribedToAll ? "<all>" : StreamId);
+
+                var subscribeTask = _streamId == string.Empty
+                    ? _connection.SubscribeToAllAsync(_resolveLinkTos, EnqueuePushedEvent, ServerSubscriptionDropped, _userCredentials)
+                    : _connection.SubscribeToStreamAsync(_streamId, _resolveLinkTos, EnqueuePushedEvent, ServerSubscriptionDropped, _userCredentials);
+
+                subscribeTask.ContinueWith(_ => HandleErrorOrContinue(_, () =>
+                                                                            {
+                                                                                _subscription = _.Result;
+                                                                                ReadMissedHistoricEvents();
+                                                                            }), TaskContinuationOptions.AttachedToParent);
+            }
+            else
+            {
+                DropSubscription(SubscriptionDropReason.UserInitiated, null);
+            }
+        }
+
+        private void ReadMissedHistoricEvents()
+        {
+            if (!ShouldStop)
+            {
+                if (Verbose) Log.Debug("Catch-up Subscription to {0}: pulling events (if left)...", IsSubscribedToAll ? "<all>" : StreamId);
+
+                ReadEventsTillAsync(_connection, _resolveLinkTos, _userCredentials, _subscription.LastCommitPosition, _subscription.LastEventNumber)
+                    .ContinueWith(_ => HandleErrorOrContinue(_, StartLiveProcessing), TaskContinuationOptions.AttachedToParent);
+            }
+            else
+            {
+                DropSubscription(SubscriptionDropReason.UserInitiated, null);
+            }
+        }
+
+        private void StartLiveProcessing()
+        {
+            if (ShouldStop)
+            {
+                DropSubscription(SubscriptionDropReason.UserInitiated, null);
+                return;
+            }
+
+            if (Verbose) Log.Debug("Catch-up Subscription to {0}: processing live events...", IsSubscribedToAll ? "<all>" : StreamId);
+
+            if (_liveProcessingStarted != null)
+                _liveProcessingStarted(this);
+
+            if (Verbose) Log.Debug("Catch-up Subscription to {0}: hooking to connection.Connected", IsSubscribedToAll ? "<all>" : StreamId);
+            _connection.Connected += OnReconnect;
+
+            _allowProcessing = true;
+            EnsureProcessingPushQueue();
+        }
+
+        private void HandleErrorOrContinue(Task task, Action continuation = null)
+        {
+            if (task.IsFaulted)
+            {
+                DropSubscription(SubscriptionDropReason.CatchUpError, task.Exception.GetBaseException());
+                task.Wait();
+            }
+            else if (task.IsCanceled)
+            {
+                DropSubscription(SubscriptionDropReason.CatchUpError, new TaskCanceledException(task));
+                task.Wait();
+            }
+            else if (continuation != null)
+            {
+                continuation();
+            }
+        }
+
         private void EnqueuePushedEvent(EventStoreSubscription subscription, ResolvedEvent e)
         {
             if (Verbose)
@@ -340,6 +393,7 @@ namespace EventStore.ClientAPI
 
         private Position _nextReadPosition;
         private Position _lastProcessedPosition;
+        private TaskCompletionSource<bool> _completion;
 
         internal EventStoreAllCatchUpSubscription(IEventStoreConnection connection,
                                                   ILogger log,
@@ -357,38 +411,74 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
-        /// Read events until the given position.
+        /// Read events until the given position async.
         /// </summary>
         /// <param name="connection">The connection.</param>
         /// <param name="resolveLinkTos">Whether to resolve Link events.</param>
         /// <param name="userCredentials">User credentials for the operation.</param>
         /// <param name="lastCommitPosition">The commit position to read until.</param>
         /// <param name="lastEventNumber">The event number to read until.</param>
-        protected override void ReadEventsTill(IEventStoreConnection connection, bool resolveLinkTos, 
-                                               UserCredentials userCredentials, long? lastCommitPosition, int? lastEventNumber)
+        /// <returns></returns>
+        protected override Task ReadEventsTillAsync(IEventStoreConnection connection, bool resolveLinkTos,
+                        UserCredentials userCredentials, long? lastCommitPosition, int? lastEventNumber)
         {
-            bool done;
-            do
-            {
-                AllEventsSlice slice = connection.ReadAllEventsForwardAsync(_nextReadPosition, ReadBatchSize, resolveLinkTos, userCredentials).Result;
-                foreach (var e in slice.Events)
+            _completion = new TaskCompletionSource<bool>();
+            ReadEventsInternal(connection, resolveLinkTos, userCredentials, lastCommitPosition, lastEventNumber);
+            return _completion.Task;
+        }
+
+        private void ReadEventsInternal(IEventStoreConnection connection, bool resolveLinkTos,
+                       UserCredentials userCredentials, long? lastCommitPosition, int? lastEventNumber)
+        {
+            try { 
+                connection.ReadAllEventsForwardAsync(_nextReadPosition, ReadBatchSize, resolveLinkTos, userCredentials)
+                .ContinueWith(_ =>
                 {
-                    if (e.OriginalPosition == null) throw new Exception("Subscription event came up with no OriginalPosition.");
-                    TryProcess(e);
-                }
-                _nextReadPosition = slice.NextPosition;
+                    if (_.IsFaulted || _.IsCanceled)
+                    {
+                        _completion.SetException(_.Exception);
+                        _.Wait(); //force exception to be thrown
+                    }
 
-                done = lastCommitPosition == null
-                               ? slice.IsEndOfStream
-                               : slice.NextPosition >= new Position(lastCommitPosition.Value, lastCommitPosition.Value);
+                    if (!ProcessEvents(lastCommitPosition, _.Result) && !ShouldStop)
+                    {
+                        ReadEventsInternal(connection, resolveLinkTos, userCredentials,
+                            lastCommitPosition, lastEventNumber);
+                    }
+                    else
+                    {
+                        if (Verbose)
+                        {
+                            Log.Debug(
+                                "Catch-up Subscription to {0}: finished reading events, nextReadPosition = {1}.",
+                                IsSubscribedToAll ? "<all>" : StreamId, _nextReadPosition);
+                        }
+                        _completion.SetResult(true);
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                _completion.SetException(ex);
+            }
+        }
 
-                if (!done && slice.IsEndOfStream)
-                    Thread.Sleep(1); // we are waiting for server to flush its data
-            } while (!done && !ShouldStop);
+        private bool ProcessEvents(long? lastCommitPosition, AllEventsSlice slice)
+        {
+            foreach (var e in slice.Events)
+            {
+                if (e.OriginalPosition == null) throw new Exception("Subscription event came up with no OriginalPosition.");
+                TryProcess(e);
+            }
+            _nextReadPosition = slice.NextPosition;
 
-            if (Verbose) 
-                Log.Debug("Catch-up Subscription to {0}: finished reading events, nextReadPosition = {1}.", 
-                          IsSubscribedToAll ? "<all>" : StreamId, _nextReadPosition);
+            var done = lastCommitPosition == null
+                ? slice.IsEndOfStream
+                : slice.NextPosition >= new Position(lastCommitPosition.Value, lastCommitPosition.Value);
+
+            if (!done && slice.IsEndOfStream)
+                Thread.Sleep(1); // we are waiting for server to flush its data
+            return done;
         }
 
         /// <summary>
@@ -423,6 +513,7 @@ namespace EventStore.ClientAPI
 
         private int _nextReadEventNumber;
         private int _lastProcessedEventNumber;
+        private TaskCompletionSource<bool> _completion;
 
         internal EventStoreStreamCatchUpSubscription(IEventStoreConnection connection,
                                                      ILogger log,
@@ -443,23 +534,63 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
-        /// Read events until the given event number.
+        /// Read events until the given event number async.
         /// </summary>
         /// <param name="connection">The connection.</param>
         /// <param name="resolveLinkTos">Whether to resolve Link events.</param>
         /// <param name="userCredentials">User credentials for the operation.</param>
         /// <param name="lastCommitPosition">The commit position to read until.</param>
         /// <param name="lastEventNumber">The event number to read until.</param>
-        protected override void ReadEventsTill(IEventStoreConnection connection, bool resolveLinkTos, 
-                                               UserCredentials userCredentials, long? lastCommitPosition, int? lastEventNumber)
+        /// <returns></returns>
+        protected override Task ReadEventsTillAsync(IEventStoreConnection connection, bool resolveLinkTos, UserCredentials userCredentials,
+            long? lastCommitPosition, int? lastEventNumber)
+        {
+            _completion = new TaskCompletionSource<bool>();
+            ReadEventsInternal(connection, resolveLinkTos, userCredentials, lastCommitPosition, lastEventNumber);
+            return _completion.Task;
+        }
+
+        private void ReadEventsInternal(IEventStoreConnection connection, bool resolveLinkTos,
+                       UserCredentials userCredentials, long? lastCommitPosition, int? lastEventNumber)
+        {
+            try {
+                connection.ReadStreamEventsForwardAsync(StreamId, _nextReadEventNumber, ReadBatchSize, resolveLinkTos, userCredentials)
+                .ContinueWith(_ =>
+                {
+                    if (_.IsFaulted || _.IsCanceled)
+                    {
+                        _completion.SetException(_.Exception);
+                        _.Wait(); //force exception to be thrown
+                    }
+
+                    if (!ProcessEvents(lastEventNumber, _.Result) && !ShouldStop)
+                    {
+                        ReadEventsInternal(connection, resolveLinkTos, userCredentials, lastCommitPosition, lastEventNumber);
+                    }
+                    else
+                    {
+                        if (Verbose)
+                        {
+                            Log.Debug(
+                                "Catch-up Subscription to {0}: finished reading events, nextReadEventNumber = {1}.",
+                                IsSubscribedToAll ? "<all>" : StreamId, _nextReadEventNumber);
+                        }
+                        _completion.SetResult(true);
+                    }
+                });
+            }
+            catch(Exception ex)
+            {
+                _completion.SetException(ex);
+            }
+        }
+
+        private bool ProcessEvents(int? lastEventNumber, StreamEventsSlice slice)
         {
             bool done;
-            do
+            switch (slice.Status)
             {
-                var slice = connection.ReadStreamEventsForwardAsync(StreamId, _nextReadEventNumber, ReadBatchSize, resolveLinkTos, userCredentials).Result;
-                switch (slice.Status)
-                {
-                    case SliceReadStatus.Success:
+                case SliceReadStatus.Success:
                     {
                         foreach (var e in slice.Events)
                         {
@@ -469,26 +600,25 @@ namespace EventStore.ClientAPI
                         done = lastEventNumber == null ? slice.IsEndOfStream : slice.NextEventNumber > lastEventNumber;
                         break;
                     }
-                    case SliceReadStatus.StreamNotFound:
+                case SliceReadStatus.StreamNotFound:
                     {
                         if (lastEventNumber.HasValue && lastEventNumber != -1)
-                            throw new Exception(string.Format("Impossible: stream {0} disappeared in the middle of catching up subscription.", StreamId));
+                            throw new Exception(
+                                string.Format("Impossible: stream {0} disappeared in the middle of catching up subscription.",
+                                    StreamId));
                         done = true;
                         break;
                     }
-                    case SliceReadStatus.StreamDeleted:
-                        throw new StreamDeletedException(StreamId);
-                    default:
-                        throw new ArgumentOutOfRangeException(string.Format("Unexpected StreamEventsSlice.Status: {0}.", slice.Status));
-                }
+                case SliceReadStatus.StreamDeleted:
+                    throw new StreamDeletedException(StreamId);
+                default:
+                    throw new ArgumentOutOfRangeException(string.Format("Unexpected StreamEventsSlice.Status: {0}.",
+                        slice.Status));
+            }
 
-                if (!done && slice.IsEndOfStream)
-                    Thread.Sleep(1); // we are waiting for server to flush its data
-            } while (!done && !ShouldStop);
-
-            if (Verbose)
-                Log.Debug("Catch-up Subscription to {0}: finished reading events, nextReadEventNumber = {1}.",
-                          IsSubscribedToAll ? "<all>" : StreamId, _nextReadEventNumber);
+            if (!done && slice.IsEndOfStream)
+                Thread.Sleep(1); // we are waiting for server to flush its data
+            return done;
         }
 
         /// <summary>

--- a/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
@@ -1,0 +1,690 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.ClientAPI;
+using EventStore.ClientAPI.ClientOperations;
+using EventStore.ClientAPI.Common.Log;
+using EventStore.ClientAPI.Internal;
+using EventStore.ClientAPI.SystemData;
+using NUnit.Framework;
+using ClientMessage = EventStore.ClientAPI.Messages.ClientMessage;
+using ResolvedEvent = EventStore.ClientAPI.ResolvedEvent;
+using StreamMetadata = EventStore.ClientAPI.StreamMetadata;
+using SystemSettings = EventStore.ClientAPI.SystemSettings;
+
+namespace EventStore.Core.Tests.ClientAPI
+{
+    [TestFixture]
+    public class catch_up_subscription_handles_errors
+    {
+        private static int TimeoutMs = 2000;
+        private FakeEventStoreConnection _connection;
+        private IList<ResolvedEvent> _raisedEvents;
+        private bool _liveProcessingStarted;
+        private bool _isDropped;
+        private ManualResetEventSlim _dropEvent;
+        private ManualResetEventSlim _raisedEventEvent;
+        private Exception _dropException;
+        private SubscriptionDropReason _dropReason;
+        private EventStoreStreamCatchUpSubscription _subscription;
+        private static readonly string StreamId = "stream1";
+
+        [SetUp]
+        public void SetUp()
+        {
+            _connection = new FakeEventStoreConnection();
+            _raisedEvents = new List<ResolvedEvent>();
+            _dropEvent = new ManualResetEventSlim();
+            _raisedEventEvent = new ManualResetEventSlim();
+            _liveProcessingStarted = false;
+            _isDropped = false;
+            _dropReason = SubscriptionDropReason.Unknown;
+            _dropException = null;
+
+            var settings = new CatchUpSubscriptionSettings(1, 1, false, false);
+            _subscription = new EventStoreStreamCatchUpSubscription(_connection, new NoopLogger(), StreamId, null, null,
+                (subscription, ev) =>
+                {
+                    _raisedEvents.Add(ev);
+                    _raisedEventEvent.Set();
+                },
+                subscription =>
+                {
+                    _liveProcessingStarted = true;
+                },
+                (subscription, reason, ex) =>
+                {
+                    _isDropped = true;
+                    _dropReason = reason;
+                    _dropException = ex;
+                    _dropEvent.Set();
+                },
+                settings);
+        }
+
+        [Test]
+        public void read_events_til_stops_subscription_when_throws_immediately()
+        {
+
+            var expectedException = new ApplicationException("Test");
+
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+                                                           {
+                                                               Assert.That(stream, Is.EqualTo(StreamId));
+                                                               Assert.That(start, Is.EqualTo(0));
+                                                               Assert.That(max, Is.EqualTo(1));
+                                                               throw expectedException;
+                                                           });
+
+            AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+        }
+
+        private void AssertStartFailsAndDropsSubscriptionWithException(ApplicationException expectedException)
+        {
+            Assert.That(() => _subscription.Start().Wait(TimeoutMs), Throws.TypeOf<AggregateException>());
+            Assert.That(_isDropped);
+            Assert.That(_dropReason, Is.EqualTo(SubscriptionDropReason.CatchUpError));
+            Assert.That(_dropException, Is.SameAs(expectedException));
+            Assert.That(_liveProcessingStarted, Is.False);
+        }
+
+        [Test]
+        public void read_events_til_stops_subscription_when_throws_asynchronously()
+        {
+         
+            var expectedException = new ApplicationException("Test");
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                Assert.That(stream, Is.EqualTo(StreamId));
+                Assert.That(start, Is.EqualTo(0));
+                Assert.That(max, Is.EqualTo(1));
+                taskCompletionSource.SetException(expectedException);
+                return taskCompletionSource.Task;
+            });
+
+            AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+        }
+
+        [Test]
+        public void read_events_til_stops_subscription_when_second_read_throws_immediately()
+        {
+            var expectedException = new ApplicationException("Test");
+
+            int callCount = 0;
+
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                Assert.That(stream, Is.EqualTo(StreamId));
+                Assert.That(max, Is.EqualTo(1));
+
+                if (callCount++ == 0)
+                {
+                    Assert.That(start, Is.EqualTo(0));
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice());
+                    return taskCompletionSource.Task;
+
+                }
+                else
+                {
+                    Assert.That(start, Is.EqualTo(1));
+                    throw expectedException;    
+                }
+            });
+
+            AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+            Assert.That(_raisedEvents.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void read_events_til_stops_subscription_when_second_read_throws_asynchronously()
+        {
+            var expectedException = new ApplicationException("Test");
+
+            int callCount = 0;
+
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                Assert.That(stream, Is.EqualTo(StreamId));
+                Assert.That(max, Is.EqualTo(1));
+
+                if (callCount++ == 0)
+                {
+                    Assert.That(start, Is.EqualTo(0));
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice());
+                    return taskCompletionSource.Task;
+
+                }
+                else
+                {
+                    Assert.That(start, Is.EqualTo(1));
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    taskCompletionSource.SetException(expectedException);
+                    return taskCompletionSource.Task;
+                }
+            });
+
+            AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+            Assert.That(_raisedEvents.Count, Is.EqualTo(1));
+        }       
+
+        [Test]
+        public void start_stops_subscription_if_subscribe_fails_immediately()
+        {
+            var expectedException = new ApplicationException("Test");
+
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
+                return taskCompletionSource.Task;
+            });
+
+            _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
+            {
+                Assert.That(stream, Is.EqualTo(StreamId));
+                throw expectedException;
+            });
+
+            AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+            Assert.That(_raisedEvents.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void start_stops_subscription_if_subscribe_fails_async()
+        {
+            var expectedException = new ApplicationException("Test");
+
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
+                return taskCompletionSource.Task;
+            });
+
+            _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
+            {
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                taskCompletionSource.SetException(expectedException);
+                return taskCompletionSource.Task;
+            });
+
+            AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+            Assert.That(_raisedEvents.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void start_stops_subscription_if_historical_missed_events_load_fails_immediate()
+        {
+            var expectedException = new ApplicationException("Test");
+
+            int callCount = 0;
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                if (callCount++ == 0)
+                {
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
+                    return taskCompletionSource.Task;
+                }
+                else
+                {
+                    Assert.That(start, Is.EqualTo(1));
+                    throw expectedException;
+                }
+            });
+
+            _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
+            {
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                taskCompletionSource.SetResult(CreateVolatileSubscription(raise, drop, 1));
+                return taskCompletionSource.Task;
+            });
+
+            AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+            Assert.That(_raisedEvents.Count, Is.EqualTo(1));
+        }
+
+
+        [Test]
+        public void start_stops_subscription_if_historical_missed_events_load_fails_async()
+        {
+            var expectedException = new ApplicationException("Test");
+
+            int callCount = 0;
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                if (callCount++ == 0)
+                {
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
+                    return taskCompletionSource.Task;
+                }
+                else
+                {
+                    Assert.That(start, Is.EqualTo(1));
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    taskCompletionSource.SetException(expectedException);
+                    return taskCompletionSource.Task;
+                }
+            });
+
+            _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
+            {
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                taskCompletionSource.SetResult(CreateVolatileSubscription(raise, drop, 1));
+                return taskCompletionSource.Task;
+            });
+
+            AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+            Assert.That(_raisedEvents.Count, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void start_completes_onces_subscription_is_live()
+        {
+            var finalEvent = new ManualResetEventSlim();
+            int callCount = 0;
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                callCount++;
+
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                if (callCount == 1)
+                {
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
+                }
+                else if (callCount == 2)
+                {
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice(fromEvent:1, isEnd: true));
+                    Assert.That(finalEvent.Wait(TimeoutMs));
+                }
+                
+                return taskCompletionSource.Task;
+            });
+
+            _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
+            {
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                taskCompletionSource.SetResult(CreateVolatileSubscription(raise, drop, 1));
+                return taskCompletionSource.Task;
+            });
+
+            var task = _subscription.Start();
+
+            Assert.That(task.Status, Is.Not.EqualTo(TaskStatus.RanToCompletion));
+            
+            finalEvent.Set();
+
+            Assert.That(task.Wait(TimeoutMs));
+        }
+
+        [Test]
+        public void when_live_processing_and_disconnected_reconnect_keeps_events_ordered()
+        {
+            int callCount = 0;
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                callCount++;
+
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                if (callCount == 1)
+                {
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice(fromEvent: 0, count: 0, isEnd: true));
+                }
+                else if (callCount == 2)
+                {
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice(fromEvent: 0, count: 0, isEnd: true));
+                }
+
+                return taskCompletionSource.Task;
+            });
+
+            VolatileEventStoreSubscription volatileEventStoreSubscription = null;
+            Action<EventStoreSubscription, SubscriptionDropReason, Exception> innerSubscriptionDrop = null;
+            _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
+            {
+                innerSubscriptionDrop = drop;
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                volatileEventStoreSubscription = CreateVolatileSubscription(raise, drop, null);
+                taskCompletionSource.SetResult(volatileEventStoreSubscription);
+                return taskCompletionSource.Task;
+            });
+
+            Assert.That(_subscription.Start().Wait(TimeoutMs));
+            Assert.That(_raisedEvents.Count, Is.EqualTo(0));
+
+            Assert.That(innerSubscriptionDrop, Is.Not.Null);
+            innerSubscriptionDrop(volatileEventStoreSubscription, SubscriptionDropReason.ConnectionClosed, null);
+
+            Assert.That(_dropEvent.Wait(TimeoutMs));
+            _dropEvent.Reset();
+
+            var waitForOutOfOrderEvent = new ManualResetEventSlim();
+            callCount = 0;
+            _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
+            {
+                callCount++;
+
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                if (callCount == 1)
+                {
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice(fromEvent: 0, count:0, isEnd: true));
+                }
+                else if (callCount == 2)
+                {
+                    Assert.That(waitForOutOfOrderEvent.Wait(TimeoutMs));
+                    taskCompletionSource.SetResult(CreateStreamEventsSlice(fromEvent: 0, count: 1, isEnd: true));
+                }
+
+                return taskCompletionSource.Task;
+            });
+
+            var event1 = new ClientMessage.ResolvedEvent(new ClientMessage.EventRecord(StreamId, 1, Guid.NewGuid().ToByteArray(), null, 0, 0, null, null, null, null), null, 0, 0);
+            
+            _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
+            {
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                VolatileEventStoreSubscription volatileEventStoreSubscription2 = CreateVolatileSubscription(raise, drop, null);
+                taskCompletionSource.SetResult(volatileEventStoreSubscription);
+
+                raise(volatileEventStoreSubscription2, new ResolvedEvent(event1));
+                
+                return taskCompletionSource.Task;
+            });
+
+
+            var reconnectTask = Task.Factory.StartNew(() =>
+            {
+                _connection.OnConnected(new ClientConnectionEventArgs(_connection, new IPEndPoint(IPAddress.Any, 1)));
+
+            }, TaskCreationOptions.AttachedToParent);
+
+            Assert.That(_raisedEventEvent.Wait(100), Is.False);
+
+            waitForOutOfOrderEvent.Set();
+
+            Assert.That(_raisedEventEvent.Wait(TimeoutMs));
+
+            Assert.That(_raisedEvents[0].OriginalEventNumber, Is.EqualTo(0));
+            Assert.That(_raisedEvents[1].OriginalEventNumber, Is.EqualTo(1));
+
+            Assert.That(reconnectTask.Wait(TimeoutMs));
+        }
+
+        private static VolatileEventStoreSubscription CreateVolatileSubscription(Action<EventStoreSubscription, ResolvedEvent> raise, Action<EventStoreSubscription, SubscriptionDropReason, Exception> drop, int? lastEventNumber)
+        {
+            return new VolatileEventStoreSubscription(new VolatileSubscriptionOperation(new NoopLogger(), new TaskCompletionSource<EventStoreSubscription>(), StreamId, false, null, raise, drop, false, () => null), StreamId, -1, lastEventNumber);
+        }
+
+        private static StreamEventsSlice CreateStreamEventsSlice(int fromEvent = 0, int count = 1, bool isEnd = false)
+        {
+            var events = Enumerable.Range(0, count)
+                .Select(
+                    i =>
+                        new ClientMessage.ResolvedIndexedEvent(
+                            new ClientMessage.EventRecord(StreamId, i, Guid.NewGuid().ToByteArray(), null, 0, 0, null,
+                                null, null, null), null))
+                .ToArray();
+
+            return new StreamEventsSlice(SliceReadStatus.Success, StreamId, fromEvent, ReadDirection.Forward, events, fromEvent + count, 100, isEnd);
+        }
+    }
+
+    internal class FakeEventStoreConnection : IEventStoreConnection
+    {
+        private Func<Position, int, bool, UserCredentials, Task<AllEventsSlice>> _readAllEventsForwardAsync;
+        private Func<string, int, int, Task<StreamEventsSlice>> _readStreamEventsForwardAsync;
+        private Func<string, Action<EventStoreSubscription, ResolvedEvent>, Action<EventStoreSubscription, SubscriptionDropReason, Exception>, Task<EventStoreSubscription>> _subscribeToStreamAsync;
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+
+        public string ConnectionName { get; private set; }
+        public ConnectionSettings Settings { get { return null; } }
+
+        public Task ConnectAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Close()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DeleteResult> DeleteStreamAsync(string stream, int expectedVersion, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<DeleteResult> DeleteStreamAsync(string stream, int expectedVersion, bool hardDelete, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<WriteResult> AppendToStreamAsync(string stream, int expectedVersion, params EventData[] events)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<WriteResult> AppendToStreamAsync(string stream, int expectedVersion, UserCredentials userCredentials, params EventData[] events)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<WriteResult> AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<EventStoreTransaction> StartTransactionAsync(string stream, int expectedVersion, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public EventStoreTransaction ContinueTransaction(long transactionId, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<EventReadResult> ReadEventAsync(string stream, int eventNumber, bool resolveLinkTos, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleReadStreamEventsForwardAsync(Func<string, int, int, Task<StreamEventsSlice>> callback)
+        {
+            _readStreamEventsForwardAsync = callback;
+        }
+
+        public Task<StreamEventsSlice> ReadStreamEventsForwardAsync(string stream, int start, int count, bool resolveLinkTos,
+            UserCredentials userCredentials = null)
+        {
+            return _readStreamEventsForwardAsync(stream, start, count);
+        }
+
+        public Task<StreamEventsSlice> ReadStreamEventsBackwardAsync(string stream, int start, int count, bool resolveLinkTos,
+            UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleReadAllEventsForwardAsync(Func<Position, int, bool, UserCredentials, Task<AllEventsSlice>> callback)
+        {
+            _readAllEventsForwardAsync = callback;
+        }
+
+        public Task<AllEventsSlice> ReadAllEventsForwardAsync(Position position, int maxCount, bool resolveLinkTos,
+            UserCredentials userCredentials = null)
+        {
+            return _readAllEventsForwardAsync(position, maxCount, resolveLinkTos, userCredentials);
+        }
+
+        public Task<AllEventsSlice> ReadAllEventsBackwardAsync(Position position, int maxCount, bool resolveLinkTos,
+            UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void HandleSubscribeToStreamAsync(Func<string, Action<EventStoreSubscription, ResolvedEvent>, Action<EventStoreSubscription, SubscriptionDropReason, Exception>, Task<EventStoreSubscription>> callback)
+        {
+            _subscribeToStreamAsync = callback;
+        }
+
+        public Task<EventStoreSubscription> SubscribeToStreamAsync(string stream, bool resolveLinkTos, Action<EventStoreSubscription, ResolvedEvent> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+            UserCredentials userCredentials = null)
+        {
+            return _subscribeToStreamAsync(stream, eventAppeared, subscriptionDropped);
+        }
+
+        public EventStoreStreamCatchUpSubscription SubscribeToStreamFrom(string stream, int? lastCheckpoint, bool resolveLinkTos,
+            Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared, Action<EventStoreCatchUpSubscription> liveProcessingStarted = null, Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+            UserCredentials userCredentials = null, int readBatchSize = 500)
+        {
+            throw new NotImplementedException();
+        }
+
+        public EventStoreStreamCatchUpSubscription SubscribeToStreamFrom(
+            string stream,
+            int? lastCheckpoint,
+            CatchUpSubscriptionSettings settings,
+            Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+            Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
+            Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+            UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<EventStoreSubscription> SubscribeToAllAsync(bool resolveLinkTos, Action<EventStoreSubscription, ResolvedEvent> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+            UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(string stream, string groupName,
+            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared, Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null, int bufferSize = 10,
+            bool autoAck = true)
+        {
+            throw new NotImplementedException();
+        }
+
+        public EventStoreAllCatchUpSubscription SubscribeToAllFrom(Position? lastCheckpoint, bool resolveLinkTos, Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+            Action<EventStoreCatchUpSubscription> liveProcessingStarted = null, Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null,
+            int readBatchSize = 500)
+        {
+            throw new NotImplementedException();
+        }
+
+        public EventStoreAllCatchUpSubscription SubscribeToAllFrom(
+            Position? lastCheckpoint,
+            CatchUpSubscriptionSettings settings,
+            Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+            Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
+            Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+            UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings,
+            UserCredentials credentials)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings,
+            UserCredentials credentials)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task DeletePersistentSubscriptionAsync(string stream, string groupName, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVersion, StreamMetadata metadata,
+            UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<WriteResult> SetStreamMetadataAsync(string stream, int expectedMetastreamVersion, byte[] metadata,
+            UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<StreamMetadataResult> GetStreamMetadataAsync(string stream, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<RawStreamMetadataResult> GetStreamMetadataAsRawBytesAsync(string stream, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task SetSystemSettingsAsync(SystemSettings settings, UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        public event EventHandler<ClientConnectionEventArgs> Connected;
+        public event EventHandler<ClientConnectionEventArgs> Disconnected;
+        public event EventHandler<ClientReconnectingEventArgs> Reconnecting;
+        public event EventHandler<ClientClosedEventArgs> Closed;
+        public event EventHandler<ClientErrorEventArgs> ErrorOccurred;
+        public event EventHandler<ClientAuthenticationFailedEventArgs> AuthenticationFailed;
+
+        protected virtual void OnErrorOccurred(ClientErrorEventArgs e)
+        {
+            var handler = ErrorOccurred;
+            if (handler != null) handler(this, e);
+        }
+
+        protected virtual void OnAuthenticationFailed(ClientAuthenticationFailedEventArgs e)
+        {
+            var handler = AuthenticationFailed;
+            if (handler != null) handler(this, e);
+        }
+
+        protected virtual void OnClosed(ClientClosedEventArgs e)
+        {
+            var handler = Closed;
+            if (handler != null) handler(this, e);
+        }
+
+        protected virtual void OnReconnecting(ClientReconnectingEventArgs e)
+        {
+            var handler = Reconnecting;
+            if (handler != null) handler(this, e);
+        }
+
+        protected virtual void OnDisconnected(ClientConnectionEventArgs e)
+        {
+            var handler = Disconnected;
+            if (handler != null) handler(this, e);
+        }
+
+        public void OnConnected(ClientConnectionEventArgs e)
+        {
+            var handler = Connected;
+            if (handler != null) handler(this, e);
+        }
+
+        public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(string stream, string groupName, Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared, Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null, int bufferSize = 10, bool autoAck = true)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/ClientAPI/catchup_subscription_handles_small_batch_sizes.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catchup_subscription_handles_small_batch_sizes.cs
@@ -1,0 +1,93 @@
+﻿using EventStore.ClientAPI;
+using EventStore.ClientAPI.SystemData;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace EventStore.Core.Tests.ClientAPI
+{
+    [TestFixture, Ignore("Very long running")]
+    [Category("LongRunning")]
+    public class catchup_subscription_handles_small_batch_sizes : SpecificationWithDirectoryPerTestFixture
+    {
+        private MiniNode _node;
+        private string _streamName = "TestStream";
+        private CatchUpSubscriptionSettings _settings;
+        private IEventStoreConnection _conn;
+
+        [TestFixtureSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            _node = new MiniNode(PathName, inMemDb: true);
+            _node.Start();
+
+            _conn = BuildConnection(_node);
+            _conn.ConnectAsync().Wait();
+            //Create 80000 events
+            for(var i = 0; i < 80; i++)
+            {
+                _conn.AppendToStreamAsync(_streamName, ExpectedVersion.Any, CreateThousandEvents()).Wait();
+            }
+
+            _settings = new CatchUpSubscriptionSettings(100, 1, false, true);
+        }
+
+        private EventData[] CreateThousandEvents()
+        {
+            var events = new List<EventData>();
+            for(var i = 0; i < 1000; i++)
+            {
+                events.Add(new EventData(Guid.NewGuid(), "testEvent", true, Encoding.UTF8.GetBytes("{ \"Foo\":\"Bar\" }"), null));
+            }
+            return events.ToArray();
+        }
+
+        [TestFixtureTearDown]
+        public override void TestFixtureTearDown()
+        {
+            _conn.Dispose();
+            _node.Shutdown();
+            base.TestFixtureTearDown();
+        }
+
+        protected virtual IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return TestConnection.Create(node.TcpEndPoint);
+        }
+
+        [Test]
+        public void CatchupSubscriptionToAllHandlesManyEventsWithSmallBatchSize()
+        {
+            var mre = new ManualResetEvent(false);
+            _conn.SubscribeToAllFrom(null, _settings, (sub, evnt) => {
+                if(evnt.OriginalEventNumber % 1000 == 0)
+                {
+                    Console.WriteLine("Processed {0} events", evnt.OriginalEventNumber);
+                }
+            }, (sub) => { mre.Set(); }, null, new UserCredentials("admin", "changeit"));
+
+            if (!mre.WaitOne(TimeSpan.FromMinutes(10)))
+                Assert.Fail("Timed out waiting for test to complete");
+        }
+
+        [Test]
+        public void CatchupSubscriptionToStreamHandlesManyEventsWithSmallBatchSize()
+        {
+            var mre = new ManualResetEvent(false);
+            _conn.SubscribeToStreamFrom(_streamName, null, _settings, (sub, evnt) => {
+                if (evnt.OriginalEventNumber % 1000 == 0)
+                {
+                    Console.WriteLine("Processed {0} events", evnt.OriginalEventNumber);
+                }
+            }, (sub) => { mre.Set(); }, null, new UserCredentials("admin", "changeit"));
+
+            if (!mre.WaitOne(TimeSpan.FromMinutes(10)))
+                Assert.Fail("Timed out waiting for test to complete");
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -88,7 +88,9 @@
     <Compile Include="Bus\when_unsubscribing_from_memory_bus.cs" />
     <Compile Include="ClientAPI\appending_to_implicitly_created_stream.cs" />
     <Compile Include="ClientAPI\appending_to_implicitly_created_stream_using_transaction.cs" />
+    <Compile Include="ClientAPI\catchup_subscription_handles_small_batch_sizes.cs" />
     <Compile Include="ClientAPI\connecting_to_a_persistent_subscription_async.cs" />
+    <Compile Include="ClientAPI\catch_up_subscription_handles_errors.cs" />
     <Compile Include="ClientAPI\connecting_to_a_persistent_subscription.cs" />
     <Compile Include="ClientAPI\connection_string.cs" />
     <Compile Include="ClientAPI\create_persistent_subscription.cs" />


### PR DESCRIPTION
Patches and reintroduces the changes in this PR https://github.com/EventStore/EventStore/pull/837

Using the AttachedToParent continuation option on the task that was reading the historical events from the connection was causing a StackOverflowException when too many nested tasks were created.

This has been changed to use the default continuation option, and a taskCompletionSource is used to determine whether the subscription has finished reading the historical events from the stream.