### PR TITLE
Change EventNumber.Invalid from long.MinValue to int.MinValue

### DIFF
--- a/src/EventStore.Core/Data/EventNumber.cs
+++ b/src/EventStore.Core/Data/EventNumber.cs
@@ -3,6 +3,6 @@ namespace EventStore.Core.Data
     public static class EventNumber
     {
         public const long DeletedStream = long.MaxValue;
-        public const long Invalid = long.MinValue;
+        public const long Invalid = int.MinValue;
     }
 }


### PR DESCRIPTION
This is to prevent issues with older clients overflowing when EventNumber.Invalid is returned to them for any reason.