### PR TITLE
Monitoring service now includes Ssl tcp connections in tcp stats

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -136,7 +136,8 @@ namespace EventStore.Core
                                                    vNodeSettings.StatsPeriod,
                                                    _nodeInfo.ExternalHttp,
                                                    vNodeSettings.StatsStorage,
-                                                   _nodeInfo.ExternalTcp);
+                                                   _nodeInfo.ExternalTcp,
+                                                   _nodeInfo.ExternalSecureTcp);
             _mainBus.Subscribe(monitoringQueue.WidenFrom<SystemMessage.SystemInit, Message>());
             _mainBus.Subscribe(monitoringQueue.WidenFrom<SystemMessage.StateChangeMessage, Message>());
             _mainBus.Subscribe(monitoringQueue.WidenFrom<SystemMessage.BecomeShuttingDown, Message>());

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -206,6 +206,7 @@ namespace EventStore.Core.Messages
             public int PendingSendBytes { get; set; }
             public int PendingReceivedBytes { get; set; }
             public bool IsExternalConnection { get; set; }
+            public bool IsSslConnection { get; set; }
         }
 
         public class InternalStatsRequest : Message

--- a/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
+++ b/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
@@ -59,6 +59,7 @@ namespace EventStore.Core.Services.Monitoring
         private IMonitoredTcpConnection[] _memoizedTcpConnections;
         private DateTime _lastTcpConnectionsRequestTime;
         private IPEndPoint _tcpEndpoint;
+        private IPEndPoint _tcpSecureEndpoint;
 
         public MonitoringService(IQueuedHandler monitoringQueue,
                                  IPublisher statsCollectionBus,
@@ -68,7 +69,8 @@ namespace EventStore.Core.Services.Monitoring
                                  TimeSpan statsCollectionPeriod,
                                  IPEndPoint nodeEndpoint,
                                  StatsStorage statsStorage,
-                                 IPEndPoint tcpEndpoint)
+                                 IPEndPoint tcpEndpoint,
+                                 IPEndPoint tcpSecureEndpoint)
         {
             Ensure.NotNull(monitoringQueue, "monitoringQueue");
             Ensure.NotNull(statsCollectionBus, "statsCollectionBus");
@@ -87,6 +89,7 @@ namespace EventStore.Core.Services.Monitoring
             _statsCollectionPeriodMs = statsCollectionPeriod > TimeSpan.Zero ? (long)statsCollectionPeriod.TotalMilliseconds : Timeout.Infinite;
             _nodeStatsStream = string.Format("{0}-{1}", SystemStreams.StatsStreamPrefix, nodeEndpoint);
             _tcpEndpoint = tcpEndpoint;
+            _tcpSecureEndpoint = tcpSecureEndpoint;
             _timer = new Timer(OnTimerTick, null, Timeout.Infinite, Timeout.Infinite);
         }
 
@@ -319,7 +322,26 @@ namespace EventStore.Core.Services.Monitoring
                             TotalBytesSent = tcpConn.TotalBytesSent,
                             TotalBytesReceived = tcpConn.TotalBytesReceived,
                             PendingSendBytes = tcpConn.PendingSendBytes,
-                            PendingReceivedBytes = tcpConn.PendingReceivedBytes
+                            PendingReceivedBytes = tcpConn.PendingReceivedBytes,
+                            IsSslConnection = false
+                        });
+                    }
+
+                    var tcpConnSsl = conn as TcpConnectionSsl;
+                    if (tcpConnSsl != null)
+                    {
+                        var isExternalConnection = _tcpSecureEndpoint != null && _tcpSecureEndpoint.Port == tcpConnSsl.LocalEndPoint.Port;
+                        connStats.Add(new MonitoringMessage.TcpConnectionStats
+                        {
+                            IsExternalConnection = isExternalConnection,
+                            RemoteEndPoint = tcpConnSsl.RemoteEndPoint.ToString(),
+                            LocalEndPoint = tcpConnSsl.LocalEndPoint.ToString(),
+                            ConnectionId = tcpConnSsl.ConnectionId,
+                            TotalBytesSent = tcpConnSsl.TotalBytesSent,
+                            TotalBytesReceived = tcpConnSsl.TotalBytesReceived,
+                            PendingSendBytes = tcpConnSsl.PendingSendBytes,
+                            PendingReceivedBytes = tcpConnSsl.PendingReceivedBytes,
+                            IsSslConnection = true
                         });
                     }
                 }


### PR DESCRIPTION
Fixes #1184. 

Added so that SSL Connections are returned in the /stats/tcp get call. 