### PR TITLE
Fix performance counters for a process.

### DIFF
--- a/src/EventStore.Core/Services/Monitoring/Utils/PerfCounterHelper.cs
+++ b/src/EventStore.Core/Services/Monitoring/Utils/PerfCounterHelper.cs
@@ -57,7 +57,11 @@ namespace EventStore.Core.Services.Monitoring.Utils
             string processName = null;
             try
             {
+                #if __MonoCS__
+                processName = Process.GetCurrentProcess().Id.ToString();
+                #else
                 processName = Process.GetCurrentProcess().ProcessName;
+                #endif
                 return CreatePerfCounter(category, counter, processName);
             }
             catch (Exception ex)


### PR DESCRIPTION
For process based counters, the id of the process should be used instead of the name on mono.