### PR TITLE
Check if the ContentType header on a forwarded http message is null

### DIFF
--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -268,7 +268,9 @@ namespace EventStore.Transport.Http.EntityManagement
                 HttpEntity.Response.StatusDescription = response.ReasonPhrase;
                 if(response.Content != null) 
                 {
-                    HttpEntity.Response.ContentType = response.Content.Headers.ContentType.MediaType;
+                    if(response.Content.Headers.ContentType != null) {
+                        HttpEntity.Response.ContentType = response.Content.Headers.ContentType.MediaType;
+                    }
                     HttpEntity.Response.ContentLength64 = response.Content.Headers.ContentLength.GetValueOrDefault();
                 }
                 foreach (var header in response.Headers)


### PR DESCRIPTION
Fixes #947 

Check if the ContentType header is null before trying to get the mediaType for forwarded messages.