### PR TITLE
Makes possible to set logger when using the connection string #1093

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -64,11 +64,12 @@ namespace EventStore.ClientAPI
         /// <summary>
         /// Returns a <see cref="ConnectionSettings"></see> for a given connection string.
         /// </summary>
-        /// <param name="connectionString"></param>
+        /// <param name="connectionString">Connection string to read setting from</param>
+        /// <param name="builder">Pre-populated settings builder, optional. If not specified, a new builder will be created.</param>
         /// <returns>a <see cref="ConnectionSettings"/> from the connection string</returns>
-        public static ConnectionSettings GetConnectionSettings(string connectionString)
+        public static ConnectionSettings GetConnectionSettings(string connectionString, ConnectionSettingsBuilder builder = null)
         {
-            var settings = ConnectionSettings.Create().Build();
+            var settings = (builder ?? ConnectionSettings.Create()).Build();
             var items = GetConnectionStringInfo(connectionString).ToArray();
             return Apply(items, settings);
         }

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -30,17 +30,27 @@ namespace EventStore.ClientAPI
         /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
         /// <param name="connectionString">The connection string to for this connection.</param>
         /// <returns>a new <see cref="IEventStoreConnection"/></returns>
-        public static IEventStoreConnection Create(string connectionString, string connectionName = null)
+        public static IEventStoreConnection Create(string connectionString, string connectionName = null) =>
+            Create(connectionString, null, connectionName);
+
+        /// <summary>
+        /// Creates a new <see cref="IEventStoreConnection"/> to single node using default <see cref="ConnectionSettings"/> provided via a connectionstring
+        /// </summary>
+        /// <param name="connectionString">The connection string to for this connection.</param>
+        /// <param name="builder">Pre-populated settings builder, optional. If not specified, a new builder will be created.</param>
+        /// <param name="connectionName">Optional name of connection (will be generated automatically, if not provided)</param>
+        /// <returns>a new <see cref="IEventStoreConnection"/></returns>
+        public static IEventStoreConnection Create(string connectionString, ConnectionSettingsBuilder builder, string connectionName = null)
         {
-            var settings = ConnectionString.GetConnectionSettings(connectionString);
+            var settings = ConnectionString.GetConnectionSettings(connectionString, builder);
             var uri = GetUriFromConnectionString(connectionString);
             if(uri == null && (settings.GossipSeeds == null || settings.GossipSeeds.Length == 0))
             {
-                throw new Exception(string.Format("Did not find ConnectTo or GossipSeeds in the connection string.\n'{0}'", connectionString));
+                throw new Exception($"Did not find ConnectTo or GossipSeeds in the connection string.\n'{connectionString}'");
             }
             if(uri != null && settings.GossipSeeds != null && settings.GossipSeeds.Length > 0)
             {
-                throw new NotSupportedException(string.Format("Setting ConnectTo as well as GossipSeeds on the connection string is currently not supported.\n{0}", connectionString));
+                throw new NotSupportedException($"Setting ConnectTo as well as GossipSeeds on the connection string is currently not supported.\n{connectionString}");
             }
             return Create(settings, uri, connectionName);
         }


### PR DESCRIPTION
Addresses #1093. Currently it is impossible to specify custom logger with using the connection string. By adding an overload that accepts the connection settings builder, this issue is resolved. It is still possible to use the existing overload without the builder, in this case a new builder will be created.