### PR TITLE
Copy the input stream if it has a body

### DIFF
--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -212,7 +212,7 @@ namespace EventStore.Core.Services
             // Copy content (if content body is allowed)
             if (!string.Equals(srcReq.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase)
                 && !string.Equals(srcReq.HttpMethod, "HEAD", StringComparison.OrdinalIgnoreCase)
-                && srcReq.ContentLength64 > 0)
+                && srcReq.HasEntityBody)
             {
                 var streamContent = new StreamContent(srcReq.InputStream);
                 streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse(srcReq.ContentType);


### PR DESCRIPTION
Fixes #725

Use `HasEntityBody` to determine whether we should forward the request's body, since Transfer-Encoded:Chunked doesn't have a content length.