### PR TITLE
#1051: Fixed missing await when invoking the async eventAppeared

### DIFF
--- a/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
@@ -191,7 +191,7 @@ namespace EventStore.ClientAPI
         }
 
 
-        private void ProcessQueue()
+        private async void ProcessQueue()
         {
             do
             {
@@ -217,7 +217,7 @@ namespace EventStore.ClientAPI
                         }
                         try
                         {
-                            _eventAppeared(this, e);
+                            await _eventAppeared(this, e);
                             if (_autoAck)
                                 _subscription.NotifyEventsProcessed(new[] { e.OriginalEvent.EventId });
                             if (_verbose)


### PR DESCRIPTION
This is a fix for an error introduced in previous PR #1310 
@salgat spotted that there was a missing async/await when invoking _eventAppeared