### PR TITLE
Limit the number of entries returned from PTable

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -115,6 +115,8 @@ namespace EventStore.ClusterNode
         public long ChunksCacheSize { get; set; }
         [ArgDescription(Opts.MaxMemTableSizeDescr, Opts.DbGroup)]
         public int MaxMemTableSize { get; set; }
+        [ArgDescription(Opts.HashCollisionReadLimitDescr, Opts.DbGroup)]
+        public int HashCollisionReadLimit { get; set; }
 
         [ArgDescription(Opts.DbPathDescr, Opts.DbGroup)]
         public string Db { get; set; }
@@ -222,6 +224,7 @@ namespace EventStore.ClusterNode
             CommitCount = Opts.CommitCountDefault;
             PrepareCount = Opts.PrepareCountDefault;
             MaxMemTableSize = Opts.MaxMemtableSizeDefault;
+            HashCollisionReadLimit = Opts.HashCollisionReadLimitDefault;
 
             DiscoverViaDns = Opts.DiscoverViaDnsDefault;
             ClusterDns = Opts.ClusterDnsDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -172,6 +172,7 @@ namespace EventStore.ClusterNode
                         .WithExternalHeartbeatTimeout(TimeSpan.FromMilliseconds(options.ExtTcpHeartbeatTimeout))
                         .WithExternalHeartbeatInterval(TimeSpan.FromMilliseconds(options.ExtTcpHeartbeatInterval))
                         .MaximumMemoryTableSizeOf(options.MaxMemTableSize)
+                        .WithHashCollisionReadLimitOf(options.HashCollisionReadLimit)
                         .WithGossipInterval(TimeSpan.FromMilliseconds(options.GossipIntervalMs))
                         .WithGossipAllowedTimeDifference(TimeSpan.FromMilliseconds(options.GossipAllowedDifferenceMs))
                         .WithGossipTimeout(TimeSpan.FromMilliseconds(options.GossipTimeoutMs))

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
@@ -282,6 +282,21 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
     }
 
     [TestFixture]
+    public class with_custom_hash_collision_read_limit : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithHashCollisionReadLimitOf(200);
+        }
+
+        [Test]
+        public void should_set_the_hash_collision_read_limit()
+        {
+            Assert.AreEqual(200, _settings.HashCollisionReadLimit);
+        }
+    }
+
+    [TestFixture]
     public class with_standard_projections_started : SingleNodeScenario
     {
         public override void Given()

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -21,6 +21,7 @@ using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.Services.Transport.Http.Controllers;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.Helpers
 {
@@ -92,7 +93,7 @@ namespace EventStore.Core.Tests.Helpers
                 gossipAllowedTimeDifference: TimeSpan.FromSeconds(1), gossipTimeout: TimeSpan.FromSeconds(1),
                 extTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), extTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
                 intTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), intTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
-                verifyDbHash: false, maxMemtableEntryCount: memTableSize, startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false);
+                verifyDbHash: false, maxMemtableEntryCount: memTableSize, hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault, startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false);
 
             Log.Info(
                 "\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
-                TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, false, false, false);
+                TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false, false, false);
 
             return vnode;
         }

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -47,7 +47,7 @@ namespace EventStore.Core.Tests.Services.Storage
             return false;
         }
 
-        public IEnumerable<IndexEntry> GetRange(uint stream, int startVersion, int endVersion)
+        public IEnumerable<IndexEntry> GetRange(uint stream, int startVersion, int endVersion, int? limit = null)
         {
             yield break;
         }

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -15,6 +15,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.Services.Storage
 {
@@ -88,7 +89,8 @@ namespace EventStore.Core.Tests.Services.Storage
                                       hasher,
                                       0,
                                       additionalCommitChecks: true,
-                                      metastreamMaxCount: MetastreamMaxCount);
+                                      metastreamMaxCount: MetastreamMaxCount,
+                                      hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault);
 
             ReadIndex.Init(ChaserCheckpoint.Read());
 

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -8,6 +8,7 @@ using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Util;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Storage
@@ -66,7 +67,8 @@ namespace EventStore.Core.Tests.Services.Storage
                                       new ByLengthHasher(),
                                       0,
                                       additionalCommitChecks: true,
-                                      metastreamMaxCount: _metastreamMaxCount);
+                                      metastreamMaxCount: _metastreamMaxCount,
+                                      hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault);
 
             ReadIndex.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
         }

--- a/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
@@ -12,6 +12,7 @@ using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.Services.Storage.Transactions
 {
@@ -41,7 +42,8 @@ namespace EventStore.Core.Tests.Services.Storage.Transactions
                                       new ByLengthHasher(),
                                       0,
                                       additionalCommitChecks: true, 
-                                      metastreamMaxCount: 1);
+                                      metastreamMaxCount: 1,
+                                      hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault);
             ReadIndex.Init(ChaserCheckpoint.Read());
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -16,6 +16,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
 {
@@ -69,7 +70,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
                                             maxSizeForMemory: 100,
                                             maxTablesPerLevel: 2);
             var hasher = new XXHashUnsafe();
-            ReadIndex = new ReadIndex(new NoopPublisher(), readerPool, tableIndex, hasher, 100, true, _metastreamMaxCount);
+            ReadIndex = new ReadIndex(new NoopPublisher(), readerPool, tableIndex, hasher, 100, true, _metastreamMaxCount, Opts.HashCollisionReadLimitDefault);
             ReadIndex.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 
             //var scavengeReadIndex = new ScavengeReadIndex(_dbResult.Streams, _metastreamMaxCount);

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -8,6 +8,7 @@ using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation
 {
@@ -49,7 +50,8 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
                                       new ByLengthHasher(),
                                       0,
                                       additionalCommitChecks: true,
-                                      metastreamMaxCount: MetastreamMaxCount);
+                                      metastreamMaxCount: MetastreamMaxCount,
+                                      hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault);
             ReadIndex.Init(ChaserCheckpoint.Read());
         }
     }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -61,6 +61,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly bool UnsafeIgnoreHardDeletes;
         public readonly bool VerifyDbHash;
         public readonly int MaxMemtableEntryCount;
+        public readonly int HashCollisionReadLimit;
         public readonly int IndexCacheDepth;
 
         public readonly bool BetterOrdering;
@@ -111,6 +112,7 @@ namespace EventStore.Core.Cluster.Settings
                                     TimeSpan extTcpHeartbeatInterval,
 				                    bool verifyDbHash,
 				                    int maxMemtableEntryCount,
+                                    int hashCollisionReadLimit,
                                     bool startStandardProjections,
                                     bool disableHTTPCaching,
                                     bool logHttpRequests,
@@ -194,6 +196,7 @@ namespace EventStore.Core.Cluster.Settings
 
             VerifyDbHash = verifyDbHash;
             MaxMemtableEntryCount = maxMemtableEntryCount;
+            HashCollisionReadLimit = hashCollisionReadLimit;
 
             EnableHistograms = enableHistograms;
             IndexCacheDepth = indexCacheDepth;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -179,7 +179,8 @@ namespace EventStore.Core
                                           hash,
                                           ESConsts.StreamInfoCacheCapacity,
                                           Application.IsDefined(Application.AdditionalCommitChecks),
-                                          Application.IsDefined(Application.InfiniteMetastreams) ? int.MaxValue : 1);
+                                          Application.IsDefined(Application.InfiniteMetastreams) ? int.MaxValue : 1,
+                                          vNodeSettings.HashCollisionReadLimit);
             var writer = new TFChunkWriter(db);
             var epochManager = new EpochManager(ESConsts.CachedEpochCount,
                                                 db.Config.EpochCheckpoint,

--- a/src/EventStore.Core/Index/HashListMemTable.cs
+++ b/src/EventStore.Core/Index/HashListMemTable.cs
@@ -174,7 +174,7 @@ namespace EventStore.Core.Index
             _hash.Clear();
         }
 
-        public IEnumerable<IndexEntry> GetRange(uint stream, int startNumber, int endNumber)
+        public IEnumerable<IndexEntry> GetRange(uint stream, int startNumber, int endNumber, int? limit = null)
         {
             if (startNumber < 0)
                 throw new ArgumentOutOfRangeException("startNumber");
@@ -193,7 +193,7 @@ namespace EventStore.Core.Index
                     for (int i = endIdx; i >= 0; i--)
                     {
                         var key = list.Keys[i];
-                        if (key.EvNum < startNumber)
+                        if (key.EvNum < startNumber || ret.Count == limit)
                             break;
                         ret.Add(new IndexEntry(stream, version: key.EvNum, position: key.LogPos));
                     }

--- a/src/EventStore.Core/Index/ISearchTable.cs
+++ b/src/EventStore.Core/Index/ISearchTable.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Index
         bool TryGetOneValue(uint stream, int number, out long position);
         bool TryGetLatestEntry(uint stream, out IndexEntry entry);
         bool TryGetOldestEntry(uint stream, out IndexEntry entry);
-        IEnumerable<IndexEntry> GetRange(uint stream, int startNumber, int endNumber);
+        IEnumerable<IndexEntry> GetRange(uint stream, int startNumber, int endNumber, int? limit = null);
         IEnumerable<IndexEntry> IterateAllInOrder();
     }
 }

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -17,6 +17,6 @@ namespace EventStore.Core.Index
         bool TryGetLatestEntry(uint stream, out IndexEntry entry);
         bool TryGetOldestEntry(uint stream, out IndexEntry entry);
 
-        IEnumerable<IndexEntry> GetRange(uint stream, int startVersion, int endVersion);
+        IEnumerable<IndexEntry> GetRange(uint stream, int startVersion, int endVersion, int? limit = null);
     }
 }

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -349,7 +349,7 @@ namespace EventStore.Core.Index
             }
         }
 
-        public IEnumerable<IndexEntry> GetRange(uint stream, int startNumber, int endNumber)
+        public IEnumerable<IndexEntry> GetRange(uint stream, int startNumber, int endNumber, int? limit = null)
         {
             Ensure.Nonnegative(startNumber, "startNumber");
             Ensure.Nonnegative(endNumber, "endNumber");
@@ -383,10 +383,11 @@ namespace EventStore.Core.Index
                 {
                     IndexEntry entry = ReadNextNoSeek(workItem);
                     if (entry.Key > endKey)
-                        throw new Exception(string.Format("enty.Key {0} > endKey {1}, stream {2}, startNum {3}, endNum {4}, PTable: {5}.", entry.Key, endKey, stream, startNumber, endNumber, Filename));
+                        throw new Exception(string.Format("entry.Key {0} > endKey {1}, stream {2}, startNum {3}, endNum {4}, PTable: {5}.", entry.Key, endKey, stream, startNumber, endNumber, Filename));
                     if (entry.Key < startKey)
                         return result;
                     result.Add(entry);
+                    if (result.Count == limit) break;
                 }
                 return result;
             }

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -438,7 +438,7 @@ namespace EventStore.Core.Index
             return false;
         }
 
-        public IEnumerable<IndexEntry> GetRange(uint stream, int startVersion, int endVersion)
+        public IEnumerable<IndexEntry> GetRange(uint stream, int startVersion, int endVersion, int? limit = null)
         {
             var counter = 0;
             while (counter < 5)
@@ -446,7 +446,7 @@ namespace EventStore.Core.Index
                 counter++;
                 try
                 {
-                    return GetRangeInternal(stream, startVersion, endVersion);
+                    return GetRangeInternal(stream, startVersion, endVersion, limit);
                 }
                 catch (FileBeingDeletedException)
                 {
@@ -456,7 +456,7 @@ namespace EventStore.Core.Index
             throw new InvalidOperationException("Files are locked.");
         }
 
-        private IEnumerable<IndexEntry> GetRangeInternal(uint stream, int startVersion, int endVersion)
+        private IEnumerable<IndexEntry> GetRangeInternal(uint stream, int startVersion, int endVersion, int? limit = null)
         {
             if (startVersion < 0)
                 throw new ArgumentOutOfRangeException("startVersion");
@@ -468,7 +468,7 @@ namespace EventStore.Core.Index
             var awaiting = _awaitingMemTables;
             for (int index = 0; index < awaiting.Count; index++)
             {
-                var range = awaiting[index].Table.GetRange(stream, startVersion, endVersion).GetEnumerator();
+                var range = awaiting[index].Table.GetRange(stream, startVersion, endVersion, limit).GetEnumerator();
                 if (range.MoveNext())
                     candidates.Add(range);
             }
@@ -476,7 +476,7 @@ namespace EventStore.Core.Index
             var map = _indexMap;
             foreach (var table in map.InOrder())
             {
-                var range = table.GetRange(stream, startVersion, endVersion).GetEnumerator();
+                var range = table.GetRange(stream, startVersion, endVersion, limit).GetEnumerator();
                 if (range.MoveNext())
                     candidates.Add(range);
             }

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/ReadIndex.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/ReadIndex.cs
@@ -30,7 +30,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
                          IHasher hasher,
                          int streamInfoCacheCapacity,
                          bool additionalCommitChecks,
-                         int metastreamMaxCount)
+                         int metastreamMaxCount,
+                         int hashCollisionReadLimit)
         {
             Ensure.NotNull(bus, "bus");
             Ensure.NotNull(readerPool, "readerPool");
@@ -42,7 +43,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
             var metastreamMetadata = new StreamMetadata(maxCount: metastreamMaxCount);
 
             _indexBackend = new IndexBackend(readerPool, streamInfoCacheCapacity, streamInfoCacheCapacity);
-            _indexReader = new IndexReader(_indexBackend, hasher, tableIndex, metastreamMetadata);
+            _indexReader = new IndexReader(_indexBackend, hasher, tableIndex, metastreamMetadata, hashCollisionReadLimit);
             _indexWriter = new IndexWriter(_indexBackend, _indexReader);
             _indexCommitter = new IndexCommitter(bus, _indexBackend, _indexReader, tableIndex, hasher, additionalCommitChecks);
             _allReader = new AllReader(_indexBackend, _indexCommitter);

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -101,6 +101,9 @@ namespace EventStore.Core.Util
         public const string MaxMemTableSizeDescr = "Adjusts the maximum size of a mem table.";
         public const int MaxMemtableSizeDefault = 1000000;
 
+        public const string HashCollisionReadLimitDescr = "The number of events to read per candidate in the case of a hash collision";
+        public const int HashCollisionReadLimitDefault = 100;
+
         public const string SkipDbVerifyDescr = "Bypasses the checking of file hashes of database during startup (allows for faster startup).";
         public const bool SkipDbVerifyDefault = false;
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -93,6 +93,7 @@ namespace EventStore.Core
 
         protected bool _skipVerifyDbHashes;
         protected int _maxMemtableSize;
+        protected int _hashCollisionReadLimit;
         protected List<ISubsystem> _subsystems;
         protected int _clusterGossipPort;
 
@@ -504,6 +505,18 @@ namespace EventStore.Core
             _maxMemtableSize = size;
             return this;
         }
+
+        /// <summary>
+        /// Sets the maximum number of events to read in case of a stream Id hash collision
+        /// </summary>
+        /// <param name="hashCollisionReadLimit">The maximum count</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithHashCollisionReadLimitOf(int hashCollisionReadLimit)
+        {
+            _hashCollisionReadLimit = hashCollisionReadLimit;
+            return this;
+        }
+
 
         /// <summary>
         /// Marks that the existing database files should not be checked for checksums on startup.
@@ -1221,6 +1234,7 @@ namespace EventStore.Core
                     _extTcpHeartbeatInterval,
                     !_skipVerifyDbHashes,
                     _maxMemtableSize,
+                    _hashCollisionReadLimit,
                     _startStandardProjections,
                     _disableHTTPCaching,
                     _logHttpRequests,


### PR DESCRIPTION
On the hash collision path we limit the number of items returned. This has been made configurable and added as an option.