### PR TITLE
Remove System.Net.Http PCL.

### DIFF
--- a/scripts/package-mono/package-linux.sh
+++ b/scripts/package-mono/package-linux.sh
@@ -100,6 +100,24 @@ cp "$MONOCONFIG" "$MONOCONFIG.custom"
 sed -e 's/$mono_libdir\///g' -i "$MONOCONFIG.custom"
 MONOCONFIG="$MONOCONFIG.custom"
 
+# mkbundle -c -o clusternode.c -oo clusternode.a \
+# 	EventStore.ClusterNode.exe \
+# 	EventStore.Rags.dll \
+# 	EventStore.Core.dll \
+# 	EventStore.BufferManagement.dll \
+# 	EventStore.Common.dll \
+# 	EventStore.Projections.Core.dll \
+# 	EventStore.ClusterNode.Web.dll \
+# 	EventStore.Transport.Http.dll \
+# 	EventStore.Transport.Tcp.dll \
+# 	HdrHistogram.NET.dll \
+# 	Newtonsoft.Json.dll \
+# 	NLog.dll protobuf-net.dll \
+# 	Mono.Security.dll \
+# 	./System.Net.Http.dll \
+# 	--static --deps --config $MONOCONFIG --machine-config $MACHINECONFIG
+
+#Removed System.Net.Http and Mono.Security.dll, preserved original command above.
 mkbundle -c -o clusternode.c -oo clusternode.a \
 	EventStore.ClusterNode.exe \
 	EventStore.Rags.dll \
@@ -113,8 +131,6 @@ mkbundle -c -o clusternode.c -oo clusternode.a \
 	HdrHistogram.NET.dll \
 	Newtonsoft.Json.dll \
 	NLog.dll protobuf-net.dll \
-	Mono.Security.dll \
-	./System.Net.Http.dll \
 	--static --deps --config $MONOCONFIG --machine-config $MACHINECONFIG
 
 # mkbundle appears to be doing it wrong, though maybe there's something I'm not seeing.
@@ -147,6 +163,25 @@ popd
 
 pushd "$SCRIPTDIR/../../bin/testclient"
 
+# mkbundle -c \
+# 	-o testclient.c \
+# 	-oo testclient.a \
+# 	EventStore.TestClient.exe \
+# 	EventStore.Core.dll \
+# 	EventStore.Rags.dll \
+# 	EventStore.ClientAPI.dll \
+# 	EventStore.BufferManagement.dll \
+# 	EventStore.Common.dll \
+# 	EventStore.Transport.Http.dll \
+# 	EventStore.Transport.Tcp.dll \
+# 	HdrHistogram.NET.dll \
+# 	Newtonsoft.Json.dll \
+# 	NLog.dll \
+# 	protobuf-net.dll \
+# 	./System.Net.Http.dll \
+# 	--static --deps --config $MONOCONFIG --machine-config $MACHINECONFIG
+
+#Removed System.Net.Http, preserved original command above.
 mkbundle -c \
 	-o testclient.c \
 	-oo testclient.a \
@@ -162,7 +197,6 @@ mkbundle -c \
 	Newtonsoft.Json.dll \
 	NLog.dll \
 	protobuf-net.dll \
-	./System.Net.Http.dll \
 	--static --deps --config $MONOCONFIG --machine-config $MACHINECONFIG
 
 # mkbundle appears to be doing it wrong, though maybe there's something I'm not seeing.

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -45,10 +45,7 @@
     <Reference Include="protobuf-net">
       <HintPath>..\libs\protobuf-v2\protobuf-net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\libs\Microsoft.Net.Http\System.Net.Http.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -53,10 +53,7 @@
       <HintPath>..\libs\nunit.framework.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <SpecificVersion>True</SpecificVersion>
-      <HintPath>..\libs\Microsoft.Net.Http\System.Net.Http.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ServiceModel" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -53,10 +53,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\protobuf-v2\protobuf-net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-      <SpecificVersion>True</SpecificVersion>
-      <HintPath>..\libs\Microsoft.Net.Http\System.Net.Http.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />

--- a/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
+++ b/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
@@ -39,10 +39,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libs\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http">
-        <SpecificVersion>False</SpecificVersion>
-        <HintPath>..\libs\Microsoft.Net.Http\System.Net.Http.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net.Http" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
This was included originally to resolve an issue with HttpClient on mono which appears to be fixed in 4.6.2