### PR TITLE
Remove upgrade during scavenge

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -670,6 +670,7 @@
     <Compile Include="ClientAPI\ExpectedVersion64Bit\MiniNodeWithExistingRecords.cs" />
     <Compile Include="Services\Storage\DeletingStream\when_hard_deleting_stream_with_log_version_0.cs" />
     <Compile Include="Services\Transport\Tcp\TcpClientDispatcherTests.cs" />
+    <Compile Include="Services\Storage\Scavenge\when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1.cs" />
     <Compile Include="ClientAPI\ExpectedVersion64Bit\read_stream_with_link_to_event_with_event_number_greater_than_int_maxvalue.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/EventStore.Core.Tests/Index/FakeIndexReader.cs
+++ b/src/EventStore.Core.Tests/Index/FakeIndexReader.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Fakes
         public RecordReadResult TryReadAt(long position)
         {
             var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0, position.ToString(), -1, DateTime.UtcNow, PrepareFlags.None, "type", new byte[0], null);
-            return new RecordReadResult(true, position + 1, record, 1, 0);
+            return new RecordReadResult(true, position + 1, record, 1);
         }
 
         public bool ExistsAt(long position)

--- a/src/EventStore.Core.Tests/Index/IndexV2/table_index_hash_collision_when_upgrading_to_64bit.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/table_index_hash_collision_when_upgrading_to_64bit.cs
@@ -150,7 +150,7 @@ namespace EventStore.Core.Tests.Index.IndexV2
         public RecordReadResult TryReadAt(long position)
         {
             var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0, position % 2 == 0 ? "account--696193173" : "LPN-FC002_LPK51001", -1, DateTime.UtcNow, PrepareFlags.None, "type", new byte[0], null);
-            return new RecordReadResult(true, position + 1, record, 1, 0);
+            return new RecordReadResult(true, position + 1, record, 1);
         }
 
         public bool ExistsAt(long position)

--- a/src/EventStore.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
@@ -150,7 +150,7 @@ namespace EventStore.Core.Tests.Index.IndexV3
         public RecordReadResult TryReadAt(long position)
         {
             var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0, position % 2 == 0 ? "testStream-2" : "testStream-1", -1, DateTime.UtcNow, PrepareFlags.None, "type", new byte[0], null);
-            return new RecordReadResult(true, position + 1, record, 1, 0);
+            return new RecordReadResult(true, position + 1, record, 1);
         }
 
         public bool ExistsAt(long position)

--- a/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
@@ -325,7 +325,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions
         public RecordReadResult TryReadAt(long position)
         {
             var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0, position % 2 == 0 ? "account--696193173" : "LPN-FC002_LPK51001", -1, DateTime.UtcNow, PrepareFlags.None, "type", new byte[0], null);
-            return new RecordReadResult(true, position + 1, record, 1, 0);
+            return new RecordReadResult(true, position + 1, record, 1);
         }
 
         public bool ExistsAt(long position)

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records.cs
@@ -1,74 +1,52 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using EventStore.Core.Data;
-using EventStore.Core.Tests.Services.Storage;
-using EventStore.Core.TransactionLog;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Storage.Scavenge
 {
     [TestFixture]
-    public class when_scavenging_tfchunk_with_version0_log_records_and_incomplete_chunk : ReadIndexTestScenario
+    public class when_scavenging_tfchunk_with_version0_log_records_and_incomplete_chunk : ScavengeTestScenario
     {
-        private string _eventStreamId = "ES";
-        private LogRecord[] _firstChunkRecords, _secondChunkRecords;
-
-        protected override void WriteTestScenario()
+        private const byte _version = LogRecordVersion.LogRecordV0;
+        protected override DbResult CreateDb(TFChunkDbCreationHelper dbCreator)
         {
-            _firstChunkRecords = new LogRecord[11];
-            _secondChunkRecords = new LogRecord[2];
-
-            for(var i = 0; i < 11; i++) { // Chunk 1 with 11 events
-                _firstChunkRecords[i] = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(), i);
-            }
-            Writer.CompleteChunk();
-
-            for(var i = 0; i < 2; i++) { // Incomplete chunk with 2 events
-                _secondChunkRecords[i] = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(), i + 10);
-            }
-
-            Scavenge(completeLast: false, mergeChunks: true);
+            return dbCreator.Chunk(Rec.Prepare(0, "ES1", version: _version),
+                                   Rec.Commit(0, "ES1", version: _version),
+                                   Rec.Prepare(1, "ES1", version: _version),
+                                   Rec.Commit(1, "ES1", version: _version))
+                            .CompleteLastChunk()
+                            .Chunk(Rec.Prepare(2, "ES2", version: _version),
+                                   Rec.Commit(2, "ES2", version: _version),
+                                   Rec.Prepare(3, "ES2", version: _version),
+                                   Rec.Commit(3, "ES2", version: _version))
+                            .CreateDb();
         }
 
-        [Test]
-        public void should_be_able_to_read_the_stream()
+        protected override LogRecord[][] KeptRecords(DbResult dbResult)
         {
-            var events = ReadIndex.ReadAllEventsForward(new TFPos(0, 0), 100).Records.Select(r => r.Event).ToArray();
-            Assert.AreEqual(13, events.Length);
-        }
-
-        [Test]
-        public void the_new_log_records_are_version_1_in_first_chunk()
-        {
-            var chunk = Db.Manager.GetChunk(0);
-
-            var chunkRecords = new List<LogRecord>();
-            RecordReadResult result = chunk.TryReadFirst();
-            while (result.Success)
+            return new[]
             {
-                chunkRecords.Add(result.LogRecord);
-                result = chunk.TryReadClosestForward(result.NextPosition);
-            }
-            Assert.IsTrue(chunkRecords.All(x=>x.Version == LogRecordVersion.LogRecordV1));
-            Assert.AreEqual(22, chunkRecords.Count);
+                new[]
+                {
+                        dbResult.Recs[0][0],
+                        dbResult.Recs[0][1],
+                        dbResult.Recs[0][2],
+                        dbResult.Recs[0][3]
+                },
+                new[]
+                {
+                        dbResult.Recs[1][0],
+                        dbResult.Recs[1][1],
+                        dbResult.Recs[1][2],
+                        dbResult.Recs[1][3]
+                }
+            };
         }
 
         [Test]
-        public void the_log_records_in_the_second_chunk_should_be_unchanged()
+        public void should_not_have_changed_any_records()
         {
-            var chunk = Db.Manager.GetChunk(1);
-
-            var chunkRecords = new List<LogRecord>();
-            RecordReadResult result = chunk.TryReadFirst();
-            while (result.Success)
-            {
-                chunkRecords.Add(result.LogRecord);
-                result = chunk.TryReadClosestForward(result.NextPosition);
-            }
-            Assert.IsTrue(chunkRecords.All(x=>x.Version == LogRecordVersion.LogRecordV0));
-            Assert.AreEqual(4, chunkRecords.Count);
+            CheckRecords();
         }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
@@ -12,8 +12,8 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
     [TestFixture]
     public class when_scavenging_tfchunk_with_version0_log_records_and_deleted_records : ReadIndexTestScenario
     {
-        private string _eventStreamId = "ES";
-        private string _deletedEventStreamId = "Deleted-ES";
+        private const string _eventStreamId = "ES";
+        private const string _deletedEventStreamId = "Deleted-ES";
         private PrepareLogRecord _event1, _event2, _event3, _event4, _deleted;
 
         protected override void WriteTestScenario()
@@ -66,7 +66,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
         }
 
         [Test]
-        public void the_new_log_records_are_version_1()
+        public void the_log_records_are_still_version_0()
         {
             var chunk = Db.Manager.GetChunk(0);
             var chunkRecords = new List<LogRecord>();
@@ -76,7 +76,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
                 chunkRecords.Add(result.LogRecord);
                 result = chunk.TryReadClosestForward(result.NextPosition);
             }
-            Assert.IsTrue(chunkRecords.All(x=>x.Version == LogRecordVersion.LogRecordV1));
+            Assert.IsTrue(chunkRecords.All(x=>x.Version == LogRecordVersion.LogRecordV0));
             Assert.AreEqual(10, chunkRecords.Count);
         }
 

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
@@ -15,8 +15,8 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
     [TestFixture]
     public class when_scavenging_tfchunk_with_version0_log_records_using_transactions : ReadIndexTestScenario
     {
-        private string _streamIdOne = "ES-1";
-        private string _streamIdTwo = "ES-2";
+        private const string _streamIdOne = "ES-1";
+        private const string _streamIdTwo = "ES-2";
         private PrepareLogRecord _p1, _p2, _p3, _p4, _p5, _random1;
         private long _t2CommitPos, _t1CommitPos, _postCommitPos;
 
@@ -85,7 +85,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
         }
 
         [Test]
-        public void the_new_log_records_are_version_1_in_first_chunk()
+        public void the_log_records_are_still_version_0_in_first_chunk()
         {
             var chunk = Db.Manager.GetChunk(0);
 
@@ -96,12 +96,12 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
                 chunkRecords.Add(result.LogRecord);
                 result = chunk.TryReadClosestForward(result.NextPosition);
             }
-            Assert.IsTrue(chunkRecords.All(x=>x.Version == LogRecordVersion.LogRecordV1));
+            Assert.IsTrue(chunkRecords.All(x=>x.Version == LogRecordVersion.LogRecordV0));
             Assert.AreEqual(7, chunkRecords.Count);
         }
 
         [Test]
-        public void the_new_log_records_are_unchanged_in_second_chunk()
+        public void the_log_records_are_unchanged_in_second_chunk()
         {
             var chunk = Db.Manager.GetChunk(1);
 

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_with_log_version_0_but_some_events_are_in_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_with_log_version_0_but_some_events_are_in_multiple_chunks.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
         [Test]
         public void scavenging_goes_as_expected()
         {
-            CheckRecordsV0();
+            CheckRecords();
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_with_log_record_version_0.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_with_log_record_version_0.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+using ReadStreamResult = EventStore.Core.Services.Storage.ReaderIndex.ReadStreamResult;
+
+namespace EventStore.Core.Tests.Services.Storage.Scavenge
+{
+    [TestFixture]
+    public class when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1 : ScavengeTestScenario
+    {
+        private const string _deletedStream = "test";
+        private const string _deletedMetaStream = "$$test";
+        private const string _keptStream = "other";
+
+        protected override DbResult CreateDb(TFChunkDbCreationHelper dbCreator)
+        {
+            return dbCreator.Chunk(Rec.Prepare(0, _deletedMetaStream, metadata: new StreamMetadata(tempStream: true), version: LogRecordVersion.LogRecordV0),
+                                   Rec.Commit(0, _deletedMetaStream, version: LogRecordVersion.LogRecordV0),
+                                   Rec.Prepare(1, _keptStream, version: LogRecordVersion.LogRecordV1),
+                                   Rec.Commit(1, _keptStream, version: LogRecordVersion.LogRecordV1),
+                                   Rec.Prepare(2, _keptStream, version: LogRecordVersion.LogRecordV0),
+                                   Rec.Commit(2, _keptStream, version: LogRecordVersion.LogRecordV0),
+                                   Rec.Prepare(3, _deletedStream, version: LogRecordVersion.LogRecordV1),
+                                   Rec.Commit(3, _deletedStream, version: LogRecordVersion.LogRecordV0),
+                                   Rec.Prepare(4, _deletedStream, version: LogRecordVersion.LogRecordV0),
+                                   Rec.Commit(4, _deletedStream, version: LogRecordVersion.LogRecordV1),
+                                   Rec.Prepare(5, _keptStream, version: LogRecordVersion.LogRecordV1),
+                                   Rec.Commit(5, _keptStream, version: LogRecordVersion.LogRecordV1),
+                                   Rec.Prepare(6, _deletedMetaStream, metadata: new StreamMetadata(truncateBefore: EventNumber.DeletedStream, tempStream: true), version: LogRecordVersion.LogRecordV1),
+                                   Rec.Commit(6, _deletedMetaStream, version: LogRecordVersion.LogRecordV0))
+                            .CompleteLastChunk()
+                            .CreateDb();
+        }
+
+        protected override LogRecord[][] KeptRecords(DbResult dbResult)
+        {
+            return new[]
+            {
+                new []
+                {
+                    dbResult.Recs[0][2],
+                    dbResult.Recs[0][3],
+                    dbResult.Recs[0][4],
+                    dbResult.Recs[0][5],
+                    dbResult.Recs[0][10],
+                    dbResult.Recs[0][11]
+                } 
+            };
+        }
+
+        [Test]
+        public void scavenging_goes_as_expected()
+        {
+            CheckRecords();
+        }
+
+        [Test]
+        public void the_stream_is_absent_logically()
+        {
+            Assert.AreEqual(ReadEventResult.NoStream, ReadIndex.ReadEvent(_deletedStream, 0).Result);
+            Assert.AreEqual(ReadStreamResult.NoStream, ReadIndex.ReadStreamEventsForward(_deletedStream, 0, 100).Result);
+            Assert.AreEqual(ReadStreamResult.NoStream, ReadIndex.ReadStreamEventsBackward(_deletedStream, -1, 100).Result);
+        }
+
+        [Test]
+        public void the_metastream_is_absent_logically()
+        {
+            Assert.AreEqual(ReadEventResult.NotFound, ReadIndex.ReadEvent(_deletedMetaStream, 0).Result);
+            Assert.AreEqual(ReadStreamResult.Success, ReadIndex.ReadStreamEventsForward(_deletedMetaStream, 0, 100).Result);
+            Assert.AreEqual(ReadStreamResult.Success, ReadIndex.ReadStreamEventsBackward(_deletedMetaStream, -1, 100).Result);
+        }
+
+        [Test]
+        public void the_stream_is_absent_physically()
+        {
+            var headOfTf = new TFPos(Db.Config.WriterCheckpoint.Read(), Db.Config.WriterCheckpoint.Read());
+            Assert.IsEmpty(ReadIndex.ReadAllEventsForward(new TFPos(0, 0), 1000).Records.Where(x => x.Event.EventStreamId == _deletedStream));
+            Assert.IsEmpty(ReadIndex.ReadAllEventsBackward(headOfTf, 1000).Records.Where(x => x.Event.EventStreamId == _deletedStream));
+        }
+
+        [Test]
+        public void the_metastream_is_absent_physically()
+        {
+            var headOfTf = new TFPos(Db.Config.WriterCheckpoint.Read(), Db.Config.WriterCheckpoint.Read());
+            Assert.IsEmpty(ReadIndex.ReadAllEventsForward(new TFPos(0, 0), 1000).Records.Where(x => x.Event.EventStreamId == _deletedMetaStream));
+            Assert.IsEmpty(ReadIndex.ReadAllEventsBackward(headOfTf, 1000).Records.Where(x => x.Event.EventStreamId == _deletedMetaStream));
+        }
+
+        [Test]
+        public void the_kept_stream_is_present()
+        {
+            Assert.AreEqual(ReadEventResult.Success, ReadIndex.ReadEvent(_keptStream, 0).Result);
+            Assert.AreEqual(ReadStreamResult.Success, ReadIndex.ReadStreamEventsForward(_keptStream, 0, 100).Result);
+            Assert.AreEqual(ReadStreamResult.Success, ReadIndex.ReadStreamEventsBackward(_keptStream, -1, 100).Result);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -16,14 +16,14 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging
             var map = new List<PosMap>();
             var chunk = TFChunk.CreateNew(Filename, 1024*1024, 0, 0, true, false, false, false);
             long logPos = 0;
-            for (int i = 0, n = ChunkFooter.Size/PosMap.V3Size + 1; i < n; ++i)
+            for (int i = 0, n = ChunkFooter.Size/PosMap.FullSize + 1; i < n; ++i)
             {
                 map.Add(new PosMap(logPos, (int)logPos));
                 var res = chunk.TryAppend(LogRecord.Commit(logPos, Guid.NewGuid(), logPos, 0));
                 Assert.IsTrue(res.Success);
                 logPos = res.NewPosition;
             }
-            chunk.CompleteScavenge(map, false);
+            chunk.CompleteScavenge(map);
 
             chunk.CacheInMemory();
 

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/TFChunkDbCreationTestBase.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/TFChunkDbCreationTestBase.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
             var dataSize = actualDataSize ?? config.ChunkSize;
             var buf = new byte[ChunkHeader.Size + dataSize + ChunkFooter.Size];
             Buffer.BlockCopy(chunkBytes, 0, buf, 0, chunkBytes.Length);
-            var chunkFooter = new ChunkFooter(true, false, PosMap.CurrentPosMapVersion, dataSize, dataSize, 0, new byte[ChunkFooter.ChecksumSize]);
+            var chunkFooter = new ChunkFooter(true, true, dataSize, dataSize, 0, new byte[ChunkFooter.ChecksumSize]);
             chunkBytes = chunkFooter.AsByteArray();
             Buffer.BlockCopy(chunkBytes, 0, buf, buf.Length - ChunkFooter.Size, chunkBytes.Length);
 
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
             var logicalDataSize = logicalSize ?? (chunkEndNum - chunkStartNum + 1) * config.ChunkSize;
             var buf = new byte[ChunkHeader.Size + physicalDataSize + ChunkFooter.Size];
             Buffer.BlockCopy(chunkBytes, 0, buf, 0, chunkBytes.Length);
-            var chunkFooter = new ChunkFooter(true, false, PosMap.CurrentPosMapVersion, physicalDataSize, logicalDataSize, 0, new byte[ChunkFooter.ChecksumSize]);
+            var chunkFooter = new ChunkFooter(true, true, physicalDataSize, logicalDataSize, 0, new byte[ChunkFooter.ChecksumSize]);
             chunkBytes = chunkFooter.AsByteArray();
             Buffer.BlockCopy(chunkBytes, 0, buf, buf.Length - ChunkFooter.Size, chunkBytes.Length);
             File.WriteAllBytes(filename, buf);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_cached_empty_scavenged_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_cached_empty_scavenged_tfchunk.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
             _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
-            _chunk.CompleteScavenge(new PosMap[0], false);
+            _chunk.CompleteScavenge(new PosMap[0]);
             _chunk.CacheInMemory();
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
@@ -58,7 +58,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public void a_read_on_scavenged_chunk_does_not_include_map()
         {
             var chunk = TFChunk.CreateNew(GetFilePathFor("afile"), 200, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
-            chunk.CompleteScavenge(new[] { new PosMap(0, 0), new PosMap(1, 1) }, false);
+            chunk.CompleteScavenge(new[] { new PosMap(0, 0), new PosMap(1, 1) });
             using (var reader = chunk.AcquireReader())
             {
                 var buffer = new byte[1024];

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_uncached_empty_scavenged_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_uncached_empty_scavenged_tfchunk.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
             _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
-            _chunk.CompleteScavenge(new PosMap[0], false);
+            _chunk.CompleteScavenge(new PosMap[0]);
         }
 
         [OneTimeTearDown]

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
@@ -2,47 +2,28 @@ using System.IO;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk
 {
-    public static class PosMapVersion {
-        public const byte PosMapV3 = 3;
-        public const byte PosMapV2 = 2;
-        public const byte PosMapV1 = 1;
-    }
-
     public struct PosMap
     {
-        public const byte CurrentPosMapVersion = PosMapVersion.PosMapV3;
-
-        public const int V3Size = sizeof(long) + sizeof(int) + sizeof(int);
-        public const int V2Size = sizeof(long) + sizeof(int);
-        public const int V1Size = sizeof(long) + sizeof(int);
+        public const int FullSize = sizeof(long) + sizeof(int);
+        public const int DeprecatedSize = sizeof(int) + sizeof(int);
 
         public readonly long LogPos;
         public readonly int ActualPos;
-        public readonly int LengthOffset;
 
-        public PosMap(long logPos, int actualPos, int lengthOffset = 0)
+        public PosMap(long logPos, int actualPos)
         {
             LogPos = logPos;
             ActualPos = actualPos;
-            LengthOffset = lengthOffset;
         }
 
-        public static PosMap FromV3Format(BinaryReader reader)
-        {
-            var actualPos = reader.ReadInt32();
-            var logPos = reader.ReadInt64();
-            var lengthOffset = reader.ReadInt32();
-            return new PosMap(logPos, actualPos, lengthOffset);
-        }
-        
-        public static PosMap FromV2Format(BinaryReader reader)
+        public static PosMap FromNewFormat(BinaryReader reader)
         {
             var actualPos = reader.ReadInt32();
             var logPos = reader.ReadInt64();
             return new PosMap(logPos, actualPos);
         }
 
-        public static PosMap FromV1Format(BinaryReader reader)
+        public static PosMap FromOldFormat(BinaryReader reader)
         {
             var posmap = reader.ReadUInt64();
             var logPos = (int)(posmap >> 32);
@@ -54,12 +35,11 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
         {
             writer.Write(ActualPos);
             writer.Write(LogPos);
-            writer.Write(LengthOffset);
         }
 
         public override string ToString()
         {
-            return string.Format("LogPos: {0}, ActualPos: {1}, LengthOffset: {2}", LogPos, ActualPos, LengthOffset);
+            return string.Format("LogPos: {0}, ActualPos: {1}", LogPos, ActualPos);
         }
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -56,7 +56,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                     LogRecord record;
                     int length;
                     var result = TryReadForwardInternal(workItem, logicalPosition, out length, out record);
-                    return new RecordReadResult(result, -1, record, length, 0);
+                    return new RecordReadResult(result, -1, record, length);
                 }
                 finally
                 {
@@ -82,8 +82,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                     if (!TryReadForwardInternal(workItem, logicalPosition, out length, out record))
                         return RecordReadResult.Failure;
 
-                    long nextLogicalPos = record.GetNextLogPosition(logicalPosition, length, 0);
-                    return new RecordReadResult(true, nextLogicalPos, record, length, 0);
+                    long nextLogicalPos = record.GetNextLogPosition(logicalPosition, length);
+                    return new RecordReadResult(true, nextLogicalPos, record, length);
                 }
                 finally
                 {
@@ -110,8 +110,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                     if (!TryReadBackwardInternal(workItem, logicalPosition, out length, out record))
                         return RecordReadResult.Failure;
 
-                    long nextLogicalPos = record.GetPrevLogPosition(logicalPosition, length, 0);
-                    return new RecordReadResult(true, nextLogicalPos, record, length, 0);
+                    long nextLogicalPos = record.GetPrevLogPosition(logicalPosition, length);
+                    return new RecordReadResult(true, nextLogicalPos, record, length);
                 }
                 finally
                 {
@@ -195,23 +195,17 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
 
             private PosMap ReadPosMap(ReaderWorkItem workItem, long index)
             {
-                if (Chunk.ChunkFooter.MapVersion == PosMapVersion.PosMapV3)
+                if (Chunk.ChunkFooter.IsMap12Bytes)
                 {
-                    var pos = ChunkHeader.Size + Chunk.ChunkFooter.PhysicalDataSize + index*PosMap.V3Size;
+                    var pos = ChunkHeader.Size + Chunk.ChunkFooter.PhysicalDataSize + index*PosMap.FullSize;
                     workItem.Stream.Seek(pos, SeekOrigin.Begin);
-                    return PosMap.FromV3Format(workItem.Reader);
-                }
-                if(Chunk.ChunkFooter.MapVersion == PosMapVersion.PosMapV2)
-                {
-                    var pos = ChunkHeader.Size + Chunk.ChunkFooter.PhysicalDataSize + index*PosMap.V2Size;
-                    workItem.Stream.Seek(pos, SeekOrigin.Begin);
-                    return PosMap.FromV2Format(workItem.Reader);
+                    return PosMap.FromNewFormat(workItem.Reader);
                 }
                 else
                 {
-                    var pos = ChunkHeader.Size + Chunk.ChunkFooter.PhysicalDataSize + index*PosMap.V1Size;
+                    var pos = ChunkHeader.Size + Chunk.ChunkFooter.PhysicalDataSize + index*PosMap.DeprecatedSize;
                     workItem.Stream.Seek(pos, SeekOrigin.Begin);
-                    return PosMap.FromV1Format(workItem.Reader);
+                    return PosMap.FromOldFormat(workItem.Reader);
                 }
             }
 
@@ -220,8 +214,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 var workItem = Chunk.GetReaderWorkItem();
                 try
                 {
-                    int lengthOffset;
-                    var actualPosition = TranslateExactPosition(workItem, logicalPosition, out lengthOffset);
+                    var actualPosition = TranslateExactPosition(workItem, logicalPosition);
                     return actualPosition >= 0 && actualPosition < Chunk.PhysicalDataSize;
                 }
                 finally
@@ -235,15 +228,14 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 var workItem = Chunk.GetReaderWorkItem();
                 try
                 {
-                    int lengthOffset;
-                    var actualPosition = TranslateExactPosition(workItem, logicalPosition, out lengthOffset);
+                    var actualPosition = TranslateExactPosition(workItem, logicalPosition);
                     if (actualPosition == -1 || actualPosition >= Chunk.PhysicalDataSize)
                         return RecordReadResult.Failure;
 
                     LogRecord record;
                     int length;
                     var result = TryReadForwardInternal(workItem, actualPosition, out length, out record);
-                    return new RecordReadResult(result, -1, record, length, lengthOffset);
+                    return new RecordReadResult(result, -1, record, length);
                 }
                 finally
                 {
@@ -251,15 +243,15 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 }
             }
 
-            private int TranslateExactPosition(ReaderWorkItem workItem, long pos, out int lengthOffset)
+            private int TranslateExactPosition(ReaderWorkItem workItem, long pos)
             {
                 var midpoints = _midpoints;
                 if (workItem.IsMemory || midpoints == null)
-                    return TranslateExactWithoutMidpoints(workItem, pos, 0, Chunk.ChunkFooter.MapCount - 1, out lengthOffset);
-                return TranslateExactWithMidpoints(workItem, midpoints, pos, out lengthOffset);
+                    return TranslateExactWithoutMidpoints(workItem, pos, 0, Chunk.ChunkFooter.MapCount - 1);
+                return TranslateExactWithMidpoints(workItem, midpoints, pos);
             }
 
-            private int TranslateExactWithoutMidpoints(ReaderWorkItem workItem, long pos, long startIndex, long endIndex, out int lengthOffset)
+            private int TranslateExactWithoutMidpoints(ReaderWorkItem workItem, long pos, long startIndex, long endIndex)
             {
                 long low = startIndex;
                 long high = endIndex;
@@ -269,29 +261,22 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                     var v = ReadPosMap(workItem, mid);
 
                     if (v.LogPos == pos)
-                    {
-                        lengthOffset = v.LengthOffset;
                         return v.ActualPos;
-                    }
                     if (v.LogPos < pos)
                         low = mid + 1;
                     else
                         high = mid - 1;
                 }
-                lengthOffset = 0;
                 return -1;
             }
 
-            private int TranslateExactWithMidpoints(ReaderWorkItem workItem, Midpoint[] midpoints, long pos, out int lengthOffset)
+            private int TranslateExactWithMidpoints(ReaderWorkItem workItem, Midpoint[] midpoints, long pos)
             {
                 if (pos < midpoints[0].LogPos || pos > midpoints[midpoints.Length - 1].LogPos)
-                {
-                    lengthOffset = 0;
                     return -1;
-                }
 
                 var recordRange = LocatePosRange(midpoints, pos);
-                return TranslateExactWithoutMidpoints(workItem, pos, recordRange.Lower, recordRange.Upper, out lengthOffset);
+                return TranslateExactWithoutMidpoints(workItem, pos, recordRange.Lower, recordRange.Upper);
             }
 
             public RecordReadResult TryReadFirst()
@@ -307,8 +292,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 var workItem = Chunk.GetReaderWorkItem();
                 try
                 {
-                    int lengthOffset;
-                    var actualPosition = TranslateClosestForwardPosition(workItem, logicalPosition, out lengthOffset);
+                    var actualPosition = TranslateClosestForwardPosition(workItem, logicalPosition);
                     if (actualPosition == -1 || actualPosition >= Chunk.PhysicalDataSize)
                         return RecordReadResult.Failure;
 
@@ -317,8 +301,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                     if (!TryReadForwardInternal(workItem, actualPosition, out length, out record))
                         return RecordReadResult.Failure;
 
-                    long nextLogicalPos = Chunk.ChunkHeader.GetLocalLogPosition(record.GetNextLogPosition(record.LogPosition, length, lengthOffset));
-                    return new RecordReadResult(true, nextLogicalPos, record, length, lengthOffset);
+                    long nextLogicalPos = Chunk.ChunkHeader.GetLocalLogPosition(record.GetNextLogPosition(record.LogPosition, length));
+                    return new RecordReadResult(true, nextLogicalPos, record, length);
                 }
                 finally
                 {
@@ -339,8 +323,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 var workItem = Chunk.GetReaderWorkItem();
                 try
                 {
-                    int lengthOffset;
-                    var actualPosition = TranslateClosestForwardPosition(workItem, logicalPosition, out lengthOffset);
+                    var actualPosition = TranslateClosestForwardPosition(workItem, logicalPosition);
                     // here we allow actualPosition == _physicalDataSize as we can read backward the very last record that way
                     if (actualPosition == -1 || actualPosition > Chunk.PhysicalDataSize)
                         return RecordReadResult.Failure;
@@ -351,7 +334,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                         return RecordReadResult.Failure;
 
                     long nextLogicalPos = Chunk.ChunkHeader.GetLocalLogPosition(record.LogPosition);
-                    return new RecordReadResult(true, nextLogicalPos, record, length, lengthOffset);
+                    return new RecordReadResult(true, nextLogicalPos, record, length);
                 }
                 finally
                 {
@@ -359,30 +342,31 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 }
             }
 
-            private int TranslateClosestForwardPosition(ReaderWorkItem workItem, long logicalPosition, out int lengthOffset)
+            private int TranslateClosestForwardPosition(ReaderWorkItem workItem, long logicalPosition)
             {
                 var midpoints = _midpoints;
                 if (workItem.IsMemory || midpoints == null)
-                    return TranslateClosestForwardWithoutMidpoints(workItem, logicalPosition, 0, Chunk.ChunkFooter.MapCount - 1, out lengthOffset);
-                return TranslateClosestForwardWithMidpoints(workItem, midpoints, logicalPosition, out lengthOffset);
+                    return TranslateClosestForwardWithoutMidpoints(workItem, logicalPosition, 0, Chunk.ChunkFooter.MapCount - 1);
+                return TranslateClosestForwardWithMidpoints(workItem, midpoints, logicalPosition);
             }
 
-            private int TranslateClosestForwardWithMidpoints(ReaderWorkItem workItem, Midpoint[] midpoints, long pos, out int lengthOffset)
+            private int TranslateClosestForwardWithMidpoints(ReaderWorkItem workItem, Midpoint[] midpoints, long pos)
             {
+                // to allow backward reading of the last record, forward read will decline anyway
+                if (pos > midpoints[midpoints.Length - 1].LogPos)
+                    return Chunk.PhysicalDataSize;
+
                 var recordRange = LocatePosRange(midpoints, pos);
-                return TranslateClosestForwardWithoutMidpoints(workItem, pos, recordRange.Lower, recordRange.Upper, out lengthOffset);
+                return TranslateClosestForwardWithoutMidpoints(workItem, pos, recordRange.Lower, recordRange.Upper);
             }
 
-            private int TranslateClosestForwardWithoutMidpoints(ReaderWorkItem workItem, long pos, long startIndex, long endIndex, out int lengthOffset)
+            private int TranslateClosestForwardWithoutMidpoints(ReaderWorkItem workItem, long pos, long startIndex, long endIndex)
             {
                 PosMap res = ReadPosMap(workItem, endIndex);
 
                 // to allow backward reading of the last record, forward read will decline anyway
                 if (pos > res.LogPos)
-                {
-                    lengthOffset = res.LengthOffset;
                     return Chunk.PhysicalDataSize;
-                }
 
                 long low = startIndex;
                 long high = endIndex;
@@ -399,7 +383,6 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                         res = v;
                     }
                 }
-                lengthOffset = res.LengthOffset;
                 return res.ActualPos;
             }
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkReader.cs
@@ -69,7 +69,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 if (result.Success)
                 {
                     _curPos = chunk.ChunkHeader.ChunkStartPosition + result.NextPosition;
-                    var postPos = result.LogRecord.GetNextLogPosition(result.LogRecord.LogPosition, result.RecordLength, result.LengthOffset);
+                    var postPos = result.LogRecord.GetNextLogPosition(result.LogRecord.LogPosition, result.RecordLength);
                     var eof = postPos == writerChk;
                     return new SeqReadResult(
                         true, eof, result.LogRecord, result.RecordLength, result.LogRecord.LogPosition, postPos);
@@ -123,7 +123,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 if (result.Success)
                 {
                     _curPos = chunk.ChunkHeader.ChunkStartPosition + result.NextPosition;
-                    var postPos = result.LogRecord.GetNextLogPosition(result.LogRecord.LogPosition, result.RecordLength, result.LengthOffset);
+                    var postPos = result.LogRecord.GetNextLogPosition(result.LogRecord.LogPosition, result.RecordLength);
                     var eof = postPos == writerChk;
                     var res = new SeqReadResult(true, eof, result.LogRecord, result.RecordLength, result.LogRecord.LogPosition, postPos);
                     return res;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -184,42 +184,26 @@ namespace EventStore.Core.TransactionLog.Chunks
                 }
 
                 var positionMapping = new List<PosMap>();
-                bool isUpgrade = false;
                 foreach (var oldChunk in oldChunks)
                 {
                     TraverseChunk(oldChunk,
                                   prepare =>
                                   {
                                       if (ShouldKeepPrepare(prepare, commits, chunkStartPos, chunkEndPos))
-                                      {
-                                          var lengthOffset = 0;
-                                          var data = prepare.Data;
-                                          if(prepare.Version == LogRecordVersion.LogRecordV0) {
-                                              isUpgrade = true;
-                                              data = UpgradePrepareData(prepare);
-                                              lengthOffset = 4 + (data.Length - prepare.Data.Length);
-                                          }
-                                          var updatedPrepare = UpgradePrepareVersion(prepare, data);
-                                          positionMapping.Add(WriteRecord(newChunk, updatedPrepare, lengthOffset, isUpgrade));
-                                      }
+                                          positionMapping.Add(WriteRecord(newChunk, prepare));
                                   },
                                   commit =>
                                   {
                                       if (ShouldKeepCommit(commit, commits))
-                                      {
-                                          isUpgrade = commit.Version == LogRecordVersion.LogRecordV0;
-                                          var updatedCommit = UpgradeCommitVersion(commit);
-                                          positionMapping.Add(WriteRecord(newChunk, updatedCommit, commit.Version == LogRecordVersion.LogRecordV0 ? 4 : 0, isUpgrade));
-                                      }
+                                          positionMapping.Add(WriteRecord(newChunk, commit));
                                   },
                                   // we always keep system log records for now
-                                  system => positionMapping.Add(WriteRecord(newChunk, system, 0, isUpgrade)));
+                                  system => positionMapping.Add(WriteRecord(newChunk, system)));
                 }
-                
-                newChunk.CompleteScavenge(positionMapping, isUpgrade);
+                newChunk.CompleteScavenge(positionMapping);
 
                 var oldSize = oldChunks.Sum(x => (long)x.PhysicalDataSize + x.ChunkFooter.MapSize + ChunkHeader.Size + ChunkFooter.Size);
-                var newSize = (long)newChunk.PhysicalDataSize + PosMap.V3Size * positionMapping.Count + ChunkHeader.Size + ChunkFooter.Size;
+                var newSize = (long)newChunk.PhysicalDataSize + PosMap.FullSize * positionMapping.Count + ChunkHeader.Size + ChunkFooter.Size;
 
                 if(_unsafeIgnoreHardDeletes) {
                     Log.Trace("Forcing scavenge chunk to be kept even if bigger.");
@@ -524,33 +508,9 @@ namespace EventStore.Core.TransactionLog.Chunks
             }
         }
 
-        private PrepareLogRecord UpgradePrepareVersion(PrepareLogRecord prepare, byte[] data)
+        private static PosMap WriteRecord(TFChunk.TFChunk newChunk, LogRecord record)
         {
-            return new PrepareLogRecord(prepare.LogPosition, prepare.CorrelationId, prepare.EventId, prepare.TransactionPosition, 
-                                        prepare.TransactionOffset, prepare.EventStreamId, prepare.ExpectedVersion, prepare.TimeStamp, prepare.Flags, prepare.EventType,
-                                        data, prepare.Metadata);
-        }
-
-        private byte[] UpgradePrepareData(PrepareLogRecord prepare) 
-        {
-            if(!SystemStreams.IsMetastream(prepare.EventStreamId))
-                return prepare.Data;
-
-            var metadata = _readIndex.GetStreamMetadata(SystemStreams.OriginalStreamOf(prepare.EventStreamId));
-            if(metadata.TruncateBefore != EventNumber.DeletedStream)
-                return prepare.Data;
-
-            return metadata.ToJsonBytes();
-        }
-
-        private CommitLogRecord UpgradeCommitVersion(CommitLogRecord commit)
-        {
-            return new CommitLogRecord(commit.LogPosition, commit.CorrelationId, commit.TransactionPosition, commit.TimeStamp, commit.FirstEventNumber);
-        }
-
-        private static PosMap WriteRecord(TFChunk.TFChunk newChunk, LogRecord record, int lengthOffset, bool isUpgrade)
-        {
-            var writeResult = newChunk.TryAppend(record, isUpgrade);
+            var writeResult = newChunk.TryAppend(record);
             if (!writeResult.Success)
             {
                 throw new Exception(string.Format(
@@ -560,7 +520,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             }
             long logPos = newChunk.ChunkHeader.GetLocalLogPosition(record.LogPosition);
             int actualPos = (int) writeResult.OldPosition;
-            return new PosMap(logPos, actualPos, lengthOffset);
+            return new PosMap(logPos, actualPos);
         }
 
         internal class CommitInfo

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.TransactionLog.Chunks
 
         public bool Write(LogRecord record, out long newPos)
         {
-            var result = _currentChunk.TryAppend(record, false);
+            var result = _currentChunk.TryAppend(record);
             if (result.Success)
                 _writerCheckpoint.Write(result.NewPosition + _currentChunk.ChunkHeader.ChunkStartPosition);
             else

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
@@ -26,14 +26,14 @@ namespace EventStore.Core.TransactionLog.LogRecords
         public readonly byte Version;
         public readonly long LogPosition;
 
-        public long GetNextLogPosition(long logicalPosition, int length, int lengthOffset)
+        public long GetNextLogPosition(long logicalPosition, int length)
         {
-            return logicalPosition + length - lengthOffset + 2*sizeof(int);
+            return logicalPosition + length + 2*sizeof(int);
         }
 
-        public long GetPrevLogPosition(long logicalPosition, int length, int lengthOffset)
+        public long GetPrevLogPosition(long logicalPosition, int length)
         {
-            return logicalPosition - length + lengthOffset - 2*sizeof(int);
+            return logicalPosition - length - 2*sizeof(int);
         }
 
         public static LogRecord ReadFrom(BinaryReader reader)

--- a/src/EventStore.Core/TransactionLog/ReadResults.cs
+++ b/src/EventStore.Core/TransactionLog/ReadResults.cs
@@ -4,31 +4,28 @@ namespace EventStore.Core.TransactionLog
 {
     public struct RecordReadResult
     {
-        public static readonly RecordReadResult Failure = new RecordReadResult(false, -1, null, 0, 0);
+        public static readonly RecordReadResult Failure = new RecordReadResult(false, -1, null, 0);
 
         public readonly bool Success;
         public readonly long NextPosition;
         public readonly LogRecord LogRecord;
         public readonly int RecordLength;
-        public readonly int LengthOffset;
 
-        public RecordReadResult(bool success, long nextPosition, LogRecord logRecord, int recordLength, int lengthOffset)
+        public RecordReadResult(bool success, long nextPosition, LogRecord logRecord, int recordLength)
         {
             Success = success;
             LogRecord = logRecord;
             NextPosition = nextPosition;
             RecordLength = recordLength;
-            LengthOffset = lengthOffset;
         }
 
         public override string ToString()
         {
-            return string.Format("Success: {0}, NextPosition: {1}, RecordLength: {2}, LogRecord: {3}, LengthOffset: {4}",
+            return string.Format("Success: {0}, NextPosition: {1}, RecordLength: {2}, LogRecord: {3}",
                                  Success,
                                  NextPosition,
                                  RecordLength,
-                                 LogRecord,
-                                 LengthOffset);
+                                 LogRecord);
         }
     }
 


### PR DESCRIPTION
This reverts the changes to the TFChunkScavenger, PosMap, TFChunkReadSide and the ChunkFooter.