### PR TITLE
Change the config file default option to correctly reflect it's source

### DIFF
--- a/src/EventStore.Common/Options/EventStoreOptions.cs
+++ b/src/EventStore.Common/Options/EventStoreOptions.cs
@@ -37,7 +37,7 @@ namespace EventStore.Common.Options
             if (configFile == null && File.Exists(defaultConfigLocation))
             {
                 configFile = defaultConfigLocation;
-                yield return new OptionSource[] { OptionSource.String("Config File", "config", defaultConfigLocation) };
+                yield return new OptionSource[] { OptionSource.String("<DEFAULT>", "config", defaultConfigLocation) };
             }
             if (configFile != null)
             {
@@ -80,7 +80,7 @@ namespace EventStore.Common.Options
             var displayingModifiedOptions = true;
             dumpOptionsBuilder.AppendLine("MODIFIED OPTIONS:");
             dumpOptionsBuilder.AppendLine();
-            if (_effectiveOptions.First().Source.ToLower().Contains("default"))
+            if (_effectiveOptions.Count(x => !x.Source.ToLower().Contains("default")) == 0)
             {
                 dumpOptionsBuilder.AppendLine("NONE");
                 dumpOptionsBuilder.AppendLine();
@@ -88,7 +88,7 @@ namespace EventStore.Common.Options
                 dumpOptionsBuilder.AppendLine();
                 displayingModifiedOptions = false;
             }
-            foreach (var option in _effectiveOptions)
+            foreach (var option in _effectiveOptions.OrderBy(x => x.Source.ToLower().Contains("default") ? 1 : 0))
             {
                 if (option.Source.ToLower().Contains("default") && displayingModifiedOptions)
                 {


### PR DESCRIPTION
The other 2 changes were related to the incorrect displaying of the options and their sources.
We can't assume that if the first option in the effective options is an option that has a source of "default" that there are no modified options (config, command line).
Secondly we want to ensure that we display all the non-default options first
