### PR TITLE
shouldn't throw in this case since async is now in place

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
@@ -208,8 +208,8 @@ namespace EventStore.ClientAPI.ClientOperations
 
                 if (reason != SubscriptionDropReason.UserInitiated)
                 {
-                    if (exc == null) throw new Exception(string.Format("No exception provided for subscription drop reason '{0}", reason));
-                    _source.TrySetException(exc);
+                    var er = exc != null ? exc : new Exception(String.Format("Subscription dropped for {0}", reason));
+                    _source.TrySetException(er);
                 }
 
                 if (reason == SubscriptionDropReason.UserInitiated && _subscription != null && connection != null)

--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -332,6 +332,7 @@ namespace EventStore.ClientAPI
                     }
                     catch (Exception exc)
                     {
+                        Log.Debug("Catch-up Subscription to {0} Exception occurred in subscription {1}",IsSubscribedToAll ? "<all>" : StreamId, exc);
                         DropSubscription(SubscriptionDropReason.EventHandlerException, exc);
                         return;
                     }


### PR DESCRIPTION
we hit: https://github.com/EventStore/EventStore/blob/release-v4.0.0/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs#L348
this then calls the subscription.Unsubscribe

which is: https://github.com/EventStore/EventStore/blob/release-v4.0.0/src/EventStore.ClientAPI/Internal/VolatileEventStoreSubscription.cs#L17 obviously just forwards to the operation.

ends up here: https://github.com/EventStore/EventStore/blob/release-v4.0.0/src/EventStore.ClientAPI/ClientOperations/VolatileSubscriptionOperation.cs

which is then implemented in the base:
https://github.com/EventStore/EventStore/blob/release-v4.0.0/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs#L203

Note that in the log we never get the closing message. which means unsubscribed == 1)

We later hit: https://github.com/EventStore/EventStore/blob/release-v4.0.0/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs#L209

And we throw. This must have been introduced in the async refactor. The exception appears to end up out in never never land somewhere.