### PR TITLE
Use the correct metadata when parsing c/p position

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
@@ -82,8 +82,12 @@ namespace EventStore.Projections.Core.Services.Processing
                     else
                     {
                         tag = positionEvent.Metadata.ParseCheckpointTagJson();
-
                         var parsedPosition = tag.Position;
+                        if (parsedPosition == new TFPos(long.MinValue, long.MinValue))
+                        {
+                            parsedPosition = @event.Metadata.ParseCheckpointTagJson().Position;
+                        }
+
                         eventOrLinkTargetPosition = parsedPosition != new TFPos(long.MinValue, long.MinValue)
                             ? parsedPosition
                             : new TFPos(-1, resolvedEvent.Event.LogPosition);


### PR DESCRIPTION
Fixes #490 

When a link to event is resolved the event part of the resolved event will
contain the metadata from the event and in the amended code it was assumed
that the checkpoint metadata lives on the link.

What is then happening is that a projection's subscription
(ReaderSubscriptionBase) is being fed events
that do not have a complete position but a commit/prepare position of -1
and log position respectively

Reproduction of the issue
Prerequisites:
Start Event Store with projections enabled

1. Write 2 events each with a different event type (TestEventType1,
TestEventType2)
2. Create a projection that
   a. Uses fromAll
   b. Has an event matcher, $any won't do. (TestEventType1)
3. Create a projection that
   a. Uses fromStreams $et-TestEventType1, $et-TestEventType2
   b. Links the events to a stream (projected_stream)
4. Enable the $by_event_type system projection which will produce the
streams that your projection in 3. is reading from
5. Reset projection 3. and you will observe an error "Complete TF
Position...". This projection's subscription is attempting to determine
whether the given event is past it's checkpoint and the position tagger
that will fail is the EventByTypeIndexPositionTagger which is only used
for projections that uses fromAll and has an event matcher.

Resetting the projection will cause the -order stream for the projection
to be rewritten and this stream links to the events in each stream. When
the events in this stream gets read and resolved, the metadata contains
the prepare and commit information the ResolvedEvent in projections is
trying to parse from the metadata. The ResolvedEvent assumes that the
metadata is in the link, which it's not.