### PR TITLE
Handle read timeouts when eof is reached

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_eof_for_all_streams_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_eof_for_all_streams_and_idle_eof.cs
@@ -79,7 +79,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                 correlationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 3, 2, true, 400));
             _fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
-            correlationId = _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().CorrelationId;
+            correlationId = ((ClientMessage.ReadStreamEventsForward)(_consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().ReplyWithMessage)).CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                 correlationId, "a", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 2, 1, true, 600));

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_and_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_and_no_stream.cs
@@ -130,7 +130,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
         [Test]
         public void publishes_subscribe_awake()
         {
-            Assert.AreEqual(1, _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Count());
+            Assert.AreEqual(2, _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Count());
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_and_eofs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_read_completed_for_all_streams_and_eofs.cs
@@ -152,7 +152,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
         [Test]
         public void publishes_subscribe_awake()
         {
-            Assert.AreEqual(2, _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Count());
+            Assert.AreEqual(4, _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Count());
         }
 
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_eof_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_eof_and_idle_eof.cs
@@ -34,7 +34,6 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [SetUp]
         public new void When()
         {
-            //_publishWithCorrelationId = Guid.NewGuid();
             _distibutionPointCorrelationId = Guid.NewGuid();
             _fakeTimeProvider = new FakeTimeProvider();
             _edp = new StreamEventReader(_bus, _distibutionPointCorrelationId, null, "stream", 10, _fakeTimeProvider, false,
@@ -66,7 +65,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                     correlationId, "stream", 100, 100, ReadStreamResult.Success,
                     new ResolvedEvent[] { }, null, false, "", 12, 11, true, 400));
             _fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
-            correlationId = _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().CorrelationId;
+            correlationId = ((ClientMessage.ReadStreamEventsForward)(_consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().ReplyWithMessage)).CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                     correlationId, "stream", 100, 100, ReadStreamResult.Success,

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_no_stream.cs
@@ -75,8 +75,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [Test]
         public void publishes_subscribe_awake()
         {
-            Assert.AreEqual(1, _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Count());
+            Assert.AreEqual(2, _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Count());
         }
-
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_and_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_and_eof.cs
@@ -115,9 +115,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         [Test]
         public void publishes_subscribe_awake()
         {
-            Assert.AreEqual(1, _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Count());
+            Assert.AreEqual(2, _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Count());
         }
-
-        
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_eof_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_eof_and_idle_eof.cs
@@ -31,7 +31,6 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
         [SetUp]
         public new void When()
         {
-
             _distibutionPointCorrelationId = Guid.NewGuid();
             _fakeTimeProvider = new FakeTimeProvider();
             _edp = new TransactionFileEventReader(_bus, _distibutionPointCorrelationId, null, new TFPos(100, 50), _fakeTimeProvider,
@@ -65,7 +64,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 					correlationId, ReadAllResult.Success, null,
                     new EventStore.Core.Data.ResolvedEvent[0], null, false, 100, new TFPos(), new TFPos(), new TFPos(), 500));
             _fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
-			correlationId = _consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().CorrelationId;
+            correlationId = ((ClientMessage.ReadAllEventsForward)(_consumer.HandledMessages.OfType<AwakeServiceMessage.SubscribeAwake>().Last().ReplyWithMessage)).CorrelationId;
             _edp.Handle(
                 new ClientMessage.ReadAllEventsForwardCompleted(
 					correlationId, ReadAllResult.Success, null,


### PR DESCRIPTION
Fixes #1218 

There is a condition that exists that when the eof is reached for a projection reader that the read message would be expired by the time it reaches the read worker. This PR resolves this issue by utilising a previously fixed bug's read timeout message to be published alongside the read request message so that if the message expires that the read timeout would kick off another read request message.