### PR TITLE
Don't set the exception on the task completion source twice

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -451,7 +451,6 @@ namespace EventStore.ClientAPI
             {
                 if (task.IsFaulted || task.IsCanceled)
                 {
-                    _completion.SetException(task.Exception);
                     task.Wait(); //force exception to be thrown
                 }
 
@@ -587,7 +586,6 @@ namespace EventStore.ClientAPI
             {
                 if (task.IsFaulted || task.IsCanceled)
                 {
-                    _completion.SetException(task.Exception);
                     task.Wait(); //force exception to be thrown
                 }
 


### PR DESCRIPTION
Fixes an issue that could occur if an exception is thrown while reading events in a catchup subscription. The exception would be set on the completion source twice, resulting in an exception being thrown. 

Because the task has already returned, the exception on the task would not be checked by the client, and an exception would eventually be thrown later when the task gets disposed.