### PR TITLE
Start the node in the VNodeBuilder tests so calling stop does not throw an exception

### DIFF
--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
@@ -21,6 +21,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests
             _node = _builder.Build();
             _settings = ((TestVNodeBuilder)_builder).GetSettings();
             _dbConfig = ((TestVNodeBuilder)_builder).GetDbConfig();
+            _node.Start();
         }
 
         [TestFixtureTearDown]
@@ -52,6 +53,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests
             _node = _builder.Build();
             _settings = ((TestVNodeBuilder)_builder).GetSettings();
             _dbConfig = ((TestVNodeBuilder)_builder).GetDbConfig();
+            _node.Start();
         }
         
         [TestFixtureTearDown]


### PR DESCRIPTION
The VNodeBuilder tests did not start the node they were building, so when Stop() was being called in the test teardown, an exception was being thrown. This made these tests run very slowly.

This PR starts the node before tearing the test down so that this exception is not thrown. 
If Stop() is not called, the nodes aren't cleaned up properly and the tests on appveyor fail.