### PR TITLE
Time out reads in the ProjectionManagerResponseReader

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -80,6 +80,7 @@ namespace EventStore.Core.Tests.Helpers
         private Queue<ClientMessage.WriteEvents> _writesQueue;
         private bool _readAllEnabled;
         private bool _noOtherStreams;
+        private bool _readsTimeOut;
         private static readonly char[] _linkToSeparator = new []{'@'};
 
         protected TFPos ExistingStreamMetadata(string streamId, string metadata)
@@ -108,6 +109,11 @@ namespace EventStore.Core.Tests.Helpers
             _all.Add(eventPosition, eventRecord);
             _fakePosition += 100;
             return eventPosition;
+        }
+
+        protected void AllReadsTimeOut()
+        {
+            _readsTimeOut = true;
         }
 
         protected void EnableReadAll()
@@ -215,6 +221,7 @@ namespace EventStore.Core.Tests.Helpers
 
         void IHandle<ClientMessage.ReadStreamEventsBackward>.Handle(ClientMessage.ReadStreamEventsBackward message)
         {
+            if(_readsTimeOut) return;
             List<EventRecord> list;
             if (_deletedStreams.Contains(message.EventStreamId))
             {
@@ -280,6 +287,7 @@ namespace EventStore.Core.Tests.Helpers
 
         public void Handle(ClientMessage.ReadStreamEventsForward message)
         {
+            if(_readsTimeOut) return;
             List<EventRecord> list;
             if (_deletedStreams.Contains(message.EventStreamId))
             {
@@ -474,6 +482,7 @@ namespace EventStore.Core.Tests.Helpers
 
         public void Handle(ClientMessage.ReadAllEventsForward message)
         {
+            if(_readsTimeOut) return;
             if (!_readAllEnabled)
                 return;
             var from = new TFPos(message.CommitPosition, message.PreparePosition);

--- a/src/EventStore.Core/Helpers/IODispatcher.cs
+++ b/src/EventStore.Core/Helpers/IODispatcher.cs
@@ -103,14 +103,16 @@ namespace EventStore.Core.Helpers
             int maxCount,
             bool resolveLinks,
             IPrincipal principal,
-            Action<ClientMessage.ReadStreamEventsForwardCompleted> action)
+            Action<ClientMessage.ReadStreamEventsForwardCompleted> action,
+            Guid? corrId = null)
         {
-            var corrId = Guid.NewGuid();
+            if (!corrId.HasValue)
+                corrId = Guid.NewGuid();
             return
                 ForwardReader.Publish(
                     new ClientMessage.ReadStreamEventsForward(
-                        corrId,
-                        corrId,
+                        corrId.Value,
+                        corrId.Value,
                         ForwardReader.Envelope,
                         streamId,
                         fromEventNumber,

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -537,6 +537,9 @@
     <Compile Include="Services\event_reader\event_by_type_index_event_reader\when_index_based_checkpoint_read_timeout_occurs.cs" />
     <Compile Include="Services\event_reader\event_by_type_index_event_reader\when_tf_based_read_timeout_occurs.cs" />
     <Compile Include="Services\event_reader\event_by_type_index_event_reader\EventByTypeIndexEventReaderTestFixture.cs" />
+    <Compile Include="Services\projections_manager\projection_manager_response_reader\when_read_times_out.cs" />
+    <Compile Include="Services\projections_manager\projection_manager_response_reader\when_timeout_received_after_read_succeeds.cs" />
+    <Compile Include="Services\projections_manager\projection_manager_response_reader\when_read_results_in_an_error.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/specification_with_projection_manager_response_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/specification_with_projection_manager_response_reader.cs
@@ -8,7 +8,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.project
 {
     public class specification_with_projection_manager_response_reader : TestFixtureWithExistingEvents
     {
-        private ProjectionManagerResponseReader _commandReader;
+        protected ProjectionManagerResponseReader _commandReader;
 
         protected override void Given()
         {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/when_read_results_in_an_error.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/when_read_results_in_an_error.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Data;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager.projection_manager_response_reader
+{
+    [TestFixture]
+    public class when_read_results_in_an_error : specification_with_projection_manager_response_reader_started
+    {
+        private Guid _projectionId;
+        private Guid _readStreamEventsCorrelationId;
+        private string _projectionsMasterStream = "$projections-$master";
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            AllReadsTimeOut();
+            _consumer.HandledMessages.Clear();
+
+            _projectionId = Guid.NewGuid();
+            yield return
+                CreateWriteEvent(
+                    _projectionsMasterStream,
+                    "$stopped",
+                    @"{
+                        ""id"":""" + _projectionId.ToString("N") + @""",
+                    }",
+                    null,
+                    true);
+            var readStreamMessage = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().LastOrDefault(x => x.EventStreamId == _projectionsMasterStream);
+            Assert.IsNotNull(readStreamMessage, "Initial read was not issued");
+
+            _readStreamEventsCorrelationId = readStreamMessage.CorrelationId;
+            readStreamMessage.Envelope.ReplyWith(new ClientMessage.ReadStreamEventsForwardCompleted(
+                                _readStreamEventsCorrelationId, _projectionsMasterStream, -1, -1,
+                                ReadStreamResult.Error, new ResolvedEvent[0], null, false, "Test error while reading stream",
+                                -1, -1, true, 0));
+        }
+
+        [Test]
+        public void issues_a_new_read()
+        {
+            var response = HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == _projectionsMasterStream);
+            Assert.IsNotNull(response);
+            Assert.AreNotEqual(_readStreamEventsCorrelationId, response.CorrelationId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/when_read_times_out.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/when_read_times_out.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Projections.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager.projection_manager_response_reader
+{
+    [TestFixture]
+    public class when_read_times_out : specification_with_projection_manager_response_reader_started
+    {
+        private Guid _projectionId;
+        private Guid _readStreamEventsCorrelationId;
+        private string _projectionsMasterStream = "$projections-$master";
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            AllReadsTimeOut();
+            _consumer.HandledMessages.Clear();
+
+            _projectionId = Guid.NewGuid();
+            yield return
+                CreateWriteEvent(
+                    _projectionsMasterStream,
+                    "$stopped",
+                    @"{
+                        ""id"":""" + _projectionId.ToString("N") + @""",
+                    }",
+                    null,
+                    true);
+            var readStreamMessage = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().LastOrDefault(x => x.EventStreamId == _projectionsMasterStream);
+            Assert.IsNotNull(readStreamMessage, "Initial read was not issued");
+            _readStreamEventsCorrelationId = readStreamMessage.CorrelationId;
+            _commandReader.Handle(new ProjectionManagementMessage.Internal.ReadTimeout(_readStreamEventsCorrelationId, _projectionsMasterStream));
+        }
+
+        [Test]
+        public void issues_a_new_read()
+        {
+            var response = HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == _projectionsMasterStream);
+            Assert.IsNotNull(response);
+            Assert.AreNotEqual(_readStreamEventsCorrelationId, response.CorrelationId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/when_timeout_received_after_read_succeeds.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/when_timeout_received_after_read_succeeds.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager.projection_manager_response_reader
+{
+    [TestFixture]
+    public class when_timeout_received_after_read_succeeds : specification_with_projection_manager_response_reader_started
+    {
+        private Guid _projectionId;
+        private Guid _readStreamEventsCorrelationId;
+        private string _projectionsMasterStream = "$projections-$master";
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            AllReadsTimeOut();
+            _consumer.HandledMessages.Clear();
+
+            _projectionId = Guid.NewGuid();
+            yield return
+                CreateWriteEvent(
+                    _projectionsMasterStream,
+                    "$stopped",
+                    @"{
+                        ""id"":""" + _projectionId.ToString("N") + @""",
+                    }",
+                    null,
+                    true);
+            var readStreamMessage = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().LastOrDefault(x => x.EventStreamId == _projectionsMasterStream);
+            Assert.IsNotNull(readStreamMessage, "Initial read was not issued");
+
+            _readStreamEventsCorrelationId = readStreamMessage.CorrelationId;
+            readStreamMessage.Envelope.ReplyWith(new ClientMessage.ReadStreamEventsForwardCompleted(
+                                _readStreamEventsCorrelationId, _projectionsMasterStream, readStreamMessage.FromEventNumber, readStreamMessage.MaxCount,
+                                ReadStreamResult.Success, new ResolvedEvent[0], null, false, "", readStreamMessage.FromEventNumber, readStreamMessage.FromEventNumber,
+                                true, 1000));
+        }
+
+        [Test]
+        public void does_not_issue_a_new_read()
+        {
+            _commandReader.Handle(new ProjectionManagementMessage.Internal.ReadTimeout(_readStreamEventsCorrelationId, _projectionsMasterStream));
+
+            var response = HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == _projectionsMasterStream);
+            Assert.IsNotNull(response);
+            Assert.AreEqual(_readStreamEventsCorrelationId, response.CorrelationId);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1330 

Implement the `$projections-$master` read loop using a series of messages rather than using a while loop.
Add a read timeout that will kick off a new read to prevent the response reader from stalling.