### PR TITLE
Return if lowest is 0

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -295,6 +295,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 var lowestBufferedRetry = _streamBuffer.GetLowestRetry();
                 lowest = Math.Min(lowest, lowestBufferedRetry);
                 if (lowest == int.MinValue) lowest = _lastKnownMessage;
+                if (lowest == 0) return;
                 //no outstanding messages. in this case we can say that the last known
                 //event would be our checkpoint place (we have already completed it)
                 var difference = lowest - _lastCheckPoint;


### PR DESCRIPTION
Fixes an issue where if the subscription does a take over and is perfectly caught up, with nothing connected to it. The checkpoint would write to last known message which is 0