### PR TITLE
Copy metadata values including custom metadata

### DIFF
--- a/src/EventStore.ClientAPI/StreamMetadata.cs
+++ b/src/EventStore.ClientAPI/StreamMetadata.cs
@@ -88,12 +88,38 @@ namespace EventStore.ClientAPI
         }
 
         /// <summary>
-        /// Builds a <see cref="StreamMetadata"/> from a <see cref="StreamMetadataBuilder" />.
+        /// Creates a <see cref="StreamMetadataBuilder" /> for building a new <see cref="StreamMetadata"/>.
         /// </summary>
-        /// <returns>An instance of <see cref="StreamMetadata"/>.</returns>
+        /// <returns>An instance of <see cref="StreamMetadataBuilder"/>.</returns>
         public static StreamMetadataBuilder Build()
         {
             return new StreamMetadataBuilder();
+        }
+
+        /// <summary>
+        /// Creates a <see cref="StreamMetadataBuilder" /> initialized with the values of this <see cref="StreamMetadata"/>
+        /// </summary>
+        /// <returns>An instance of <see cref="StreamMetadataBuilder"/>.</returns>
+        public StreamMetadataBuilder Copy()
+        {
+            if(Acl == null)
+                return new StreamMetadataBuilder(
+                    MaxCount, 
+                    MaxAge, 
+                    TruncateBefore, 
+                    CacheControl, 
+                    customMetadata: _customMetadata);
+            return new StreamMetadataBuilder(
+                MaxCount,
+                MaxAge,
+                TruncateBefore,
+                CacheControl,
+                Acl.ReadRoles,
+                Acl.WriteRoles,
+                Acl.DeleteRoles,
+                Acl.MetaReadRoles,
+                Acl.MetaWriteRoles,
+                _customMetadata);
         }
 
         /// <summary>

--- a/src/EventStore.ClientAPI/StreamMetadataBuilder.cs
+++ b/src/EventStore.ClientAPI/StreamMetadataBuilder.cs
@@ -22,8 +22,28 @@ namespace EventStore.ClientAPI
 
         private readonly IDictionary<string, JToken> _customMetadata = new Dictionary<string, JToken>();
 
-        internal StreamMetadataBuilder()
+        internal StreamMetadataBuilder(
+            int? maxCount = null,
+            TimeSpan? maxAge = null,
+            int? truncateBefore = null,
+            TimeSpan? cacheControl = null,
+            string[] aclRead = null,
+            string[] aclWrite = null,
+            string[] aclDelete = null,
+            string[] aclMetaRead = null,
+            string[] aclMetaWrite = null,
+            IDictionary<string, JToken> customMetadata = null)
         {
+            _maxCount = maxCount;
+            _maxAge = maxAge;
+            _truncateBefore = truncateBefore;
+            _cacheControl = cacheControl;
+            _aclRead = aclRead;
+            _aclWrite = aclWrite;
+            _aclDelete = aclDelete;
+            _aclMetaRead = aclMetaRead;
+            _aclMetaWrite = aclMetaWrite;
+            _customMetadata = customMetadata == null ? new Dictionary<string, JToken>() : new Dictionary<string, JToken>(customMetadata);
         }
 
         /// <summary>

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Common\VNodeBuilderTests\when_building\with_single_node_and_custom_settings.cs" />
     <Compile Include="Common\VNodeBuilderTests\when_building\with_cluster_node_and_custom_settings.cs" />
     <Compile Include="Common\VNodeBuilderTests\TestAuthentictaionProviderFactory.cs" />
+    <Compile Include="copying_metadata.cs" />
     <Compile Include="DefaultData.cs" />
     <Compile Include="Fakes\FakeTfReader.cs" />
     <Compile Include="Helpers\CollectionsExtensions.cs" />

--- a/src/EventStore.Core.Tests/copying_metadata.cs
+++ b/src/EventStore.Core.Tests/copying_metadata.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EventStore.ClientAPI;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests
+{
+    [TestFixture]
+    public class copying_metadata
+    {
+        [Test]
+        public void copies_empty_metadata()
+        {
+            var empty = StreamMetadata.Build().Build();
+            var copied = empty.Copy().Build();
+            Assert.AreEqual(empty.AsJsonString(), copied.AsJsonString());
+        }
+
+        [Test]
+        public void copies_all_values()
+        {
+            var source = StreamMetadata.Build()
+                .SetCacheControl(TimeSpan.FromDays(1))
+                .SetCustomProperty("Test", "Value")
+                .SetReadRole("foo")
+                .SetWriteRole("bar")
+                .SetDeleteRole("baz")
+                .SetMetadataReadRole("qux")
+                .SetMetadataWriteRole("quux")
+                .SetMaxAge(TimeSpan.FromHours(1))
+                .SetMaxCount(2)
+                .SetTruncateBefore(4)
+                .Build();
+            var copied = source.Copy().Build();
+            Assert.AreEqual(source.AsJsonString(), copied.AsJsonString());
+        }
+
+        [Test]
+        public void can_mutate_copy()
+        {
+            var source = StreamMetadata.Build()
+                .SetCacheControl(TimeSpan.FromDays(1))
+                .SetCustomProperty("Test", "Value")
+                .SetReadRole("foo")
+                .SetWriteRole("bar")
+                .SetDeleteRole("baz")
+                .SetMetadataReadRole("qux")
+                .SetMetadataWriteRole("quux")
+                .SetMaxAge(TimeSpan.FromHours(1))
+                .SetMaxCount(2)
+                .SetTruncateBefore(4)
+                .Build();
+
+            var expected = StreamMetadata.Build()
+                .SetCacheControl(TimeSpan.FromDays(1))
+                .SetCustomProperty("Test", "Value")
+                .SetCustomProperty("Test2", "Value2")
+                .SetReadRole("foo")
+                .SetWriteRole("bar")
+                .SetDeleteRole("baz")
+                .SetMetadataReadRole("qux")
+                .SetMetadataWriteRole("quux")
+                .SetMaxAge(TimeSpan.FromHours(1))
+                .SetMaxCount(4)
+                .SetTruncateBefore(4)
+                .Build();
+
+
+            var copied = source.Copy()
+                .SetMaxCount(4)
+                .SetCustomProperty("Test2", "Value2")
+                .Build();
+
+            Assert.AreEqual(expected.AsJsonString(), copied.AsJsonString());
+            
+
+        }
+    }
+}


### PR DESCRIPTION
Adds facility to create a new StreamMetadataBuilder from existing metadata.  Useful when wanting to update metadata with custom values