### PR TITLE
Get the default proxy when an httpAsyncClient is constructed

### DIFF
--- a/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
@@ -25,6 +25,13 @@ namespace EventStore.ClientAPI.Transport.Http
         {
             _client = new HttpClient();
             _client.Timeout = timeout;
+            GetProxy();
+        }
+
+        private void GetProxy()
+        {
+            var defaultProxy = WebRequest.DefaultWebProxy;
+            defaultProxy.GetProxy(new Uri("http://127.0.0.1"));
         }
 
         public void Get(string url, UserCredentials userCredentials,

--- a/src/EventStore.Transport.Http/Client/HttpAsyncClient.cs
+++ b/src/EventStore.Transport.Http/Client/HttpAsyncClient.cs
@@ -22,6 +22,13 @@ namespace EventStore.Transport.Http.Client
         public HttpAsyncClient(TimeSpan timeout) {
             _client = new HttpClient();
             _client.Timeout = timeout;
+            GetProxy();
+        }
+
+        private void GetProxy()
+        {
+            var defaultProxy = WebRequest.DefaultWebProxy;
+            defaultProxy.GetProxy(new Uri("http://127.0.0.1"));
         }
 
         public void Get(string url, Action<HttpResponse> onSuccess, Action<Exception> onException)


### PR DESCRIPTION
This is to fix an issue on Windows where the first request from HttpClient can take an extremely long time (sometimes upwards of 5 seconds), which can cause gossips and clientAPI connections to time out when connecting over Http.
This happens because it can take an excessively long time for HttpClient to find the default proxy on Windows.

This fix gets the default proxy up front when HttpAsyncClient is created. Once the proxy has been set once, any further requests for a proxy are returned immediately.