### PR TITLE
Amend the prepare position returned from a prepare

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -415,6 +415,8 @@
     <Compile Include="Services\Replication\WriteStream\when_write_stream_gets_commit_timeout_before_commit_stage.cs" />
     <Compile Include="Services\Replication\WriteStream\when_write_stream_gets_commit_timeout_before_final_commit.cs" />
     <Compile Include="Services\Replication\WriteStream\when_write_stream_gets_prepare_timeout_before_prepares.cs" />
+    <Compile Include="Services\Storage\AllReader\when_a_single_write_before_the_transaction_is_present.cs" />
+    <Compile Include="Services\Storage\AllReader\when_multiple_single_writes_are_after_transaction_end_but_before_commit_is_present.cs" />
     <Compile Include="Services\Storage\CheckCommitStartingAt\when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs" />
     <Compile Include="Services\Storage\CheckCommitStartingAt\when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs" />
     <Compile Include="Services\Storage\CheckCommitStartingAt\when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs" />
@@ -440,9 +442,11 @@
     <Compile Include="Services\Storage\Metastreams\when_having_multiple_metaevents_in_metastream_and_read_index_is_set_to_keep_just_last.cs" />
     <Compile Include="Services\Storage\Metastreams\when_having_deleted_stream_and_no_metastream_metastream_is_declared_deleted_as_well.cs" />
     <Compile Include="Services\Storage\Metastreams\when_having_deleted_stream_its_metastream_is_deleted_as_well.cs" />
+    <Compile Include="Services\Storage\AllReader\when_a_single_write_is_after_transaction_end_but_before_commit_is_present.cs" />
     <Compile Include="Services\Storage\Scavenge\when_stream_is_softdeleted_and_temp_but_some_metaevents_are_in_multiple_chunks.cs" />
     <Compile Include="Services\Storage\Scavenge\when_stream_is_softdeleted_and_temp_but_some_events_are_in_multiple_chunks.cs" />
     <Compile Include="Services\Storage\Scavenge\when_stream_is_softdeleted_and_temp_and_all_events_and_metaevents_are_in_one_chunk.cs" />
+    <Compile Include="Services\Storage\RepeatableDbTestScenario.cs" />
     <Compile Include="Services\Storage\SimpleDbTestScenario.cs" />
     <Compile Include="Services\Storage\Scavenge\when_having_commit_spanning_multiple_chunks.cs" />
     <Compile Include="Services\Storage\Scavenge\when_having_commits_spanning_multiple_chunks.cs" />

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_a_single_write_before_the_transaction_is_present.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_a_single_write_before_the_transaction_is_present.cs
@@ -1,0 +1,44 @@
+﻿using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.AllReader
+{
+    [TestFixture]
+    public class when_a_single_write_before_the_transaction_is_present : RepeatableDbTestScenario
+    {
+        [Test]
+        public void should_be_able_to_read_the_transactional_writes_when_the_commit_is_present()
+        {
+            CreateDb(Rec.Prepare(0, "single_write_stream_id_1", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.TransSt(1, "transaction_stream_id"),
+                     Rec.Prepare(1, "transaction_stream_id"),
+                     Rec.TransEnd(1, "transaction_stream_id"),
+                     Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Prepare(4, "single_write_stream_id_4", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted));
+
+            var firstRead = ReadIndex.ReadAllEventsForward(new Data.TFPos(0, 0), 10);
+
+            Assert.AreEqual(4, firstRead.Records.Count);
+            Assert.AreEqual("single_write_stream_id_1", firstRead.Records[0].Event.EventStreamId);
+            Assert.AreEqual("single_write_stream_id_2", firstRead.Records[1].Event.EventStreamId);
+            Assert.AreEqual("single_write_stream_id_3", firstRead.Records[2].Event.EventStreamId);
+            Assert.AreEqual("single_write_stream_id_4", firstRead.Records[3].Event.EventStreamId);
+
+            CreateDb(Rec.Prepare(0, "single_write_stream_id_1", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.TransSt(1, "transaction_stream_id"),
+                     Rec.Prepare(1, "transaction_stream_id"),
+                     Rec.TransEnd(1, "transaction_stream_id"),
+                     Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Prepare(4, "single_write_stream_id_4", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Commit(1, "transaction_stream_id"));
+
+            var transactionRead = ReadIndex.ReadAllEventsForward(firstRead.NextPos, 10);
+
+            Assert.AreEqual(1, transactionRead.Records.Count);
+            Assert.AreEqual("transaction_stream_id", transactionRead.Records[0].Event.EventStreamId);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_a_single_write_is_after_transaction_end_but_before_commit_is_present.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_a_single_write_is_after_transaction_end_but_before_commit_is_present.cs
@@ -1,0 +1,35 @@
+﻿using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.AllReader
+{
+    [TestFixture]
+    public class when_a_single_write_is_after_transaction_end_but_before_commit_is_present : RepeatableDbTestScenario
+    {
+        [Test]
+        public void should_be_able_to_read_the_transactional_writes_when_the_commit_is_present()
+        {
+            CreateDb(Rec.TransSt(0, "transaction_stream_id"),
+                     Rec.Prepare(0, "transaction_stream_id"),
+                     Rec.TransEnd(0, "transaction_stream_id"),
+                     Rec.Prepare(1, "single_write_stream_id", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted));
+
+            var firstRead = ReadIndex.ReadAllEventsForward(new Data.TFPos(0, 0), 10);
+
+            Assert.AreEqual(1, firstRead.Records.Count);
+            Assert.AreEqual("single_write_stream_id", firstRead.Records[0].Event.EventStreamId);
+
+            CreateDb(Rec.TransSt(0, "transaction_stream_id"),
+                     Rec.Prepare(0, "transaction_stream_id"),
+                     Rec.TransEnd(0, "transaction_stream_id"),
+                     Rec.Prepare(1, "single_write_stream_id", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Commit(0, "transaction_stream_id"));
+
+            var transactionRead = ReadIndex.ReadAllEventsForward(firstRead.NextPos, 10);
+
+            Assert.AreEqual(1, transactionRead.Records.Count);
+            Assert.AreEqual("transaction_stream_id", transactionRead.Records[0].Event.EventStreamId);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_multiple_single_writes_are_after_transaction_end_but_before_commit_is_present.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_multiple_single_writes_are_after_transaction_end_but_before_commit_is_present.cs
@@ -1,0 +1,47 @@
+﻿using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.AllReader
+{
+    [TestFixture]
+    public class when_multiple_single_writes_are_after_transaction_end_but_before_commit_is_present : RepeatableDbTestScenario
+    {
+        [Test]
+        public void should_be_able_to_read_the_transactional_writes_when_the_commit_is_present()
+        {
+            /*
+             * create a db with a transaction where the commit is not present yet (read happened before the chaser could commit)
+             * in the following case the read will return the event for the single non-transactional write
+             * performing a read from the next position returned will fail as the prepares are all less than what we have asked for.
+             */
+            CreateDb(Rec.TransSt(0, "transaction_stream_id"),
+                     Rec.Prepare(0, "transaction_stream_id"),
+                     Rec.TransEnd(0, "transaction_stream_id"),
+                     Rec.Prepare(1, "single_write_stream_id_1", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted));
+
+            var firstRead = ReadIndex.ReadAllEventsForward(new Data.TFPos(0, 0), 10);
+
+            Assert.AreEqual(3, firstRead.Records.Count);
+            Assert.AreEqual("single_write_stream_id_1", firstRead.Records[0].Event.EventStreamId);
+            Assert.AreEqual("single_write_stream_id_2", firstRead.Records[1].Event.EventStreamId);
+            Assert.AreEqual("single_write_stream_id_3", firstRead.Records[2].Event.EventStreamId);
+
+            //create the exact same db as above but now with the transaction's commit
+            CreateDb(Rec.TransSt(0, "transaction_stream_id"),
+                     Rec.Prepare(0, "transaction_stream_id"),
+                     Rec.TransEnd(0, "transaction_stream_id"),
+                     Rec.Prepare(1, "single_write_stream_id_1", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+                     Rec.Commit(0, "transaction_stream_id"));
+
+            var transactionRead = ReadIndex.ReadAllEventsForward(firstRead.NextPos, 10);
+
+            Assert.AreEqual(1, transactionRead.Records.Count);
+            Assert.AreEqual("transaction_stream_id", transactionRead.Records[0].Event.EventStreamId);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -1,0 +1,94 @@
+﻿using EventStore.Common.Utils;
+using EventStore.Core.DataStructures;
+using EventStore.Core.Index;
+using EventStore.Core.Index.Hashes;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Util;
+using NUnit.Framework;
+using System;
+
+namespace EventStore.Core.Tests.Services.Storage
+{
+    [TestFixture]
+    public abstract class RepeatableDbTestScenario : SpecificationWithDirectoryPerTestFixture
+    {
+        protected readonly int MaxEntriesInMemTable;
+        protected TableIndex TableIndex;
+        protected IReadIndex ReadIndex;
+
+        protected DbResult DbRes;
+        protected TFChunkDbCreationHelper DbCreationHelper;
+
+        private readonly int _metastreamMaxCount;
+
+        protected RepeatableDbTestScenario(int maxEntriesInMemTable = 20, int metastreamMaxCount = 1)
+        {
+            Ensure.Positive(maxEntriesInMemTable, "maxEntriesInMemTable");
+            MaxEntriesInMemTable = maxEntriesInMemTable;
+            _metastreamMaxCount = metastreamMaxCount;
+        }
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+        }
+
+        public void CreateDb(params Rec[] records)
+        {
+            if (DbRes != null)
+            {
+                DbRes.Db.Close();
+            }
+
+            var dbConfig = new TFChunkDbConfig(PathName,
+                                   new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
+                                   1024 * 1024,
+                                   0,
+                                   new InMemoryCheckpoint(0),
+                                   new InMemoryCheckpoint(0),
+                                   new InMemoryCheckpoint(-1),
+                                   new InMemoryCheckpoint(-1),
+                                   inMemDb: true);
+            var dbHelper = new TFChunkDbCreationHelper(dbConfig);
+
+            DbRes = dbHelper.Chunk(records).CreateDb();
+
+            DbRes.Db.Config.WriterCheckpoint.Flush();
+            DbRes.Db.Config.ChaserCheckpoint.Write(DbRes.Db.Config.WriterCheckpoint.Read());
+            DbRes.Db.Config.ChaserCheckpoint.Flush();
+
+            var readers = new ObjectPool<ITransactionFileReader>(
+                "Readers", 2, 2, () => new TFChunkReader(DbRes.Db, DbRes.Db.Config.WriterCheckpoint));
+
+            var lowHasher = new XXHashUnsafe();
+            var highHasher = new Murmur3AUnsafe();
+            TableIndex = new TableIndex(GetFilePathFor("index"), lowHasher, highHasher,
+                                        () => new HashListMemTable(PTableVersions.Index64Bit, MaxEntriesInMemTable * 2),
+                                        () => new TFReaderLease(readers),
+                                        PTableVersions.Index64Bit,
+                                        MaxEntriesInMemTable);
+
+            ReadIndex = new ReadIndex(new NoopPublisher(),
+                                      readers,
+                                      TableIndex,
+                                      0,
+                                      additionalCommitChecks: true,
+                                      metastreamMaxCount: _metastreamMaxCount,
+                                      hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault);
+
+            ReadIndex.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
+        }
+
+        public override void TestFixtureTearDown()
+        {
+            DbRes.Db.Close();
+            base.TestFixtureTearDown();
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
@@ -140,7 +140,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
                                                        transOffset,
                                                        rec.StreamId,
                                                        expectedVersion,
-                                                       PrepareFlags.Data
+                                                       rec.PrepareFlags
                                                        | (transInfo.FirstPrepareId == rec.Id ? PrepareFlags.TransactionBegin : PrepareFlags.None)
                                                        | (transInfo.LastPrepareId == rec.Id ? PrepareFlags.TransactionEnd : PrepareFlags.None)
                                                        | (rec.Metadata == null ? PrepareFlags.None : PrepareFlags.IsJson),
@@ -302,8 +302,9 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
         public readonly string EventType;
         public readonly DateTime TimeStamp;
         public readonly StreamMetadata Metadata;
+        public readonly PrepareFlags PrepareFlags;
 
-        public Rec(RecType type, int transaction, string streamId, string eventType, DateTime? timestamp, StreamMetadata metadata = null)
+        public Rec(RecType type, int transaction, string streamId, string eventType, DateTime? timestamp, StreamMetadata metadata = null, PrepareFlags prepareFlags = PrepareFlags.Data)
         {
             Ensure.NotNullOrEmpty(streamId, "streamId");
             Ensure.Nonnegative(transaction, "transaction");
@@ -315,6 +316,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
             EventType = eventType ?? string.Empty;
             TimeStamp = timestamp ?? DateTime.UtcNow;
             Metadata = metadata;
+            PrepareFlags = prepareFlags;
         }
 
         public static Rec Delete(int transaction, string stream, DateTime? timestamp = null)
@@ -327,9 +329,9 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
             return new Rec(RecType.TransStart, transaction, stream, null, timestamp);
         }
 
-        public static Rec Prepare(int transaction, string stream, string eventType = null, DateTime? timestamp = null, StreamMetadata metadata = null)
+        public static Rec Prepare(int transaction, string stream, string eventType = null, DateTime? timestamp = null, StreamMetadata metadata = null, PrepareFlags prepareFlags = PrepareFlags.Data)
         {
-            return new Rec(RecType.Prepare, transaction, stream, eventType, timestamp, metadata);
+            return new Rec(RecType.Prepare, transaction, stream, eventType, timestamp, metadata, prepareFlags);
         }
 
         public static Rec TransEnd(int transaction, string stream, DateTime? timestamp = null)

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/AllReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/AllReader.cs
@@ -83,7 +83,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
                                     var eventRecord = new EventRecord(prepare.ExpectedVersion + 1 /* EventNumber */, prepare);
                                     records.Add(new CommitEventRecord(eventRecord, prepare.LogPosition));
                                     count++;
-                                    nextPos = new TFPos(result.RecordPostPosition, result.RecordPostPosition);
+                                    nextPos = new TFPos(result.RecordPostPosition, 0);
                                 }
                                 break;
                             }


### PR DESCRIPTION
Fixes #627

There is a case where a read could happen before a transaction's commit
record has been written and where a single write could appear after the
transaction end and in this case, given the current next position that
is returned from the reader, the next read from that position would skip
the transaction's prepares as they have lower positions than that
returned from the previous read.

It is safe to use 0 as the prepare position for a position returned from
a committed prepare in this case as we use the provided commit position
to move the reader to where we will be reading from an upon reading a
commit, we will use the transaction position to adjust the reader
position, however we still use the provided position to validate
whether the prepare is one we actually care about.