### PR TITLE
Get rid of __MonoCS__

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,6 +39,7 @@ EOF
 }
 
 CONFIGURATION="Release"
+DEFINES="USE_UNIX_IO MONO"
 
 function checkParams() {
     version=$1
@@ -199,7 +200,7 @@ function buildEventStore {
     patchVersionFiles
     patchVersionInfo
     rm -rf bin/
-    xbuild src/EventStore.sln /p:Platform="Any CPU" /p:Configuration="$CONFIGURATION" || err
+    xbuild src/EventStore.sln /p:Platform="Any CPU" /p:DefineConstants="$DEFINES" /p:Configuration="$CONFIGURATION" || err
     revertVersionFiles
     revertVersionInfo
 }

--- a/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
@@ -76,7 +76,8 @@ namespace EventStore.ClientAPI.Transport.Http
                              Action<HttpResponse> onSuccess, Action<Exception> onException, string hostHeader = "")
         {
             var request = new HttpRequestMessage();
-#if __MonoCS__
+//MONOCHECK IS THIS STILL NEEDED?
+#if MONO
             request.Headers.Add("Keep-alive", "false");
 #endif
             request.RequestUri = new Uri(url);

--- a/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
+++ b/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
@@ -30,7 +30,8 @@ namespace EventStore.Core.Tests.Http
         protected string _lastResponseBody;
         protected byte[] _lastResponseBytes;
         protected JsonException _lastJsonException;
-#if !__MonoCS__
+//MONOCHECK Does this work now?
+#if !MONO
         private Func<HttpWebResponse, byte[]> _dumpResponse;
         private Func<HttpWebResponse, int> _dumpResponse2;
         private Func<HttpWebRequest, byte[]> _dumpRequest;
@@ -41,7 +42,7 @@ namespace EventStore.Core.Tests.Http
 
         public override void TestFixtureSetUp()
         {
-#if !__MonoCS__
+#if !MONO
             Helper.EatException(() => _dumpResponse = CreateDumpResponse());
             Helper.EatException(() => _dumpResponse2 = CreateDumpResponse2());
             Helper.EatException(() => _dumpRequest = CreateDumpRequest());
@@ -368,7 +369,7 @@ namespace EventStore.Core.Tests.Http
             {
                 response = (HttpWebResponse) ex.Response;
             }
-#if !__MonoCS__
+#if !MONO
             if (_dumpRequest != null)
             {
                 var bytes = _dumpRequest(request);

--- a/src/EventStore.Core.Tests/Http/Streams/basic.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/basic.cs
@@ -426,11 +426,7 @@ namespace EventStore.Core.Tests.Http.Streams
             }
         }
 
-#if __MonoCS__
-        [TestFixture, Category("LongRunning"), Ignore("https://bugzilla.xamarin.com/show_bug.cgi?id=16960")]
-#else
         [TestFixture, Category("LongRunning")]
-#endif
         public class when_getting_from_encoded_all_stream_with_slash : HttpBehaviorSpecification
         {
             private HttpWebResponse _response;

--- a/src/EventStore.Core/Bus/QueuedHandler.cs
+++ b/src/EventStore.Core/Bus/QueuedHandler.cs
@@ -5,7 +5,8 @@ namespace EventStore.Core.Bus
 {
     // on Windows AutoReset version is much slower, but on Linux ManualResetEventSlim version is much slower
     public class QueuedHandler :
-#if __MonoCS__
+//MONOCHECK is this still worthwhile or should we use MPMC?
+#if MONO
         QueuedHandlerAutoReset,
 #else
         QueuedHandlerMRES,
@@ -41,7 +42,7 @@ namespace EventStore.Core.Bus
         }
 
         class QueueHandlerUsingMpsc :
-#if __MonoCS__
+#if MONO
         QueuedHandlerAutoResetWithMpsc,
 #else
             QueuedHandlerMresWithMpsc,

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -166,7 +166,7 @@ namespace EventStore.Core.Index
             var count = Count;
             if (count == 0 || depth == 0)
                 return null;
-#if  __MonoCS__
+#if  MONO
             var workItem = GetWorkItem();
             var stream = workItem.Stream;
             try {
@@ -232,7 +232,7 @@ namespace EventStore.Core.Index
                     throw;
                 }
             }
-#if __MonoCS__
+#if MONO
             finally
             {
                 ReturnWorkItem(workItem);

--- a/src/EventStore.Core/Services/Monitoring/Utils/PerfCounterHelper.cs
+++ b/src/EventStore.Core/Services/Monitoring/Utils/PerfCounterHelper.cs
@@ -57,7 +57,7 @@ namespace EventStore.Core.Services.Monitoring.Utils
             string processName = null;
             try
             {
-                #if __MonoCS__
+                #if MONO
                 processName = Process.GetCurrentProcess().Id.ToString();
                 #else
                 processName = Process.GetCurrentProcess().ProcessName;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -379,7 +379,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 throw new InvalidOperationException("You can't verify hash of not-completed TFChunk.");
 
             Log.Trace("Verifying hash for TFChunk '{0}'...", _filename);
-#if  __MonoCS__
+#if  MONO
             using (var reader = AcquireReader())
             {
                 reader.Stream.Seek(0, SeekOrigin.Begin);

--- a/src/EventStore.Core/TransactionLog/Unbuffered/WinNative.cs
+++ b/src/EventStore.Core/TransactionLog/Unbuffered/WinNative.cs
@@ -5,7 +5,7 @@ using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Unbuffered
 {
-#if ! __MonoCS__ && !USE_UNIX_IO
+#if !USE_UNIX_IO
     internal unsafe static class WinNative
     {
         [DllImport("KERNEL32", SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]

--- a/src/EventStore.Transport.Http/Client/HttpAsyncClient.cs
+++ b/src/EventStore.Transport.Http/Client/HttpAsyncClient.cs
@@ -84,7 +84,8 @@ namespace EventStore.Transport.Http.Client
                              Action<HttpResponse> onSuccess, Action<Exception> onException)
         {
             var request = new HttpRequestMessage();
-#if __MonoCS__
+//MONOCHECK is this still needed?
+#if MONO
             request.Headers.Add("Keep-alive", "false");
 #endif
             request.Method = new System.Net.Http.HttpMethod(method);

--- a/src/EventStore.Transport.Http/Server/HttpAsyncServer.cs
+++ b/src/EventStore.Transport.Http/Server/HttpAsyncServer.cs
@@ -201,8 +201,8 @@ namespace EventStore.Transport.Http.Server
             if (handler != null)
                 handler(this, context);
         }
-
-#if __MonoCS__
+//MONOCHECK is this still needed?
+#if MONO
        private static Func<HttpListenerRequest, HttpListenerContext> CreateGetContext()
         {
             var r = System.Linq.Expressions.Expression.Parameter(typeof (HttpListenerRequest), "r");

--- a/src/esquery/Program.cs
+++ b/src/esquery/Program.cs
@@ -137,8 +137,8 @@ namespace esquery
             }
         }
 
-
-#if __MonoCS__
+//MONOCHECK
+#if MONO
         //mono apparently doesnt work with secure strings.
         //TODO delete me when its no longer broken
         private static string ReadPassword()


### PR DESCRIPTION
Replaced with existing USE_UNIX_IO and MONO for other places.
Also added a few MONOCKECK comments where we should follow up if it
is still needed or not fixes #1157 