### PR TITLE
Fix reverse proxy issues

### DIFF
--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/feed.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/feed.cs
@@ -204,7 +204,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
         [Test]
         public void returns_a_feed_with_a_single_entry_referring_to_the_last_event()
         {
-            HelperExtensions.AssertJson(new { entries = new[] { new { Id = _lastEventLocation } } }, _feed);
+            Assert.AreEqual(MakeUrl(_feed["entries"][0]["id"].ToObject<String>()).AbsolutePath, _lastEventLocation);
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/Http/Streams/basic.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/basic.cs
@@ -316,7 +316,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream).AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -351,7 +351,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream).AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -386,7 +386,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream).AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -422,7 +422,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl("/streams/$all"), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl("/streams/$all").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -458,7 +458,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl("/streams/$all").ToString(), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl("/streams/$all").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -495,7 +495,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream + "/metadata"), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream + "/metadata").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -532,7 +532,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream + "/metadata"), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream + "/metadata").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -572,7 +572,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_feed_with_a_single_entry_referring_to_the_last_event()
             {
-                HelperExtensions.AssertJson(new {entries = new[] {new {Id = _lastEventLocation}}}, _feed);
+                Assert.AreEqual(MakeUrl(_feed["entries"][0]["id"].ToObject<String>()).AbsolutePath, _lastEventLocation);
             }
         }
 

--- a/src/EventStore.Core.Tests/Http/Users/users.cs
+++ b/src/EventStore.Core.Tests/Http/Users/users.cs
@@ -45,7 +45,7 @@ namespace EventStore.Core.Tests.Http.Users
             public void returns_created_status_code_and_location()
             {
                 Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
-                Assert.AreEqual(MakeUrl("/users/test1"), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl("/users/test1").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
@@ -29,8 +29,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         protected override void SubscribeCore(IHttpService service)
         {
             _clusterNodeWeb.RegisterControllerActions(service);
-            RegisterRedirectAction(service, "", "/web/index.html");
-            RegisterRedirectAction(service, "/web", "/web/index.html");
+            RegisterRedirectAction(service, "", "/web/index.html",true);
+            RegisterRedirectAction(service, "/web", "/web/index.html",true);
 
             service.RegisterAction(
                 new ControllerAction("/sys/subsystems", HttpMethod.Get, Codec.NoCodecs, new ICodec[] { Codec.Json }),
@@ -49,7 +49,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 				);
         }
 
-        private static void RegisterRedirectAction(IHttpService service, string fromUrl, string toUrl)
+		private static void RegisterRedirectAction(IHttpService service, string fromUrl, string toUrl,bool isRelativeUrl=false)
         {
             service.RegisterAction(
                 new ControllerAction(
@@ -62,7 +62,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                         new[]
                             {
                                 new KeyValuePair<string, string>(
-                                    "Location",   new Uri(http.HttpEntity.RequestedUrl, toUrl).AbsoluteUri)
+								"Location",   isRelativeUrl?new Uri(toUrl,UriKind.Relative).ToString():new Uri(http.HttpEntity.RequestedUrl, toUrl).AbsoluteUri)
                             }, Console.WriteLine));
         }
     }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
@@ -29,8 +29,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         protected override void SubscribeCore(IHttpService service)
         {
             _clusterNodeWeb.RegisterControllerActions(service);
-            RegisterRedirectAction(service, "", "/web/index.html",true);
-            RegisterRedirectAction(service, "/web", "/web/index.html",true);
+            RegisterRedirectAction(service, "", "/web/index.html");
+            RegisterRedirectAction(service, "/web", "/web/index.html");
 
             service.RegisterAction(
                 new ControllerAction("/sys/subsystems", HttpMethod.Get, Codec.NoCodecs, new ICodec[] { Codec.Json }),
@@ -49,7 +49,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 				);
         }
 
-		private static void RegisterRedirectAction(IHttpService service, string fromUrl, string toUrl,bool isRelativeUrl=false)
+        private static void RegisterRedirectAction(IHttpService service, string fromUrl, string toUrl)
         {
             service.RegisterAction(
                 new ControllerAction(
@@ -62,7 +62,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                         new[]
                             {
                                 new KeyValuePair<string, string>(
-								"Location",   isRelativeUrl?new Uri(toUrl,UriKind.Relative).ToString():new Uri(http.HttpEntity.RequestedUrl, toUrl).AbsoluteUri)
+                                    "Location",   new Uri(http.HttpEntity.RequestedUrl, toUrl).AbsoluteUri)
                             }, Console.WriteLine));
         }
     }

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -166,9 +166,9 @@ namespace EventStore.Transport.Http.EntityManagement
             {
                 foreach (var kvp in headers)
                 {
-                    if(kvp.Key.Equals("Location") && kvp.Value!=null && _requestedUrlBase!=null && kvp.Value.StartsWith(_requestedUrlBase)){
-                      //rewrite the "Location" header as a root-relative URL if it starts with the requested URL base
-                      HttpEntity.Response.AddHeader(kvp.Key, kvp.Value.Substring(_requestedUrlBase.Length));
+                    if(kvp.Key.Equals("Location") && kvp.Value!=null && _requestedUrlBase!=null && AbsoluteUriEqual(_requestedUrlBase,kvp.Value)){
+                      //rewrite the "Location" header as a root-relative URL if the location base matches requested URL base
+                      HttpEntity.Response.AddHeader(kvp.Key, new Uri(kvp.Value).AbsolutePath);
                     }
                     else{
                       HttpEntity.Response.AddHeader(kvp.Key, kvp.Value);
@@ -182,6 +182,22 @@ namespace EventStore.Transport.Http.EntityManagement
             catch (Exception e)
             {
                 Log.Debug("Failed to set additional response headers: {0}.", e.Message);
+            }
+        }
+
+        private bool AbsoluteUriEqual(string urlString1, string urlString2)
+        {
+            try
+            {
+                Uri url1 = new Uri(urlString1);
+                Uri url2 = new Uri(urlString2);
+                return url1.IsAbsoluteUri && url2.IsAbsoluteUri && url1.Scheme == url2.Scheme &&
+                       url1.Host == url2.Host && url1.Port == url2.Port;
+            }
+            catch (Exception e)
+            {
+                Log.Debug("Failed to compare Urls: {0}.", e.Message);
+                return false;
             }
         }
 

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -33,6 +33,7 @@ namespace EventStore.Transport.Http.EntityManagement
         private readonly ICodec _requestCodec;
         private readonly ICodec _responseCodec;
         private readonly Uri _requestedUrl;
+        private readonly string _requestedUrlBase;
         private readonly bool _logHttpRequests;
         public readonly DateTime TimeStamp;
 
@@ -52,6 +53,7 @@ namespace EventStore.Transport.Http.EntityManagement
             _requestCodec = requestCodec;
             _responseCodec = responseCodec;
             _requestedUrl = httpEntity.RequestedUrl;
+            _requestedUrlBase = httpEntity.RequestedUrlBase;
             _logHttpRequests = logHttpRequests;
 
             if (HttpEntity.Request != null && HttpEntity.Request.ContentLength64 == 0)
@@ -164,7 +166,13 @@ namespace EventStore.Transport.Http.EntityManagement
             {
                 foreach (var kvp in headers)
                 {
-                    HttpEntity.Response.AddHeader(kvp.Key, kvp.Value);
+                    if(kvp.Key.Equals("Location") && kvp.Value!=null && _requestedUrlBase!=null && kvp.Value.StartsWith(_requestedUrlBase)){
+                      //rewrite the "Location" header as a root-relative URL if it starts with the requested URL base
+                      HttpEntity.Response.AddHeader(kvp.Key, kvp.Value.Substring(_requestedUrlBase.Length));
+                    }
+                    else{
+                      HttpEntity.Response.AddHeader(kvp.Key, kvp.Value);
+                    }
                 }
             }
             catch (ObjectDisposedException)
@@ -261,12 +269,12 @@ namespace EventStore.Transport.Http.EntityManagement
 
             if (Interlocked.CompareExchange(ref _processing, 1, 0) != 0)
                 return;
-            
+
             try
             {
                 HttpEntity.Response.StatusCode = (int)response.StatusCode;
                 HttpEntity.Response.StatusDescription = response.ReasonPhrase;
-                if(response.Content != null) 
+                if(response.Content != null)
                 {
                     if(response.Content.Headers.ContentType != null) {
                         HttpEntity.Response.ContentType = response.Content.Headers.ContentType.MediaType;
@@ -281,9 +289,9 @@ namespace EventStore.Transport.Http.EntityManagement
                         case "Content-Length": break;
                         case "Keep-Alive": break;
                         case "Transfer-Encoding": break;
-                        case "WWW-Authenticate": 
+                        case "WWW-Authenticate":
                             headerValue = header.Value.FirstOrDefault();
-                            HttpEntity.Response.AddHeader(header.Key, headerValue); 
+                            HttpEntity.Response.AddHeader(header.Key, headerValue);
                             break;
 
                         default:
@@ -298,8 +306,8 @@ namespace EventStore.Transport.Http.EntityManagement
                     response.Content.ReadAsStreamAsync()
                         .ContinueWith(task => {
                             new AsyncStreamCopier<HttpListenerResponse>(
-                                task.Result, 
-                                HttpEntity.Response.OutputStream, 
+                                task.Result,
+                                HttpEntity.Response.OutputStream,
                                 HttpEntity.Response,
                                 copier => {
                                     Helper.EatException(HttpEntity.Response.Close);


### PR DESCRIPTION
Fixes reverse proxy issues (#1231) by rewriting the "Location" header as an absolute URL before sending out the response if the "Location" base matches the Requested URL base.

This should work by default under any reverse proxy if ES is mapped under the root directory. However, if the reverse proxy is mapping ES under a subfolder e.g. /es/, then the X-Forwarded-Prefix header must be set. Since URLs are now relative, there is now no need for X-Forwarded-Proto, X-Forwarded-Host and X-Forwarded-Port but it has been still kept in the code.