### PR TITLE
Fail on reading a null checkpoint tag

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -279,6 +279,10 @@ namespace EventStore.Projections.Core.Services.Processing
                 if (!newPhysicalStream && message.Events.Length > 0)
                 {
                     parsed = message.Events[0].Event.Metadata.ParseCheckpointTagVersionExtraJson(_projectionVersion);
+                    if(parsed.Tag == null){
+                        Failed(string.Format("The '{0}' stream managed by projection {1} has been written to from the outside.", _streamId, _projectionVersion.ProjectionId));
+                        return;
+                    }
                     if (_projectionVersion.ProjectionId != parsed.Version.ProjectionId)
                     {
                         Failed(


### PR DESCRIPTION
This doesn't fix #1001 but introduces a better error message than the `NullReferenceException` when the checkpoint tag is null.

When reading the last event from an existing projection managed stream (EmittedStream) and there isn't a checkpoint tag stored in the metadata of the event
the projection should fail. This means that a something else possibly wrote to the
stream.