### PR TITLE
Change how registered projections are read

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -127,6 +127,8 @@
     <Compile Include="Services\event_reader\heading_event_reader\when_the_heading_event_reader_with_a_subscribed_projection_handles_a_live_event_and_throws.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_system_projection.cs" />
     <Compile Include="Services\projections_manager\when_posting_a_persistent_projection_and_registration_write_fails.cs" />
+    <Compile Include="Services\projections_manager\when_reading_registered_projections\with_no_stream_and_intialize_system_projections.cs" />
+    <Compile Include="Services\projections_manager\when_reading_registered_projections\with_no_stream.cs" />
     <Compile Include="Services\SpecificationWithEmittedStreamsTrackerAndDeleter.cs" />
     <Compile Include="Services\emitted_streams_deleter\when_deleting\with_multiple_tracked_streams.cs" />
     <Compile Include="Services\emitted_streams_deleter\when_deleting\with_an_existing_emitted_streams_stream.cs" />
@@ -476,7 +478,7 @@
     <Compile Include="Services\projections_manager\when_posting_an_onetime_projection.cs" />
     <Compile Include="Services\projections_manager\when_posting_a_persistent_projection.cs" />
     <Compile Include="Services\projections_manager\when_starting_the_projection_manager_with_existing_projection.cs" />
-    <Compile Include="Services\projections_manager\when_starting_the_projection_manager_with_existing_projections.cs" />
+    <Compile Include="Services\projections_manager\when_starting_the_projection_manager_with_existing_partially_created_projection.cs" />
     <Compile Include="Services\projections_manager\when_updating_an_onetime_projection_query_text.cs" />
     <Compile Include="Services\projections_manager\when_updating_a_persistent_projection_query_text.cs" />
     <Compile Include="Services\v8\when_v8_projection_loading_state.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -35,7 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _initializeSystemProjections = GivenInitializeSystemProjections();
             if (!_initializeSystemProjections)
             {
-                ExistingEvent("$projections-$all", "$ProjectionsInitialized", "", "");
+                ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, "$ProjectionsInitialized", "", "");
             }
         }
 
@@ -99,6 +99,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _bus.Subscribe<ProjectionManagementMessage.Command.Reset>(_manager);
             _bus.Subscribe<ProjectionManagementMessage.Command.StartSlaveProjections>(_manager);
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<ClientMessage.DeleteStreamCompleted>(_manager);
             _bus.Subscribe<SystemMessage.StateChangeMessage>(_manager);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_completed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_completed_projection.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Messaging;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
+using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
 {
@@ -18,7 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
             protected override void Given()
             {
                 base.Given();
-                AllWritesToSucceed("$projections-" + _projectionName + "-result");
+                AllWritesToSucceed(ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName + "-result");
                 AllWritesToSucceed("$$$projections-" + _projectionName + "-result");
                 NoOtherStreams();
             }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
@@ -11,6 +11,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Messages.ParallelQueryProcessingMessages;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
+using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -28,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _initializeSystemProjections = GivenInitializeSystemProjections();
             if (!_initializeSystemProjections)
             {
-                ExistingEvent("$projections-$all", "$ProjectionsInitialized", "", "");
+                ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, "$ProjectionsInitialized", "", "");
             }
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_a_disabled_projection_has_been_loaded.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_a_disabled_projection_has_been_loaded.cs
@@ -6,6 +6,8 @@ using EventStore.Core.Messaging;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
+using EventStore.Projections.Core.Common;
+using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -19,9 +21,9 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             NoStream("$projections-test-projection-order");
             AllWritesToSucceed("$projections-test-projection-order");
             NoStream("$projections-test-projection-checkpoint");
-            ExistingEvent("$projections-$all", "$ProjectionCreated", null, "test-projection");
+            ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, EventTypes.ProjectionCreated, null, "test-projection");
             ExistingEvent(
-                "$projections-test-projection", "$ProjectionUpdated", null,
+                "$projections-test-projection", EventTypes.ProjectionUpdated, null,
                 @"{
                     ""Query"":""fromAll(); on_any(function(){});log('hello-from-projection-definition');"", 
                     ""Mode"":""3"", 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
@@ -9,6 +9,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -51,7 +52,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         public void a_projection_created_event_is_written()
         {
             Assert.AreEqual(
-                "$ProjectionCreated",
+                EventTypes.ProjectionCreated,
                 _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().First().Events[0].EventType);
             Assert.AreEqual(
                 _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_registration_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_registration_write_fails.cs
@@ -7,6 +7,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
+using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -40,12 +41,12 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         public void retries_creating_the_projection_only_the_specified_number_of_times()
         {
             int retryCount = 0;
-            var projectionRegistrationWrite = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Where(x => x.EventStreamId == "$projections-$all").Last();
+            var projectionRegistrationWrite = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Where(x => x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream).Last();
             while (projectionRegistrationWrite != null)
             {
                 projectionRegistrationWrite.Envelope.ReplyWith(new ClientMessage.WriteEventsCompleted(projectionRegistrationWrite.CorrelationId, OperationResult.CommitTimeout, "Commit Timeout"));
                 _queue.Process();
-                projectionRegistrationWrite = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Where(x => x.EventStreamId == "$projections-$all").LastOrDefault();
+                projectionRegistrationWrite = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Where(x => x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream).LastOrDefault();
                 if(projectionRegistrationWrite != null)
                 {
                     retryCount++;

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
@@ -7,6 +7,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -52,7 +53,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             Assert.IsTrue(
                 _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Any(
-                    v => v.Events[0].EventType == "$ProjectionUpdated"));
+                    v => v.Events[0].EventType == EventTypes.ProjectionUpdated));
         }
 
         [Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+using EventStore.Projections.Core.Services.Processing;
+using System.Collections.Generic;
+using EventStore.Projections.Core.Common;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager.when_reading_registered_projections
+{
+    [TestFixture]
+    public class with_no_stream : TestFixtureWithProjectionCoreAndManagementServices
+    {
+        protected override void Given()
+        {
+            AllWritesSucceed();
+            NoStream(ProjectionNamesBuilder.ProjectionsRegistrationStream);
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.SystemCoreReady();
+        }
+
+        protected override bool GivenInitializeSystemProjections()
+        {
+            return false;
+        }
+
+        [Test]
+        public void it_should_write_the_projections_initialized_event()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Count(x => 
+                    x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream && 
+                    x.Events[0].EventType == EventTypes.ProjectionsInitialized));
+        }
+
+        [Test]
+        public void it_should_not_write_any_projection_created_events()
+        {
+            Assert.AreEqual(0, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Count(x => 
+                    x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream && 
+                    x.Events[0].EventType == EventTypes.ProjectionCreated));
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream_and_intialize_system_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream_and_intialize_system_projections.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+using EventStore.Projections.Core.Services.Processing;
+using System.Collections.Generic;
+using EventStore.Projections.Core.Common;
+using System.Collections;
+using EventStore.Common.Utils;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager.when_reading_registered_projections
+{
+    [TestFixture, TestFixtureSource(typeof(SystemProjectionNames))]
+    public class with_no_stream_and_intialize_system_projections : TestFixtureWithProjectionCoreAndManagementServices
+    {
+        private string _systemProjectionName;
+        public with_no_stream_and_intialize_system_projections(string projectionName)
+        {
+            _systemProjectionName = projectionName;
+        }
+
+        protected override void Given()
+        {
+            AllWritesSucceed();
+            NoStream(ProjectionNamesBuilder.ProjectionsRegistrationStream);
+            NoOtherStreams();
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.SystemCoreReady();
+        }
+
+        protected override bool GivenInitializeSystemProjections()
+        {
+            return true;
+        }
+
+        [Test]
+        public void it_should_write_the_projections_initialized_event()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Count(x => 
+                    x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream && 
+                    x.Events[0].EventType == EventTypes.ProjectionsInitialized));
+        }
+
+        [Test]
+        public void it_should_write_the_system_projection_created_event()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Count(x =>
+                    x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream &&
+                    x.Events[0].EventType == EventTypes.ProjectionCreated &&
+                    Helper.UTF8NoBom.GetString(x.Events[0].Data) == _systemProjectionName));
+        }
+    }
+
+    public class SystemProjectionNames : IEnumerable
+    {
+        public IEnumerator GetEnumerator()
+        {
+            return typeof(ProjectionNamesBuilder.StandardProjections).GetFields(
+                System.Reflection.BindingFlags.Public |
+                System.Reflection.BindingFlags.Static |
+                System.Reflection.BindingFlags.FlattenHierarchy)
+                .Where(x => x.IsLiteral && !x.IsInitOnly)
+                .Select(x => x.GetRawConstantValue()).
+                GetEnumerator();
+        }
+    }
+
+
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
@@ -1,13 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         public void a_projection_created_event_should_be_written()
         {
             Assert.AreEqual(
-                "$ProjectionCreated",
+                EventTypes.ProjectionCreated,
                 _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().First().Events[0].EventType);
             Assert.AreEqual(
                 _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_requesting_partition_state_from_a_stopped_foreach_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_requesting_partition_state_from_a_stopped_foreach_projection.cs
@@ -5,6 +5,8 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Projections.Core.Messages;
 using NUnit.Framework;
+using EventStore.Projections.Core.Common;
+using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -15,9 +17,9 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override void Given()
         {
             NoStream("$projections-test-projection-order");
-            ExistingEvent("$projections-$all", "$ProjectionCreated", null, "test-projection");
+            ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, EventTypes.ProjectionCreated, null, "test-projection");
             ExistingEvent(
-                "$projections-test-projection", "$ProjectionUpdated", null,
+                "$projections-test-projection", EventTypes.ProjectionUpdated, null,
                 @"{""Query"":""fromCategory('test').foreachStream().when({'e': function(s,e){}})"", 
                     ""Mode"":""3"", ""Enabled"":false, ""HandlerType"":""JS"",
                     ""SourceDefinition"":{

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_partially_created_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_partially_created_projection.cs
@@ -12,6 +12,8 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Management;
 using EventStore.Projections.Core.Tests.Services.core_projection;
 using NUnit.Framework;
+using EventStore.Projections.Core.Common;
+using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -26,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override void Given()
         {
             _workerId = Guid.NewGuid();
-            ExistingEvent("$projections-$all", "$ProjectionCreated", null, "projection1");
+            ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, EventTypes.ProjectionCreated, null, "projection1");
             NoStream("$projections-projection1");
         }
 
@@ -45,6 +47,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 _ioDispatcher);
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);
             _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
             _manager.Handle(new ProjectionManagementMessage.ReaderReady());
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projection.cs
@@ -7,11 +7,12 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Services.TimeService;
-using EventStore.Core.Util;
+using EventStore.Projections.Core.Common;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Management;
 using EventStore.Projections.Core.Tests.Services.core_projection;
 using NUnit.Framework;
+using EventStore.Projections.Core.Services.Processing;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -25,9 +26,9 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override void Given()
         {
             _workerId = Guid.NewGuid();
-            ExistingEvent("$projections-$all", "$ProjectionCreated", null, "projection1");
+            ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, EventTypes.ProjectionCreated, null, "projection1");
             ExistingEvent(
-                "$projections-projection1", "$ProjectionUpdated", null,
+                "$projections-projection1", EventTypes.ProjectionUpdated, null,
                 @"{""Query"":""fromAll(); on_any(function(){});log('hello-from-projection-definition');"", ""Mode"":""3"", ""Enabled"":true, ""HandlerType"":""JS""}");
         }
 
@@ -46,6 +47,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 _ioDispatcher);
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);
             _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
             _manager.Handle(new ProjectionManagementMessage.ReaderReady());
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projection_config.cs
@@ -1,3 +1,5 @@
+using EventStore.Projections.Core.Services.Processing;
+
 namespace EventStore.Projections.Core.Tests.Services.projections_system
 {
     public abstract class with_projection_config : with_projections_subsystem
@@ -18,9 +20,9 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
             _trackEmittedStreams = true;
             _emitEnabled = true;
 
-            NoStream("$projections-" + _projectionName + "-checkpoint");
-            NoStream("$projections-" + _projectionName + "-order");
-            NoStream("$projections-" + _projectionName + "-emittedstreams");
+            NoStream(ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName + "-checkpoint");
+            NoStream(ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName + "-order");
+            NoStream(ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName + "-emittedstreams");
             AllWritesSucceed();
         }
 

--- a/src/EventStore.Projections.Core/Common/EventTypes.cs
+++ b/src/EventStore.Projections.Core/Common/EventTypes.cs
@@ -1,0 +1,10 @@
+﻿namespace EventStore.Projections.Core.Common
+{
+    public static class EventTypes
+    {
+        public const string ProjectionCreated = "$ProjectionCreated";
+        public const string ProjectionDeleted = "$ProjectionDeleted";
+        public const string ProjectionsInitialized = "$ProjectionsInitialized";
+        public const string ProjectionUpdated = "$ProjectionUpdated";
+    }
+}

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -122,6 +122,7 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\EventTypes.cs" />
     <Compile Include="EventReaders\Feeds\FeedReader.cs" />
     <Compile Include="EventReaders\Feeds\FeedReaderService.cs" />
     <Compile Include="Messages\CoreProjectionManagementMessage.cs" />

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -114,6 +114,7 @@ namespace EventStore.Projections.Core
             mainBus.Subscribe<ClientMessage.WriteEventsCompleted>(projectionManager);
             mainBus.Subscribe<ClientMessage.DeleteStreamCompleted>(projectionManager);
             mainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(projectionManager);
+            mainBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(projectionManager);
 
             mainBus.Subscribe(ioDispatcher.Awaker);
             mainBus.Subscribe(ioDispatcher.BackwardReader);

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -16,6 +16,7 @@ using EventStore.Projections.Core.Utils;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 using System.Threading;
 using EventStore.Core.Helpers;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Services.Management
 {
@@ -579,7 +580,7 @@ namespace EventStore.Projections.Core.Services.Management
             var corrId = Guid.NewGuid();
             _readDispatcher.Publish(
                 new ClientMessage.ReadStreamEventsBackward(
-                    corrId, corrId, _readDispatcher.Envelope, "$projections-" + name, -1, 1, 
+                    corrId, corrId, _readDispatcher.Envelope, ProjectionNamesBuilder.ProjectionsStreamPrefix + name, -1, 1, 
                     resolveLinkTos: false, requireMaster: false, validationStreamVersion: null, user: SystemAccount.Principal), 
                 PersistedStateReadCompleted);
         }
@@ -686,12 +687,12 @@ namespace EventStore.Projections.Core.Services.Management
             }
             _writing = true;
             var managedProjectionSerializedState = PersistedProjectionState.ToJsonBytes();
-            var eventStreamId = "$projections-" + _name;
+            var eventStreamId = ProjectionNamesBuilder.ProjectionsStreamPrefix + _name;
             var corrId = Guid.NewGuid();
             _writeDispatcher.Publish(
                 new ClientMessage.WriteEvents(
                     corrId, corrId, _writeDispatcher.Envelope, true, eventStreamId, ExpectedVersion.Any,
-                    new Event(Guid.NewGuid(), "$ProjectionUpdated", true, managedProjectionSerializedState, Empty.ByteArray),
+                    new Event(Guid.NewGuid(), EventTypes.ProjectionUpdated, true, managedProjectionSerializedState, Empty.ByteArray),
                     SystemAccount.Principal),
                 m => WritePersistedStateCompleted(m, eventStreamId));
         }

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionNamesBuilder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionNamesBuilder.cs
@@ -75,7 +75,7 @@ namespace EventStore.Projections.Core.Services.Processing
                    ?? ProjectionsStreamPrefix + EffectiveProjectionName + "-{0}" + ProjectionsStateStreamSuffix;
         }
 
-        private const string ProjectionsStreamPrefix = "$projections-";
+        public const string ProjectionsStreamPrefix = "$projections-";
         private const string ProjectionsControlStreamPrefix = "$projections-$";
         private const string ProjectionsStateStreamSuffix = "-result";
         private const string ProjectionCheckpointStreamSuffix = "-checkpoint";
@@ -85,6 +85,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private const string CategoryCatalogStreamNamePrefix = "$category-";
         public const string _projectionsControlStream = "$projections-$control";
         public const string _projectionsMasterStream = "$projections-$master";
+        public const string ProjectionsRegistrationStream = "$projections-$all";
 
         public string GetPartitionCatalogStreamName()
         {


### PR DESCRIPTION
There is a case where projections that have been deleted can come back to life due to the way that registered projections are currently read.

Reproduction Steps:

1. Create 200 (double the current batch size) projections and then delete the first projection and don't
specify that you want any of it's state streams deleted.
2. Restart Event Store.
The projection that you have deleted will start up in a stopped state

To remedy this, the way the registration stream is being read has been
changed from the hard to reason about reading the stream backwards
and then using grouping logic to determine whether the projection is
alive/dead.

It has been changed to reading the stream forwards from the beginning and
building up state which represents the projections which are alive.

Another part of this commit addresses the issue of hardcoded strings in
particular those that pertain to the registered projections, namely the
projection registration stream ($projections-$all), the event types such
as $ProjectionCreated, $ProjectionDeleted, $ProjectionsInitialized as
well as the $ProjectionUpdated (which is written to the projection's
configuration stream $projections-{name})