### PR TITLE
add Https for gossip discovery

### DIFF
--- a/src/EventStore.ClientAPI/GossipSeed.cs
+++ b/src/EventStore.ClientAPI/GossipSeed.cs
@@ -20,13 +20,20 @@ namespace EventStore.ClientAPI
         /// </summary>
         public readonly string HostHeader;
 
+        ///<summary>
+        /// Whether or not to use HTTPS for gossip.
+        /// </summary>
+        public readonly bool UseHttps;
+
         /// <summary>
         /// Creates a new <see cref="GossipSeed" />.
         /// </summary>
         /// <param name="endPoint">The <see cref="IPEndPoint"/> for the External HTTP endpoint of the gossip seed. The standard port is 2113.</param>
         /// <param name="hostHeader">The host header to be sent when requesting gossip. Defaults to String.Empty</param>
-        public GossipSeed(IPEndPoint endPoint, string hostHeader = "")
+        /// <param name="useHttps">Whether to gossip over https. Defaults to false</param>
+        public GossipSeed(IPEndPoint endPoint, string hostHeader = "", bool useHttps = false)
         {
+            UseHttps = useHttps;
             EndPoint = endPoint;
             HostHeader = hostHeader;
         }

--- a/src/EventStore.ClientAPI/Transport.Http/IPEndpointExtensions.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/IPEndpointExtensions.cs
@@ -4,7 +4,15 @@ namespace EventStore.ClientAPI.Transport.Http
 {
     internal static class IPEndPointExtensions
     {
-        public static string ToHttpUrl(this IPEndPoint endPoint, string rawUrl = null)
+      public static string ToHttpsUrl(this IPEndPoint endPoint, string rawUrl = null)
+      {
+        return string.Format("https://{0}:{1}/{2}",
+          endPoint.Address,
+          endPoint.Port,
+          rawUrl != null ? rawUrl.TrimStart('/') : string.Empty);
+      }
+
+      public static string ToHttpUrl(this IPEndPoint endPoint, string rawUrl = null)
         {
             return string.Format("http://{0}:{1}/{2}",
                                  endPoint.Address,


### PR DESCRIPTION
Fixes #1017

This allows for initial discovery of gossip over https. We had assumed http to be available. To use set GossipSeed UseHttps.

I believe the rest of gossip works over https but this should be tested to verify.