### PR TITLE
Fixes checkpoint bug

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/OutstandingMessageCacheTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/OutstandingMessageCacheTests.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             cache.StartMessage(new OutstandingMessage(id, null, Helper.BuildFakeEvent(id, "type", "name", 1), 0), DateTime.Now);
             cache.Remove(id);
             Assert.AreEqual(0, cache.Count);
-            Assert.AreEqual(long.MinValue, cache.GetLowestPosition());
+            Assert.AreEqual(long.MaxValue, cache.GetLowestPosition());
         }
 
         [Test]
@@ -65,7 +65,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             cache.StartMessage(new OutstandingMessage(id, null, Helper.BuildFakeEvent(id, "type", "name", 0), 0), DateTime.Now);
             cache.Remove(id);
             Assert.AreEqual(0, cache.Count);
-            Assert.AreEqual(long.MinValue, cache.GetLowestPosition());
+            Assert.AreEqual(long.MaxValue, cache.GetLowestPosition());
         }
 
         [Test]
@@ -92,17 +92,17 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
         }
 
         [Test]
-        public void lowest_on_empty_cache_returns_min()
+        public void lowest_on_empty_cache_returns_max()
         {
             var cache = new OutstandingMessageCache();
-            Assert.AreEqual(long.MinValue, cache.GetLowestPosition());
+            Assert.AreEqual(long.MaxValue, cache.GetLowestPosition());
         }
         [Test]
-        public void get_expired_messages_returns_min_value_on_empty_cache()
+        public void get_expired_messages_returns_max_value_on_empty_cache()
         {
             var cache = new OutstandingMessageCache();
             Assert.AreEqual(0, cache.GetMessagesExpiringBefore(DateTime.Now).Count());
-            Assert.AreEqual(long.MinValue, cache.GetLowestPosition());
+            Assert.AreEqual(long.MaxValue, cache.GetLowestPosition());
         }
 
         [Test]

--- a/src/EventStore.Core/Services/PersistentSubscription/OutstandingMessageCache.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/OutstandingMessageCache.cs
@@ -91,7 +91,7 @@ namespace EventStore.Core.Services.PersistentSubscription
         public long GetLowestPosition()
         {
             //TODO is there a better way of doing this?
-            if (_bySequences.Count == 0) return long.MinValue;
+            if (_bySequences.Count == 0) return long.MaxValue;
             return _bySequences.Values[0];
         }
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -294,7 +294,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 //TODO? COMPETING better to make -1? as of now we are inclusive of checkpoint.
                 var lowestBufferedRetry = _streamBuffer.GetLowestRetry();
                 lowest = Math.Min(lowest, lowestBufferedRetry);
-                if (lowest == long.MinValue) lowest = _lastKnownMessage;
+                if (lowest == long.MaxValue) lowest = _lastKnownMessage;
                 if (lowest == 0) return;
                 //no outstanding messages. in this case we can say that the last known
                 //event would be our checkpoint place (we have already completed it)


### PR DESCRIPTION
Fixes #1301 
Wrong sentinel value was being used as described in issue.

From what I understood, correct behaviour is:
If there's at least one message in either _streamBuffer or _outstandingMessages:
"lowest" will contain the smallest event number among all messages
Otherwise:
"lowest" will contain the event number of "_lastKnownMessage"