### PR TITLE
Throw an exception with details about what is happening

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexPositionTagger.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexPositionTagger.cs
@@ -129,7 +129,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     return CheckpointTag.FromEventTypeIndexPositions(
                         tag.Phase, tag.Position, _eventTypes.ToDictionary(v => v, v => -1));
                 default:
-                    throw new Exception();
+                    throw new NotSupportedException(string.Format("The given checkpoint is invalid. Possible causes might include having written an event to the projection's managed stream. The bad checkpoint: {0}", tag.ToString()));
             }
         }
     }

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamPositionTagger.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamPositionTagger.cs
@@ -95,7 +95,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     throw new NotSupportedException(
                         "Conversion from Position to MultiStream position tag is not supported");
                 default:
-                    throw new Exception();
+                    throw new NotSupportedException(string.Format("The given checkpoint is invalid. Possible causes might include having written an event to the projection's managed stream. The bad checkpoint: {0}", tag.ToString()));
             }
         }
     }

--- a/src/EventStore.Projections.Core/Services/Processing/PreparePositionTagger.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/PreparePositionTagger.cs
@@ -78,7 +78,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     throw new NotSupportedException(
                         "Conversion from Position to PreparePosition position tag is not supported");
                 default:
-                    throw new Exception();
+                    throw new NotSupportedException(string.Format("The given checkpoint is invalid. Possible causes might include having written an event to the projection's managed stream. The bad checkpoint: {0}", tag.ToString()));
             }
         }
     }

--- a/src/EventStore.Projections.Core/Services/Processing/StreamPositionTagger.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamPositionTagger.cs
@@ -103,7 +103,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 case CheckpointTag.Mode.Position:
                     throw new NotSupportedException("Conversion from Position to Stream position tag is not supported");
                 default:
-                    throw new Exception();
+                    throw new NotSupportedException(string.Format("The given checkpoint is invalid. Possible causes might include having written an event to the projection's managed stream. The bad checkpoint: {0}", tag.ToString()));
             }
         }
     }

--- a/src/EventStore.Projections.Core/Services/Processing/TransactionFilePositionTagger.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/TransactionFilePositionTagger.cs
@@ -40,7 +40,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     throw new NotSupportedException(
                         "Conversion from PreparePosition to Position position tag is not supported");
                 default:
-                    throw new Exception();
+                    throw new NotSupportedException(string.Format("The given checkpoint is invalid. Possible causes might include having written an event to the projection's managed stream. The bad checkpoint: {0}", tag.ToString()));
             }
         }
 


### PR DESCRIPTION
The exception in this case will be caught and the projection faulted in the case where one of these exceptions are thrown.

There exists a case where a user could have written to a stream with some metadata that could be incorrectly parsed as a checkpoint and then when it comes time to use the checkpoint, the checks would fail and in turn throw an exception. 

Previously this was just reported as an empty exception, but this should make it a little more obvious to the user as to what is happening . Previously the projection would also just keep throwing these exceptions which is not ideal.