### PR TITLE
Added gzip & deflate support for Accept-Encoding HTTP header

### DIFF
--- a/src/EventStore.BufferManagement/BufferManager.cs
+++ b/src/EventStore.BufferManagement/BufferManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using EventStore.Common.Log;
 
 namespace EventStore.BufferManagement
 {
@@ -35,6 +36,7 @@ namespace EventStore.BufferManagement
 
         private readonly List<byte[]> _segments;
         private readonly object _creatingNewSegmentLock = new object();
+        private static readonly ILogger Log = LogManager.GetLoggerFor<BufferManager>();
 
         /// <summary>
         /// Gets the default buffer manager
@@ -161,7 +163,7 @@ namespace EventStore.BufferManagement
                     _buffers.Push(chunk);
                 }
 
-                Console.WriteLine("Segments count: {0}, buffers count: {1}, should be when full: {2}",
+                Log.Debug("Segments count: {0}, buffers count: {1}, should be when full: {2}",
                                   _segments.Count,
                                   _buffers.Count,
                                   _segments.Count * _segmentChunks);

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -1,4 +1,5 @@
-﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -24,7 +25,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile></DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -509,6 +511,7 @@
     <Compile Include="Services\Transport\Http\Authentication\basic_http_authentication_provider.cs" />
     <Compile Include="Services\Transport\Http\Authentication\rfc_2898_password_hash_algorithm.cs" />
     <Compile Include="Authentication\with_internal_authentication_provider.cs" />
+    <Compile Include="Services\Transport\Http\compress_response_should.cs" />
     <Compile Include="Services\Transport\Http\media_type.cs" />
     <Compile Include="Services\Transport\Http\atom_specs.cs" />
     <Compile Include="Services\Transport\Http\auto_convertion.cs" />

--- a/src/EventStore.Core.Tests/Services/Transport/Http/compress_response_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/compress_response_should.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.IO;
+using System.IO.Compression;
+using EventStore.Transport.Http.EntityManagement;
+using NUnit.Framework;
+using System.Net;
+using System.Text;
+using EventStore.Transport.Http;
+
+namespace EventStore.Core.Tests.Services.Transport.Http
+{
+    [TestFixture]
+    class compress_response_should
+    {
+        private string inputData = "my test string 123456.";
+
+        [Test]
+        public void with_gzip_compression_algo_data_is_gzipped()
+        {
+            var response = HttpEntityManager.CompressResponse(Encoding.ASCII.GetBytes(inputData),CompressionAlgorithms.Gzip);
+
+            String uncompressed;
+
+            using (var inputStream = new MemoryStream(response))
+            using (var uncompressedStream = new GZipStream(inputStream, CompressionMode.Decompress))
+            using (var outputStream = new MemoryStream())
+            {
+                uncompressedStream.CopyTo(outputStream);
+                uncompressed = Encoding.UTF8.GetString(outputStream.ToArray());
+            }
+
+            Assert.AreEqual(uncompressed,inputData);
+        }
+
+        [Test]
+        public void with_gzip_compression_algo_and_string_larger_than_50kb_data_is_gzipped()
+        {
+            StringBuilder sb = new StringBuilder();
+            for(int i=0;i<60*1024;i++) sb.Append("A");
+            String testString = sb.ToString();
+
+            var response = HttpEntityManager.CompressResponse(Encoding.ASCII.GetBytes(testString),CompressionAlgorithms.Gzip);
+
+            String uncompressed;
+
+            using (var inputStream = new MemoryStream(response))
+            using (var uncompressedStream = new GZipStream(inputStream, CompressionMode.Decompress))
+            using (var outputStream = new MemoryStream())
+            {
+                uncompressedStream.CopyTo(outputStream);
+                uncompressed = Encoding.UTF8.GetString(outputStream.ToArray());
+            }
+
+            Assert.AreEqual(uncompressed,testString);
+        }
+
+        [Test]
+        public void with_deflate_compression_algo_data_is_deflated()
+        {
+            var response = HttpEntityManager.CompressResponse(Encoding.ASCII.GetBytes(inputData),CompressionAlgorithms.Deflate);
+
+            String uncompressed;
+
+            using (var inputStream = new MemoryStream(response))
+            using (var uncompressedStream = new DeflateStream(inputStream, CompressionMode.Decompress))
+            using (var outputStream = new MemoryStream())
+            {
+                uncompressedStream.CopyTo(outputStream);
+                uncompressed = Encoding.UTF8.GetString(outputStream.ToArray());
+            }
+
+            Assert.AreEqual(uncompressed,inputData);
+        }
+
+        [Test]
+        public void with_deflate_compression_algo_and_string_larger_than_50kb_data_is_deflated()
+        {
+            StringBuilder sb = new StringBuilder();
+            for(int i=0;i<60*1024;i++) sb.Append("A");
+            String testString = sb.ToString();
+
+            var response = HttpEntityManager.CompressResponse(Encoding.ASCII.GetBytes(testString),CompressionAlgorithms.Deflate);
+
+            String uncompressed;
+
+            using (var inputStream = new MemoryStream(response))
+            using (var uncompressedStream = new DeflateStream(inputStream, CompressionMode.Decompress))
+            using (var outputStream = new MemoryStream())
+            {
+                uncompressedStream.CopyTo(outputStream);
+                uncompressed = Encoding.UTF8.GetString(outputStream.ToArray());
+            }
+
+            Assert.AreEqual(uncompressed,testString);
+        }
+
+        [Test]
+        public void with_invalid_compression_algo_data_remains_the_same()
+        {
+            var response = HttpEntityManager.CompressResponse(Encoding.ASCII.GetBytes(inputData),"invalid_compression_algo");
+            Assert.AreEqual(Encoding.ASCII.GetString(response),inputData);
+        }
+
+        [Test]
+        public void with_null_compression_algo_data_remains_the_same()
+        {
+            var response = HttpEntityManager.CompressResponse(Encoding.ASCII.GetBytes(inputData),null);
+            Assert.AreEqual(Encoding.ASCII.GetString(response),inputData);
+        }
+    }
+}

--- a/src/EventStore.Transport.Http/CompressionAlgorithms.cs
+++ b/src/EventStore.Transport.Http/CompressionAlgorithms.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace EventStore.Transport.Http
+{
+    public class CompressionAlgorithms
+    {
+        public const string Gzip = "gzip";
+        public const string Deflate = "deflate";
+    }
+}

--- a/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
+++ b/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Codecs\NoCodec.cs" />
     <Compile Include="Codecs\TextCodec.cs" />
     <Compile Include="Codecs\XmlCodec.cs" />
+    <Compile Include="CompressionAlgorithms.cs" />
     <Compile Include="MediaType.cs" />
     <Compile Include="AsyncQueuedBufferWriter.cs" />
     <Compile Include="Client\ClientOperationState.cs" />
@@ -78,6 +79,10 @@
     <Compile Include="WebRequestExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj">
+      <Project>{A794D3FB-06AC-471F-AB8D-6E98CBFA0021}</Project>
+      <Name>EventStore.BufferManagement</Name>
+    </ProjectReference>
     <ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj">
       <Project>{B4C9BE3D-43B1-4049-A23A-5DC53DB3F0B0}</Project>
       <Name>EventStore.Common</Name>


### PR DESCRIPTION
Fixes #965 Also related to #1082.

Did a basic performance test with a 50MB event:
On my machine, increase in response time varies from 0.5s,99.9% compression (repeating a single character) to 2.1s,25% compression (random data), so compression takes around 10ms to 40ms per MB