### PR TITLE
Fault the projection on failed subscription handle

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -119,7 +119,10 @@
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_phase.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_catalog_stream.cs" />
     <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_null_streamId.cs" />
+    <Compile Include="Services\core_service\when_a_subscribed_projection_handler_throws.cs" />
     <Compile Include="Services\emitted_stream\when_handling_a_timeout.cs" />
+    <Compile Include="Services\event_reader\heading_event_reader\when_the_heading_event_reader_with_a_subscribed_projection_handles_a_cached_event_and_throws.cs" />
+    <Compile Include="Services\event_reader\heading_event_reader\when_the_heading_event_reader_with_a_subscribed_projection_handles_a_live_event_and_throws.cs" />
     <Compile Include="Services\SpecificationWithEmittedStreamsTrackerAndDeleter.cs" />
     <Compile Include="Services\emitted_streams_deleter\when_deleting\with_multiple_tracked_streams.cs" />
     <Compile Include="Services\emitted_streams_deleter\when_deleting\with_an_existing_emitted_streams_stream.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using EventStore.Projections.Core.Tests.Services.event_reader.heading_event_reader;
+using EventStore.Core.Data;
+
+namespace EventStore.Projections.Core.Tests.Services.core_service
+{
+    [TestFixture]
+    public class when_a_subscribed_projection_handler_throws : TestFixtureWithProjectionCoreService
+    {
+        [SetUp]
+        public new void Setup()
+        {
+            var readerStrategy = new FakeReaderStrategy();
+            var projectionCorrelationId = Guid.NewGuid();
+            _readerService.Handle(
+                new ReaderSubscriptionManagement.Subscribe(
+                    projectionCorrelationId, CheckpointTag.FromPosition(0, 0, 0), readerStrategy,
+                    new ReaderSubscriptionOptions(1000, 2000, false, stopAfterNEvents: null)));
+            _readerService.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    readerStrategy.EventReaderId, new TFPos(20, 10), "throws", 10, false, Guid.NewGuid(),
+                    "type", false, new byte[0], new byte[0]));
+        }
+
+        [Test]
+        public void projection_is_notified_that_it_is_to_fault()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<EventReaderSubscriptionMessage.Failed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_heading_event_reader_has_been_created.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_heading_event_reader_has_been_created.cs
@@ -21,7 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
             _exception = null;
             try
             {
-                _point = new HeadingEventReader(10);
+                _point = new HeadingEventReader(10, _bus);
             }
             catch (Exception ex)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_starting_a_heading_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_starting_a_heading_event_reader.cs
@@ -23,7 +23,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
             _exception = null;
             try
             {
-                _point = new HeadingEventReader(10);
+                _point = new HeadingEventReader(10, _bus);
             }
             catch (Exception ex)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_handles_an_event.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_handles_an_event.cs
@@ -22,7 +22,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
             _exception = null;
             try
             {
-                _point = new HeadingEventReader(10);
+                _point = new HeadingEventReader(10, _bus);
             }
             catch (Exception ex)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_subscribes_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_subscribes_a_projection.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
             _exception = null;
             try
             {
-                _point = new HeadingEventReader(10);
+                _point = new HeadingEventReader(10, _bus);
             }
             catch (Exception ex)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_a_cached_event_and_throws.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_a_cached_event_and_throws.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_reader
+{
+    [TestFixture]
+    public class when_the_heading_event_reader_with_a_subscribed_projection_handles_a_cached_event_and_throws :
+        TestFixtureWithReadWriteDispatchers
+    {
+        private HeadingEventReader _point;
+        private Guid _distibutionPointCorrelationId;
+        private Guid _projectionSubscriptionId;
+
+        [SetUp]
+        public void setup()
+        {
+            _point = new HeadingEventReader(10, _bus);
+
+            _distibutionPointCorrelationId = Guid.NewGuid();
+            _point.Start(
+                _distibutionPointCorrelationId,
+                new TransactionFileEventReader(_bus, _distibutionPointCorrelationId, null, new TFPos(0, -1), new RealTimeProvider()));
+            _point.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    _distibutionPointCorrelationId, new TFPos(20, 10), "throws", 10, false, Guid.NewGuid(),
+                    "type", false, new byte[0], new byte[0]));
+            _point.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    _distibutionPointCorrelationId, new TFPos(40, 30), "throws", 11, false, Guid.NewGuid(),
+                    "type", false, new byte[0], new byte[0]));
+            _projectionSubscriptionId = Guid.NewGuid();
+            _point.TrySubscribe(_projectionSubscriptionId, new FakeReaderSubscription(), 30);
+        }
+
+
+        [Test]
+        public void projection_is_notified_that_it_is_to_fault()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<EventReaderSubscriptionMessage.Failed>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_an_event.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_an_event.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
             _exception = null;
             try
             {
-                _point = new HeadingEventReader(10);
+                _point = new HeadingEventReader(10, _bus);
             }
             catch (Exception ex)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_an_idle_notification.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_with_a_subscribed_projection_handles_an_idle_notification.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
             //_exception = null;
             try
             {
-                _point = new HeadingEventReader(10);
+                _point = new HeadingEventReader(10, _bus);
             }
             catch (Exception)
             {

--- a/src/EventStore.Projections.Core/Messages/EventReaderSubscriptionMessageBase.cs
+++ b/src/EventStore.Projections.Core/Messages/EventReaderSubscriptionMessageBase.cs
@@ -73,6 +73,24 @@ namespace EventStore.Projections.Core.Messages
             }
         }
 
+        public sealed class Failed : EventReaderSubscriptionMessageBase
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            private readonly string _reason;
+            public string Reason
+            {
+                get { return _reason; }
+            }
+
+            public Failed(Guid subscriptionId, string reason)
+                : base(subscriptionId, CheckpointTag.Empty, 100.0f, -1, null)
+            {
+                _reason = reason;
+            }
+        }
+
         public class EofReached : EventReaderSubscriptionMessageBase
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);

--- a/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
@@ -107,6 +107,7 @@ namespace EventStore.Projections.Core
             coreInputBus.Subscribe(_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.SubscriptionStarted>());
             coreInputBus.Subscribe(_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.NotAuthorized>());
             coreInputBus.Subscribe(_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.ReaderAssignedReader>());
+            coreInputBus.Subscribe(_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.Failed>());
             coreInputBus.Subscribe(_spoolProcessingResponseDispatcher.CreateSubscriber<PartitionProcessingResult>());
             coreInputBus.Subscribe(_spoolProcessingResponseDispatcher.CreateSubscriber<PartitionMeasured>());
             coreInputBus.Subscribe(_spoolProcessingResponseDispatcher.CreateSubscriber<PartitionProcessingProgress>());

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
@@ -361,7 +361,6 @@ namespace EventStore.Projections.Core.Services.Processing
 
         public void EnsureUnsubscribed()
         {
-
             if (_projectionProcessingPhase != null)
                 _projectionProcessingPhase.EnsureUnsubscribed();
         }

--- a/src/EventStore.Projections.Core/Services/Processing/EventProcessingProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventProcessingProjectionProcessingPhase.cs
@@ -139,7 +139,6 @@ namespace EventStore.Projections.Core.Services.Processing
             }
         }
 
-
         public string TransformCatalogEvent(EventReaderSubscriptionMessage.CommittedEventReceived message)
         {
             switch (_state)

--- a/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
@@ -18,6 +18,7 @@ namespace EventStore.Projections.Core.Services.Processing
         IHandle<EventReaderSubscriptionMessage.EofReached>,
         IHandle<EventReaderSubscriptionMessage.CheckpointSuggested>,
         IHandle<EventReaderSubscriptionMessage.ReaderAssignedReader>,
+        IHandle<EventReaderSubscriptionMessage.Failed>,
         IProjectionProcessingPhase,
         IProjectionPhaseStateManager
     {
@@ -297,6 +298,11 @@ namespace EventStore.Projections.Core.Services.Processing
                         message.CorrelationId, _projectionCorrelationId, message.Partition, result: null, position: null));
                 _coreProjection.SetFaulted(ex);
             }
+        }
+
+        public void Handle(EventReaderSubscriptionMessage.Failed message)
+        {
+            _coreProjection.SetFaulted(message.Reason);
         }
 
         protected void UnsubscribeFromPreRecordedOrderEvents()
@@ -621,7 +627,6 @@ namespace EventStore.Projections.Core.Services.Processing
 
         public void Handle(EventReaderSubscriptionMessage.ReaderAssignedReader message)
         {
-            // this is possible hen aborting
             if (_state != PhaseState.Starting)
                 return;
             if (_wasReaderAssigned)

--- a/src/EventStore.Projections.Core/Services/Processing/IReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/IReaderSubscription.cs
@@ -15,6 +15,7 @@ namespace EventStore.Projections.Core.Services.Processing
                                                IHandle<ReaderSubscriptionMessage.EventReaderNotAuthorized>
     {
         string Tag { get; }
+        Guid SubscriptionId { get; }
         IEventReader CreatePausedEventReader(IPublisher publisher, IODispatcher ioDispatcher, Guid forkedEventReaderId);
     }
 }

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
@@ -66,6 +66,11 @@ namespace EventStore.Projections.Core.Services.Processing
             get { return _tag; }
         }
 
+        public Guid SubscriptionId
+        {
+            get { return _subscriptionId; }
+        }
+
         protected void ProcessOne(ReaderSubscriptionMessage.CommittedEventDistributed message)
         {
             if (_eofReached)
@@ -75,6 +80,7 @@ namespace EventStore.Projections.Core.Services.Processing
             // and they may not pass out source filter.  Discard them first
             var roundedProgress = (float) Math.Round(message.Progress, 1);
             bool progressChanged = _progress != roundedProgress;
+
             if (
                 !_eventFilter.PassesSource(
                     message.Data.ResolvedLinkTo, message.Data.PositionStreamId, message.Data.EventType))


### PR DESCRIPTION
Fixes #803 
There are cases where the projection subscription has failed to handle a
distributed event and in those cases, the other projection subscriptions
would not have received the event and in those cases, those projection
subscriptions would have "skipped" those events.

The solution here is to fault the projection and cancel it's
subscription.

The other part of this is that the projection would need it's checkpoint
amended so it can continue processing.