### PR TITLE
Fix 2 additional duplicate entry issues

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -614,6 +614,7 @@
     <Compile Include="ClientAPI\read_stream_events_backward_with_hash_collision.cs" />
     <Compile Include="ClientAPI\read_stream_events_forward_with_hash_collision.cs" />
     <Compile Include="Services\Storage\Scavenge\when_deleting_duplicate_events.cs" />
+    <Compile Include="Services\Storage\BuildingIndex\when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj">

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -1,0 +1,193 @@
+using EventStore.Common.Utils;
+using EventStore.Core.Bus;
+using EventStore.Core.DataStructures;
+using EventStore.Core.Helpers;
+using EventStore.Core.Index;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Util;
+using EventStore.Core.Index.Hashes;
+using System;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+using ReadStreamResult = EventStore.Core.Services.Storage.ReaderIndex.ReadStreamResult;
+
+namespace EventStore.Core.Tests.Services.Storage.BuildingIndex
+{
+    [TestFixture, Category("test")]
+    public class when_building_an_index_off_tfile_with_duplicate_events_in_a_stream : DuplicateReadIndexTestScenario
+    {
+        private Guid _id1;
+        private Guid _id2;
+        private Guid _id3;
+        private Guid _id4;
+
+        private long pos1, pos2, pos3, pos4, pos5, pos6, pos7;
+
+        public when_building_an_index_off_tfile_with_duplicate_events_in_a_stream() : base(maxEntriesInMemTable: 3) {}
+
+        protected override void SetupDB()
+        {
+            _id1 = Guid.NewGuid();
+            _id2 = Guid.NewGuid();
+            _id3 = Guid.NewGuid();
+
+            //stream id: duplicate_stream at version: 0
+            Writer.Write(new PrepareLogRecord(0, _id1, _id1, 0, 0, "duplicate_stream", ExpectedVersion.Any, DateTime.UtcNow,
+                                              PrepareFlags.SingleWrite, "type", new byte[0], new byte[0]), out pos1);
+            Writer.Write(new CommitLogRecord(pos1, _id1, 0, DateTime.UtcNow, 0), out pos2);
+
+            //stream id: duplicate_stream at version: 1
+            Writer.Write(new PrepareLogRecord(pos2, _id2, _id2, pos2, 0, "duplicate_stream", ExpectedVersion.Any, DateTime.UtcNow,
+                                              PrepareFlags.SingleWrite, "type", new byte[0], new byte[0]), out pos3);
+            Writer.Write(new CommitLogRecord(pos3, _id2, pos2, DateTime.UtcNow, 1), out pos4);
+
+            //stream id: duplicate_stream at version: 2
+            Writer.Write(new PrepareLogRecord(pos4, _id3, _id3, pos4, 0, "duplicate_stream", ExpectedVersion.Any, DateTime.UtcNow,
+                                              PrepareFlags.SingleWrite, "type", new byte[0], new byte[0]), out pos5);
+            Writer.Write(new CommitLogRecord(pos5, _id3, pos4, DateTime.UtcNow, 2), out pos6);
+        }
+
+        protected override void Given()
+        {
+            _id4 = Guid.NewGuid();
+            long pos8;
+
+            //stream id: duplicate_stream at version: 0 (duplicate event/index entry)
+            Writer.Write(new PrepareLogRecord(pos6, _id4, _id4, pos6, 0, "duplicate_stream", ExpectedVersion.Any, DateTime.UtcNow,
+                                              PrepareFlags.SingleWrite, "type", new byte[0], new byte[0]), out pos7);
+            Writer.Write(new CommitLogRecord(pos7, _id4, pos6, DateTime.UtcNow, 0), out pos8);
+        }
+
+        [Test]
+        public void should_read_the_correct_last_event_number()
+        {
+            var result = ReadIndex.GetStreamLastEventNumber("duplicate_stream");
+            Assert.AreEqual(2, result);
+        }
+    }
+
+    public abstract class DuplicateReadIndexTestScenario : SpecificationWithDirectoryPerTestFixture
+    {
+        protected readonly int MaxEntriesInMemTable;
+        protected readonly int MetastreamMaxCount;
+        protected readonly bool PerformAdditionalCommitChecks;
+        protected readonly byte IndexBitnessVersion;
+        protected TFChunkWriter Writer;
+        protected IReadIndex ReadIndex;
+
+        private TFChunkDb _db;
+        private TableIndex _tableIndex;
+
+        protected DuplicateReadIndexTestScenario(int maxEntriesInMemTable = 20, int metastreamMaxCount = 1, byte indexBitnessVersion = Opts.IndexBitnessVersionDefault, bool performAdditionalChecks = false)
+        {
+            Ensure.Positive(maxEntriesInMemTable, "maxEntriesInMemTable");
+            MaxEntriesInMemTable = maxEntriesInMemTable;
+            MetastreamMaxCount = metastreamMaxCount;
+            IndexBitnessVersion = indexBitnessVersion;
+            PerformAdditionalCommitChecks = performAdditionalChecks;
+        }
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var writerCheckpoint = new InMemoryCheckpoint(0);
+            var chaserCheckpoint = new InMemoryCheckpoint(0);
+
+            var bus = new InMemoryBus("bus");
+            new IODispatcher(bus, new PublishEnvelope(bus));
+
+            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
+                                                   new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
+                                                   10000,
+                                                   0,
+                                                   writerCheckpoint,
+                                                   chaserCheckpoint,
+                                                   new InMemoryCheckpoint(-1),
+                                                   new InMemoryCheckpoint(-1)));
+
+            _db.Open();
+            // create db
+            Writer = new TFChunkWriter(_db);
+            Writer.Open();
+            SetupDB();
+            Writer.Close();
+            Writer = null;
+
+            writerCheckpoint.Flush();
+            chaserCheckpoint.Write(writerCheckpoint.Read());
+            chaserCheckpoint.Flush();
+
+            var readers = new ObjectPool<ITransactionFileReader>("Readers", 2, 5, () => new TFChunkReader(_db, _db.Config.WriterCheckpoint));
+            var lowHasher = new XXHashUnsafe();
+            var highHasher = new Murmur3AUnsafe();
+            _tableIndex = new TableIndex(GetFilePathFor("index"), lowHasher, highHasher,
+                                        () => new HashListMemTable(IndexBitnessVersion, MaxEntriesInMemTable * 2),
+                                        () => new TFReaderLease(readers),
+                                        IndexBitnessVersion,
+                                        MaxEntriesInMemTable);
+
+            ReadIndex = new ReadIndex(new NoopPublisher(),
+                                      readers,
+                                      _tableIndex,
+                                      EventStore.Core.Settings.ESConsts.StreamInfoCacheCapacity,
+                                      additionalCommitChecks: PerformAdditionalCommitChecks,
+                                      metastreamMaxCount: MetastreamMaxCount,
+                                      hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault);
+
+
+            ReadIndex.Init(chaserCheckpoint.Read());
+
+            _tableIndex.Close(false);
+
+            Writer = new TFChunkWriter(_db);
+            Writer.Open();
+            Given();
+            Writer.Close();
+            Writer = null;
+
+            writerCheckpoint.Flush();
+            chaserCheckpoint.Write(writerCheckpoint.Read());
+            chaserCheckpoint.Flush();
+
+            _tableIndex = new TableIndex(GetFilePathFor("index"), lowHasher, highHasher,
+                            () => new HashListMemTable(IndexBitnessVersion, MaxEntriesInMemTable * 2),
+                            () => new TFReaderLease(readers),
+                            IndexBitnessVersion,
+                            MaxEntriesInMemTable);
+
+            ReadIndex = new ReadIndex(new NoopPublisher(),
+                                      readers,
+                                      _tableIndex,
+                                      EventStore.Core.Settings.ESConsts.StreamInfoCacheCapacity,
+                                      additionalCommitChecks: PerformAdditionalCommitChecks,
+                                      metastreamMaxCount: MetastreamMaxCount,
+                                      hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault);
+
+            ReadIndex.Init(chaserCheckpoint.Read());
+        }
+
+        public override void TestFixtureTearDown()
+        {
+            ReadIndex.Close();
+            ReadIndex.Dispose();
+
+            _tableIndex.Close();
+
+            _db.Close();
+            _db.Dispose();
+
+            base.TestFixtureTearDown();
+        }
+
+        protected abstract void SetupDB();
+        protected abstract void Given();
+    }
+}

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -260,7 +260,7 @@ namespace EventStore.Core.Services.Storage
             CommitPendingTransaction(_transaction, isTfEof);
 
             var firstEventNumber = record.FirstEventNumber;
-            var lastEventNumber = _indexCommitter.Commit(record, isTfEof);
+            var lastEventNumber = _indexCommitter.Commit(record, isTfEof, true);
             if (lastEventNumber == EventNumber.Invalid)
                 lastEventNumber = record.FirstEventNumber - 1;
             _masterBus.Publish(new StorageMessage.CommitAck(record.CorrelationId, record.LogPosition, record.TransactionPosition, firstEventNumber, lastEventNumber, true));
@@ -285,7 +285,7 @@ namespace EventStore.Core.Services.Storage
         {
             if (transaction.Count > 0)
             {
-                _indexCommitter.Commit(_transaction, isTfEof);
+                _indexCommitter.Commit(_transaction, isTfEof, true);
                 _transaction.Clear();
             }
         }


### PR DESCRIPTION
## When the duplicate entry is in the memory table.

When reading backwards or forwards in the index reader there is a
case where the duplicate index entry could be in the memory table (which is
64bit by default) and the rest of the index entries are 32bit. This
means that instead of the range query on the index returning something
along the lines of

Stream Hash | Version | Position
--- | --- | ---
111 | 2 | 3
111 | 2 | 3
111 | 1  | 2
1111111 | 0 | 4 (duplicate)
111 | 0 | 1

it will return

Stream Hash | Version | Position
--- | --- | ---
1111111 | 0 | 4 (duplicate)
111 | 2 | 3
111 | 2 | 3
111 | 1  | 2
111 | 0 | 1

### Proposed Solution

The `IndexReader::ReadStreamEventsForward` and
`IndexReader::ReadStreamEventsBackward`  will now order by version
for the entries returned from the index so that the correct
non-duplicate entry can be selected.

## When rebuilding the memory table on node startup and the duplicate entry is cached as the last event number.

When a node starts up, it will rebuild the memory index and cache the
event numbers as it reads. This can cause an issue in the case
where the duplicate event exists which will result in the incorrect last event
number being cached for the stream.

### Proposed Solution

- Disable the caching when building up the memory index.
- The additional checks are also disabled during index rebuilding.
    Note: as of this time, the additional checks aren't running in
    production, only for tests.
- `IndexReader::GetStreamLastEventNumberUncached` will now always look one
ahead and determine if it's really the latest event number for the
stream.

### Note
There is a possibility that the above mentioned looking **one** ahead will
not find the "real" latest event number, as the user could have written many
duplicate events to the stream.

Running a scavenge should get rid of all of the duplicates.