### PR TITLE
Revert "Fix projections getting stuck in preparing when a node becomes master"

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_starting.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_starting.cs
@@ -38,7 +38,6 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
         protected override IEnumerable<WhenStep> When()
         {
             yield return new ProjectionCoreServiceMessage.StartCore();
-            yield return CreateWriteEvent("$projections-$control", "$response-reader-started", "{}");
         }
 
         [Test]


### PR DESCRIPTION
This PR needs to be re-reviewed as it's causing unrelated test failures in our CI environment.