### PR TITLE
lastKnownMessage should be -1 from init

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -72,6 +72,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         {
             _state = PersistentSubscriptionState.NotReady;
             _lastCheckPoint = -1;
+            _lastKnownMessage = -1;
             _statistics.SetLastKnownEventNumber(-1);
             _settings.CheckpointReader.BeginLoadState(SubscriptionId, OnCheckpointLoaded);
 


### PR DESCRIPTION
when default was 0 the checkpoint 0 was made from NotifyClockTick. This
leaded to full re-consumption of all messages again.

first NotifyClockTick -> TryMarkCheckpoint:
var difference = lowest - _lastCheckPoint;
1 = 0 - (-1) <- pushed checkpoint 0