### PR TITLE
Use external or advertised http ip address for links returned over http

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
                 var httpAuthenticationProviders = new HttpAuthenticationProvider[] {new AnonymousHttpAuthenticationProvider()};
 
                 _service = new HttpService(ServiceAccessibility.Private, _bus, new NaiveUriRouter(),
-                                           _multiQueuedHandler, false, null, 0, _serverEndPoint.ToHttpUrl());
+                                           _multiQueuedHandler, false, _serverEndPoint, _serverEndPoint.ToHttpUrl());
                 HttpService.CreateAndSubscribePipeline(pipelineBus, httpAuthenticationProviders);
                 _client = new HttpAsyncClient(_timeout);
             }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/build_requested_url_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/build_requested_url_should.cs
@@ -16,39 +16,19 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         {
             var requestedUri =
                 HttpEntity.BuildRequestedUrl(inputUri,
-                                             new NameValueCollection(), null, 0);
+                                             new NameValueCollection(), null);
 
             Assert.AreEqual(inputUri, requestedUri);
         }
 
         [Test]
-        public void with_advertise_http_port_set_only_port_is_changed()
+        public void with_external_http_endpoint_set_external_http_is_used()
         {
             var requestedUri =
                 HttpEntity.BuildRequestedUrl(inputUri,
-                                             new NameValueCollection(), null, 2116);
+                                             new NameValueCollection(), new IPEndPoint(IPAddress.Parse("192.168.1.13"), 2117));
 
-            Assert.AreEqual(new Uri("http://www.example.com:2116/path/?key=value#anchor"), requestedUri);
-        }
-
-        [Test]
-        public void with_advertise_ip_set_only_host_is_changed()
-        {
-            var requestedUri =
-                HttpEntity.BuildRequestedUrl(inputUri,
-                                             new NameValueCollection(), IPAddress.Parse("192.168.1.13"), 0);
-
-            Assert.AreEqual(new Uri("http://192.168.1.13:1234/path/?key=value#anchor"), requestedUri);
-        }
-
-        [Test]
-        public void with_advertise_ip_and_http_port_set_both_host_and_port_is_changed()
-        {
-            var requestedUri =
-                HttpEntity.BuildRequestedUrl(inputUri,
-                                             new NameValueCollection(), IPAddress.Parse("192.168.1.13"), 2116);
-
-            Assert.AreEqual(new Uri("http://192.168.1.13:2116/path/?key=value#anchor"), requestedUri);
+            Assert.AreEqual(new Uri("http://192.168.1.13:2117/path/?key=value#anchor"), requestedUri);
         }
 
         [Test]
@@ -56,7 +36,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         {
             var headers = new NameValueCollection { { "X-Forwarded-Port", "4321" } };
             var requestedUri =
-                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null);
 
             Assert.AreEqual(new Uri("http://www.example.com:4321/path/?key=value#anchor"), requestedUri);
         }
@@ -66,7 +46,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         {
             var headers = new NameValueCollection { { "X-Forwarded-Port", "abc" } };
             var requestedUri =
-                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null);
 
             Assert.AreEqual(inputUri, requestedUri);
         }
@@ -76,7 +56,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         {
             var headers = new NameValueCollection { { "X-Forwarded-Proto", "https" } };
             var requestedUri =
-                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null);
 
             Assert.AreEqual(new Uri("https://www.example.com:1234/path/?key=value#anchor"), requestedUri);
         }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
@@ -139,7 +140,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
             var multiQueuedHandler = new MultiQueuedHandler(new IQueuedHandler[]{queue}, null);
             var providers = new HttpAuthenticationProvider[] {new AnonymousHttpAuthenticationProvider()};
             var httpService = new HttpService(ServiceAccessibility.Public, inputBus,
-                                              new TrieUriRouter(), multiQueuedHandler, false, null, 0, "http://localhost:12345/");
+                                              new TrieUriRouter(), multiQueuedHandler, false, new IPEndPoint(IPAddress.Loopback, 12345), "http://localhost:12345/");
             HttpService.CreateAndSubscribePipeline(bus, providers);
 
             var fakeController = new FakeController(iterations, null);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -308,8 +308,8 @@ namespace EventStore.Core
 
             // EXTERNAL HTTP
             _externalHttpService = new HttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
-                                                    _workersHandler, vNodeSettings.LogHttpRequests, vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalIPAs, 
-                                                    vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalHttpPortAs, vNodeSettings.ExtHttpPrefixes);
+                                                    _workersHandler, vNodeSettings.LogHttpRequests, 
+                                                    vNodeSettings.GossipAdvertiseInfo.ExternalHttp, vNodeSettings.ExtHttpPrefixes);
             _externalHttpService.SetupController(persistentSubscriptionController);
             if(vNodeSettings.AdminOnPublic)
                 _externalHttpService.SetupController(adminController);
@@ -328,8 +328,8 @@ namespace EventStore.Core
             // INTERNAL HTTP
             if(!isSingleNode) {
                 _internalHttpService = new HttpService(ServiceAccessibility.Private, _mainQueue, new TrieUriRouter(),
-                                                       _workersHandler, vNodeSettings.LogHttpRequests, vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalIPAs, 
-                                                       vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalHttpPortAs, vNodeSettings.IntHttpPrefixes);
+                                                       _workersHandler, vNodeSettings.LogHttpRequests,
+                                                       vNodeSettings.GossipAdvertiseInfo.ExternalHttp, vNodeSettings.IntHttpPrefixes);
                 _internalHttpService.SetupController(adminController);
                 _internalHttpService.SetupController(pingController);
                 _internalHttpService.SetupController(infoController);

--- a/src/EventStore.Core/Services/Transport/Http/HttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/HttpService.cs
@@ -34,11 +34,10 @@ namespace EventStore.Core.Services.Transport.Http
         private readonly HttpAsyncServer _server;
         private readonly MultiQueuedHandler _requestsMultiHandler;
 
-        private IPAddress _advertiseAsAddress;
-        private int _advertiseAsPort;
+        private readonly IPEndPoint _externalHttpEndPoint;
 
         public HttpService(ServiceAccessibility accessibility, IPublisher inputBus, IUriRouter uriRouter,
-                           MultiQueuedHandler multiQueuedHandler, bool logHttpRequests, IPAddress advertiseAsAddress, int advertiseAsPort, params string[] prefixes)
+                           MultiQueuedHandler multiQueuedHandler, bool logHttpRequests, IPEndPoint externalHttpEndPoint, params string[] prefixes)
         {
             Ensure.NotNull(inputBus, "inputBus");
             Ensure.NotNull(uriRouter, "uriRouter");
@@ -55,8 +54,7 @@ namespace EventStore.Core.Services.Transport.Http
             _server = new HttpAsyncServer(prefixes);
             _server.RequestReceived += RequestReceived;
 
-            _advertiseAsAddress = advertiseAsAddress;
-            _advertiseAsPort = advertiseAsPort;
+            _externalHttpEndPoint = externalHttpEndPoint;
         }
 
         public static void CreateAndSubscribePipeline(IBus bus, HttpAuthenticationProvider[] httpAuthenticationProviders)
@@ -101,7 +99,7 @@ namespace EventStore.Core.Services.Transport.Http
 
         private void RequestReceived(HttpAsyncServer sender, HttpListenerContext context)
         {
-            var entity = new HttpEntity(context.Request, context.Response, context.User, _logHttpRequests, _advertiseAsAddress, _advertiseAsPort);
+            var entity = new HttpEntity(context.Request, context.Response, context.User, _logHttpRequests, _externalHttpEndPoint);
             _requestsMultiHandler.Handle(new IncomingHttpRequestMessage(this, entity, _requestsMultiHandler));
         }
 

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntity.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntity.cs
@@ -16,31 +16,28 @@ namespace EventStore.Transport.Http.EntityManagement
         internal readonly HttpListenerResponse Response;
         public readonly IPrincipal User;
 
-        public HttpEntity(HttpListenerRequest request, HttpListenerResponse response, IPrincipal user, bool logHttpRequests, IPAddress advertiseAsAddress, int advertiseAsPort)
+        public HttpEntity(HttpListenerRequest request, HttpListenerResponse response, IPrincipal user, bool logHttpRequests, IPEndPoint externalHttpEndPoint)
         {
             Ensure.NotNull(request, "request");
             Ensure.NotNull(response, "response");
 
             _logHttpRequests = logHttpRequests;
-            RequestedUrl = BuildRequestedUrl(request.Url, request.Headers, advertiseAsAddress, advertiseAsPort);
+            RequestedUrl = BuildRequestedUrl(request.Url, request.Headers, externalHttpEndPoint);
             Request = request;
             Response = response;
             User = user;
         }
 
-        public static Uri BuildRequestedUrl(Uri requestUrl, NameValueCollection requestHeaders, IPAddress advertiseAsAddress, int advertiseAsPort)
+        public static Uri BuildRequestedUrl(Uri requestUrl, NameValueCollection requestHeaders, IPEndPoint externalHttpEndPoint)
         {
             var uriBuilder = new UriBuilder(requestUrl);
 
-            if(advertiseAsAddress != null)
+            if(externalHttpEndPoint != null)
             {
-                uriBuilder.Host = advertiseAsAddress.ToString();
+                uriBuilder.Host = externalHttpEndPoint.Address.ToString();
+                uriBuilder.Port = externalHttpEndPoint.Port;
             }
-            if(advertiseAsPort > 0)
-            {
-                uriBuilder.Port = advertiseAsPort;
-            }
-
+            
             var forwardedPortHeaderValue = requestHeaders[ProxyHeaders.XForwardedPort];
 
             if (!string.IsNullOrEmpty(forwardedPortHeaderValue))


### PR DESCRIPTION
Fixes #969 

Previously the links returned by queries to the streams, users or projections were built up either from the advertised address or from the url that the request came through. This meant that requests that were forwarded between nodes over internal http would return links based on the internal http address.

This pull request changes the `BuildRequestedUrl` method so that these links are always built using the external http address (which will be set to the advertised address if it is being used), regardless of the url the request came over.