### PR TITLE
Handling message expiry on reads for projections

### DIFF
--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -5,6 +5,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
+using EventStore.Core.Settings;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 
 namespace EventStore.Core.Messages
@@ -82,7 +83,7 @@ namespace EventStore.Core.Messages
 
             public readonly IPrincipal User;
 
-            public DateTime Expires = DateTime.UtcNow.AddSeconds(10);
+            public DateTime Expires = DateTime.UtcNow.AddMilliseconds(ESConsts.ReadRequestTimeout);
 
             protected ReadRequestMessage(Guid internalCorrId, Guid correlationId, IEnvelope envelope, IPrincipal user)
             {

--- a/src/EventStore.Core/Settings/ESConsts.cs
+++ b/src/EventStore.Core/Settings/ESConsts.cs
@@ -26,6 +26,7 @@ namespace EventStore.Core.Settings
         public const int TransactionMetadataCacheCapacity = 50000;
         public const int CommitedEventsMemCacheLimit = 8*1024*1024;
         public const int CachedEpochCount = 1000;
+        public const int ReadRequestTimeout = 10000;
 
         public const int CachedPrincipalCount = 1000;
 

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -511,6 +511,13 @@
     <Compile Include="ClientAPI\projectionsManager\projectionsManagerTests.cs" />
     <Compile Include="ClientAPI\projectionsManager\ProjectionsManagerTestSuiteMarkerBase.cs" />
     <Compile Include="ClientAPI\projectionsManager\SpecificationWithNodeAndProjectionsManager.cs" />
+    <Compile Include="Services\event_reader\transaction_file_reader\when_read_timeout_occurs.cs" />
+    <Compile Include="Services\event_reader\stream_reader\when_read_timeout_occurs.cs" />
+    <Compile Include="Services\event_reader\stream_reader\when_read_completes_before_timeout.cs" />
+    <Compile Include="Services\event_reader\transaction_file_reader\when_read_completes_before_timeout.cs" />
+    <Compile Include="Services\event_reader\multi_stream_reader\when_read_timeout_occurs.cs" />
+    <Compile Include="Services\event_reader\multi_stream_reader\when_read_completes_before_timeout.cs" />
+    <Compile Include="Services\event_reader\multi_stream_reader\when_read_for_one_stream_completes_but_times_out_for_another.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_eof_for_all_streams_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_eof_for_all_streams_and_idle_eof.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
@@ -12,6 +11,7 @@ using EventStore.Projections.Core.Tests.Services.core_projection;
 using NUnit.Framework;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+using EventStore.Core.Services.AwakeReaderService;
 
 namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_reader
 {
@@ -46,9 +46,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
+                    correlationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -57,9 +58,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type1", new byte[] {1}, new byte[] {2})),
                         }, null, false, "", 2, 1, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, 
+                    correlationId, "b", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -68,16 +70,19 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type1", new byte[] {1}, new byte[] {2})),
                         }, null, false, "", 3, 2, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 2, 1, true, 400));
+                correlationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 2, 1, true, 400));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 3, 2, true, 400));
+                correlationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 3, 2, true, 400));
             _fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
+            correlationId = _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 2, 1, true, 600));
+                correlationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 2, 1, true, 600));
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
@@ -44,9 +43,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
+                correlationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                     {
                         ResolvedEvent.ForUnresolvedEvent( 
@@ -96,9 +96,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
         [Test, ExpectedException(typeof (InvalidOperationException))]
         public void cannot_handle_repeated_read_events_completed()
         {
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
+                    correlationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                     {
                         ResolvedEvent.ForUnresolvedEvent( 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_and_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_and_no_stream.cs
@@ -43,9 +43,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
+                correlationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -59,9 +60,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "",
+                    correlationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "",
                     -1, ExpectedVersion.NoStream, true, 200));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams.cs
@@ -46,9 +46,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
             _secondEventId = Guid.NewGuid();
             _thirdEventId = Guid.NewGuid();
             _fourthEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
+                    correlationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -62,9 +63,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success,
+                correlationId, "b", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -164,9 +166,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
         [Test]
         public void can_handle_following_read_events_completed()
         {
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
+                correlationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_and_eofs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_and_eofs.cs
@@ -47,9 +47,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
             _secondEventId = Guid.NewGuid();
             _thirdEventId = Guid.NewGuid();
             _fourthEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success,
+                correlationId, "a", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -63,9 +64,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success,
+                correlationId, "b", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -79,13 +81,15 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 4, 3, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "", 3,
+                correlationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "", 3,
                     2, true, 400));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "", 4,
+                    correlationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0], null, false, "", 4,
                     3, true, 400));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_then_pause_requested_then_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_then_pause_requested_then_eof.cs
@@ -9,6 +9,7 @@ using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Tests.Services.core_projection;
 using NUnit.Framework;
+using EventStore.Projections.Core.Messages;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
 
@@ -48,9 +49,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
             _secondEventId = Guid.NewGuid();
             _thirdEventId = Guid.NewGuid();
             _fourthEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
+                    correlationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -64,9 +66,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 3, 2, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, 
+                    correlationId, "b", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -81,9 +84,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 4, 3, true, 200));
             _edp.Pause();
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 3, 2, true, 400));
+                correlationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 3, 2, true, 400));
         }
 
         [Test]
@@ -111,7 +115,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
         [Test]
         public void does_not_publish_schedule()
         {
-            Assert.AreEqual(0, _consumer.HandledMessages.OfType<TimerMessage.Schedule>().Count());
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<TimerMessage.Schedule>().Where(x=>x.ReplyMessage.GetType() != typeof(ProjectionManagementMessage.Internal.ReadTimeout)).Count());
         }
 
     }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_onetime_reader_handles_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_onetime_reader_handles_eof.cs
@@ -46,9 +46,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, 
+                correlationId, "a", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -57,9 +58,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type1", new byte[] {1}, new byte[] {2})),
                         }, null, false, "", 2, 1, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, 
+                    correlationId, "b", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -69,12 +71,14 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type1", new byte[] {1}, new byte[] {2})),
                         }, null, false, "", 3, 2, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 2, 1, true, 400));
+                correlationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 2, 1, true, 400));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 3, 2, true, 400));
+                correlationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 3, 2, true, 400));
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_read_completes_before_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_read_completes_before_timeout.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_reader
+{
+    [TestFixture]
+    public class when_read_completes_before_timeout : TestFixtureWithExistingEvents
+    {
+        private MultiStreamEventReader _eventReader;
+        private Guid _distibutionPointCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private string[] _abStreams;
+        private Dictionary<string, int> _ab12Tag;
+
+        [SetUp]
+        public new void When()
+        {
+            _ab12Tag = new Dictionary<string, int> {{"a", 1}, {"b", 2}};
+            _abStreams = new[] {"a", "b"};
+
+            _distibutionPointCorrelationId = Guid.NewGuid();
+            _eventReader = new MultiStreamEventReader(
+                _ioDispatcher, _bus, _distibutionPointCorrelationId, null, 0, _abStreams, _ab12Tag, false,
+                new RealTimeProvider());
+            _eventReader.Resume();
+			var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
+            _eventReader.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+					correlationId, "a", 100, 100, ReadStreamResult.Success,
+                    new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type2", new byte[] {3}, new byte[] {4}))
+                        }, null, false, "", 3, 2, true, 200));
+            _eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "a"));
+			correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
+            _eventReader.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+					correlationId, "b", 100, 100, ReadStreamResult.Success,
+                    new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            3, 200, Guid.NewGuid(), Guid.NewGuid(), 200, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type2", new byte[] {3}, new byte[] {4}))
+                        }, null, false, "", 4, 3, true, 200));
+            _eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "b"));
+        }
+
+        [Test]
+        public void should_deliver_events()
+        {
+            Assert.AreEqual(3, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_read_for_one_stream_completes_but_times_out_for_another.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_read_for_one_stream_completes_but_times_out_for_another.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_reader
+{
+    [TestFixture]
+    public class when_read_for_one_stream_completes_but_times_out_for_another : TestFixtureWithExistingEvents
+    {
+        private MultiStreamEventReader _eventReader;
+        private Guid _distibutionPointCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private string[] _abStreams;
+        private Dictionary<string, int> _ab12Tag;
+
+        [SetUp]
+        public new void When()
+        {
+            _ab12Tag = new Dictionary<string, int> {{"a", 1}, {"b", 2}};
+            _abStreams = new[] {"a", "b"};
+            _distibutionPointCorrelationId = Guid.NewGuid();
+            _eventReader = new MultiStreamEventReader(
+                _ioDispatcher, _bus, _distibutionPointCorrelationId, null, 0, _abStreams, _ab12Tag, false,
+                new RealTimeProvider());
+            _eventReader.Resume();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
+            _eventReader.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, "a", 100, 100, ReadStreamResult.Success,
+                    new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type2", new byte[] {3}, new byte[] {4}))
+                        }, null, false, "", 3, 2, true, 200));
+            //timeout follows
+            _eventReader.Handle(
+                new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "a"));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
+            _eventReader.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, "b", 100, 100, ReadStreamResult.Success,
+                    new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            3, 200, Guid.NewGuid(), Guid.NewGuid(), 200, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type2", new byte[] {3}, new byte[] {4}))
+                        }, null, false, "", 4, 3, true, 200));
+			//timeout follows
+			_eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "b"));
+			correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
+			_consumer.HandledMessages.Clear();
+			//timeout before read completes
+            _eventReader.Handle(
+                new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "a"));
+			_eventReader.Handle(
+				new ClientMessage.ReadStreamEventsForwardCompleted(
+					correlationId, "a", 100, 100, ReadStreamResult.Success,
+					new[]
+					{
+						ResolvedEvent.ForUnresolvedEvent(
+							new EventRecord(
+								3, 300, Guid.NewGuid(), Guid.NewGuid(), 300, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
+								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+								"event_type1", new byte[] {4}, new byte[] {6})),
+						ResolvedEvent.ForUnresolvedEvent(
+							new EventRecord(
+								4, 400, Guid.NewGuid(), Guid.NewGuid(), 400, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
+								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+								"event_type2", new byte[] {6}, new byte[] {8}))
+					}, null, false, "", 3, 2, true, 200));
+        }
+
+        [Test]
+        public void should_not_deliver_events_from_last_read()
+        {
+			Assert.AreEqual(0, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_read_timeout_occurs.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_reader
+{
+    [TestFixture]
+    public class when_read_timeout_occurs : TestFixtureWithExistingEvents
+    {
+        private MultiStreamEventReader _eventReader;
+        private Guid _distibutionPointCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private string[] _abStreams;
+        private Dictionary<string, int> _ab12Tag;
+
+        [SetUp]
+        public new void When()
+        {
+            _ab12Tag = new Dictionary<string, int> {{"a", 1}, {"b", 2}};
+            _abStreams = new[] {"a", "b"};
+
+            _distibutionPointCorrelationId = Guid.NewGuid();
+            _eventReader = new MultiStreamEventReader(
+                _ioDispatcher, _bus, _distibutionPointCorrelationId, null, 0, _abStreams, _ab12Tag, false,
+                new RealTimeProvider());
+            _eventReader.Resume();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "a").CorrelationId;
+            _eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "a"));
+            _eventReader.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+					correlationId, "a", 100, 100, ReadStreamResult.Success,
+                    new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "a", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type2", new byte[] {3}, new byte[] {4}))
+                        }, null, false, "", 3, 2, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == "b").CorrelationId;
+            _eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(Guid.NewGuid(), "b"));
+            _eventReader.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+					correlationId, "b", 100, 100, ReadStreamResult.Success,
+                    new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type1", new byte[] {1}, new byte[] {2})),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            3, 200, Guid.NewGuid(), Guid.NewGuid(), 200, 0, "b", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "event_type2", new byte[] {3}, new byte[] {4}))
+                        }, null, false, "", 4, 3, true, 200));
+        }
+
+        [Test]
+        public void should_not_deliver_events()
+        {
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_eof_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_eof_and_idle_eof.cs
@@ -12,6 +12,7 @@ using EventStore.Projections.Core.Tests.Services.core_projection;
 using NUnit.Framework;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+using EventStore.Core.Services.AwakeReaderService;
 
 namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
 {
@@ -41,9 +42,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success, 
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -58,14 +60,16 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success,
                     new ResolvedEvent[] { }, null, false, "", 12, 11, true, 400));
             _fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
+            correlationId = _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success,
                     new ResolvedEvent[] { }, null, false, "", 12, 11, true, 400));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_no_stream.cs
@@ -32,9 +32,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
             _edp = new StreamEventReader(_bus, _distibutionPointCorrelationId, null, "stream", 0, new RealTimeProvider(), false,
                 produceStreamDeletes: false);
             _edp.Resume();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100,
+                    correlationId, "stream", 100, 100,
                     ReadStreamResult.NoStream, new ResolvedEvent[0], null, false, "", -1, ExpectedVersion.NoStream, true, 200));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_and_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_and_eof.cs
@@ -35,9 +35,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -52,9 +53,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0]
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0]
                     , null, false, "", 12, 11, true, 400));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_stream_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_stream_event_reader.cs
@@ -34,9 +34,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -114,9 +115,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [Test, ExpectedException(typeof (InvalidOperationException))]
         public void cannot_handle_repeated_read_events_completed()
         {
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -131,9 +133,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [Test]
         public void can_handle_following_read_events_completed()
         {
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_then_pause_then_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_then_pause_then_eof.cs
@@ -34,9 +34,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success,
+                    correlationId, "stream", 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
@@ -52,9 +53,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                                     "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
             _edp.Pause();
+            correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0]
+                correlationId, "stream", 100, 100, ReadStreamResult.Success, new ResolvedEvent[0]
                     , null, false, "", 12, 11, true, 400));
         }
 
@@ -113,7 +115,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [Test]
         public void does_not_publish_schedule()
         {
-            Assert.AreEqual(0, _consumer.HandledMessages.OfType<TimerMessage.Schedule>().Count());
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<TimerMessage.Schedule>().Where(x=>x.ReplyMessage.GetType() != typeof(ProjectionManagementMessage.Internal.ReadTimeout)).Count());
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_soft_deleted_stream_with_a_single_event_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_soft_deleted_stream_with_a_single_event_event_reader.cs
@@ -36,9 +36,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [SetUp]
         public new void When()
         {
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _streamEventReader.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, _streamId, 100, 100, ReadStreamResult.Success,
+                correlationId, _streamId, 100, 100, ReadStreamResult.Success,
                     new[]
                         {
                         ResolvedEvent.ForUnresolvedEvent(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_paused_then_handling_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_paused_then_handling_no_stream.cs
@@ -32,9 +32,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                 produceStreamDeletes: false);
             _edp.Resume();
             _edp.Pause();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    _distibutionPointCorrelationId, "stream", 100, 100, ReadStreamResult.NoStream, new ResolvedEvent[0]
+                correlationId, "stream", 100, 100, ReadStreamResult.NoStream, new ResolvedEvent[0]
                     , null, false, "", -1, ExpectedVersion.NoStream, true, 200));
         }
 
@@ -74,7 +75,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [Test]
         public void does_not_publish_schedule()
         {
-            Assert.AreEqual(0, _consumer.HandledMessages.OfType<TimerMessage.Schedule>().Count());
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<TimerMessage.Schedule>().Where(x=>x.ReplyMessage.GetType() != typeof(ProjectionManagementMessage.Internal.ReadTimeout)).Count());
         }
 
     }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_read_completes_before_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_read_completes_before_timeout.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
@@ -15,13 +14,10 @@ using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
 namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
 {
     [TestFixture]
-    public class when_onetime_reader_handles_eof : TestFixtureWithExistingEvents
+    public class when_read_completes_before_timeout : TestFixtureWithExistingEvents
     {
-        private StreamEventReader _edp;
-        //private Guid _publishWithCorrelationId;
-        private Guid _distibutionPointCorrelationId;
-        private Guid _firstEventId;
-        private Guid _secondEventId;
+        private StreamEventReader _eventReader;
+        private Guid _distributionCorrelationId;
         private FakeTimeProvider _fakeTimeProvider;
 
         protected override void Given()
@@ -32,50 +28,37 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [SetUp]
         public new void When()
         {
-            //_publishWithCorrelationId = Guid.NewGuid();
-            _distibutionPointCorrelationId = Guid.NewGuid();
+            _distributionCorrelationId = Guid.NewGuid();
             _fakeTimeProvider = new FakeTimeProvider();
-            _edp = new StreamEventReader(_bus, _distibutionPointCorrelationId, null, "stream", 10, _fakeTimeProvider,
+            _eventReader = new StreamEventReader(_bus, _distributionCorrelationId, null, "stream", 10, _fakeTimeProvider,
                 resolveLinkTos: false, stopOnEof: true, produceStreamDeletes: false);
-            _edp.Resume();
-            _firstEventId = Guid.NewGuid();
-            _secondEventId = Guid.NewGuid();
+            _eventReader.Resume();
 			var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
-            _edp.Handle(
+            _eventReader.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
 					correlationId, "stream", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
-                            10, 50, Guid.NewGuid(), _firstEventId, 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
+                            10, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type1", new byte[] {1}, new byte[] {2})),
                             ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
-                            11, 100, Guid.NewGuid(), _secondEventId, 100, 0, "stream", ExpectedVersion.Any,
+                            11, 100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
-			correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
-            _edp.Handle(
-                new ClientMessage.ReadStreamEventsForwardCompleted(
-					correlationId, "stream", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 12, 11, true, 400));
+            _eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "stream"));
         }
 
         [Test]
-        public void publishes_eof_message()
+        public void should_deliver_events()
         {
-            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderEof>().Count());
-            var first = _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderEof>().First();
-            Assert.AreEqual(first.CorrelationId, _distibutionPointCorrelationId);
-        }
-
-        [Test]
-        public void does_not_publish_read_messages_anymore()
-        {
-            Assert.AreEqual(2, _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Count());
+            Assert.AreEqual(2, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_read_timeout_occurs.cs
@@ -2,7 +2,6 @@ using System;
 using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
@@ -15,13 +14,10 @@ using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
 namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
 {
     [TestFixture]
-    public class when_onetime_reader_handles_eof : TestFixtureWithExistingEvents
+    public class when_read_timeout_occurs : TestFixtureWithExistingEvents
     {
-        private StreamEventReader _edp;
-        //private Guid _publishWithCorrelationId;
-        private Guid _distibutionPointCorrelationId;
-        private Guid _firstEventId;
-        private Guid _secondEventId;
+        private StreamEventReader _eventReader;
+        private Guid _distributionCorrelationId;
         private FakeTimeProvider _fakeTimeProvider;
 
         protected override void Given()
@@ -32,50 +28,37 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [SetUp]
         public new void When()
         {
-            //_publishWithCorrelationId = Guid.NewGuid();
-            _distibutionPointCorrelationId = Guid.NewGuid();
+            _distributionCorrelationId = Guid.NewGuid();
             _fakeTimeProvider = new FakeTimeProvider();
-            _edp = new StreamEventReader(_bus, _distibutionPointCorrelationId, null, "stream", 10, _fakeTimeProvider,
+            _eventReader = new StreamEventReader(_bus, _distributionCorrelationId, null, "stream", 10, _fakeTimeProvider,
                 resolveLinkTos: false, stopOnEof: true, produceStreamDeletes: false);
-            _edp.Resume();
-            _firstEventId = Guid.NewGuid();
-            _secondEventId = Guid.NewGuid();
+            _eventReader.Resume();
 			var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
-            _edp.Handle(
+            _eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "stream"));
+            _eventReader.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
 					correlationId, "stream", 100, 100, ReadStreamResult.Success, 
                     new[]
                         {
                             ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
-                            10, 50, Guid.NewGuid(), _firstEventId, 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
+                            10, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "stream", ExpectedVersion.Any, DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type1", new byte[] {1}, new byte[] {2})),
                             ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
-                            11, 100, Guid.NewGuid(), _secondEventId, 100, 0, "stream", ExpectedVersion.Any,
+                            11, 100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, "stream", ExpectedVersion.Any,
                             DateTime.UtcNow,
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type2", new byte[] {3}, new byte[] {4}))
                         }, null, false, "", 12, 11, true, 200));
-			correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
-            _edp.Handle(
-                new ClientMessage.ReadStreamEventsForwardCompleted(
-					correlationId, "stream", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 12, 11, true, 400));
         }
-
+			
         [Test]
-        public void publishes_eof_message()
+        public void should_not_deliver_events()
         {
-            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderEof>().Count());
-            var first = _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderEof>().First();
-            Assert.AreEqual(first.CorrelationId, _distibutionPointCorrelationId);
-        }
-
-        [Test]
-        public void does_not_publish_read_messages_anymore()
-        {
-            Assert.AreEqual(2, _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Count());
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_eof_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_eof_and_idle_eof.cs
@@ -9,6 +9,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Tests.Services.core_projection;
 using NUnit.Framework;
+using EventStore.Core.Services.AwakeReaderService;
 
 namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_file_reader
 {
@@ -38,9 +39,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+			var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadAllEventsForwardCompleted(
-                    _distibutionPointCorrelationId, ReadAllResult.Success, null,
+					correlationId, ReadAllResult.Success, null,
                     new[]
                     {
                         EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
@@ -57,15 +59,16 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
                                 "event_type1", new byte[] {1}, new byte[] {2}), 200),
                     }, null, false, 100,
                     new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));
-
+			correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadAllEventsForwardCompleted(
-                    _distibutionPointCorrelationId, ReadAllResult.Success, null,
+					correlationId, ReadAllResult.Success, null,
                     new EventStore.Core.Data.ResolvedEvent[0], null, false, 100, new TFPos(), new TFPos(), new TFPos(), 500));
             _fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
+			correlationId = _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadAllEventsForwardCompleted(
-                    _distibutionPointCorrelationId, ReadAllResult.Success, null,
+					correlationId, ReadAllResult.Success, null,
                     new EventStore.Core.Data.ResolvedEvent[0], null, false, 100, new TFPos(), new TFPos(), new TFPos(), 500));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_hard_deleted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_hard_deleted.cs
@@ -38,9 +38,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadAllEventsForwardCompleted(
-                    _distibutionPointCorrelationId, ReadAllResult.Success, null,
+                    correlationId, ReadAllResult.Success, null,
                     new[]
                     {
                         ResolvedEvent.ForUnresolvedEvent(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_soft_deleted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_soft_deleted.cs
@@ -39,9 +39,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadAllEventsForwardCompleted(
-                    _distibutionPointCorrelationId, ReadAllResult.Success, null,
+                    correlationId, ReadAllResult.Success, null,
                     new[]
                     {
                         ResolvedEvent.ForUnresolvedEvent(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_onetime_reader_handles_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_onetime_reader_handles_eof.cs
@@ -37,9 +37,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
             _edp.Resume();
             _firstEventId = Guid.NewGuid();
             _secondEventId = Guid.NewGuid();
+			var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadAllEventsForwardCompleted(
-                    _distibutionPointCorrelationId, ReadAllResult.Success, null,
+					correlationId, ReadAllResult.Success, null,
                     new[]
                     {
                         EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
@@ -55,10 +56,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
                                 PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                                 "event_type1", new byte[] {1}, new byte[] {2}), 200),
                     }, null, false, 100, new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));
-
+			correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadAllEventsForwardCompleted(
-                    _distibutionPointCorrelationId, ReadAllResult.Success, null,
+					correlationId, ReadAllResult.Success, null,
                     new EventStore.Core.Data.ResolvedEvent[0], null, false, 100, new TFPos(), new TFPos(), new TFPos(), 500));
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_completes_before_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_completes_before_timeout.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_file_reader
+{
+    [TestFixture]
+    public class when_read_completes_before_timeout : TestFixtureWithExistingEvents
+    {
+        private TransactionFileEventReader _eventReader;
+		private Guid _distributionCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private FakeTimeProvider _fakeTimeProvider;
+
+        [SetUp]
+        public new void When()
+        {
+			_distributionCorrelationId = Guid.NewGuid();
+            _fakeTimeProvider = new FakeTimeProvider();
+			_eventReader = new TransactionFileEventReader(_bus, _distributionCorrelationId, null, new TFPos(100, 50), _fakeTimeProvider,
+                deliverEndOfTFPosition: false, stopOnEof: true);
+            _eventReader.Resume();
+			var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
+			_eventReader.Handle(
+				new ClientMessage.ReadAllEventsForwardCompleted(
+					correlationId, ReadAllResult.Success, null,
+					new[]
+					{
+						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
+							new EventRecord(
+								1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any,
+								_fakeTimeProvider.Now,
+								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+								"event_type1", new byte[] {1}, new byte[] {2}), 100),
+						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
+							new EventRecord(
+								2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "b", ExpectedVersion.Any,
+								_fakeTimeProvider.Now,
+								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+								"event_type1", new byte[] {1}, new byte[] {2}), 200),
+					}, null, false, 100, new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));
+            _eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "$all"));
+        }
+			
+        [Test]
+        public void should_deliver_events()
+        {
+            Assert.AreEqual(2, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_timeout_occurs.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_file_reader
+{
+    [TestFixture]
+    public class when_read_timeout_occurs : TestFixtureWithExistingEvents
+    {
+        private TransactionFileEventReader _eventReader;
+		private Guid _distributionCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private FakeTimeProvider _fakeTimeProvider;
+
+        [SetUp]
+        public new void When()
+        {
+			_distributionCorrelationId = Guid.NewGuid();
+            _fakeTimeProvider = new FakeTimeProvider();
+			_eventReader = new TransactionFileEventReader(_bus, _distributionCorrelationId, null, new TFPos(100, 50), _fakeTimeProvider,
+                deliverEndOfTFPosition: false, stopOnEof: true);
+            _eventReader.Resume();
+			var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
+            _eventReader.Handle(
+				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "$all"));
+			_eventReader.Handle(
+				new ClientMessage.ReadAllEventsForwardCompleted(
+					correlationId, ReadAllResult.Success, null,
+					new[]
+					{
+						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
+							new EventRecord(
+								1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any,
+								_fakeTimeProvider.Now,
+								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+								"event_type1", new byte[] {1}, new byte[] {2}), 100),
+						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
+							new EventRecord(
+								2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "b", ExpectedVersion.Any,
+								_fakeTimeProvider.Now,
+								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+								"event_type1", new byte[] {1}, new byte[] {2}), 200),
+					}, null, false, 100, new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));
+        }
+			
+        [Test]
+        public void should_not_deliver_events()
+        {
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -797,6 +797,31 @@ namespace EventStore.Projections.Core.Messages
                 public override int MsgTypeId { get { return TypeId; } }
             }
 
+            public class ReadTimeout : Message
+            {
+                private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+                public override int MsgTypeId { get { return TypeId; } }
+
+                private readonly Guid _correlationId;
+                private readonly string _streamId;
+
+                public Guid CorrelationId
+                {
+                    get { return _correlationId; }
+                }
+
+                public string StreamId
+                {
+                    get { return _streamId; }
+                }
+
+                public ReadTimeout(Guid correlationId, string streamId)
+                {
+                    _correlationId = correlationId;
+                    _streamId = streamId;
+                }
+            }
+
             public class Deleted : Message
             {
                 private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -38,12 +38,6 @@ namespace EventStore.Projections.Core.Services.Management
             public int NumberOfPrequisitesMetForDeletion;
             public string Message { get; set; }
 
-            [Obsolete]
-            public ProjectionSourceDefinition SourceDefintion
-            {
-                set { SourceDefinition = value; }
-            }
-
             public ProjectionSourceDefinition SourceDefinition { get; set; }
             public bool? EmitEnabled { get; set; }
             public bool? CreateTempStreams { get; set; }

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointReader.cs
@@ -33,8 +33,6 @@ namespace EventStore.Projections.Core.Services.Processing
         public CoreProjectionCheckpointReader(
             IPublisher publisher, Guid projectionCorrelationId, IODispatcher ioDispatcher, string projectionCheckpointStreamId, ProjectionVersion projectionVersion, bool useCheckpoints)
         {
-
-
             _publisher = publisher;
             _projectionCorrelationId = projectionCorrelationId;
             _ioDispatcher = ioDispatcher;

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionQueue.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionQueue.cs
@@ -79,7 +79,6 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             _subscriptionPaused = false;
             _unsubscribed = false;
-            _unsubscribed = false;
             _subscriptionId = Guid.Empty;
 
             _queuePendingEvents.Initialize();

--- a/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
@@ -8,10 +8,13 @@ using EventStore.Core.Services.AwakeReaderService;
 using EventStore.Core.Services.TimerService;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Standard;
+using EventStore.Core.Settings;
 
 namespace EventStore.Projections.Core.Services.Processing
 {
-    public class StreamEventReader : EventReader, IHandle<ClientMessage.ReadStreamEventsForwardCompleted>
+    public class StreamEventReader : EventReader,
+        IHandle<ClientMessage.ReadStreamEventsForwardCompleted>,
+        IHandle<ProjectionManagementMessage.Internal.ReadTimeout>
     {
         private readonly string _streamName;
         private int _fromSequenceNumber;
@@ -23,6 +26,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private int _maxReadCount = 111;
         private long _lastPosition;
         private bool _eof;
+        private Guid _pendingRequestCorrelationId;
 
         public StreamEventReader(
             IPublisher publisher,
@@ -62,6 +66,10 @@ namespace EventStore.Projections.Core.Services.Processing
                     string.Format("Invalid stream name: {0}.  Expected: {1}", message.EventStreamId, _streamName));
             if (Paused)
                 throw new InvalidOperationException("Paused");
+            if(message.CorrelationId != _pendingRequestCorrelationId){
+                return;
+            }
+
             _eventsRequested = false;
             _lastPosition = message.TfLastCommitPosition;
             NotifyIfStarting(message.TfLastCommitPosition);
@@ -123,6 +131,16 @@ namespace EventStore.Projections.Core.Services.Processing
             }
         }
 
+        public void Handle(ProjectionManagementMessage.Internal.ReadTimeout message)
+        {
+            if(_disposed) return;
+            if(Paused) return;
+            if(message.CorrelationId != _pendingRequestCorrelationId) return;
+
+            _eventsRequested = false;
+            PauseOrContinueProcessing();
+        }
+
         private int StartFrom(ClientMessage.ReadStreamEventsForwardCompleted message, int fromSequenceNumber)
         {
             if (fromSequenceNumber != 0) return fromSequenceNumber;
@@ -148,21 +166,33 @@ namespace EventStore.Projections.Core.Services.Processing
                 throw new InvalidOperationException("Paused or pause requested");
             _eventsRequested = true;
 
-
-            var readEventsForward = CreateReadEventsMessage();
-            if (_eof)
-                _publisher.Publish(
-                    new AwakeServiceMessage.SubscribeAwake(
-                        new PublishEnvelope(_publisher, crossThread: true), Guid.NewGuid(), null,
-                        new TFPos(_lastPosition, _lastPosition), readEventsForward));
-            else
+            _pendingRequestCorrelationId = Guid.NewGuid();
+            var readEventsForward = CreateReadEventsMessage(_pendingRequestCorrelationId);
+			if (_eof) {
+				_publisher.Publish (
+					new AwakeServiceMessage.SubscribeAwake (
+						new PublishEnvelope (_publisher, crossThread: true), _pendingRequestCorrelationId, null,
+						new TFPos (_lastPosition, _lastPosition), readEventsForward));
+			}
+            else{
                 _publisher.Publish(readEventsForward);
+                ScheduleReadTimeoutMessage(_pendingRequestCorrelationId, _streamName);
+            }
         }
 
-        private Message CreateReadEventsMessage()
+        private void ScheduleReadTimeoutMessage(Guid readCorrelationId, string streamId)
+        {
+            _publisher.Publish(
+                TimerMessage.Schedule.Create(
+                    TimeSpan.FromMilliseconds(ESConsts.ReadRequestTimeout),
+                    new SendToThisEnvelope(this),
+                    new ProjectionManagementMessage.Internal.ReadTimeout(readCorrelationId, streamId)));
+        }
+
+        private Message CreateReadEventsMessage(Guid readCorrelationId)
         {
             return new ClientMessage.ReadStreamEventsForward(
-                Guid.NewGuid(), EventReaderCorrelationId, new SendToThisEnvelope(this), _streamName, _fromSequenceNumber,
+                readCorrelationId, readCorrelationId, new SendToThisEnvelope(this), _streamName, _fromSequenceNumber,
                 _maxReadCount, _resolveLinkTos, false, null, ReadAs);
         }
 


### PR DESCRIPTION
The projection event readers have no logic to handle messages that have
passed their expiry. Currently if a message expires, the node will drop
the message and the "client" will receive nothing back for the read.

The readers will now send a timeout message after sending the read
events message. First message that is returned will win and the other
message is ignored.

Remove obsolete Source Definition
Remove duplicate set of unsubscribed
Remove blank lines