### PR TITLE
Fix issue when merging mixed indexes where hash collisions occur

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -267,6 +267,7 @@
     <Compile Include="Index\FakeIndexHasher.cs" />
     <Compile Include="Index\FakeIndexReader.cs" />
     <Compile Include="Index\Index32Bit\when_merging_ptables.cs" />
+    <Compile Include="Index\Index64Bit\table_index_hash_collision_when_upgrading_to_64bit.cs" />
     <Compile Include="Index\MemTableTests.cs" />
     <Compile Include="Index\Index64Bit\adding_four_items_to_empty_index_map_with_four_tables_per_level_causes_merge.cs" />
     <Compile Include="Index\Index64Bit\adding_four_items_to_empty_index_map_with_two_tables_per_level_causes_double_merge.cs" />

--- a/src/EventStore.Core.Tests/Index/Index64Bit/table_index_hash_collision_when_upgrading_to_64bit.cs
+++ b/src/EventStore.Core.Tests/Index/Index64Bit/table_index_hash_collision_when_upgrading_to_64bit.cs
@@ -1,0 +1,155 @@
+﻿using System.Linq;
+using System.Threading;
+using EventStore.Core.Index;
+using EventStore.Core.TransactionLog;
+using NUnit.Framework;
+using EventStore.Core.Index.Hashes;
+using System;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.Tests.Index.Index64Bit
+{
+    [TestFixture, Category("LongRunning")]
+    public class table_index_hash_collision_when_upgrading_to_64bit : SpecificationWithDirectoryPerTestFixture
+    {
+        private TableIndex _tableIndex;
+        private IHasher _lowHasher;
+        private IHasher _highHasher;
+        private string _indexDir;
+
+        [TestFixtureSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            _indexDir = PathName;
+            var fakeReader = new TFReaderLease(new FakeIndexReader());
+            _lowHasher = new XXHashUnsafe();
+            _highHasher = new Murmur3AUnsafe();
+            _tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+                                         () => new HashListMemTable(PTableVersions.Index32Bit, maxSize: 5),
+                                         () => fakeReader,
+                                         PTableVersions.Index32Bit,
+                                         maxSizeForMemory: 5,
+                                         maxTablesPerLevel: 2);
+            _tableIndex.Initialize(long.MaxValue);
+
+            _tableIndex.Add(1, "LPN-FC002_LPK51001", 0, 1);
+            _tableIndex.Add(1, "account--696193173", 0, 2);
+            _tableIndex.Add(1, "LPN-FC002_LPK51001", 1, 3);
+            _tableIndex.Add(1, "account--696193173", 1, 4);
+            _tableIndex.Add(1, "LPN-FC002_LPK51001", 2, 5);
+
+            _tableIndex.Close(false);
+
+            _tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+                                         () => new HashListMemTable(PTableVersions.Index64Bit, maxSize: 5),
+                                         () => fakeReader,
+                                         PTableVersions.Index64Bit,
+                                         maxSizeForMemory: 5,
+                                         maxTablesPerLevel: 2);
+            _tableIndex.Initialize(long.MaxValue);
+
+            _tableIndex.Add(1, "account--696193173", 2, 6);
+            _tableIndex.Add(1, "LPN-FC002_LPK51001", 3, 7);
+            _tableIndex.Add(1, "account--696193173", 3, 8);
+            _tableIndex.Add(1, "LPN-FC002_LPK51001", 4, 9);
+            _tableIndex.Add(1, "account--696193173", 4, 10);
+
+            Thread.Sleep(500);
+        }
+
+        [TestFixtureTearDown]
+        public override void TestFixtureTearDown()
+        {
+            _tableIndex.Close();
+
+            base.TestFixtureTearDown();
+        }
+
+        [Test]
+        public void should_have_entries_in_sorted_order()
+        {
+            var streamId = "account--696193173";
+            var result = _tableIndex.GetRange(streamId, 0, 4).ToArray();
+            var hash = (ulong)_lowHasher.Hash(streamId) << 32 | _highHasher.Hash(streamId);
+
+            Assert.That(result.Count(), Is.EqualTo(5));
+
+            Assert.That(result[0].Stream, Is.EqualTo(hash));
+            Assert.That(result[0].Version, Is.EqualTo(4));
+            Assert.That(result[0].Position, Is.EqualTo(10));
+
+            Assert.That(result[1].Stream, Is.EqualTo(hash));
+            Assert.That(result[1].Version, Is.EqualTo(3));
+            Assert.That(result[1].Position, Is.EqualTo(8));
+
+            Assert.That(result[2].Stream, Is.EqualTo(hash));
+            Assert.That(result[2].Version, Is.EqualTo(2));
+            Assert.That(result[2].Position, Is.EqualTo(6));
+
+            Assert.That(result[3].Stream, Is.EqualTo(hash));
+            Assert.That(result[3].Version, Is.EqualTo(1));
+            Assert.That(result[3].Position, Is.EqualTo(4));
+
+            Assert.That(result[4].Stream, Is.EqualTo(hash));
+            Assert.That(result[4].Version, Is.EqualTo(0));
+            Assert.That(result[4].Position, Is.EqualTo(2));
+
+            streamId = "LPN-FC002_LPK51001";
+            result = _tableIndex.GetRange(streamId, 0, 4).ToArray();
+            hash = (ulong)_lowHasher.Hash(streamId) << 32 | _highHasher.Hash(streamId);
+
+            Assert.That(result.Count(), Is.EqualTo(5));
+
+            Assert.That(result[0].Stream, Is.EqualTo(hash));
+            Assert.That(result[0].Version, Is.EqualTo(4));
+            Assert.That(result[0].Position, Is.EqualTo(9));
+
+            Assert.That(result[1].Stream, Is.EqualTo(hash));
+            Assert.That(result[1].Version, Is.EqualTo(3));
+            Assert.That(result[1].Position, Is.EqualTo(7));
+
+            Assert.That(result[2].Stream, Is.EqualTo(hash));
+            Assert.That(result[2].Version, Is.EqualTo(2));
+            Assert.That(result[2].Position, Is.EqualTo(5));
+
+            Assert.That(result[3].Stream, Is.EqualTo(hash));
+            Assert.That(result[3].Version, Is.EqualTo(1));
+            Assert.That(result[3].Position, Is.EqualTo(3));
+
+            Assert.That(result[4].Stream, Is.EqualTo(hash));
+            Assert.That(result[4].Version, Is.EqualTo(0));
+            Assert.That(result[4].Position, Is.EqualTo(1));
+        }
+    }
+
+    public class FakeIndexReader : ITransactionFileReader
+    {
+        public void Reposition(long position)
+        {
+            throw new NotImplementedException();
+        }
+
+        public SeqReadResult TryReadNext()
+        {
+            throw new NotImplementedException();
+        }
+
+        public SeqReadResult TryReadPrev()
+        {
+            throw new NotImplementedException();
+        }
+
+        public RecordReadResult TryReadAt(long position)
+        {
+            var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0, position % 2 == 0 ? "account--696193173" : "LPN-FC002_LPK51001", -1, DateTime.UtcNow, PrepareFlags.None, "type", new byte[0], null);
+            return new RecordReadResult(true, position + 1, record, 1);
+        }
+
+        public bool ExistsAt(long position)
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
There is a case that is not being handled by the current implementation of the upgrade during a merge between a 32 bit index and a 64bit index.

The issue is encountered when hash collisions in the 32bit index occurs in the same index file.

The proposed solution is to read the entries from the 32bit index file up to where a different hash is encountered and then upgrade those entries to 64bit in a sorted list. The sorted list is then used to merge with the 64bit index.