### PR TITLE
allows single node to gossip for testing purposes.

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -71,6 +71,8 @@ namespace EventStore.ClusterNode
         public int IntTcpHeartbeatInterval { get; set; }
         [ArgDescription(Opts.ExtTcpHeartbeatIntervalDescr, Opts.InterfacesGroup)]
         public int ExtTcpHeartbeatInterval { get; set; }
+        [ArgDescription(Opts.GossipOnSingleNodeDescr, Opts.InterfacesGroup)]
+        public bool GossipOnSingleNode { get; set; }
 
 
         [ArgDescription(Opts.ForceDescr, Opts.AppGroup)]
@@ -227,6 +229,7 @@ namespace EventStore.ClusterNode
             ClusterSize = Opts.ClusterSizeDefault;
             MinFlushDelayMs = Opts.MinFlushDelayMsDefault;
             NodePriority = Opts.NodePriorityDefault;
+            GossipOnSingleNode = Opts.GossipOnSingleNodeDefault;
 
             CommitCount = Opts.CommitCountDefault;
             PrepareCount = Opts.PrepareCountDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -216,7 +216,10 @@ namespace EventStore.ClusterNode
             if (!options.AddInterfacePrefixes){
                 builder.DontAddInterfacePrefixes();
             }
-
+            if (options.GossipOnSingleNode)
+            {
+                builder.GossipAsSingleNode();
+            }
             foreach(var prefix in options.IntHttpPrefixes) {
                 builder.AddInternalHttpPrefix(prefix);
             }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -71,6 +71,8 @@ namespace EventStore.Core.Cluster.Settings
         public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
         public readonly bool AlwaysKeepScavenged;
 
+        public readonly bool GossipOnSingleNode;
+
         public ClusterVNodeSettings(Guid instanceId, int debugIndex,
                                     IPEndPoint internalTcpEndPoint,
                                     IPEndPoint internalSecureTcpEndPoint,
@@ -125,7 +127,8 @@ namespace EventStore.Core.Cluster.Settings
                                     bool unsafeIgnoreHardDeletes = false,
                                     bool betterOrdering = false,
                                     int readerThreadsCount = 4,
-                                    bool alwaysKeepScavenged = false)
+                                    bool alwaysKeepScavenged = false,
+                                    bool gossipOnSingleNode = false)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -168,6 +171,7 @@ namespace EventStore.Core.Cluster.Settings
             DiscoverViaDns = discoverViaDns;
             ClusterDns = clusterDns;
             GossipSeeds = gossipSeeds;
+            GossipOnSingleNode = gossipOnSingleNode;
 
             ClusterNodeCount = clusterNodeCount;
             MinFlushDelay = minFlushDelay;
@@ -212,7 +216,6 @@ namespace EventStore.Core.Cluster.Settings
             ReaderThreadsCount = readerThreadsCount;
             AlwaysKeepScavenged = alwaysKeepScavenged;
         }
-
 
 
         public override string ToString()

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -521,7 +521,7 @@ namespace EventStore.Core
                                                         db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint,
                                                         epochManager, () => readIndex.LastCommitPosition, vNodeSettings.NodePriority);
             electionsService.SubscribeMessages(_mainBus);
-            if(!isSingleNode) {
+            if(!isSingleNode || vNodeSettings.GossipOnSingleNode) {
             // GOSSIP
 
                 var gossip = new NodeGossipService(_mainQueue, gossipSeedSource, gossipInfo, db.Config.WriterCheckpoint,

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -64,6 +64,8 @@ namespace EventStore.Core.Util
         public const string IntTcpHeartbeatIntervalDescr = "Heartbeat interval for internal TCP sockets";
         public const int IntTcpHeartbeatIntervalDefault = 700;
 
+        public const string GossipOnSingleNodeDescr = "When enabled tells a single node to run gossip as if it is a cluster";
+        public const bool GossipOnSingleNodeDefault = false;
 
         public const string StatsPeriodDescr = "The number of seconds between statistics gathers.";
         public const int    StatsPeriodDefault = 30;

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -120,6 +120,7 @@ namespace EventStore.Core
         protected byte _indexBitnessVersion;
         protected bool _alwaysKeepScavenged;
 
+        private bool _gossipOnSingleNode;
         // ReSharper restore FieldCanBeMadeReadOnly.Local
 
         protected VNodeBuilder()
@@ -381,6 +382,17 @@ namespace EventStore.Core
             _advertiseInternalTcpPortAs = intTcpPortAdvertiseAs;
             return this;
         }
+
+        /// <summary>
+        /// Enables gossip when running on a single node for testing purposes
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder GossipAsSingleNode()
+        {
+            _gossipOnSingleNode = true;
+            return this;
+        }
+
 
         /// <summary>
         /// Sets up the External TCP Port that would be advertised 
@@ -1267,7 +1279,8 @@ namespace EventStore.Core
                     _unsafeIgnoreHardDelete,
                     _betterOrdering,
                     _readerThreadsCount,
-                    _alwaysKeepScavenged);
+                    _alwaysKeepScavenged,
+                    _gossipOnSingleNode);
             var infoController = new InfoController(options, _projectionType);
 
             _log.Info("{0,-25} {1}", "INSTANCE ID:", _vNodeSettings.NodeInfo.InstanceId);


### PR DESCRIPTION
In order to use you force dns on ext. You must also as of now disable dns resolution and use a gossip seed to nowhere. Fixes #1161 

Example command line:

bin/clusternode/EventStore.ClusterNode.exe --gossip-on-single-node --gossip-seed 127.0.0.1:5555 --gossip-interval-ms 10000 --discover-via-dns 0

Result:

➜  eventstore git:(single-gossip) ✗ curl -v http://127.0.0.1:2113/gossip
*   Trying 127.0.0.1...
* Connected to 127.0.0.1 (127.0.0.1) port 2113 (#0)
> GET /gossip HTTP/1.1
> Host: 127.0.0.1:2113
> User-Agent: curl/7.47.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Access-Control-Allow-Methods: GET, OPTIONS
< Access-Control-Allow-Headers: Content-Type, X-Requested-With, X-Forwarded-Host, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion, ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTo
< Access-Control-Allow-Origin: *
< Access-Control-Expose-Headers: Location, ES-Position, ES-CurrentVersion
< Cache-Control: max-age=0, no-cache, must-revalidate
< Vary: Accept
< Content-Type: application/json; charset=utf-8
< Server: Mono-HTTPAPI/1.0
< Date: Thu, 05 Jan 2017 02:58:01 GMT
< Content-Length: 1551
< Keep-Alive: timeout=15,max=100
< 
{
  "members": [
    {
      "instanceId": "00000000-0000-0000-0000-000000000000",
      "timeStamp": "2017-01-05T02:57:55.668947Z",
      "state": "Manager",
      "isAlive": false,
      "internalTcpIp": "127.0.0.1",
      "internalTcpPort": 5555,
      "internalSecureTcpPort": 0,
      "externalTcpIp": "127.0.0.1",
      "externalTcpPort": 5555,
      "externalSecureTcpPort": 0,
      "internalHttpIp": "127.0.0.1",
      "internalHttpPort": 5555,
      "externalHttpIp": "127.0.0.1",
      "externalHttpPort": 5555,
      "lastCommitPosition": -1,
      "writerCheckpoint": -1,
      "chaserCheckpoint": -1,
      "epochPosition": -1,
      "epochNumber": -1,
      "epochId": "00000000-0000-0000-0000-000000000000",
      "nodePriority": 0
    },
    {
      "instanceId": "2ef78da9-fc8d-4f8e-af73-b906a5683016",
      "timeStamp": "2017-01-05T02:58:01.935504Z",
      "state": "Master",
      "isAlive": true,
      "internalTcpIp": "127.0.0.1",
      "internalTcpPort": 1112,
      "internalSecureTcpPort": 0,
      "externalTcpIp": "127.0.0.1",
      "externalTcpPort": 1113,
      "externalSecureTcpPort": 0,
      "internalHttpIp": "127.0.0.1",
      "internalHttpPort": 2112,
      "externalHttpIp": "127.0.0.1",
      "externalHttpPort": 2113,
      "lastCommitPosition": 2179,
      "writerCheckpoint": 2305,
      "chaserCheckpoint": 2305,
      "epochPosition": 1965,
      "epochNumber": 2,
      "epochId": "4422c0f7-e8e3-4639-a8f6-1a562168e16c",
      "nodePriority": 0
    }
  ],
  "serverIp": "127.0.0.1",
  "serverPort": 2112
* Connection #0 to host 127.0.0.1 left intact
