### PR TITLE
Retry with same event id on write timeout

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Services\emitted_stream\another_epoch\when_handling_a_timeout.cs" />
     <Compile Include="Services\event_reader\heading_event_reader\when_the_heading_event_reader_with_a_subscribed_projection_handles_a_cached_event_and_throws.cs" />
     <Compile Include="Services\event_reader\heading_event_reader\when_the_heading_event_reader_with_a_subscribed_projection_handles_a_live_event_and_throws.cs" />
+    <Compile Include="Services\projections_manager\managed_projection\when_persisted_state_write_fails.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_system_projection.cs" />
     <Compile Include="Services\projections_manager\when_posting_a_persistent_projection_and_registration_write_fails.cs" />
     <Compile Include="Services\projections_manager\when_reading_registered_projections\with_no_stream_and_intialize_system_projections.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
@@ -1,0 +1,129 @@
+﻿using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed_projection
+{
+    public class FailureConditions : IEnumerable
+    {
+        public IEnumerator GetEnumerator()
+        {
+            yield return OperationResult.CommitTimeout;
+            yield return OperationResult.ForwardTimeout;
+            yield return OperationResult.PrepareTimeout;
+        }
+    }
+
+    [TestFixture, TestFixtureSource(typeof(FailureConditions))]
+    public class when_persisted_state_write_fails : TestFixtureWithExistingEvents
+    {
+        private new ITimeProvider _timeProvider;
+        private ManagedProjection _managedProjection;
+        private Guid _coreProjectionId;
+        private string _projectionName;
+        private string _projectionDefinitionStreamId;
+        private Guid _originalPersistedStateEventId;
+
+        private OperationResult _failureCondition;
+        public when_persisted_state_write_fails(OperationResult failureCondition)
+        {
+            _failureCondition = failureCondition;
+        }
+
+        protected override ManualQueue GiveInputQueue()
+        {
+            return new ManualQueue(_bus, _timeProvider);
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            AllWritesQueueUp();
+            WhenLoop();
+        }
+
+        protected override void Given()
+        {
+            _projectionName = "projectionName";
+            _projectionDefinitionStreamId = ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName;
+            _coreProjectionId = Guid.NewGuid();
+            _timeProvider = new FakeTimeProvider();
+            _managedProjection = new ManagedProjection(
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                1,
+                _projectionName,
+                true,
+                null,
+                _streamDispatcher,
+                _writeDispatcher,
+                _readDispatcher,
+                _bus,
+                _timeProvider, new RequestResponseDispatcher
+                    <CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
+                    _bus,
+                    v => v.CorrelationId,
+                    v => v.CorrelationId,
+                    new PublishEnvelope(_bus)), new RequestResponseDispatcher
+                        <CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
+                        _bus,
+                        v => v.CorrelationId,
+                        v => v.CorrelationId,
+                        new PublishEnvelope(_bus)), _ioDispatcher);
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
+                Envelope, ProjectionMode.OneTime, _projectionName, ProjectionManagementMessage.RunAs.System,
+                typeof(FakeForeachStreamProjection), "", true, false, false, false);
+            _managedProjection.InitializeNew(
+                new ManagedProjection.PersistedState
+                {
+                    Enabled = message.Enabled,
+                    HandlerType = message.HandlerType,
+                    Query = message.Query,
+                    Mode = message.Mode,
+                    EmitEnabled = message.EmitEnabled,
+                    CheckpointsDisabled = !message.CheckpointsEnabled,
+                    Epoch = -1,
+                    Version = -1,
+                    RunAs = message.EnableRunAs ? SerializedRunAs.SerializePrincipal(message.RunAs) : null,
+                },
+                null);
+
+            var sourceDefinition = new FakeForeachStreamProjection("", Console.WriteLine).GetSourceDefinition();
+            var projectionSourceDefinition = ProjectionSourceDefinition.From(sourceDefinition);
+
+            _managedProjection.Handle(
+                new CoreProjectionStatusMessage.Prepared(
+                    _coreProjectionId, projectionSourceDefinition));
+
+            _originalPersistedStateEventId = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Where(x => x.EventStreamId == _projectionDefinitionStreamId).First().Events[0].EventId;
+
+            CompleteWriteWithResult(_failureCondition);
+
+            _consumer.HandledMessages.Clear();
+
+            yield break;
+        }
+
+        [Test]
+        public void should_retry_writing_the_persisted_state_with_the_same_event_id()
+        {
+            var eventId = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Where(x => x.EventStreamId == _projectionDefinitionStreamId).First().Events[0].EventId;
+            Assert.AreEqual(eventId, _originalPersistedStateEventId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -666,7 +666,7 @@ namespace EventStore.Projections.Core.Services.Management
         internal void WriteStartOrLoadStopped()
         {
             if (_pendingWritePersistedState)
-                WritePersistedState();
+                WritePersistedState(CreatePersistedStateEvent(Guid.NewGuid(), PersistedProjectionState, ProjectionNamesBuilder.ProjectionsStreamPrefix + _name));
             else
                 StartOrLoadStopped();
         }
@@ -676,7 +676,15 @@ namespace EventStore.Projections.Core.Services.Management
             Reply();
         }
 
-        private void WritePersistedState()
+        private ClientMessage.WriteEvents CreatePersistedStateEvent(Guid correlationId, PersistedState persistedState, string eventStreamId)
+        {
+            return new ClientMessage.WriteEvents(
+                correlationId, correlationId, _writeDispatcher.Envelope, true, eventStreamId, ExpectedVersion.Any,
+                new Event(Guid.NewGuid(), EventTypes.ProjectionUpdated, true, persistedState.ToJsonBytes(), Empty.ByteArray),
+                SystemAccount.Principal);
+        }
+
+        private void WritePersistedState(ClientMessage.WriteEvents persistedStateEvent)
         {
             if (Mode == ProjectionMode.Transient)
             {
@@ -686,18 +694,12 @@ namespace EventStore.Projections.Core.Services.Management
                 return;
             }
             _writing = true;
-            var managedProjectionSerializedState = PersistedProjectionState.ToJsonBytes();
-            var eventStreamId = ProjectionNamesBuilder.ProjectionsStreamPrefix + _name;
-            var corrId = Guid.NewGuid();
             _writeDispatcher.Publish(
-                new ClientMessage.WriteEvents(
-                    corrId, corrId, _writeDispatcher.Envelope, true, eventStreamId, ExpectedVersion.Any,
-                    new Event(Guid.NewGuid(), EventTypes.ProjectionUpdated, true, managedProjectionSerializedState, Empty.ByteArray),
-                    SystemAccount.Principal),
-                m => WritePersistedStateCompleted(m, eventStreamId));
+                persistedStateEvent,
+                m => WritePersistedStateCompleted(m, persistedStateEvent, persistedStateEvent.EventStreamId));
         }
 
-        private void WritePersistedStateCompleted(ClientMessage.WriteEventsCompleted message, string eventStreamId)
+        private void WritePersistedStateCompleted(ClientMessage.WriteEventsCompleted message, ClientMessage.WriteEvents eventToRetry, string eventStreamId)
         {
             if (!_writing)
             {
@@ -724,7 +726,7 @@ namespace EventStore.Projections.Core.Services.Management
                 || message.Result == OperationResult.WrongExpectedVersion)
             {
                 _logger.Info("Retrying write projection source for {0}", _name);
-                WritePersistedState();
+                WritePersistedState(eventToRetry);
             }
             else
                 throw new NotSupportedException("Unsupported error code received");


### PR DESCRIPTION
When a projection attempts to write it's persisted state, when retrying this needs to be done with the same event id so that the write is handled in an idempotent manner by Event Store.