### PR TITLE
Projection Processing Phase can be null

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
@@ -248,7 +248,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
         public void Handle(CoreProjectionManagementMessage.GetState message)
         {
-            if (_state == State.LoadStateRequested || _state == State.StateLoaded)
+            if (_state == State.LoadStateRequested || _state == State.StateLoaded || _projectionProcessingPhase == null)
             {
                 _publisher.Publish(
                     new CoreProjectionStatusMessage.StateReport(
@@ -265,7 +265,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
         public void Handle(CoreProjectionManagementMessage.GetResult message)
         {
-            if (_state == State.LoadStateRequested || _state == State.StateLoaded)
+            if (_state == State.LoadStateRequested || _state == State.StateLoaded || _projectionProcessingPhase == null)
             {
                 _publisher.Publish(
                     new CoreProjectionStatusMessage.ResultReport(


### PR DESCRIPTION
There are cases when the Processing Phase can be null, the check is to
ensure that the logs aren't filled with unecessary failed attempts at
getting state or result when the processing phase is null