### PR TITLE
Only initialise projections when the core worker readers are ready

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/specification_with_projection_manager_response_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/specification_with_projection_manager_response_reader.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.project
             AllWritesSucceed();
             NoOtherStreams();
 
-            _commandReader = new ProjectionManagerResponseReader(_bus, _ioDispatcher);
+            _commandReader = new ProjectionManagerResponseReader(_bus, _ioDispatcher, 0);
 
             _bus.Subscribe<ProjectionManagementMessage.Starting>(_commandReader);
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/when_creating.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/when_creating.cs
@@ -13,7 +13,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.project
         [SetUp]
         public new void When()
         {
-            _commandReader = new ProjectionManagerResponseReader(_bus, _ioDispatcher);
+            _commandReader = new ProjectionManagerResponseReader(_bus, _ioDispatcher, 0);
         }
 
         [Test]

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -47,7 +47,7 @@ namespace EventStore.Projections.Core
 
             var commandWriter = new MultiStreamMessageWriter(ioDispatcher);
             var projectionManagerCommandWriter = new ProjectionManagerCommandWriter(commandWriter);
-            var projectionManagerResponseReader = new ProjectionManagerResponseReader(outputBus, ioDispatcher);
+            var projectionManagerResponseReader = new ProjectionManagerResponseReader(outputBus, ioDispatcher, queues.Count);
 
             var projectionManager = new ProjectionManager(
                 inputQueue,

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreServiceCommandReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreServiceCommandReader.cs
@@ -45,7 +45,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
         public void Handle(ProjectionCoreServiceMessage.StopCore message)
         {
-            Log.Debug("Stopping Projection Core Reader ({0})", _coreServiceId);
+            Log.Debug("PROJECTIONS: Stopping Projection Core Reader ({0})", _coreServiceId);
             _cancellationScope.Cancel();
             _stopped = true;
         }
@@ -78,7 +78,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 fromEventNumber = readResult.LastEventNumber + 1;
             }
 
-            Log.Debug("Starting read control from {0}", fromEventNumber);
+            Log.Debug("PROJECTIONS: Starting read control from {0}", fromEventNumber);
 
             //TODO: handle shutdown here and in other readers
             long subscribeFrom = 0;

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionNamesBuilder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionNamesBuilder.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private readonly string _checkpointStreamName;
         private readonly string _orderStreamName;
 
-        public static TimeSpan MastrerStreamMaxAge = TimeSpan.FromHours(2);
+        public static TimeSpan MasterStreamMaxAge = TimeSpan.FromHours(2);
         public static TimeSpan ControlStreamMaxAge = TimeSpan.FromHours(2);
         public static TimeSpan SlaveProjectionControlStreamMaxAge = TimeSpan.FromHours(2);
         public static TimeSpan CoreControlStreamMaxAge = TimeSpan.FromHours(2);


### PR DESCRIPTION
There are cases when the core worker readers takes a while to start up and
by that time the manager could have started the projections and messages
could have been written to the core worker's stream and they could have
been missed. 

The reason they can be missed is that when the core reader
starts, it will read the last event in the $projections-${worker_id} stream
and marks that as the starting point to read from.

The issue can result in some if not all projections to be stuck in the `preparing` state.