### PR TITLE
Add current version to client api

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/AppendToStreamOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/AppendToStreamOperation.cs
@@ -55,7 +55,7 @@ namespace EventStore.ClientAPI.ClientOperations
                     _wasCommitTimeout = true;
                     return new InspectionResult(InspectionDecision.Retry, "CommitTimeout");
                 case ClientMessage.OperationResult.WrongExpectedVersion:
-                    var err = string.Format("Append failed due to WrongExpectedVersion. Stream: {0}, Expected version: {1}", _stream, _expectedVersion);
+                    var err = string.Format("Append failed due to WrongExpectedVersion. Stream: {0}, Expected version: {1}, Current version: {2}", _stream, _expectedVersion, response.CurrentVersion);
                     Fail(new WrongExpectedVersionException(err));
                     return new InspectionResult(InspectionDecision.EndOperation, "WrongExpectedVersion");
                 case ClientMessage.OperationResult.StreamDeleted:

--- a/src/EventStore.ClientAPI/Messages/ClientMessage.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessage.cs
@@ -192,9 +192,12 @@ namespace EventStore.ClientAPI.Messages
     [ProtoMember(6, IsRequired = false, Name=@"commit_position", DataFormat = DataFormat.TwosComplement)]
     public readonly long? CommitPosition;
   
+    [ProtoMember(7, IsRequired = false, Name=@"current_version", DataFormat = DataFormat.TwosComplement)]
+    public readonly int? CurrentVersion;
+  
     private WriteEventsCompleted() {}
   
-    public WriteEventsCompleted(OperationResult result, string message, int firstEventNumber, int lastEventNumber, long? preparePosition, long? commitPosition)
+    public WriteEventsCompleted(OperationResult result, string message, int firstEventNumber, int lastEventNumber, long? preparePosition, long? commitPosition, int? currentVersion)
     {
         Result = result;
         Message = message;
@@ -202,6 +205,7 @@ namespace EventStore.ClientAPI.Messages
         LastEventNumber = lastEventNumber;
         PreparePosition = preparePosition;
         CommitPosition = commitPosition;
+        CurrentVersion = currentVersion;
     }
   }
   

--- a/src/EventStore.Core/Messages/TcpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDto.cs
@@ -192,9 +192,12 @@ namespace EventStore.Core.Messages
             [ProtoMember(6, IsRequired = false, Name = @"commit_position", DataFormat = DataFormat.TwosComplement)]
             public readonly long? CommitPosition;
 
+            [ProtoMember(7, IsRequired = false, Name = @"current_version", DataFormat = DataFormat.TwosComplement)]
+            public readonly int? CurrentVersion;
+
             private WriteEventsCompleted() { }
 
-            public WriteEventsCompleted(OperationResult result, string message, int firstEventNumber, int lastEventNumber, long? preparePosition, long? commitPosition)
+            public WriteEventsCompleted(OperationResult result, string message, int firstEventNumber, int lastEventNumber, long? preparePosition, long? commitPosition, int? currentVersion)
             {
                 Result = result;
                 Message = message;
@@ -202,6 +205,7 @@ namespace EventStore.Core.Messages
                 LastEventNumber = lastEventNumber;
                 PreparePosition = preparePosition;
                 CommitPosition = commitPosition;
+                CurrentVersion = currentVersion;
             }
         }
 

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -165,7 +165,8 @@ namespace EventStore.Core.Services.Transport.Tcp
                                                                    msg.FirstEventNumber,
                                                                    msg.LastEventNumber,
                                                                    msg.PreparePosition,
-                                                                   msg.CommitPosition);
+                                                                   msg.CommitPosition,
+                                                                   msg.CurrentVersion);
             return new TcpPackage(TcpCommand.WriteEventsCompleted, msg.CorrelationId, dto.Serialize());
         }
 

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -60,6 +60,7 @@ message WriteEventsCompleted {
 	required int32 last_event_number = 4;
 	optional int64 prepare_position = 5;
 	optional int64 commit_position = 6;
+	optional int32 current_version  = 7;
 }
 
 message DeleteStream {


### PR DESCRIPTION
Fixes #1052

When a WrongExpectedVersion is now thrown, it will include what the
current version is instead of only what you passed as the expected
version.