### PR TITLE
Support TLS 1.0/1.1/1.2 and SSL 3.0

### DIFF
--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -124,7 +124,8 @@ namespace EventStore.Transport.Tcp
                 _sslStream = new SslStream(new NetworkStream(socket, true), false);
                 try
                 {
-                    _sslStream.BeginAuthenticateAsServer(certificate, false, SslProtocols.Default, true, OnEndAuthenticateAsServer, _sslStream);
+                    var enabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Default;
+                    _sslStream.BeginAuthenticateAsServer(certificate, false, enabledSslProtocols, true, OnEndAuthenticateAsServer, _sslStream);
                 }
                 catch (AuthenticationException exc)
                 {


### PR DESCRIPTION
SslProtocols.Default is stand for SSL 3.0 and TLS 1.0. Due to the security concerns, the enterprise server is usually disabled TLS1.0. So we want to enable the EventStore compatibility for TLS 1.1/1.2.