### PR TITLE
Fix reverse proxy issues

### DIFF
--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/feed.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/feed.cs
@@ -204,7 +204,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
         [Test]
         public void returns_a_feed_with_a_single_entry_referring_to_the_last_event()
         {
-            HelperExtensions.AssertJson(new { entries = new[] { new { Id = _lastEventLocation } } }, _feed);
+            Assert.AreEqual(MakeUrl(_feed["entries"][0]["id"].ToObject<String>()).AbsolutePath, _lastEventLocation);
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/Http/Streams/basic.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/basic.cs
@@ -316,7 +316,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream).AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -351,7 +351,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream).AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -386,7 +386,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream).AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -422,7 +422,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl("/streams/$all"), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl("/streams/$all").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -458,7 +458,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl("/streams/$all").ToString(), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl("/streams/$all").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -495,7 +495,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream + "/metadata"), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream + "/metadata").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 
@@ -532,7 +532,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_location_header_that_is_to_stream_without_slash()
             {
-                Assert.AreEqual(MakeUrl(TestStream + "/metadata"), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl(TestStream + "/metadata").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -572,7 +572,7 @@ namespace EventStore.Core.Tests.Http.Streams
             [Test]
             public void returns_a_feed_with_a_single_entry_referring_to_the_last_event()
             {
-                HelperExtensions.AssertJson(new {entries = new[] {new {Id = _lastEventLocation}}}, _feed);
+                Assert.AreEqual(MakeUrl(_feed["entries"][0]["id"].ToObject<String>()).AbsolutePath, _lastEventLocation);
             }
         }
 

--- a/src/EventStore.Core.Tests/Http/Users/users.cs
+++ b/src/EventStore.Core.Tests/Http/Users/users.cs
@@ -45,7 +45,7 @@ namespace EventStore.Core.Tests.Http.Users
             public void returns_created_status_code_and_location()
             {
                 Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
-                Assert.AreEqual(MakeUrl("/users/test1"), _response.Headers[HttpResponseHeader.Location]);
+                Assert.AreEqual(MakeUrl("/users/test1").AbsolutePath, _response.Headers[HttpResponseHeader.Location]);
             }
         }
 


### PR DESCRIPTION
Fixes reverse proxy issues (#1231) by rewriting the "Location" header as an absolute URL before sending out the response if the "Location" base matches the original Requested URL base.

This should work by default under any reverse proxy if ES is mapped under the root directory. However, if the reverse proxy is mapping ES under a subfolder e.g. /es/, then the X-Forwarded-Prefix header must be set. Since URLs are now relative, there is now no need for X-Forwarded-Proto, X-Forwarded-Host and X-Forwarded-Port but it has been still kept in the code.