### PR TITLE
Adding ConditionalAppendToStream API

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/ConditionalAppendToStreamOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/ConditionalAppendToStreamOperation.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.ClientAPI.Exceptions;
+using EventStore.ClientAPI.Messages;
+using EventStore.ClientAPI.SystemData;
+
+namespace EventStore.ClientAPI.ClientOperations
+{
+    internal class ConditionalAppendToStreamOperation : OperationBase<ConditionalWriteResult, ClientMessage.WriteEventsCompleted>
+    {
+        private readonly bool _requireMaster;
+        private readonly string _stream;
+        private readonly int _expectedVersion;
+        private readonly IEnumerable<EventData> _events;
+
+        private bool _wasCommitTimeout;
+
+        public ConditionalAppendToStreamOperation(ILogger log,
+                                       TaskCompletionSource<ConditionalWriteResult> source,
+                                       bool requireMaster,
+                                       string stream,
+                                       int expectedVersion,
+                                       IEnumerable<EventData> events,
+                                       UserCredentials userCredentials)
+            : base(log, source, TcpCommand.WriteEvents, TcpCommand.WriteEventsCompleted, userCredentials)
+        {
+            _requireMaster = requireMaster;
+            _stream = stream;
+            _expectedVersion = expectedVersion;
+            _events = events;
+        }
+
+        protected override object CreateRequestDto()
+        {
+            var dtos = _events.Select(x => new ClientMessage.NewEvent(x.EventId.ToByteArray(), x.Type, x.IsJson ? 1 : 0, 0, x.Data, x.Metadata)).ToArray();
+            return new ClientMessage.WriteEvents(_stream, _expectedVersion, dtos, _requireMaster);
+        }
+
+        protected override InspectionResult InspectResponse(ClientMessage.WriteEventsCompleted response)
+        {
+            switch (response.Result)
+            {
+                case ClientMessage.OperationResult.Success:
+                    if (_wasCommitTimeout)
+                        Log.Debug("IDEMPOTENT WRITE SUCCEEDED FOR {0}.", this);
+                    Succeed();
+                    return new InspectionResult(InspectionDecision.EndOperation, "Success");
+                case ClientMessage.OperationResult.PrepareTimeout:
+                    return new InspectionResult(InspectionDecision.Retry, "PrepareTimeout");
+                case ClientMessage.OperationResult.ForwardTimeout:
+                    return new InspectionResult(InspectionDecision.Retry, "ForwardTimeout");
+                case ClientMessage.OperationResult.CommitTimeout:
+                    _wasCommitTimeout = true;
+                    return new InspectionResult(InspectionDecision.Retry, "CommitTimeout");
+                case ClientMessage.OperationResult.WrongExpectedVersion:
+                    Succeed();
+                    return new InspectionResult(InspectionDecision.EndOperation, "ExpectedVersionMismatch");
+                case ClientMessage.OperationResult.StreamDeleted:
+                    Succeed();
+                    return new InspectionResult(InspectionDecision.EndOperation, "StreamDeleted");
+                case ClientMessage.OperationResult.InvalidTransaction:
+                    Fail(new InvalidTransactionException());
+                    return new InspectionResult(InspectionDecision.EndOperation, "InvalidTransaction");
+                case ClientMessage.OperationResult.AccessDenied:
+                    Fail(new AccessDeniedException(string.Format("Write access denied for stream '{0}'.", _stream)));
+                    return new InspectionResult(InspectionDecision.EndOperation, "AccessDenied");
+                default:
+                    throw new Exception(string.Format("Unexpected OperationResult: {0}.", response.Result));
+            }
+        }
+
+        protected override ConditionalWriteResult TransformResponse(ClientMessage.WriteEventsCompleted response)
+        {
+            if (response.Result == ClientMessage.OperationResult.WrongExpectedVersion)
+            {
+                return new ConditionalWriteResult(ConditionalWriteStatus.VersionMismatch);
+            }
+            if (response.Result == ClientMessage.OperationResult.StreamDeleted)
+            {
+                return new ConditionalWriteResult(ConditionalWriteStatus.StreamDeleted);
+            }
+            return new ConditionalWriteResult(response.LastEventNumber, new Position(response.PreparePosition ?? -1, response.CommitPosition ?? -1));
+        }
+
+        public override string ToString()
+        {
+            return string.Format("Stream: {0}, ExpectedVersion: {1}", _stream, _expectedVersion);
+        }
+    }
+}

--- a/src/EventStore.ClientAPI/ConditionalWriteFailureReason.cs
+++ b/src/EventStore.ClientAPI/ConditionalWriteFailureReason.cs
@@ -1,0 +1,21 @@
+namespace EventStore.ClientAPI
+{
+    /// <summary>
+    /// The reason why a conditional write fails
+    /// </summary>
+    public enum ConditionalWriteStatus
+    {
+        /// <summary>
+        /// The write operation succeeded
+        /// </summary>
+        Succeeded = 0,
+        /// <summary>
+        /// The expected version does not match actual stream version
+        /// </summary>
+        VersionMismatch = 1,
+        /// <summary>
+        /// The stream has been deleted
+        /// </summary>
+        StreamDeleted = 2
+    }
+}

--- a/src/EventStore.ClientAPI/ConditionalWriteResult.cs
+++ b/src/EventStore.ClientAPI/ConditionalWriteResult.cs
@@ -1,0 +1,52 @@
+using System;
+
+namespace EventStore.ClientAPI
+{
+    /// <summary>
+    /// Result type returned after conditionally writing to a stream.
+    /// </summary>
+    public struct ConditionalWriteResult
+    {
+        /// <summary>
+        /// Returns if the write was successful.
+        /// </summary>
+        public readonly ConditionalWriteStatus Status;
+
+        /// <summary>
+        /// The next expected version for the stream.
+        /// </summary>
+        public readonly int? NextExpectedVersion;
+
+        /// <summary>
+        /// The <see cref="LogPosition"/> of the write.
+        /// </summary>
+        public readonly Position? LogPosition;
+
+        /// <summary>
+        /// Constructs a new <see cref="WriteResult"/>.
+        /// </summary>
+        /// <param name="nextExpectedVersion">The next expected version for the stream.</param>
+        /// <param name="logPosition">The position of the write in the log</param>
+        public ConditionalWriteResult(int nextExpectedVersion, Position logPosition)
+        {
+            LogPosition = logPosition;
+            NextExpectedVersion = nextExpectedVersion;
+            Status = ConditionalWriteStatus.Succeeded;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="WriteResult"/>.
+        /// </summary>
+        /// <param name="status">The status of the write operation.</param>
+        public ConditionalWriteResult(ConditionalWriteStatus status)
+        {
+            if (status == ConditionalWriteStatus.Succeeded)
+            {
+                throw new Exception("For successful write pass next expected version and log position.");
+            }
+            LogPosition = null;
+            NextExpectedVersion = null;
+            Status = status;
+        }
+    }
+}

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\libs\protobuf-v2\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http">
-        <SpecificVersion>False</SpecificVersion>
-        <HintPath>..\libs\Microsoft.Net.Http\System.Net.Http.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\libs\Microsoft.Net.Http\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml.Linq" />
@@ -56,6 +56,7 @@
   <ItemGroup>
     <Compile Include="AllCheckpoint.cs" />
     <Compile Include="AllEventsSlice.cs" />
+    <Compile Include="ClientOperations\ConditionalAppendToStreamOperation.cs" />
     <Compile Include="ClientOperations\ConnectToPersistentSubscriptionOperation.cs" />
     <Compile Include="ClientOperations\CreatePersistentSubscriptionOperation.cs" />
     <Compile Include="ClientOperations\DeletePersistentSubscriptionOperation.cs" />
@@ -64,6 +65,8 @@
     <Compile Include="ClientOperations\VolatileSubscriptionOperation.cs" />
     <Compile Include="Common\Log\FileLogger.cs" />
     <Compile Include="Common\Utils\Threading\ManualResetEventSlimExtensions.cs" />
+    <Compile Include="ConditionalWriteFailureReason.cs" />
+    <Compile Include="ConditionalWriteResult.cs" />
     <Compile Include="ConnectionString.cs" />
     <Compile Include="EventStorePersistentSubscription.cs" />
     <Compile Include="EventStorePersistentSubscriptionBase.cs" />

--- a/src/EventStore.ClientAPI/IEventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnection.cs
@@ -116,6 +116,26 @@ namespace EventStore.ClientAPI
         Task<WriteResult> AppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events, UserCredentials userCredentials = null);
 
         /// <summary>
+        /// Appends Events asynchronously to a stream if the stream version matches the <paramref name="expectedVersion"/>.
+        /// </summary>
+        /// <remarks>
+        /// When appending events to a stream the <see cref="ExpectedVersion"/> choice can
+        /// make a very large difference in the observed behavior. For example, if no stream exists
+        /// and ExpectedVersion.Any is used, a new stream will be implicitly created when appending.
+        ///
+        /// There are also differences in idempotency between different types of calls.
+        /// If you specify an ExpectedVersion aside from ExpectedVersion.Any the Event Store
+        /// will give you an idempotency guarantee. If using ExpectedVersion.Any the Event Store
+        /// will do its best to provide idempotency but does not guarantee idempotency
+        /// </remarks>
+        /// <param name="stream">The name of the stream to append events to</param>
+        /// <param name="expectedVersion">The <see cref="ExpectedVersion"/> of the stream to append to</param>
+        /// <param name="events">The events to append to the stream</param>
+        /// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+        /// <returns>If the operation succeeded and, if not, the reason for failure (which can be either stream version mismatch or trying to write to a deleted stream)</returns>
+        Task<ConditionalWriteResult> ConditionalAppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events, UserCredentials userCredentials = null);
+
+        /// <summary>
         /// Starts a transaction in the event store on a given stream asynchronously
         /// </summary>
         /// <remarks>

--- a/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
@@ -130,6 +130,20 @@ namespace EventStore.ClientAPI.Internal
 // ReSharper restore PossibleMultipleEnumeration
         }
 
+        public Task<ConditionalWriteResult> ConditionalAppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events,
+            UserCredentials userCredentials = null)
+        {
+            // ReSharper disable PossibleMultipleEnumeration
+            Ensure.NotNullOrEmpty(stream, "stream");
+            Ensure.NotNull(events, "events");
+
+            var source = new TaskCompletionSource<ConditionalWriteResult>();
+            EnqueueOperation(new ConditionalAppendToStreamOperation(_settings.Log, source, _settings.RequireMaster,
+                                                         stream, expectedVersion, events, userCredentials));
+            return source.Task;
+            // ReSharper restore PossibleMultipleEnumeration
+        }
+
         public Task<EventStoreTransaction> StartTransactionAsync(string stream, int expectedVersion, UserCredentials userCredentials = null)
         {
             Ensure.NotNullOrEmpty(stream, "stream");

--- a/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
@@ -485,6 +485,12 @@ namespace EventStore.Core.Tests.ClientAPI
             throw new NotImplementedException();
         }
 
+        public Task<ConditionalWriteResult> ConditionalAppendToStreamAsync(string stream, int expectedVersion, IEnumerable<EventData> events,
+            UserCredentials userCredentials = null)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<EventStoreTransaction> StartTransactionAsync(string stream, int expectedVersion, UserCredentials userCredentials = null)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
The ConditionalAppendToStream returns the status instead of throwing an exception in cases of stream version mismatch or stream being deleted.

It may be useful in cases where there are a couple of different index streams that contain links to multiple source streams. When processing an index stream, the changes to source streams are applied only if the link leads to the latest version of the source stream and the stream itself exists.