### PR TITLE
Fix kramdown parsing issues

### DIFF
--- a/etc/EventStore.Documentation/DocumentGenerator.cs
+++ b/etc/EventStore.Documentation/DocumentGenerator.cs
@@ -38,7 +38,7 @@ namespace EventStore.Documentation
                             if (currentGroup != property.Attr<ArgDescriptionAttribute>().Group)
                             {
                                 currentGroup = property.Attr<ArgDescriptionAttribute>().Group;
-                                optionDocumentation += String.Format("{0}###{1}{0}", Environment.NewLine, currentGroup);
+                                optionDocumentation += String.Format("{0}### {1}{0}{0}", Environment.NewLine, currentGroup);
                                 optionDocumentation += String.Format("| Parameter | Environment *(all prefixed with EVENTSTORE_)* | Yaml | Description |{0}", Environment.NewLine);
                                 optionDocumentation += String.Format("| --------- | --------------------------------------------- | ---- | ----------- |{0}", Environment.NewLine);
                             }


### PR DESCRIPTION
Update docs generator to generate the command line arguments tables with correct spacing for kramdown.

Related to the kramdown issues mentioned in this PR https://github.com/EventStore/docs.geteventstore.com/pull/176