### PR TITLE
Better GetHashCode

### DIFF
--- a/src/EventStore.Core/Data/EventRecord.cs
+++ b/src/EventStore.Core/Data/EventRecord.cs
@@ -115,14 +115,14 @@ namespace EventStore.Core.Data
         {
             unchecked
             {
-                int hashCode = (int)(EventNumber >> 32);
+                int hashCode = EventNumber.GetHashCode();
                 hashCode = (hashCode*397) ^ LogPosition.GetHashCode();
                 hashCode = (hashCode*397) ^ CorrelationId.GetHashCode();
                 hashCode = (hashCode*397) ^ EventId.GetHashCode();
                 hashCode = (hashCode*397) ^ TransactionPosition.GetHashCode();
                 hashCode = (hashCode*397) ^ TransactionOffset;
                 hashCode = (hashCode*397) ^ EventStreamId.GetHashCode();
-                hashCode = (hashCode*397) ^ (int)(ExpectedVersion >> 32);
+                hashCode = (hashCode*397) ^ ExpectedVersion.GetHashCode();
                 hashCode = (hashCode*397) ^ TimeStamp.GetHashCode();
                 hashCode = (hashCode*397) ^ Flags.GetHashCode();
                 hashCode = (hashCode*397) ^ EventType.GetHashCode();

--- a/src/EventStore.Core/TransactionLog/LogRecords/CommitLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/CommitLogRecord.cs
@@ -98,7 +98,7 @@ namespace EventStore.Core.TransactionLog.LogRecords
             {
                 int result = LogPosition.GetHashCode();
                 result = (result * 397) ^ TransactionPosition.GetHashCode();
-                result = (result * 397) ^ (int)(FirstEventNumber.GetHashCode() >> 32);
+                result = (result * 397) ^ FirstEventNumber.GetHashCode();
                 result = (result * 397) ^ SortKey.GetHashCode();
                 result = (result * 397) ^ CorrelationId.GetHashCode();
                 result = (result * 397) ^ TimeStamp.GetHashCode();

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -216,7 +216,7 @@ namespace EventStore.Core.TransactionLog.LogRecords
                 result = (result * 397) ^ Flags.GetHashCode();
                 result = (result * 397) ^ TransactionPosition.GetHashCode();
                 result = (result * 397) ^ TransactionOffset;
-                result = (result * 397) ^ (int)(ExpectedVersion >> 32);
+                result = (result * 397) ^ ExpectedVersion.GetHashCode();
                 result = (result * 397) ^ EventStreamId.GetHashCode();
 
                 result = (result * 397) ^ EventId.GetHashCode();

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionVersion.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionVersion.cs
@@ -28,9 +28,9 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             unchecked
             {
-                var hashCode = (int)(ProjectionId >> 32);
-                hashCode = (hashCode*397) ^ (int)(Epoch >> 32);
-                hashCode = (hashCode*397) ^ (int)(Version >> 32);
+                var hashCode = ProjectionId.GetHashCode();
+                hashCode = (hashCode*397) ^ Epoch.GetHashCode();
+                hashCode = (hashCode*397) ^ Version.GetHashCode();
                 return hashCode;
             }
         }

--- a/src/EventStore.Projections.Core/Services/ProjectionStatistics.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionStatistics.cs
@@ -90,9 +90,9 @@ namespace EventStore.Projections.Core.Services
                 hashCode = (hashCode*397) ^ (int) MasterStatus;
                 hashCode = (hashCode*397) ^ (StateReason != null ? StateReason.GetHashCode() : 0);
                 hashCode = (hashCode*397) ^ (Name != null ? Name.GetHashCode() : 0);
-                hashCode = (hashCode*397) ^ (int)(ProjectionId >> 32);
-                hashCode = (hashCode*397) ^ (int)(Epoch >> 32);
-                hashCode = (hashCode*397) ^ (int)(Version >> 32);
+                hashCode = (hashCode*397) ^ ProjectionId.GetHashCode();
+                hashCode = (hashCode*397) ^ Epoch.GetHashCode();
+                hashCode = (hashCode*397) ^ Version.GetHashCode();
                 hashCode = (hashCode*397) ^ (int) Mode;
                 hashCode = (hashCode*397) ^ (Position != null ? Position.GetHashCode() : 0);
                 hashCode = (hashCode*397) ^ Progress.GetHashCode();


### PR DESCRIPTION
When moving from int to longs, there GetHashCode methods were changed and in
some cases only the high order bits were used. This fixes this.

Impact is relatively low as the GetHashCode methods are currently not
being used and the objects that override them aren't exposed publicly.