### PR TITLE
scavenge: overwrite commit with same tx position

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -176,7 +176,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                                   commit =>
                                   {
                                       if (commit.TransactionPosition >= chunkStartPos)
-                                          commits.Add(commit.TransactionPosition, new CommitInfo(commit));
+                                          commits[commit.TransactionPosition] = new CommitInfo(commit);
                                   },
                                   system => { /* NOOP */ });
                 }


### PR DESCRIPTION
we had problems with scavenge. It stopped with

```
System.ArgumentException: An item with the same key has already been added.
   at System.Collections.Generic.Dictionary`2.Insert(TKey key, TValue value, Boolean add)
   at EventStore.Core.TransactionLog.Chunks.TFChunkScavenger.TraverseChunk(TFChunk chunk, Action`1 processPrepare, Action`1 processCommit, Action`1 processSystem) in D:\Dev\GitHub\mpielikis\EventStore\src\EventStore.Core\TransactionLog\Chunks\TFChunkScavenger.cs:line 467
   at EventStore.Core.TransactionLog.Chunks.TFChunkScavenger.ScavengeChunks(Boolean alwaysKeepScavenged, IList`1 oldChunks, Int64& spaceSaved) in D:\Dev\GitHub\mpielikis\EventStore\src\EventStore.Core\TransactionLog\Chunks\TFChunkScavenger.cs:line 172
   at EventStore.Core.TransactionLog.Chunks.TFChunkScavenger.Scavenge(Boolean alwaysKeepScavenged, Boolean mergeChunks) in D:\Dev\GitHub\mpielikis\EventStore\src\EventStore.Core\TransactionLog\Chunks\TFChunkScavenger.cs:line 78
   at EventStore.Core.Services.Storage.StorageScavenger.Scavenge(ScavengeDatabase message) in D:\Dev\GitHub\mpielikis\EventStore\src\EventStore.Core\Services\Storage\StorageScavenger.cs:line 100
```
made a simple patch and scavenge passed. I am not sure if this is ok.