### PR TITLE
Add method to VNodeBuilder not to add the interface prefixes

### DIFF
--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
@@ -35,13 +35,8 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
             Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 2112), _settings.NodeInfo.InternalHttp);
             Assert.AreEqual(new IPEndPoint(IPAddress.Loopback, 2113), _settings.NodeInfo.ExternalHttp);
 
-            var intHttpPrefixes = new List<string> { "http://127.0.0.1:2112/" };
-            var extHttpPrefixes = new List<string> { "http://127.0.0.1:2113/" };
-            if (Runtime.IsMono)
-            {
-                intHttpPrefixes.Add("http://localhost:2112/");
-                extHttpPrefixes.Add("http://localhost:2113/");
-            }
+            var intHttpPrefixes = new List<string> { "http://127.0.0.1:2112/", "http://localhost:2112/" };
+            var extHttpPrefixes = new List<string> { "http://127.0.0.1:2113/", "http://localhost:2113/" };
             CollectionAssert.AreEqual(intHttpPrefixes, _settings.IntHttpPrefixes);
             CollectionAssert.AreEqual(extHttpPrefixes, _settings.ExtHttpPrefixes);
         }
@@ -120,13 +115,9 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
             Assert.AreEqual(internalHttp, _settings.NodeInfo.InternalHttp);
             Assert.AreEqual(externalHttp, _settings.NodeInfo.ExternalHttp);
 
-            var intHttpPrefixes = new List<string> { "http://127.0.0.1:2112/" };
-            var extHttpPrefixes = new List<string> { "http://127.0.0.1:2113/" };
-            if (Runtime.IsMono)
-            {
-                intHttpPrefixes.Add("http://localhost:2112/");
-                extHttpPrefixes.Add("http://localhost:2113/");
-            }
+            var intHttpPrefixes = new List<string> { "http://127.0.0.1:2112/", "http://localhost:2112/" };
+            var extHttpPrefixes = new List<string> { "http://127.0.0.1:2113/", "http://localhost:2113/" };
+
             CollectionAssert.AreEqual(intHttpPrefixes, _settings.IntHttpPrefixes);
             CollectionAssert.AreEqual(extHttpPrefixes, _settings.ExtHttpPrefixes);
 

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
@@ -3,6 +3,8 @@ using System;
 using System.Net;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.Services.Monitoring;
+using System.Collections.Generic;
+using EventStore.Common.Utils;
 
 namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
 {
@@ -574,6 +576,75 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
         public void should_set_external_http_prefixes()
         {
             CollectionAssert.AreEqual(new string[] {_extPrefix, _extLoopbackPrefix}, _settings.ExtHttpPrefixes);
+        }
+    }
+
+    [TestFixture]
+    public class with_add_interface_prefixes : SingleNodeScenario
+    {
+        private IPEndPoint _internalHttp;
+        private IPEndPoint _externalHttp;
+        private IPEndPoint _internalTcp;
+        private IPEndPoint _externalTcp;
+        public override void Given()
+        {
+            var baseIpAddress = IPAddress.Loopback;
+            _internalHttp = new IPEndPoint(baseIpAddress, 1112);
+            _externalHttp = new IPEndPoint(baseIpAddress, 1113);
+            _internalTcp = new IPEndPoint(baseIpAddress, 1114);
+            _externalTcp = new IPEndPoint(baseIpAddress, 1115);
+            _builder.WithInternalHttpOn(_internalHttp)
+                .WithExternalHttpOn(_externalHttp)
+                .WithExternalTcpOn(_externalTcp)
+                .WithInternalTcpOn(_internalTcp);
+        }
+
+        [Test]
+        public void should_set_internal_http_prefixes()
+        {
+            var internalHttpPrefixes = new List<string> { string.Format("http://{0}/", _internalHttp), string.Format("http://localhost:{0}/", _internalHttp.Port) };
+            CollectionAssert.AreEqual(internalHttpPrefixes, _settings.IntHttpPrefixes);
+        }
+
+        [Test]
+        public void should_set_external_http_prefixes()
+        {
+            var externalHttpPrefixes = new List<string> { string.Format("http://{0}/", _externalHttp), string.Format("http://localhost:{0}/", _externalHttp.Port) };
+            CollectionAssert.AreEqual(externalHttpPrefixes, _settings.ExtHttpPrefixes);
+        }
+    }
+
+    [TestFixture]
+    public class with_dont_add_interface_prefixes : SingleNodeScenario
+    {
+        private IPEndPoint _internalHttp;
+        private IPEndPoint _externalHttp;
+        private IPEndPoint _internalTcp;
+        private IPEndPoint _externalTcp;
+        public override void Given()
+        {
+            var baseIpAddress = IPAddress.Loopback;
+            _internalHttp = new IPEndPoint(baseIpAddress, 1112);
+            _externalHttp = new IPEndPoint(baseIpAddress, 1113);
+            _internalTcp = new IPEndPoint(baseIpAddress, 1114);
+            _externalTcp = new IPEndPoint(baseIpAddress, 1115);
+            _builder.WithInternalHttpOn(_internalHttp)
+                    .WithExternalHttpOn(_externalHttp)
+                    .WithExternalTcpOn(_externalTcp)
+                    .WithInternalTcpOn(_internalTcp)
+                    .DontAddInterfacePrefixes();
+        }
+
+        [Test]
+        public void should_set_no_internal_http_prefixes()
+        {
+            CollectionAssert.IsEmpty(_settings.IntHttpPrefixes);
+        }
+
+        [Test]
+        public void should_set_no_external_http_prefixes()
+        {
+            CollectionAssert.IsEmpty(_settings.ExtHttpPrefixes);
         }
     }
 


### PR DESCRIPTION
There can be some additional work done around making sure that we align more with the regular node by looking [this](https://github.com/EventStore/EventStore/blob/release-v3.7.0/src/EventStore.ClusterNode/Program.cs#L150) can be pulled into the `VNodeBuilder`
