### PR TITLE
Revert "Try reconnect to master the first time the connection is dropped"

### DIFF
--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -46,8 +46,6 @@ namespace EventStore.Core.Services.Replication
 
         private readonly InternalTcpDispatcher _tcpDispatcher = new InternalTcpDispatcher();
 
-        private bool _hasAttemptedToReconnect;
-        private VNodeInfo _masterNodeInfo;
         private VNodeState _state = VNodeState.Initializing;
         private TcpConnectionManager _connection;
 
@@ -132,19 +130,12 @@ namespace EventStore.Core.Services.Replication
 
         private void OnConnectionEstablished(TcpConnectionManager manager)
         {
-            _hasAttemptedToReconnect = false;
             _publisher.Publish(new SystemMessage.VNodeConnectionEstablished(manager.RemoteEndPoint, manager.ConnectionId));
         }
 
         private void OnConnectionClosed(TcpConnectionManager manager, SocketError socketError)
         {
-            if(!_hasAttemptedToReconnect && _masterNodeInfo != null) {
-                Log.Info("Attempting to reconnect to master");
-                _hasAttemptedToReconnect = true;
-                ConnectToMaster(_masterNodeInfo);
-            } else {
-                _publisher.Publish(new SystemMessage.VNodeConnectionLost(manager.RemoteEndPoint, manager.ConnectionId));
-            }
+            _publisher.Publish(new SystemMessage.VNodeConnectionLost(manager.RemoteEndPoint, manager.ConnectionId));
         }
 
         public void Handle(ReplicationMessage.ReconnectToMaster message)
@@ -155,7 +146,6 @@ namespace EventStore.Core.Services.Replication
         private void ConnectToMaster(VNodeInfo master)
         {
             Debug.Assert(_state == VNodeState.PreReplica);
-            _masterNodeInfo = master;
 
             var masterEndPoint = GetMasterEndPoint(master, _useSsl);
 


### PR DESCRIPTION
After testing it appears that once the reconnection happens, the `/stats/replication` does not return the the node that reconnected.

Reverting this as it's a small change and the work should be re-done as a new PR instead of being patched on the current release branch.