### PR TITLE
Handle timeouts in the Event By Type Reader

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -519,6 +519,12 @@
     <Compile Include="Services\event_reader\multi_stream_reader\when_read_completes_before_timeout.cs" />
     <Compile Include="Services\event_reader\multi_stream_reader\when_read_for_one_stream_completes_but_times_out_for_another.cs" />
     <Compile Include="Services\event_filter\specific_events_event_filter.cs" />
+    <Compile Include="Services\event_reader\event_by_type_index_event_reader\when_tf_based_read_completes_before_timeout.cs" />
+    <Compile Include="Services\event_reader\event_by_type_index_event_reader\when_index_based_read_timeout_occurs.cs" />
+    <Compile Include="Services\event_reader\event_by_type_index_event_reader\when_index_based_read_completes_before_timeout.cs" />
+    <Compile Include="Services\event_reader\event_by_type_index_event_reader\when_index_based_checkpoint_read_timeout_occurs.cs" />
+    <Compile Include="Services\event_reader\event_by_type_index_event_reader\when_tf_based_read_timeout_occurs.cs" />
+    <Compile Include="Services\event_reader\event_by_type_index_event_reader\EventByTypeIndexEventReaderTestFixture.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/EventByTypeIndexEventReaderTestFixture.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/EventByTypeIndexEventReaderTestFixture.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+public class EventByTypeIndexEventReaderTestFixture : TestFixtureWithExistingEvents
+{
+    public Guid CompleteForwardStreamRead(string streamId, Guid corrId, params ResolvedEvent[] events){
+        var lastEventNumber = events != null && events.Length > 0 ? events.Last().Event.EventNumber : 0;
+        var message = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == streamId);
+        message.Envelope.ReplyWith(
+            new ClientMessage.ReadStreamEventsForwardCompleted(
+                corrId == Guid.Empty ? message.CorrelationId : corrId, streamId, 0, 100, ReadStreamResult.Success,
+                events, null, false, "", lastEventNumber + 1, lastEventNumber, true, 200));
+        return message.CorrelationId;
+    }
+
+    public Guid CompleteForwardAllStreamRead(Guid corrId, params ResolvedEvent[] events){
+        var message = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last();
+        message.Envelope.ReplyWith(
+            new ClientMessage.ReadAllEventsForwardCompleted(
+                corrId == Guid.Empty ? message.CorrelationId : corrId, ReadAllResult.Success,
+                "", events, null, false, 100, new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));
+        return message.CorrelationId;
+    }
+
+    public Guid CompleteBackwardStreamRead(string streamId, Guid corrId, params ResolvedEvent[] events){
+        var lastEventNumber = events != null && events.Length > 0 ? events.Last().Event.EventNumber : 0;
+        var message = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsBackward>().Last(x => x.EventStreamId == streamId);
+        message.Envelope.ReplyWith(
+            new ClientMessage.ReadStreamEventsBackwardCompleted(
+                corrId == Guid.Empty ? message.CorrelationId : corrId, streamId, 0, 100, ReadStreamResult.Success,
+                new ResolvedEvent[]{}, null, false, "", lastEventNumber + 1,lastEventNumber, true, 200));
+        return message.CorrelationId;
+    }
+
+    public Guid TimeoutRead(string streamId, Guid corrId){
+        var timeoutMessage = _consumer.HandledMessages.OfType<EventStore.Core.Services.TimerService.TimerMessage.Schedule>().Last(x => ((ProjectionManagementMessage.Internal.ReadTimeout)x.ReplyMessage).StreamId == streamId);
+        var correlationId = ((ProjectionManagementMessage.Internal.ReadTimeout)timeoutMessage.ReplyMessage).CorrelationId;
+        correlationId = corrId == Guid.Empty ? correlationId : corrId;
+        timeoutMessage.Envelope.ReplyWith(
+            new ProjectionManagementMessage.Internal.ReadTimeout(corrId == Guid.Empty ? correlationId : corrId, streamId));
+        return correlationId;
+    }
+
+    protected static string TFPosToMetadata(TFPos tfPos)
+    {
+        return string.Format(@"{{""$c"":{0},""$p"":{1}}}", tfPos.CommitPosition, tfPos.PreparePosition);
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_index_based_checkpoint_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_index_based_checkpoint_read_timeout_occurs.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Common.Utils;
+using NUnit.Framework;
+using EventStore.Core.Messages;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_index_event_reader
+{
+    [TestFixture, Category("test")]
+    public class when_index_based_checkpoint_read_timeout_occurs : EventByTypeIndexEventReaderTestFixture
+    {
+        private EventByTypeIndexEventReader _eventReader;
+        private Guid _distributionCorrelationId;
+        private Guid _checkpointStreamCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private FakeTimeProvider _fakeTimeProvider;
+
+        [SetUp]
+        public new void When()
+        {
+            _distributionCorrelationId = Guid.NewGuid();
+            _fakeTimeProvider = new FakeTimeProvider();
+            var fromPositions = new Dictionary<string, int>();
+            fromPositions.Add("$et-eventTypeOne", 0);
+            fromPositions.Add("$et-eventTypeTwo", 0);
+            _eventReader = new EventByTypeIndexEventReader(_bus, _distributionCorrelationId, 
+                null, new []{"eventTypeOne", "eventTypeTwo"}, 
+                false, new TFPos(0, 0), 
+                fromPositions, true,
+                _fakeTimeProvider,
+                stopOnEof: true);
+
+            _eventReader.Resume();
+
+            _checkpointStreamCorrelationId = TimeoutRead("$et", Guid.Empty);
+
+            CompleteForwardStreamRead("$et-eventTypeOne", Guid.Empty, new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "$et-eventTypeOne", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "$>", Helper.UTF8NoBom.GetBytes("0@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(50, 50))))),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "$et-eventTypeOne", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "$>", Helper.UTF8NoBom.GetBytes("1@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(150, 150)))))
+                        });
+
+            CompleteForwardStreamRead("$et-eventTypeTwo", Guid.Empty, new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, "$et-eventTypeTwo", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "$>", Helper.UTF8NoBom.GetBytes("2@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(100, 100))))),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 200, Guid.NewGuid(), Guid.NewGuid(), 200, 0, "$et-eventTypeTwo", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                "$>", Helper.UTF8NoBom.GetBytes("3@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(200, 200)))))
+                        });
+        }
+
+        [Test]
+        public void should_not_deliver_events()
+        {
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+
+        [Test]
+        public void should_attempt_another_checkpoint_read()
+        {
+            var checkpointReads = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsBackward>()
+                            .Where(x => x.EventStreamId == "$et");
+
+            Assert.AreEqual(checkpointReads.First().CorrelationId, _checkpointStreamCorrelationId);
+            Assert.AreEqual(1, checkpointReads.Skip(1).Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_index_based_read_completes_before_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_index_based_read_completes_before_timeout.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using EventStore.Common.Utils;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_index_event_reader
+{
+    [TestFixture]
+    public class when_index_based_read_completes_before_timeout : EventByTypeIndexEventReaderTestFixture
+    {
+        private EventByTypeIndexEventReader _eventReader;
+        private Guid _distributionCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private FakeTimeProvider _fakeTimeProvider;
+
+        [SetUp]
+        public new void When()
+        {
+            _distributionCorrelationId = Guid.NewGuid();
+            _fakeTimeProvider = new FakeTimeProvider();
+            var fromPositions = new Dictionary<string, int>();
+            fromPositions.Add("$et-eventTypeOne", 0);
+            fromPositions.Add("$et-eventTypeTwo", 0);
+            _eventReader = new EventByTypeIndexEventReader(_bus, _distributionCorrelationId, 
+                null, new string[]{"eventTypeOne", "eventTypeTwo"}, 
+                false, new TFPos(-1, -1), 
+                fromPositions, true,
+                _fakeTimeProvider,
+                stopOnEof: true);
+            
+            _eventReader.Resume();
+
+            var correlationId = CompleteForwardStreamRead("$et-eventTypeOne", Guid.Empty, new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "$et-eventTypeOne", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "$>", Helper.UTF8NoBom.GetBytes("0@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(50, 50))))),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "$et-eventTypeOne", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "$>", Helper.UTF8NoBom.GetBytes("1@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(150, 150)))))
+                        });
+
+            TimeoutRead("$et-eventTypeOne", correlationId);
+
+            correlationId = CompleteForwardStreamRead("$et-eventTypeTwo", Guid.Empty, new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, "$et-eventTypeTwo", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "$>", Helper.UTF8NoBom.GetBytes("2@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(100, 100))))),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 200, Guid.NewGuid(), Guid.NewGuid(), 200, 0, "$et-eventTypeTwo", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                "$>", Helper.UTF8NoBom.GetBytes("3@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(200, 200)))))
+                        });
+
+            TimeoutRead("$et-eventTypeTwo", correlationId);
+        }
+
+        [Test]
+        public void should_deliver_events()
+        {
+            Assert.AreEqual(3, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_index_based_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_index_based_read_timeout_occurs.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using EventStore.Common.Utils;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_index_event_reader
+{
+    [TestFixture]
+    public class when_index_based_read_timeout_occurs : EventByTypeIndexEventReaderTestFixture
+    {
+        private EventByTypeIndexEventReader _eventReader;
+        private Guid _distributionCorrelationId;
+        private Guid _eventTypeOneStreamReadCorrelationId;
+        private Guid _eventTypeTwoStreamReadCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private FakeTimeProvider _fakeTimeProvider;
+
+        [SetUp]
+        public new void When()
+        {
+			_distributionCorrelationId = Guid.NewGuid();
+            _fakeTimeProvider = new FakeTimeProvider();
+            var fromPositions = new Dictionary<string, int>();
+            fromPositions.Add("$et-eventTypeOne", 0);
+            fromPositions.Add("$et-eventTypeTwo", 0);
+            _eventReader = new EventByTypeIndexEventReader(_bus, _distributionCorrelationId, 
+                null, new string[]{"eventTypeOne", "eventTypeTwo"}, 
+                false, new TFPos(0, 0), 
+                fromPositions, true,
+                _fakeTimeProvider,
+                stopOnEof: true);
+
+            _eventReader.Resume();
+
+            _eventTypeOneStreamReadCorrelationId = TimeoutRead("$et-eventTypeOne", Guid.Empty);
+
+            CompleteForwardStreamRead("$et-eventTypeOne", _eventTypeOneStreamReadCorrelationId, new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "$et-eventTypeOne", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "$>", Helper.UTF8NoBom.GetBytes("0@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(50, 50))))),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "$et-eventTypeOne", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            "$>", Helper.UTF8NoBom.GetBytes("1@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(150, 150)))))
+                        });
+
+            _eventTypeTwoStreamReadCorrelationId = TimeoutRead("$et-eventTypeTwo", Guid.Empty);
+
+            CompleteForwardStreamRead("$et-eventTypeTwo", _eventTypeTwoStreamReadCorrelationId, new[]
+                        {
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            1, 100, Guid.NewGuid(), Guid.NewGuid(), 100, 0, "$et-eventTypeTwo", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | PrepareFlags.IsJson,
+                            "$>", Helper.UTF8NoBom.GetBytes("2@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(100, 100))))),
+                            ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            2, 200, Guid.NewGuid(), Guid.NewGuid(), 200, 0, "$et-eventTypeTwo", ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                "$>", Helper.UTF8NoBom.GetBytes("3@test-stream"), Helper.UTF8NoBom.GetBytes(TFPosToMetadata(new TFPos(200, 200)))))
+                        });
+        }
+        
+        [Test]
+        public void should_not_deliver_events()
+        {
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+
+        [Test]
+        public void should_attempt_another_read_for_the_timed_out_reads()
+        {
+            var eventTypeOneStreamReads = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>()
+                            .Where(x => x.EventStreamId == "$et-eventTypeOne");
+
+            Assert.AreEqual(eventTypeOneStreamReads.First().CorrelationId, _eventTypeOneStreamReadCorrelationId);
+            Assert.AreEqual(1, eventTypeOneStreamReads.Skip(1).Count());
+
+            var eventTypeTwoStreamReads = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>()
+                .Where(x => x.EventStreamId == "$et-eventTypeTwo");
+
+            Assert.AreEqual(eventTypeTwoStreamReads.First().CorrelationId, _eventTypeTwoStreamReadCorrelationId);
+            Assert.AreEqual(1, eventTypeTwoStreamReads.Skip(1).Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_tf_based_read_completes_before_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_tf_based_read_completes_before_timeout.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_index_event_reader
+{
+    [TestFixture]
+    public class when_tf_based_read_completes_before_timeout : EventByTypeIndexEventReaderTestFixture
+    {
+        private EventByTypeIndexEventReader _eventReader;
+        private Guid _distributionCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private FakeTimeProvider _fakeTimeProvider;
+
+        [SetUp]
+        public new void When()
+        {
+            _distributionCorrelationId = Guid.NewGuid();
+            _fakeTimeProvider = new FakeTimeProvider();
+            var fromPositions = new Dictionary<string, int>();
+            fromPositions.Add("$et-eventTypeOne", 0);
+            fromPositions.Add("$et-eventTypeTwo", 0);
+            _eventReader = new EventByTypeIndexEventReader(_bus, _distributionCorrelationId, 
+                null, new string[]{"eventTypeOne", "eventTypeTwo"}, 
+                false, new TFPos(0, 0), 
+                fromPositions, true,
+                _fakeTimeProvider,
+                stopOnEof: true);
+            
+            _eventReader.Resume();
+            
+            CompleteForwardStreamRead("$et-eventTypeOne", Guid.Empty);
+            CompleteForwardStreamRead("$et-eventTypeTwo", Guid.Empty);
+            CompleteBackwardStreamRead("$et", Guid.Empty);
+
+            var correlationId = CompleteForwardAllStreamRead(Guid.Empty, new[]
+                    {
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
+                            new EventRecord(
+                                1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "test_stream", ExpectedVersion.Any,
+                                _fakeTimeProvider.Now,
+                                PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                "eventTypeOne", new byte[] {1}, new byte[] {2}), 100),
+                        EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
+                            new EventRecord(
+                                2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "test_stream", ExpectedVersion.Any,
+                                _fakeTimeProvider.Now,
+                                PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                "eventTypeTwo", new byte[] {1}, new byte[] {2}), 200),
+                    });
+            
+            TimeoutRead("$all", correlationId);
+        }
+
+        [Test]
+        public void should_deliver_events()
+        {
+            Assert.AreEqual(2, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_tf_based_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_tf_based_read_timeout_occurs.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_index_event_reader
+{
+    [TestFixture]
+    public class when_tf_based_read_timeout_occurs : EventByTypeIndexEventReaderTestFixture
+    {
+        private EventByTypeIndexEventReader _eventReader;
+        private Guid _distributionCorrelationId;
+        private Guid _readAllEventsForwardCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+        }
+
+        private FakeTimeProvider _fakeTimeProvider;
+
+        [SetUp]
+        public new void When()
+        {
+            _distributionCorrelationId = Guid.NewGuid();
+            _fakeTimeProvider = new FakeTimeProvider();
+            var fromPositions = new Dictionary<string, int>();
+            fromPositions.Add("$et-eventTypeOne", 0);
+            fromPositions.Add("$et-eventTypeTwo", 0);
+            _eventReader = new EventByTypeIndexEventReader(_bus, _distributionCorrelationId, 
+                null, new string[]{"eventTypeOne", "eventTypeTwo"}, 
+                false, new TFPos(0, 0), 
+                fromPositions, true,
+                _fakeTimeProvider,
+                stopOnEof: true);
+
+            _eventReader.Resume();
+            
+            CompleteForwardStreamRead("$et-eventTypeOne", Guid.Empty);
+            CompleteForwardStreamRead("$et-eventTypeTwo", Guid.Empty);
+            CompleteBackwardStreamRead("$et", Guid.Empty);
+
+            _readAllEventsForwardCorrelationId = TimeoutRead("$all", Guid.Empty);
+
+            CompleteForwardAllStreamRead(_readAllEventsForwardCorrelationId, new[]
+                    {
+                        ResolvedEvent.ForUnresolvedEvent(
+                            new EventRecord(
+                                1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "test_stream", ExpectedVersion.Any,
+                                _fakeTimeProvider.Now,
+                                PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                "eventTypeOne", new byte[] {1}, new byte[] {2}), 100),
+                        ResolvedEvent.ForUnresolvedEvent(
+                            new EventRecord(
+                                2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "test_stream", ExpectedVersion.Any,
+                                _fakeTimeProvider.Now,
+                                PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                                "eventTypeTwo", new byte[] {1}, new byte[] {2}), 200),
+                    });
+        }
+
+        [Test]
+        public void should_not_deliver_events()
+        {
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+
+        [Test]
+        public void should_attempt_another_read_for_the_timed_out_reads()
+        {
+            var readAllEventsForwardMessages = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>();
+
+            Assert.AreEqual(readAllEventsForwardMessages.First().CorrelationId, _readAllEventsForwardCorrelationId);
+            Assert.AreEqual(1, readAllEventsForwardMessages.Skip(1).Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_timeout_occurs.cs
@@ -16,6 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
     {
         private TransactionFileEventReader _eventReader;
 		private Guid _distributionCorrelationId;
+		private Guid _readAllEventsForwardCorrelationId;
 
         protected override void Given()
         {
@@ -32,12 +33,12 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 			_eventReader = new TransactionFileEventReader(_bus, _distributionCorrelationId, null, new TFPos(100, 50), _fakeTimeProvider,
                 deliverEndOfTFPosition: false, stopOnEof: true);
             _eventReader.Resume();
-			var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
+			_readAllEventsForwardCorrelationId = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>().Last().CorrelationId;
             _eventReader.Handle(
-				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, "$all"));
+				new ProjectionManagementMessage.Internal.ReadTimeout(_readAllEventsForwardCorrelationId, "$all"));
 			_eventReader.Handle(
 				new ClientMessage.ReadAllEventsForwardCompleted(
-					correlationId, ReadAllResult.Success, null,
+					_readAllEventsForwardCorrelationId, ReadAllResult.Success, null,
 					new[]
 					{
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
@@ -59,6 +60,15 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
         public void should_not_deliver_events()
         {
             Assert.AreEqual(0, _consumer.HandledMessages.OfType<ReaderSubscriptionMessage.CommittedEventDistributed>().Count());
+        }
+
+        [Test]
+        public void should_attempt_another_read_for_the_timed_out_reads()
+        {
+            var readAllEventsForwardMessages = _consumer.HandledMessages.OfType<ClientMessage.ReadAllEventsForward>();
+
+            Assert.AreEqual(readAllEventsForwardMessages.First().CorrelationId, _readAllEventsForwardCorrelationId);
+            Assert.AreEqual(1, readAllEventsForwardMessages.Skip(1).Count());
         }
     }
 }


### PR DESCRIPTION
The event by type index event reader first attempts to read each of the
streams of the event types it cares about. e.g. "$et-eventTypeExample"
and after there are no more events, it will switch to an $all reader.

These readers will now handle the case where a message expiry could have
resulted in not returning a result for the reads that the reader sent
off.

Add additional tests to verify that another read is attempted for the
reads that timed out