### PR TITLE
Use Environment.Exit when exiting to prevent hanging on shut down

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -28,10 +28,13 @@ namespace EventStore.ClusterNode
         private ExclusiveDbLock _dbLock;
         private ClusterNodeMutex _clusterNodeMutex;
 
-        public static int Main(string[] args)
+        public static void Main(string[] args)
         {
+            Console.CancelKeyPress += delegate {
+                Environment.Exit((int)ExitCode.Success);
+            };
             var p = new Program();
-            return p.Run(args);
+            p.Run(args);
         }
 
         protected override string GetLogsDirectory(ClusterNodeOptions options)

--- a/src/EventStore.Common/Log/LogManager.cs
+++ b/src/EventStore.Common/Log/LogManager.cs
@@ -17,6 +17,14 @@ namespace EventStore.Common.Log
             }
         }
 
+        public static bool Initialized
+        {
+            get 
+            {
+                return _initialized;
+            }
+        }
+
         private const string EVENTSTORE_LOG_FILENAME = "log.config";
         private static readonly ILogger GlobalLogger = GetLogger("GLOBAL-LOGGER");
         private static bool _initialized;

--- a/src/EventStore.Core/ProgramBase.cs
+++ b/src/EventStore.Core/ProgramBase.cs
@@ -29,7 +29,7 @@ namespace EventStore.Core
         protected abstract void Start();
         public abstract void Stop();
 
-        public int Run(string[] args)
+        public void Run(string[] args)
         {
             try
             {
@@ -68,23 +68,35 @@ namespace EventStore.Core
             }
             catch (ApplicationInitializationException ex)
             {
-                Log.FatalException(ex, "Application initialization error: {0}", FormatExceptionMessage(ex));
-                Application.Exit(ExitCode.Error, FormatExceptionMessage(ex));
+                var msg = String.Format("Application initialization error: {0}", FormatExceptionMessage(ex));
+                if(LogManager.Initialized)
+                {
+                    Log.FatalException(ex, msg);
+                }
+                else 
+                {
+                    Console.Error.WriteLine(msg);
+                }
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
-                Log.FatalException(ex, "Unhandled exception while starting application:");
-                Log.FatalException(ex, "{0}", FormatExceptionMessage(ex));
-                Application.Exit(ExitCode.Error, FormatExceptionMessage(ex));
+                var msg = "Unhandled exception while starting application:";
+                if(LogManager.Initialized)
+                {
+                    Log.FatalException(ex, msg);
+                    Log.FatalException(ex, "{0}", FormatExceptionMessage(ex));
+                }
+                else
+                {
+                    Console.Error.WriteLine(msg);
+                    Console.Error.WriteLine(FormatExceptionMessage(ex));
+                }
             }
             finally
             {
                 Log.Flush();
             }
-
-            Application.ExitSilent(_exitCode, "Normal exit.");
-            return _exitCode;
+            Environment.Exit(_exitCode);
         }
 
         protected virtual void PreInit(TOptions options)

--- a/src/EventStore.TestClient/Program.cs
+++ b/src/EventStore.TestClient/Program.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core;
 
@@ -8,10 +9,13 @@ namespace EventStore.TestClient
     {
         private Client _client;
 
-        public static int Main(string[] args)
+        public static void Main(string[] args)
         {
+            Console.CancelKeyPress += delegate {
+                Environment.Exit((int)ExitCode.Success);
+            };
             var p = new Program();
-            return p.Run(args);
+            p.Run(args);
         }
 
         protected override string GetLogsDirectory(ClientOptions options)


### PR DESCRIPTION
Handle `Console.CancelKeyPress` in ClusterNode and TestClient to ensure they call Environment.Exit and shutdown properly.
Also add a new property `Initialized` to LogManager to determine whether to write output to the console or to the log.