### PR TITLE
Pass correct parameter into IndexMap.FromFile

### DIFF
--- a/src/EventStore.Core.Tests/Index/Index32Bit/index_map_should.cs
+++ b/src/EventStore.Core.Tests/Index/Index32Bit/index_map_should.cs
@@ -56,7 +56,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
         public void throw_corruptedindexexception_when_prepare_checkpoint_is_less_than_minus_one()
         {
             CreateArtificialIndexMapFile(_indexMapFileName, -2, 0, null);
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
             CreateArtificialIndexMapFile(_indexMapFileName, -1, 0, null);
             Assert.DoesNotThrow(() =>
             {
-                var indexMap = IndexMap.FromFile(_indexMapFileName, 2);
+                var indexMap = IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2);
                 indexMap.InOrder().ToList().ForEach(x => x.Dispose());
             });
         }
@@ -74,14 +74,14 @@ namespace EventStore.Core.Tests.Index.Index32Bit
         public void throw_corruptedindexexception_if_prepare_checkpoint_is_minus_one_and_there_are_ptables_in_indexmap()
         {
             CreateArtificialIndexMapFile(_indexMapFileName, -1, 0, _ptableFileName);
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
         public void throw_corruptedindexexception_when_commit_checkpoint_is_less_than_minus_one()
         {
             CreateArtificialIndexMapFile(_indexMapFileName, 0, -2, null);
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -90,7 +90,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
             CreateArtificialIndexMapFile(_indexMapFileName, 0, -1, null);
             Assert.DoesNotThrow(() =>
             {
-                var indexMap = IndexMap.FromFile(_indexMapFileName, 2);
+                var indexMap = IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2);
                 indexMap.InOrder().ToList().ForEach(x => x.Dispose());
             });
         }
@@ -99,7 +99,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
         public void throw_corruptedindexexception_if_commit_checkpoint_is_minus_one_and_there_are_ptables_in_indexmap()
         {
             CreateArtificialIndexMapFile(_indexMapFileName, 0, -1, _ptableFileName);
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         private void CreateArtificialIndexMapFile(string filePath, long prepareCheckpoint, long commitCheckpoint, string ptablePath)

--- a/src/EventStore.Core.Tests/Index/Index32Bit/index_map_should_detect_corruption.cs
+++ b/src/EventStore.Core.Tests/Index/Index32Bit/index_map_should_detect_corruption.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
             _ptable = null;
             File.Delete(_ptableFileName);
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
             var lines = File.ReadAllLines(_indexMapFileName);
             File.WriteAllLines(_indexMapFileName, lines.Skip(1));
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -66,7 +66,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
             var lines = File.ReadAllLines(_indexMapFileName);
             File.WriteAllLines(_indexMapFileName, lines.Where((x,i) => i != 1));
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
         {
             File.WriteAllText(_indexMapFileName, "");
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
         {
             File.WriteAllText(_indexMapFileName, "alkfjasd;lkf\nasdfasdf\n");
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
                 fs.WriteByte(b);
             }
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -106,7 +106,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
             var lines = File.ReadAllLines(_indexMapFileName);
             File.WriteAllLines(_indexMapFileName, new[] { lines[0], lines[1], string.Format("0,{0}", _ptableFileName)});
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -115,7 +115,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
             var lines = File.ReadAllLines(_indexMapFileName);
             File.WriteAllLines(_indexMapFileName, new[] { lines[0], lines[1], _ptableFileName });
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
             var lines = File.ReadAllLines(_indexMapFileName);
             File.WriteAllLines(_indexMapFileName, new[] { lines[0], lines[1], "0,0" });
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -138,7 +138,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
                 fs.WriteByte(b);
             }
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -156,7 +156,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
                 fs.WriteByte(b);
             }
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
                 fs.WriteByte(123);
             }
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -189,7 +189,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
                 fs.WriteByte(b);
             }
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace EventStore.Core.Tests.Index.Index32Bit
                 fs.WriteByte(b);
             }
 
-            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, 2));
+            Assert.Throws<CorruptIndexException>(() => IndexMap.FromFile(_indexMapFileName, _ptableVersion, maxTablesPerLevel: 2));
         }
     }
 }

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -112,7 +112,7 @@ namespace EventStore.Core.Index
             // this can happen (very unlikely, though) on master crash
             try
             {
-                _indexMap = IndexMap.FromFile(indexmapFile, _ptableVersion, _maxTablesPerLevel, cacheDepth: _indexCacheDepth);
+                _indexMap = IndexMap.FromFile(indexmapFile, _ptableVersion, maxTablesPerLevel: _maxTablesPerLevel, cacheDepth: _indexCacheDepth);
                 if (_indexMap.CommitCheckpoint >= chaserCheckpoint)
                 {
                     _indexMap.Dispose(TimeSpan.FromMilliseconds(5000));
@@ -125,7 +125,7 @@ namespace EventStore.Core.Index
                 LogIndexMapContent(indexmapFile);
                 DumpAndCopyIndex();
                 File.Delete(indexmapFile);
-                _indexMap = IndexMap.FromFile(indexmapFile, _maxTablesPerLevel, cacheDepth: _indexCacheDepth);
+                _indexMap = IndexMap.FromFile(indexmapFile, _ptableVersion, maxTablesPerLevel: _maxTablesPerLevel, cacheDepth: _indexCacheDepth);
             }
             _prepareCheckpoint = _indexMap.PrepareCheckpoint;
             _commitCheckpoint = _indexMap.CommitCheckpoint;


### PR DESCRIPTION
In the TableIndex corrupted index exception path, the incorrect parameter for PTableVersion is being passed. The PTableVersion parameter is currently being set by the MaxTablesPerLevel (which is set to 2).