### PR TITLE
Competingtime

### DIFF
--- a/src/EventStore.ClientAPI/PersistentSubscriptionSettings.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionSettings.cs
@@ -72,7 +72,7 @@ namespace EventStore.ClientAPI
         public int HistoryBufferSize;
 
         /// <summary>
-        /// The amount of time to try to checkpoint after 
+        /// The amount of time to try to checkpoint after
         /// </summary>
         public readonly TimeSpan CheckPointAfter;
 
@@ -101,9 +101,11 @@ namespace EventStore.ClientAPI
         /// </summary>
         internal PersistentSubscriptionSettings(bool resolveLinkTos, int startFrom, bool extraStatistics, TimeSpan messageTimeout,
                                                 int maxRetryCount, int liveBufferSize, int readBatchSize, int historyBufferSize,
-                                                TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount, 
+                                                TimeSpan checkPointAfter, int minCheckPointCount, int maxCheckPointCount,
                                                 int maxSubscriberCount, string namedConsumerStrategy)
         {
+            if(messageTimeout.TotalMilliseconds > Int32.MaxValue) throw new ArgumentException("messageTimeout", "milliseconds must be less or equal to than int32.MaxValue");
+            if(checkPointAfter.TotalMilliseconds > Int32.MaxValue) throw new ArgumentException("checkPointAfter", "milliseconds must be less or equal to than int32.MaxValue");
             MessageTimeout = messageTimeout;
             ResolveLinkTos = resolveLinkTos;
             StartFrom = startFrom;

--- a/src/EventStore.ClientAPI/PersistentSubscriptionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptionSettingsBuilder.cs
@@ -134,7 +134,7 @@ namespace EventStore.ClientAPI
         /// <returns>A new <see cref="PersistentSubscriptionSettingsBuilder"></see></returns>
         public PersistentSubscriptionSettingsBuilder DontTimeoutMessages()
         {
-            _timeout = TimeSpan.MaxValue;
+            _timeout = TimeSpan.Zero; 
             return this;
         }
 

--- a/src/EventStore.Core.Tests/ClientAPI/create_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/create_persistent_subscription.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.ClientAPI
                                                                 .StartFromCurrent();
         protected override void When()
         {
-            
+
         }
 
         [Test]
@@ -60,13 +60,47 @@ namespace EventStore.Core.Tests.ClientAPI
                                                                 .StartFromCurrent();
         protected override void When()
         {
-            
+
         }
 
         [Test]
         public void the_completion_fails_with_invalid_stream()
         {
             Assert.Throws<AggregateException>(() => _conn.CreatePersistentSubscriptionAsync("$all", "shitbird", _settings, DefaultData.AdminCredentials).Wait());
+        }
+    }
+
+
+    [TestFixture, Category("LongRunning")]
+    public class create_persistent_subscription_with_too_big_message_timeout : SpecificationWithMiniNode
+    {
+
+        protected override void When()
+        {
+
+        }
+
+        [Test]
+        public void the_build_fails_with_argument_exception()
+        {
+            Assert.Throws<ArgumentException>(() => PersistentSubscriptionSettings.Create().WithMessageTimeoutOf(TimeSpan.FromDays(25 * 365)).Build());
+        }
+    }
+
+
+    [TestFixture, Category("LongRunning")]
+    public class create_persistent_subscription_with_too_big_retry_after : SpecificationWithMiniNode
+    {
+
+        protected override void When()
+        {
+
+        }
+
+        [Test]
+        public void the_build_fails_with_argument_exception()
+        {
+            Assert.Throws<ArgumentException>(() => PersistentSubscriptionSettings.Create().CheckPointAfter(TimeSpan.FromDays(25 * 365)).Build());
         }
     }
 
@@ -110,7 +144,7 @@ namespace EventStore.Core.Tests.ClientAPI
         protected override void When()
         {
             _conn.CreatePersistentSubscriptionAsync(_stream, "group3211", _settings, DefaultData.AdminCredentials).Wait();
-            
+
         }
 
         [Test]
@@ -162,7 +196,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 new EventData(Guid.NewGuid(), "whatever", true, Encoding.UTF8.GetBytes("{'foo' : 2}"), new Byte[0]));
             _conn.CreatePersistentSubscriptionAsync(_stream, "existing", _settings, DefaultData.AdminCredentials).Wait();
             _conn.DeletePersistentSubscriptionAsync(_stream, "existing", DefaultData.AdminCredentials).Wait();
-            
+
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/OutstandingMessageCacheTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/OutstandingMessageCacheTests.cs
@@ -129,6 +129,59 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
         }
 
         [Test]
+        public void message_that_is_removed_does_not_show_up_in_expired_list()
+        {
+            var id = Guid.NewGuid();
+            var cache = new OutstandingMessageCache();
+            cache.StartMessage(new OutstandingMessage(id, null, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "name", 1), 0), DateTime.Now.AddSeconds(-11));
+            cache.Remove(id);
+            var expired = cache.WaitingTimeMessages();
+            Assert.AreEqual(0, expired.Count());
+        }
+
+        [Test]
+        public void can_remove_non_first_message_and_have_removed_from_time()
+        {
+            var id1 = Guid.NewGuid();
+            var id2 = Guid.NewGuid();
+            var cache = new OutstandingMessageCache();
+            cache.StartMessage(new OutstandingMessage(id1, null, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "name", 1), 0), DateTime.Now.AddSeconds(-12));
+            cache.StartMessage(new OutstandingMessage(id2, null, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "name", 2), 0), DateTime.Now.AddSeconds(-11));
+            cache.Remove(id2);
+            var expired = cache.WaitingTimeMessages();
+            Assert.AreEqual(1, expired.Count());
+            Assert.AreEqual(id1, expired.FirstOrDefault().Item2.MessageId);
+        }
+
+        [Test]
+        public void can_add_multiple_messages_same_time_different_ids()
+        {
+            var id1 = Guid.NewGuid();
+            var id2 = Guid.NewGuid();
+            var cache = new OutstandingMessageCache();
+            var time = DateTime.Now.AddSeconds(-12);
+            cache.StartMessage(new OutstandingMessage(id1, null, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "name", 1), 0), time);
+            cache.StartMessage(new OutstandingMessage(id2, null, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "name", 2), 0), time);
+            var expired = cache.WaitingTimeMessages();
+            Assert.AreEqual(2, expired.Count());
+        }
+
+        [Test]
+        public void can_remove_second_message_same_time_different_ids()
+        {
+            var id1 = Guid.NewGuid();
+            var id2 = Guid.NewGuid();
+            var cache = new OutstandingMessageCache();
+            var time = DateTime.Now.AddSeconds(-12);
+            cache.StartMessage(new OutstandingMessage(id1, null, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "name", 1), 0), time);
+            cache.StartMessage(new OutstandingMessage(id2, null, Helper.BuildFakeEvent(Guid.NewGuid(), "type", "name", 2), 0), time);
+            cache.Remove(id2);
+            var expired = cache.WaitingTimeMessages();
+            Assert.AreEqual(id1, expired.FirstOrDefault().Item2.MessageId);
+            Assert.AreEqual(1, expired.Count());
+        }
+
+        [Test]
         public void message_that_notexpired_is_not_included_in_expired_list()
         {
             var id = Guid.NewGuid();

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -234,7 +234,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         private void MarkBeginProcessing(OutstandingMessage message)
         {
             _statistics.IncrementProcessed();
-            StartMessage(message, DateTime.UtcNow + _settings.MessageTimeout);
+            StartMessage(message, _settings.MessageTimeout == TimeSpan.MaxValue ? DateTime.MaxValue : DateTime.UtcNow + _settings.MessageTimeout);
         }
 
         public void AddClient(Guid correlationId, Guid connectionId, IEnvelope envelope, int maxInFlight, string user, string @from)

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -27,14 +27,14 @@ namespace EventStore.Core.Services.PersistentSubscription
         private readonly IPersistentSubscriptionCheckpointWriter _checkpointWriter;
         private IPersistentSubscriptionMessageParker _messageParker;
 
-        public PersistentSubscriptionParams(bool resolveLinkTos, string subscriptionId, string eventStreamId, string groupName, 
-                                           int startFrom, bool extraStatistics, TimeSpan messageTimeout, 
+        public PersistentSubscriptionParams(bool resolveLinkTos, string subscriptionId, string eventStreamId, string groupName,
+                                           int startFrom, bool extraStatistics, TimeSpan messageTimeout,
                                            int maxRetryCount, int liveBufferSize, int bufferSize, int readBatchSize,
                                            TimeSpan checkPointAfter, int minCheckPointCount,
-                                           int maxCheckPointCount, int maxSubscriberCount, 
+                                           int maxCheckPointCount, int maxSubscriberCount,
                                            IPersistentSubscriptionConsumerStrategy consumerStrategy,
-                                           IPersistentSubscriptionStreamReader streamReader, 
-                                           IPersistentSubscriptionCheckpointReader checkpointReader, 
+                                           IPersistentSubscriptionStreamReader streamReader,
+                                           IPersistentSubscriptionCheckpointReader checkpointReader,
                                            IPersistentSubscriptionCheckpointWriter checkpointWriter,
                                            IPersistentSubscriptionMessageParker messageParker)
         {


### PR DESCRIPTION
This should be a fix for #1147

It required moving bytime to be a sorteddictionary on a dual key (time/message id) as time can be duplicated. A pairing heap as it was would not be able to handle the remove operation. Under anything near normal circumstances the perf difference should be minimal. As it was all encapsulated into outstandingmessagecache I just used tuples where needed. Two item named classes may be preferred.

Also this changes how timeouts are working more in line with what #1140 wanted.

Have tested (unit tests only in linux).
Have not stress tested live subscriptions
Have not tested the infinite timeout though it should work
Have not tested in windows at all

