### PR TITLE
[WIP] Embedded Persistent Subscription Ack/Nack Fix

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
@@ -13,10 +13,10 @@ namespace EventStore.ClientAPI.Embedded
     internal class EmbeddedPersistentSubscription : EmbeddedSubscriptionBase<PersistentEventStoreSubscription>, 
         IConnectToPersistentSubscriptions
     {
-        private readonly string _subscriptionId;
         private readonly UserCredentials _userCredentials;
         private readonly IAuthenticationProvider _authenticationProvider;
         private readonly int _bufferSize;
+        private string _subscriptionId;
 
         public EmbeddedPersistentSubscription(
             ILogger log, IPublisher publisher, Guid connectionId,
@@ -48,6 +48,11 @@ namespace EventStore.ClientAPI.Embedded
                     new PublishEnvelope(Publisher, true), ConnectionId, _subscriptionId, StreamId, _bufferSize,
                     String.Empty,
                     user));
+        }
+
+        public void UpdateSubscriptionId(string subscriptionId)
+        {
+            _subscriptionId = subscriptionId;
         }
 
         public void NotifyEventsProcessed(Guid[] processedEvents)

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriber.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriber.cs
@@ -49,7 +49,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public void Handle(ClientMessage.PersistentSubscriptionConfirmation message)
         {
-            ConfirmSubscription(message.CorrelationId, message.LastCommitPosition, message.LastEventNumber);
+            ConfirmSubscription(message.SubscriptionId, message.CorrelationId, message.LastCommitPosition, message.LastEventNumber);
         }
 
         public void Handle(ClientMessage.PersistentSubscriptionStreamEventAppeared message)
@@ -68,6 +68,14 @@ namespace EventStore.ClientAPI.Embedded
         {
             IEmbeddedSubscription subscription;
             _subscriptions.TryGetActiveSubscription(correlationId, out subscription);
+            subscription.ConfirmSubscription(lastCommitPosition, lastEventNumber);
+        }
+
+        private void ConfirmSubscription(string subscriptionId, Guid correlationId, long lastCommitPosition, long? lastEventNumber)
+        {
+            IEmbeddedSubscription subscription;
+            _subscriptions.TryGetActiveSubscription(correlationId, out subscription);
+            ((EmbeddedPersistentSubscription)subscription).UpdateSubscriptionId(subscriptionId);
             subscription.ConfirmSubscription(lastCommitPosition, lastEventNumber);
         }
 

--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -97,6 +97,8 @@ namespace EventStore.ClientAPI.Embedded
             _subscriptionBus.Subscribe(new AdHocHandler<ClientMessage.SubscribeToStream>(_publisher.Publish));
             _subscriptionBus.Subscribe(new AdHocHandler<ClientMessage.UnsubscribeFromStream>(_publisher.Publish));
             _subscriptionBus.Subscribe(new AdHocHandler<ClientMessage.ConnectToPersistentSubscription>(_publisher.Publish));
+            _subscriptionBus.Subscribe(new AdHocHandler<ClientMessage.PersistentSubscriptionAckEvents>(_publisher.Publish));
+            _subscriptionBus.Subscribe(new AdHocHandler<ClientMessage.PersistentSubscriptionNackEvents>(_publisher.Publish));
 
             bus.Subscribe(new AdHocHandler<SystemMessage.BecomeShutdown>(_ => Disconnected(this, new ClientConnectionEventArgs(this, new IPEndPoint(IPAddress.None, 0)))));
         }

--- a/src/EventStore.Core.Tests/ClientAPI/Embedded/persistent_connect_integration_tests.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Embedded/persistent_connect_integration_tests.cs
@@ -1,0 +1,63 @@
+﻿using EventStore.ClientAPI;
+using NUnit.Framework;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using EventStore.Core.Tests.Helpers;
+
+namespace EventStore.Core.Tests.ClientAPI.Embedded
+{
+    public class happy_case_writing_and_subscribing_to_normal_events_manual_ack : ClientAPI.happy_case_writing_and_subscribing_to_normal_events_manual_ack
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    public class happy_case_writing_and_subscribing_to_normal_events_auto_ack : ClientAPI.happy_case_writing_and_subscribing_to_normal_events_auto_ack
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    public class happy_case_catching_up_to_normal_events_auto_ack : ClientAPI.happy_case_catching_up_to_normal_events_auto_ack
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    public class happy_case_catching_up_to_normal_events_manual_ack : ClientAPI.happy_case_catching_up_to_normal_events_manual_ack
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    public class happy_case_catching_up_to_link_to_events_manual_ack : ClientAPI.happy_case_catching_up_to_link_to_events_manual_ack
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    public class happy_case_catching_up_to_link_to_events_auto_ack : ClientAPI.happy_case_catching_up_to_link_to_events_auto_ack
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+
+    public class when_writing_and_subscribing_to_normal_events_manual_nack : ClientAPI.when_writing_and_subscribing_to_normal_events_manual_nack
+    {
+        protected override IEventStoreConnection BuildConnection(MiniNode node)
+        {
+            return EmbeddedTestConnection.To(node);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/ClientAPI/persistent_connect_integration_tests.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/persistent_connect_integration_tests.cs
@@ -343,4 +343,60 @@ namespace EventStore.Core.Tests.ClientAPI
             }
         }
     }
+
+    [TestFixture, Category("ClientAPI"), Category("LongRunning")]
+    public class when_writing_and_subscribing_to_normal_events_manual_nack : SpecificationWithMiniNode
+    {
+        private readonly string StreamName = Guid.NewGuid().ToString();
+        private readonly string GroupName = Guid.NewGuid().ToString();
+        private const int BufferCount = 10;
+        private const int EventWriteCount = BufferCount * 2;
+
+        private readonly ManualResetEvent _eventsReceived = new ManualResetEvent(false);
+        private int _eventReceivedCount;
+
+        protected override void When()
+        {
+
+        }
+
+
+        [Test]
+        public void Test()
+        {
+            var settings = PersistentSubscriptionSettings
+                .Create()
+                .StartFromCurrent()
+                .ResolveLinkTos()
+                .Build();
+
+            _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials)
+                .Wait();
+            _conn.ConnectToPersistentSubscription(StreamName, GroupName,
+                (subscription, resolvedEvent) =>
+                {
+                    subscription.Fail(resolvedEvent, PersistentSubscriptionNakEventAction.Park, "fail");
+
+                    if (Interlocked.Increment(ref _eventReceivedCount) == EventWriteCount)
+                    {
+                        _eventsReceived.Set();
+                    }
+                },
+                (sub, reason, exception) =>
+                    Console.WriteLine("Subscription dropped (reason:{0}, exception:{1}).", reason, exception),
+                bufferSize: 10, autoAck: false, userCredentials: DefaultData.AdminCredentials);
+
+            for (var i = 0; i < EventWriteCount; i++)
+            {
+                var eventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
+
+                _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
+            }
+
+            if (!_eventsReceived.WaitOne(TimeSpan.FromSeconds(5)))
+            {
+                throw new Exception("Timed out waiting for events.");
+            }
+        }
+    }
 }

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -99,6 +99,7 @@
     <Compile Include="ClientAPI\Embedded\connecting_to_a_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\create_persistent_subscription.cs" />
     <Compile Include="ClientAPI\Embedded\deleting_persistent_subscription.cs" />
+    <Compile Include="ClientAPI\Embedded\persistent_connect_integration_tests.cs" />
     <Compile Include="ClientAPI\Embedded\Security\authorized_default_credentials_security.cs" />
     <Compile Include="ClientAPI\Embedded\update_persistent_subscription.cs" />
     <Compile Include="ClientAPI\ExpectedVersion64Bit\subscribe_to_stream_with_link_to_event_with_event_number_greater_than_int_maxvalue.cs" />


### PR DESCRIPTION
Fixes #1240 

`Not Ready for Merge`

Currently the Embedded Persistent Subscription does not Ack/Nack due to some wireups missing. This PR is a WIP that will address these issues but unfortunately it currently needs to be parked due to other priorities. Anyone is more than welcome to pick up this up.

The important part here was adding the failing tests for the embedded client for persistent subscriptions.