### PR TITLE
Add track and delete emitted streams options to ProjectionsManager

### DIFF
--- a/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
@@ -50,9 +50,9 @@ namespace EventStore.ClientAPI.Projections
                 HttpStatusCode.Created);
         }
 
-        public Task CreateContinuous(IPEndPoint endPoint, string name, string query, UserCredentials userCredentials = null)
+        public Task CreateContinuous(IPEndPoint endPoint, string name, string query, bool trackEmitted, UserCredentials userCredentials = null)
         {
-            return SendPost(endPoint.ToHttpUrl("/projections/continuous?name={0}&type=JS&emit=1", name),
+            return SendPost(endPoint.ToHttpUrl("/projections/continuous?name={0}&type=JS&emit=1&trackemittedstreams={1}", name, trackEmitted),
                             query, userCredentials, HttpStatusCode.Created);
         }
 
@@ -147,9 +147,9 @@ namespace EventStore.ClientAPI.Projections
             return SendPut(endPoint.ToHttpUrl("/projection/{0}/query?type=JS", name), query, userCredentials, HttpStatusCode.OK);
         }
 
-        public Task Delete(IPEndPoint endPoint, string name, UserCredentials userCredentials = null)
+        public Task Delete(IPEndPoint endPoint, string name, bool deleteEmittedStreams, UserCredentials userCredentials = null)
         {
-            return SendDelete(endPoint.ToHttpUrl("/projection/{0}", name), userCredentials, HttpStatusCode.OK);
+            return SendDelete(endPoint.ToHttpUrl("/projection/{0}?deleteEmittedStreams={1}", name, deleteEmittedStreams), userCredentials, HttpStatusCode.OK);
         }
 
         private Task<string> SendGet(string url, UserCredentials userCredentials, int expectedCode)

--- a/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
@@ -99,10 +99,22 @@ namespace EventStore.ClientAPI.Projections
         /// <param name="userCredentials">Credentials for a user with permission to create a query.</param>
         public Task CreateContinuousAsync(string name, string query, UserCredentials userCredentials = null)
         {
+            return CreateContinuousAsync(name, query, false, userCredentials);
+        }
+
+        /// <summary>
+        /// Asynchronously creates a continuous projection.
+        /// </summary>
+        /// <param name="name">The name of the projection.</param>
+        /// <param name="query">The JavaScript source code for the query.</param>
+        /// <param name="trackEmittedStreams">Whether the streams emitted by this projection should be tracked.</param>
+        /// <param name="userCredentials">Credentials for a user with permission to create a query.</param>
+        public Task CreateContinuousAsync(string name, string query, bool trackEmittedStreams, UserCredentials userCredentials = null)
+        {
             Ensure.NotNullOrEmpty(name, "name");
             Ensure.NotNullOrEmpty(query, "query");
 
-            return _client.CreateContinuous(_httpEndPoint, name, query, userCredentials);
+            return _client.CreateContinuous(_httpEndPoint, name, query, trackEmittedStreams, userCredentials);
         }
 
         /// <summary>
@@ -278,8 +290,20 @@ namespace EventStore.ClientAPI.Projections
         /// <returns>A task representing the operation.</returns>
         public Task DeleteAsync(string name, UserCredentials userCredentials = null)
         {
+            return DeleteAsync(name, false, userCredentials);
+        }
+
+        /// <summary>
+        /// Asynchronously deletes a projection 
+        /// </summary>
+        /// <param name="name">The name of the projection.</param>
+        /// <param name="deleteEmittedStreams">Whether to delete the streams that were emitted by this projection.</param>
+        /// <param name="userCredentials">Credentials for a user with permission to delete a projection</param>
+        /// <returns>A task representing the operation.</returns>
+        public Task DeleteAsync(string name, bool deleteEmittedStreams, UserCredentials userCredentials = null)
+        {
             Ensure.NotNullOrEmpty(name, "name");
-            return _client.Delete(_httpEndPoint, name, userCredentials);
+            return _client.Delete(_httpEndPoint, name, deleteEmittedStreams, userCredentials);
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/ProjectionsManagerTestSuiteMarkerBase.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/ProjectionsManagerTestSuiteMarkerBase.cs
@@ -1,0 +1,57 @@
+using System;
+using NUnit.Framework;
+using EventStore.ClientAPI;
+using EventStore.Common.Options;
+using EventStore.Core;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using System.IO;
+
+namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
+{
+	class ProjectionsManagerTestSuiteMarkerBase
+    {
+        public static MiniNode Node;
+        public static IEventStoreConnection Connection;
+        public static string PathName;
+        public static int Counter;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var typeName = GetType().Name.Length > 30 ? GetType().Name.Substring(0, 30) : GetType().Name;
+            PathName = Path.Combine(Path.GetTempPath(), string.Format("{0}-{1}", Guid.NewGuid(), typeName));
+            Directory.CreateDirectory(PathName);
+
+            Counter = 0;
+            CreateNode();
+
+            Connection = TestConnection.Create(Node.TcpEndPoint);
+            Connection.ConnectAsync().Wait();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Connection.Close();
+            Node.Shutdown();
+            Connection = null;
+            Node = null;
+
+            Directory.Delete(PathName, true);
+        }
+
+        protected void CreateNode()
+		{
+            var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All, startStandardProjections: false);
+            Node = new MiniNode(
+                PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { projections });
+            Node.Start();
+		}
+    }
+
+    [SetUpFixture]
+    class SetUpFixture : ProjectionsManagerTestSuiteMarkerBase
+    {
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Text;
+using NUnit.Framework;
+using EventStore.ClientAPI;
+using EventStore.ClientAPI.Projections;
+using EventStore.ClientAPI.Common.Log;
+using EventStore.ClientAPI.SystemData;
+using EventStore.Common.Options;
+using EventStore.Core;
+using EventStore.Core.Tests;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using EventStore.Core.Services;
+
+namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
+{
+    public abstract class SpecificationWithNodeAndProjectionsManager : SpecificationWithDirectoryPerTestFixture
+    {
+        protected MiniNode _node;
+        protected ProjectionsManager _projManager;
+        protected IEventStoreConnection _connection;
+        protected UserCredentials _credentials;
+        protected TimeSpan _timeout;
+        protected string _tag;
+
+        [TestFixtureSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            _credentials = new UserCredentials(SystemUsers.Admin, SystemUsers.DefaultAdminPassword);
+            var createdMiniNode = false;
+            _timeout = TimeSpan.FromSeconds(10);
+            // Check if a node is running in ProjectionsManagerTestSuiteMarkerBase
+            if (SetUpFixture.Connection != null && SetUpFixture.Node != null)
+            {
+                _tag = "_" + (++SetUpFixture.Counter);
+                _node = SetUpFixture.Node;
+                _connection = SetUpFixture.Connection;
+            }
+            else
+            {
+                createdMiniNode = true;
+                _tag = "_1";
+
+                _node = CreateNode();
+                _node.Start();
+
+                _connection = TestConnection.Create(_node.TcpEndPoint);
+                _connection.ConnectAsync().Wait();
+            }
+
+            try
+            {
+                _projManager = new ProjectionsManager(new ConsoleLogger(), _node.ExtHttpEndPoint, _timeout);
+                Given();
+                When();
+            }
+            catch
+            {
+                if (createdMiniNode)
+                {
+                    if (_connection != null)
+                    {
+                        try {
+                            _connection.Close();
+                        } catch { 
+                        }
+                    }
+                    if (_node != null)
+                    {
+                        try { 
+                        	_node.Shutdown();
+                        } catch {
+                        }
+                    }
+                }
+                throw;
+            }
+        }
+
+        [TestFixtureTearDown]
+        public override void TestFixtureTearDown()
+        {
+            if (SetUpFixture.Connection == null || SetUpFixture.Node == null)
+            {
+                _connection.Close();
+                _node.Shutdown();
+            }
+            base.TestFixtureTearDown();
+        }
+
+        public abstract void Given();
+        public abstract void When();
+
+        protected MiniNode CreateNode()
+        {
+            var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All, startStandardProjections: false);
+            return new MiniNode(
+            PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { projections });
+        }
+
+        protected EventData CreateEvent(string eventType, string data)
+        {
+            return new EventData(Guid.NewGuid(), eventType, true, Encoding.UTF8.GetBytes(data), null);
+        }
+
+        protected void PostEvent(string stream, string eventType, string data)
+        {
+            _connection.AppendToStreamAsync(stream, ExpectedVersion.Any, new[] { CreateEvent(eventType, data) }).Wait();
+        }
+
+        protected void CreateOneTimeProjection()
+        {
+            var query = CreateStandardQuery(Guid.NewGuid().ToString());
+            _projManager.CreateOneTimeAsync(query, _credentials).Wait();
+        }
+
+        protected void CreateContinuousProjection(string projectionName)
+        {
+            var query = CreateStandardQuery(Guid.NewGuid().ToString());
+            _projManager.CreateContinuousAsync(projectionName, query, _credentials).Wait();
+        }
+
+        protected string CreateStandardQuery(string stream) {
+            return @"fromStream(""" + stream + @""")
+                .when({
+                    ""$any"":function(s,e) {
+                        s.count = 1;
+                        return s;
+                    }
+            });";
+        }
+
+        protected string CreateEmittingQuery(string stream, string emittingStream)
+        {
+            return @"fromStream(""" + stream + @""")
+                .when({
+                    ""$any"":function(s,e) {
+                        emit(""" + emittingStream + @""", ""emittedEvent"", e);
+                    } 
+                });";
+        }
+    }
+
+}

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/projectionsManagerTests.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/projectionsManagerTests.cs
@@ -1,0 +1,384 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using Newtonsoft.Json.Linq;
+using EventStore.ClientAPI;
+using EventStore.ClientAPI.Projections;
+using EventStore.Common.Utils;
+
+namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
+{
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_creating_one_time_projection : SpecificationWithNodeAndProjectionsManager
+	{
+		private string _streamName;
+		private string _query;
+
+		public override void Given()
+		{
+			_streamName = "test-stream-" + Guid.NewGuid().ToString();
+			PostEvent(_streamName, "testEvent", "{\"A\":\"1\"}");
+			PostEvent(_streamName, "testEvent", "{\"A\":\"2\"}");
+
+			_query = CreateStandardQuery(_streamName);
+		}
+
+		public override void When()
+		{
+			_projManager.CreateOneTimeAsync(_query, _credentials).Wait();
+		}
+
+		[Test]
+		public void should_create_projection()
+		{
+			var projections = _projManager.ListOneTimeAsync(_credentials).Result;
+			Assert.AreEqual(1, projections.Count);
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_creating_transient_projection : SpecificationWithNodeAndProjectionsManager
+	{
+		private string _streamName;
+		private string _projectionName;
+		private string _query;
+
+		public override void Given()
+		{
+			_streamName = "test-stream-" + Guid.NewGuid().ToString();
+			_projectionName = "when_creating_transient_projection";
+			PostEvent(_streamName, "testEvent", "{\"A\":\"1\"}");
+			PostEvent(_streamName, "testEvent", "{\"A\":\"2\"}");
+
+			_query = CreateStandardQuery(_streamName);
+		}
+
+		public override void When()
+		{
+			_projManager.CreateTransientAsync(_projectionName, _query, _credentials).Wait();
+		}
+
+		[Test]
+		public void should_create_projection()
+		{
+			var status = _projManager.GetStatusAsync(_projectionName, _credentials).Result;
+			Assert.IsNotEmpty(status);
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_creating_continuous_projection : SpecificationWithNodeAndProjectionsManager
+	{
+		private string _streamName;
+		private string _emittedStreamName;
+		private string _projectionName;
+		private string _query;
+		private string _projectionId;
+
+		public override void Given()
+		{
+			_streamName = "test-stream-" + Guid.NewGuid().ToString();
+			_projectionName = "when_creating_continuous_projection";
+			_emittedStreamName = "emittedStream-" + Guid.NewGuid().ToString();
+			PostEvent(_streamName, "testEvent", "{\"A\":\"1\"}");
+			PostEvent(_streamName, "testEvent", "{\"A\":\"2\"}");
+
+			_query = CreateEmittingQuery(_streamName, _emittedStreamName);
+		}
+
+		public override void When()
+		{
+			_projManager.CreateContinuousAsync(_projectionName, _query, _credentials).Wait();
+		}
+
+		[Test]
+		public void should_create_projection()
+		{
+			var allProjections = _projManager.ListContinuousAsync(_credentials).Result;
+			var proj = allProjections.FirstOrDefault(x=>x.EffectiveName == _projectionName);
+			_projectionId = proj.Name;
+			Assert.IsNotNull(proj);
+		}
+
+		[Test]
+		public void should_have_turn_on_emit_to_stream()
+		{
+			var events = _connection.ReadEventAsync(string.Format("$projections-{0}", _projectionId), 0, true, _credentials).Result;
+			var data = System.Text.Encoding.UTF8.GetString(events.Event.Value.Event.Data);
+			var eventData = data.ParseJson<JObject>();
+			Assert.IsTrue((bool)eventData["emitEnabled"]);
+		}
+
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_creating_continuous_projection_with_track_emitted_streams : SpecificationWithNodeAndProjectionsManager
+	{
+		private string _streamName;
+		private string _emittedStreamName;
+		private string _projectionName;
+		private string _query;
+		private string _projectionId;
+
+		public override void Given()
+		{
+			_streamName = "test-stream-" + Guid.NewGuid().ToString();
+			_projectionName = "when_creating_continuous_projection_with_track_emitted_streams";
+			_emittedStreamName = "emittedStream-" + Guid.NewGuid().ToString();
+			PostEvent(_streamName, "testEvent", "{\"A\":\"1\"}");
+
+			_query = CreateEmittingQuery(_streamName, _emittedStreamName);
+		}
+
+		public override void When()
+		{
+			_projManager.CreateContinuousAsync(_projectionName, _query, true, _credentials).Wait();
+		}
+
+		[Test]
+		public void should_create_projection()
+		{
+			var allProjections = _projManager.ListContinuousAsync(_credentials).Result;
+			var proj = allProjections.FirstOrDefault(x=>x.EffectiveName == _projectionName);
+			_projectionId = proj.Name;
+			Assert.IsNotNull(proj);
+		}
+
+		[Test]
+		public void should_enable_track_emitted_streams()
+		{
+			var events = _connection.ReadEventAsync(string.Format("$projections-{0}", _projectionId), 0, true, _credentials).Result;
+			var data = System.Text.Encoding.UTF8.GetString(events.Event.Value.Event.Data);
+			var eventData = data.ParseJson<JObject>();
+			Assert.IsTrue((bool)eventData["trackEmittedStreams"]);
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_disabling_projections : SpecificationWithNodeAndProjectionsManager
+	{
+		private string _streamName;
+		private string _projectionName;
+		private string _query;
+
+		public override void Given()
+		{
+			_streamName = "test-stream-" + Guid.NewGuid().ToString();
+			_projectionName = "when_disabling_projection";
+			PostEvent(_streamName, "testEvent", "{\"A\":\"1\"}");
+			PostEvent(_streamName, "testEvent", "{\"A\":\"2\"}");
+
+			_query = CreateStandardQuery(_streamName);
+
+			_projManager.CreateContinuousAsync(_projectionName, _query, _credentials).Wait();
+		}
+
+		public override void When()
+		{
+			_projManager.DisableAsync(_projectionName, _credentials).Wait();
+		}
+
+		[Test]
+		public void should_stop_the_projection()
+		{
+			var projectionStatus = _projManager.GetStatusAsync(_projectionName, _credentials).Result;
+			var status = projectionStatus.ParseJson<JObject>()["status"].ToString();
+			Assert.IsTrue(status.Contains("Stopped"));
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_enabling_projections : SpecificationWithNodeAndProjectionsManager
+	{
+		private string _streamName;
+		private string _projectionName;
+		private string _query;
+
+		public override void Given()
+		{
+			_streamName = "test-stream-" + Guid.NewGuid().ToString();
+			_projectionName = "when_enabling_projections";
+			PostEvent(_streamName, "testEvent", "{\"A\":\"1\"}");
+			PostEvent(_streamName, "testEvent", "{\"A\":\"2\"}");
+
+			_query = CreateStandardQuery(_streamName);
+
+			_projManager.CreateContinuousAsync(_projectionName, _query, _credentials).Wait();
+			_projManager.DisableAsync(_projectionName, _credentials).Wait();
+		}
+
+		public override void When()
+		{
+			_projManager.EnableAsync(_projectionName, _credentials).Wait();
+		}
+
+		[Test]
+		public void should_reenable_projection()
+		{
+			var projectionStatus = _projManager.GetStatusAsync(_projectionName, _credentials).Result;
+			var status = projectionStatus.ParseJson<JObject>()["status"].ToString();
+			Assert.IsTrue(status.Contains("Running"));
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_listing_all_projections : SpecificationWithNodeAndProjectionsManager
+	{
+		private List<ProjectionDetails> _result;
+		public override void Given()
+		{
+		}
+
+		public override void When()
+		{
+			_result = _projManager.ListAllAsync(_credentials).Result.ToList();
+		}
+
+		[Test]
+		public void should_return_all_projections()
+		{
+			Assert.IsNotEmpty(_result);
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_listing_one_time_projections : SpecificationWithNodeAndProjectionsManager
+	{
+		private List<ProjectionDetails> _result;
+		public override void Given()
+		{
+			CreateOneTimeProjection();
+		}
+
+		public override void When()
+		{
+			_result = _projManager.ListOneTimeAsync(_credentials).Result.ToList();
+		}
+
+		[Test]
+		public void should_return_projections()
+		{
+			Assert.IsNotEmpty(_result);
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_listing_continuous_projections : SpecificationWithNodeAndProjectionsManager
+	{
+		private List<ProjectionDetails> _result;
+		private string _projectionName;
+
+		public override void Given()
+		{
+			_projectionName = Guid.NewGuid().ToString();
+			CreateContinuousProjection(_projectionName);
+		}
+
+		public override void When()
+		{
+			_result = _projManager.ListContinuousAsync(_credentials).Result.ToList();
+		}
+
+		[Test]
+		public void should_return_continuous_projections()
+		{
+			Assert.IsTrue(_result.Any(x=>x.EffectiveName == _projectionName));
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_a_projection_is_running : SpecificationWithNodeAndProjectionsManager
+	{
+		private string _projectionName;
+		private string _streamName;
+		private string _query;
+
+		public override void Given()
+		{
+			_projectionName = "when_getting_projection_information";
+			_streamName = "test-stream-" + Guid.NewGuid().ToString();
+			
+			PostEvent(_streamName, "testEvent", "{\"A\":\"1\"}");
+			PostEvent(_streamName, "testEvent", "{\"A\":\"2\"}");
+		}
+
+		public override void When()
+		{
+			_query = CreateStandardQuery(_streamName);
+			_projManager.CreateContinuousAsync(_projectionName, _query, _credentials).Wait();
+		}
+
+		[Test]
+		public void should_be_able_to_get_the_projection_state()
+		{
+			var state = _projManager.GetStateAsync(_projectionName, _credentials).Result;
+			Assert.IsNotEmpty(state);
+		}
+
+		[Test]
+		public void should_be_able_to_get_the_projection_status()
+		{
+			var status = _projManager.GetStatusAsync(_projectionName, _credentials).Result;
+			Assert.IsNotEmpty(status);
+		}
+
+		[Test]
+		public void should_be_able_to_get_the_projection_result()
+		{
+			var result = _projManager.GetResultAsync(_projectionName, _credentials).Result;
+			Assert.AreEqual("{\"count\":1}", result);
+		}
+
+		[Test]
+		public void should_be_able_to_get_the_projection_query()
+		{
+			var query = _projManager.GetQueryAsync(_projectionName, _credentials).Result;
+			Assert.AreEqual(_query, query);
+		}
+	}
+
+	[TestFixture]
+	[Category("ProjectionsManager")]
+	public class when_updating_a_projection_query : SpecificationWithNodeAndProjectionsManager
+	{
+		private string _projectionName;
+		private string _streamName;
+		private string _newQuery;
+
+		public override void Given()
+		{
+			_projectionName = "when_updating_a_projection_query";
+			_streamName = "test-stream-" + Guid.NewGuid().ToString();
+			
+			PostEvent(_streamName, "testEvent", "{\"A\":\"1\"}");
+			PostEvent(_streamName, "testEvent", "{\"A\":\"2\"}");
+
+			var origQuery = CreateStandardQuery(_streamName);
+			_newQuery = CreateStandardQuery("DifferentStream");
+			_projManager.CreateContinuousAsync(_projectionName, origQuery, _credentials).Wait();
+		}
+
+		public override void When()
+		{
+			_projManager.UpdateQueryAsync(_projectionName, _newQuery, _credentials).Wait();
+		}
+
+		[Test]
+		public void should_update_the_projection_query()
+		{
+			var query = _projManager.GetQueryAsync(_projectionName, _credentials).Result;
+			Assert.AreEqual(_newQuery, query);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -507,6 +507,9 @@
     <Compile Include="Services\position_tagging\transaction_file_position_tagger\when_reinitializing_transaction_file_postion_tracker.cs" />
     <Compile Include="Services\write_query_result_phase\creating.cs" />
     <Compile Include="TestsInitFixture.cs" />
+    <Compile Include="ClientAPI\projectionsManager\projectionsManagerTests.cs" />
+    <Compile Include="ClientAPI\projectionsManager\ProjectionsManagerTestSuiteMarkerBase.cs" />
+    <Compile Include="ClientAPI\projectionsManager\SpecificationWithNodeAndProjectionsManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">


### PR DESCRIPTION
Fixes #983 

Adds options to ProjectionsManager for tracking and deleting emitted streams.
Also adds tests around the ProjectionsManager.