### PR TITLE
Set the attributes of the chunk before writing

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
@@ -131,6 +131,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                                   chunkHeader.ChunkStartNumber, chunkHeader.ChunkEndNumber, chunkFilename, truncateChk, chunkHeader));
             }
 
+            File.SetAttributes(chunkFilename, FileAttributes.Normal);
             using (var fs = new FileStream(chunkFilename, FileMode.Open, FileAccess.ReadWrite, FileShare.Read))
             {
                 fs.SetLength(ChunkHeader.Size + chunkHeader.ChunkSize + ChunkFooter.Size);


### PR DESCRIPTION
Fix a case where an already completed chunk could be opened for writing because for instance the truncate position is in a completed chunk.