### PR TITLE
Fix cases where projections are just buffering

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
@@ -346,7 +346,8 @@ namespace EventStore.Projections.Core.Services.Processing
                 return;
             }
 
-                //
+            //
+            CompleteCheckpointSuggestedWorkItem();
             EnsureUnsubscribed();
             StopSlaveProjections(); 
             GoToState(State.Initial);
@@ -625,6 +626,11 @@ namespace EventStore.Projections.Core.Services.Processing
             if (!_tickPending)
                 return;
             // process messages in almost all states as we now ignore work items when processing
+            if (_state == State.LoadStateRequested)
+            {
+                _tickPending = false;
+                return;
+            }
 
             EnsureState(
                 State.Running | State.Stopping | State.Stopped | State.FaultedStopping | State.Faulted

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointManager.cs
@@ -228,7 +228,6 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             if (_stopping || _stopped)
                 return;
-            EnsureStarted();
             _lastProcessedEventProgress = progress;
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/StagedProcessingQueue.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StagedProcessingQueue.cs
@@ -287,6 +287,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
         public void Initialize()
         {
+            _correlationLastEntries.Clear();
             _byUnorderedStageFirst = new StageEntry[_orderedStage.Length];
             _byUnorderedStageLast = new StageEntry[_orderedStage.Length];
             _byOrderedStageLast = new TaskEntry[_orderedStage.Length];


### PR DESCRIPTION
There exists a couple obscure cases where projections appear to just
buffer events instead of just processing them.

The fixes are as follows
- Ensure that everything from the Core Projection Queue is cleaned up,
even the Staged Processing Queue. This could cause some items not to be
processed and just buffer events to be processed.
- In the Checkpoint Manager, we might still receive progress updates
from writes that have completed from before the restart
- In the Core Projection mark the existing checkpoint work item as
complete, we have cleared everything else, we cannot expect it to ever
complete as it failed and we restarted the projection because the
failure.
- In the Core Projection, we might still be observing messages from the
message pump (CoreTick) from prior to restarting the projection, in this
case it could be while the projection is in a loading state. In this
case, we just explicitly check for it and mark the tick as having been
processed to ensure that it's in a prestine state waiting for the next
processing to happen.

## 1. Projection writes a checkpoint with a WrongExpectedVersion

Reproduction Steps
- Manually write a valid checkpoint event to the projection's checkpoint
stream
- Write enough events for the projection to checkpoint and watch it
attempt to restart itself because of the WrongExpectedVersion
- The Projection will no longer process any events but merely buffer
them.

## 2. After restart a projection still attempts to process writes coming
back from before the restart

Reproduction Steps
- Slow down writes to the projection's designated stream.
e.g. $et-TakeSomeSpaceEvent in the StorageWriterService
- Ensure that the EmittedStream for the Projection fails to write a set
of events due to a WrongExpectedVersion
- Watch the projection attempt to restart itself and note a couple of
issues

- The Checkpoint Manager receives progress updates while it's still
initializing
- The Core Projection is on a restart not resetting some of it's state
such as the fact that it cannot have a pending checkpoint work item as
we have restarted the projection
- The core projection pump (CoreTick) could potentially have been
scheduled which will throw since the CoreProjection is still starting up

- Where are the tests?

I attempted to write a test but the test setup does not replicate the
issues as described above. This needs to be investigated and corrected
as making these changes without tests is scary