### PR TITLE
Add translator for UserCredentials

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text;
+using EventStore.ClientAPI.SystemData;
 
 namespace EventStore.ClientAPI
 {
@@ -44,6 +45,21 @@ namespace EventStore.ClientAPI
                         throw new Exception(string.Format("Gossip seed {0} is not in correct format", q), ex);
                     }
                 }).ToArray()
+                },
+                {typeof(UserCredentials), x =>
+                {
+                    try
+                    {
+                        var pieces = x.Trim().Split(':');
+                        if (pieces.Length != 2) throw new Exception("Could not split into username and password.");
+                        
+                        return new UserCredentials(pieces[0], pieces[1]);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception(string.Format("User credentials {0} is not in correct format. Expected format is username:password.", x), ex);
+                    }
+                }
                 }
             };
         }

--- a/src/EventStore.Core.Tests/ClientAPI/connection_string.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connection_string.cs
@@ -63,5 +63,13 @@ namespace EventStore.Core.Tests.ClientAPI
             var settings = ConnectionString.GetConnectionSettings("gossipseeds=111.222.222.111:1111,111.222.222.111:1112,111.222.222.111:1113");
             Assert.AreEqual(3, settings.GossipSeeds.Length);
         }
+
+        [Test]
+        public void can_set_default_user_credentials()
+        {
+            var settings = ConnectionString.GetConnectionSettings("DefaultUserCredentials=foo:bar");
+            Assert.AreEqual("foo", settings.DefaultUserCredentials.Username);
+            Assert.AreEqual("bar", settings.DefaultUserCredentials.Password);
+        }
     }
 }


### PR DESCRIPTION
Fixes an issue raised on [google groups](https://groups.google.com/forum/#!topic/event-store/5F8fOWfQG-A). Added translator for `UserCredentials`.