### PR TITLE
Checkpoint after a certain period

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -130,6 +130,8 @@
     <Compile Include="Services\projections_manager\when_posting_a_persistent_projection_and_registration_write_fails.cs" />
     <Compile Include="Services\projections_manager\when_reading_registered_projections\with_no_stream_and_intialize_system_projections.cs" />
     <Compile Include="Services\projections_manager\when_reading_registered_projections\with_no_stream.cs" />
+    <Compile Include="Services\projection_subscription\when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses.cs" />
+    <Compile Include="Services\projection_subscription\when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses.cs" />
     <Compile Include="Services\SpecificationWithEmittedStreamsTrackerAndDeleter.cs" />
     <Compile Include="Services\emitted_streams_deleter\when_deleting\with_multiple_tracked_streams.cs" />
     <Compile Include="Services\emitted_streams_deleter\when_deleting\with_an_existing_emitted_streams_stream.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services
             _node.Node.MainBus.Subscribe(_ioDispatcher.Awaker);
             _node.Node.MainBus.Subscribe(_ioDispatcher);
             _projectionNamesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
-            _emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher, new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, false, _trackEmittedStreams), _projectionNamesBuilder);
+            _emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher, new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, false, _trackEmittedStreams, 10000), _projectionNamesBuilder);
             _emittedStreamsDeleter = new EmittedStreamsDeleter(_ioDispatcher, _projectionNamesBuilder.GetEmittedStreamsName(), _projectionNamesBuilder.GetEmittedStreamsCheckpointName());
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
@@ -104,7 +104,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             return new ProjectionConfig(
                 null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold, GivenPendingEventsThreshold(),
                 GivenMaxWriteBatchLength(), GivenEmitEventEnabled(), GivenCheckpointsEnabled(), _createTempStreams,
-                GivenStopOnEof(), GivenIsSlaveProjection(), GivenTrackEmittedStreams());
+                GivenStopOnEof(), GivenIsSlaveProjection(), GivenTrackEmittedStreams(), GivenCheckpointAfterMs());
         }
 
         protected virtual bool GivenIsSlaveProjection()
@@ -140,6 +140,11 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         protected virtual bool GivenEmitEventEnabled()
         {
             return true;
+        }
+
+        protected virtual int GivenCheckpointAfterMs()
+        {
+            return 10000;
         }
 
         protected virtual FakeProjectionStateHandler GivenProjectionStateHandler()

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -18,6 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
         protected bool _emitEventEnabled;
         protected bool _checkpointsEnabled;
         protected bool _trackEmittedStreams;
+        protected int _checkpointAfterMs;
         protected bool _producesResults;
         protected bool _definesFold = true;
         protected Guid _projectionCorrelationId;
@@ -37,7 +38,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
             _namingBuilder = ProjectionNamesBuilder.CreateForTest("projection");
             _config = new ProjectionConfig(null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold,
                 _pendingEventsThreshold, _maxWriteBatchLength, _emitEventEnabled,
-                _checkpointsEnabled, _createTempStreams, _stopOnEof, false, _trackEmittedStreams);
+                _checkpointsEnabled, _createTempStreams, _stopOnEof, false, _trackEmittedStreams, _checkpointAfterMs);
             When();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
@@ -24,7 +24,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         }
 
         private readonly ProjectionConfig _defaultProjectionConfig = new ProjectionConfig(
-            null, 5, 10, 1000, 250, true, true, true, true, false, true);
+            null, 5, 10, 1000, 250, true, true, true, true, false, true, 10000);
 
         private IODispatcher _ioDispatcher;
 
@@ -39,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             Assert.Throws<ArgumentException>(() => {
                 IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
                 var version = new ProjectionVersion(1, 0, 0);
-                var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false, false, true);
+                var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false, false, true, 10000);
                 new ContinuousProjectionProcessingStrategy(
                     "projection",
                     version,
@@ -65,7 +65,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             Assert.Throws<ArgumentOutOfRangeException>(() => {
                 IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
                 var version = new ProjectionVersion(1, 0, 0);
-                var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false, false, true);
+                var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false, false, true, 10000);
                 new ContinuousProjectionProcessingStrategy(
                     "projection",
                     version,
@@ -264,7 +264,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             Assert.Throws<ArgumentOutOfRangeException>(() => {
                 IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
                 var version = new ProjectionVersion(1, 0, 0);
-                var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false, false, true);
+                var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false, false, true, 10000);
                 new ContinuousProjectionProcessingStrategy(
                     "projection",
                     version,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             _bus.Subscribe(_ioDispatcher.Writer);
             _bus.Subscribe(_ioDispatcher);
             IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
-            _projectionConfig = new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, false, true);
+            _projectionConfig = new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, false, true, 10000);
             var version = new ProjectionVersion(1, 0, 0);
             var projectionProcessingStrategy = new ContinuousProjectionProcessingStrategy(
                 "projection", version, projectionStateHandler, _projectionConfig,

--- a/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
@@ -19,7 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_service
             _readerService.Handle(
                 new ReaderSubscriptionManagement.Subscribe(
                     projectionCorrelationId, CheckpointTag.FromPosition(0, 0, 0), readerStrategy,
-                    new ReaderSubscriptionOptions(1000, 2000, false, stopAfterNEvents: null)));
+                    new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
             _readerService.Handle(
                 ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
                     readerStrategy.EventReaderId, new TFPos(20, 10), "throws", 10, false, Guid.NewGuid(),

--- a/src/EventStore.Projections.Core.Tests/Services/core_service/when_unsubscribing_a_subscribed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_service/when_unsubscribing_a_subscribed_projection.cs
@@ -24,11 +24,11 @@ namespace EventStore.Projections.Core.Tests.Services.core_service
             _readerService.Handle(
                 new ReaderSubscriptionManagement.Subscribe(
                     _projectionCorrelationId, CheckpointTag.FromPosition(0, 0, 0), CreateReaderStrategy(),
-                    new ReaderSubscriptionOptions(1000, 2000, false, stopAfterNEvents: null)));
+                    new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
             _readerService.Handle(
                 new ReaderSubscriptionManagement.Subscribe(
                     _projectionCorrelationId2, CheckpointTag.FromPosition(0, 0, 0), CreateReaderStrategy(),
-                    new ReaderSubscriptionOptions(1000, 2000, false, stopAfterNEvents: null)));
+                    new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
             // when
             _readerService.Handle(new ReaderSubscriptionManagement.Unsubscribe(_projectionCorrelationId));
         }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_catalog_event_reader/when_reading_catalog.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_catalog_event_reader/when_reading_catalog.cs
@@ -54,7 +54,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.all_streams_ca
                     SystemAccount.Principal,
                     _timeProvider);
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: true,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  
+                    stopOnEof: true,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_including_links.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_including_links.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.all_streams_wi
                     stopOnEof: true,
                     runAs: null);
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: true,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  stopOnEof: true,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_not_including_links.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_not_including_links.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.all_streams_wi
                     stopOnEof: true,
                     runAs: null);
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: true,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  stopOnEof: true,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/by_stream_catalog_event_reader/when_reading_catalog.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/by_stream_catalog_event_reader/when_reading_catalog.cs
@@ -56,7 +56,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.by_stream_cata
                     stopOnEof: true,
                     runAs: null);
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: true,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  stopOnEof: true,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
@@ -51,7 +51,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
                     stopOnEof: false,
                     runAs: null);
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: false,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  stopOnEof: false,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_one_event_type_has_been_never_emitted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_one_event_type_has_been_never_emitted.cs
@@ -58,7 +58,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
                     stopOnEof: false,
                     runAs: null);
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: false,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  stopOnEof: false,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_reordering_happens_in_event_by_type_index.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_reordering_happens_in_event_by_type_index.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
                     runAs: null);
 
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: false,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  stopOnEof: false,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/externally_fed_by_stream_event_reader/when_fed_with_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/externally_fed_by_stream_event_reader/when_fed_with_streams.cs
@@ -45,7 +45,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.externally_fed
                     limitingCommitPosition: 10000);
 
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: true,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  stopOnEof: true,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/reordering.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/reordering.cs
@@ -49,7 +49,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
                     runAs: null);
 
                 _readerSubscriptionOptions = new ReaderSubscriptionOptions(
-                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, stopOnEof: false,
+                    checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100, checkpointAfterMs: 10000,  stopOnEof: false,
                     stopAfterNEvents: null);
             }
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/TestFixtureWithEventReorderingProjectionSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/TestFixtureWithEventReorderingProjectionSubscription.cs
@@ -30,12 +30,12 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 
         protected override IReaderSubscription CreateProjectionSubscription()
         {
-            return new EventReorderingReaderSubscription(_bus, 
+            return new EventReorderingReaderSubscription(_bus,
                 _projectionCorrelationId, 
                 CheckpointTag.FromStreamPositions(0, new Dictionary<string, long> {{"a", ExpectedVersion.NoStream}, {"b", ExpectedVersion.NoStream}}),
                 _readerStrategy,
                 _timeProvider,
-                _checkpointUnhandledBytesThreshold, _checkpointProcessedEventsThreshold, _processingLagMs);
+                _checkpointUnhandledBytesThreshold, _checkpointProcessedEventsThreshold, _checkpointAfterMs, _processingLagMs);
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/when_creating_projection_subscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/when_creating_projection_subscription.cs
@@ -21,6 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
                 new FakeTimeProvider(),
                 1000,
                 2000,
+                10000,
                 500);
         }
 
@@ -36,6 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
                 new FakeTimeProvider(),
                 1000,
                 2000,
+                10000,
                 500);
             });
         }
@@ -52,6 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
                 new FakeTimeProvider(),
                 1000,
                 2000,
+                10000,
                 500);
             });
         }
@@ -68,6 +71,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
                 null,
                 1000,
                 2000,
+                10000,
                 500);
             });
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
@@ -28,6 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription
         protected Action<SourceDefinitionBuilder> _source = null;
         protected int _checkpointUnhandledBytesThreshold;
         protected int _checkpointProcessedEventsThreshold;
+        protected int _checkpointAfterMs;
         protected IReaderStrategy _readerStrategy;
 
         [SetUp]
@@ -35,9 +36,10 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription
         {
             _checkpointUnhandledBytesThreshold = 1000;
             _checkpointProcessedEventsThreshold = 2000;
+            _checkpointAfterMs = 10000;
+            _timeProvider = new RealTimeProvider();
             Given();
             _bus = new InMemoryBus("bus");
-            _timeProvider = new RealTimeProvider();
             _projectionCorrelationId = Guid.NewGuid();
             _eventHandler = new TestHandler<EventReaderSubscriptionMessage.CommittedEventReceived>();
             _checkpointHandler = new TestHandler<EventReaderSubscriptionMessage.CheckpointSuggested>();
@@ -72,7 +74,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription
                 _readerStrategy,
                 _timeProvider,
                 _checkpointUnhandledBytesThreshold,
-                _checkpointProcessedEventsThreshold);
+                _checkpointProcessedEventsThreshold,
+                _checkpointAfterMs);
         }
 
         protected virtual void Given()
@@ -95,12 +98,11 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription
             }
             var config = ProjectionConfig.GetTest();
             IQuerySources sources = readerBuilder.Build();
-            ITimeProvider timeProvider = new RealTimeProvider();
             var readerStrategy = Core.Services.Processing.ReaderStrategy.Create(
                 "test",
                 0,
                 sources,
-                timeProvider,
+                _timeProvider,
                 stopOnEof: false,
                 runAs: config.RunAs);
             return readerStrategy;

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_creating_projection_subscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_creating_projection_subscription.cs
@@ -21,7 +21,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription
                 CreateReaderStrategy(),
                 new FakeTimeProvider(),
                 1000,
-                2000);
+                2000,
+                10000);
         }
 
         [Test]
@@ -36,7 +37,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription
                 CreateReaderStrategy(),
                 new FakeTimeProvider(),
                 1000,
-                2000);
+                2000,
+                10000);
             });
         }
 
@@ -52,7 +54,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription
                 null,
                 new FakeTimeProvider(),
                 1000,
-                2000);
+                2000,
+                10000);
             });
         }
 
@@ -68,7 +71,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription
                 CreateReaderStrategy(),
                 null,
                 1000,
-                2000);
+                2000,
+                10000);
             });
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Messages;
+using NUnit.Framework;
+using EventStore.Core.Tests.Services.TimeService;
+
+namespace EventStore.Projections.Core.Tests.Services.projection_subscription
+{
+    [TestFixture]
+    public class when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses : TestFixtureWithProjectionSubscription
+    {
+        protected override void Given()
+        {
+            _checkpointAfterMs = 1000;
+            _checkpointProcessedEventsThreshold = 1;
+            _timeProvider = new FakeTimeProvider();
+        }
+
+        protected override void When()
+        {
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+            _checkpointHandler.HandledMessages.Clear();
+            ((FakeTimeProvider)_timeProvider).AddTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+        }
+
+        [Test]
+        public void checkpoint_is_suggested()
+        {
+            Assert.AreEqual(1, _checkpointHandler.HandledMessages.Count);
+        }
+    }
+
+    [TestFixture]
+    public class when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses_and_not_passing_filter : TestFixtureWithProjectionSubscription
+    {
+        protected override void Given()
+        {
+            _source = source =>
+                {
+                    source.FromAll();
+                    source.IncludeEvent("specific-event");
+                };
+            _checkpointAfterMs = 1000;
+            _checkpointUnhandledBytesThreshold = 50;
+            _checkpointProcessedEventsThreshold = 1;
+            _timeProvider = new FakeTimeProvider();
+        }
+
+        protected override void When()
+        {
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+            _checkpointHandler.HandledMessages.Clear();
+            ((FakeTimeProvider)_timeProvider).AddTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(400, 400), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+        }
+
+        [Test]
+        public void checkpoint_is_suggested()
+        {
+            Assert.AreEqual(1, _checkpointHandler.HandledMessages.Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Messages;
+using NUnit.Framework;
+using EventStore.Core.Tests.Services.TimeService;
+
+namespace EventStore.Projections.Core.Tests.Services.projection_subscription
+{
+    [TestFixture]
+    public class when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses : TestFixtureWithProjectionSubscription
+    {
+        protected override void Given()
+        {
+            _checkpointAfterMs = 1000;
+            _checkpointProcessedEventsThreshold = 1;
+            _timeProvider = new FakeTimeProvider();
+        }
+
+        protected override void When()
+        {
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+            _checkpointHandler.HandledMessages.Clear();
+            ((FakeTimeProvider)_timeProvider).AddTime(TimeSpan.FromMilliseconds(_checkpointAfterMs));
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+        }
+
+        [Test]
+        public void checkpoint_is_not_suggested()
+        {
+            Assert.AreEqual(0, _checkpointHandler.HandledMessages.Count);
+        }
+    }
+
+    [TestFixture]
+    public class when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses_and_not_passing_filter : TestFixtureWithProjectionSubscription
+    {
+        protected override void Given()
+        {
+            _source = source =>
+            {
+                source.FromAll();
+                source.IncludeEvent("specific-event");
+            };
+            _checkpointAfterMs = 1000;
+            _checkpointUnhandledBytesThreshold = 50;
+            _checkpointProcessedEventsThreshold = 1;
+            _timeProvider = new FakeTimeProvider();
+        }
+
+        protected override void When()
+        {
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+            _checkpointHandler.HandledMessages.Clear();
+            ((FakeTimeProvider)_timeProvider).AddTime(TimeSpan.FromMilliseconds(_checkpointAfterMs));
+            _subscription.Handle(
+                ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                    Guid.NewGuid(), new TFPos(400, 400), "test-stream", 1, false, Guid.NewGuid(),
+                    "bad-event-type", false, new byte[0], new byte[0]));
+        }
+
+        [Test]
+        public void checkpoint_is_not_suggested()
+        {
+            Assert.AreEqual(0, _checkpointHandler.HandledMessages.Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_message.cs
@@ -38,7 +38,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
-                true);
+                true,
+                10000);
 
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_slave_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_slave_message.cs
@@ -42,7 +42,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
-                true);
+                true,
+                10000);
 
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_prepared_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_prepared_message.cs
@@ -39,7 +39,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
-                true);
+                true,
+                10000);
 
             var builder = new SourceDefinitionBuilder();
             builder.FromStream("s1");

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
@@ -47,7 +47,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.slave_p
                         false,
                         true,
                         true,
-                        true),
+                        true,
+                        10000),
                     _masterWorkerId,
                     _coreProjectionCorrelationId,
                     //(handlerType, query) => new FakeProjectionStateHandler(

--- a/src/EventStore.Projections.Core/EventReaders/Feeds/FeedReader.cs
+++ b/src/EventStore.Projections.Core/EventReaders/Feeds/FeedReader.cs
@@ -85,6 +85,7 @@ namespace EventStore.Projections.Core.EventReaders.Feeds
             //TODO: make reader mode explicit
             var readerOptions = new ReaderSubscriptionOptions(
                 1024*1024,
+                checkpointAfterMs: 10000,
                 checkpointProcessedEventsThreshold: null,
                 stopOnEof: true,
                 stopAfterNEvents: _maxEvents);

--- a/src/EventStore.Projections.Core/Messages/Persisted/Commands/PersistedProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Messages/Persisted/Commands/PersistedProjectionConfig.cs
@@ -19,6 +19,7 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
         public bool StopOnEof;
         public bool IsSlaveProjection;
         public bool TrackEmittedStreams;
+        public int CheckpointAfterMs;
 
         public PersistedProjectionConfig()
         {
@@ -41,6 +42,7 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
             StopOnEof = config.StopOnEof;
             IsSlaveProjection = config.IsSlaveProjection;
             TrackEmittedStreams = config.TrackEmittedStreams;
+            CheckpointAfterMs = config.CheckpointAfterMs;
         }
 
         public ProjectionConfig ToConfig()
@@ -59,7 +61,8 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
                     CreateTempStreams,
                     StopOnEof,
                     IsSlaveProjection,
-                    TrackEmittedStreams);
+                    TrackEmittedStreams,
+                    CheckpointAfterMs);
         }
     }
 }

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -929,6 +929,7 @@ namespace EventStore.Projections.Core.Services.Management
             var checkpointsEnabled = PersistedProjectionState.CheckpointsDisabled != true;
             var trackEmittedStreams = PersistedProjectionState.TrackEmittedStreams == true;
             var checkpointHandledThreshold = checkpointsEnabled ? 4000 : 0;
+            var checkpointAfterMs = checkpointsEnabled ? 10000 : 0;
             var checkpointUnhandledBytesThreshold = checkpointsEnabled ? 10*1000*1000 : 0;
             var pendingEventsThreshold = 5000;
             var maxWriteBatchLength = 500;
@@ -947,7 +948,8 @@ namespace EventStore.Projections.Core.Services.Management
                 createTempStreams,
                 stopOnEof,
                 false,
-                trackEmittedStreams);
+                trackEmittedStreams,
+                checkpointAfterMs);
             return projectionConfig;
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/EventReorderingReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReorderingReaderSubscription.cs
@@ -22,6 +22,7 @@ namespace EventStore.Projections.Core.Services.Processing
             ITimeProvider timeProvider,
             long? checkpointUnhandledBytesThreshold,
             int? checkpointProcessedEventsThreshold,
+            int checkpointAfterMs,
             int processingLagMs,
             bool stopOnEof = false,
             int? stopAfterNEvents = null)
@@ -33,6 +34,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 timeProvider,
                 checkpointUnhandledBytesThreshold,
                 checkpointProcessedEventsThreshold,
+                checkpointAfterMs,
                 stopOnEof,
                 stopAfterNEvents)
         {

--- a/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
@@ -321,6 +321,7 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             return new ReaderSubscriptionOptions(
                 _projectionConfig.CheckpointUnhandledBytesThreshold, _projectionConfig.CheckpointHandledThreshold,
+                _projectionConfig.CheckpointAfterMs,
                 _stopOnEof, stopAfterNEvents: null);
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/ExternallyFedReaderStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ExternallyFedReaderStrategy.cs
@@ -55,6 +55,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 _timeProvider, 
                 readerSubscriptionOptions.CheckpointUnhandledBytesThreshold,
                 readerSubscriptionOptions.CheckpointProcessedEventsThreshold,
+                readerSubscriptionOptions.CheckpointAfterMs,
                 readerSubscriptionOptions.StopOnEof,
                 readerSubscriptionOptions.StopAfterNEvents);
         }

--- a/src/EventStore.Projections.Core/Services/Processing/ParallelQueryAllStreamsMasterReaderStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ParallelQueryAllStreamsMasterReaderStrategy.cs
@@ -55,6 +55,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 _timeProvider, 
                 readerSubscriptionOptions.CheckpointUnhandledBytesThreshold,
                 readerSubscriptionOptions.CheckpointProcessedEventsThreshold,
+                readerSubscriptionOptions.CheckpointAfterMs,
                 readerSubscriptionOptions.StopOnEof,
                 readerSubscriptionOptions.StopAfterNEvents);
         }

--- a/src/EventStore.Projections.Core/Services/Processing/ParallelQueryMasterReaderStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ParallelQueryMasterReaderStrategy.cs
@@ -55,6 +55,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 _timeProvider, 
                 readerSubscriptionOptions.CheckpointUnhandledBytesThreshold,
                 readerSubscriptionOptions.CheckpointProcessedEventsThreshold,
+                readerSubscriptionOptions.CheckpointAfterMs,
                 readerSubscriptionOptions.StopOnEof,
                 readerSubscriptionOptions.StopAfterNEvents);
         }

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderStrategy.cs
@@ -188,6 +188,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     _timeProvider,
                     readerSubscriptionOptions.CheckpointUnhandledBytesThreshold,
                     readerSubscriptionOptions.CheckpointProcessedEventsThreshold,
+                    readerSubscriptionOptions.CheckpointAfterMs,
                     _processingLag,
                     readerSubscriptionOptions.StopOnEof,
                     readerSubscriptionOptions.StopAfterNEvents);
@@ -201,6 +202,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     _timeProvider, 
                     readerSubscriptionOptions.CheckpointUnhandledBytesThreshold,
                     readerSubscriptionOptions.CheckpointProcessedEventsThreshold,
+                    readerSubscriptionOptions.CheckpointAfterMs,
                     readerSubscriptionOptions.StopOnEof,
                     readerSubscriptionOptions.StopAfterNEvents);
         }

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
@@ -16,6 +16,7 @@ namespace EventStore.Projections.Core.Services.Processing
             ITimeProvider timeProvider,
             long? checkpointUnhandledBytesThreshold,
             int? checkpointProcessedEventsThreshold,
+            int checkpointAfterMs,
             bool stopOnEof = false,
             int? stopAfterNEvents = null)
             : base(
@@ -26,6 +27,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 timeProvider,
                 checkpointUnhandledBytesThreshold,
                 checkpointProcessedEventsThreshold,
+                checkpointAfterMs,
                 stopOnEof,
                 stopAfterNEvents)
         {

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionOptions.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionOptions.cs
@@ -4,14 +4,16 @@ namespace EventStore.Projections.Core.Services.Processing
     {
         private readonly long _checkpointUnhandledBytesThreshold;
         private readonly int? _checkpointProcessedEventsThreshold;
+        private readonly int _checkpointAfterMs;
         private readonly bool _stopOnEof;
         private readonly int? _stopAfterNEvents;
 
         public ReaderSubscriptionOptions(
-            long checkpointUnhandledBytesThreshold, int? checkpointProcessedEventsThreshold, bool stopOnEof, int? stopAfterNEvents)
+            long checkpointUnhandledBytesThreshold, int? checkpointProcessedEventsThreshold, int checkpointAfterMs, bool stopOnEof, int? stopAfterNEvents)
         {
             _checkpointUnhandledBytesThreshold = checkpointUnhandledBytesThreshold;
             _checkpointProcessedEventsThreshold = checkpointProcessedEventsThreshold;
+            _checkpointAfterMs = checkpointAfterMs;
             _stopOnEof = stopOnEof;
             _stopAfterNEvents = stopAfterNEvents;
         }
@@ -24,6 +26,11 @@ namespace EventStore.Projections.Core.Services.Processing
         public int? CheckpointProcessedEventsThreshold
         {
             get { return _checkpointProcessedEventsThreshold; }
+        }
+
+        public int CheckpointAfterMs
+        {
+            get { return _checkpointAfterMs; }
         }
 
         public bool StopOnEof

--- a/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
@@ -16,10 +16,11 @@ namespace EventStore.Projections.Core.Services
         private readonly bool _stopOnEof;
         private readonly bool _isSlaveProjection;
         private readonly bool _trackEmittedStreams;
+        private readonly int _checkpointAfterMs;
 
         public ProjectionConfig(IPrincipal runAs, int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold,
             int pendingEventsThreshold, int maxWriteBatchLength, bool emitEventEnabled, bool checkpointsEnabled,
-            bool createTempStreams, bool stopOnEof, bool isSlaveProjection, bool trackEmittedStreams)
+            bool createTempStreams, bool stopOnEof, bool isSlaveProjection, bool trackEmittedStreams, int checkpointAfterMs)
         {
             if (checkpointsEnabled)
             {
@@ -46,6 +47,7 @@ namespace EventStore.Projections.Core.Services
             _stopOnEof = stopOnEof;
             _isSlaveProjection = isSlaveProjection;
             _trackEmittedStreams = trackEmittedStreams;
+            _checkpointAfterMs = checkpointAfterMs;
         }
 
         public int CheckpointHandledThreshold
@@ -103,16 +105,21 @@ namespace EventStore.Projections.Core.Services
             get { return _trackEmittedStreams; }
         }
 
+        public int CheckpointAfterMs
+        {
+            get { return _checkpointAfterMs; }
+        }
+
         public static ProjectionConfig GetTest()
         {
-            return new ProjectionConfig(null, 1000, 1000*1000, 100, 500, true, true, false, false, false, true);
+            return new ProjectionConfig(null, 1000, 1000*1000, 100, 500, true, true, false, false, false, true, 10000);
         }
 
         public ProjectionConfig SetIsSlave()
         {
             return new ProjectionConfig(
                 _runAs, CheckpointHandledThreshold, CheckpointUnhandledBytesThreshold, PendingEventsThreshold,
-                MaxWriteBatchLength, EmitEventEnabled, _checkpointsEnabled, CreateTempStreams, StopOnEof, true, true);
+                MaxWriteBatchLength, EmitEventEnabled, _checkpointsEnabled, CreateTempStreams, StopOnEof, true, true, _checkpointAfterMs);
         }
     }
 }


### PR DESCRIPTION
We don't want to be checkpointing too often in a busy projection. There
is a lot of overhead associated with creating a checkpoint and creating
the associated emitted streams.

This commit adds a checkpoint after configuration value for projections
which will only checkpoint after x number of events and only once the
checkpoint after period has elapsed

Todo:
Convert all the constants to actual constants.