### PR TITLE
Fixes #1034

### DIFF
--- a/src/EventStore.Core/Messages/ReplicationMessage.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessage.cs
@@ -430,14 +430,14 @@ namespace EventStore.Core.Messages
             public Guid SubscriptionId { get; private set; }
             public Guid ConnectionId { get; private set; }
             public string SubscriptionEndpoint { get; private set; }
-            public int TotalBytesSent { get; private set; }
-            public int TotalBytesReceived { get; private set; }
+            public long TotalBytesSent { get; private set; }
+            public long TotalBytesReceived { get; private set; }
             public int PendingSendBytes { get; private set; }
             public int PendingReceivedBytes { get; private set; }
             public int SendQueueSize { get; private set; }
 
             public ReplicationStats(Guid subscriptionId, Guid connectionId, string subscriptionEndpoint, int sendQueueSize,
-                                int totalBytesSent, int totalBytesReceived, int pendingSendBytes, int pendingReceivedBytes)
+                                long totalBytesSent, long totalBytesReceived, int pendingSendBytes, int pendingReceivedBytes)
             {
                 SubscriptionId = subscriptionId;
                 ConnectionId = connectionId;

--- a/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
@@ -161,7 +161,7 @@ namespace EventStore.Core.Services.Replication
                     if (subscription.Value != null)
                     {
                         var stats = new ReplicationMessage.ReplicationStats(subscription.Key, tcpConn.ConnectionId, subscription.Value.ReplicaEndPoint.ToString(), tcpConn.SendQueueSize,
-                                            (int)conn.TotalBytesSent, (int)conn.TotalBytesReceived, conn.PendingSendBytes, conn.PendingReceivedBytes);
+                                            conn.TotalBytesSent, conn.TotalBytesReceived, conn.PendingSendBytes, conn.PendingReceivedBytes);
                         replicaStats.Add(stats);
                     }
                 }


### PR DESCRIPTION
The eventstore made the wrong conversion and returned a negative value for totalbytessent in JSON response from the http://*:1114/stats/replication API call.