### PR TITLE
Ensure persistent subscription checkpoint version doesn't get corrupted

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointWriter.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointWriter.cs
@@ -50,7 +50,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         private void PublishCheckpoint(int state)
         {
-            Log.Debug("publishing checkpoint " + state);
+            Log.Debug("Publishing checkpoint for {0}: {1}", _subscriptionStateStream, state);
             _outstandingWrite = true;
             var evnt = new Event(Guid.NewGuid(), "SubscriptionCheckpoint", true, state.ToJson(), null);            
             _ioDispatcher.WriteEvent(_subscriptionStateStream, _version, evnt, SystemAccount.Principal, WriteStateCompleted);
@@ -90,12 +90,13 @@ namespace EventStore.Core.Services.PersistentSubscription
             _outstandingWrite = false;
             if (msg.Result == OperationResult.Success)
             {
-                Log.Debug("state write successful");
+                Log.Debug("Checkpoint write successful for {0}", _subscriptionStateStream);
                 _version = msg.LastEventNumber;
             }
             else
             {
-                Log.Debug("error writing checkpoint " + msg.Result);
+                Log.Debug("Error writing checkpoint for {0}: {1}", _subscriptionStateStream, msg.Result);
+                _version = ExpectedVersion.Any;
             }
         }
     }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Services.PersistentSubscription
     {
         private readonly IODispatcher _ioDispatcher;
         private readonly string _parkedStreamId;
-        private static readonly ILogger Log = LogManager.GetLoggerFor<PersistentSubscriptionCheckpointWriter>();
+        private static readonly ILogger Log = LogManager.GetLoggerFor<PersistentSubscriptionMessageParker>();
 
         public PersistentSubscriptionMessageParker(string subscriptionId, IODispatcher ioDispatcher)
         {


### PR DESCRIPTION
When an error occurs writing a persistent subscription checkpoint (CommitTimeout for example) it can result in the expected version for the next write to be incorrect. The state is now corrupt permanently until the node is cycled. 

This isn't apparent from the statistics as the writing of the checkpoint is not considered for the state of the persistent subscription. The result in a silent issue. This has lead to us replaying large numbers of events when the master node randomly changes.

I also noticed the checkpoint metadata will never be written as the version is never set to NoStream. I've left that for somebody else to decide how to handle given there will be people will un-truncated checkpoint streams in production.