### PR TITLE
Use X-Forwarded-* headers for generating atom feed urls

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
                 var httpAuthenticationProviders = new HttpAuthenticationProvider[] {new AnonymousHttpAuthenticationProvider()};
 
                 _service = new HttpService(ServiceAccessibility.Private, _bus, new NaiveUriRouter(),
-                                           _multiQueuedHandler, false, _serverEndPoint, _serverEndPoint.ToHttpUrl());
+                                           _multiQueuedHandler, false, null, 0, _serverEndPoint.ToHttpUrl());
                 HttpService.CreateAndSubscribePipeline(pipelineBus, httpAuthenticationProviders);
                 _client = new HttpAsyncClient(_timeout);
             }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/build_requested_url_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/build_requested_url_should.cs
@@ -80,5 +80,45 @@ namespace EventStore.Core.Tests.Services.Transport.Http
 
             Assert.AreEqual(new Uri("https://www.example.com:1234/path/?key=value#anchor"), requestedUri);
         }
+
+        [Test]
+        public void with_proto_forward_host_only_host_is_changed()
+        {
+            string host = "www.my-host.com";
+            var headers = new NameValueCollection { { "X-Forwarded-Host", host } };
+            var requestedUri = 
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
+            Assert.AreEqual(new Uri("http://www.my-host.com:1234/path/?key=value#anchor"), requestedUri);
+        }
+
+        [Test]
+        public void with_proto_forward_host_and_advertised_ip_forwarded_host_is_used()
+        {
+            string host = "www.my-host.com";
+            var headers = new NameValueCollection { { "X-Forwarded-Host", host } };
+            var requestedUri = 
+                HttpEntity.BuildRequestedUrl(inputUri, headers, IPAddress.Parse("192.168.10.13"), 0);
+            Assert.AreEqual(new Uri("http://www.my-host.com:1234/path/?key=value#anchor"), requestedUri);
+        }
+
+        [Test]
+        public void with_proto_forward_host_containing_comma_delimited_list_first_forwarded_host_is_used()
+        {
+            string host = "www.my-first-host.com, www.my-second-host.com";
+            var headers = new NameValueCollection { { "X-Forwarded-Host", host } };
+            var requestedUri = 
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
+            Assert.AreEqual(new Uri("http://www.my-first-host.com:1234/path/?key=value#anchor"), requestedUri);
+        }
+
+        [Test]
+        public void with_proto_forward_host_containing_hosts_with_ports_host_and_port_is_used()
+        {
+            string host = "192.168.10.13:2231";
+            var headers = new NameValueCollection { { "X-Forwarded-Host", host } };
+            var requestedUri = 
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
+            Assert.AreEqual(new Uri("http://192.168.10.13:2231/path/?key=value#anchor"), requestedUri);
+        }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/build_requested_url_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/build_requested_url_should.cs
@@ -16,19 +16,39 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         {
             var requestedUri =
                 HttpEntity.BuildRequestedUrl(inputUri,
-                                             new NameValueCollection(), null);
+                                             new NameValueCollection(), null, 0);
 
             Assert.AreEqual(inputUri, requestedUri);
         }
 
         [Test]
-        public void with_external_http_endpoint_set_external_http_is_used()
+        public void with_advertise_http_port_set_only_port_is_changed()
         {
             var requestedUri =
                 HttpEntity.BuildRequestedUrl(inputUri,
-                                             new NameValueCollection(), new IPEndPoint(IPAddress.Parse("192.168.1.13"), 2117));
+                                             new NameValueCollection(), null, 2116);
 
-            Assert.AreEqual(new Uri("http://192.168.1.13:2117/path/?key=value#anchor"), requestedUri);
+            Assert.AreEqual(new Uri("http://www.example.com:2116/path/?key=value#anchor"), requestedUri);
+        }
+
+        [Test]
+        public void with_advertise_ip_set_only_host_is_changed()
+        {
+            var requestedUri =
+                HttpEntity.BuildRequestedUrl(inputUri,
+                                             new NameValueCollection(), IPAddress.Parse("192.168.1.13"), 0);
+
+            Assert.AreEqual(new Uri("http://192.168.1.13:1234/path/?key=value#anchor"), requestedUri);
+        }
+
+        [Test]
+        public void with_advertise_ip_and_http_port_set_both_host_and_port_is_changed()
+        {
+            var requestedUri =
+                HttpEntity.BuildRequestedUrl(inputUri,
+                                             new NameValueCollection(), IPAddress.Parse("192.168.1.13"), 2116);
+
+            Assert.AreEqual(new Uri("http://192.168.1.13:2116/path/?key=value#anchor"), requestedUri);
         }
 
         [Test]
@@ -36,7 +56,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         {
             var headers = new NameValueCollection { { "X-Forwarded-Port", "4321" } };
             var requestedUri =
-                HttpEntity.BuildRequestedUrl(inputUri, headers, null);
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
 
             Assert.AreEqual(new Uri("http://www.example.com:4321/path/?key=value#anchor"), requestedUri);
         }
@@ -46,7 +66,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         {
             var headers = new NameValueCollection { { "X-Forwarded-Port", "abc" } };
             var requestedUri =
-                HttpEntity.BuildRequestedUrl(inputUri, headers, null);
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
 
             Assert.AreEqual(inputUri, requestedUri);
         }
@@ -56,7 +76,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
         {
             var headers = new NameValueCollection { { "X-Forwarded-Proto", "https" } };
             var requestedUri =
-                HttpEntity.BuildRequestedUrl(inputUri, headers, null);
+                HttpEntity.BuildRequestedUrl(inputUri, headers, null, 0);
 
             Assert.AreEqual(new Uri("https://www.example.com:1234/path/?key=value#anchor"), requestedUri);
         }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net;
 using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
@@ -140,7 +139,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
             var multiQueuedHandler = new MultiQueuedHandler(new IQueuedHandler[]{queue}, null);
             var providers = new HttpAuthenticationProvider[] {new AnonymousHttpAuthenticationProvider()};
             var httpService = new HttpService(ServiceAccessibility.Public, inputBus,
-                                              new TrieUriRouter(), multiQueuedHandler, false, new IPEndPoint(IPAddress.Loopback, 12345), "http://localhost:12345/");
+                                              new TrieUriRouter(), multiQueuedHandler, false, null, 0, "http://localhost:12345/");
             HttpService.CreateAndSubscribePipeline(bus, providers);
 
             var fakeController = new FakeController(iterations, null);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -308,8 +308,8 @@ namespace EventStore.Core
 
             // EXTERNAL HTTP
             _externalHttpService = new HttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
-                                                    _workersHandler, vNodeSettings.LogHttpRequests, 
-                                                    vNodeSettings.GossipAdvertiseInfo.ExternalHttp, vNodeSettings.ExtHttpPrefixes);
+                                                    _workersHandler, vNodeSettings.LogHttpRequests, vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalIPAs, 
+                                                    vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalHttpPortAs, vNodeSettings.ExtHttpPrefixes);
             _externalHttpService.SetupController(persistentSubscriptionController);
             if(vNodeSettings.AdminOnPublic)
                 _externalHttpService.SetupController(adminController);
@@ -328,8 +328,8 @@ namespace EventStore.Core
             // INTERNAL HTTP
             if(!isSingleNode) {
                 _internalHttpService = new HttpService(ServiceAccessibility.Private, _mainQueue, new TrieUriRouter(),
-                                                       _workersHandler, vNodeSettings.LogHttpRequests,
-                                                       vNodeSettings.GossipAdvertiseInfo.ExternalHttp, vNodeSettings.IntHttpPrefixes);
+                                                       _workersHandler, vNodeSettings.LogHttpRequests, vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalIPAs, 
+                                                       vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalHttpPortAs, vNodeSettings.IntHttpPrefixes);
                 _internalHttpService.SetupController(adminController);
                 _internalHttpService.SetupController(pingController);
                 _internalHttpService.SetupController(infoController);

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -190,8 +190,7 @@ namespace EventStore.Core.Services
                     case "content-length":    break;
                     case "date":              request.Headers.Date = DateTime.Parse(srcReq.Headers[headerKey]); break;
                     case "expect":            break;
-                    case "host":              request.Headers.Add("X-Forwarded-Host", srcReq.Headers[headerKey]);
-                                              request.Headers.Host = forwardUri.Host; break;
+                    case "host":              request.Headers.Host = forwardUri.Host; break;
                     case "if-modified-since": request.Headers.IfModifiedSince = DateTime.Parse(srcReq.Headers[headerKey]); break;
                     case "proxy-connection":  break;
                     case "range":             break;
@@ -204,6 +203,12 @@ namespace EventStore.Core.Services
                         break;
                 }
             }
+
+            if(!request.Headers.Contains(ProxyHeaders.XForwardedHost)) {
+                request.Headers.Add(ProxyHeaders.XForwardedHost, string.Format("{0}:{1}", 
+                    manager.RequestedUrl.Host, manager.RequestedUrl.Port));
+            }
+
             // Copy content (if content body is allowed)
             if (!string.Equals(srcReq.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase)
                 && !string.Equals(srcReq.HttpMethod, "HEAD", StringComparison.OrdinalIgnoreCase)

--- a/src/EventStore.Core/Services/Transport/Http/HttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/HttpService.cs
@@ -34,10 +34,11 @@ namespace EventStore.Core.Services.Transport.Http
         private readonly HttpAsyncServer _server;
         private readonly MultiQueuedHandler _requestsMultiHandler;
 
-        private readonly IPEndPoint _externalHttpEndPoint;
+        private IPAddress _advertiseAsAddress;
+        private int _advertiseAsPort;
 
         public HttpService(ServiceAccessibility accessibility, IPublisher inputBus, IUriRouter uriRouter,
-                           MultiQueuedHandler multiQueuedHandler, bool logHttpRequests, IPEndPoint externalHttpEndPoint, params string[] prefixes)
+                           MultiQueuedHandler multiQueuedHandler, bool logHttpRequests, IPAddress advertiseAsAddress, int advertiseAsPort, params string[] prefixes)
         {
             Ensure.NotNull(inputBus, "inputBus");
             Ensure.NotNull(uriRouter, "uriRouter");
@@ -54,7 +55,8 @@ namespace EventStore.Core.Services.Transport.Http
             _server = new HttpAsyncServer(prefixes);
             _server.RequestReceived += RequestReceived;
 
-            _externalHttpEndPoint = externalHttpEndPoint;
+            _advertiseAsAddress = advertiseAsAddress;
+            _advertiseAsPort = advertiseAsPort;
         }
 
         public static void CreateAndSubscribePipeline(IBus bus, HttpAuthenticationProvider[] httpAuthenticationProviders)
@@ -99,7 +101,7 @@ namespace EventStore.Core.Services.Transport.Http
 
         private void RequestReceived(HttpAsyncServer sender, HttpListenerContext context)
         {
-            var entity = new HttpEntity(context.Request, context.Response, context.User, _logHttpRequests, _externalHttpEndPoint);
+            var entity = new HttpEntity(context.Request, context.Response, context.User, _logHttpRequests, _advertiseAsAddress, _advertiseAsPort);
             _requestsMultiHandler.Handle(new IncomingHttpRequestMessage(this, entity, _requestsMultiHandler));
         }
 

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntity.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntity.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Security.Principal;
 using EventStore.Common.Utils;
 using EventStore.Transport.Http.Codecs;
+using System.Linq;
 
 namespace EventStore.Transport.Http.EntityManagement
 {
@@ -42,7 +43,6 @@ namespace EventStore.Transport.Http.EntityManagement
             }
 
             var forwardedPortHeaderValue = requestHeaders[ProxyHeaders.XForwardedPort];
-
             if (!string.IsNullOrEmpty(forwardedPortHeaderValue))
             {
                 int requestPort;
@@ -56,6 +56,21 @@ namespace EventStore.Transport.Http.EntityManagement
             if (!string.IsNullOrEmpty(forwardedProtoHeaderValue))
             {
                 uriBuilder.Scheme = forwardedProtoHeaderValue;
+            }
+
+            var forwardedHostHeaderValue = requestHeaders[ProxyHeaders.XForwardedHost];
+            if (!string.IsNullOrEmpty(forwardedHostHeaderValue))
+            {
+                var host = forwardedHostHeaderValue.Split(new []{","}, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                if(!string.IsNullOrEmpty(host)) 
+                {
+                    var parts = host.Split(new []{":"}, StringSplitOptions.RemoveEmptyEntries);
+                    uriBuilder.Host = parts.First();
+                    int port;
+                    if(parts.Count() > 1 && int.TryParse(parts[1], out port)) {
+                        uriBuilder.Port = port;
+                    }
+                }
             }
 
             return uriBuilder.Uri;

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntity.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntity.cs
@@ -16,28 +16,31 @@ namespace EventStore.Transport.Http.EntityManagement
         internal readonly HttpListenerResponse Response;
         public readonly IPrincipal User;
 
-        public HttpEntity(HttpListenerRequest request, HttpListenerResponse response, IPrincipal user, bool logHttpRequests, IPEndPoint externalHttpEndPoint)
+        public HttpEntity(HttpListenerRequest request, HttpListenerResponse response, IPrincipal user, bool logHttpRequests, IPAddress advertiseAsAddress, int advertiseAsPort)
         {
             Ensure.NotNull(request, "request");
             Ensure.NotNull(response, "response");
 
             _logHttpRequests = logHttpRequests;
-            RequestedUrl = BuildRequestedUrl(request.Url, request.Headers, externalHttpEndPoint);
+            RequestedUrl = BuildRequestedUrl(request.Url, request.Headers, advertiseAsAddress, advertiseAsPort);
             Request = request;
             Response = response;
             User = user;
         }
 
-        public static Uri BuildRequestedUrl(Uri requestUrl, NameValueCollection requestHeaders, IPEndPoint externalHttpEndPoint)
+        public static Uri BuildRequestedUrl(Uri requestUrl, NameValueCollection requestHeaders, IPAddress advertiseAsAddress, int advertiseAsPort)
         {
             var uriBuilder = new UriBuilder(requestUrl);
 
-            if(externalHttpEndPoint != null)
+            if(advertiseAsAddress != null)
             {
-                uriBuilder.Host = externalHttpEndPoint.Address.ToString();
-                uriBuilder.Port = externalHttpEndPoint.Port;
+                uriBuilder.Host = advertiseAsAddress.ToString();
             }
-            
+            if(advertiseAsPort > 0)
+            {
+                uriBuilder.Port = advertiseAsPort;
+            }
+
             var forwardedPortHeaderValue = requestHeaders[ProxyHeaders.XForwardedPort];
 
             if (!string.IsNullOrEmpty(forwardedPortHeaderValue))

--- a/src/EventStore.Transport.Http/ProxyHeaders.cs
+++ b/src/EventStore.Transport.Http/ProxyHeaders.cs
@@ -4,6 +4,7 @@
     {
         public const string XForwardedPort = "X-Forwarded-Port";
         public const string XForwardedProto = "X-Forwarded-Proto";
+        public const string XForwardedHost = "X-Forwarded-Host";
     }
 
     public static class ProxyHeaderValues


### PR DESCRIPTION
This PR reverts https://github.com/EventStore/EventStore/pull/973 and fixes both issue #969 and issue #984 

The url that is built up for the atom feed urls now uses the `X-Forwarded-Host` header, if it is available, to set the host and port of the requested url. If the forwarded host header is not available, the url will be built with the advertised address, otherwise it will just use the requested host.

It also sets the `X-Forwarded-Host` header to the requested url on http requests that are forwarded between nodes. This ensures that when the atom feed urls are created, they are created using the url of the original node that received the request.