### PR TITLE
Handle expected wrong expected version write failure when storage scavenger initializes

### DIFF
--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -134,7 +134,7 @@ namespace EventStore.Core.Services.Storage
             var indexInitializedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeIndexInitialized,
                     true, new Dictionary<string, object>{}.ToJsonBytes(), null);
             _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.NoStream, indexInitializedEvent, SystemAccount.Principal, m => {
-                if(m.Result != OperationResult.Success){
+                if(m.Result != OperationResult.Success && m.Result != OperationResult.WrongExpectedVersion){
                     Log.Error("Failed to write the {0} event to the {1} stream. Reason: {2}", SystemEventTypes.ScavengeIndexInitialized, SystemStreams.ScavengesStream, m.Result);
                 }
              });


### PR DESCRIPTION
The expected result of a second write to the `$scavenges` would be a wrong expected version. We don't need to log this out as it's expected.