### PR TITLE
[WIP] Better queues

### DIFF
--- a/src/EventStore.Core/Bus/MultiProducerSinglerConsumerConcurrentQueue.cs
+++ b/src/EventStore.Core/Bus/MultiProducerSinglerConsumerConcurrentQueue.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Bus
+{
+    /// <summary>
+    /// A much better concurrent queue than <see cref="System.Collections.Concurrent.ConcurrentQueue{T}"/> for multi producer single consumer scenarios.
+    /// </summary>
+    [StructLayout(LayoutKind.Explicit)]
+    public class MultiProducerSinglerConsumerConcurrentQueue
+    {
+        const int MinimalSize = 4096;
+        const int MinimalSizeLog = 12;
+        const int MaskSize = MinimalSizeLog/2;
+        const int MaskLow = (1 << (MaskSize + 1)) - 1;
+        const int MaskHigh = MaskLow << MaskSize;
+        const int MaskUnchanged = ~0 ^ (MaskLow | MaskHigh);
+
+        [FieldOffset(0)] private readonly Message[] array;
+
+        [FieldOffset(32)] private readonly int count;
+
+        [FieldOffset(64)] private long sequence;
+
+        [FieldOffset(128)] private long sequenceReadTo;
+
+        public MultiProducerSinglerConsumerConcurrentQueue(int size)
+        {
+            if (IsPowerOf2(size) == false)
+            {
+                throw new ArgumentException("Use only sizes equal power of 2");
+            }
+            if (size < MinimalSize)
+            {
+                throw new ArgumentException("The size should be at least " + MinimalSize);
+            }
+
+            array = new Message[size];
+            count = size;
+            sequence = 0;
+            sequenceReadTo = 0;
+        }
+
+        public void Enqueue(Message item)
+        {
+            var next = Interlocked.Increment(ref sequence);
+            var index = Map((int) (next & (count - 1)));
+
+            if (Interlocked.CompareExchange(ref array[index], item, null) == null)
+            {
+                return;
+            }
+
+            var wait = new SpinWait();
+            while (Interlocked.CompareExchange(ref array[index], item, null) == null)
+            {
+                wait.SpinOnce();
+            }
+        }
+
+        public int TryDequeue(Message[] segment)
+        {
+            var i = 0;
+            var length = segment.Length;
+            var current = sequenceReadTo;
+
+            while (i < length)
+            {
+                current += 1;
+                var index = Map((int) (current & (count - 1)));
+                var stored = Interlocked.Exchange(ref array[index], null);
+                if (stored != null)
+                {
+                    segment[i] = stored;
+                    i += 1;
+                }
+                else
+                {
+                    sequenceReadTo += i;
+                    return i;
+                }
+            }
+
+            return 0;
+        }
+
+        private static int Map(int s)
+        {
+            var low = s & MaskLow;
+            var high = s & MaskHigh;
+            var unchanged = s & MaskUnchanged;
+
+            return (low << MaskSize) | high >> MaskSize | unchanged;
+        }
+
+        private static bool IsPowerOf2(int n)
+        {
+            return (n & (n - 1)) == 0;
+        }
+    }
+}

--- a/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
@@ -18,15 +18,19 @@ namespace EventStore.Core.Bus
     {
         private static readonly ILogger Log = LogManager.GetLoggerFor<QueuedHandlerMRES>();
 
-        public int MessageCount { get { return _queue.Count; } }
-        public string Name { get { return _queueStats.Name; } }
+        public string Name
+        {
+            get { return _queueStats.Name; }
+        }
 
         private readonly IHandle<Message> _consumer;
 
         private readonly bool _watchSlowMsg;
         private readonly TimeSpan _slowMsgThreshold;
 
-        private readonly ConcurrentQueue<Message> _queue = new ConcurrentQueue<Message>();
+        private readonly MultiProducerSinglerConsumerConcurrentQueue _queue =
+            new MultiProducerSinglerConsumerConcurrentQueue(ushort.MaxValue + 1);
+
         private readonly ManualResetEventSlim _msgAddEvent = new ManualResetEventSlim(false);
 
         private Thread _thread;
@@ -37,13 +41,13 @@ namespace EventStore.Core.Bus
 
         private readonly QueueMonitor _queueMonitor;
         private readonly QueueStatsCollector _queueStats;
-        
+
         public QueuedHandlerMRES(IHandle<Message> consumer,
-                                 string name,
-                                 bool watchSlowMsg = true,
-                                 TimeSpan? slowMsgThreshold = null,
-                                 TimeSpan? threadStopWaitTimeout = null,
-                                 string groupName = null)
+            string name,
+            bool watchSlowMsg = true,
+            TimeSpan? slowMsgThreshold = null,
+            TimeSpan? threadStopWaitTimeout = null,
+            string groupName = null)
         {
             Ensure.NotNull(consumer, "consumer");
             Ensure.NotNull(name, "name");
@@ -67,7 +71,7 @@ namespace EventStore.Core.Bus
 
             _stopped.Reset();
 
-            _thread = new Thread(ReadFromQueue) { IsBackground = true, Name = Name };
+            _thread = new Thread(ReadFromQueue) {IsBackground = true, Name = Name};
             _thread.Start();
         }
 
@@ -87,13 +91,15 @@ namespace EventStore.Core.Bus
         {
             _queueStats.Start();
             Thread.BeginThreadAffinity(); // ensure we are not switching between OS threads. Required at least for v8.
-            
+
+            var batch = new Message[128];
             while (!_stop)
             {
                 Message msg = null;
                 try
                 {
-                    if (!_queue.TryDequeue(out msg))
+                    var retrieved = _queue.TryDequeue(batch);
+                    if (retrieved == 0)
                     {
                         _starving = true;
 
@@ -105,36 +111,43 @@ namespace EventStore.Core.Bus
                     }
                     else
                     {
-                        _queueStats.EnterBusy();
+                        for (int i = 0; i < retrieved; i++)
+                        {
+                            msg = batch[i];
+
+
+                            _queueStats.EnterBusy();
 #if DEBUG
                         _queueStats.Dequeued(msg);
 #endif
 
-                        var cnt = _queue.Count;
-                        _queueStats.ProcessingStarted(msg.GetType(), cnt);
+                            //var cnt = _queue.Count;
+                            var cnt = 1;
+                            _queueStats.ProcessingStarted(msg.GetType(), cnt);
 
-                        if (_watchSlowMsg)
-                        {
-                            var start = DateTime.UtcNow;
-
-                            _consumer.Handle(msg);
-
-                            var elapsed = DateTime.UtcNow - start;
-                            if (elapsed > _slowMsgThreshold)
+                            if (_watchSlowMsg)
                             {
-                                Log.Trace("SLOW QUEUE MSG [{0}]: {1} - {2}ms. Q: {3}/{4}.",
-                                          Name, _queueStats.InProgressMessage.Name, (int)elapsed.TotalMilliseconds, cnt, _queue.Count);
-                                if (elapsed > QueuedHandler.VerySlowMsgThreshold && !(msg is SystemMessage.SystemInit))
-                                    Log.Error("---!!! VERY SLOW QUEUE MSG [{0}]: {1} - {2}ms. Q: {3}/{4}.",
-                                              Name, _queueStats.InProgressMessage.Name, (int)elapsed.TotalMilliseconds, cnt, _queue.Count);
-                            }
-                        }
-                        else
-                        {
-                            _consumer.Handle(msg);
-                        }
+                                var start = DateTime.UtcNow;
 
-                        _queueStats.ProcessingEnded(1);
+                                _consumer.Handle(msg);
+
+                                var elapsed = DateTime.UtcNow - start;
+                                if (elapsed > _slowMsgThreshold)
+                                {
+                                    //Log.Trace("SLOW QUEUE MSG [{0}]: {1} - {2}ms. Q: {3}/{4}.",
+                                    //          Name, _queueStats.InProgressMessage.Name, (int)elapsed.TotalMilliseconds, cnt, _queue.Count);
+                                    //if (elapsed > QueuedHandler.VerySlowMsgThreshold && !(msg is SystemMessage.SystemInit))
+                                    //    Log.Error("---!!! VERY SLOW QUEUE MSG [{0}]: {1} - {2}ms. Q: {3}/{4}.",
+                                    //              Name, _queueStats.InProgressMessage.Name, (int)elapsed.TotalMilliseconds, cnt, _queue.Count);
+                                }
+                            }
+                            else
+                            {
+                                _consumer.Handle(msg);
+                            }
+
+                            _queueStats.ProcessingEnded(1);
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -167,8 +180,8 @@ namespace EventStore.Core.Bus
 
         public QueueStats GetStatistics()
         {
-            return _queueStats.GetStatistics(_queue.Count);
+            //return _queueStats.GetStatistics(_queue.Count);
+            return _queueStats.GetStatistics(1);
         }
     }
 }
-

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Authentication\IAuthenticationProviderFactory.cs" />
     <Compile Include="Authentication\InternalAuthenticationProviderFactory.cs" />
     <Compile Include="Bus\AdHocHandler.cs" />
+    <Compile Include="Bus\MultiProducerSinglerConsumerConcurrentQueue.cs" />
     <Compile Include="Bus\QueueStatsCollector.cs" />
     <Compile Include="Bus\IQueuedHandler.cs" />
     <Compile Include="Bus\QueuedHandlerThreadPool.cs" />


### PR DESCRIPTION
This PR is still WIP. I'm interested in gathering some early info about the approach.
It addresses two things:

1. `QueuedHandler` performance tests that could have been suffering from the friction over one `Interlocked.Add` field. Now the cost is amortized
1. Providing a better multiple producer single consumer queue than `ConcurrentQueue` with some smart batching. Initial tests show that amortization brings performance benefits for multiple writers (10).

If we only had .NET 4.5 or more, it'd be faster with `Volatile.Read` and `Volatile.Write` ;-)