### PR TITLE
Check specifically for known system projections

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_system_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_system_projection.cs
@@ -6,13 +6,32 @@ using EventStore.Core.Messaging;
 using EventStore.Projections.Core.Messages;
 using NUnit.Framework;
 using EventStore.ClientAPI.Common.Utils;
+using System.Collections;
+using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
-    [TestFixture]
+    public class SystemProjectionNames : IEnumerable
+    {
+        public IEnumerator GetEnumerator()
+        {
+            return typeof(ProjectionNamesBuilder.StandardProjections).GetFields(
+                System.Reflection.BindingFlags.Public | 
+                System.Reflection.BindingFlags.Static | 
+                System.Reflection.BindingFlags.FlattenHierarchy)
+                .Where(x => x.IsLiteral && !x.IsInitOnly)
+                .Select(x => x.GetRawConstantValue()).
+                GetEnumerator();
+        }
+    }
+    [TestFixture, TestFixtureSource(typeof(SystemProjectionNames))]
     public class when_deleting_a_system_projection : TestFixtureWithProjectionCoreAndManagementServices
     {
         private string _systemProjectionName;
+        public when_deleting_a_system_projection(string projectionName)
+        {
+            _systemProjectionName = projectionName;
+        }
 
         protected override bool GivenInitializeSystemProjections()
         {
@@ -21,7 +40,6 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override void Given()
         {
-            _systemProjectionName = "$system_projection"; //identified by the $ prefix
             AllWritesSucceed();
             NoOtherStreams();
         }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -241,7 +241,7 @@ namespace EventStore.Projections.Core.Services.Management
                 message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
             if (IsSystemProjection(message.Name))
             {
-                message.Envelope.ReplyWith(new ProjectionManagementMessage.OperationFailed("We currently don't allow for the deletion of System Projections. System projections are identified by the projection name starting with a `$`"));
+                message.Envelope.ReplyWith(new ProjectionManagementMessage.OperationFailed("We currently don't allow for the deletion of System Projections."));
                 return;
             }
             else
@@ -259,7 +259,10 @@ namespace EventStore.Projections.Core.Services.Management
 
         private bool IsSystemProjection(string name)
         {
-            return SystemStreams.IsSystemStream(name);
+            return name == ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection ||
+                   name == ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection ||
+                   name == ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection ||
+                   name == ProjectionNamesBuilder.StandardProjections.StreamsStandardProjection;
         }
 
         public void Handle(ProjectionManagementMessage.Command.GetQuery message)


### PR DESCRIPTION
There are users who are creating projections prefixed with `$`. We
cannot not allow them to delete their own projections.

This change will explicitly check for system projections.