### PR TITLE
Prevent possible errors when setting the task result for a catchup subscription

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -440,7 +440,7 @@ namespace EventStore.ClientAPI
             }
             catch (Exception ex)
             {
-                _completion.SetException(ex);
+                _completion.TrySetException(ex);
             }
         }
 
@@ -467,12 +467,12 @@ namespace EventStore.ClientAPI
                             "Catch-up Subscription to {0}: finished reading events, nextReadPosition = {1}.",
                             IsSubscribedToAll ? "<all>" : StreamId, _nextReadPosition);
                     }
-                    _completion.SetResult(true);
+                    _completion.TrySetResult(true);
                 }
             }
             catch (Exception e)
             {
-                _completion.SetException(e);
+                _completion.TrySetException(e);
             }
         }
 
@@ -575,7 +575,7 @@ namespace EventStore.ClientAPI
             }
             catch(Exception ex)
             {
-                _completion.SetException(ex);
+                _completion.TrySetException(ex);
             }
         }
 
@@ -601,12 +601,12 @@ namespace EventStore.ClientAPI
                             "Catch-up Subscription to {0}: finished reading events, nextReadEventNumber = {1}.",
                             IsSubscribedToAll ? "<all>" : StreamId, _nextReadEventNumber);
                     }
-                    _completion.SetResult(true);
+                    _completion.TrySetResult(true);
                 }
             }
             catch (Exception e)
             {
-                _completion.SetException(e);
+                _completion.TrySetException(e);
             }
         }
 


### PR DESCRIPTION
Use the Try* methods on the TaskCompletionSource in catchup subscriptions to prevent errors from being thrown when the task has been disposed.