### PR TITLE
Provide the stream to which the WritedResult pertains when available fixes #1176

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/AppendToStreamOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/AppendToStreamOperation.cs
@@ -74,7 +74,7 @@ namespace EventStore.ClientAPI.ClientOperations
 
         protected override WriteResult TransformResponse(ClientMessage.WriteEventsCompleted response)
         {
-            return new WriteResult(response.LastEventNumber, new Position(response.PreparePosition ?? -1, response.CommitPosition ?? -1));
+            return new WriteResult(response.LastEventNumber, new Position(response.PreparePosition ?? -1, response.CommitPosition ?? -1), _stream);
         }
 
         public override string ToString()

--- a/src/EventStore.ClientAPI/WriteResult.cs
+++ b/src/EventStore.ClientAPI/WriteResult.cs
@@ -1,3 +1,4 @@
+using EventStore.ClientAPI.Common.Utils;
 namespace EventStore.ClientAPI
 {
     /// <summary>
@@ -5,6 +6,11 @@ namespace EventStore.ClientAPI
     /// </summary>
     public struct WriteResult
     {
+        /// <summary>
+        /// The stream to which this <see cref="WriteResult"/> pertains.
+        /// </summary>
+        public readonly string StreamName;
+
         /// <summary>
         /// The next expected version for the stream.
         /// </summary>
@@ -14,16 +20,18 @@ namespace EventStore.ClientAPI
         /// The <see cref="LogPosition"/> of the write.
         /// </summary>
         public readonly Position LogPosition;
-
+    
         /// <summary>
         /// Constructs a new <see cref="WriteResult"/>.
         /// </summary>
         /// <param name="nextExpectedVersion">The next expected version for the stream.</param>
         /// <param name="logPosition">The position of the write in the log</param>
-        public WriteResult(int nextExpectedVersion, Position logPosition)
+        /// <param name="streamName">The name of the stream to which this <see cref="WriteResult"/> pertains.</param>
+        public WriteResult(int nextExpectedVersion, Position logPosition, string streamName =null)
         {
-            LogPosition = logPosition;
-            NextExpectedVersion = nextExpectedVersion;
+            this.StreamName = streamName;
+            this.NextExpectedVersion = nextExpectedVersion;
+            this.LogPosition = logPosition;
         }
     }
 }

--- a/src/other-solutions/EventStoreClientAPI.sln
+++ b/src/other-solutions/EventStoreClientAPI.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.40629.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventStore.ClientAPI", "..\EventStore.ClientAPI\EventStore.ClientAPI.csproj", "{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}"
 EndProject
 Global
@@ -13,12 +15,10 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Debug|x86.ActiveCfg = Debug|x86
-		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Debug|x86.Build.0 = Debug|x86
+		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Release|x86.ActiveCfg = Release|x86
-		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Release|x86.Build.0 = Release|x86
+		{C7C0A3C2-A0EB-4FF4-A0CD-67EADF3F553F}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
fixes #1176 
Allows us to detect the stream to which a write has happened, but is not available when a transaction is committed.