### PR TITLE
Handle read timeouts during projection recovery

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -78,6 +78,8 @@ namespace EventStore.Core.Tests.Helpers
         private readonly HashSet<string> _writesToSucceed = new HashSet<string>();
         private bool _allWritesQueueUp;
         private Queue<ClientMessage.WriteEvents> _writesQueue;
+        private Queue<ClientMessage.ReadStreamEventsBackward> _readEventsBackwardsQueue;
+        private bool _readsBackwardsQueuesUp;
         private bool _readAllEnabled;
         private bool _noOtherStreams;
         private bool _readsTimeOut;
@@ -119,6 +121,17 @@ namespace EventStore.Core.Tests.Helpers
         protected void EnableReadAll()
         {
             _readAllEnabled = true;
+        }
+
+        protected void ReadsBackwardQueuesUp()
+        {
+            _readsBackwardsQueuesUp = true;
+        }
+
+        protected void CompleteOneReadBackwards()
+        {
+            var read = _readEventsBackwardsQueue.Dequeue();
+            ProcessRead(read);
         }
 
         protected void NoStream(string streamId)
@@ -187,6 +200,7 @@ namespace EventStore.Core.Tests.Helpers
         public void setup1()
         {
             _writesQueue = new Queue<ClientMessage.WriteEvents>();
+            _readEventsBackwardsQueue = new Queue<ClientMessage.ReadStreamEventsBackward>();
             _listEventsHandler = new TestHandler<ClientMessage.ReadStreamEventsBackward>();
             _bus.Subscribe(_listEventsHandler);
             _bus.Subscribe<ClientMessage.WriteEvents>(this);
@@ -219,9 +233,19 @@ namespace EventStore.Core.Tests.Helpers
         {
         }
 
-        void IHandle<ClientMessage.ReadStreamEventsBackward>.Handle(ClientMessage.ReadStreamEventsBackward message)
+        public void Handle(ClientMessage.ReadStreamEventsBackward message)
         {
+            if (_readsBackwardsQueuesUp)
+            {
+                _readEventsBackwardsQueue.Enqueue(message);
+                return;
+            }
             if(_readsTimeOut) return;
+            ProcessRead(message);
+        }
+
+        private void ProcessRead(ClientMessage.ReadStreamEventsBackward message)
+        {
             List<EventRecord> list;
             if (_deletedStreams.Contains(message.EventStreamId))
             {
@@ -268,22 +292,9 @@ namespace EventStore.Core.Tests.Helpers
                         return;
                     }
                     throw new NotImplementedException();
-/*
-                    message.Envelope.ReplyWith(
-                            new ClientMessage.ReadStreamEventsBackwardCompleted(
-                                    message.CorrelationId,
-                                    message.EventStreamId,
-                                    new EventLinkPair[0],
-                                    ReadStreamResult.Success,
-                                    nextEventNumber: -1,
-                                    lastEventNumber: list.Safe().Last().EventNumber,
-                                    isEndOfStream: true,// NOTE AN: don't know how to correctly determine this here
-                                    lastCommitPosition: _lastPosition));
-*/
                 }
             }
         }
-
 
         public void Handle(ClientMessage.ReadStreamEventsForward message)
         {

--- a/src/EventStore.Core/Helpers/IODispatcher.cs
+++ b/src/EventStore.Core/Helpers/IODispatcher.cs
@@ -78,14 +78,16 @@ namespace EventStore.Core.Helpers
             int maxCount,
             bool resolveLinks,
             IPrincipal principal,
-            Action<ClientMessage.ReadStreamEventsBackwardCompleted> action)
+            Action<ClientMessage.ReadStreamEventsBackwardCompleted> action,
+            Guid? corrId = null)
         {
-            var corrId = Guid.NewGuid();
+            if (!corrId.HasValue)
+                corrId = Guid.NewGuid();
             return
                 BackwardReader.Publish(
                     new ClientMessage.ReadStreamEventsBackward(
-                        corrId,
-                        corrId,
+                        corrId.Value,
+                        corrId.Value,
                         BackwardReader.Envelope,
                         streamId,
                         fromEventNumber,

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -122,6 +122,8 @@
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_catalog_stream.cs" />
     <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_null_streamId.cs" />
     <Compile Include="Services\core_service\when_a_subscribed_projection_handler_throws.cs" />
+    <Compile Include="Services\emitted_stream\when_a_read_completes_before_a_timeout_in_recovery.cs" />
+    <Compile Include="Services\emitted_stream\when_a_read_times_out_in_recovery.cs" />
     <Compile Include="Services\emitted_stream\when_handling_a_timeout.cs" />
     <Compile Include="Services\event_reader\heading_event_reader\when_the_heading_event_reader_with_a_subscribed_projection_handles_a_cached_event_and_throws.cs" />
     <Compile Include="Services\event_reader\heading_event_reader\when_the_heading_event_reader_with_a_subscribed_projection_handles_a_live_event_and_throws.cs" />

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/the_non_started_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/the_non_started_checkpoint.cs
@@ -15,7 +15,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/the_started_checkpoint_with_some_events_emitted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/the_started_checkpoint_with_some_events_emitted.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();;
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             _checkpoint.Start();
             _checkpoint.ValidateOrderAndEmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_creating_a_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_creating_a_projection_checkpoint.cs
@@ -26,11 +26,21 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         }
 
         [Test]
+        public void null_publisher_throws_argument_null_exception()
+        {
+            Assert.Throws<ArgumentNullException>(() => {
+            new ProjectionCheckpoint(
+                null, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+            });
+        }
+
+        [Test]
         public void null_io_dispatcher_throws_argument_null_exception()
         {
             Assert.Throws<ArgumentNullException>(() => {
             new ProjectionCheckpoint(
-                null, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _fakePublisher, null, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             });
         }
@@ -40,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             Assert.Throws<ArgumentNullException>(() => {
             new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, null,
+                _fakePublisher, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, null,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             });
         }
@@ -50,7 +60,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             Assert.Throws<ArgumentException>(() => {
             new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _fakePublisher, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 101), new TransactionFilePositionTagger(0), 250);
             });
         }
@@ -59,7 +69,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         public void it_can_be_created()
         {
             new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _fakePublisher, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_before_from_position_the_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_before_from_position_the_projection_checkpoint.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             try
             {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_backward_order_to_the_same_stream_the_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_backward_order_to_the_same_stream_the_projection_checkpoint.cs
@@ -18,7 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             try
             {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_correct_order_the_started_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_correct_order_the_started_projection_checkpoint.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             _checkpoint.Start();
             _checkpoint.ValidateOrderAndEmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_the_non_started_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_the_non_started_checkpoint.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_null_streamId.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_null_streamId.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             try
             {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_handling_stream_awaiting_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_handling_stream_awaiting_message.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
 
             _fakeEnvelope = new FakeEnvelope();

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_requesting_checkpoint_after_all_writes_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_requesting_checkpoint_after_all_writes_completed.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             _checkpoint.Start();
             _checkpoint.ValidateOrderAndEmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_requesting_checkpoint_before_all_writes_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_requesting_checkpoint_before_all_writes_completed.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             _checkpoint.Start();
             _checkpoint.ValidateOrderAndEmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_starting_the_projection_checkpoint_with_some_events_already_emitted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_starting_the_projection_checkpoint_with_some_events_already_emitted.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_the_projection_checkpoint_has_been_started.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_the_projection_checkpoint_has_been_started.cs
@@ -15,7 +15,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
-                _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
                 CheckpointTag.FromPosition(0, 0, -1), new TransactionFilePositionTagger(0), 250);
             _checkpoint.Start();
         }

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/a_checkpoint_requested_on_a_non_started_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/a_checkpoint_requested_on_a_non_started_stream.cs
@@ -20,7 +20,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             ;
             _stream = new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, _readyHandler);
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             try
             {
                 _stream.Checkpoint();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoc
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_emits_with_previously_written_events_at_the_same_position.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_emits_with_previously_written_events_at_the_same_position.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoc
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 100, 50),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(CreateEventBatch());
             OneWriteCompletes();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_emits_with_previously_written_events_in_different_epochs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_emits_with_previously_written_events_in_different_epochs.cs
@@ -48,7 +48,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoc
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 20, 10),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(CreateEventBatch());
             OneWriteCompletes();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_projection/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_projection/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_proj
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_a_read_completes_before_a_timeout_in_recovery.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_a_read_completes_before_a_timeout_in_recovery.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Services.TimerService;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_stream
+{
+    [TestFixture]
+    public class when_a_read_completes_before_a_timeout_in_recovery : TestFixtureWithExistingEvents
+    {
+        private const string TestStreamId = "test_stream";
+        private EmittedStream _stream;
+        private TestCheckpointManagerMessageHandler _readyHandler;
+
+        protected override void Given()
+        {
+            AllWritesQueueUp();
+            ExistingEvent(TestStreamId, "type", @"{""c"": 100, ""p"": 50}", "data");
+            ReadsBackwardQueuesUp();
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            _readyHandler = new TestCheckpointManagerMessageHandler();
+            _stream = new EmittedStream(
+                TestStreamId, new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
+                _bus, _ioDispatcher, _readyHandler);
+            _stream.Start();
+            _stream.EmitEvents(
+                new[]
+                {
+                    new EmittedDataEvent(
+                        TestStreamId, Guid.NewGuid(), "type", true, "data", null, CheckpointTag.FromPosition(0, 200, 150), null)
+                });
+            CompleteOneReadBackwards();
+        }
+
+        [Test]
+        public void should_not_retry_the_read_upon_the_read_timing_out()
+        {
+            var scheduledReadTimeout = _consumer.HandledMessages.OfType<TimerMessage.Schedule>().First().ReplyMessage as ProjectionManagementMessage.Internal.ReadTimeout;
+            _stream.Handle(scheduledReadTimeout);
+
+            var readEventsBackwards = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsBackward>().Where(x => x.EventStreamId == TestStreamId);
+
+            Assert.AreEqual(1, readEventsBackwards.Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_a_read_times_out_in_recovery.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_a_read_times_out_in_recovery.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Services.TimerService;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_stream
+{
+    [TestFixture]
+    public class when_a_read_times_out_in_recovery : TestFixtureWithExistingEvents
+    {
+        private const string TestStreamId = "test_stream";
+        private EmittedStream _stream;
+        private TestCheckpointManagerMessageHandler _readyHandler;
+
+        protected override void Given()
+        {
+            AllWritesQueueUp();
+            ExistingEvent(TestStreamId, "type", @"{""c"": 100, ""p"": 50}", "data");
+            ReadsBackwardQueuesUp();
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            _readyHandler = new TestCheckpointManagerMessageHandler();
+            _stream = new EmittedStream(
+                TestStreamId, new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
+                _bus, _ioDispatcher, _readyHandler);
+            _stream.Start();
+            _stream.EmitEvents(
+                new[]
+                {
+                    new EmittedDataEvent(
+                       TestStreamId, Guid.NewGuid(), "type", true, "data", null, CheckpointTag.FromPosition(0, 200, 150), null)
+                });
+        }
+
+
+        [Test]
+        public void should_have_attempted_a_single_read()
+        {
+            var readEventsBackwards = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsBackward>().Where(x=>x.EventStreamId == TestStreamId);
+            Assert.AreEqual(1, readEventsBackwards.Count());
+        }
+
+        [Test]
+        public void should_retry_the_read_upon_the_read_timing_out()
+        {
+            var scheduledReadTimeout = _consumer.HandledMessages.OfType<TimerMessage.Schedule>().First().ReplyMessage as ProjectionManagementMessage.Internal.ReadTimeout;
+            _stream.Handle(scheduledReadTimeout);
+
+            var readEventsBackwards = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsBackward>().Where(x => x.EventStreamId == TestStreamId );
+
+            Assert.AreEqual(2, readEventsBackwards.Count());
+            Assert.AreEqual(readEventsBackwards.First().FromEventNumber, readEventsBackwards.Last().FromEventNumber);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested.cs
@@ -18,7 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             ;
             _stream = new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, _readyHandler);
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.Checkpoint();
         }

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_but_disabled.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_but_disabled.cs
@@ -19,7 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, _readyHandler,
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler,
                 noCheckpoints: true);
             _stream.Start();
             try

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_with_all_writes_already_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_with_all_writes_already_completed.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, _readyHandler);
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_with_pending_writes.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_with_pending_writes.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             ;
             _stream = new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, _readyHandler);
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_creating_an_emitted_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_creating_an_emitted_stream.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
                 null, new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher,
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher,
                 new TestCheckpointManagerMessageHandler());
             });
         }
@@ -39,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
                 null, null, new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher,
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher,
                 new TestCheckpointManagerMessageHandler());
             });
         }
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
                 "", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher,
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher,
                 new TestCheckpointManagerMessageHandler());
             });
         }
@@ -61,7 +61,18 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
                 "", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), null, _ioDispatcher, new TestCheckpointManagerMessageHandler());
+                new TransactionFilePositionTagger(0), null, _fakePublisher, _ioDispatcher, new TestCheckpointManagerMessageHandler());
+            });
+        }
+
+        [Test]
+        public void null_publisher_throws_argument_null_exception()
+        {
+            Assert.Throws<ArgumentNullException>(() => {
+            new EmittedStream(
+                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), null, _ioDispatcher,
+                new TestCheckpointManagerMessageHandler());
             });
         }
 
@@ -71,7 +82,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), null,
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, null,
                 new TestCheckpointManagerMessageHandler());
             });
         }
@@ -82,7 +93,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, null);
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher, null);
             });
         }
 
@@ -91,7 +102,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher,
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher,
                 new TestCheckpointManagerMessageHandler());
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_a_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_a_timeout.cs
@@ -44,7 +44,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoc
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.Empty,
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(CreateEventBatch());
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_the_not_started_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_the_not_started_stream.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             ;
             _stream = new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, _readyHandler);
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.EmitEvents(
                 new[]
                 {

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_the_started_in_recovery_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_the_started_in_recovery_stream.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_to_the_nonexisting_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_to_the_nonexisting_stream.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_caused_by_and_correlation_id.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_caused_by_and_correlation_id.cs
@@ -44,7 +44,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(new[] {_emittedDataEvent});
         }

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_committed_callback.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_committed_callback.cs
@@ -24,7 +24,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_extra_metadata.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_extra_metadata.cs
@@ -31,7 +31,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
 
             _stream.EmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_not_ready_event.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_not_ready_event.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_stream_metadata.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_stream_metadata.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
                 "test_stream", _writerConfiguration, new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0),
-                CheckpointTag.FromPosition(0, 40, 30), _ioDispatcher, _readyHandler);
+                CheckpointTag.FromPosition(0, 40, 30), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_write_as_configured.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_write_as_configured.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), _writeAs, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
 
             _stream.EmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_in_invalid_order.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_in_invalid_order.cs
@@ -23,7 +23,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_with_previously_written_events.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_with_previously_written_events.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0),
-                CheckpointTag.FromPosition(0, 100, 50), _ioDispatcher, _readyHandler);
+                CheckpointTag.FromPosition(0, 100, 50), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_with_previously_written_events_at_the_same_position.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_with_previously_written_events_at_the_same_position.cs
@@ -47,7 +47,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _stream = new EmittedStream(
                 "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 20, 10),
-                _ioDispatcher, _readyHandler);
+                _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(CreateEventBatch());
             OneWriteCompletes();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_the_stream_is_started.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_the_stream_is_started.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, _readyHandler);
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             ;
             _stream.Start();
         }

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_the_stream_is_started_with_already_emitted_events.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_the_stream_is_started_with_already_emitted_events.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             ;
             _stream = new EmittedStream(
                 "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
-                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _ioDispatcher, _readyHandler);
+                new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.EmitEvents(
                 new[]
                 {

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Services;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
+using System.Collections.Generic;
 
 namespace EventStore.Projections.Core.Messages
 {
@@ -804,6 +805,7 @@ namespace EventStore.Projections.Core.Messages
 
                 private readonly Guid _correlationId;
                 private readonly string _streamId;
+                private readonly Dictionary<string, object> _parameters;
 
                 public Guid CorrelationId
                 {
@@ -815,10 +817,20 @@ namespace EventStore.Projections.Core.Messages
                     get { return _streamId; }
                 }
 
-                public ReadTimeout(Guid correlationId, string streamId)
+                public Dictionary<string, object> Parameters
+                {
+                    get { return _parameters; }
+                }
+
+                public ReadTimeout(Guid correlationId, string streamId, Dictionary<string, object> parameters)
                 {
                     _correlationId = correlationId;
                     _streamId = streamId;
+                    _parameters = parameters;
+                }
+
+                public ReadTimeout(Guid correlationId, string streamId) : this(correlationId, streamId, new Dictionary<string, object>())
+                {
                 }
             }
 

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointManager.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
         private readonly bool _usePersistentCheckpoints;
 
-        private readonly IPublisher _publisher;
+        protected readonly IPublisher _publisher;
         private readonly Guid _projectionCorrelationId;
         private readonly CheckpointTag _zeroTag;
 

--- a/src/EventStore.Projections.Core/Services/Processing/DefaultCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/DefaultCheckpointManager.cs
@@ -154,7 +154,7 @@ namespace EventStore.Projections.Core.Services.Processing
         protected override ProjectionCheckpoint CreateProjectionCheckpoint(CheckpointTag checkpointPosition)
         {
             return new ProjectionCheckpoint(
-                _ioDispatcher, _projectionVersion, _runAs, this, checkpointPosition, _positionTagger,
+                _publisher, _ioDispatcher, _projectionVersion, _runAs, this, checkpointPosition, _positionTagger,
                 _projectionConfig.MaxWriteBatchLength, _logger);
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -13,12 +13,19 @@ using EventStore.Core.Services;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Projections.Core.Messages;
 using Newtonsoft.Json.Linq;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Settings;
 
 namespace EventStore.Projections.Core.Services.Processing
 {
-    public class EmittedStream : IDisposable, IHandle<CoreProjectionProcessingMessage.EmittedStreamWriteCompleted>
+    public class EmittedStream : IDisposable, 
+        IHandle<CoreProjectionProcessingMessage.EmittedStreamWriteCompleted>,
+        IHandle<ProjectionManagementMessage.Internal.ReadTimeout>
     {
+        private const string ReadUpTo = "upTo";
+        private const string ReadFromEventNumber = "readFromEventNumber";
         private readonly IODispatcher _ioDispatcher;
+        private readonly IPublisher _publisher;
 
 
         private readonly ILogger _logger;
@@ -56,7 +63,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private bool _recoveryCompleted;
         private Event _submittedWriteMetaStreamEvent;
         private const int MaxRetryCount = 5;
-
+        private Guid _pendingRequestCorrelationId;
 
         public class WriterConfiguration
         {
@@ -130,13 +137,14 @@ namespace EventStore.Projections.Core.Services.Processing
 
         public EmittedStream(
             string streamId, WriterConfiguration writerConfiguration, ProjectionVersion projectionVersion,
-            PositionTagger positionTagger, CheckpointTag fromCheckpointPosition, IODispatcher ioDispatcher,
+            PositionTagger positionTagger, CheckpointTag fromCheckpointPosition, IPublisher publisher, IODispatcher ioDispatcher,
             IEmittedStreamContainer readyHandler, bool noCheckpoints = false)
         {
             if (string.IsNullOrEmpty(streamId)) throw new ArgumentNullException("streamId");
             if (writerConfiguration == null) throw new ArgumentNullException("writerConfiguration");
             if (positionTagger == null) throw new ArgumentNullException("positionTagger");
             if (fromCheckpointPosition == null) throw new ArgumentNullException("fromCheckpointPosition");
+            if (publisher == null) throw new ArgumentNullException("publisher");
             if (ioDispatcher == null) throw new ArgumentNullException("ioDispatcher");
             if (readyHandler == null) throw new ArgumentNullException("readyHandler");
             _streamId = streamId;
@@ -148,6 +156,7 @@ namespace EventStore.Projections.Core.Services.Processing
             _zeroPosition = positionTagger.MakeZeroCheckpointTag();
             _fromCheckpointPosition = fromCheckpointPosition;
             _lastQueuedEventPosition = null;
+            _publisher = publisher;
             _ioDispatcher = ioDispatcher;
             _readyHandler = readyHandler;
             _maxWriteBatchLength = writerConfiguration.MaxWriteBatchLength;
@@ -271,6 +280,9 @@ namespace EventStore.Projections.Core.Services.Processing
                 throw new InvalidOperationException("ReadStreamEventsBackward has not been requested");
             if (_disposed)
                 return;
+            if (message.CorrelationId != _pendingRequestCorrelationId)
+                return;
+            _pendingRequestCorrelationId = Guid.Empty;
             _awaitingListEventsCompleted = false;
 
             var newPhysicalStream = message.LastEventNumber == ExpectedVersion.NoStream;
@@ -401,10 +413,35 @@ namespace EventStore.Projections.Core.Services.Processing
             if (_awaitingWriteCompleted || _awaitingMetadataWriteCompleted || _awaitingListEventsCompleted)
                 throw new Exception();
             _awaitingListEventsCompleted = true;
+            _pendingRequestCorrelationId = Guid.NewGuid();
             _ioDispatcher.ReadBackward(
-                //TODO: reading events history in batches of 1 event (slow?)
                 _streamId, fromEventNumber, 1, resolveLinks: false, principal: SystemAccount.Principal,
-                action: completed => ReadStreamEventsBackwardCompleted(completed, upTo));
+                action: completed => ReadStreamEventsBackwardCompleted(completed, upTo), corrId: _pendingRequestCorrelationId);
+            ScheduleReadTimeoutMessage(_pendingRequestCorrelationId, _streamId, upTo, fromEventNumber);
+        }
+
+        private void ScheduleReadTimeoutMessage(Guid correlationId, string streamId, CheckpointTag upTo, long fromEventNumber)
+        {
+            _publisher.Publish(CreateReadTimeoutMessage(correlationId, streamId, new Dictionary<string, object>{
+                { ReadUpTo, upTo },
+                { ReadFromEventNumber, fromEventNumber}
+            }));
+        }
+
+        private Message CreateReadTimeoutMessage(Guid correlationId, string streamId, Dictionary<string, object> parameters)
+        {
+            return TimerMessage.Schedule.Create(
+                TimeSpan.FromMilliseconds(ESConsts.ReadRequestTimeout),
+                new SendToThisEnvelope(this),
+                new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, streamId, parameters));
+        }
+
+        public void Handle(ProjectionManagementMessage.Internal.ReadTimeout message)
+        {
+            if (message.CorrelationId != _pendingRequestCorrelationId) return;
+            _pendingRequestCorrelationId = Guid.Empty;
+            _awaitingListEventsCompleted = false;
+            SubmitListEvents((CheckpointTag)message.Parameters[ReadUpTo], (long)message.Parameters[ReadFromEventNumber]);
         }
 
         private void SubmitWriteMetadata()

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
@@ -77,7 +77,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 _namingBuilder.GetOrderStreamName(),
                 new EmittedStream.WriterConfiguration(
                     new EmittedStream.WriterConfiguration.StreamMetadata(), SystemAccount.Principal, 100, _logger),
-                _projectionVersion, _positionTagger, @from, _ioDispatcher, this, noCheckpoints: true);
+                _projectionVersion, _positionTagger, @from, _publisher, _ioDispatcher, this, noCheckpoints: true);
         }
 
         public override void GetStatistics(ProjectionStatistics info)


### PR DESCRIPTION
When a projection is in recovery mode, it will verify what is about to
written against what was written.

During the recovery process, the emitted stream will read the stream
backwards and if the read times out for whatever reason, it will cause
the projection to still process events but not write them to the
destination stream as the write is blocked by a flag that indicates that
a read is currently in progress.