### PR TITLE
Return the current version on a WrongExpectedVersion response over HTTP

### DIFF
--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -104,6 +104,12 @@ namespace EventStore.Core.Tests.Http.Streams
             }
 
             [Test]
+            public void should_return_the_current_version_in_the_header()
+            {
+                Assert.AreEqual("0", _response.Headers.Get("CurrentVersion"));
+            }
+
+            [Test]
             public void should_not_append_to_stream()
             {
                 Assert.AreEqual(1, _read.Count);
@@ -254,6 +260,13 @@ namespace EventStore.Core.Tests.Http.Streams
                 Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
                 Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
             }
+
+            [Test]
+            public void should_return_the_current_version_in_the_header()
+            {
+                Assert.AreEqual("1", _response.Headers.Get("CurrentVersion"));
+            }
+
             [Test]
             public void should_not_append_event()
             {
@@ -282,6 +295,12 @@ namespace EventStore.Core.Tests.Http.Streams
             {
                 Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
                 Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
+            }
+
+            [Test]
+            public void should_return_the_current_version_in_the_header()
+            {
+                Assert.AreEqual("-1", _response.Headers.Get("CurrentVersion"));
             }
 
             [Test]
@@ -458,6 +477,13 @@ namespace EventStore.Core.Tests.Http.Streams
             {
                 Assert.AreEqual(HttpStatusCode.BadRequest, _response.StatusCode);
                 Assert.AreEqual(WrongExpectedVersionDesc, _response.StatusDescription);
+            }
+
+
+            [Test]
+            public void should_return_the_current_version_in_the_header()
+            {
+                Assert.AreEqual("-1", _response.Headers.Get("CurrentVersion"));
             }
 
             [Test]

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -188,6 +188,7 @@ namespace EventStore.Core.Messages
             public readonly int LastEventNumber;
             public readonly long PreparePosition;
             public readonly long CommitPosition;
+            public readonly int CurrentVersion;
 
             public WriteEventsCompleted(Guid correlationId, int firstEventNumber, int lastEventNumber, long preparePosition, long commitPosition)
             {
@@ -205,7 +206,7 @@ namespace EventStore.Core.Messages
                 CommitPosition = commitPosition;
             }
 
-            public WriteEventsCompleted(Guid correlationId, OperationResult result, string message)
+            public WriteEventsCompleted(Guid correlationId, OperationResult result, string message, int currentVersion = -1)
             {
                 if (result == OperationResult.Success)
                     throw new ArgumentException("Invalid constructor used for successful write.", "result");
@@ -216,6 +217,7 @@ namespace EventStore.Core.Messages
                 FirstEventNumber = EventNumber.Invalid;
                 LastEventNumber = EventNumber.Invalid;
                 PreparePosition = EventNumber.Invalid;
+                CurrentVersion = currentVersion;
             }
 
             private WriteEventsCompleted(Guid correlationId, OperationResult result, string message, int firstEventNumber, int lastEventNumber, long preparePosition, long commitPosition)

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -298,11 +298,13 @@ namespace EventStore.Core.Messages
             public override int MsgTypeId { get { return TypeId; } }
 
             public readonly Guid CorrelationId;
+            public readonly int CurrentVersion;
 
-            public WrongExpectedVersion(Guid correlationId)
+            public WrongExpectedVersion(Guid correlationId, int currentVersion)
             {
                 Ensure.NotEmptyGuid(correlationId, "correlationId");
                 CorrelationId = correlationId;
+                CurrentVersion = currentVersion;
             }
         }
 
@@ -327,12 +329,14 @@ namespace EventStore.Core.Messages
 
             public readonly Guid CorrelationId;
             public readonly bool Success;
+            public readonly int CurrentVersion;
 
-            public RequestCompleted(Guid correlationId, bool success)
+            public RequestCompleted(Guid correlationId, bool success, int currentVersion = -1)
             {
                 Ensure.NotEmptyGuid(correlationId, "correlationId");
                 CorrelationId = correlationId;
                 Success = success;
+                CurrentVersion = currentVersion;
             }
         }
 

--- a/src/EventStore.Core/Services/RequestManager/Managers/DeleteStreamTwoPhaseRequestManager.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/DeleteStreamTwoPhaseRequestManager.cs
@@ -46,9 +46,9 @@ namespace EventStore.Core.Services.RequestManager.Managers
             ResponseEnvelope.ReplyWith(responseMsg);
         }
 
-        protected override void CompleteFailedRequest(OperationResult result, string error)
+        protected override void CompleteFailedRequest(OperationResult result, string error, int currentVersion = -1)
         {
-            base.CompleteFailedRequest(result, error);
+            base.CompleteFailedRequest(result, error, currentVersion);
             var responseMsg = new ClientMessage.DeleteStreamCompleted(ClientCorrId, result, error);
             ResponseEnvelope.ReplyWith(responseMsg);
         }

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommitTwoPhaseRequestManager.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommitTwoPhaseRequestManager.cs
@@ -42,9 +42,9 @@ namespace EventStore.Core.Services.RequestManager.Managers
             ResponseEnvelope.ReplyWith(responseMsg);
         }
 
-        protected override void CompleteFailedRequest(OperationResult result, string error)
+        protected override void CompleteFailedRequest(OperationResult result, string error, int currentVersion)
         {
-            base.CompleteFailedRequest(result, error);
+            base.CompleteFailedRequest(result, error, currentVersion);
             var responseMsg = new ClientMessage.TransactionCommitCompleted(ClientCorrId, _transactionId, result, error);
             ResponseEnvelope.ReplyWith(responseMsg);
         }

--- a/src/EventStore.Core/Services/RequestManager/Managers/TwoPhaseRequestManagerBase.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TwoPhaseRequestManagerBase.cs
@@ -118,7 +118,7 @@ namespace EventStore.Core.Services.RequestManager.Managers
             if (_completed)
                 return;
 
-            CompleteFailedRequest(OperationResult.WrongExpectedVersion, "Wrong expected version.");
+            CompleteFailedRequest(OperationResult.WrongExpectedVersion, "Wrong expected version.", message.CurrentVersion);
         }
 
         public void Handle(StorageMessage.StreamDeleted message)
@@ -182,11 +182,11 @@ namespace EventStore.Core.Services.RequestManager.Managers
             Publisher.Publish(new StorageMessage.RequestCompleted(_internalCorrId, true));
         }
 
-        protected virtual void CompleteFailedRequest(OperationResult result, string error)
+        protected virtual void CompleteFailedRequest(OperationResult result, string error, int currentVersion = -1)
         {
             Debug.Assert(result != OperationResult.Success);
             _completed = true;
-            Publisher.Publish(new StorageMessage.RequestCompleted(_internalCorrId, false));
+            Publisher.Publish(new StorageMessage.RequestCompleted(_internalCorrId, false, currentVersion));
         }
     }
 }

--- a/src/EventStore.Core/Services/RequestManager/Managers/WriteStreamTwoPhaseRequestManager.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/WriteStreamTwoPhaseRequestManager.cs
@@ -42,10 +42,10 @@ namespace EventStore.Core.Services.RequestManager.Managers
             ResponseEnvelope.ReplyWith(new ClientMessage.WriteEventsCompleted(ClientCorrId, firstEventNumber, lastEventNumber, preparePosition, commitPosition));
         }
 
-        protected override void CompleteFailedRequest(OperationResult result, string error)
+        protected override void CompleteFailedRequest(OperationResult result, string error, int currentVersion = -1)
         {
-            base.CompleteFailedRequest(result, error);
-            ResponseEnvelope.ReplyWith(new ClientMessage.WriteEventsCompleted(ClientCorrId, result, error));
+            base.CompleteFailedRequest(result, error, currentVersion);
+            ResponseEnvelope.ReplyWith(new ClientMessage.WriteEventsCompleted(ClientCorrId, result, error, currentVersion));
         }
 
     }

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -572,7 +572,7 @@ namespace EventStore.Core.Services.Storage
             switch (result.Decision)
             {
                 case CommitDecision.WrongExpectedVersion:
-                    envelope.ReplyWith(new StorageMessage.WrongExpectedVersion(correlationId));
+                    envelope.ReplyWith(new StorageMessage.WrongExpectedVersion(correlationId, result.CurrentVersion));
                     break;
                 case CommitDecision.Deleted:
                     envelope.ReplyWith(new StorageMessage.StreamDeleted(correlationId));
@@ -586,7 +586,7 @@ namespace EventStore.Core.Services.Storage
                 case CommitDecision.CorruptedIdempotency:
                     // in case of corrupted idempotency (part of transaction is ok, other is different)
                     // then we can say that the transaction is not idempotent, so WrongExpectedVersion is ok answer
-                    envelope.ReplyWith(new StorageMessage.WrongExpectedVersion(correlationId));
+                    envelope.ReplyWith(new StorageMessage.WrongExpectedVersion(correlationId, result.CurrentVersion));
                     break;
                 case CommitDecision.InvalidTransaction:
                     envelope.ReplyWith(new StorageMessage.InvalidTransaction(correlationId));

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -314,7 +314,8 @@ namespace EventStore.Core.Services.Transport.Http
                     case OperationResult.ForwardTimeout:
                         return InternalServerError("Write timeout");
                     case OperationResult.WrongExpectedVersion:
-                        return BadRequest("Wrong expected EventNumber");
+                        return new ResponseConfiguration(HttpStatusCode.BadRequest, "Wrong expected EventNumber", "text/plain", Helper.UTF8NoBom,
+                                                         new KeyValuePair<string, string>("CurrentVersion", msg.CurrentVersion.ToString()));
                     case OperationResult.StreamDeleted:
                         return Gone("Stream deleted");
                     case OperationResult.InvalidTransaction:


### PR DESCRIPTION
Fixes #754

Adds a CurrentVersion property to the WriteEventsCompleted message,
which is set to the current event version when the write results in a WrongExpectedVersion message.

The current version is then returned as a header called CurrentVersion on the HTTP response.