### PR TITLE
Track and deleting of emitted streams

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -442,6 +442,12 @@ namespace EventStore.Core.Tests.Helpers
             }
             if (!_streams.TryGetValue(message.EventStreamId, out list) || list == null)
             {
+                if(message.ExpectedVersion == ExpectedVersion.Any)
+                {
+                    message.Envelope.ReplyWith(new ClientMessage.DeleteStreamCompleted(message.CorrelationId, OperationResult.StreamDeleted, string.Empty, -1, -1));
+                    _deletedStreams.Add(message.EventStreamId);
+                    return;
+                }
                 message.Envelope.ReplyWith(new ClientMessage.DeleteStreamCompleted(message.CorrelationId, OperationResult.WrongExpectedVersion, string.Empty));
                 return;
             }

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithReadWriteDispatchers.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithReadWriteDispatchers.cs
@@ -62,6 +62,7 @@ namespace EventStore.Core.Tests.Helpers
             _ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(GetInputQueue()));
             _readDispatcher = _ioDispatcher.BackwardReader;
             _writeDispatcher = _ioDispatcher.Writer;
+            _streamDispatcher = _ioDispatcher.StreamDeleter;
 
             _bus.Subscribe(_ioDispatcher.ForwardReader);
             _bus.Subscribe(_ioDispatcher.BackwardReader);

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -115,9 +115,17 @@
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_phase.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_catalog_stream.cs" />
     <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_null_streamId.cs" />
+    <Compile Include="Services\SpecificationWithEmittedStreamsTrackerAndDeleter.cs" />
+    <Compile Include="Services\emitted_streams_deleter\when_deleting\with_multiple_tracked_streams.cs" />
+    <Compile Include="Services\emitted_streams_deleter\when_deleting\with_an_existing_emitted_streams_stream.cs" />
+    <Compile Include="Services\emitted_streams_deleter\when_deleting\with_no_emitted_streams_stream.cs" />
+    <Compile Include="Services\emitted_streams_tracker\when_tracking\with_tracking_disabled.cs" />
+    <Compile Include="Services\emitted_streams_tracker\when_tracking\with_tracking_enabled_with_duplicate_event_streams.cs" />
+    <Compile Include="Services\emitted_streams_tracker\when_tracking\with_tracking_enabled.cs" />
     <Compile Include="Services\event_reader\all_streams_with_links_event_reader\when_not_including_links.cs" />
     <Compile Include="Services\event_reader\all_streams_with_links_event_reader\when_including_links.cs" />
     <Compile Include="Services\event_reader\stream_reader\when_handling_soft_deleted_stream_with_a_single_event_event_reader.cs" />
+    <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection_and_keep_emitted_streams_stream.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_persistent_projection_and_not_authorised.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_running_persistent_projection.cs" />
     <Compile Include="Services\projections_manager\when_recreating_a_deleted_projection.cs" />

--- a/src/EventStore.Projections.Core.Tests/Integration/parallel_query/when_running_from_catalog_stream_query_twice.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/parallel_query/when_running_from_catalog_stream_query_twice.cs
@@ -45,6 +45,7 @@ fromStreamCatalog('catalog').foreachStream().when({
                     new PublishEnvelope(_bus), _projectionMode, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS",
                     _projectionSource, enabled: false, checkpointsEnabled: false,
+                    trackEmittedStreams: false,
                     emitEnabled: false));
             yield return
                 new ProjectionManagementMessage.Command.Enable(

--- a/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
@@ -18,6 +18,7 @@ namespace EventStore.Projections.Core.Tests.Integration
         protected string _projectionSource;
         protected ProjectionMode _projectionMode;
         protected bool _checkpointsEnabled;
+        protected bool _trackEmittedStreams;
         protected bool _emitEnabled;
         protected bool _startSystemProjections;
 
@@ -32,6 +33,7 @@ namespace EventStore.Projections.Core.Tests.Integration
             _projectionSource = GivenQuery();
             _projectionMode = ProjectionMode.Transient;
             _checkpointsEnabled = false;
+            _trackEmittedStreams = false;
             _emitEnabled = false;
             _startSystemProjections = GivenStartSystemProjections();
         }
@@ -72,7 +74,7 @@ namespace EventStore.Projections.Core.Tests.Integration
         {
             return new ProjectionManagementMessage.Command.Post(
                 new PublishEnvelope(_bus), ProjectionMode.Transient, name,
-                ProjectionManagementMessage.RunAs.System, "JS", source, enabled: true, checkpointsEnabled: false,
+                ProjectionManagementMessage.RunAs.System, "JS", source, enabled: true, checkpointsEnabled: false, trackEmittedStreams: false,
                 emitEnabled: false);
         }
 
@@ -80,7 +82,7 @@ namespace EventStore.Projections.Core.Tests.Integration
         {
             return new ProjectionManagementMessage.Command.Post(
                 new PublishEnvelope(_bus), ProjectionMode.Continuous, name, ProjectionManagementMessage.RunAs.System,
-                "JS", source, enabled: true, checkpointsEnabled: true, emitEnabled: true);
+                "JS", source, enabled: true, checkpointsEnabled: true, trackEmittedStreams: true, emitEnabled: true);
         }
 
         protected override IEnumerable<WhenStep> When()
@@ -113,7 +115,7 @@ namespace EventStore.Projections.Core.Tests.Integration
                 yield return
                     (new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), ProjectionMode.Continuous, "other_" + index,
-                        ProjectionManagementMessage.RunAs.System, "JS", source, enabled: true, checkpointsEnabled: true,
+                        ProjectionManagementMessage.RunAs.System, "JS", source, enabled: true, checkpointsEnabled: true, trackEmittedStreams: true,
                         emitEnabled: true));
                 index++;
             }
@@ -123,7 +125,7 @@ namespace EventStore.Projections.Core.Tests.Integration
                     (new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName,
                         ProjectionManagementMessage.RunAs.System, "JS", _projectionSource, enabled: true,
-                        checkpointsEnabled: _checkpointsEnabled, emitEnabled: _emitEnabled));
+                        checkpointsEnabled: _checkpointsEnabled, emitEnabled: _emitEnabled, trackEmittedStreams: _trackEmittedStreams));
             }
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
@@ -1,0 +1,34 @@
+﻿using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.ClientAPI;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+
+namespace EventStore.Projections.Core.Tests.Services
+{
+    public abstract class SpecificationWithEmittedStreamsTrackerAndDeleter : SpecificationWithMiniNode
+    {
+        protected IEmittedStreamsTracker _emittedStreamsTracker;
+        protected IEmittedStreamsDeleter _emittedStreamsDeleter;
+        protected ProjectionNamesBuilder _projectionNamesBuilder;
+        protected ClientMessage.ReadStreamEventsForwardCompleted _readCompleted;
+        protected IODispatcher _ioDispatcher;
+        protected bool _trackEmittedStreams = true;
+        protected string _projectionName = "test_projection";
+
+        protected override void Given()
+        {
+            _ioDispatcher = new IODispatcher(_node.Node.MainQueue, new PublishEnvelope(_node.Node.MainQueue));
+            _node.Node.MainBus.Subscribe(_ioDispatcher.BackwardReader);
+            _node.Node.MainBus.Subscribe(_ioDispatcher.ForwardReader);
+            _node.Node.MainBus.Subscribe(_ioDispatcher.Writer);
+            _node.Node.MainBus.Subscribe(_ioDispatcher.StreamDeleter);
+            _node.Node.MainBus.Subscribe(_ioDispatcher.Awaker);
+            _node.Node.MainBus.Subscribe(_ioDispatcher);
+            _projectionNamesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
+            _emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher, new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, false, _trackEmittedStreams), _projectionNamesBuilder);
+            _emittedStreamsDeleter = new EmittedStreamsDeleter(_ioDispatcher, _projectionNamesBuilder);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
@@ -104,7 +104,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             return new ProjectionConfig(
                 null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold, GivenPendingEventsThreshold(),
                 GivenMaxWriteBatchLength(), GivenEmitEventEnabled(), GivenCheckpointsEnabled(), _createTempStreams,
-                GivenStopOnEof(), isSlaveProjection: GivenIsSlaveProjection());
+                GivenStopOnEof(), GivenIsSlaveProjection(), GivenTrackEmittedStreams());
         }
 
         protected virtual bool GivenIsSlaveProjection()
@@ -128,6 +128,11 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         }
 
         protected virtual bool GivenCheckpointsEnabled()
+        {
+            return true;
+        }
+
+        protected virtual bool GivenTrackEmittedStreams()
         {
             return true;
         }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -17,6 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
         protected int _maxWriteBatchLength;
         protected bool _emitEventEnabled;
         protected bool _checkpointsEnabled;
+        protected bool _trackEmittedStreams;
         protected bool _producesResults;
         protected bool _definesFold = true;
         protected Guid _projectionCorrelationId;
@@ -36,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
             _namingBuilder = ProjectionNamesBuilder.CreateForTest("projection");
             _config = new ProjectionConfig(null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold,
                 _pendingEventsThreshold, _maxWriteBatchLength, _emitEventEnabled,
-                _checkpointsEnabled, _createTempStreams, _stopOnEof, isSlaveProjection: false);
+                _checkpointsEnabled, _createTempStreams, _stopOnEof, false, _trackEmittedStreams);
             When();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
@@ -4,7 +4,6 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Fakes;
-using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
@@ -25,7 +24,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         }
 
         private readonly ProjectionConfig _defaultProjectionConfig = new ProjectionConfig(
-            null, 5, 10, 1000, 250, true, true, true, true, false);
+            null, 5, 10, 1000, 250, true, true, true, true, false, true);
 
         private IODispatcher _ioDispatcher;
 
@@ -40,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         {
             IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
             var version = new ProjectionVersion(1, 0, 0);
-            var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false, false);
+            var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false, false, true);
             new ContinuousProjectionProcessingStrategy(
                 "projection",
                 version,
@@ -64,7 +63,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         {
             IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
             var version = new ProjectionVersion(1, 0, 0);
-            var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false, false);
+            var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false, false, true);
             new ContinuousProjectionProcessingStrategy(
                 "projection",
                 version,
@@ -249,7 +248,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         {
             IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
             var version = new ProjectionVersion(1, 0, 0);
-            var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false, false);
+            var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false, false, true);
             new ContinuousProjectionProcessingStrategy(
                 "projection",
                 version,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -1,11 +1,8 @@
 using System;
-using EventStore.Common.Log;
 using EventStore.Core.Bus;
-using EventStore.Core.Data;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.Tests.Bus.Helpers;
@@ -57,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             _bus.Subscribe(_ioDispatcher.Writer);
             _bus.Subscribe(_ioDispatcher);
             IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
-            _projectionConfig = new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, false);
+            _projectionConfig = new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, false, true);
             var version = new ProjectionVersion(1, 0, 0);
             var projectionProcessingStrategy = new ContinuousProjectionProcessingStrategy(
                 "projection", version, projectionStateHandler, _projectionConfig,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_an_existing_projection_missing_last_state_snapshot.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_an_existing_projection_missing_last_state_snapshot.cs
@@ -41,9 +41,9 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         [Test]
         public void should_not_emit_events_but_write_the_new_state_snapshot()
         {
-            Assert.AreEqual(1, _writeEventHandler.HandledMessages.Count);
+            Assert.AreEqual(2, _writeEventHandler.HandledMessages.Count);
 
-            var data = Helper.UTF8NoBom.GetString(_writeEventHandler.HandledMessages[0].Events[0].Data);
+            var data = Helper.UTF8NoBom.GetString(_writeEventHandler.HandledMessages[1].Events[0].Data);
             Assert.AreEqual("data", data);
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_an_existing_emitted_streams_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_an_existing_emitted_streams_stream.cs
@@ -1,0 +1,69 @@
+﻿using EventStore.ClientAPI;
+using EventStore.Common.Utils;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
+{
+    [TestFixture]
+    public class with_an_existing_emitted_streams_stream : SpecificationWithEmittedStreamsTrackerAndDeleter
+    {
+        protected Action _onDeleteStreamCompleted;
+        protected ManualResetEvent _resetEvent = new ManualResetEvent(false);
+        private string _testStreamName = "test_stream";
+
+        protected override void Given()
+        {
+            _onDeleteStreamCompleted = () =>
+            {
+                _resetEvent.Set();
+            };
+
+            base.Given();
+
+            _emittedStreamsTracker.TrackEmittedStream(new EmittedEvent[]
+            {
+                new EmittedDataEvent(
+                    _testStreamName, Guid.NewGuid(),  "type1",  true,
+                    "data", null, CheckpointTag.FromPosition(0, 100, 50), null),
+            });
+
+            var emittedStreamResult = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsName(), 0, 1, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(1, emittedStreamResult.Events.Length);
+            Assert.AreEqual(SliceReadStatus.Success, emittedStreamResult.Status);
+        }
+
+        protected override void When()
+        {
+            _emittedStreamsDeleter.DeleteEmittedStreams(_onDeleteStreamCompleted);
+            if (!_resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+            {
+                throw new Exception("Timed out waiting callback.");
+            };
+        }
+
+        [Test]
+        public void should_have_deleted_the_tracked_emitted_stream()
+        {
+            var result = _conn.ReadStreamEventsForwardAsync(_testStreamName, 0, 1, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(SliceReadStatus.StreamNotFound, result.Status);
+        }
+
+
+        [Test]
+        public void should_have_deleted_the_checkpoint_stream()
+        {
+            var result = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsCheckpointName(), 0, 1, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(SliceReadStatus.StreamNotFound, result.Status);
+        }
+
+        [Test]
+        public void should_have_deleted_the_emitted_streams_stream()
+        {
+            var result = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsName(), 0, 1, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(SliceReadStatus.StreamNotFound, result.Status);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_multiple_tracked_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_multiple_tracked_streams.cs
@@ -1,0 +1,76 @@
+﻿using EventStore.ClientAPI;
+using EventStore.Common.Utils;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
+{
+    [TestFixture]
+    public class with_multiple_tracked_streams : SpecificationWithEmittedStreamsTrackerAndDeleter
+    {
+        protected Action _onDeleteStreamCompleted;
+        protected ManualResetEvent _resetEvent = new ManualResetEvent(false);
+        private int _numberOfTrackedEvents = 200;
+        private string _testStreamFormat = "test_stream_{0}";
+
+        protected override void Given()
+        {
+            _onDeleteStreamCompleted = () =>
+            {
+                _resetEvent.Set();
+            };
+            base.Given();
+
+            for (int i = 0; i < _numberOfTrackedEvents; i++)
+            {
+                _conn.AppendToStreamAsync(String.Format(_testStreamFormat, i), ExpectedVersion.Any, new EventData(Guid.NewGuid(), "type1", true, Helper.UTF8NoBom.GetBytes("data"), null));
+                _emittedStreamsTracker.TrackEmittedStream(new EmittedEvent[]
+                {
+                    new EmittedDataEvent(
+                        String.Format(_testStreamFormat, i), Guid.NewGuid(),  "type1",  true,
+                        "data", null, CheckpointTag.FromPosition(0, 100, 50), null),
+                });
+            }
+
+            var emittedStreamResult = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsName(), 0, _numberOfTrackedEvents, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(_numberOfTrackedEvents, emittedStreamResult.Events.Length);
+            Assert.AreEqual(SliceReadStatus.Success, emittedStreamResult.Status);
+        }
+
+        protected override void When()
+        {
+            _emittedStreamsDeleter.DeleteEmittedStreams(_onDeleteStreamCompleted);
+            if (!_resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+            {
+                throw new Exception("Timed out waiting callback.");
+            };
+        }
+
+        [Test]
+        public void should_have_deleted_the_tracked_emitted_streams()
+        {
+            for(int i = 0; i < _numberOfTrackedEvents; i++)
+            {
+                var result = _conn.ReadStreamEventsForwardAsync(String.Format(_testStreamFormat, i), 0, 1, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+                Assert.AreEqual(SliceReadStatus.StreamNotFound, result.Status);
+            }
+        }
+
+
+        [Test]
+        public void should_have_deleted_the_checkpoint_stream()
+        {
+            var result = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsCheckpointName(), 0, 1, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(SliceReadStatus.StreamNotFound, result.Status);
+        }
+
+        [Test]
+        public void should_have_deleted_the_emitted_streams_stream()
+        {
+            var result = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsName(), 0, 1, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(SliceReadStatus.StreamNotFound, result.Status);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_no_emitted_streams_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_no_emitted_streams_stream.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+using System;
+using System.Threading;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
+{
+    [TestFixture]
+    public class with_no_emitted_streams_stream : SpecificationWithEmittedStreamsTrackerAndDeleter
+    {
+        protected Action _onDeleteStreamCompleted;
+        protected ManualResetEvent _resetEvent = new ManualResetEvent(false);
+
+        protected override void Given()
+        {
+            _onDeleteStreamCompleted = () =>
+            {
+                _resetEvent.Set();
+            };
+            base.Given();
+        }
+
+        protected override void When()
+        {
+            _emittedStreamsDeleter.DeleteEmittedStreams(_onDeleteStreamCompleted);
+        }
+
+        [Test]
+        public void should_have_called_completed()
+        {
+            if (!_resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+            {
+                throw new Exception("Timed out waiting callback.");
+            };
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_tracker/when_tracking/with_tracking_disabled.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_tracker/when_tracking/with_tracking_disabled.cs
@@ -1,0 +1,32 @@
+﻿using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using System;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_tracker.when_tracking
+{
+    public class with_tracking_disabled : SpecificationWithEmittedStreamsTrackerAndDeleter
+    {
+        protected override void Given()
+        {
+            _trackEmittedStreams = false;
+            base.Given();
+        }
+
+        protected override void When()
+        {
+            _emittedStreamsTracker.TrackEmittedStream(new EmittedEvent[]
+            {
+                new EmittedDataEvent(
+                     "test_stream", Guid.NewGuid(),  "type1",  true,
+                     "data",  null, CheckpointTag.FromPosition(0, 100, 50),  null, null)
+            });
+        }
+
+        [Test]
+        public void should_write_a_stream_tracked_event()
+        {
+            var result = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsName(), 0, 200, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(0, result.Events.Length);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_tracker/when_tracking/with_tracking_enabled.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_tracker/when_tracking/with_tracking_enabled.cs
@@ -1,0 +1,34 @@
+﻿using EventStore.ClientAPI.Common.Utils;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using System;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_tracker.when_tracking
+{
+    [TestFixture]
+    public class with_tracking_enabled : SpecificationWithEmittedStreamsTrackerAndDeleter
+    {
+        protected override void Given()
+        {
+            base.Given();
+        }
+
+        protected override void When()
+        {
+            _emittedStreamsTracker.TrackEmittedStream(new EmittedEvent[]
+            {
+                new EmittedDataEvent(
+                     "test_stream", Guid.NewGuid(),  "type1",  true,
+                     "data",  null, CheckpointTag.FromPosition(0, 100, 50),  null, null)
+            });
+        }
+
+        [Test]
+        public void should_write_a_stream_tracked_event()
+        {
+            var result = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsName(), 0, 200, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(1, result.Events.Length);
+            Assert.AreEqual("test_stream", Helper.UTF8NoBom.GetString(result.Events[0].Event.Data));
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_tracker/when_tracking/with_tracking_enabled_with_duplicate_event_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_tracker/when_tracking/with_tracking_enabled_with_duplicate_event_streams.cs
@@ -1,0 +1,37 @@
+﻿using EventStore.ClientAPI.Common.Utils;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using System;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_stream_manager.when_tracking
+{
+    [TestFixture]
+    public class with_tracking_enabled_with_duplicate_event_streams : SpecificationWithEmittedStreamsTrackerAndDeleter
+    {
+        protected override void Given()
+        {
+            base.Given();
+        }
+
+        protected override void When()
+        {
+            _emittedStreamsTracker.TrackEmittedStream(new EmittedEvent[]
+            {
+                new EmittedDataEvent(
+                     "test_stream", Guid.NewGuid(),  "type1",  true,
+                     "data",  null, CheckpointTag.FromPosition(0, 100, 50),  null, null),
+                new EmittedDataEvent(
+                     "test_stream", Guid.NewGuid(),  "type1",  true,
+                     "data",  null, CheckpointTag.FromPosition(0, 100, 50),  null, null)
+            });
+        }
+
+        [Test]
+        public void should_at_best_attempt_to_track_a_unique_list_of_streams()
+        {
+            var result = _conn.ReadStreamEventsForwardAsync(_projectionNamesBuilder.GetEmittedStreamsName(), 0, 200, false, new EventStore.ClientAPI.SystemData.UserCredentials("admin", "changeit")).Result;
+            Assert.AreEqual(1, result.Events.Length);
+            Assert.AreEqual("test_stream", Helper.UTF8NoBom.GetString(result.Events[0].Event.Data));
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_response_writer/when_delete_command.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_response_writer/when_delete_command.cs
@@ -13,6 +13,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
         private ProjectionManagementMessage.RunAs _runAs;
         private bool _deleteCheckpointStream;
         private bool _deleteStateStream;
+        private bool _deleteEmittedStreams;
 
         protected override void Given()
         {
@@ -20,6 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
             _runAs = ProjectionManagementMessage.RunAs.System;
             _deleteCheckpointStream = true;
             _deleteStateStream = true;
+            _deleteEmittedStreams = false;
         }
 
         protected override void When()
@@ -30,7 +32,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
                     _name,
                     _runAs,
                     _deleteCheckpointStream,
-                    _deleteStateStream));
+                    _deleteStateStream,
+                    _deleteEmittedStreams));
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_response_writer/when_handling_post_command.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_response_writer/when_handling_post_command.cs
@@ -18,6 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
         private bool _checkpointsEnabled;
         private bool _emitEnabled;
         private bool _enableRunAs;
+        private bool _trackEmittedStreams;
 
         protected override void Given()
         {
@@ -30,6 +31,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
             _checkpointsEnabled = true;
             _emitEnabled = true;
             _enableRunAs = true;
+            _trackEmittedStreams = true;
         }
 
         protected override void When()
@@ -45,6 +47,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
                     _enabled,
                     _checkpointsEnabled,
                     _emitEnabled,
+                    _trackEmittedStreams,
                     _enableRunAs));
         }
 
@@ -60,6 +63,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
             Assert.AreEqual(_enabled, command.Enabled);
             Assert.AreEqual(_checkpointsEnabled, command.CheckpointsEnabled);
             Assert.AreEqual(_emitEnabled, command.EmitEnabled);
+            Assert.AreEqual(_trackEmittedStreams, command.TrackEmittedStreams);
             Assert.AreEqual(_enableRunAs, command.EnableRunAs);
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_response_writer/when_handling_start_slave_projections_command.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_response_writer/when_handling_start_slave_projections_command.cs
@@ -34,6 +34,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_res
                         true,
                         true,
                         true,
+                        true,
                         ProjectionManagementMessage.RunAs.System));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -64,6 +64,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 queues,
                 _timeProvider,
                 ProjectionType.All,
+                _ioDispatcher,
                 _initializeSystemProjections);
 
             _coordinator = new ProjectionCoreCoordinator(
@@ -99,6 +100,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _bus.Subscribe<ProjectionManagementMessage.Command.StartSlaveProjections>(_manager);
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
+            _bus.Subscribe<ClientMessage.DeleteStreamCompleted>(_manager);
             _bus.Subscribe<SystemMessage.StateChangeMessage>(_manager);
             _bus.Subscribe<SystemMessage.SystemCoreReady>(_manager);
             _bus.Subscribe<ProjectionManagementMessage.ReaderReady>(_manager);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
@@ -8,7 +8,6 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
-using EventStore.Projections.Core.Services.Management;
 using EventStore.Projections.Core.Tests.Services.core_projection;
 using NUnit.Framework;
 
@@ -23,6 +22,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
             protected Type _fakeProjectionType;
             protected ProjectionMode _projectionMode;
             protected bool _checkpointsEnabled;
+            protected bool _trackEmittedStreams;
             protected bool _emitEnabled;
 
             protected override void Given()
@@ -36,6 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
                 _fakeProjectionType = typeof (FakeBiStateProjection);
                 _projectionMode = ProjectionMode.Continuous;
                 _checkpointsEnabled = true;
+                _trackEmittedStreams = true;
                 _emitEnabled = false;
             }
 
@@ -47,7 +48,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
                     (new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName,
                         ProjectionManagementMessage.RunAs.System, "native:" + _fakeProjectionType.AssemblyQualifiedName,
-                        _projectionSource, enabled: true, checkpointsEnabled: _checkpointsEnabled,
+                        _projectionSource, enabled: true, checkpointsEnabled: _checkpointsEnabled, trackEmittedStreams: _trackEmittedStreams,
                         emitEnabled: _emitEnabled));
             }
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_message.cs
@@ -37,6 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
+                true,
                 true);
 
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_slave_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_slave_message.cs
@@ -41,6 +41,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
+                true,
                 true);
 
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_prepared_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_prepared_message.cs
@@ -38,6 +38,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
+                true,
                 true);
 
             var builder = new SourceDefinitionBuilder();

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
@@ -21,6 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
             protected Type _fakeProjectionType;
             protected ProjectionMode _projectionMode;
             protected bool _checkpointsEnabled;
+            protected bool _trackEmittedStreams;
             protected bool _emitEnabled;
             protected bool _projectionEnabled;
 
@@ -33,6 +34,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
                 _fakeProjectionType = typeof (FakeProjection);
                 _projectionMode = ProjectionMode.Continuous;
                 _checkpointsEnabled = true;
+                _trackEmittedStreams = true;
                 _emitEnabled = true;
                 _projectionEnabled = true;
                 
@@ -50,7 +52,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(_bus), _projectionMode, _projectionName, ProjectionManagementMessage.RunAs.System,
                         "native:" + _fakeProjectionType.AssemblyQualifiedName, _projectionSource, enabled: _projectionEnabled,
-                        checkpointsEnabled: _checkpointsEnabled, emitEnabled: _emitEnabled));
+                        checkpointsEnabled: _checkpointsEnabled, trackEmittedStreams: _trackEmittedStreams, emitEnabled: _emitEnabled));
             }
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
@@ -61,7 +61,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                 _bus,
                 _timeProvider,
                 _getStateDispatcher,
-                _getResultDispatcher);
+                _getResultDispatcher,
+                _ioDispatcher);
         }
 
         [Test, ExpectedException(typeof (ArgumentException))]
@@ -90,7 +91,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     _bus,
                     v => v.CorrelationId,
                     v => v.CorrelationId,
-                    new PublishEnvelope(_bus)));
+                    new PublishEnvelope(_bus)),
+                _ioDispatcher);
         }
 
         [Test, ExpectedException(typeof (ArgumentNullException))]
@@ -119,7 +121,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     _bus,
                     v => v.CorrelationId,
                     v => v.CorrelationId,
-                    new PublishEnvelope(_bus)));
+                    new PublishEnvelope(_bus)),
+                _ioDispatcher);
         }
 
         [Test, ExpectedException(typeof (ArgumentNullException))]
@@ -148,7 +151,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     _bus,
                     v => v.CorrelationId,
                     v => v.CorrelationId,
-                    new PublishEnvelope(_bus)));
+                    new PublishEnvelope(_bus)),
+                _ioDispatcher);
         }
 
         [Test, ExpectedException(typeof (ArgumentException))]
@@ -177,7 +181,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     _bus,
                     v => v.CorrelationId,
                     v => v.CorrelationId,
-                    new PublishEnvelope(_bus)));
+                    new PublishEnvelope(_bus)),
+                _ioDispatcher);
         }
 
         [Test, ExpectedException(typeof (ArgumentException))]
@@ -206,7 +211,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     _bus,
                     v => v.CorrelationId,
                     v => v.CorrelationId,
-                    new PublishEnvelope(_bus)));
+                    new PublishEnvelope(_bus)),
+                _ioDispatcher);
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
@@ -42,7 +42,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                         _bus, 
                         v => v.CorrelationId,
                         v => v.CorrelationId,
-                        new PublishEnvelope(_bus)));
+                        new PublishEnvelope(_bus)),
+                _ioDispatcher);
         }
 
         [Test, ExpectedException(typeof (ArgumentNullException))]
@@ -50,7 +51,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
         {
             ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
                 new NoopEnvelope(), ProjectionMode.OneTime, "name", ProjectionManagementMessage.RunAs.Anonymous,
-                (string)null, @"log(1);", enabled: true, checkpointsEnabled: false, emitEnabled: false);
+                (string)null, @"log(1);", enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: false);
             _mp.InitializeNew(
                 new ManagedProjection.PersistedState
                 {
@@ -72,7 +73,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
         {
             ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
                 new NoopEnvelope(), ProjectionMode.OneTime, "name", ProjectionManagementMessage.RunAs.Anonymous, "",
-                @"log(1);", enabled: true, checkpointsEnabled: false, emitEnabled: false);
+                @"log(1);", enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: false);
             _mp.InitializeNew(
                 new ManagedProjection.PersistedState
                 {
@@ -94,7 +95,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
         {
             ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
                 new NoopEnvelope(), ProjectionMode.OneTime, "name", ProjectionManagementMessage.RunAs.Anonymous,
-                "JS", query: null, enabled: true, checkpointsEnabled: false, emitEnabled: false);
+                "JS", query: null, enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: false);
             _mp.InitializeNew(
                 new ManagedProjection.PersistedState
                 {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_slave_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_slave_projections.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
-using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Projections.Core.Messages;
@@ -14,6 +12,8 @@ using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 using TestFixtureWithExistingEvents =
     EventStore.Projections.Core.Tests.Services.core_projection.TestFixtureWithExistingEvents;
+using EventStore.Core.Helpers;
+using EventStore.Core.Tests.Fakes;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed_projection
 {
@@ -63,14 +63,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                         _bus, 
                         v => v.CorrelationId,
                         v => v.CorrelationId,
-                        new PublishEnvelope(_bus)));
+                        new PublishEnvelope(_bus)), _ioDispatcher);
         }
 
         protected override IEnumerable<WhenStep> When()
         {
             ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
                 Envelope, ProjectionMode.Transient, _projectionName, ProjectionManagementMessage.RunAs.System,
-                typeof(FakeForeachStreamProjection), "", true, false, false);
+                typeof(FakeForeachStreamProjection), "", true, false, false, false);
             _mp.InitializeNew(
                 new ManagedProjection.PersistedState
                 {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
@@ -20,6 +20,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
             protected Type _fakeProjectionType;
             protected ProjectionMode _projectionMode;
             protected bool _checkpointsEnabled;
+            protected bool _trackEmittedStreams;
             protected bool _emitEnabled;
 
             protected override void Given()
@@ -31,6 +32,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
                 _fakeProjectionType = typeof (FakeProjection);
                 _projectionMode = ProjectionMode.Transient;
                 _checkpointsEnabled = false;
+                _trackEmittedStreams = false;
                 _emitEnabled = false;
                 NoOtherStreams();
             }
@@ -44,7 +46,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
                         new PublishEnvelope(_bus), _projectionMode, _projectionName,
                         ProjectionManagementMessage.RunAs.System, "native:" + _fakeProjectionType.AssemblyQualifiedName,
                         _projectionSource, enabled: true, checkpointsEnabled: _checkpointsEnabled,
-                        emitEnabled: _emitEnabled));
+                        emitEnabled: _emitEnabled, trackEmittedStreams: _trackEmittedStreams));
             }
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
-using EventStore.Core.Tests.Helpers;
 using EventStore.Projections.Core.Messages;
 using NUnit.Framework;
 
@@ -18,6 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
 
             protected override void Given()
             {
+                AllWritesSucceed();
                 base.Given();
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
@@ -40,7 +40,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
                         new ProjectionManagementMessage.RunAs(_testUserPrincipal), "JS", _projectionBody, enabled: true,
-                        checkpointsEnabled: true, emitEnabled: true, enableRunAs: true);
+                        checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
             }
 
             [Test, Ignore]
@@ -95,7 +95,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
                         ProjectionManagementMessage.RunAs.Anonymous, "JS", _projectionBody, enabled: true,
-                        checkpointsEnabled: true, emitEnabled: true, enableRunAs: true);
+                        checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
             }
 
             [Test]
@@ -138,7 +138,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
                         new ProjectionManagementMessage.RunAs(_testUserPrincipal), "JS", _projectionBody, enabled: true,
-                        checkpointsEnabled: true, emitEnabled: true, enableRunAs: true);
+                        checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
             }
 
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -41,7 +41,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Transient, _projectionName,
                         new ProjectionManagementMessage.RunAs(_testUserPrincipal), "JS", _projectionBody, enabled: true,
-                        checkpointsEnabled: true, emitEnabled: true, enableRunAs: true);
+                        checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
             }
 
             [Test, Ignore]
@@ -96,7 +96,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
                     new ProjectionManagementMessage.Command.Post(
                         new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
                         ProjectionManagementMessage.RunAs.Anonymous, "JS", _projectionBody, enabled: true,
-                        checkpointsEnabled: true, emitEnabled: true, enableRunAs: true);
+                        checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
             }
 
             [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
@@ -46,7 +46,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.slave_p
                         false,
                         false,
                         true,
-                        isSlaveProjection: true),
+                        true,
+                        true),
                     _masterWorkerId,
                     _coreProjectionCorrelationId,
                     //(handlerType, query) => new FakeProjectionStateHandler(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
@@ -56,6 +56,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 queues,
                 _timeProvider,
                 ProjectionType.All,
+                _ioDispatcher,
                 _initializeSystemProjections);
 
             IPublisher inputQueue = GetInputQueue();

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_creating_projection_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_creating_projection_manager.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
+using EventStore.Core.Helpers;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -18,6 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         private ITimeProvider _timeProvider;
         private Dictionary<Guid, IPublisher> _queues;
         private TimeoutScheduler[] _timeoutSchedulers;
+        private IODispatcher _ioDispatcher;
 
         [SetUp]
         public void setup()
@@ -25,12 +27,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _timeProvider = new FakeTimeProvider();
             _queues = new Dictionary<Guid, IPublisher> {{Guid.NewGuid(), new FakePublisher()}};
             _timeoutSchedulers = ProjectionCoreWorkersNode.CreateTimeoutSchedulers(_queues.Count);
+            var fakePublisher = new FakePublisher();
             new ProjectionCoreCoordinator(
                 ProjectionType.All, 
                 _timeoutSchedulers,
                 _queues.Values.ToArray(),
-                new FakePublisher(),
+                fakePublisher,
                 new NoopEnvelope());
+            _ioDispatcher = new IODispatcher(fakePublisher, new PublishEnvelope(fakePublisher));
         }
 
         [Test]
@@ -42,7 +46,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     new FakePublisher(),
                     _queues,
                     _timeProvider,
-                    ProjectionType.All))
+                    ProjectionType.All,
+                    _ioDispatcher))
             {
             }
 
@@ -57,7 +62,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     new FakePublisher(),
                     _queues,
                     _timeProvider,
-                    ProjectionType.All))
+                    ProjectionType.All,
+                    _ioDispatcher))
             {
             }
         }
@@ -71,7 +77,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     null,
                     _queues,
                     _timeProvider,
-                    ProjectionType.All))
+                    ProjectionType.All,
+                    _ioDispatcher))
             {
             }
         }
@@ -85,7 +92,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     new FakePublisher(),
                     null,
                     _timeProvider,
-                    ProjectionType.All))
+                    ProjectionType.All,
+                    _ioDispatcher))
             {
             }
         }
@@ -99,7 +107,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     new FakePublisher(),
                     new Dictionary<Guid, IPublisher>(),
                     _timeProvider,
-                    ProjectionType.All))
+                    ProjectionType.All,
+                    _ioDispatcher))
             {
             }
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_emitted_streams_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_emitted_streams_stream.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Common.Utils;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager
+{
+    [TestFixture]
+    public class when_deleting_a_persistent_projection_and_keep_emitted_streams_stream : TestFixtureWithProjectionCoreAndManagementServices
+    {
+        private string _projectionName;
+        private const string _projectionEmittedStreamsStream = "$projections-test-projection-emittedstreams";
+
+        protected override void Given()
+        {
+            _projectionName = "test-projection";
+            AllWritesSucceed();
+            NoOtherStreams();
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.SystemCoreReady();
+            yield return
+                new ProjectionManagementMessage.Command.Post(
+                    new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
+                    ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
+                    enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+            yield return
+                new ProjectionManagementMessage.Command.Disable(
+                    new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);
+            yield return
+                new ProjectionManagementMessage.Command.Delete(
+                    new PublishEnvelope(_bus), _projectionName,
+                    ProjectionManagementMessage.RunAs.System, false, false, false);
+        }
+
+        [Test, Category("v8")]
+        public void a_projection_deleted_event_is_written()
+        {
+            Assert.AreEqual(
+                true,
+                _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Any(x => x.Events[0].EventType == "$ProjectionDeleted" && Helper.UTF8NoBom.GetString(x.Events[0].Data) == _projectionName));
+        }
+
+        [Test, Category("v8")]
+        public void should_not_have_attempted_to_delete_the_emitted_streams_stream()
+        {
+            Assert.IsFalse(
+                _consumer.HandledMessages.OfType<ClientMessage.DeleteStream>().Any(x=>x.EventStreamId == _projectionEmittedStreamsStream));
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
@@ -30,14 +30,14 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
-                    enabled: true, checkpointsEnabled: true, emitEnabled: false);
+                    enabled: true, checkpointsEnabled: true, emitEnabled: false, trackEmittedStreams: true);
             yield return
                 new ProjectionManagementMessage.Command.Disable(
                     new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);
             yield return
                 new ProjectionManagementMessage.Command.Delete(
                     new PublishEnvelope(_bus), _projectionName,
-                    ProjectionManagementMessage.RunAs.Anonymous, false, false);
+                    ProjectionManagementMessage.RunAs.Anonymous, false, false, false);
         }
 
         [Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
@@ -30,11 +30,11 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
-                    enabled: true, checkpointsEnabled: true, emitEnabled: true);
+                    enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
             yield return
                 new ProjectionManagementMessage.Command.Delete(
                     new PublishEnvelope(_bus), _projectionName,
-                    ProjectionManagementMessage.RunAs.System, true, true);
+                    ProjectionManagementMessage.RunAs.System, true, true, false);
         }
 
         [Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_handling_start_slave_projections_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_handling_start_slave_projections_message.cs
@@ -38,7 +38,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     new SlaveProjectionDefinitions.Definition(
                         "slave", StateHandlerFactory(), "",
                         SlaveProjectionDefinitions.SlaveProjectionRequestedNumber.OnePerThread, ProjectionMode.Transient,
-                        false, false, true, ProjectionManagementMessage.RunAs.System));
+                        false, false, true, false, ProjectionManagementMessage.RunAs.System));
         }
 
         protected override IEnumerable<WhenStep> When()

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
@@ -32,7 +32,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
-                    enabled: true, checkpointsEnabled: true, emitEnabled: true);
+                    enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
             OneWriteCompletes();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
@@ -33,7 +33,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
-                    enabled: true, checkpointsEnabled: true, emitEnabled: true);
+                    enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
         }
 
         [Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
@@ -31,19 +31,19 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
-                    enabled: true, checkpointsEnabled: true, emitEnabled: true);
+                    enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
             yield return
                 new ProjectionManagementMessage.Command.Disable(
                     new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);
             yield return
                 new ProjectionManagementMessage.Command.Delete(
                     new PublishEnvelope(_bus), _projectionName,
-                    ProjectionManagementMessage.RunAs.System, true, true);
+                    ProjectionManagementMessage.RunAs.System, true, true, false);
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().whenAny(function(s,e){return s;});",
-                    enabled: true, checkpointsEnabled: true, emitEnabled: true);
+                    enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
         }
 
         [Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projection.cs
@@ -42,7 +42,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 _bus,
                 queues,
                 _timeProvider,
-                ProjectionType.All);
+                ProjectionType.All,
+                _ioDispatcher);
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projections.cs
@@ -41,7 +41,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 _bus,
                 queues,
                 _timeProvider,
-                ProjectionType.All);
+                ProjectionType.All,
+                _ioDispatcher);
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
@@ -35,7 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll(); on_any(function(){});log(1);",
-                    enabled: false, checkpointsEnabled: true, emitEnabled: true));
+                    enabled: false, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true));
             // when
             _newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
             yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
@@ -36,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll(); on_any(function(){});log(1****);",
-                    enabled: false, checkpointsEnabled: true, emitEnabled: true));
+                    enabled: false, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true));
             // when
             _newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
             yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", _source, enabled: true, checkpointsEnabled: true,
-                    emitEnabled: true));
+                    emitEnabled: true, trackEmittedStreams: true));
             // when
             yield return
                 (new ProjectionManagementMessage.Command.UpdateQuery(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
@@ -35,7 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
                     ProjectionManagementMessage.RunAs.System, "JS", @"fromAll(); on_any(function(){return {};});log(1);",
-                    enabled: true, checkpointsEnabled: true, emitEnabled: true));
+                    enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true));
             // when
             _newProjectionSource = @"fromAll().when({a:function(){return {};}});log(2);";
             yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
@@ -77,7 +77,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 (new ProjectionManagementMessage.Command.Post(
                     new PublishEnvelope(_bus), ProjectionMode.Transient, _projectionName,
                     ProjectionManagementMessage.RunAs.Anonymous, "JS", @"fromAll(); on_any(function(){});log(1);",
-                    enabled: true, checkpointsEnabled: false, emitEnabled: false));
+                    enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: true));
             // when
             _newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
             yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/updating_projections/updating_projection_sources.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/updating_projections/updating_projection_sources.cs
@@ -36,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system.updating
                     new ProjectionManagementMessage.Command.Post(
                         Envelope, ProjectionMode.Continuous, _projectionName,
                         ProjectionManagementMessage.RunAs.System, "js", GivenOriginalSource(), true,
-                        _checkpointsEnabled, _emitEnabled);
+                        _checkpointsEnabled, _emitEnabled, _trackEmittedStreams);
                 yield return CreateWriteEvent("stream1", "type2", "{\"Data\": 2}");
                 yield return CreateWriteEvent("stream2", "type2", "{\"Data\": 3}");
                 yield return CreateWriteEvent("stream3", "type3", "{\"Data\": 4}");

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_requesting_state_from_a_faulted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_requesting_state_from_a_faulted_projection.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
             yield return
                 new ProjectionManagementMessage.Command.Post(
                     Envelope, ProjectionMode.Continuous, _projectionName, ProjectionManagementMessage.RunAs.System, "js",
-                    _projectionSource, enabled: true, checkpointsEnabled: true, emitEnabled: true);
+                    _projectionSource, enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
             yield return Yield;
             yield return new ProjectionManagementMessage.Command.GetState(Envelope, _projectionName, "");
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projection_config.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using EventStore.Core.Tests.Helpers;
-using EventStore.Projections.Core.Services;
-using EventStore.Projections.Core.Tests.Services.projections_manager;
-
 namespace EventStore.Projections.Core.Tests.Services.projections_system
 {
     public abstract class with_projection_config : with_projections_subsystem
@@ -11,6 +5,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
         protected string _projectionName;
         protected string _projectionSource;
         protected bool _checkpointsEnabled;
+        protected bool _trackEmittedStreams;
         protected bool _emitEnabled;
         
         protected override void Given()
@@ -20,10 +15,12 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
             _projectionName = "test-projection";
             _projectionSource = @"";
             _checkpointsEnabled = true;
+            _trackEmittedStreams = true;
             _emitEnabled = true;
 
             NoStream("$projections-" + _projectionName + "-checkpoint");
             NoStream("$projections-" + _projectionName + "-order");
+            NoStream("$projections-" + _projectionName + "-emittedstreams");
             AllWritesSucceed();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/write_query_result_phase/creating.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/write_query_result_phase/creating.cs
@@ -22,6 +22,7 @@ namespace EventStore.Projections.Core.Tests.Services.write_query_result_phase
                 var stateCache = new PartitionStateCache();
                 var bus = new InMemoryBus("test");
                 var fakeCheckpointManager = new specification_with_multi_phase_core_projection.FakeCheckpointManager(bus, Guid.NewGuid());
+                var fakeEmittedStreamsTracker = new specification_with_multi_phase_core_projection.FakeEmittedStreamsTracker();
                 TestHelper.Consume(
                     new WriteQueryResultProjectionProcessingPhase(
                         bus,
@@ -30,7 +31,8 @@ namespace EventStore.Projections.Core.Tests.Services.write_query_result_phase
                         coreProjection,
                         stateCache,
                         fakeCheckpointManager,
-                        fakeCheckpointManager));
+                        fakeCheckpointManager,
+                        fakeEmittedStreamsTracker));
             }
         }
 
@@ -38,6 +40,7 @@ namespace EventStore.Projections.Core.Tests.Services.write_query_result_phase
         {
             protected WriteQueryResultProjectionProcessingPhase _phase;
             protected specification_with_multi_phase_core_projection.FakeCheckpointManager _checkpointManager;
+            protected specification_with_multi_phase_core_projection.FakeEmittedStreamsTracker _emittedStreamsTracker;
             protected InMemoryBus _publisher;
             protected PartitionStateCache _stateCache;
             protected string _resultStreamName;
@@ -51,6 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.write_query_result_phase
                 _coreProjection = new FakeCoreProjection();
                 _checkpointManager = new specification_with_multi_phase_core_projection.FakeCheckpointManager(
                     _publisher, Guid.NewGuid());
+                _emittedStreamsTracker = new specification_with_multi_phase_core_projection.FakeEmittedStreamsTracker();
                 _resultStreamName = "result-stream";
                 _phase = new WriteQueryResultProjectionProcessingPhase(
                     _publisher,
@@ -59,7 +63,8 @@ namespace EventStore.Projections.Core.Tests.Services.write_query_result_phase
                     _coreProjection,
                     _stateCache,
                     _checkpointManager,
-                    _checkpointManager);
+                    _checkpointManager,
+                    _emittedStreamsTracker);
                 When();
             }
 

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -188,6 +188,8 @@
     <Compile Include="ProjectionsSubsystem.cs" />
     <Compile Include="Services\Http\ProjectionsStatisticsHttpFormatted.cs" />
     <Compile Include="Services\ISingletonTimeoutScheduler.cs" />
+    <Compile Include="Services\Management\ManagedProjectionStates\ManagedProjectionStateBase.cs" />
+    <Compile Include="Services\Management\ManagedProjectionStates\DeletingState.cs" />
     <Compile Include="Services\Management\MasterCoreProjectionResponseReader.cs" />
     <Compile Include="Services\Management\MultiStreamMessageWriter.cs" />
     <Compile Include="Services\Management\IMultiStreamMessageWriter.cs" />
@@ -238,6 +240,8 @@
     <Compile Include="Services\Processing\EmittedDataEvent.cs" />
     <Compile Include="Services\Processing\EmittedEventEnvelope.cs" />
     <Compile Include="Services\Processing\EmittedLinkTo.cs" />
+    <Compile Include="Services\Processing\EmittedStreamsDeleter.cs" />
+    <Compile Include="Services\Processing\EmittedStreamsTracker.cs" />
     <Compile Include="Services\Processing\EventByTypeIndexEventFilter.cs" />
     <Compile Include="Services\Processing\EventByTypeIndexEventReader.cs" />
     <Compile Include="Services\Processing\EventByTypeIndexPositionTagger.cs" />
@@ -346,6 +350,7 @@
     <Compile Include="Services\Processing\RequestResponseQueueForwarder.cs" />
     <Compile Include="Services\ReaderSubscriptionDispatcher.cs" />
     <Compile Include="Services\ReadWrite.cs" />
+    <Compile Include="Services\SystemNames.cs" />
     <Compile Include="Services\v8\DefaultV8ProjectionStateHandler.cs" />
     <Compile Include="Services\v8\V8ProjectionStateHandler.cs" />
     <Compile Include="Standard\CategorizeEventsByStreamPath.cs" />

--- a/src/EventStore.Projections.Core/Messages/Persisted/Commands/PersistedProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Messages/Persisted/Commands/PersistedProjectionConfig.cs
@@ -18,6 +18,7 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
         public bool CreateTempStreams;
         public bool StopOnEof;
         public bool IsSlaveProjection;
+        public bool TrackEmittedStreams;
 
         public PersistedProjectionConfig()
         {
@@ -39,6 +40,7 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
             CreateTempStreams = config.CreateTempStreams;
             StopOnEof = config.StopOnEof;
             IsSlaveProjection = config.IsSlaveProjection;
+            TrackEmittedStreams = config.TrackEmittedStreams;
         }
 
         public ProjectionConfig ToConfig()
@@ -56,7 +58,8 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
                     CheckpointsEnabled,
                     CreateTempStreams,
                     StopOnEof,
-                    IsSlaveProjection);
+                    IsSlaveProjection,
+                    TrackEmittedStreams);
         }
     }
 }

--- a/src/EventStore.Projections.Core/Messages/Persisted/Responses/DeleteCommand.cs
+++ b/src/EventStore.Projections.Core/Messages/Persisted/Responses/DeleteCommand.cs
@@ -8,5 +8,6 @@ namespace EventStore.Projections.Core.Messages.Persisted.Responses
         public SerializedRunAs RunAs;
         public bool DeleteCheckpointStream;
         public bool DeleteStateStream;
+        public bool DeleteEmittedStreams;
     }
 }

--- a/src/EventStore.Projections.Core/Messages/Persisted/Responses/PostCommand.cs
+++ b/src/EventStore.Projections.Core/Messages/Persisted/Responses/PostCommand.cs
@@ -9,6 +9,7 @@ namespace EventStore.Projections.Core.Messages.Persisted.Responses
         public SerializedRunAs RunAs;
 
         public bool CheckpointsEnabled;
+        public bool TrackEmittedStreams;
         public bool EmitEnabled;
         public bool EnableRunAs;
         public bool Enabled;

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -47,10 +47,11 @@ namespace EventStore.Projections.Core.Messages
                 private readonly bool _checkpointsEnabled;
                 private readonly bool _emitEnabled;
                 private readonly bool _enableRunAs;
+                private readonly bool _trackEmittedStreams;
 
                 public Post(
                     IEnvelope envelope, ProjectionMode mode, string name, RunAs runAs, string handlerType, string query,
-                    bool enabled, bool checkpointsEnabled, bool emitEnabled, bool enableRunAs = false)
+                    bool enabled, bool checkpointsEnabled, bool emitEnabled, bool trackEmittedStreams, bool enableRunAs = false)
                     : base(envelope, runAs)
                 {
                     _name = name;
@@ -60,12 +61,13 @@ namespace EventStore.Projections.Core.Messages
                     _enabled = enabled;
                     _checkpointsEnabled = checkpointsEnabled;
                     _emitEnabled = emitEnabled;
+                    _trackEmittedStreams = trackEmittedStreams;
                     _enableRunAs = enableRunAs;
                 }
 
                 public Post(
                     IEnvelope envelope, ProjectionMode mode, string name, RunAs runAs, Type handlerType, string query,
-                    bool enabled, bool checkpointsEnabled, bool emitEnabled, bool enableRunAs = false)
+                    bool enabled, bool checkpointsEnabled, bool emitEnabled, bool trackEmittedStreams, bool enableRunAs = false)
                     : base(envelope, runAs)
                 {
                     _name = name;
@@ -75,6 +77,7 @@ namespace EventStore.Projections.Core.Messages
                     _enabled = enabled;
                     _checkpointsEnabled = checkpointsEnabled;
                     _emitEnabled = emitEnabled;
+                    _trackEmittedStreams = trackEmittedStreams;
                     _enableRunAs = enableRunAs;
                 }
                 // shortcut for posting ad-hoc JS queries
@@ -88,6 +91,7 @@ namespace EventStore.Projections.Core.Messages
                     _enabled = enabled;
                     _checkpointsEnabled = false;
                     _emitEnabled = false;
+                    _trackEmittedStreams = false;
                 }
 
                 public ProjectionMode Mode
@@ -128,6 +132,11 @@ namespace EventStore.Projections.Core.Messages
                 public bool EnableRunAs
                 {
                     get { return _enableRunAs; }
+                }
+
+                public bool TrackEmittedStreams
+                {
+                    get { return _trackEmittedStreams; }
                 }
             }
 
@@ -288,14 +297,16 @@ namespace EventStore.Projections.Core.Messages
                 private readonly string _name;
                 private readonly bool _deleteCheckpointStream;
                 private readonly bool _deleteStateStream;
+                private readonly bool _deleteEmittedStreams;
 
                 public Delete(
-                    IEnvelope envelope, string name, RunAs runAs, bool deleteCheckpointStream, bool deleteStateStream)
+                    IEnvelope envelope, string name, RunAs runAs, bool deleteCheckpointStream, bool deleteStateStream, bool deleteEmittedStreams)
                     : base(envelope, runAs)
                 {
                     _name = name;
                     _deleteCheckpointStream = deleteCheckpointStream;
                     _deleteStateStream = deleteStateStream;
+                    _deleteEmittedStreams = deleteEmittedStreams;
                 }
 
                 public string Name
@@ -311,6 +322,11 @@ namespace EventStore.Projections.Core.Messages
                 public bool DeleteStateStream
                 {
                     get { return _deleteStateStream; }
+                }
+
+                public bool DeleteEmittedStreams
+                {
+                    get { return _deleteEmittedStreams; }
                 }
             }
 

--- a/src/EventStore.Projections.Core/Messages/SlaveProjectionDefinitions.cs
+++ b/src/EventStore.Projections.Core/Messages/SlaveProjectionDefinitions.cs
@@ -18,7 +18,7 @@ namespace EventStore.Projections.Core.Messages
         {
             public Definition(
                 string name, string handlerType, string query, SlaveProjectionRequestedNumber requestedNumber,
-                ProjectionMode mode, bool emitEnabled, bool checkpointsEnabled, bool enableRunAs,
+                ProjectionMode mode, bool emitEnabled, bool checkpointsEnabled, bool enableRunAs, bool trackEmittedStreams,
                 SerializedRunAs runAs1)
             {
                 Name = name;
@@ -28,6 +28,7 @@ namespace EventStore.Projections.Core.Messages
                 RunAs1 = runAs1;
                 EnableRunAs = enableRunAs;
                 CheckpointsEnabled = checkpointsEnabled;
+                TrackEmittedStreams = trackEmittedStreams;
                 EmitEnabled = emitEnabled;
                 Mode = mode;
             }
@@ -41,6 +42,8 @@ namespace EventStore.Projections.Core.Messages
             public bool EmitEnabled;
 
             public bool CheckpointsEnabled;
+
+            public bool TrackEmittedStreams;
 
             public bool EnableRunAs;
 

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -54,7 +54,8 @@ namespace EventStore.Projections.Core
                 outputBus,
                 queues,
                 new RealTimeProvider(),
-                projectionsStandardComponents.RunProjections);
+                projectionsStandardComponents.RunProjections,
+                ioDispatcher);
 
             SubscribeMainBus(
                 projectionsStandardComponents.MasterMainBus,

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionState.cs
@@ -16,5 +16,6 @@ namespace EventStore.Projections.Core.Services.Management
         Completed,
         Aborted,
         Faulted,
+        Deleting,
     }
 }

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/AbortedState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/AbortedState.cs
@@ -1,6 +1,6 @@
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class AbortedState : ManagedProjection.ManagedProjectionStateBase
+    class AbortedState : ManagedProjectionStateBase
     {
         public AbortedState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/AbortingState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/AbortingState.cs
@@ -2,7 +2,7 @@ using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class AbortingState : ManagedProjection.ManagedProjectionStateBase
+    class AbortingState : ManagedProjectionStateBase
     {
         public AbortingState(ManagedProjection managedProjection)
             : base(managedProjection)
@@ -12,13 +12,13 @@ namespace EventStore.Projections.Core.Services.Management.ManagedProjectionState
         protected internal override void Stopped(CoreProjectionStatusMessage.Stopped message)
         {
             _managedProjection.SetState(ManagedProjectionState.Aborted);
-            _managedProjection.StoppedOrReadyToStart();
+            _managedProjection.PrepareOrWriteStartOrLoadStopped();
         }
 
         protected internal override void Faulted(CoreProjectionStatusMessage.Faulted message)
         {
             _managedProjection.SetState(ManagedProjectionState.Aborted);
-            _managedProjection.StoppedOrReadyToStart();
+            _managedProjection.PrepareOrWriteStartOrLoadStopped();
         }
 
     }

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/CompletedState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/CompletedState.cs
@@ -1,6 +1,6 @@
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class CompletedState : ManagedProjection.ManagedProjectionStateBase
+    class CompletedState : ManagedProjectionStateBase
     {
         public CompletedState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/CreatingLoadingLoadedState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/CreatingLoadingLoadedState.cs
@@ -1,6 +1,6 @@
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class CreatingLoadingLoadedState : ManagedProjection.ManagedProjectionStateBase
+    class CreatingLoadingLoadedState : ManagedProjectionStateBase
     {
         public CreatingLoadingLoadedState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/DeletingState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/DeletingState.cs
@@ -1,0 +1,11 @@
+namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
+{
+    class DeletingState : ManagedProjectionStateBase
+    {
+        public DeletingState(ManagedProjection managedProjection)
+            : base(managedProjection)
+        {
+            managedProjection.DeleteProjectionStreams();
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/FaultedState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/FaultedState.cs
@@ -1,6 +1,6 @@
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class FaultedState : ManagedProjection.ManagedProjectionStateBase
+    class FaultedState : ManagedProjectionStateBase
     {
         public FaultedState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/LoadingStateState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/LoadingStateState.cs
@@ -2,7 +2,7 @@ using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class LoadingStateState : ManagedProjection.ManagedProjectionStateBase
+    class LoadingStateState : ManagedProjectionStateBase
     {
         public LoadingStateState(ManagedProjection managedProjection)
             : base(managedProjection)
@@ -12,13 +12,13 @@ namespace EventStore.Projections.Core.Services.Management.ManagedProjectionState
         protected internal override void Stopped(CoreProjectionStatusMessage.Stopped message)
         {
             _managedProjection.SetState(ManagedProjectionState.Stopped);
-            _managedProjection.StoppedOrReadyToStart();
+            _managedProjection.PrepareOrWriteStartOrLoadStopped();
         }
 
         protected internal override void Faulted(CoreProjectionStatusMessage.Faulted message)
         {
             SetFaulted(message.FaultedReason);
-            _managedProjection.StoppedOrReadyToStart();
+            _managedProjection.PrepareOrWriteStartOrLoadStopped();
         }
     }
 }

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/ManagedProjectionStateBase.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/ManagedProjectionStateBase.cs
@@ -1,0 +1,44 @@
+﻿using EventStore.Projections.Core.Messages;
+
+namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
+{
+    internal abstract class ManagedProjectionStateBase
+    {
+        protected readonly ManagedProjection _managedProjection;
+
+        protected ManagedProjectionStateBase(ManagedProjection managedProjection)
+        {
+            _managedProjection = managedProjection;
+        }
+
+        private void Unexpected(string message)
+        {
+            _managedProjection.Fault(message + " in " + this.GetType().Name);
+        }
+
+        protected void SetFaulted(string reason)
+        {
+            _managedProjection.Fault(reason);
+        }
+
+        protected internal virtual void Started()
+        {
+            Unexpected("Unexpected 'STARTED' message");
+        }
+
+        protected internal virtual void Stopped(CoreProjectionStatusMessage.Stopped message)
+        {
+            Unexpected("Unexpected 'STOPPED' message");
+        }
+
+        protected internal virtual void Faulted(CoreProjectionStatusMessage.Faulted message)
+        {
+            Unexpected("Unexpected 'FAULTED' message"); 
+        }
+
+        protected internal virtual void Prepared(CoreProjectionStatusMessage.Prepared message)
+        {
+            Unexpected("Unexpected 'PREPARED' message");
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/PreparedState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/PreparedState.cs
@@ -1,6 +1,6 @@
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class PreparedState : ManagedProjection.ManagedProjectionStateBase
+    class PreparedState : ManagedProjectionStateBase
     {
         public PreparedState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/PreparingState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/PreparingState.cs
@@ -2,7 +2,7 @@ using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class PreparingState : ManagedProjection.ManagedProjectionStateBase
+    class PreparingState : ManagedProjectionStateBase
     {
         public PreparingState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/RunningState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/RunningState.cs
@@ -2,7 +2,7 @@ using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class RunningState : ManagedProjection.ManagedProjectionStateBase
+    class RunningState : ManagedProjectionStateBase
     {
         public RunningState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/StartingState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/StartingState.cs
@@ -2,7 +2,7 @@ using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class StartingState : ManagedProjection.ManagedProjectionStateBase
+    class StartingState : ManagedProjectionStateBase
     {
         public StartingState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/StoppedState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/StoppedState.cs
@@ -1,6 +1,6 @@
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class StoppedState : ManagedProjection.ManagedProjectionStateBase
+    class StoppedState : ManagedProjectionStateBase
     {
         public StoppedState(ManagedProjection managedProjection)
             : base(managedProjection)

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/StoppingState.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjectionStates/StoppingState.cs
@@ -2,7 +2,7 @@ using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core.Services.Management.ManagedProjectionStates
 {
-    class StoppingState : ManagedProjection.ManagedProjectionStateBase
+    class StoppingState : ManagedProjectionStateBase
     {
         public StoppingState(ManagedProjection managedProjection)
             : base(managedProjection)
@@ -13,13 +13,13 @@ namespace EventStore.Projections.Core.Services.Management.ManagedProjectionState
         {
             _managedProjection.SetState(
                 message.Completed ? ManagedProjectionState.Completed : ManagedProjectionState.Stopped);
-            _managedProjection.StoppedOrReadyToStart();
+            _managedProjection.PrepareOrWriteStartOrLoadStopped();
         }
 
         protected internal override void Faulted(CoreProjectionStatusMessage.Faulted message)
         {
             SetFaulted(message.FaultedReason);
-            _managedProjection.StoppedOrReadyToStart();
+            _managedProjection.PrepareOrWriteStartOrLoadStopped();
         }
 
     }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionCoreResponseWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionCoreResponseWriter.cs
@@ -194,6 +194,7 @@ namespace EventStore.Projections.Core.Services.Management
                 Name = message.Name,
                 RunAs = message.RunAs,
                 CheckpointsEnabled = message.CheckpointsEnabled,
+                TrackEmittedStreams = message.TrackEmittedStreams,
                 EmitEnabled = message.EmitEnabled,
                 EnableRunAs = message.EnableRunAs,
                 Enabled = message.Enabled,
@@ -260,6 +261,7 @@ namespace EventStore.Projections.Core.Services.Management
                 RunAs = message.RunAs,
                 DeleteCheckpointStream = message.DeleteCheckpointStream,
                 DeleteStateStream = message.DeleteStateStream,
+                DeleteEmittedStreams = message.DeleteEmittedStreams,
             };
             _writer.PublishCommand("$delete", command);
         }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManagerResponseReader.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManagerResponseReader.cs
@@ -325,6 +325,7 @@ namespace EventStore.Projections.Core.Services.Management
                             commandBody.Enabled,
                             commandBody.CheckpointsEnabled,
                             commandBody.EmitEnabled,
+                            commandBody.TrackEmittedStreams,
                             commandBody.EnableRunAs));
                     break;
                 }
@@ -371,7 +372,8 @@ namespace EventStore.Projections.Core.Services.Management
                             commandBody.Name,
                             commandBody.RunAs,
                             commandBody.DeleteCheckpointStream,
-                            commandBody.DeleteStateStream));
+                            commandBody.DeleteStateStream,
+                            commandBody.DeleteEmittedStreams));
                     break;
                 }
                 default:

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
@@ -383,7 +383,7 @@ namespace EventStore.Projections.Core.Services.Processing
                         _publisher.Publish(
                             new ProjectionManagementMessage.Command.Delete(
                                 new NoopEnvelope(), channel.ManagedProjectionName,
-                                ProjectionManagementMessage.RunAs.System, true, true));
+                                ProjectionManagementMessage.RunAs.System, true, true, false));
                     }
                 }
 
@@ -502,6 +502,8 @@ namespace EventStore.Projections.Core.Services.Processing
             _partitionStateCache.Initialize();
             _projectionProcessingPhase = null;
             _checkpointManager = _projectionProcessingPhases[0].CheckpointManager;
+            var emittedStreamsTracker = _projectionProcessingPhases[0].EmittedStreamsTracker;
+            emittedStreamsTracker.Initialize();
             _checkpointManager.Initialize();
             _checkpointReader.Initialize();
             _tickPending = false;

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointReader.cs
@@ -85,7 +85,7 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             if (message.Events.Length > 0)
             {
-                var checkpoint = message.Events.Where(v => v.Event.EventType == ProjectionNamesBuilder.EventType_ProjectionCheckpoint).Select(x => x.Event).FirstOrDefault();
+                var checkpoint = message.Events.Where(v => v.Event.EventType == ProjectionEventTypes.ProjectionCheckpoint).Select(x => x.Event).FirstOrDefault();
                 if (checkpoint != null)
                 {
                     var parsed = checkpoint.Metadata.ParseCheckpointTagVersionExtraJson(_projectionVersion);

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointWriter.cs
@@ -45,7 +45,7 @@ namespace EventStore.Projections.Core.Services.Processing
             _inCheckpointWriteAttempt = 1;
             //TODO: pass correct expected version
             _checkpointEventToBePublished = new Event(
-                Guid.NewGuid(), ProjectionNamesBuilder.EventType_ProjectionCheckpoint, true,
+                Guid.NewGuid(), ProjectionEventTypes.ProjectionCheckpoint, true,
                 requestedCheckpointState == null ? null : Helper.UTF8NoBom.GetBytes(requestedCheckpointState),
                 requestedCheckpointPosition.ToJsonBytes(projectionVersion: _projectionVersion));
             PublishWriteStreamMetadataAndCheckpointEvent();

--- a/src/EventStore.Projections.Core/Services/Processing/DefaultCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/DefaultCheckpointManager.cs
@@ -87,7 +87,7 @@ namespace EventStore.Projections.Core.Services.Processing
         public override void BeginLoadPartitionStateAt(
             string statePartition, CheckpointTag requestedStateCheckpointTag, Action<PartitionState> loadCompleted)
         {
-            var stateEventType = ProjectionNamesBuilder.EventType_PartitionCheckpoint;
+            var stateEventType = ProjectionEventTypes.PartitionCheckpoint;
             var partitionCheckpointStreamName = _namingBuilder.MakePartitionCheckpointStreamName(statePartition);
             _readRequestsInProgress++;
             var requestId = _ioDispatcher.ReadBackward(

--- a/src/EventStore.Projections.Core/Services/Processing/DefaultProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/DefaultProjectionProcessingStrategy.cs
@@ -52,11 +52,12 @@ namespace EventStore.Projections.Core.Services.Processing
                 definesFold,
                 readerStrategy);
 
-
             var resultWriter = CreateFirstPhaseResultWriter(
                 checkpointManager as IEmittedEventWriter,
                 zeroCheckpointTag,
                 namingBuilder);
+
+            var emittedStreamsTracker = new EmittedStreamsTracker(ioDispatcher, _projectionConfig, namingBuilder);
 
             var firstPhase = CreateFirstProcessingPhase(
                 publisher,
@@ -69,7 +70,8 @@ namespace EventStore.Projections.Core.Services.Processing
                 zeroCheckpointTag,
                 checkpointManager,
                 readerStrategy,
-                resultWriter);
+                resultWriter,
+                emittedStreamsTracker);
 
             return CreateProjectionProcessingPhases(
                 publisher,
@@ -93,7 +95,8 @@ namespace EventStore.Projections.Core.Services.Processing
             CheckpointTag zeroCheckpointTag,
             ICoreProjectionCheckpointManager checkpointManager,
             IReaderStrategy readerStrategy,
-            IResultWriter resultWriter);
+            IResultWriter resultWriter,
+            IEmittedStreamsTracker emittedStreamsTracker);
 
         protected virtual IReaderStrategy CreateReaderStrategy(ITimeProvider timeProvider)
         {
@@ -195,12 +198,12 @@ namespace EventStore.Projections.Core.Services.Processing
             CheckpointTag zeroCheckpointTag,
             ICoreProjectionCheckpointManager checkpointManager,
             IReaderStrategy readerStrategy,
-            IResultWriter resultWriter)
+            IResultWriter resultWriter,
+            IEmittedStreamsTracker emittedStreamsTracker)
         {
             var statePartitionSelector = CreateStatePartitionSelector();
 
             var orderedPartitionProcessing = _sourceDefinition.ByStreams && _sourceDefinition.IsBiState;
-
             return new EventProcessingProjectionProcessingPhase(
                 coreProjection,
                 projectionCorrelationId,
@@ -222,7 +225,8 @@ namespace EventStore.Projections.Core.Services.Processing
                 _projectionConfig.CheckpointsEnabled,
                 this.GetStopOnEof(),
                 _sourceDefinition.IsBiState,
-                orderedPartitionProcessing: orderedPartitionProcessing);
+                orderedPartitionProcessing: orderedPartitionProcessing,
+                emittedStreamsTracker: emittedStreamsTracker);
         }
 
         protected virtual StatePartitionSelector CreateStatePartitionSelector()

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsDeleter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsDeleter.cs
@@ -1,0 +1,156 @@
+﻿using EventStore.Common.Log;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.UserManagement;
+using System;
+using System.Linq;
+
+namespace EventStore.Projections.Core.Services.Processing
+{
+    public interface IEmittedStreamsDeleter
+    {
+        void DeleteEmittedStreams(Action onEmittedStreamsDeleted);
+    }
+
+    public class EmittedStreamsDeleter : IEmittedStreamsDeleter
+    {
+        private static readonly ILogger Log = LogManager.GetLoggerFor<EmittedStreamsDeleter>();
+        private readonly IODispatcher _ioDispatcher;
+        private readonly ProjectionNamesBuilder _projectionNamesBuilder;
+        private readonly int _checkPointThreshold = 4000;
+        private int _numberOfEventsProcessed = 0;
+        private const int RetryLimit = 3;
+        private int _retryCount = RetryLimit;
+
+        public EmittedStreamsDeleter(IODispatcher ioDispatcher, ProjectionNamesBuilder projectionNamesBuilder)
+        {
+            _ioDispatcher = ioDispatcher;
+            _projectionNamesBuilder = projectionNamesBuilder;
+        }
+
+        public void DeleteEmittedStreams(Action onEmittedStreamsDeleted)
+        {
+            ReadLastCheckpoint(result =>
+            {
+                var deleteFromPosition = GetPositionToDeleteFrom(result);
+                DeleteEmittedStreamsFrom(deleteFromPosition, onEmittedStreamsDeleted);
+            });
+        }
+
+        private void ReadLastCheckpoint(Action<ClientMessage.ReadStreamEventsBackwardCompleted> onReadCompleted)
+        {
+            _ioDispatcher.ReadBackward(_projectionNamesBuilder.GetEmittedStreamsCheckpointName(), -1, 1, false, SystemAccount.Principal, onReadCompleted);
+        }
+
+        private int GetPositionToDeleteFrom(ClientMessage.ReadStreamEventsBackwardCompleted onReadCompleted)
+        {
+            int deleteFromPosition = 0;
+            if (onReadCompleted.Result == ReadStreamResult.Success)
+            {
+                if (onReadCompleted.Events.Length > 0)
+                {
+                    var checkpoint = onReadCompleted.Events.Where(v => v.Event.EventType == ProjectionEventTypes.ProjectionCheckpoint).Select(x => x.Event).FirstOrDefault();
+                    if (checkpoint != null)
+                    {
+                        deleteFromPosition = checkpoint.Data.ParseJson<int>();
+                    }
+                }
+            }
+            return deleteFromPosition;
+        }
+
+        private void DeleteEmittedStreamsFrom(int fromPosition, Action onEmittedStreamsDeleted)
+        {
+            _ioDispatcher.ReadForward(_projectionNamesBuilder.GetEmittedStreamsName(), fromPosition, 1, false, SystemAccount.Principal, x => ReadCompleted(x, onEmittedStreamsDeleted));
+        }
+
+        private void ReadCompleted(ClientMessage.ReadStreamEventsForwardCompleted onReadCompleted, Action onEmittedStreamsDeleted)
+        {
+            if (onReadCompleted.Result == ReadStreamResult.Success ||
+                onReadCompleted.Result == ReadStreamResult.NoStream)
+            {
+                if (onReadCompleted.Events.Length == 0 && !onReadCompleted.IsEndOfStream)
+                {
+                    DeleteEmittedStreamsFrom(onReadCompleted.NextEventNumber, onEmittedStreamsDeleted);
+                    return;
+                }
+                if (onReadCompleted.Events.Length == 0)
+                {
+                    _ioDispatcher.DeleteStream(_projectionNamesBuilder.GetEmittedStreamsCheckpointName(), ExpectedVersion.Any, false, SystemAccount.Principal, x =>
+                    {
+                        if (x.Result == OperationResult.Success || x.Result == OperationResult.StreamDeleted)
+                        {
+                            Log.Info("PROJECTIONS: Projection Stream '{0}' deleted", _projectionNamesBuilder.GetEmittedStreamsCheckpointName());
+                        }
+                        else
+                        {
+                            Log.Error("PROJECTIONS: Failed to delete projection stream '{0}'. Reason: {1}", _projectionNamesBuilder.GetEmittedStreamsCheckpointName(), x.Result);
+                        }
+                        _ioDispatcher.DeleteStream(_projectionNamesBuilder.GetEmittedStreamsName(), ExpectedVersion.Any, false, SystemAccount.Principal, y =>
+                        {
+                            if (y.Result == OperationResult.Success || y.Result == OperationResult.StreamDeleted)
+                            {
+                                Log.Info("PROJECTIONS: Projection Stream '{0}' deleted", _projectionNamesBuilder.GetEmittedStreamsName());
+                            }
+                            else
+                            {
+                                Log.Error("PROJECTIONS: Failed to delete projection stream '{0}'. Reason: {1}", _projectionNamesBuilder.GetEmittedStreamsName(), y.Result);
+                            }
+                            onEmittedStreamsDeleted();
+                        });
+                    });
+                }
+                else
+                {
+                    var streamId = Helper.UTF8NoBom.GetString(onReadCompleted.Events[0].Event.Data);
+                    _ioDispatcher.DeleteStream(streamId, ExpectedVersion.Any, false, SystemAccount.Principal, x => DeleteStreamCompleted(x, onEmittedStreamsDeleted, streamId, onReadCompleted.Events[0].OriginalEventNumber));
+                }
+            }
+        }
+
+        private void DeleteStreamCompleted(ClientMessage.DeleteStreamCompleted deleteStreamCompleted, Action onEmittedStreamsDeleted, string streamId, int eventNumber)
+        {
+            if (deleteStreamCompleted.Result == OperationResult.Success || deleteStreamCompleted.Result == OperationResult.StreamDeleted)
+            {
+                _retryCount = RetryLimit;
+                _numberOfEventsProcessed++;
+                if (_numberOfEventsProcessed >= _checkPointThreshold)
+                {
+                    _numberOfEventsProcessed = 0;
+                    TryMarkCheckpoint(eventNumber);
+                }
+                DeleteEmittedStreamsFrom(eventNumber + 1, onEmittedStreamsDeleted);
+            }
+            else
+            {
+                if (_retryCount == 0)
+                {
+                    Log.Error("PROJECTIONS: Retry limit reached, could not delete stream: {0}. Manual intervention is required and you may need to delete this stream manually", streamId);
+                    _retryCount = RetryLimit;
+                    DeleteEmittedStreamsFrom(eventNumber + 1, onEmittedStreamsDeleted);
+                    return;
+                }
+                Log.Error("PROJECTIONS: Failed to delete emitted stream {0}, Retrying ({1}/{2}). Reason: {3}", streamId, (RetryLimit - _retryCount) + 1, RetryLimit, deleteStreamCompleted.Result);
+                _retryCount--;
+                DeleteEmittedStreamsFrom(eventNumber, onEmittedStreamsDeleted);
+            }
+        }
+
+        private void TryMarkCheckpoint(int eventNumber)
+        {
+            _ioDispatcher.WriteEvent(_projectionNamesBuilder.GetEmittedStreamsCheckpointName(), ExpectedVersion.Any, new Event(Guid.NewGuid(), "$Checkpoint", true, eventNumber.ToJson(), null), SystemAccount.Principal, x =>
+            {
+                if (x.Result == OperationResult.Success)
+                {
+                    Log.Debug("PROJECTIONS: Emitted Stream Deletion Checkpoint written at {0}", eventNumber);
+                }
+                else
+                {
+                    Log.Debug("PROJECTIONS: Emitted Stream Deletion Checkpoint Failed to be written at {0}", eventNumber);
+                }
+            });
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsTracker.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsTracker.cs
@@ -1,0 +1,102 @@
+﻿using EventStore.Common.Log;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Core.Settings;
+using System;
+
+namespace EventStore.Projections.Core.Services.Processing
+{
+    public interface IEmittedStreamsTracker
+    {
+        void TrackEmittedStream(EmittedEvent[] emittedEvents);
+        void Initialize();
+    }
+
+    public class EmittedStreamsTracker : IEmittedStreamsTracker
+    {
+        private static readonly ILogger Log = LogManager.GetLoggerFor<EmittedStreamsTracker>();
+        private readonly IODispatcher _ioDispatcher;
+        private readonly ProjectionConfig _projectionConfig;
+        private readonly ProjectionNamesBuilder _projectionNamesBuilder;
+        private readonly BoundedCache<string, string> _streamIdCache = new BoundedCache<string, string>(int.MaxValue, ESConsts.CommitedEventsMemCacheLimit, x => 16 + 4 + IntPtr.Size + 2 * x.Length);
+        private const int MaxRetryCount = 3;
+        private readonly object _locker = new object();
+
+        public EmittedStreamsTracker(IODispatcher ioDispatcher, ProjectionConfig projectionConfig, ProjectionNamesBuilder projectionNamesBuilder)
+        {
+            _ioDispatcher = ioDispatcher;
+            _projectionConfig = projectionConfig;
+            _projectionNamesBuilder = projectionNamesBuilder;
+        }
+
+        public void Initialize()
+        {
+            ReadEmittedStreamStreamIdsIntoCache(0); //start from the beginning
+        }
+
+        private void ReadEmittedStreamStreamIdsIntoCache(int position)
+        {
+            _ioDispatcher.ReadForward(_projectionNamesBuilder.GetEmittedStreamsName(), position, 1, false, SystemAccount.Principal, x =>
+            {
+                if (x.Events.Length > 0)
+                {
+                    for (int i = 0; i < x.Events.Length; i++)
+                    {
+                        var streamId = Helper.UTF8NoBom.GetString(x.Events[i].Event.Data);
+                        lock (_locker)
+                        {
+                            _streamIdCache.PutRecord(streamId, streamId, false);
+                        }
+                    }
+                }
+                if (!x.IsEndOfStream)
+                {
+                    ReadEmittedStreamStreamIdsIntoCache(x.NextEventNumber);
+                }
+            });
+        }
+
+        public void TrackEmittedStream(EmittedEvent[] emittedEvents)
+        {
+            if (!_projectionConfig.TrackEmittedStreams) return;
+            foreach (var emittedEvent in emittedEvents)
+            {
+                string streamId;
+                if (!_streamIdCache.TryGetRecord(emittedEvent.StreamId, out streamId))
+                {
+                    var trackEvent = new Event(Guid.NewGuid(), ProjectionEventTypes.StreamTracked, false, Helper.UTF8NoBom.GetBytes(emittedEvent.StreamId), null);
+                    lock (_locker)
+                    {
+                        _streamIdCache.PutRecord(emittedEvent.StreamId, emittedEvent.StreamId, false);
+                    }
+                    WriteEvent(trackEvent, MaxRetryCount);
+                }
+            }
+        }
+
+        private void WriteEvent(Event evnt, int retryCount)
+        {
+            _ioDispatcher.WriteEvent(_projectionNamesBuilder.GetEmittedStreamsName(), ExpectedVersion.Any, evnt, SystemAccount.Principal, x => OnWriteComplete(x, evnt, Helper.UTF8NoBom.GetString(evnt.Data), retryCount));
+        }
+
+        private void OnWriteComplete(ClientMessage.WriteEventsCompleted completed, Event evnt, string streamId, int retryCount)
+        {
+            if (completed.Result != OperationResult.Success)
+            {
+                if (retryCount > 0)
+                {
+                    Log.Error("PROJECTIONS: Failed to write a tracked stream id of {0} to the {1} stream. Retrying {2}/{3}. Reason: {4}", streamId, _projectionNamesBuilder.GetEmittedStreamsName(), (MaxRetryCount - retryCount) + 1, MaxRetryCount, completed.Result);
+                    WriteEvent(evnt, retryCount - 1);
+                }
+                else
+                {
+                    Log.Error("PROJECTIONS: Failed to write a tracked stream id of {0} to the {1} stream. Retry limit of {2} reached. Reason: {3}", streamId, _projectionNamesBuilder.GetEmittedStreamsName(), MaxRetryCount, completed.Result);
+                }
+            }
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/EventProcessingProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventProcessingProjectionProcessingPhase.cs
@@ -45,7 +45,8 @@ namespace EventStore.Projections.Core.Services.Processing
             bool useCheckpoints,
             bool stopOnEof,
             bool isBiState,
-            bool orderedPartitionProcessing)
+            bool orderedPartitionProcessing,
+            IEmittedStreamsTracker emittedStreamsTracker)
             : base(
                 publisher,
                 inputQueue,
@@ -64,7 +65,8 @@ namespace EventStore.Projections.Core.Services.Processing
                 useCheckpoints,
                 stopOnEof,
                 orderedPartitionProcessing,
-                isBiState)
+                isBiState,
+                emittedStreamsTracker)
         {
 
             _projectionStateHandler = projectionStateHandler;

--- a/src/EventStore.Projections.Core/Services/Processing/IProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/IProjectionProcessingPhase.cs
@@ -36,6 +36,6 @@ namespace EventStore.Projections.Core.Services.Processing
 
         CheckpointTag MakeZeroCheckpointTag();
         ICoreProjectionCheckpointManager CheckpointManager { get; }
-
+        IEmittedStreamsTracker EmittedStreamsTracker { get; }
     }
 }

--- a/src/EventStore.Projections.Core/Services/Processing/ParallelQueryMasterProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ParallelQueryMasterProjectionProcessingPhase.cs
@@ -42,7 +42,8 @@ namespace EventStore.Projections.Core.Services.Processing
             IResultWriter resultWriter,
             bool checkpointsEnabled,
             bool stopOnEof,
-            SpooledStreamReadingDispatcher spoolProcessingResponseDispatcher)
+            SpooledStreamReadingDispatcher spoolProcessingResponseDispatcher,
+            IEmittedStreamsTracker emittedStreamsTracker)
             : base(
                 publisher,
                 inputQueue,
@@ -61,7 +62,8 @@ namespace EventStore.Projections.Core.Services.Processing
                 checkpointsEnabled,
                 stopOnEof,
                 orderedPartitionProcessing: true,
-                isBiState: false)
+                isBiState: false,
+                emittedStreamsTracker: emittedStreamsTracker)
         {
             _stateHandler = stateHandler;
             _spoolProcessingResponseDispatcher = spoolProcessingResponseDispatcher;

--- a/src/EventStore.Projections.Core/Services/Processing/ParallelQueryProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ParallelQueryProcessingStrategy.cs
@@ -102,7 +102,8 @@ namespace EventStore.Projections.Core.Services.Processing
                 coreProjection,
                 partitionStateCache,
                 checkpointManager2,
-                checkpointManager2);
+                checkpointManager2,
+                firstPhase.EmittedStreamsTracker);
 
             return new[] {firstPhase, writeResultsPhase};
         }
@@ -132,7 +133,8 @@ namespace EventStore.Projections.Core.Services.Processing
             CheckpointTag zeroCheckpointTag,
             ICoreProjectionCheckpointManager checkpointManager,
             IReaderStrategy readerStrategy,
-            IResultWriter resultWriter)
+            IResultWriter resultWriter,
+            IEmittedStreamsTracker emittedStreamsTracker)
         {
             return new ParallelQueryMasterProjectionProcessingPhase(
                 coreProjection,
@@ -152,7 +154,8 @@ namespace EventStore.Projections.Core.Services.Processing
                 resultWriter,
                 _projectionConfig.CheckpointsEnabled,
                 this.GetStopOnEof(),
-                _spoolProcessingResponseDispatcher);
+                _spoolProcessingResponseDispatcher,
+                emittedStreamsTracker);
         }
 
         public override bool GetStopOnEof()
@@ -191,7 +194,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     new SlaveProjectionDefinitions.Definition(
                         "slave", _handlerType, _query,
                         SlaveProjectionDefinitions.SlaveProjectionRequestedNumber.OnePerThread, ProjectionMode.Transient,
-                        _projectionConfig.EmitEventEnabled, _projectionConfig.CheckpointsEnabled,
+                        _projectionConfig.EmitEventEnabled, _projectionConfig.CheckpointsEnabled, trackEmittedStreams: _projectionConfig.TrackEmittedStreams,
                         runAs1: new ProjectionManagementMessage.RunAs(_projectionConfig.RunAs), enableRunAs: true));
         }
     }

--- a/src/EventStore.Projections.Core/Services/Processing/PartitionStateUpdateManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/PartitionStateUpdateManager.cs
@@ -52,7 +52,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     list.Add(
                         new EmittedEventEnvelope(
                             new EmittedDataEvent(
-                                streamId, Guid.NewGuid(), ProjectionNamesBuilder.EventType_PartitionCheckpoint, true,
+                                streamId, Guid.NewGuid(), ProjectionEventTypes.PartitionCheckpoint, true,
                                 data, null, causedBy, expectedTag), _partitionCheckpointStreamMetadata));
                 }
                 //NOTE: order yb is required to satisfy internal emit events validation

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionNamesBuilder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionNamesBuilder.cs
@@ -14,9 +14,6 @@ namespace EventStore.Projections.Core.Services.Processing
             public const string EventByTypeStandardProjection = "$by_event_type";
         }
 
-        public const string EventType_ProjectionCheckpoint = "$ProjectionCheckpoint";
-        public const string EventType_PartitionCheckpoint = "$Checkpoint";
-
         public static ProjectionNamesBuilder CreateForTest(string name)
         {
             return new ProjectionNamesBuilder(name);
@@ -28,6 +25,8 @@ namespace EventStore.Projections.Core.Services.Processing
         private readonly string _partitionCatalogStreamName;
         private readonly string _checkpointStreamName;
         private readonly string _orderStreamName;
+        private readonly string _emittedStreamsName;
+        private readonly string _emittedStreamsCheckpointName;
 
         public static TimeSpan MasterStreamMaxAge = TimeSpan.FromHours(2);
         public static TimeSpan ControlStreamMaxAge = TimeSpan.FromHours(2);
@@ -50,6 +49,8 @@ namespace EventStore.Projections.Core.Services.Processing
                                           + ProjectionPartitionCatalogStreamSuffix;
             _checkpointStreamName = ProjectionsStreamPrefix + EffectiveProjectionName + ProjectionCheckpointStreamSuffix;
             _orderStreamName = ProjectionsStreamPrefix + EffectiveProjectionName + ProjectionOrderStreamSuffix;
+            _emittedStreamsName = ProjectionsStreamPrefix + EffectiveProjectionName + ProjectionEmittedStreamSuffix;
+            _emittedStreamsCheckpointName = ProjectionsStreamPrefix + EffectiveProjectionName + ProjectionEmittedStreamSuffix + ProjectionCheckpointStreamSuffix;
         }
 
         public string EffectiveProjectionName
@@ -78,6 +79,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private const string ProjectionsControlStreamPrefix = "$projections-$";
         private const string ProjectionsStateStreamSuffix = "-result";
         private const string ProjectionCheckpointStreamSuffix = "-checkpoint";
+        private const string ProjectionEmittedStreamSuffix = "-emittedstreams";
         private const string ProjectionOrderStreamSuffix = "-order";
         private const string ProjectionPartitionCatalogStreamSuffix = "-partitions";
         private const string CategoryCatalogStreamNamePrefix = "$category-";
@@ -114,6 +116,16 @@ namespace EventStore.Projections.Core.Services.Processing
         public string MakeCheckpointStreamName()
         {
             return _checkpointStreamName;
+        }
+
+        public string GetEmittedStreamsName()
+        {
+            return _emittedStreamsName;
+        }
+
+        public string GetEmittedStreamsCheckpointName()
+        {
+            return _emittedStreamsCheckpointName;
         }
 
         public string GetOrderStreamName()

--- a/src/EventStore.Projections.Core/Services/Processing/QueryProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/QueryProcessingStrategy.cs
@@ -68,7 +68,8 @@ namespace EventStore.Projections.Core.Services.Processing
                     coreProjection,
                     partitionStateCache,
                     checkpointManager2,
-                    checkpointManager2);
+                    checkpointManager2,
+                    firstPhase.EmittedStreamsTracker);
             else
                 writeResultsPhase = new WriteQueryResultProjectionProcessingPhase(
                     publisher,
@@ -77,7 +78,8 @@ namespace EventStore.Projections.Core.Services.Processing
                     coreProjection,
                     partitionStateCache,
                     checkpointManager2,
-                    checkpointManager2);
+                    checkpointManager2,
+                    firstPhase.EmittedStreamsTracker);
 
             return new[] {firstPhase, writeResultsPhase};
         }

--- a/src/EventStore.Projections.Core/Services/Processing/WriteQueryEofProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/WriteQueryEofProjectionProcessingPhase.cs
@@ -12,8 +12,9 @@ namespace EventStore.Projections.Core.Services.Processing
             ICoreProjectionForProcessingPhase coreProjection,
             PartitionStateCache stateCache,
             ICoreProjectionCheckpointManager checkpointManager,
-            IEmittedEventWriter emittedEventWriter)
-            : base(publisher, phase, resultStream, coreProjection, stateCache, checkpointManager, emittedEventWriter)
+            IEmittedEventWriter emittedEventWriter,
+            IEmittedStreamsTracker emittedStreamsTracker)
+            : base(publisher, phase, resultStream, coreProjection, stateCache, checkpointManager, emittedEventWriter, emittedStreamsTracker)
         {
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/WriteQueryResultProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/WriteQueryResultProjectionProcessingPhase.cs
@@ -14,8 +14,9 @@ namespace EventStore.Projections.Core.Services.Processing
             ICoreProjectionForProcessingPhase coreProjection,
             PartitionStateCache stateCache,
             ICoreProjectionCheckpointManager checkpointManager,
-            IEmittedEventWriter emittedEventWriter)
-            : base(publisher, phase, resultStream, coreProjection, stateCache, checkpointManager, emittedEventWriter)
+            IEmittedEventWriter emittedEventWriter,
+            IEmittedStreamsTracker emittedStreamsTracker)
+            : base(publisher, phase, resultStream, coreProjection, stateCache, checkpointManager, emittedEventWriter, emittedStreamsTracker)
         {
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/WriteQueryResultProjectionProcessingPhaseBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/WriteQueryResultProjectionProcessingPhaseBase.cs
@@ -15,6 +15,7 @@ namespace EventStore.Projections.Core.Services.Processing
         protected readonly PartitionStateCache _stateCache;
         protected readonly ICoreProjectionCheckpointManager _checkpointManager;
         protected readonly IEmittedEventWriter _emittedEventWriter;
+        protected readonly IEmittedStreamsTracker _emittedStreamsTracker;
         private bool _subscribed;
         private PhaseState _projectionState;
 
@@ -25,13 +26,15 @@ namespace EventStore.Projections.Core.Services.Processing
             ICoreProjectionForProcessingPhase coreProjection,
             PartitionStateCache stateCache,
             ICoreProjectionCheckpointManager checkpointManager,
-            IEmittedEventWriter emittedEventWriter)
+            IEmittedEventWriter emittedEventWriter,
+            IEmittedStreamsTracker emittedStreamsTracker)
         {
             if (resultStream == null) throw new ArgumentNullException("resultStream");
             if (coreProjection == null) throw new ArgumentNullException("coreProjection");
             if (stateCache == null) throw new ArgumentNullException("stateCache");
             if (checkpointManager == null) throw new ArgumentNullException("checkpointManager");
             if (emittedEventWriter == null) throw new ArgumentNullException("emittedEventWriter");
+            if (emittedStreamsTracker == null) throw new ArgumentNullException("emittedStreamsTracker");
             if (string.IsNullOrEmpty(resultStream)) throw new ArgumentException("resultStream");
 
             _publisher = publisher;
@@ -41,11 +44,17 @@ namespace EventStore.Projections.Core.Services.Processing
             _stateCache = stateCache;
             _checkpointManager = checkpointManager;
             _emittedEventWriter = emittedEventWriter;
+            _emittedStreamsTracker = emittedStreamsTracker;
         }
 
         public ICoreProjectionCheckpointManager CheckpointManager
         {
             get { return _checkpointManager; }
+        }
+
+        public IEmittedStreamsTracker EmittedStreamsTracker
+        {
+            get { return _emittedStreamsTracker; }
         }
 
         public void Dispose()

--- a/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
@@ -15,10 +15,11 @@ namespace EventStore.Projections.Core.Services
         private readonly bool _createTempStreams;
         private readonly bool _stopOnEof;
         private readonly bool _isSlaveProjection;
+        private readonly bool _trackEmittedStreams;
 
         public ProjectionConfig(IPrincipal runAs, int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold,
             int pendingEventsThreshold, int maxWriteBatchLength, bool emitEventEnabled, bool checkpointsEnabled,
-            bool createTempStreams, bool stopOnEof, bool isSlaveProjection)
+            bool createTempStreams, bool stopOnEof, bool isSlaveProjection, bool trackEmittedStreams)
         {
             if (checkpointsEnabled)
             {
@@ -44,6 +45,7 @@ namespace EventStore.Projections.Core.Services
             _createTempStreams = createTempStreams;
             _stopOnEof = stopOnEof;
             _isSlaveProjection = isSlaveProjection;
+            _trackEmittedStreams = trackEmittedStreams;
         }
 
         public int CheckpointHandledThreshold
@@ -96,16 +98,21 @@ namespace EventStore.Projections.Core.Services
             get { return _isSlaveProjection; }
         }
 
+        public bool TrackEmittedStreams
+        {
+            get { return _trackEmittedStreams; }
+        }
+
         public static ProjectionConfig GetTest()
         {
-            return new ProjectionConfig(null, 1000, 1000*1000, 100, 500, true, true, false, false, false);
+            return new ProjectionConfig(null, 1000, 1000*1000, 100, 500, true, true, false, false, false, true);
         }
 
         public ProjectionConfig SetIsSlave()
         {
             return new ProjectionConfig(
                 _runAs, CheckpointHandledThreshold, CheckpointUnhandledBytesThreshold, PendingEventsThreshold,
-                MaxWriteBatchLength, EmitEventEnabled, _checkpointsEnabled, CreateTempStreams, StopOnEof, true);
+                MaxWriteBatchLength, EmitEventEnabled, _checkpointsEnabled, CreateTempStreams, StopOnEof, true, true);
         }
     }
 }

--- a/src/EventStore.Projections.Core/Services/ProjectionStatistics.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionStatistics.cs
@@ -1,5 +1,4 @@
 using EventStore.Projections.Core.Services.Management;
-using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Services
 {

--- a/src/EventStore.Projections.Core/Services/SystemNames.cs
+++ b/src/EventStore.Projections.Core/Services/SystemNames.cs
@@ -1,0 +1,9 @@
+﻿namespace EventStore.Projections.Core.Services
+{
+    public static class ProjectionEventTypes
+    {
+        public const string ProjectionCheckpoint = "$ProjectionCheckpoint";
+        public const string PartitionCheckpoint = "$Checkpoint";
+        public const string StreamTracked = "$StreamTracked";
+    }
+}

--- a/src/EventStore.Projections.Core/Standard/IndexEventsByEventType.cs
+++ b/src/EventStore.Projections.Core/Standard/IndexEventsByEventType.cs
@@ -118,7 +118,7 @@ namespace EventStore.Projections.Core.Standard
             {
                 new EmittedEventEnvelope(
                     new EmittedDataEvent(
-                        _indexCheckpointStream, Guid.NewGuid(), ProjectionNamesBuilder.EventType_PartitionCheckpoint,
+                        _indexCheckpointStream, Guid.NewGuid(), ProjectionEventTypes.PartitionCheckpoint,
                         true, checkpointPosition.ToJsonString(), null, checkpointPosition, expectedTag: null))
             };
         }


### PR DESCRIPTION
Fixes #968 
The emitted streams can be tracked if the user indicates that he/she wants
to do so. This is an additional parameter that can be passed when creating a projection.

The user also has the ability to indicate that he/she wants to delete the emitted streams of a projection if it has been tracked. This is an additional parameter that can be passed when deleting a projection.

For the above to work correctly (especially if the user creates another projection that emits to the previously deleted emitted streams), the `EmittedStream` needed to have it's logic adjusted for establishing whether an emitted stream is a new physical stream or not. Previously this was done by checking against the number of events in the read result. It has been adjusted to check whether the `LastEventNumber` of the read result is -1 (NoStream)

The ManagedProjection has also been reviewed and cleaned up as part of
this exercise.

The Projection Event Types have also extracted and moved into it's own class in a class called `ProjectionEventTypes`