### PR TITLE
Always keep scavenged chunks

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -200,6 +200,10 @@ namespace EventStore.ClusterNode
 
         [ArgDescription(Opts.LogHttpRequestsDescr, Opts.AppGroup)]
         public bool LogHttpRequests { get; set; }
+
+        [ArgDescription(Opts.AlwaysKeepScavengedDescr, Opts.DbGroup)]
+        public bool AlwaysKeepScavenged { get; set; }
+        
         public ClusterNodeOptions()
         {
             Config = "";
@@ -302,6 +306,8 @@ namespace EventStore.ClusterNode
             StartStandardProjections = Opts.StartStandardProjectionsDefault;
             DisableHTTPCaching = Opts.DisableHttpCachingDefault;
             LogHttpRequests = Opts.LogHttpRequestsDefault;
+
+            AlwaysKeepScavenged = Opts.AlwaysKeepScavengedDefault;
         }
     }
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -251,6 +251,8 @@ namespace EventStore.ClusterNode
                 builder.NoGossipOnPublicInterface();
             if(options.SkipDbVerify)
                 builder.DoNotVerifyDbHashes();
+            if(options.AlwaysKeepScavenged)
+                builder.AlwaysKeepScavenged();
 
             if (options.IntSecureTcpPort > 0 || options.ExtSecureTcpPort > 0)
             {

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
@@ -167,6 +167,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
 
             Assert.AreEqual(TFConsts.ChunkSize, _dbConfig.ChunkSize, "ChunkSize");
             Assert.AreEqual(Opts.ChunksCacheSizeDefault, _dbConfig.MaxChunksCacheSize, "MaxChunksCacheSize");
+            Assert.AreEqual(Opts.AlwaysKeepScavengedDefault, _settings.AlwaysKeepScavenged, "AlwaysKeepScavenged");
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
@@ -784,4 +784,18 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
             Assert.AreEqual(_advertiseInfo.AdvertiseExternalHttpPortAs, _settings.GossipAdvertiseInfo.AdvertiseExternalHttpPortAs);
         }
     }
+
+    public class with_always_keep_scavenged : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.AlwaysKeepScavenged();
+        }
+
+        [Test]
+        public void should_always_keep_scavenged() 
+        {
+            Assert.AreEqual(true, _settings.AlwaysKeepScavenged);
+        }
+    }
 }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -69,6 +69,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly string Index;
         public readonly int ReaderThreadsCount;
         public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
+        public readonly bool AlwaysKeepScavenged;
 
         public ClusterVNodeSettings(Guid instanceId, int debugIndex,
                                     IPEndPoint internalTcpEndPoint,
@@ -123,7 +124,8 @@ namespace EventStore.Core.Cluster.Settings
                                     IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null,
                                     bool unsafeIgnoreHardDeletes = false,
                                     bool betterOrdering = false,
-                                    int readerThreadsCount = 4)
+                                    int readerThreadsCount = 4,
+                                    bool alwaysKeepScavenged = false)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -208,6 +210,7 @@ namespace EventStore.Core.Cluster.Settings
             UnsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
             BetterOrdering = betterOrdering;
             ReaderThreadsCount = readerThreadsCount;
+            AlwaysKeepScavenged = alwaysKeepScavenged;
         }
 
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -467,7 +467,7 @@ namespace EventStore.Core
                                                         ioDispatcher,
                                                         tableIndex,
                                                         readIndex,
-                                                        Application.IsDefined(Application.AlwaysKeepScavenged),
+                                                        vNodeSettings.AlwaysKeepScavenged,
                                                         _nodeInfo.ExternalHttp.ToString(),
                                                         !vNodeSettings.DisableScavengeMerging,
                                                         vNodeSettings.ScavengeHistoryMaxAge,

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -129,6 +129,9 @@ namespace EventStore.Core.Util
         public const string UnsafeIgnoreHardDeleteDescr = "Disables Hard Deletes (UNSAFE: use to remove hard deletes)";
         public static readonly bool UnsafeIgnoreHardDeleteDefault = false;
 
+        public const string AlwaysKeepScavengedDescr = "Always keeps the newer chunks from a scavenge operation.";
+        public static readonly bool AlwaysKeepScavengedDefault = false;
+
         public const string UnsafeDisableFlushToDiskDescr = "Disable flushing to disk.  (UNSAFE: on power off)";
         public static readonly bool UnsafeDisableFlushToDiskDefault = false;
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -118,6 +118,7 @@ namespace EventStore.Core
         private int _advertiseInternalTcpPortAs;
         private int _advertiseExternalTcpPortAs;
         protected byte _indexBitnessVersion;
+        protected bool _alwaysKeepScavenged;
 
         // ReSharper restore FieldCanBeMadeReadOnly.Local
 
@@ -198,6 +199,7 @@ namespace EventStore.Core
             _unsafeIgnoreHardDelete = Opts.UnsafeIgnoreHardDeleteDefault;
             _betterOrdering = Opts.BetterOrderingDefault;
             _unsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
+            _alwaysKeepScavenged = Opts.AlwaysKeepScavengedDefault;
         }
 
         protected VNodeBuilder WithSingleNodeSettings()
@@ -1075,6 +1077,16 @@ namespace EventStore.Core
             return this;
         }
 
+        /// <summary>
+        /// The newer chunks during a scavenge are always kept
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder AlwaysKeepScavenged(){
+            _alwaysKeepScavenged = true;
+
+            return this;
+        }
+
         private void EnsureHttpPrefixes()
         {
             if (_intHttpPrefixes == null || _intHttpPrefixes.IsEmpty())
@@ -1254,7 +1266,8 @@ namespace EventStore.Core
                     consumerStrategies,
                     _unsafeIgnoreHardDelete,
                     _betterOrdering,
-                    _readerThreadsCount);
+                    _readerThreadsCount,
+                    _alwaysKeepScavenged);
             var infoController = new InfoController(options, _projectionType);
 
             _log.Info("{0,-25} {1}", "INSTANCE ID:", _vNodeSettings.NodeInfo.InstanceId);


### PR DESCRIPTION
Provide an option to always keep scavenged chunks. This option is turned off by default.