### PR TITLE
Pass in correct IndexMapVersion

### DIFF
--- a/src/EventStore.Core.Tests/Index/Index32Bit/saving_index_with_single_item_to_a_file.cs
+++ b/src/EventStore.Core.Tests/Index/Index32Bit/saving_index_with_single_item_to_a_file.cs
@@ -67,7 +67,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
 
                 Assert.AreEqual(5, lines.Count());
                 Assert.AreEqual(md5String, lines[0]);
-                Assert.AreEqual(_ptableVersion.ToString(), lines[1]);
+                Assert.AreEqual(_map.Version.ToString(), lines[1]);
                 Assert.AreEqual("7/11", lines[2]);
                 Assert.AreEqual("0,0," + Path.GetFileName(_tablename), lines[3]);
                 Assert.AreEqual("", lines[4]);

--- a/src/EventStore.Core.Tests/Index/Index32Bit/saving_index_with_six_items_to_a_file.cs
+++ b/src/EventStore.Core.Tests/Index/Index32Bit/saving_index_with_six_items_to_a_file.cs
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
 
                 Assert.AreEqual(7, lines.Count());
                 Assert.AreEqual(md5String, lines[0]);
-                Assert.AreEqual(_ptableVersion.ToString(), lines[1]);
+                Assert.AreEqual(_map.Version.ToString(), lines[1]);
                 Assert.AreEqual("7/11", lines[2]);
                 var name = new FileInfo(_tablename).Name;
                 Assert.AreEqual("0,0," + name, lines[3]);

--- a/src/EventStore.Core/Index/IndexMap.cs
+++ b/src/EventStore.Core/Index/IndexMap.cs
@@ -341,7 +341,7 @@ namespace EventStore.Core.Index
                 }
             }
 
-            var indexMap = new IndexMap(version, tables, prepareCheckpoint, commitCheckpoint, _maxTablesPerLevel);
+            var indexMap = new IndexMap(Version, tables, prepareCheckpoint, commitCheckpoint, _maxTablesPerLevel);
             return new MergeResult(indexMap, toDelete);
         }
 


### PR DESCRIPTION
This was a typo from the recent 64bit change.
Fix up bad tests against IndexMap version.