### PR TITLE
Correctly convert the subscription confirmations

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -77,6 +77,23 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
         }
 
         [Test]
+        public void when_wrapping_read_stream_events_forward_and_stream_was_deleted_should_not_downgrade_last_event_number_for_v2_clients()
+        {
+            var msg = new ClientMessage.ReadStreamEventsForwardCompleted(Guid.NewGuid(), "test-stream", 0, 100,
+                                                ReadStreamResult.StreamDeleted, new ResolvedEvent[0], new StreamMetadata(),
+                                                true, "", -1, long.MaxValue, true, 1000);
+
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.ReadStreamEventsForwardCompleted, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.ReadStreamEventsCompleted>();
+            Assert.IsNotNull(dto, "DTO is null");
+
+            Assert.AreEqual(long.MaxValue, dto.LastEventNumber, "Last Event Number");
+        }
+
+        [Test]
         public void when_wrapping_read_stream_events_backward_and_stream_was_deleted_should_downgrade_last_event_number()
         {
             var msg = new ClientMessage.ReadStreamEventsBackwardCompleted(Guid.NewGuid(), "test-stream", 0, 100,
@@ -91,6 +108,23 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
             Assert.IsNotNull(dto, "DTO is null");
 
             Assert.AreEqual(int.MaxValue, dto.LastEventNumber, "Last Event Number");
+        }
+
+        [Test]
+        public void when_wrapping_read_stream_events_backward_and_stream_was_deleted_should_not_downgrade_last_event_number_for_v2_clients()
+        {
+            var msg = new ClientMessage.ReadStreamEventsBackwardCompleted(Guid.NewGuid(), "test-stream", 0, 100,
+                                                ReadStreamResult.StreamDeleted, new ResolvedEvent[0], new StreamMetadata(),
+                                                true, "", -1, long.MaxValue, true, 1000);
+
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.ReadStreamEventsBackwardCompleted, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.ReadStreamEventsCompleted>();
+            Assert.IsNotNull(dto, "DTO is null");
+
+            Assert.AreEqual(long.MaxValue, dto.LastEventNumber, "Last Event Number");
         }
 
         [Test]
@@ -112,6 +146,27 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
             Assert.AreEqual(1, dto.Events.Count(), "Number of events");
 
             Assert.AreEqual(int.MaxValue, dto.Events[0].Event.EventNumber, "Event Number");
+        }
+
+        [Test]
+        public void when_wrapping_read_all_events_forward_completed_with_deleted_event_should_not_downgrade_last_event_number_for_v2_clients()
+        {
+            var events = new ResolvedEvent[] {
+                ResolvedEvent.ForUnresolvedEvent(CreateDeletedEventRecord(), 0),
+            };
+            var msg = new ClientMessage.ReadAllEventsForwardCompleted(Guid.NewGuid(), ReadAllResult.Success, "", events,
+                                                                      new StreamMetadata(), true, 10, new TFPos(0,0),
+                                                                      new TFPos(200,200), new TFPos(0,0), 100);
+
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.ReadAllEventsForwardCompleted, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.ReadAllEventsCompleted>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(1, dto.Events.Count(), "Number of events");
+
+            Assert.AreEqual(long.MaxValue, dto.Events[0].Event.EventNumber, "Event Number");
         }
 
         [Test]
@@ -137,6 +192,28 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
         }
 
         [Test]
+        public void when_wrapping_read_all_events_forward_completed_with_link_to_deleted_event_should_not_downgrade_version_for_v2_clients()
+        {
+            var events = new ResolvedEvent[] {
+                ResolvedEvent.ForResolvedLink(CreateLinkEventRecord(), CreateDeletedEventRecord(), 100)
+            };
+            var msg = new ClientMessage.ReadAllEventsForwardCompleted(Guid.NewGuid(), ReadAllResult.Success, "", events,
+                                                                      new StreamMetadata(), true, 10, new TFPos(0,0),
+                                                                      new TFPos(200,200), new TFPos(0,0), 100);
+
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.ReadAllEventsForwardCompleted, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.ReadAllEventsCompleted>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(1, dto.Events.Count(), "Number of events");
+
+            Assert.AreEqual(0, dto.Events[0].Event.EventNumber, "Event Number");
+            Assert.AreEqual(long.MaxValue, dto.Events[0].Link.EventNumber, "Link Event Number");
+        }
+
+        [Test]
         public void when_wrapping_read_all_events_backward_completed_with_deleted_event_should_downgrade_version()
         {
             var events = new ResolvedEvent[] {
@@ -155,6 +232,27 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
             Assert.AreEqual(1, dto.Events.Count(), "Number of events");
 
             Assert.AreEqual(int.MaxValue, dto.Events[0].Event.EventNumber, "Event Number");
+        }
+
+        [Test]
+        public void when_wrapping_read_all_events_backward_completed_with_deleted_event_should_not_downgrade_version_for_v2_clients()
+        {
+            var events = new ResolvedEvent[] {
+                ResolvedEvent.ForUnresolvedEvent(CreateDeletedEventRecord(), 0),
+            };
+            var msg = new ClientMessage.ReadAllEventsBackwardCompleted(Guid.NewGuid(), ReadAllResult.Success, "", events,
+                                                                       new StreamMetadata(), true, 10, new TFPos(0, 0),
+                                                                       new TFPos(200, 200), new TFPos(0, 0), 100);
+
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.ReadAllEventsBackwardCompleted, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.ReadAllEventsCompleted>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(1, dto.Events.Count(), "Number of events");
+
+            Assert.AreEqual(long.MaxValue, dto.Events[0].Event.EventNumber, "Event Number");
         }
 
         [Test]
@@ -180,6 +278,28 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
         }
 
         [Test]
+        public void when_wrapping_read_all_events_backward_completed_with_link_to_deleted_event_should_not_downgrade_version_for_v2_clients()
+        {
+            var events = new ResolvedEvent[] {
+                ResolvedEvent.ForResolvedLink(CreateLinkEventRecord(), CreateDeletedEventRecord(), 100)
+            };
+            var msg = new ClientMessage.ReadAllEventsBackwardCompleted(Guid.NewGuid(), ReadAllResult.Success, "", events,
+                                                                       new StreamMetadata(), true, 10, new TFPos(0, 0),
+                                                                       new TFPos(200, 200), new TFPos(0, 0), 100);
+
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.ReadAllEventsBackwardCompleted, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.ReadAllEventsCompleted>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(1, dto.Events.Count(), "Number of events");
+
+            Assert.AreEqual(0, dto.Events[0].Event.EventNumber, "Event Number");
+            Assert.AreEqual(long.MaxValue, dto.Events[0].Link.EventNumber, "Link Event Number");
+        }
+
+        [Test]
         public void when_wrapping_stream_event_appeared_with_deleted_event_should_downgrade_version()
         {
             var msg = new ClientMessage.StreamEventAppeared(Guid.NewGuid(),
@@ -195,6 +315,21 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
         }
 
         [Test]
+        public void when_wrapping_stream_event_appeared_with_deleted_event_should_not_downgrade_version_for_v2_clients()
+        {
+            var msg = new ClientMessage.StreamEventAppeared(Guid.NewGuid(),
+                                                            ResolvedEvent.ForUnresolvedEvent(CreateDeletedEventRecord(), 0));
+
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.StreamEventAppeared, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.StreamEventAppeared>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(long.MaxValue, dto.Event.Event.EventNumber, "Event Number");
+        }
+
+        [Test]
         public void when_wrapping_subscribe_to_stream_confirmation_when_stream_deleted_should_downgrade_last_event_number()
         {
             var msg = new ClientMessage.SubscriptionConfirmation(Guid.NewGuid(), 100, long.MaxValue);
@@ -205,6 +340,32 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
             var dto = package.Value.Data.Deserialize<TcpClientMessageDto.SubscriptionConfirmation>();
             Assert.IsNotNull(dto, "DTO is null");
             Assert.AreEqual(int.MaxValue, dto.LastEventNumber, "Last Event Number");
+        }
+
+        [Test]
+        public void when_wrapping_subscribe_to_stream_confirmation_when_stream_deleted_should_not_downgrade_version_for_v2_clients()
+        {
+            var msg = new ClientMessage.SubscriptionConfirmation(Guid.NewGuid(), 100, long.MaxValue);
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.SubscriptionConfirmation, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.SubscriptionConfirmation>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(long.MaxValue, dto.LastEventNumber, "Last Event Number");
+        }
+
+        [Test]
+        public void when_wrapping_subscribe_to_stream_confirmation_when_stream_deleted_should_not_downgrade_last_event_number_for_v2_clients()
+        {
+            var msg = new ClientMessage.SubscriptionConfirmation(Guid.NewGuid(), 100, long.MaxValue);
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.SubscriptionConfirmation, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.SubscriptionConfirmation>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(long.MaxValue, dto.LastEventNumber, "Last Event Number");
         }
 
         [Test]
@@ -237,6 +398,22 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
         }
 
         [Test]
+        public void when_wrapping_stream_event_appeared_with_link_to_deleted_event_should_not_downgrade_version_for_v2_clients()
+        {
+            var msg = new ClientMessage.StreamEventAppeared(Guid.NewGuid(),
+                                                            ResolvedEvent.ForResolvedLink(CreateLinkEventRecord(), CreateDeletedEventRecord(), 0));
+
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.StreamEventAppeared, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.StreamEventAppeared>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(0, dto.Event.Event.EventNumber, "Event Number");
+            Assert.AreEqual(long.MaxValue, dto.Event.Link.EventNumber, "Link Event Number");
+        }
+
+        [Test]
         public void when_wrapping_persistent_subscription_confirmation_when_stream_deleted_should_downgrade_last_event_number()
         {
             var msg = new ClientMessage.PersistentSubscriptionConfirmation("subscription", Guid.NewGuid(), 100, long.MaxValue);
@@ -247,6 +424,19 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
             var dto = package.Value.Data.Deserialize<TcpClientMessageDto.PersistentSubscriptionConfirmation>();
             Assert.IsNotNull(dto, "DTO is null");
             Assert.AreEqual(int.MaxValue, dto.LastEventNumber, "Last event number");
+        }
+
+        [Test]
+        public void when_wrapping_persistent_subscription_confirmation_when_stream_deleted_should_not_downgrade_last_event_number_for_v2_clients()
+        {
+            var msg = new ClientMessage.PersistentSubscriptionConfirmation("subscription", Guid.NewGuid(), 100, long.MaxValue);
+            var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+            Assert.IsNotNull(package, "Package is null");
+            Assert.AreEqual(TcpCommand.PersistentSubscriptionConfirmation, package.Value.Command, "TcpCommand");
+
+            var dto = package.Value.Data.Deserialize<TcpClientMessageDto.PersistentSubscriptionConfirmation>();
+            Assert.IsNotNull(dto, "DTO is null");
+            Assert.AreEqual(long.MaxValue, dto.LastEventNumber, "Last event number");
         }
 
         [Test]

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -95,9 +95,9 @@ namespace EventStore.Core.Services.Transport.Tcp
             AddWrapper<ClientMessage.ReadStreamEventsBackwardCompleted>(WrapReadStreamEventsBackwardCompletedV1, ClientVersion.V1);
             AddWrapper<ClientMessage.ReadAllEventsForwardCompleted>(WrapReadAllEventsForwardCompletedV1, ClientVersion.V1);
             AddWrapper<ClientMessage.ReadAllEventsBackwardCompleted>(WrapReadAllEventsBackwardCompletedV1, ClientVersion.V1);
-            AddWrapper<ClientMessage.SubscriptionConfirmation>(WrapSubscribedToStreamV1, ClientVersion.V2);
+            AddWrapper<ClientMessage.SubscriptionConfirmation>(WrapSubscribedToStreamV1, ClientVersion.V1);
             AddWrapper<ClientMessage.StreamEventAppeared>(WrapStreamEventAppearedV1, ClientVersion.V1);
-            AddWrapper<ClientMessage.PersistentSubscriptionConfirmation>(WrapPersistentSubscriptionConfirmationV1, ClientVersion.V2);
+            AddWrapper<ClientMessage.PersistentSubscriptionConfirmation>(WrapPersistentSubscriptionConfirmationV1, ClientVersion.V1);
             AddWrapper<ClientMessage.PersistentSubscriptionStreamEventAppeared>(WrapPersistentSubscriptionStreamEventAppearedV1, ClientVersion.V1);
         }
 


### PR DESCRIPTION
This fix pertains to the Client Tcp Dispatcher subscription confirmations
for persistent subscriptions as well as the client subscriptions and
their event numbers for hard deletes.