### PR TITLE
Resubscribe a paused projection

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionQueue.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionQueue.cs
@@ -48,7 +48,13 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             var processed = false;
             if (_queuePendingEvents.Count > 0)
+            {
                 processed = ProcessOneEventBatch();
+            }
+            else if (_queuePendingEvents.Count == 0 && _subscriptionPaused && !_unsubscribed)
+            {
+                ResumeSubscription();
+            }
             return processed;
         }
 


### PR DESCRIPTION
If the projection subscription has been paused due to it reaching events
in the queue above it's threshold. It will no longer receive any events.

What then happens is that either work items in the queue are completed
or new events come in (which are enqueued and process is called on the
queue) which will keep the queue processing events.

However in a case where no events are longer received due to the
projection being paused and the last item in the queue being a
checkpoint work item. The queue will remain paused as once the
checkpoint has been completed it will attempt to process messages in the
queue which should resume the subscription, however there are no items
in the queue to process and therefore the projection remains paused and
essentially stuck.