### PR TITLE
Retry the projections initialized write idempotently

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="Services\projections_manager\managed_projection\when_persisted_state_write_fails.cs" />
     <Compile Include="Services\projections_manager\when_deleting_a_system_projection.cs" />
     <Compile Include="Services\projections_manager\when_posting_a_persistent_projection_and_registration_write_fails.cs" />
+    <Compile Include="Services\projections_manager\when_the_projections_initialized_write_fails.cs" />
     <Compile Include="Services\projections_manager\when_reading_registered_projections\with_no_stream_and_intialize_system_projections.cs" />
     <Compile Include="Services\projections_manager\when_reading_registered_projections\with_no_stream.cs" />
     <Compile Include="Services\projection_subscription\when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_projections_initialized_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_projections_initialized_write_fails.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+using EventStore.Projections.Core.Services.Processing;
+using System.Collections;
+using EventStore.Projections.Core.Common;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager
+{
+    [TestFixture, TestFixtureSource(typeof(FailureConditions))]
+    public class when_writing_the_projections_initialized_event_fails : TestFixtureWithProjectionCoreAndManagementServices
+    {
+        private class FailureConditions : IEnumerable
+        {
+            public IEnumerator GetEnumerator()
+            {
+                yield return OperationResult.CommitTimeout;
+                yield return OperationResult.ForwardTimeout;
+                yield return OperationResult.PrepareTimeout;
+            }
+        }
+
+        private OperationResult _failureCondition;
+        public when_writing_the_projections_initialized_event_fails(OperationResult failureCondition)
+        {
+            _failureCondition = failureCondition;
+        }
+
+        protected override void Given()
+        {
+            AllWritesQueueUp();
+            NoStream(ProjectionNamesBuilder.ProjectionsRegistrationStream);
+        }
+
+        protected override bool GivenInitializeSystemProjections()
+        {
+            return false;
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.SystemCoreReady();
+        }
+
+        [Test, Category("v8")]
+        public void retries_writing_with_the_same_event_id()
+        {
+            int retryCount = 0;
+            var projectionsInitializedWrite = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Where(x => x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream && x.Events[0].EventType == EventTypes.ProjectionsInitialized).Last();
+            var eventId = projectionsInitializedWrite.Events[0].EventId;
+            while (retryCount < 5)
+            {
+                Assert.AreEqual(eventId, projectionsInitializedWrite.Events[0].EventId);
+                projectionsInitializedWrite.Envelope.ReplyWith(new ClientMessage.WriteEventsCompleted(projectionsInitializedWrite.CorrelationId, _failureCondition, Enum.GetName(typeof(OperationResult), _failureCondition)));
+                _queue.Process();
+                projectionsInitializedWrite = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Where(x => x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream && x.Events[0].EventType == EventTypes.ProjectionsInitialized).LastOrDefault();
+                if (projectionsInitializedWrite != null)
+                {
+                    retryCount++;
+                }
+                _consumer.HandledMessages.Clear();
+            }
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -732,7 +732,8 @@ namespace EventStore.Projections.Core.Services.Management
                     {
                         completedAction();
                         CreateSystemProjections();
-                    });
+                    },
+                    Guid.NewGuid());
                 return;
             }
             _logger.Debug("PROJECTIONS: Found the following projections. {1}", ProjectionNamesBuilder.ProjectionsRegistrationStream, 
@@ -758,7 +759,7 @@ namespace EventStore.Projections.Core.Services.Management
                    || _runProjections == ProjectionType.System && projectionName.StartsWith("$");
         }
 
-        private void WriteProjectionsInitialized(Action action)
+        private void WriteProjectionsInitialized(Action action, Guid registrationEventId)
         {
             var corrId = Guid.NewGuid();
             _writeDispatcher.Publish(
@@ -769,12 +770,12 @@ namespace EventStore.Projections.Core.Services.Management
                     true,
                     ProjectionNamesBuilder.ProjectionsRegistrationStream,
                     ExpectedVersion.NoStream,
-                    new Event(Guid.NewGuid(), EventTypes.ProjectionsInitialized, false, Empty.ByteArray, Empty.ByteArray),
+                    new Event(registrationEventId, EventTypes.ProjectionsInitialized, false, Empty.ByteArray, Empty.ByteArray),
                     SystemAccount.Principal),
-                completed => WriteProjectionsInitializedCompleted(completed, action));
+                completed => WriteProjectionsInitializedCompleted(completed, registrationEventId, action));
         }
 
-        private void WriteProjectionsInitializedCompleted(ClientMessage.WriteEventsCompleted completed, Action action)
+        private void WriteProjectionsInitializedCompleted(ClientMessage.WriteEventsCompleted completed, Guid registrationEventId, Action action)
         {
             switch (completed.Result)
             {
@@ -784,7 +785,7 @@ namespace EventStore.Projections.Core.Services.Management
                 case OperationResult.CommitTimeout:
                 case OperationResult.ForwardTimeout:
                 case OperationResult.PrepareTimeout:
-                    WriteProjectionsInitialized(action);
+                    WriteProjectionsInitialized(action, registrationEventId);
                     break;
                 default:
                     _logger.Fatal("Cannot initialize projections subsystem. Cannot write a fake projection");


### PR DESCRIPTION
The accompanying test for the change is not infinitely retrying
because the write is being retried indefinitely.