### PR TITLE
Better handling of timeouts when emitting to streams

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -161,6 +161,16 @@ namespace EventStore.Core.Tests.Helpers
                     message.CorrelationId, OperationResult.WrongExpectedVersion, "wrong expected version"));
         }
 
+        protected void CompleteWriteWithResult(OperationResult result)
+        {
+            var message = _writesQueue.Dequeue();
+            ProcessWrite(
+                message.Envelope, message.CorrelationId, message.EventStreamId, ExpectedVersion.Any, message.Events,
+                (firstEventNumber, lastEventNumber) => new ClientMessage.WriteEventsCompleted(message.CorrelationId, result, String.Empty),
+                new ClientMessage.WriteEventsCompleted(
+                    message.CorrelationId, OperationResult.WrongExpectedVersion, "wrong expected version"));
+        }
+
         protected void AllWriteComplete()
         {
             while (_writesQueue.Count > 0)

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_phase.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_catalog_stream.cs" />
     <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_null_streamId.cs" />
+    <Compile Include="Services\emitted_stream\when_handling_a_timeout.cs" />
     <Compile Include="Services\SpecificationWithEmittedStreamsTrackerAndDeleter.cs" />
     <Compile Include="Services\emitted_streams_deleter\when_deleting\with_multiple_tracked_streams.cs" />
     <Compile Include="Services\emitted_streams_deleter\when_deleting\with_an_existing_emitted_streams_stream.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_a_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_a_timeout.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoch
+{
+    [TestFixture]
+    public class when_handling_a_timeout : TestFixtureWithExistingEvents
+    {
+        private EmittedStream _stream;
+        private TestCheckpointManagerMessageHandler _readyHandler;
+
+        protected override void Given()
+        {
+            AllWritesQueueUp();
+            ExistingEvent("test_stream", "type1", @"{""v"": 1, ""c"": 100, ""p"": 50}", "data");
+            ExistingEvent("test_stream", "type1", @"{""v"": 2, ""c"": 100, ""p"": 50}", "data");
+        }
+
+        private EmittedEvent[] CreateEventBatch()
+        {
+            return new EmittedEvent[]
+            {
+                new EmittedDataEvent(
+                    (string) "test_stream", Guid.NewGuid(), (string) "type1", (bool) true,
+                    (string) "data", (ExtraMetaData) null, CheckpointTag.FromPosition(0, 100, 50), (CheckpointTag) null, null),
+                new EmittedDataEvent(
+                    (string) "test_stream", Guid.NewGuid(), (string) "type2", (bool) true,
+                    (string) "data", (ExtraMetaData) null, CheckpointTag.FromPosition(0, 100, 50), (CheckpointTag) null, null),
+                new EmittedDataEvent(
+                    (string) "test_stream", Guid.NewGuid(), (string) "type3", (bool) true,
+                    (string) "data", (ExtraMetaData) null, CheckpointTag.FromPosition(0, 100, 50), (CheckpointTag) null, null)
+            };
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            _readyHandler = new TestCheckpointManagerMessageHandler();
+            _stream = new EmittedStream(
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.Empty,
+                _ioDispatcher, _readyHandler);
+            _stream.Start();
+            _stream.EmitEvents(CreateEventBatch());
+
+            CompleteWriteWithResult(OperationResult.CommitTimeout);
+        }
+
+        [Test]
+        public void should_retry_the_write_with_the_same_events()
+        {
+            var current = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Last();
+            while (_consumer.HandledMessages.Last().GetType() == typeof(EventStore.Core.Services.TimerService.TimerMessage.Schedule))
+            {
+                var message = _consumer.HandledMessages.Last() as EventStore.Core.Services.TimerService.TimerMessage.Schedule;
+                message.Envelope.ReplyWith(message.ReplyMessage);
+
+                CompleteWriteWithResult(OperationResult.CommitTimeout);
+
+                var last = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Last();
+
+                Assert.AreEqual(current.EventStreamId, last.EventStreamId);
+                Assert.AreEqual(current.Events, last.Events);
+                
+                current = last;
+            }
+
+            Assert.AreEqual(1, _readyHandler.HandledFailedMessages.OfType<CoreProjectionProcessingMessage.Failed>().Count(), "Should fail the projection after exhausting all the write retries");
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -23,6 +23,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
         private readonly ILogger _logger;
         private readonly string _streamId;
+        private readonly string _metadataStreamId;
         private readonly WriterConfiguration _writerConfiguration;
         private readonly ProjectionVersion _projectionVersion;
         private readonly IPrincipal _writeAs;
@@ -54,6 +55,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private bool _disposed;
         private bool _recoveryCompleted;
         private Event _submittedWriteMetaStreamEvent;
+        private const int MaxRetryCount = 5;
 
 
         public class WriterConfiguration
@@ -139,6 +141,7 @@ namespace EventStore.Projections.Core.Services.Processing
             if (readyHandler == null) throw new ArgumentNullException("readyHandler");
             if (streamId == "") throw new ArgumentException("streamId");
             _streamId = streamId;
+            _metadataStreamId = SystemStreams.MetastreamOf(streamId);
             _writerConfiguration = writerConfiguration;
             _projectionVersion = projectionVersion;
             _writeAs = writerConfiguration.WriteAs;
@@ -211,7 +214,7 @@ namespace EventStore.Projections.Core.Services.Processing
             return _awaitingListEventsCompleted ? 1 : 0;
         }
 
-        public void Handle(ClientMessage.WriteEventsCompleted message)
+        private void HandleWriteEventsCompleted(ClientMessage.WriteEventsCompleted message, int retryCount)
         {
             if (!_awaitingWriteCompleted)
                 throw new InvalidOperationException("WriteEvents has not been submitted");
@@ -239,8 +242,15 @@ namespace EventStore.Projections.Core.Services.Processing
                 case OperationResult.PrepareTimeout:
                 case OperationResult.ForwardTimeout:
                 case OperationResult.CommitTimeout:
-                    if (_logger != null) _logger.Info("Retrying write to {0}", _streamId);
-                    PublishWriteEvents();
+                    if(retryCount > 0)
+                    {
+                        if (_logger != null) _logger.Info("Retrying write to {0} (Retry {1} of {2})", _streamId, (MaxRetryCount - retryCount) + 1, MaxRetryCount);
+                        PublishWriteEvents(--retryCount);
+                    }
+                    else
+                    {
+                        Failed(string.Format("Failed to write an events to {0}. Retry limit of {1} reached. Reason: {2}", _streamId, MaxRetryCount, message.Result));
+                    }
                     break;
                 default:
                     throw new NotSupportedException("Unsupported error code received");
@@ -416,17 +426,28 @@ namespace EventStore.Projections.Core.Services.Processing
 
             _awaitingMetadataWriteCompleted = true;
 
-            PublishWriteMetaStream();
+            PublishWriteMetaStream(MaxRetryCount);
         }
 
-        private void PublishWriteMetaStream()
+        private void PublishWriteMetaStream(int retryCount)
         {
-            _ioDispatcher.WriteEvent(
-                SystemStreams.MetastreamOf(_streamId), ExpectedVersion.Any, _submittedWriteMetaStreamEvent, _writeAs,
-                HandleMetadataWriteCompleted);
+            var delayInSeconds = MaxRetryCount - retryCount;
+            if (delayInSeconds == 0)
+            {
+                _ioDispatcher.WriteEvent(
+                    _metadataStreamId, ExpectedVersion.Any, _submittedWriteMetaStreamEvent, _writeAs,
+                    m => HandleMetadataWriteCompleted(m, retryCount));
+            }
+            else
+            {
+                _ioDispatcher.Delay(TimeSpan.FromSeconds(delayInSeconds),
+                    () => _ioDispatcher.WriteEvent(
+                            _metadataStreamId, ExpectedVersion.Any, _submittedWriteMetaStreamEvent, _writeAs,
+                            m => HandleMetadataWriteCompleted(m, retryCount)));
+            }
         }
 
-        private void HandleMetadataWriteCompleted(ClientMessage.WriteEventsCompleted message)
+        private void HandleMetadataWriteCompleted(ClientMessage.WriteEventsCompleted message, int retryCount)
         {
             if (!_awaitingMetadataWriteCompleted)
                 throw new InvalidOperationException("WriteEvents to metadata stream has not been submitted");
@@ -436,25 +457,32 @@ namespace EventStore.Projections.Core.Services.Processing
             {
                 _metadataStreamCreated = true;
                 _awaitingMetadataWriteCompleted = false;
-                PublishWriteEvents();
+                PublishWriteEvents(MaxRetryCount);
                 return;
             }
             if (_logger != null)
             {
                 _logger.Info("Failed to write events to stream {0}. Error: {1}",
-                             SystemStreams.MetastreamOf(_streamId),
+                             _metadataStreamId,
                              Enum.GetName(typeof(OperationResult), message.Result));
             }
             switch (message.Result)
             {
                 case OperationResult.WrongExpectedVersion:
-                    RequestRestart(string.Format("The '{0}' stream has been written to from the outside", _streamId));
+                    RequestRestart(string.Format("The '{0}' stream has been written to from the outside", _metadataStreamId));
                     break;
                 case OperationResult.PrepareTimeout:
                 case OperationResult.ForwardTimeout:
                 case OperationResult.CommitTimeout:
-                    if (_logger != null) _logger.Info("Retrying write to {0}", _streamId);
-                    PublishWriteMetaStream();
+                    if (retryCount > 0)
+                    {
+                        if (_logger != null) _logger.Info("Retrying write to {0} (Retry {1} of {2})", _metadataStreamId, (MaxRetryCount - retryCount) + 1, MaxRetryCount);
+                        PublishWriteMetaStream(--retryCount);
+                    }
+                    else
+                    {
+                        Failed(string.Format("Failed to write an events to {0}. Retry limit of {1} reached. Reason: {2}", _metadataStreamId, MaxRetryCount, message.Result));
+                    }
                     break;
                 default:
                     throw new NotSupportedException("Unsupported error code received");
@@ -505,7 +533,7 @@ namespace EventStore.Projections.Core.Services.Processing
             _submittedToWriteEmittedEvents = emittedEvents.ToArray();
 
             if (_submittedToWriteEvents.Length > 0)
-                PublishWriteEvents();
+                PublishWriteEvents(MaxRetryCount);
         }
 
         private IEnumerable<KeyValuePair<string, JToken>> MetadataWithCausedByAndCorrelationId(
@@ -546,7 +574,7 @@ namespace EventStore.Projections.Core.Services.Processing
             return expectedTag != _lastCommittedOrSubmittedEventPosition;
         }
 
-        private void PublishWriteEvents()
+        private void PublishWriteEvents(int retryCount)
         {
             if (!_metadataStreamCreated)
             {
@@ -554,8 +582,20 @@ namespace EventStore.Projections.Core.Services.Processing
                 return;
             }
             _awaitingWriteCompleted = true;
-            _ioDispatcher.WriteEvents(_streamId, _lastKnownEventNumber, _submittedToWriteEvents, _writeAs, Handle);
-
+            var delayInSeconds = MaxRetryCount - retryCount;
+            if (delayInSeconds == 0)
+            {
+                _ioDispatcher.WriteEvents(
+                    _streamId, _lastKnownEventNumber, _submittedToWriteEvents, _writeAs,
+                    m => HandleWriteEventsCompleted(m, retryCount));
+            }
+            else
+            {
+                _ioDispatcher.Delay(TimeSpan.FromSeconds(delayInSeconds), 
+                    () => _ioDispatcher.WriteEvents(
+                        _streamId, _lastKnownEventNumber, _submittedToWriteEvents, _writeAs,
+                        m => HandleWriteEventsCompleted(m, retryCount)));
+            }
         }
 
         private void EnsureCheckpointNotRequested()


### PR DESCRIPTION
Fixes #1190
Allow the emitted stream to backoff with incremental intervals between
retries