### PR TITLE
Cache ability: Off by one. LastEvent is the id of the last event

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -202,7 +202,7 @@ namespace EventStore.Core.Services.Transport.Http
                         var codec = entity.ResponseCodec;
                         var etag = GetPositionETag(msg.LastEventNumber, codec.ContentType);
                         var cacheSeconds = GetCacheSeconds(msg.StreamMetadata);
-                        if (msg.LastEventNumber >= msg.FromEventNumber + msg.MaxCount)
+                        if (msg.LastEventNumber + 1 >= msg.FromEventNumber + msg.MaxCount)
                             return Ok(codec.ContentType, codec.Encoding, null, MaxPossibleAge, msg.IsCachePublic);
                         return Ok(codec.ContentType, codec.Encoding, etag, cacheSeconds, msg.IsCachePublic);
                     case ReadStreamResult.NoStream:


### PR DESCRIPTION
if it is 0 forward 1 with 1 event in stream:
lastevent=0
start=0
maxcount=1

As such if you aligned exactly on the page it would
mark it as uncacheable though it is cacheable