### PR TITLE
1051 async OnEventAppeared

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedEventStorePersistentSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedEventStorePersistentSubscription.cs
@@ -10,7 +10,7 @@ namespace EventStore.ClientAPI.Embedded
 
         internal EmbeddedEventStorePersistentSubscription(
             string subscriptionId, string streamId,
-            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped,
             UserCredentials userCredentials, ILogger log, bool verboseLogging, ConnectionSettings settings,
             EmbeddedSubscriber subscriptions,
@@ -24,7 +24,7 @@ namespace EventStore.ClientAPI.Embedded
 
         internal override Task<PersistentEventStoreSubscription> StartSubscription(
             string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials,
-            Action<EventStoreSubscription, ResolvedEvent> onEventAppeared,
+            Func<EventStoreSubscription, ResolvedEvent, Task> onEventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> onSubscriptionDropped,
             ConnectionSettings settings)
         {

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
@@ -6,7 +6,6 @@ using EventStore.Core.Authentication;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.UserManagement;
 
 namespace EventStore.ClientAPI.Embedded
 {
@@ -22,7 +21,7 @@ namespace EventStore.ClientAPI.Embedded
             ILogger log, IPublisher publisher, Guid connectionId,
             TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId,
             UserCredentials userCredentials, IAuthenticationProvider authenticationProvider, int bufferSize,
-            Action<EventStoreSubscription, ResolvedEvent> eventAppeared,
+            Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries,
             TimeSpan operationTimeout)
             : base(log, publisher, connectionId, source, streamId, eventAppeared, subscriptionDropped)

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriber.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriber.cs
@@ -79,7 +79,7 @@ namespace EventStore.ClientAPI.Embedded
             subscription.ConfirmSubscription(lastCommitPosition, lastEventNumber);
         }
 
-        public void StartSubscription(Guid correlationId, TaskCompletionSource<EventStoreSubscription> source, string stream, UserCredentials userCredentials, bool resolveLinkTos, Action<EventStoreSubscription, ResolvedEvent> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped)
+        public void StartSubscription(Guid correlationId, TaskCompletionSource<EventStoreSubscription> source, string stream, UserCredentials userCredentials, bool resolveLinkTos, Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped)
         {
             var subscription = new EmbeddedSubscription(
                 _log, _publisher, _connectionId, source, stream, userCredentials, _authenticationProvider,
@@ -89,7 +89,7 @@ namespace EventStore.ClientAPI.Embedded
             _subscriptions.StartSubscription(correlationId, subscription);
         }
 
-        public void StartPersistentSubscription(Guid correlationId, TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId, UserCredentials userCredentials, int bufferSize, Action<EventStoreSubscription, ResolvedEvent> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries, TimeSpan operationTimeout)
+        public void StartPersistentSubscription(Guid correlationId, TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId, UserCredentials userCredentials, int bufferSize, Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries, TimeSpan operationTimeout)
         {
             var subscription = new EmbeddedPersistentSubscription(_log, _publisher, _connectionId, source,
                 subscriptionId, streamId, userCredentials, _authenticationProvider, bufferSize, eventAppeared,

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscription.cs
@@ -1,9 +1,5 @@
 using System;
-using System.Collections.Concurrent;
-using System.Threading;
 using System.Threading.Tasks;
-using EventStore.ClientAPI.Common.Utils;
-using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.SystemData;
 using EventStore.Core.Authentication;
 using EventStore.Core.Bus;
@@ -22,7 +18,7 @@ namespace EventStore.ClientAPI.Embedded
         public EmbeddedSubscription(
             ILogger log, IPublisher publisher, Guid connectionId, TaskCompletionSource<EventStoreSubscription> source,
             string streamId, UserCredentials userCredentials, IAuthenticationProvider authenticationProvider,
-            bool resolveLinkTos, Action<EventStoreSubscription, ResolvedEvent> eventAppeared,
+            bool resolveLinkTos, Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped)
             : base(log, publisher, connectionId, source, streamId, eventAppeared, subscriptionDropped)
         {

--- a/src/EventStore.ClientAPI.Embedded/IEmbeddedSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/IEmbeddedSubscription.cs
@@ -1,11 +1,12 @@
 using System;
+using System.Threading.Tasks;
 
 namespace EventStore.ClientAPI.Embedded
 {
     internal interface IEmbeddedSubscription
     {
         void DropSubscription(EventStore.Core.Services.SubscriptionDropReason reason, Exception ex = null);
-        void EventAppeared(EventStore.Core.Data.ResolvedEvent resolvedEvent);
+        Task EventAppeared(EventStore.Core.Data.ResolvedEvent resolvedEvent);
         void ConfirmSubscription(long lastCommitPosition, long? lastEventNumber);
         void Unsubscribe();
         void Start(Guid correlationId);

--- a/src/EventStore.ClientAPI/ClientOperations/ConnectToPersistentSubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/ConnectToPersistentSubscriptionOperation.cs
@@ -15,7 +15,7 @@ namespace EventStore.ClientAPI.ClientOperations
         private readonly int _bufferSize;
         private string _subscriptionId;
 
-        public ConnectToPersistentSubscriptionOperation(ILogger log, TaskCompletionSource<PersistentEventStoreSubscription> source, string groupName, int bufferSize, string streamId, UserCredentials userCredentials, Action<PersistentEventStoreSubscription, ResolvedEvent> eventAppeared, Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, bool verboseLogging, Func<TcpPackageConnection> getConnection)
+        public ConnectToPersistentSubscriptionOperation(ILogger log, TaskCompletionSource<PersistentEventStoreSubscription> source, string groupName, int bufferSize, string streamId, UserCredentials userCredentials, Func<PersistentEventStoreSubscription, ResolvedEvent, Task> eventAppeared, Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, bool verboseLogging, Func<TcpPackageConnection> getConnection)
             : base(log, source, streamId, false, userCredentials, eventAppeared, subscriptionDropped, verboseLogging, getConnection)
         {
             _groupName = groupName;

--- a/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
@@ -17,7 +17,7 @@ namespace EventStore.ClientAPI.ClientOperations
         protected readonly string _streamId;
         protected readonly bool _resolveLinkTos;
         protected readonly UserCredentials _userCredentials;
-        protected readonly Action<T, ResolvedEvent> _eventAppeared;
+        protected readonly Func<T, ResolvedEvent, Task> _eventAppeared;
         private readonly Action<T, SubscriptionDropReason, Exception> _subscriptionDropped;
         private readonly bool _verboseLogging;
         protected readonly Func<TcpPackageConnection> _getConnection;
@@ -33,7 +33,7 @@ namespace EventStore.ClientAPI.ClientOperations
                                      string streamId,
                                      bool resolveLinkTos,
                                      UserCredentials userCredentials,
-                                     Action<T, ResolvedEvent> eventAppeared,
+                                     Func<T, ResolvedEvent, Task> eventAppeared,
                                      Action<T, SubscriptionDropReason, Exception> subscriptionDropped,
                                      bool verboseLogging,
                                      Func<TcpPackageConnection> getConnection)
@@ -208,7 +208,7 @@ namespace EventStore.ClientAPI.ClientOperations
 
                 if (reason != SubscriptionDropReason.UserInitiated)
                 {
-                    var er = exc != null ? exc : new Exception(String.Format("Subscription dropped for {0}", reason));
+                    var er = exc ?? new Exception(String.Format("Subscription dropped for {0}", reason));
                     _source.TrySetException(er);
                 }
 
@@ -223,7 +223,7 @@ namespace EventStore.ClientAPI.ClientOperations
         protected void ConfirmSubscription(long lastCommitPosition, long? lastEventNumber)
         {
             if (lastCommitPosition < -1)
-                throw new ArgumentOutOfRangeException("lastCommitPosition", string.Format("Invalid lastCommitPosition {0} on subscription confirmation.", lastCommitPosition));
+                throw new ArgumentOutOfRangeException(nameof(lastCommitPosition), string.Format("Invalid lastCommitPosition {0} on subscription confirmation.", lastCommitPosition));
             if (_subscription != null)
                 throw new Exception("Double confirmation of subscription.");
 

--- a/src/EventStore.ClientAPI/ClientOperations/VolatileSubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/VolatileSubscriptionOperation.cs
@@ -9,7 +9,7 @@ namespace EventStore.ClientAPI.ClientOperations
 {
     internal class VolatileSubscriptionOperation : SubscriptionOperation<EventStoreSubscription>
     {
-        public VolatileSubscriptionOperation(ILogger log, TaskCompletionSource<EventStoreSubscription> source, string streamId, bool resolveLinkTos, UserCredentials userCredentials, Action<EventStoreSubscription, ResolvedEvent> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, bool verboseLogging, Func<TcpPackageConnection> getConnection)
+        public VolatileSubscriptionOperation(ILogger log, TaskCompletionSource<EventStoreSubscription> source, string streamId, bool resolveLinkTos, UserCredentials userCredentials, Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, bool verboseLogging, Func<TcpPackageConnection> getConnection)
             : base(log, source, streamId, resolveLinkTos, userCredentials, eventAppeared, subscriptionDropped, verboseLogging, getConnection)
         {
         }

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Exceptions\UserCommandConflictException.cs" />
     <Compile Include="Exceptions\UserCommandFailedException.cs" />
     <Compile Include="IConnectToPersistentSubscriptions.cs" />
+    <Compile Include="IEventStoreConnectionExtensions.cs" />
     <Compile Include="Internal\Consts.cs" />
     <Compile Include="Internal\Empty.cs" />
     <Compile Include="Internal\EventStoreNodeConnection.cs" />

--- a/src/EventStore.ClientAPI/EventStorePersistentSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscription.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using EventStore.ClientAPI.Common.Utils.Threading;
 using EventStore.ClientAPI.Internal;
 using EventStore.ClientAPI.SystemData;
 
@@ -15,7 +14,7 @@ namespace EventStore.ClientAPI
 
         internal EventStorePersistentSubscription(
             string subscriptionId, string streamId,
-            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped,
             UserCredentials userCredentials, ILogger log, bool verboseLogging, ConnectionSettings settings,
             EventStoreConnectionLogicHandler handler, int bufferSize = 10, bool autoAck = true)
@@ -27,7 +26,8 @@ namespace EventStore.ClientAPI
         }
 
         internal override Task<PersistentEventStoreSubscription> StartSubscription(
-            string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials, Action<EventStoreSubscription, ResolvedEvent> onEventAppeared,
+            string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials,
+            Func<EventStoreSubscription, ResolvedEvent, Task> onEventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> onSubscriptionDropped, ConnectionSettings settings)
         {
             var source = new TaskCompletionSource<PersistentEventStoreSubscription>();

--- a/src/EventStore.ClientAPI/EventStoreSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreSubscription.cs
@@ -11,11 +11,11 @@ namespace EventStore.ClientAPI
         /// <summary>
         /// True if this subscription is to all streams.
         /// </summary>
-        public bool IsSubscribedToAll { get { return _streamId == string.Empty; } }
+        public bool IsSubscribedToAll { get { return StreamId == string.Empty; } }
         /// <summary>
         /// The name of the stream to which the subscription is subscribed.
         /// </summary>
-        public string StreamId { get { return _streamId; } }
+        public string StreamId { get; }
         /// <summary>
         /// The last commit position seen on the subscription (if this is
         /// a subscription to all events).
@@ -27,11 +27,9 @@ namespace EventStore.ClientAPI
         /// </summary>
         public readonly long? LastEventNumber;
 
-        private readonly string _streamId;
-
         internal EventStoreSubscription(string streamId, long lastCommitPosition, long? lastEventNumber)
         {
-            _streamId = streamId;
+            StreamId = streamId;
             LastCommitPosition = lastCommitPosition;
             LastEventNumber = lastEventNumber;
         }

--- a/src/EventStore.ClientAPI/IEventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnection.cs
@@ -221,14 +221,14 @@ namespace EventStore.ClientAPI
         /// </summary>
         /// <param name="stream">The stream to subscribe to</param>
         /// <param name="resolveLinkTos">Whether to resolve Link events automatically</param>
-        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
         /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
         Task<EventStoreSubscription> SubscribeToStreamAsync(
                 string stream,
                 bool resolveLinkTos,
-                Action<EventStoreSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null);
 
@@ -257,7 +257,7 @@ namespace EventStore.ClientAPI
         /// NOTE: Using <see cref="StreamPosition.Start" /> here will result in missing
         /// the first event in the stream.</param>
         /// <param name="resolveLinkTos">Whether to resolve Link events automatically</param>
-        /// <param name="eventAppeared">An action invoked when an event is received over the subscription</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
@@ -269,7 +269,7 @@ namespace EventStore.ClientAPI
                 string stream,
                 long? lastCheckpoint,
                 bool resolveLinkTos,
-                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreCatchUpSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null,
@@ -300,7 +300,7 @@ namespace EventStore.ClientAPI
         ///
         /// NOTE: Using <see cref="StreamPosition.Start" /> here will result in missing
         /// the first event in the stream.</param>
-        /// <param name="eventAppeared">An action invoked when an event is received over the subscription</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
@@ -310,7 +310,7 @@ namespace EventStore.ClientAPI
                 string stream,
                 long? lastCheckpoint,
                 CatchUpSubscriptionSettings settings,
-                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreCatchUpSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null);
@@ -323,13 +323,13 @@ namespace EventStore.ClientAPI
         /// will be pushed to the client.
         /// </summary>
         /// <param name="resolveLinkTos">Whether to resolve Link events automatically</param>
-        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
         /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
         Task<EventStoreSubscription> SubscribeToAllAsync(
                 bool resolveLinkTos,
-                Action<EventStoreSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null);
 
@@ -338,7 +338,7 @@ namespace EventStore.ClientAPI
         /// </summary>
         /// <param name="groupName">The subscription group to connect to</param>
         /// <param name="stream">The stream to subscribe to</param>
-        /// <param name="eventAppeared">An action invoked when an event appears</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
         /// <param name="bufferSize">The buffer size to use for the persistent subscription</param>
@@ -354,7 +354,7 @@ namespace EventStore.ClientAPI
         EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(
             string stream,
             string groupName,
-            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
             int bufferSize = 10,
@@ -365,7 +365,7 @@ namespace EventStore.ClientAPI
         /// </summary>
         /// <param name="groupName">The subscription group to connect to</param>
         /// <param name="stream">The stream to subscribe to</param>
-        /// <param name="eventAppeared">An action invoked when an event appears</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
         /// <param name="bufferSize">The buffer size to use for the persistent subscription</param>
@@ -381,7 +381,7 @@ namespace EventStore.ClientAPI
         Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
             string stream,
             string groupName,
-            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
             int bufferSize = 10,
@@ -392,7 +392,7 @@ namespace EventStore.ClientAPI
         /// Subscribes a persistent subscription (competing consumer) to all events in the event store
         /// </summary>
         /// <param name="groupName">The subscription group to connect to</param>
-        /// <param name="eventAppeared">An action invoked when an event appears</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
         /// <param name="bufferSize">The buffer size to use for the persistent subscription</param>
@@ -437,7 +437,7 @@ namespace EventStore.ClientAPI
         /// NOTE: Using <see cref="Position.Start" /> here will result in missing
         /// the first event in the stream.</param>
         /// <param name="resolveLinkTos">Whether to resolve Link events automatically</param>
-        /// <param name="eventAppeared">An action invoked when an event is received over the subscription</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
@@ -448,7 +448,7 @@ namespace EventStore.ClientAPI
         EventStoreAllCatchUpSubscription SubscribeToAllFrom(
                 Position? lastCheckpoint,
                 bool resolveLinkTos,
-                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreCatchUpSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null,
@@ -477,7 +477,7 @@ namespace EventStore.ClientAPI
         ///
         /// NOTE: Using <see cref="Position.Start" /> here will result in missing
         /// the first event in the stream.</param>
-        /// <param name="eventAppeared">An action invoked when an event is received over the subscription</param>
+        /// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription</param>
         /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events</param>
         /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
         /// <param name="userCredentials">User credentials to use for the operation</param>
@@ -486,7 +486,7 @@ namespace EventStore.ClientAPI
         EventStoreAllCatchUpSubscription SubscribeToAllFrom(
                 Position? lastCheckpoint,
                 CatchUpSubscriptionSettings settings,
-                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreCatchUpSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null);

--- a/src/EventStore.ClientAPI/IEventStoreConnectionExtensions.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnectionExtensions.cs
@@ -1,0 +1,351 @@
+﻿using System;
+using System.Threading.Tasks;
+using EventStore.ClientAPI.SystemData;
+
+namespace EventStore.ClientAPI
+{
+    /// <summary>
+    /// Extensions for <seealso cref="IEventStoreConnection"/>
+    /// </summary>
+    public static class IEventStoreConnectionExtensions
+    {
+
+        private static Func<TConnection, ResolvedEvent, Task> ToTask<TConnection>(Action<TConnection, ResolvedEvent> eventAppeared) =>
+                            (subscription, e) =>
+                            {
+                                eventAppeared(subscription, e);
+                                return Task.CompletedTask;
+                            };
+
+        /// <summary>
+        /// Asynchronously subscribes to a single event stream. New events
+        /// written to the stream while the subscription is active will be
+        /// pushed to the client.
+        /// </summary>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="stream">The stream to subscribe to</param>
+        /// <param name="resolveLinkTos">Whether to resolve Link events automatically</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
+        public static Task<EventStoreSubscription> SubscribeToStreamAsync(
+                this IEventStoreConnection target,
+                string stream,
+                bool resolveLinkTos,
+                Action<EventStoreSubscription, ResolvedEvent> eventAppeared,
+                Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null) =>
+                    target.SubscribeToStreamAsync(
+                                    stream,
+                                    resolveLinkTos,
+                                    ToTask(eventAppeared),
+                                    subscriptionDropped,
+                                    userCredentials
+                                    );
+
+        /// <summary>
+        /// Subscribes to a single event stream. Existing events from
+        /// lastCheckpoint onwards are read from the stream
+        /// and presented to the user of <see cref="EventStoreCatchUpSubscription"/>
+        /// as if they had been pushed.
+        ///
+        /// Once the end of the stream is read the subscription is
+        /// transparently (to the user) switched to push new events as
+        /// they are written.
+        ///
+        /// The action liveProcessingStarted is called when the
+        /// <see cref="EventStoreCatchUpSubscription"/> switches from the reading
+        /// phase to the live subscription phase.
+        /// </summary>
+        /// <param name="stream">The stream to subscribe to</param>
+        /// <param name="lastCheckpoint">The event number from which to start.
+        ///
+        /// To receive all events in the stream, use <see cref="StreamCheckpoint.StreamStart" />.
+        /// If events have already been received and resubscription from the same point
+        /// is desired, use the event number of the last event processed which
+        /// appeared on the subscription.
+        ///
+        /// NOTE: Using <see cref="StreamPosition.Start" /> here will result in missing
+        /// the first event in the stream.</param>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="resolveLinkTos">Whether to resolve Link events automatically</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="readBatchSize">The batch size to use during the read phase</param>
+        /// <param name="subscriptionName">The name of subscription</param>
+        /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
+        [Obsolete("This method will be obsoleted in the next major version please switch to the overload with a settings object")]
+        public static EventStoreStreamCatchUpSubscription SubscribeToStreamFrom(
+                this IEventStoreConnection target,
+                string stream,
+                long? lastCheckpoint,
+                bool resolveLinkTos,
+                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
+                Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null,
+                int readBatchSize = 500,
+                string subscriptionName = "") =>
+            target.SubscribeToStreamFrom(
+                stream,
+                lastCheckpoint,
+                resolveLinkTos,
+                ToTask(eventAppeared),
+                liveProcessingStarted,
+                subscriptionDropped,
+                userCredentials,
+                readBatchSize,
+                subscriptionName
+                );
+
+        /// <summary>
+        /// Subscribes to a single event stream. Existing events from
+        /// lastCheckpoint onwards are read from the stream
+        /// and presented to the user of <see cref="EventStoreCatchUpSubscription"/>
+        /// as if they had been pushed.
+        ///
+        /// Once the end of the stream is read the subscription is
+        /// transparently (to the user) switched to push new events as
+        /// they are written.
+        ///
+        /// The action liveProcessingStarted is called when the
+        /// <see cref="EventStoreCatchUpSubscription"/> switches from the reading
+        /// phase to the live subscription phase.
+        /// </summary>
+        /// <param name="stream">The stream to subscribe to</param>
+        /// <param name="lastCheckpoint">The event number from which to start.
+        ///
+        /// To receive all events in the stream, use <see cref="StreamCheckpoint.StreamStart" />.
+        /// If events have already been received and resubscription from the same point
+        /// is desired, use the event number of the last event processed which
+        /// appeared on the subscription.
+        ///
+        /// NOTE: Using <see cref="StreamPosition.Start" /> here will result in missing
+        /// the first event in the stream.</param>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="settings">The <see cref="CatchUpSubscriptionSettings"/> for the subscription</param>
+        /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
+        public static EventStoreStreamCatchUpSubscription SubscribeToStreamFrom(
+                this IEventStoreConnection target,
+                string stream,
+                long? lastCheckpoint,
+                CatchUpSubscriptionSettings settings,
+                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
+                Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null) =>
+            target.SubscribeToStreamFrom(
+                stream,
+                lastCheckpoint,
+                settings,
+                ToTask(eventAppeared),
+                liveProcessingStarted,
+                subscriptionDropped,
+                userCredentials
+                );
+
+        /// <summary>
+        /// Asynchronously subscribes to all events in the Event Store. New
+        /// events written to the stream while the subscription is active
+        /// will be pushed to the client.
+        /// </summary>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="resolveLinkTos">Whether to resolve Link events automatically</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
+        public static Task<EventStoreSubscription> SubscribeToAllAsync(
+                this IEventStoreConnection target,
+                bool resolveLinkTos,
+                Action<EventStoreSubscription, ResolvedEvent> eventAppeared,
+                Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null) =>
+            target.SubscribeToAllAsync(
+                resolveLinkTos,
+                ToTask(eventAppeared),
+                subscriptionDropped,
+                userCredentials
+                );
+
+        /// <summary>
+        /// Subscribes to a persistent subscription(competing consumer) on event store
+        /// </summary>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="groupName">The subscription group to connect to</param>
+        /// <param name="stream">The stream to subscribe to</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="bufferSize">The buffer size to use for the persistent subscription</param>
+        /// <param name="autoAck">Whether the subscription should automatically acknowledge messages processed.
+        /// If not set the receiver is required to explicitly acknowledge messages through the subscription.</param>
+        /// <remarks>This will connect you to a persistent subscription group for a stream. The subscription group
+        /// must first be created with CreatePersistentSubscriptionAsync many connections
+        /// can connect to the same group and they will be treated as competing consumers within the group.
+        /// If one connection dies work will be balanced across the rest of the consumers in the group. If
+        /// you attempt to connect to a group that does not exist you will be given an exception.
+        /// </remarks>
+        /// <returns>An <see cref="EventStorePersistentSubscriptionBase"/> representing the subscription</returns>
+        public static EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(
+                this IEventStoreConnection target,
+                string stream,
+                string groupName,
+                Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+                Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null,
+                int bufferSize = 10,
+                bool autoAck = true) =>
+            target.ConnectToPersistentSubscription(
+                stream,
+                groupName,
+                ToTask(eventAppeared),
+                subscriptionDropped,
+                userCredentials,
+                bufferSize,
+                autoAck
+                );
+
+        /// <summary>
+        /// Asynchronously subscribes to a persistent subscription(competing consumer) on event store
+        /// </summary>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="groupName">The subscription group to connect to</param>
+        /// <param name="stream">The stream to subscribe to</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="bufferSize">The buffer size to use for the persistent subscription</param>
+        /// <param name="autoAck">Whether the subscription should automatically acknowledge messages processed.
+        /// If not set the receiver is required to explicitly acknowledge messages through the subscription.</param>
+        /// <remarks>This will connect you to a persistent subscription group for a stream. The subscription group
+        /// must first be created with CreatePersistentSubscriptionAsync many connections
+        /// can connect to the same group and they will be treated as competing consumers within the group.
+        /// If one connection dies work will be balanced across the rest of the consumers in the group. If
+        /// you attempt to connect to a group that does not exist you will be given an exception.
+        /// </remarks>
+        /// <returns>An <see cref="EventStorePersistentSubscriptionBase"/> representing the subscription</returns>
+        public static Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
+                this IEventStoreConnection target,
+                string stream,
+                string groupName,
+                Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+                Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null,
+                int bufferSize = 10,
+                bool autoAck = true) =>
+            target.ConnectToPersistentSubscriptionAsync(
+                stream,
+                groupName,
+                ToTask(eventAppeared),
+                subscriptionDropped,
+                userCredentials,
+                bufferSize,
+                autoAck
+                );
+
+        /// <summary>
+        /// Subscribes to all events. Existing events from lastCheckpoint
+        /// onwards are read from the Event Store and presented to the user of
+        /// <see cref="EventStoreCatchUpSubscription"/> as if they had been pushed.
+        ///
+        /// Once the end of the stream is read the subscription is
+        /// transparently (to the user) switched to push new events as
+        /// they are written.
+        ///
+        /// The action liveProcessingStarted is called when the
+        /// <see cref="EventStoreCatchUpSubscription"/> switches from the reading
+        /// phase to the live subscription phase.
+        /// </summary>
+        /// <param name="lastCheckpoint">The position from which to start.
+        ///
+        /// To receive all events in the database, use <see cref="AllCheckpoint.AllStart" />.
+        /// If events have already been received and resubscription from the same point
+        /// is desired, use the position representing the last event processed which
+        /// appeared on the subscription.
+        ///
+        /// NOTE: Using <see cref="Position.Start" /> here will result in missing
+        /// the first event in the stream.</param>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="resolveLinkTos">Whether to resolve Link events automatically</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="readBatchSize">The batch size to use during the read phase</param>
+        /// <param name="subscriptionName">The name of subscription</param>
+        /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
+        [Obsolete("This overload will be removed in the next major release please use the overload with a settings object")]
+        public static EventStoreAllCatchUpSubscription SubscribeToAllFrom(
+                this IEventStoreConnection target,
+                Position? lastCheckpoint,
+                bool resolveLinkTos,
+                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
+                Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null,
+                int readBatchSize = 500,
+                string subscriptionName = "") =>
+            target.SubscribeToAllFrom(
+                lastCheckpoint,
+                resolveLinkTos,
+                ToTask(eventAppeared),
+                liveProcessingStarted,
+                subscriptionDropped,
+                userCredentials
+                );
+
+        /// <summary>
+        /// Subscribes to a all events. Existing events from lastCheckpoint
+        /// onwards are read from the Event Store and presented to the user of
+        /// <see cref="EventStoreCatchUpSubscription"/> as if they had been pushed.
+        ///
+        /// Once the end of the stream is read the subscription is
+        /// transparently (to the user) switched to push new events as
+        /// they are written.
+        ///
+        /// The action liveProcessingStarted is called when the
+        /// <see cref="EventStoreCatchUpSubscription"/> switches from the reading
+        /// phase to the live subscription phase.
+        /// </summary>
+        /// <param name="lastCheckpoint">The position from which to start.
+        ///
+        /// To receive all events in the database, use <see cref="AllCheckpoint.AllStart" />.
+        /// If events have already been received and resubscription from the same point
+        /// is desired, use the position representing the last event processed which
+        /// appeared on the subscription.
+        ///
+        /// NOTE: Using <see cref="Position.Start" /> here will result in missing
+        /// the first event in the stream.</param>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="liveProcessingStarted">An action invoked when the subscription switches to newly-pushed events</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="settings">The <see cref="CatchUpSubscriptionSettings"/> for the subscription</param>
+        /// <returns>An <see cref="EventStoreSubscription"/> representing the subscription</returns>
+        public static EventStoreAllCatchUpSubscription SubscribeToAllFrom(
+                this IEventStoreConnection target,
+                Position? lastCheckpoint,
+                CatchUpSubscriptionSettings settings,
+                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
+                Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null) =>
+            target.SubscribeToAllFrom(
+                lastCheckpoint,
+                settings,
+                ToTask(eventAppeared),
+                liveProcessingStarted,
+                subscriptionDropped,
+                userCredentials
+                );
+    }
+}

--- a/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
@@ -122,14 +122,12 @@ namespace EventStore.ClientAPI.Internal
                 if (t.IsFaulted)
                 {
                     EnqueueMessage(new CloseConnectionMessage("Failed to resolve TCP end point to which to connect.", t.Exception));
-                    if (completionTask != null)
-                        completionTask.SetException(new CannotEstablishConnectionException("Cannot resolve target end point.", t.Exception));
+                    completionTask?.SetException(new CannotEstablishConnectionException("Cannot resolve target end point.", t.Exception));
                 }
                 else
                 {
                     EnqueueMessage(new EstablishTcpConnectionMessage(t.Result));
-                    if (completionTask != null)
-                        completionTask.SetResult(null);
+                    completionTask?.SetResult(null);
                 }
             });
         }
@@ -324,7 +322,7 @@ namespace EventStore.ClientAPI.Internal
                     }
                     if (_connectingPhase == ConnectingPhase.Identification && _stopwatch.Elapsed - _identifyInfo.TimeStamp >= _settings.OperationTimeout)
                     {
-                        string msg = "Timed out waiting for client to be identified";
+                        const string msg = "Timed out waiting for client to be identified";
                         LogDebug(msg);
                         CloseTcpConnection(msg);
                     }

--- a/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
@@ -26,29 +26,19 @@ namespace EventStore.ClientAPI.Internal
     /// </remarks>
     internal class EventStoreNodeConnection : IEventStoreConnection, IEventStoreTransactionConnection
     {
-        public string ConnectionName { get { return _connectionName; } }
-
-        private readonly string _connectionName;
-        private readonly ConnectionSettings _settings;
-        private readonly ClusterSettings _clusterSettings;
+        public string ConnectionName { get; }
         private readonly IEndPointDiscoverer _endPointDiscoverer;
         private readonly EventStoreConnectionLogicHandler _handler;
 
         /// <summary>
         /// Returns the <see cref="ConnectionSettings"/> use to create this connection
         /// </summary>
-        public ConnectionSettings Settings
-        {
-            get { return _settings; }
-        }
+        public ConnectionSettings Settings { get; }
 
         /// <summary>
         /// Returns the <see cref="ClusterSettings"/> use to create this connection
         /// </summary>
-        public ClusterSettings ClusterSettings
-        {
-            get { return _clusterSettings; }
-        }
+        public ClusterSettings ClusterSettings { get; }
 
         /// <summary>
         /// Constructs a new instance of a <see cref="EventStoreConnection"/>
@@ -62,9 +52,9 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(settings, "settings");
             Ensure.NotNull(endPointDiscoverer, "endPointDiscoverer");
 
-            _connectionName = connectionName ?? string.Format("ES-{0}", Guid.NewGuid());
-            _settings = settings;
-            _clusterSettings = clusterSettings;
+            ConnectionName = connectionName ?? string.Format("ES-{0}", Guid.NewGuid());
+            Settings = settings;
+            ClusterSettings = clusterSettings;
             _endPointDiscoverer = endPointDiscoverer;
             _handler = new EventStoreConnectionLogicHandler(this, settings);
         }
@@ -96,7 +86,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
 
             var source = new TaskCompletionSource<DeleteResult>();
-            EnqueueOperation(new DeleteStreamOperation(_settings.Log, source, _settings.RequireMaster,
+            EnqueueOperation(new DeleteStreamOperation(Settings.Log, source, Settings.RequireMaster,
                                                        stream, expectedVersion, hardDelete, userCredentials));
             return source.Task;
         }
@@ -124,7 +114,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(events, "events");
 
             var source = new TaskCompletionSource<WriteResult>();
-            EnqueueOperation(new AppendToStreamOperation(_settings.Log, source, _settings.RequireMaster,
+            EnqueueOperation(new AppendToStreamOperation(Settings.Log, source, Settings.RequireMaster,
                                                          stream, expectedVersion, events, userCredentials));
             return source.Task;
 // ReSharper restore PossibleMultipleEnumeration
@@ -138,7 +128,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(events, "events");
 
             var source = new TaskCompletionSource<ConditionalWriteResult>();
-            EnqueueOperation(new ConditionalAppendToStreamOperation(_settings.Log, source, _settings.RequireMaster,
+            EnqueueOperation(new ConditionalAppendToStreamOperation(Settings.Log, source, Settings.RequireMaster,
                                                          stream, expectedVersion, events, userCredentials));
             return source.Task;
             // ReSharper restore PossibleMultipleEnumeration
@@ -149,7 +139,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
 
             var source = new TaskCompletionSource<EventStoreTransaction>();
-            EnqueueOperation(new StartTransactionOperation(_settings.Log, source, _settings.RequireMaster,
+            EnqueueOperation(new StartTransactionOperation(Settings.Log, source, Settings.RequireMaster,
                                                            stream, expectedVersion, this, userCredentials));
             return source.Task;
         }
@@ -167,7 +157,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(events, "events");
 
             var source = new TaskCompletionSource<object>();
-            EnqueueOperation(new TransactionalWriteOperation(_settings.Log, source, _settings.RequireMaster,
+            EnqueueOperation(new TransactionalWriteOperation(Settings.Log, source, Settings.RequireMaster,
                                                              transaction.TransactionId, events, userCredentials));
             return source.Task;
 // ReSharper restore PossibleMultipleEnumeration
@@ -178,7 +168,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(transaction, "transaction");
 
             var source = new TaskCompletionSource<WriteResult>();
-            EnqueueOperation(new CommitTransactionOperation(_settings.Log, source, _settings.RequireMaster,
+            EnqueueOperation(new CommitTransactionOperation(Settings.Log, source, Settings.RequireMaster,
                                                             transaction.TransactionId, userCredentials));
             return source.Task;
         }
@@ -187,10 +177,10 @@ namespace EventStore.ClientAPI.Internal
         public Task<EventReadResult> ReadEventAsync(string stream, long eventNumber, bool resolveLinkTos, UserCredentials userCredentials = null)
         {
             Ensure.NotNullOrEmpty(stream, "stream");
-            if (eventNumber < -1) throw new ArgumentOutOfRangeException("eventNumber");
+            if (eventNumber < -1) throw new ArgumentOutOfRangeException(nameof(eventNumber));
             var source = new TaskCompletionSource<EventReadResult>();
-            var operation = new ReadEventOperation(_settings.Log, source, stream, eventNumber, resolveLinkTos,
-                                                   _settings.RequireMaster, userCredentials);
+            var operation = new ReadEventOperation(Settings.Log, source, stream, eventNumber, resolveLinkTos,
+                                                   Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
             return source.Task;
         }
@@ -202,8 +192,8 @@ namespace EventStore.ClientAPI.Internal
             Ensure.Positive(count, "count");
             if(count > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
             var source = new TaskCompletionSource<StreamEventsSlice>();
-            var operation = new ReadStreamEventsForwardOperation(_settings.Log, source, stream, start, count,
-                                                                 resolveLinkTos, _settings.RequireMaster, userCredentials);
+            var operation = new ReadStreamEventsForwardOperation(Settings.Log, source, stream, start, count,
+                                                                 resolveLinkTos, Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
             return source.Task;
         }
@@ -214,8 +204,8 @@ namespace EventStore.ClientAPI.Internal
             Ensure.Positive(count, "count");
             if (count > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
             var source = new TaskCompletionSource<StreamEventsSlice>();
-            var operation = new ReadStreamEventsBackwardOperation(_settings.Log, source, stream, start, count,
-                                                                  resolveLinkTos, _settings.RequireMaster, userCredentials);
+            var operation = new ReadStreamEventsBackwardOperation(Settings.Log, source, stream, start, count,
+                                                                  resolveLinkTos, Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
             return source.Task;
         }
@@ -225,8 +215,8 @@ namespace EventStore.ClientAPI.Internal
             Ensure.Positive(maxCount, "maxCount");
             if (maxCount > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
             var source = new TaskCompletionSource<AllEventsSlice>();
-            var operation = new ReadAllEventsForwardOperation(_settings.Log, source, position, maxCount,
-                                                              resolveLinkTos, _settings.RequireMaster, userCredentials);
+            var operation = new ReadAllEventsForwardOperation(Settings.Log, source, position, maxCount,
+                                                              resolveLinkTos, Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
             return source.Task;
         }
@@ -236,25 +226,25 @@ namespace EventStore.ClientAPI.Internal
             Ensure.Positive(maxCount, "maxCount");
             if (maxCount > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
             var source = new TaskCompletionSource<AllEventsSlice>();
-            var operation = new ReadAllEventsBackwardOperation(_settings.Log, source, position, maxCount,
-                                                               resolveLinkTos, _settings.RequireMaster, userCredentials);
+            var operation = new ReadAllEventsBackwardOperation(Settings.Log, source, position, maxCount,
+                                                               resolveLinkTos, Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
             return source.Task;
         }
 
         private void EnqueueOperation(IClientOperation operation)
         {
-            while (_handler.TotalOperationCount >= _settings.MaxQueueSize)
+            while (_handler.TotalOperationCount >= Settings.MaxQueueSize)
             {
                 Thread.Sleep(1);
             }
-            _handler.EnqueueMessage(new StartOperationMessage(operation, _settings.MaxRetries, _settings.OperationTimeout));
+            _handler.EnqueueMessage(new StartOperationMessage(operation, Settings.MaxRetries, Settings.OperationTimeout));
         }
 
         public Task<EventStoreSubscription> SubscribeToStreamAsync(
                 string stream,
                 bool resolveLinkTos,
-                Action<EventStoreSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null)
         {
@@ -264,14 +254,14 @@ namespace EventStore.ClientAPI.Internal
             var source = new TaskCompletionSource<EventStoreSubscription>();
             _handler.EnqueueMessage(new StartSubscriptionMessage(source, stream, resolveLinkTos, userCredentials,
                                                                  eventAppeared, subscriptionDropped,
-                                                                 _settings.MaxRetries, _settings.OperationTimeout));
+                                                                 Settings.MaxRetries, Settings.OperationTimeout));
             return source.Task;
         }
 
         public EventStoreStreamCatchUpSubscription SubscribeToStreamFrom(string stream,
                                                                          long? lastCheckpoint,
                                                                          bool resolveLinkTos,
-                                                                         Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                                                                         Func<EventStoreCatchUpSubscription, ResolvedEvent, Task> eventAppeared,
                                                                          Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                                                                          Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                                                                          UserCredentials userCredentials = null,
@@ -279,7 +269,7 @@ namespace EventStore.ClientAPI.Internal
                                                                          string subscriptionName = "")
         {
             var settings = new CatchUpSubscriptionSettings(Consts.CatchUpDefaultMaxPushQueueSize, readBatchSize,
-                                                                                    _settings.VerboseLogging,
+                                                                                    Settings.VerboseLogging,
                                                                                     resolveLinkTos,
                                                                                     subscriptionName);
             return SubscribeToStreamFrom(stream, lastCheckpoint, settings, eventAppeared, liveProcessingStarted, subscriptionDropped, userCredentials);
@@ -289,7 +279,7 @@ namespace EventStore.ClientAPI.Internal
                 string stream,
                 long? lastCheckpoint,
                 CatchUpSubscriptionSettings settings,
-                Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreCatchUpSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
                 Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null)
@@ -298,16 +288,16 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(settings, "settings");
             Ensure.NotNull(eventAppeared, "eventAppeared");
             var catchUpSubscription =
-                    new EventStoreStreamCatchUpSubscription(this, _settings.Log, stream, lastCheckpoint,
+                    new EventStoreStreamCatchUpSubscription(this, Settings.Log, stream, lastCheckpoint,
                                                             userCredentials, eventAppeared, liveProcessingStarted,
                                                             subscriptionDropped, settings);
-            catchUpSubscription.Start();
+            catchUpSubscription.StartAsync();
             return catchUpSubscription;
         }
 
         public Task<EventStoreSubscription> SubscribeToAllAsync(
                 bool resolveLinkTos,
-                Action<EventStoreSubscription, ResolvedEvent> eventAppeared,
+                Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
                 Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
                 UserCredentials userCredentials = null)
         {
@@ -316,14 +306,14 @@ namespace EventStore.ClientAPI.Internal
             var source = new TaskCompletionSource<EventStoreSubscription>();
             _handler.EnqueueMessage(new StartSubscriptionMessage(source, string.Empty, resolveLinkTos, userCredentials,
                                                                  eventAppeared, subscriptionDropped,
-                                                                 _settings.MaxRetries, _settings.OperationTimeout));
+                                                                 Settings.MaxRetries, Settings.OperationTimeout));
             return source.Task;
         }
 
         public EventStoreAllCatchUpSubscription SubscribeToAllFrom(
             Position? lastCheckpoint,
             bool resolveLinkTos,
-            Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+            Func<EventStoreCatchUpSubscription, ResolvedEvent, Task> eventAppeared,
             Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
             Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
@@ -331,14 +321,14 @@ namespace EventStore.ClientAPI.Internal
             string subscriptionName = "")
         {
             var settings = new CatchUpSubscriptionSettings(Consts.CatchUpDefaultMaxPushQueueSize, readBatchSize,
-                                                                                    _settings.VerboseLogging, resolveLinkTos, subscriptionName);
+                                                                                    Settings.VerboseLogging, resolveLinkTos, subscriptionName);
             return SubscribeToAllFrom(lastCheckpoint, settings,eventAppeared, liveProcessingStarted, subscriptionDropped, userCredentials);
         }
 
         public EventStoreAllCatchUpSubscription SubscribeToAllFrom(
             Position? lastCheckpoint,
             CatchUpSubscriptionSettings settings,
-            Action<EventStoreCatchUpSubscription, ResolvedEvent> eventAppeared,
+            Func<EventStoreCatchUpSubscription, ResolvedEvent, Task> eventAppeared,
             Action<EventStoreCatchUpSubscription> liveProcessingStarted = null,
             Action<EventStoreCatchUpSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null)
@@ -346,17 +336,17 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(eventAppeared, "eventAppeared");
             Ensure.NotNull(settings, "settings");
             var catchUpSubscription =
-                    new EventStoreAllCatchUpSubscription(this, _settings.Log, lastCheckpoint,
+                    new EventStoreAllCatchUpSubscription(this, Settings.Log, lastCheckpoint,
                                                          userCredentials, eventAppeared, liveProcessingStarted,
                                                          subscriptionDropped, settings);
-            catchUpSubscription.Start();
+            catchUpSubscription.StartAsync();
             return catchUpSubscription;
         }
 
         public EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(
             string stream,
             string groupName,
-            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
             int bufferSize = 10,
@@ -367,8 +357,8 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(eventAppeared, "eventAppeared");
 
             var subscription = new EventStorePersistentSubscription(
-                groupName, stream, eventAppeared, subscriptionDropped, userCredentials, _settings.Log,
-                _settings.VerboseLogging, _settings, _handler, bufferSize, autoAck);
+                groupName, stream, eventAppeared, subscriptionDropped, userCredentials, Settings.Log,
+                Settings.VerboseLogging, Settings, _handler, bufferSize, autoAck);
 
             subscription.Start().Wait();
             return subscription;
@@ -377,7 +367,7 @@ namespace EventStore.ClientAPI.Internal
         public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
             string stream,
             string groupName,
-            Action<EventStorePersistentSubscriptionBase, ResolvedEvent> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
             int bufferSize = 10,
@@ -388,8 +378,8 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(eventAppeared, "eventAppeared");
 
             var subscription = new EventStorePersistentSubscription(
-                groupName, stream, eventAppeared, subscriptionDropped, userCredentials, _settings.Log,
-                _settings.VerboseLogging, _settings, _handler, bufferSize, autoAck);
+                groupName, stream, eventAppeared, subscriptionDropped, userCredentials, Settings.Log,
+                Settings.VerboseLogging, Settings, _handler, bufferSize, autoAck);
 
             return subscription.Start();
         }
@@ -414,22 +404,22 @@ namespace EventStore.ClientAPI.Internal
         */
 
 
-        public Task CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials userCredentials = null) {
+        public Task CreatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials credentials = null) {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
             Ensure.NotNull(settings, "settings");
             var source = new TaskCompletionSource<PersistentSubscriptionCreateResult>();
-            EnqueueOperation(new CreatePersistentSubscriptionOperation(_settings.Log, source, stream, groupName, settings, userCredentials));
+            EnqueueOperation(new CreatePersistentSubscriptionOperation(Settings.Log, source, stream, groupName, settings, credentials));
             return source.Task;
         }
 
-        public Task UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials userCredentials = null)
+        public Task UpdatePersistentSubscriptionAsync(string stream, string groupName, PersistentSubscriptionSettings settings, UserCredentials credentials = null)
         {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
             Ensure.NotNull(settings, "settings");
             var source = new TaskCompletionSource<PersistentSubscriptionUpdateResult>();
-            EnqueueOperation(new UpdatePersistentSubscriptionOperation(_settings.Log, source, stream, groupName, settings, userCredentials));
+            EnqueueOperation(new UpdatePersistentSubscriptionOperation(Settings.Log, source, stream, groupName, settings, credentials));
             return source.Task;
         }
 /*
@@ -448,7 +438,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
             var source = new TaskCompletionSource<PersistentSubscriptionDeleteResult>();
-            EnqueueOperation(new DeletePersistentSubscriptionOperation(_settings.Log, source, stream, groupName, userCredentials));
+            EnqueueOperation(new DeletePersistentSubscriptionOperation(Settings.Log, source, stream, groupName, userCredentials));
             return source.Task;
         }
 /*
@@ -472,14 +462,14 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.NotNullOrEmpty(stream, "stream");
             if (SystemStreams.IsMetastream(stream))
-                throw new ArgumentException(string.Format("Setting metadata for metastream '{0}' is not supported.", stream), "stream");
+                throw new ArgumentException(string.Format("Setting metadata for metastream '{0}' is not supported.", stream), nameof(stream));
 
             var source = new TaskCompletionSource<WriteResult>();
 
             var metaevent = new EventData(Guid.NewGuid(), SystemEventTypes.StreamMetadata, true, metadata ?? Empty.ByteArray, null);
-            EnqueueOperation(new AppendToStreamOperation(_settings.Log,
+            EnqueueOperation(new AppendToStreamOperation(Settings.Log,
                                                          source,
-                                                         _settings.RequireMaster,
+                                                         Settings.RequireMaster,
                                                          SystemStreams.MetastreamOf(stream),
                                                          expectedMetastreamVersion,
                                                          new[] { metaevent },

--- a/src/EventStore.ClientAPI/Internal/Messages.cs
+++ b/src/EventStore.ClientAPI/Internal/Messages.cs
@@ -99,7 +99,7 @@ namespace EventStore.ClientAPI.Internal
         public readonly string StreamId;
         public readonly bool ResolveLinkTos;
         public readonly UserCredentials UserCredentials;
-        public readonly Action<EventStoreSubscription, ResolvedEvent> EventAppeared;
+        public readonly Func<EventStoreSubscription, ResolvedEvent, Task> EventAppeared;
         public readonly Action<EventStoreSubscription, SubscriptionDropReason, Exception> SubscriptionDropped;
            
         public readonly int MaxRetries;
@@ -109,7 +109,7 @@ namespace EventStore.ClientAPI.Internal
                                         string streamId,
                                         bool resolveLinkTos, 
                                         UserCredentials userCredentials,
-                                        Action<EventStoreSubscription, ResolvedEvent> eventAppeared, 
+                                        Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
                                         Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, 
                                         int maxRetries, 
                                         TimeSpan timeout)
@@ -136,13 +136,13 @@ namespace EventStore.ClientAPI.Internal
         public readonly string StreamId;
         public readonly int BufferSize;
         public readonly UserCredentials UserCredentials;
-        public readonly Action<PersistentEventStoreSubscription, ResolvedEvent> EventAppeared;
+        public readonly Func<PersistentEventStoreSubscription, ResolvedEvent, Task> EventAppeared;
         public readonly Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> SubscriptionDropped;
            
         public readonly int MaxRetries;
         public readonly TimeSpan Timeout;
 
-        public StartPersistentSubscriptionMessage(TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials, Action<PersistentEventStoreSubscription, ResolvedEvent> eventAppeared, Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries, TimeSpan timeout)
+        public StartPersistentSubscriptionMessage(TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials, Func<PersistentEventStoreSubscription, ResolvedEvent, Task> eventAppeared, Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries, TimeSpan timeout)
         {
             Ensure.NotNull(source, "source");
             Ensure.NotNull(eventAppeared, "eventAppeared");

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/catchup_subscription_to_all_with_event_numbers_greater_than_2_billion.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/catchup_subscription_to_all_with_event_numbers_greater_than_2_billion.cs
@@ -4,6 +4,7 @@ using EventStore.ClientAPI;
 using NUnit.Framework;
 using EventStore.Core.Data;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
 {
@@ -43,6 +44,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
                     receivedEvents.Add(e);
                     countdown.Signal();
                 }
+                return Task.CompletedTask;
             }, userCredentials: DefaultData.AdminCredentials);
 
             _store.AppendToStreamAsync(_streamId, intMaxValue + 2, evnt).Wait();

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/persistent_subscription_with_event_numbers_greater_than_2_billion.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/persistent_subscription_with_event_numbers_greater_than_2_billion.cs
@@ -4,6 +4,7 @@ using EventStore.ClientAPI;
 using NUnit.Framework;
 using EventStore.Core.Data;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
 {
@@ -61,6 +62,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
                 _store.ConnectToPersistentSubscriptionAsync(_streamId, groupId, (s,e) => {
                     receivedEvents.Add(e);
                     countdown.Signal();
+                    return Task.CompletedTask;
                 }).Wait();
 
                 _store.AppendToStreamAsync(_streamId, intMaxValue + 2, evnt).Wait();

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/subscribe_to_stream_with_link_to_event_with_event_number_greater_than_int_maxvalue.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/subscribe_to_stream_with_link_to_event_with_event_number_greater_than_int_maxvalue.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using System;
 using System.Threading;
 using ResolvedEvent = EventStore.ClientAPI.ResolvedEvent;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
 {
@@ -41,10 +42,11 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
                         ), null)).Wait();
         }
 
-        private void HandleEvent(EventStoreSubscription sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStoreSubscription sub, ResolvedEvent resolvedEvent)
         {
             _receivedEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/subscriptions_on_stream_with_event_numbers_greater_than_2_billion.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/subscriptions_on_stream_with_event_numbers_greater_than_2_billion.cs
@@ -4,6 +4,7 @@ using EventStore.ClientAPI;
 using NUnit.Framework;
 using EventStore.Core.Data;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
 {
@@ -49,6 +50,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
             _store.SubscribeToStreamAsync(_volatileStreamOne, true, (s,e) => {
                 receivedEvent = e;
                 mre.Set();
+                return Task.CompletedTask;
             }).Wait();
 
             _store.AppendToStreamAsync(_volatileStreamOne, intMaxValue + 2, evnt).Wait();
@@ -66,6 +68,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
             _store.SubscribeToAllAsync(true, (s,e) => {
                 receivedEvent = e;
                 mre.Set();
+                return Task.CompletedTask;
             }, userCredentials: DefaultData.AdminCredentials).Wait();
 
             _store.AppendToStreamAsync(_volatileStreamTwo, intMaxValue + 2, evnt).Wait();
@@ -84,6 +87,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
             _store.SubscribeToStreamFrom(_catchupStreamOne, 0, CatchUpSubscriptionSettings.Default, (s,e) => {
                 receivedEvents.Add(e);
                 countdown.Signal();
+                return Task.CompletedTask;
             });
 
             _store.AppendToStreamAsync(_catchupStreamOne, intMaxValue + 2, evnt).Wait();

--- a/src/EventStore.Core.Tests/ClientAPI/Security/AuthenticationTestBase.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/AuthenticationTestBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.SystemData;
 using EventStore.Core.Messages;
@@ -251,7 +252,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
         protected void SubscribeToStream(string streamId, string login, string password)
         {
-            using (Connection.SubscribeToStreamAsync(streamId, false, (x, y) => { }, (x, y, z) => { },
+            using (Connection.SubscribeToStreamAsync(streamId, false, (x, y) => Task.CompletedTask, (x, y, z) => { },
                                                 login == null && password == null ? null : new UserCredentials(login, password)).Result)
             {
             }
@@ -259,7 +260,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security
 
         protected void SubscribeToAll(string login, string password)
         {
-            using (Connection.SubscribeToAllAsync(false, (x, y) => { }, (x, y, z) => { },
+            using (Connection.SubscribeToAllAsync(false, (x, y) => Task.CompletedTask, (x, y, z) => { },
                                              login == null && password == null ? null : new UserCredentials(login, password)).Result)
             {
             }

--- a/src/EventStore.Core.Tests/ClientAPI/catchup_subscription_handles_small_batch_sizes.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catchup_subscription_handles_small_batch_sizes.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.ClientAPI
 {
@@ -69,6 +70,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 {
                     Console.WriteLine("Processed {0} events", evnt.OriginalEventNumber);
                 }
+                return Task.CompletedTask;
             }, (sub) => { mre.Set(); }, null, new UserCredentials("admin", "changeit"));
 
             if (!mre.WaitOne(TimeSpan.FromMinutes(10)))
@@ -84,6 +86,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 {
                     Console.WriteLine("Processed {0} events", evnt.OriginalEventNumber);
                 }
+                return Task.CompletedTask;
             }, (sub) => { mre.Set(); }, null, new UserCredentials("admin", "changeit"));
 
             if (!mre.WaitOne(TimeSpan.FromMinutes(10)))

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
@@ -9,6 +9,7 @@ using EventStore.ClientAPI.Exceptions;
 using NUnit.Framework;
 using EventStore.ClientAPI.Common;
 using EventStore.ClientAPI.Common.Utils;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.ClientAPI
 {
@@ -24,7 +25,11 @@ namespace EventStore.Core.Tests.ClientAPI
                 _conn.ConnectToPersistentSubscription(
                     "nonexisting2",
                     "foo",
-                    (sub, e) => Console.Write("appeared"),
+                    (sub, e) =>
+                    {
+                        Console.Write("appeared");
+                        return Task.CompletedTask;
+                    },
                     (sub, reason, ex) =>
                     {
                     });
@@ -59,7 +64,11 @@ namespace EventStore.Core.Tests.ClientAPI
             _conn.CreatePersistentSubscriptionAsync(_stream, "agroupname17", _settings, DefaultData.AdminCredentials).Wait();
             _sub = _conn.ConnectToPersistentSubscription(_stream,
                 "agroupname17",
-                (sub, e) => Console.Write("appeared"),
+                (sub, e) =>
+                {
+                    Console.Write("appeared");
+                    return Task.CompletedTask;
+                },
                 (sub, reason, ex) => {});
         }
 
@@ -91,7 +100,11 @@ namespace EventStore.Core.Tests.ClientAPI
                 _conn.ConnectToPersistentSubscription( 
                     _stream,
                     "agroupname55",
-                    (sub, e) => Console.Write("appeared"),
+                    (sub, e) =>
+                    {
+                        Console.Write("appeared");
+                        return Task.CompletedTask;
+                    },
                     (sub, reason, ex) => Console.WriteLine("dropped."));
                 throw new Exception("should have thrown.");
             }
@@ -125,7 +138,11 @@ namespace EventStore.Core.Tests.ClientAPI
             _conn.ConnectToPersistentSubscription(
                 _stream,
                 _group,
-                (s, e) => s.Acknowledge(e),
+                (s, e) =>
+                {
+                    s.Acknowledge(e);
+                    return Task.CompletedTask;
+                },
                 (sub, reason, ex) => { },
                 DefaultData.AdminCredentials);
         }
@@ -136,7 +153,11 @@ namespace EventStore.Core.Tests.ClientAPI
                 _conn.ConnectToPersistentSubscription(
                     _stream,
                     _group,
-                    (s, e) => s.Acknowledge(e),
+                    (s, e) =>
+                    {
+                        s.Acknowledge(e);
+                        return Task.CompletedTask;
+                    },
                     (sub, reason, ex) => { },
                     DefaultData.AdminCredentials);
                 throw new Exception("should have thrown.");
@@ -185,12 +206,13 @@ namespace EventStore.Core.Tests.ClientAPI
                 new EventData(_id, "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();            
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
-            if (_set) return;
+            if (_set) return Task.CompletedTask;
             _set = true;
             _firstEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -242,12 +264,13 @@ namespace EventStore.Core.Tests.ClientAPI
 
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
-            if (_set) return;
+            if (_set) return Task.CompletedTask;
             _set = true;
             _firstEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -301,7 +324,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 DefaultData.AdminCredentials);
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             if (!_set)
             {
@@ -309,6 +332,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 _firstEvent = resolvedEvent;
                 _resetEvent.Set();
             }
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -358,9 +382,10 @@ namespace EventStore.Core.Tests.ClientAPI
                 DefaultData.AdminCredentials);
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -414,10 +439,11 @@ namespace EventStore.Core.Tests.ClientAPI
 
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             _firstEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -476,10 +502,11 @@ namespace EventStore.Core.Tests.ClientAPI
 
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             _firstEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -534,7 +561,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
         }
 
-        private static void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private static Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             throw new Exception("test");
         }
@@ -597,10 +624,11 @@ namespace EventStore.Core.Tests.ClientAPI
 
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             _firstEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -661,12 +689,13 @@ namespace EventStore.Core.Tests.ClientAPI
         }
 
         private bool _set = false;
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
-            if (_set) return;
+            if (_set) return Task.CompletedTask;
             _set = true;
             _firstEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -721,7 +750,7 @@ namespace EventStore.Core.Tests.ClientAPI
                             string.Format("{0}@{1}", intMaxValue + 1, StreamName)), null));
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             if (!_set)
             {
@@ -729,6 +758,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 _firstEvent = resolvedEvent;
                 _resetEvent.Set();
             }
+            return Task.CompletedTask;
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription_async.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription_async.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.ClientAPI
 {
@@ -21,7 +22,11 @@ namespace EventStore.Core.Tests.ClientAPI
                 _conn.ConnectToPersistentSubscriptionAsync(
                      "nonexisting2",
                      "foo",
-                     (sub, e) => Console.Write("appeared"),
+                     (sub, e) =>
+                     {
+                         Console.Write("appeared");
+                         return Task.CompletedTask;
+                     },
                      (sub, reason, ex) =>
                      {
                      }).Wait();
@@ -51,7 +56,11 @@ namespace EventStore.Core.Tests.ClientAPI
             _conn.CreatePersistentSubscriptionAsync(_stream, "agroupname17", _settings, DefaultData.AdminCredentials).Wait();
             _sub = _conn.ConnectToPersistentSubscriptionAsync(_stream,
                 "agroupname17",
-                (sub, e) => Console.Write("appeared"),
+                (sub, e) =>
+                {
+                    Console.Write("appeared");
+                    return Task.CompletedTask;
+                },
                 (sub, reason, ex) => { }).Result;
         }
 
@@ -82,7 +91,11 @@ namespace EventStore.Core.Tests.ClientAPI
                 _conn.ConnectToPersistentSubscriptionAsync(
                    _stream,
                    "agroupname55",
-                   (sub, e) => Console.Write("appeared"),
+                   (sub, e) =>
+                   {
+                       Console.Write("appeared");
+                       return Task.CompletedTask;
+                   },
                    (sub, reason, ex) => Console.WriteLine("dropped.")).Wait();
             }).InnerException;
         }
@@ -119,7 +132,11 @@ namespace EventStore.Core.Tests.ClientAPI
             _firstConn = _conn.ConnectToPersistentSubscriptionAsync(
                 _stream,
                 _group,
-                (s, e) => s.Acknowledge(e),
+                (s, e) =>
+                {
+                    s.Acknowledge(e);
+                    return Task.CompletedTask;
+                },
                 (sub, reason, ex) => { },
                 DefaultData.AdminCredentials).Result;
         }
@@ -132,7 +149,11 @@ namespace EventStore.Core.Tests.ClientAPI
                 _conn.ConnectToPersistentSubscriptionAsync(
                     _stream,
                     _group,
-                    (s, e) => s.Acknowledge(e),
+                    (s, e) =>
+                    {
+                        s.Acknowledge(e);
+                        return Task.CompletedTask;
+                    },
                     (sub, reason, ex) => { },
                     DefaultData.AdminCredentials).Wait();
             }).InnerException;
@@ -186,12 +207,13 @@ namespace EventStore.Core.Tests.ClientAPI
                 new EventData(_id, "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
-            if (_set) return;
+            if (_set) return Task.CompletedTask;
             _set = true;
             _firstEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -241,12 +263,13 @@ namespace EventStore.Core.Tests.ClientAPI
                 new EventData(_id, "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
-            if (_set) return;
+            if (_set) return Task.CompletedTask;
             _set = true;
             _firstEvent = resolvedEvent;
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -301,7 +324,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 DefaultData.AdminCredentials).Wait();
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             if (!_set)
             {
@@ -309,6 +332,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 _firstEvent = resolvedEvent;
                 _resetEvent.Set();
             }
+            return Task.CompletedTask;
         }
 
         [Test]
@@ -359,9 +383,10 @@ namespace EventStore.Core.Tests.ClientAPI
                 DefaultData.AdminCredentials).Wait();
         }
 
-        private void HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent)
         {
             _resetEvent.Set();
+            return Task.CompletedTask;
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/ClientAPI/deleting_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/deleting_persistent_subscription.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.Core.Tests.Helpers;
@@ -43,7 +44,7 @@ namespace EventStore.Core.Tests.ClientAPI
             _conn.CreatePersistentSubscriptionAsync(_stream, "groupname123", _settings,
     DefaultData.AdminCredentials).Wait();
             _conn.ConnectToPersistentSubscription(_stream, "groupname123",
-                (s, e) => { },
+                (s, e) => Task.CompletedTask,
                 (s, r, e) => _called.Set());
         }
 

--- a/src/EventStore.Core.Tests/ClientAPI/event_store_connection_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/event_store_connection_should.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.Core.Tests.ClientAPI.Helpers;
 using EventStore.Core.Tests.Helpers;
@@ -104,10 +105,10 @@ namespace EventStore.Core.Tests.ClientAPI
             Assert.That(() => connection.StartTransactionAsync(s, 0).Wait(),
                         Throws.Exception.InstanceOf<AggregateException>().With.InnerException.InstanceOf<InvalidOperationException>());
 
-            Assert.That(() => connection.SubscribeToStreamAsync(s, false, (_, __) => { }, (_, __, ___) => { }).Wait(),
+            Assert.That(() => connection.SubscribeToStreamAsync(s, false, (_, __) => Task.CompletedTask, (_, __, ___) => { }).Wait(),
                         Throws.Exception.InstanceOf<AggregateException>().With.InnerException.InstanceOf<InvalidOperationException>());
 
-            Assert.That(() => connection.SubscribeToAllAsync(false, (_, __) => { }, (_, __, ___) => { }).Wait(),
+            Assert.That(() => connection.SubscribeToAllAsync(false, (_, __) => Task.CompletedTask, (_, __, ___) => { }).Wait(),
                         Throws.Exception.InstanceOf<AggregateException>().With.InnerException.InstanceOf<InvalidOperationException>());
         }
     }

--- a/src/EventStore.Core.Tests/ClientAPI/persistent_connect_integration_tests.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/persistent_connect_integration_tests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.Common;
 using NUnit.Framework;
@@ -44,6 +45,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     {
                         _eventsReceived.Set();
                     }
+                    return Task.CompletedTask;
                 },
                 (sub, reason, exception) =>
                     Console.WriteLine("Subscription dropped (reason:{0}, exception:{1}).", reason, exception),
@@ -96,6 +98,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     {
                         _eventsReceived.Set();
                     }
+                    return Task.CompletedTask;
                 },
                 (sub, reason, exception) =>
                     Console.WriteLine("Subscription dropped (reason:{0}, exception:{1}).", reason, exception),
@@ -155,6 +158,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     {
                         _eventsReceived.Set();
                     }
+                    return Task.CompletedTask;
                 },
                 (sub, reason, exception) =>
                 {
@@ -211,6 +215,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     {
                         _eventsReceived.Set();
                     }
+                    return Task.CompletedTask;
                 },
                 (sub, reason, exception) =>
                     Console.WriteLine("Subscription dropped (reason:{0}, exception:{1}).", reason, exception),
@@ -265,6 +270,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     {
                         _eventsReceived.Set();
                     }
+                    return Task.CompletedTask;
                 },
                 (sub, reason, exception) =>
                     Console.WriteLine("Subscription dropped (reason:{0}, exception:{1}).", reason, exception),
@@ -324,6 +330,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     {
                         _eventsReceived.Set();
                     }
+                    return Task.CompletedTask;
                 },
                 (sub, reason, exception) =>
                     Console.WriteLine("Subscription dropped (reason:{0}, exception:{1}).", reason, exception),
@@ -381,6 +388,7 @@ namespace EventStore.Core.Tests.ClientAPI
                     {
                         _eventsReceived.Set();
                     }
+                    return Task.CompletedTask;
                 },
                 (sub, reason, exception) =>
                     Console.WriteLine("Subscription dropped (reason:{0}, exception:{1}).", reason, exception),

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_catching_up_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_catching_up_should.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.SystemData;
 using EventStore.Common.Log;
@@ -59,7 +60,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 var dropped = new CountdownEvent(1);
                 var subscription = store.SubscribeToAllFrom(null,
                                                             CatchUpSubscriptionSettings.Default,
-                                                            (x, y) => { },
+                                                            (x, y) => Task.CompletedTask,
                                                             _ => Log.Info("Live processing started."),
                                                             (x, y, z) => dropped.Signal());
 
@@ -102,12 +103,13 @@ namespace EventStore.Core.Tests.ClientAPI
                                                             {
                                                                 if (!SystemStreams.IsSystemStream(x.OriginalEvent.EventStreamId))
                                                                     appeared.Set();
+                                                                return Task.CompletedTask;
                                                             },
                                                             _ => Log.Info("Live processing started."),
                                                             (_, __, ___) => dropped.Signal());
 
                 Thread.Sleep(100); // give time for first pull phase
-                store.SubscribeToAllAsync(false, (s, x) => { }, (s, r, e) => { }).Wait();
+                store.SubscribeToAllAsync(false, (s, x) => Task.CompletedTask, (s, r, e) => { }).Wait();
                 Thread.Sleep(100);
 
                 Assert.IsFalse(appeared.Wait(0), "Some event appeared.");
@@ -142,6 +144,7 @@ namespace EventStore.Core.Tests.ClientAPI
                                                                     events.Add(y);
                                                                     appeared.Signal();
                                                                 }
+                                                                return Task.CompletedTask;
                                                             },
                                                             _ => Log.Info("Live processing started."),
                                                             (x, y, z) => dropped.Signal());
@@ -193,6 +196,7 @@ namespace EventStore.Core.Tests.ClientAPI
                                                             {
                                                                 events.Add(y);
                                                                 appeared.Signal();
+                                                                return Task.CompletedTask;
                                                             },
                                                             _ => Log.Info("Live processing started."),
                                                             (x, y, z) =>
@@ -251,6 +255,7 @@ namespace EventStore.Core.Tests.ClientAPI
                                                             {
                                                                 events.Add(y);
                                                                 appeared.Signal();
+                                                                return Task.CompletedTask;
                                                             },
                                                             _ => Log.Info("Live processing started."),
                                                             (x, y, z) =>

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_should.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.SystemData;
 using EventStore.Core.Services;
@@ -54,8 +55,16 @@ namespace EventStore.Core.Tests.ClientAPI
                 var appeared = new CountdownEvent(2);
                 var dropped = new CountdownEvent(2);
 
-                using (store.SubscribeToAllAsync(false, (s, x) => appeared.Signal(), (s, r, e) => dropped.Signal()).Result)
-                using (store.SubscribeToAllAsync(false, (s, x) => appeared.Signal(), (s, r, e) => dropped.Signal()).Result)
+                using (store.SubscribeToAllAsync(false, (s, x) =>
+                {
+                    appeared.Signal();
+                    return Task.CompletedTask;
+                }, (s, r, e) => dropped.Signal()).Result)
+                using (store.SubscribeToAllAsync(false, (s, x) =>
+                {
+                    appeared.Signal();
+                    return Task.CompletedTask;
+                }, (s, r, e) => dropped.Signal()).Result)
                 {
                     var create = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent());
                     Assert.IsTrue(create.Wait(Timeout), "StreamCreateAsync timed out.");
@@ -75,7 +84,12 @@ namespace EventStore.Core.Tests.ClientAPI
                 var appeared = new CountdownEvent(1);
                 var dropped = new CountdownEvent(1);
 
-                using (store.SubscribeToAllAsync(false, (s, x) => appeared.Signal(), (s, r, e) => dropped.Signal()).Result)
+                using (store.SubscribeToAllAsync(false, (s, x) =>
+                {
+                    appeared.Signal();
+                    return Task.CompletedTask;
+                },
+                (s, r, e) => dropped.Signal()).Result)
                 {
                     var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
                     Assert.IsTrue(delete.Wait(Timeout), "DeleteStreamAsync timed out.");

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_stream_catching_up_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_stream_catching_up_should.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.Common.Log;
 using EventStore.Core.Tests.ClientAPI.Helpers;
@@ -51,12 +52,16 @@ namespace EventStore.Core.Tests.ClientAPI
                 var subscription = store.SubscribeToStreamFrom(stream,
                                                                null,
                                                                CatchUpSubscriptionSettings.Default,
-                                                               (_, x) => appeared.Set(),
+                                                               (_, x) =>
+                                                               {
+                                                                   appeared.Set();
+                                                                   return Task.CompletedTask;
+                                                               },
                                                                _ => Log.Info("Live processing started."),
                                                                (_, __, ___) => dropped.Signal());
 
                 Thread.Sleep(100); // give time for first pull phase
-                store.SubscribeToStreamAsync(stream, false, (s, x) => { }, (s, r, e) => { }).Wait();
+                store.SubscribeToStreamAsync(stream, false, (s, x) => Task.CompletedTask, (s, r, e) => { }).Wait();
                 Thread.Sleep(100);
                 Assert.IsFalse(appeared.Wait(0), "Some event appeared.");
                 Assert.IsFalse(dropped.Wait(0), "Subscription was dropped prematurely.");
@@ -78,7 +83,11 @@ namespace EventStore.Core.Tests.ClientAPI
                 var subscription = store.SubscribeToStreamFrom(stream,
                                                                null,
                                                                CatchUpSubscriptionSettings.Default,
-                                                               (_, x) => appeared.Signal(),
+                                                               (_, x) =>
+                                                               {
+                                                                   appeared.Signal();
+                                                                   return Task.CompletedTask;
+                                                               },
                                                                _ => Log.Info("Live processing started."),
                                                                (_, __, ___) => dropped.Signal());
 
@@ -110,13 +119,21 @@ namespace EventStore.Core.Tests.ClientAPI
                 var sub1 = store.SubscribeToStreamFrom(stream,
                                                        null,
                                                        CatchUpSubscriptionSettings.Default,
-                                                       (_, e) => appeared.Signal(),
+                                                       (_, e) =>
+                                                       {
+                                                           appeared.Signal();
+                                                           return Task.CompletedTask;
+                                                       },
                                                         _ => Log.Info("Live processing started."),
                                                        (x, y, z) => dropped1.Set());
                 var sub2 = store.SubscribeToStreamFrom(stream,
                                                        null,
                                                        CatchUpSubscriptionSettings.Default,
-                                                       (_, e) => appeared.Signal(),
+                                                       (_, e) =>
+                                                       {
+                                                           appeared.Signal();
+                                                           return Task.CompletedTask;
+                                                       },
                                                         _ => Log.Info("Live processing started."),
                                                        (x, y, z) => dropped2.Set());
 
@@ -151,7 +168,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 var subscription = store.SubscribeToStreamFrom(stream,
                                                                null,
                                                                CatchUpSubscriptionSettings.Default,
-                                                               (x, y) => { },
+                                                               (x, y) => Task.CompletedTask,
                                                                _ => Log.Info("Live processing started."),
                                                                (x, y, z) => dropped.Signal());
                 Assert.IsFalse(dropped.Wait(0));
@@ -203,6 +220,7 @@ namespace EventStore.Core.Tests.ClientAPI
                                                                {
                                                                    events.Add(y);
                                                                    appeared.Signal();
+                                                                   return Task.CompletedTask;
                                                                },
                                                                _ => Log.Info("Live processing started."),
                                                                (x, y, z) => dropped.Signal());
@@ -253,6 +271,7 @@ namespace EventStore.Core.Tests.ClientAPI
                                                                {
                                                                    events.Add(y);
                                                                    appeared.Signal();
+                                                                   return Task.CompletedTask;
                                                                },
                                                                _ => Log.Info("Live processing started."),
                                                                (x, y, z) => dropped.Signal());
@@ -307,6 +326,7 @@ namespace EventStore.Core.Tests.ClientAPI
                                                                {
                                                                    events.Add(y);
                                                                    appeared.Signal();
+                                                                   return Task.CompletedTask;
                                                                },
                                                                _ => Log.Info("Live processing started."),
                                                                (x, y, z) => dropped.Signal());

--- a/src/EventStore.Core.Tests/ClientAPI/update_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/update_persistent_subscription.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.Exceptions;
 using NUnit.Framework;
@@ -51,7 +52,7 @@ namespace EventStore.Core.Tests.ClientAPI
             _conn.AppendToStreamAsync(_stream, ExpectedVersion.Any,
                 new EventData(Guid.NewGuid(), "whatever", true, Encoding.UTF8.GetBytes("{'foo' : 2}"), new Byte[0]));
             _conn.CreatePersistentSubscriptionAsync(_stream, "existing", _settings, DefaultData.AdminCredentials).Wait();
-            _conn.ConnectToPersistentSubscription(_stream, "existing" , (x, y) => { },
+            _conn.ConnectToPersistentSubscription(_stream, "existing" , (x, y) => Task.CompletedTask,
                 (sub, reason, ex) =>
                 {
                     _dropped.Set();

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/deleting.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/deleting.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.Core.Tests.Http.Users.users;
 using NUnit.Framework;
@@ -104,7 +105,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
                 {
                     ResolveLinkTos = true
                 }, _admin);
-            _connection.ConnectToPersistentSubscription(_stream, _groupName, (x, y) => { },
+            _connection.ConnectToPersistentSubscription(_stream, _groupName, (x, y) => Task.CompletedTask,
                 (sub, reason, e) =>
                 {
                     _dropped.Set();

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/parked.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/parked.cs
@@ -12,6 +12,7 @@ using EventStore.Transport.Http;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.Common;
 using EventStore.Core.Data;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.Http.PersistentSubscription
 {
@@ -44,6 +45,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             {
                 _parkedEventId = y.Event.EventId;
                 _eventParked.Set();
+                return Task.CompletedTask;
             }, 
             (x,y,z)=> { }, 
             DefaultData.AdminCredentials).Wait();
@@ -93,6 +95,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             {
                 replayedParkedEvent = y;
                 _eventParked.Set();
+                return Task.CompletedTask;
             },
             (x, y, z) => { },
             DefaultData.AdminCredentials).Wait();

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -8,6 +8,7 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using HttpStatusCode = System.Net.HttpStatusCode;
 using System.Xml.Linq;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.Http.PersistentSubscription
 {
@@ -227,14 +228,26 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             _conn.CreatePersistentSubscriptionAsync(_streamName, "secondgroup", _settings,
                         DefaultData.AdminCredentials).Wait();
             _conn.ConnectToPersistentSubscription(_streamName, "secondgroup",
-                        (subscription, @event) => Console.WriteLine(),
+                        (subscription, @event) =>
+                        {
+                            Console.WriteLine();
+                            return Task.CompletedTask;
+                        },
                         (subscription, reason, arg3) => Console.WriteLine());
             _conn.ConnectToPersistentSubscription(_streamName, "secondgroup",
-                        (subscription, @event) => Console.WriteLine(),
+                        (subscription, @event) =>
+                        {
+                            Console.WriteLine();
+                            return Task.CompletedTask;
+                        },
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
             _conn.ConnectToPersistentSubscription(_streamName, "secondgroup",
-                        (subscription, @event) => Console.WriteLine(),
+                        (subscription, @event) =>
+                        {
+                            Console.WriteLine();
+                            return Task.CompletedTask;
+                        },
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
 
@@ -366,14 +379,26 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             _conn.CreatePersistentSubscriptionAsync(_streamName, "secondgroup", _settings,
                         DefaultData.AdminCredentials).Wait();
             _sub3 = _conn.ConnectToPersistentSubscription(_streamName, "secondgroup",
-                        (subscription, @event) => Console.WriteLine(),
+                        (subscription, @event) =>
+                        {
+                            Console.WriteLine();
+                            return Task.CompletedTask;
+                        },
                         (subscription, reason, arg3) => Console.WriteLine());
             _sub4 = _conn.ConnectToPersistentSubscription(_streamName, "secondgroup",
-                        (subscription, @event) => Console.WriteLine(),
+                        (subscription, @event) =>
+                        {
+                            Console.WriteLine();
+                            return Task.CompletedTask;
+                        },
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
             _sub5 = _conn.ConnectToPersistentSubscription(_streamName, "secondgroup",
-                        (subscription, @event) => Console.WriteLine(),
+                        (subscription, @event) =>
+                        {
+                            Console.WriteLine();
+                            return Task.CompletedTask;
+                        },
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
 
@@ -481,10 +506,18 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
             _conn.CreatePersistentSubscriptionAsync(_streamName, _groupName, _settings,
                     DefaultData.AdminCredentials).Wait();
             _sub1 = _conn.ConnectToPersistentSubscription(_streamName, _groupName,
-                        (subscription, @event) => Console.WriteLine(),
+                        (subscription, @event) =>
+                        {
+                            Console.WriteLine();
+                            return Task.CompletedTask;
+                        },
                         (subscription, reason, arg3) => Console.WriteLine());
             _sub2 = _conn.ConnectToPersistentSubscription(_streamName, _groupName,
-                        (subscription, @event) => Console.WriteLine(),
+                        (subscription, @event) =>
+                        {
+                            Console.WriteLine();
+                            return Task.CompletedTask;
+                        },
                         (subscription, reason, arg3) => Console.WriteLine(),
                         DefaultData.AdminCredentials);
 

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/updating.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/updating.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.SystemData;
 using EventStore.Core.Tests.Http.Users.users;
@@ -90,7 +91,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
 
         private void SetupSubscription()
         {
-            _connection.ConnectToPersistentSubscription(_stream, _groupName, (x, y) => { },
+            _connection.ConnectToPersistentSubscription(_stream, _groupName, (x, y) => Task.CompletedTask,
                 (sub, reason, ex) =>
                 {
                     _droppedReason = reason;

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -15,6 +15,7 @@ using NUnit.Framework;
 using ExpectedVersion = EventStore.Core.Data.ExpectedVersion;
 using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
 using EventStore.Core.Tests.ClientAPI;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.Services.PersistentSubscription
 {
@@ -1324,6 +1325,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
                 {
                     manualResetEventSlim.Set();
                 }
+                return Task.CompletedTask;
             },
                 (sub, reason, ex) => { });
             Assert.IsTrue(manualResetEventSlim.Wait(TimeSpan.FromSeconds(30)), "Failed to receive all events in 2 minutes. Assume event store is deadlocked.");
@@ -1340,7 +1342,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
         }
     }
 
-    public class Helper
+    public static class Helper
     {
         public static ResolvedEvent BuildFakeEvent(Guid id, string type, string stream, long version)
         {

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
@@ -12,7 +12,7 @@ using EventStore.Core.Services.UserManagement;
 using EventStore.ClientAPI;
 using NUnit.Framework;
 using ILogger = EventStore.Common.Log.ILogger;
-
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.Services.Storage.Scavenge
 {
@@ -55,7 +55,8 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
 					(x, y) => {
 						_result.Add(y);
 						countdown.Signal();
-					},
+                        return Task.CompletedTask;
+                    },
 					_ => Log.Info("Processing events started."),
 					(x, y, z) =>
 					{

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -286,7 +286,6 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
             var actualMeta = resultEvents.Aggregate(
                 "", (a, v) => a + "\r\n" + v.OriginalEvent.EventType + ":" + v.OriginalEvent.DebugMetadataView);
 
-
             Debug.WriteLine(
                 "Stream: '{0}'\r\n{1}\r\n\r\nExisting events: \r\n{2}\r\n \r\nActual metas:{3}", streamId,
                 message, actual, actualMeta);

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -569,9 +569,6 @@
     <Folder Include="Services\checkpoint_strategy\" />
     <Folder Include="Services\projections_manager\parallel_query\" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <IsMac>false</IsMac>

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_an_existing_emitted_streams_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_an_existing_emitted_streams_stream.cs
@@ -4,6 +4,7 @@ using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
 {
@@ -27,6 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.whe
             base.Given();
             var sub = _conn.SubscribeToStreamAsync(_projectionNamesBuilder.GetEmittedStreamsName(), true, (s, evnt) => {
                 _eventAppeared.Set();
+                return Task.CompletedTask;
             }, userCredentials: _credentials).Result;
 
             _emittedStreamsTracker.TrackEmittedStream(new EmittedEvent[]

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_multiple_tracked_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_multiple_tracked_streams.cs
@@ -4,6 +4,7 @@ using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 using System;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
 {
@@ -29,6 +30,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.whe
 
             var sub = _conn.SubscribeToStreamAsync(_projectionNamesBuilder.GetEmittedStreamsName(), true, (s, evnt) => {
                 _eventAppeared.Signal();
+                return Task.CompletedTask;
             }, userCredentials: _credentials).Result;
 
             for (int i = 0; i < _numberOfTrackedEvents; i++)

--- a/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
+++ b/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.ClientAPI;
 
 namespace EventStore.TestClient.Commands
@@ -46,6 +47,7 @@ namespace EventStore.TestClient.Commands
                             context.Log.Trace("Received total {0} events ({1} per sec)...", c, 100000.0/sw.Elapsed.TotalSeconds);
                             sw.Restart();
                         }
+                        return Task.CompletedTask;
                     }).Wait();
             }
             context.Log.Info("Subscribed to {0} streams...", subscriptionCount);


### PR DESCRIPTION
Following from the discussions on #1051, this is a PR to support async OnEventAppeared.

This probably doesn't solve all the problems described in all the related issues (#861, #1051, #1179) but should at least allow real async OnEventAppeared handlers, i.e. give the client the ability to use async APIs without blocking at any point.

I have checked that all existing tests pass, and that our own real life applications runs correctly using this modified version.

API breaking changes:

1. OnEventAppeared is now a Func<T, ResolvedEvent, Task>
2. CatchUpSubscription.Start is now StartAsync

Please, let me know if there are improvements you require in order to get this PR approved.

Further improvements, which I'd be happy to work on as separate PRs if you'd be willing to consider them:

1. Replace more of the existing TaskCompletionSource-based and manual ThreadPool with async/await. Taking this all the way down to the SocketAsyncEventArgs would help simplify the code, leaving a lot of the current complexity to the language/compiler by means of async/await
2. The above should also help with scalability in cases where GetEventStore is sharing the Thread Pool with other components (OWIN, SignalR, other EventStore connections, etc.)
3. Modernizing the code base to use more C#6 features like auto-implemented properties, coalesce and conditional operators, expression bodied functions, etc. This would help with readability. I understand why the team wouldn't want to spend some time on this (no clear value added) but perhaps the value proposition is different if an external person does it.
