### PR TITLE
Limit pending send bytes and drop messages to closed connections

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -73,6 +73,8 @@ namespace EventStore.ClusterNode
         public int ExtTcpHeartbeatInterval { get; set; }
         [ArgDescription(Opts.GossipOnSingleNodeDescr, Opts.InterfacesGroup)]
         public bool GossipOnSingleNode { get; set; }
+        [ArgDescription(Opts.ConnectionPendingSendBytesThresholdDescr, Opts.InterfacesGroup)]
+        public bool ConnectionPendingSendBytesThreshold { get; set; }
 
 
         [ArgDescription(Opts.ForceDescr, Opts.AppGroup)]

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
@@ -744,6 +744,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
         }
     }
 
+    [TestFixture]
     public class with_custom_advertise_as : SingleNodeScenario
     {
         private Data.GossipAdvertiseInfo _advertiseInfo;
@@ -786,6 +787,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
         }
     }
 
+    [TestFixture]
     public class with_always_keep_scavenged : SingleNodeScenario
     {
         public override void Given()
@@ -797,6 +799,23 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
         public void should_always_keep_scavenged() 
         {
             Assert.AreEqual(true, _settings.AlwaysKeepScavenged);
+        }
+    }
+
+    [TestFixture]
+    public class with_connection_pending_send_bytes_threshold : SingleNodeScenario
+    {
+        private int _threshold = 40 * 1024;
+        
+        public override void Given()
+        {
+            _builder.WithConnectionPendingSendBytesThreshold(_threshold);
+        }
+
+        [Test]
+        public void should_set_connection_pending_send_bytes_threshold() 
+        {
+            Assert.AreEqual(_threshold, _settings.ConnectionPendingSendBytesThreshold);
         }
     }
 }

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -93,7 +93,9 @@ namespace EventStore.Core.Tests.Helpers
                 gossipAllowedTimeDifference: TimeSpan.FromSeconds(1), gossipTimeout: TimeSpan.FromSeconds(1),
                 extTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), extTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
                 intTcpHeartbeatTimeout: TimeSpan.FromSeconds(10), intTcpHeartbeatInterval: TimeSpan.FromSeconds(10),
-                verifyDbHash: false, maxMemtableEntryCount: memTableSize, hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault, startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false);
+                verifyDbHash: false, maxMemtableEntryCount: memTableSize, hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
+                startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false,
+                connectionPendingSendBytesThreshold: Opts.ConnectionPendingSendBytesThresholdDefault);
 
             Log.Info(
                 "\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -41,7 +41,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
-                TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false, false, false);
+                TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false, false, false,
+                Opts.ConnectionPendingSendBytesThresholdDefault);
 
             return vnode;
         }

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -12,6 +12,7 @@ using System.Text;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.Services.Transport.Tcp
 {
@@ -34,7 +35,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
                 Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
                 InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(
                                 new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), new StubPasswordHashAlgorithm(), 1),
-                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { });
+                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { }, Opts.ConnectionPendingSendBytesThresholdDefault, true);
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -9,6 +9,7 @@ using System.Net.Sockets;
 using EventStore.Core.Authentication;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Authentication;
+using EventStore.Core.TransactionLog.LogRecords;
 using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -19,6 +20,8 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
     [TestFixture]
     public class TcpConnectionManagerTests
     {
+        private int _connectionPendingSendBytesThreshold = 10 * 1024;
+
         public void when_handling_trusted_write_on_external_service()
         {
             var package = new TcpPackage(TcpCommand.WriteEvents, TcpFlags.TrustedWrite, Guid.NewGuid(), null, null, new byte[] { });
@@ -28,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
             var tcpConnectionManager = new TcpConnectionManager(
                 Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
                 InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), new StubPasswordHashAlgorithm(), 1),
-                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { });
+                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { }, _connectionPendingSendBytesThreshold, true);
 
             tcpConnectionManager.ProcessPackage(package);
 
@@ -61,7 +64,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
             var tcpConnectionManager = new TcpConnectionManager(
                 Guid.NewGuid().ToString(), TcpServiceType.Internal, new ClientTcpDispatcher(),
                 publisher, dummyConnection, publisher, new InternalAuthenticationProvider(new Core.Helpers.IODispatcher(publisher, new NoopEnvelope()), new StubPasswordHashAlgorithm(), 1),
-                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { });
+                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { }, _connectionPendingSendBytesThreshold, true);
 
             tcpConnectionManager.ProcessPackage(package);
 
@@ -70,6 +73,86 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
                 throw new Exception("Timed out waiting for events.");
             }
             Assert.AreEqual(evnt.EventId, publishedWrite.Events.First().EventId, "Expected the published write to be the event that was sent through the tcp connection manager to be the event {0} but got {1}", evnt.EventId, publishedWrite.Events.First().EventId);
+        }
+
+        [Test]
+        public void when_limit_pending_and_sending_message_smaller_than_threshold_and_pending_bytes_over_threshold_should_close_conenction()
+        {
+            var mre = new ManualResetEventSlim();
+
+            var messageSize = _connectionPendingSendBytesThreshold / 2;
+            var evnt = new EventRecord(0, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "testStream", 0, DateTime.Now, PrepareFlags.None, "eventType", new byte[messageSize], new byte[0]);
+            var record = ResolvedEvent.ForUnresolvedEvent(evnt, null);
+            var message = new ClientMessage.ReadEventCompleted(Guid.NewGuid(), "testStream", ReadEventResult.Success, record, StreamMetadata.Empty, false, "");
+            
+            var dummyConnection = new DummyTcpConnection();
+            dummyConnection.PendingSendBytes = _connectionPendingSendBytesThreshold + 1000;
+
+            var tcpConnectionManager = new TcpConnectionManager(
+                Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+                InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1),
+                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => {
+                    mre.Set();
+                }, _connectionPendingSendBytesThreshold, true);
+
+            tcpConnectionManager.SendMessage(message);
+
+            if (!mre.Wait(2000))
+            {
+                Assert.Fail("Timed out waiting for connection to close");
+            }
+        }
+
+        [Test]
+        public void when_limit_pending_and_sending_message_larger_than_pending_bytes_threshold_but_no_bytes_pending_should_not_close_connection()
+        {
+            var messageSize = _connectionPendingSendBytesThreshold + 1000;
+            var evnt = new EventRecord(0, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "testStream", 0, DateTime.Now, PrepareFlags.None, "eventType", new byte[messageSize], new byte[0]);
+            var record = ResolvedEvent.ForUnresolvedEvent(evnt, null);
+            var message = new ClientMessage.ReadEventCompleted(Guid.NewGuid(), "testStream", ReadEventResult.Success, record, StreamMetadata.Empty, false, "");
+            
+            var dummyConnection = new DummyTcpConnection();
+            dummyConnection.PendingSendBytes = 0;
+
+            var tcpConnectionManager = new TcpConnectionManager(
+                Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+                InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1),
+                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { }, _connectionPendingSendBytesThreshold, true);
+
+            tcpConnectionManager.SendMessage(message);
+
+            var data = dummyConnection.ReceivedData.Last();
+            var receivedPackage = TcpPackage.FromArraySegment(data);
+           
+            Assert.AreEqual(receivedPackage.Command, TcpCommand.ReadEventCompleted, "Expected ReadEventCompleted but got {0}", receivedPackage.Command);
+        }
+
+        [Test]
+        public void when_not_limit_pending_and_sending_message_smaller_than_threshold_and_pending_bytes_over_threshold_should_close_conenction()
+        {
+            var mre = new ManualResetEventSlim();
+
+            var messageSize = _connectionPendingSendBytesThreshold / 2;
+            var evnt = new EventRecord(0, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "testStream", 0, DateTime.Now, PrepareFlags.None, "eventType", new byte[messageSize], new byte[0]);
+            var record = ResolvedEvent.ForUnresolvedEvent(evnt, null);
+            var message = new ClientMessage.ReadEventCompleted(Guid.NewGuid(), "testStream", ReadEventResult.Success, record, StreamMetadata.Empty, false, "");
+            
+            var dummyConnection = new DummyTcpConnection();
+            dummyConnection.PendingSendBytes = _connectionPendingSendBytesThreshold + 1000;
+
+            var tcpConnectionManager = new TcpConnectionManager(
+                Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+                InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1),
+                TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => {
+                    mre.Set();
+                }, _connectionPendingSendBytesThreshold, false);
+
+            tcpConnectionManager.SendMessage(message);
+
+            var data = dummyConnection.ReceivedData.Last();
+            var receivedPackage = TcpPackage.FromArraySegment(data);
+           
+            Assert.AreEqual(receivedPackage.Command, TcpCommand.ReadEventCompleted, "Expected ReadEventCompleted but got {0}", receivedPackage.Command);
         }
     }
 
@@ -119,7 +202,20 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
         {
             get
             {
-                throw new NotImplementedException();
+                return 0;
+            }
+        }
+
+        private int _pendingSendBytes;
+        public int PendingSendBytes
+        {
+            get
+            {
+                return _pendingSendBytes;
+            }
+            set
+            {
+                _pendingSendBytes = value;
             }
         }
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -59,6 +59,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly TimeSpan IntTcpHeartbeatInterval;
         public readonly TimeSpan ExtTcpHeartbeatTimeout;
         public readonly TimeSpan ExtTcpHeartbeatInterval;
+        public readonly int ConnectionPendingSendBytesThreshold;
         public readonly bool UnsafeIgnoreHardDeletes;
         public readonly bool VerifyDbHash;
         public readonly int MaxMemtableEntryCount;
@@ -122,6 +123,7 @@ namespace EventStore.Core.Cluster.Settings
                                     bool startStandardProjections,
                                     bool disableHTTPCaching,
                                     bool logHttpRequests,
+                                    int connectionPendingSendBytesThreshold,
                                     string index = null, bool enableHistograms = false,
                                     int indexCacheDepth = 16,
                                     byte indexBitnessVersion = 2,
@@ -205,6 +207,7 @@ namespace EventStore.Core.Cluster.Settings
             IntTcpHeartbeatInterval = intTcpHeartbeatInterval;
             ExtTcpHeartbeatTimeout = extTcpHeartbeatTimeout;
             ExtTcpHeartbeatInterval = extTcpHeartbeatInterval;
+            ConnectionPendingSendBytesThreshold = connectionPendingSendBytesThreshold;
 
             VerifyDbHash = verifyDbHash;
             MaxMemtableEntryCount = maxMemtableEntryCount;
@@ -258,7 +261,8 @@ namespace EventStore.Core.Cluster.Settings
                                  + "HistogramEnabled: {32}\n"
                                  + "HTTPCachingDisabled: {33}\n"
                                  + "IndexPath: {34}\n"
-                                 + "ScavengeHistoryMaxAge: {35}\n",
+                                 + "ScavengeHistoryMaxAge: {35}\n"
+                                 + "ConnectionPendingSendBytesThreshold: {36}\n",
                                  NodeInfo.InstanceId,
                                  NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
                                  NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -275,7 +279,8 @@ namespace EventStore.Core.Cluster.Settings
                                  UseSsl, SslTargetHost, SslValidateServer,
                                  StatsPeriod, StatsStorage, AuthenticationProviderFactory.GetType(),
                                  NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout,
-                                 EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge);
+                                 EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge,
+                                 ConnectionPendingSendBytesThreshold);
         }
     }
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -225,7 +225,7 @@ namespace EventStore.Core
                     var extTcpService = new TcpService(_mainQueue, _nodeInfo.ExternalTcp, _workersHandler,
                                                        TcpServiceType.External, TcpSecurityType.Normal, new ClientTcpDispatcher(),
                                                        vNodeSettings.ExtTcpHeartbeatInterval, vNodeSettings.ExtTcpHeartbeatTimeout,
-                                                       _internalAuthenticationProvider, null);
+                                                       _internalAuthenticationProvider, null, vNodeSettings.ConnectionPendingSendBytesThreshold);
                     _mainBus.Subscribe<SystemMessage.SystemInit>(extTcpService);
                     _mainBus.Subscribe<SystemMessage.SystemStart>(extTcpService);
                     _mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(extTcpService);
@@ -237,7 +237,7 @@ namespace EventStore.Core
                     var extSecTcpService = new TcpService(_mainQueue, _nodeInfo.ExternalSecureTcp, _workersHandler,
                                                           TcpServiceType.External, TcpSecurityType.Secure, new ClientTcpDispatcher(),
                                                           vNodeSettings.ExtTcpHeartbeatInterval, vNodeSettings.ExtTcpHeartbeatTimeout,
-                                                          _internalAuthenticationProvider, vNodeSettings.Certificate);
+                                                          _internalAuthenticationProvider, vNodeSettings.Certificate, vNodeSettings.ConnectionPendingSendBytesThreshold);
                     _mainBus.Subscribe<SystemMessage.SystemInit>(extSecTcpService);
                     _mainBus.Subscribe<SystemMessage.SystemStart>(extSecTcpService);
                     _mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(extSecTcpService);
@@ -249,7 +249,7 @@ namespace EventStore.Core
                                                           TcpServiceType.Internal, TcpSecurityType.Normal,
                                                         new InternalTcpDispatcher(),
                                                         vNodeSettings.IntTcpHeartbeatInterval, vNodeSettings.IntTcpHeartbeatTimeout,
-                                                        _internalAuthenticationProvider, null);
+                                                        _internalAuthenticationProvider, null, vNodeSettings.ConnectionPendingSendBytesThreshold);
                         _mainBus.Subscribe<SystemMessage.SystemInit>(intTcpService);
                         _mainBus.Subscribe<SystemMessage.SystemStart>(intTcpService);
                         _mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(intTcpService);
@@ -262,7 +262,7 @@ namespace EventStore.Core
                                                             TcpServiceType.Internal, TcpSecurityType.Secure,
                                                             new InternalTcpDispatcher(),
                                                             vNodeSettings.IntTcpHeartbeatInterval, vNodeSettings.IntTcpHeartbeatTimeout,
-                                                            _internalAuthenticationProvider, vNodeSettings.Certificate);
+                                                            _internalAuthenticationProvider, vNodeSettings.Certificate, vNodeSettings.ConnectionPendingSendBytesThreshold);
                         _mainBus.Subscribe<SystemMessage.SystemInit>(intSecTcpService);
                         _mainBus.Subscribe<SystemMessage.SystemStart>(intSecTcpService);
                         _mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(intSecTcpService);

--- a/src/EventStore.Core/Services/Transport/Tcp/SendOverTcpEnvelope.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/SendOverTcpEnvelope.cs
@@ -20,7 +20,10 @@ namespace EventStore.Core.Services.Transport.Tcp
 
         public void ReplyWith<T>(T message) where T : Message
         {
-            _networkSendQueue.Publish(new TcpMessage.TcpSend(_manager, message));
+            if (_manager != null && !_manager.IsClosed)
+            {
+                _networkSendQueue.Publish(new TcpMessage.TcpSend(_manager, message));
+            }
         }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -52,6 +52,8 @@ namespace EventStore.Core.Services.Transport.Tcp
         private readonly SendToWeakThisEnvelope _weakThisEnvelope;
         private readonly TimeSpan _heartbeatInterval;
         private readonly TimeSpan _heartbeatTimeout;
+        private readonly int _connectionPendingSendBytesThreshold;
+        private readonly bool _limitPendingSendBytes;
 
         private readonly IAuthenticationProvider _authProvider;
         private UserCredentials _defaultUser;
@@ -66,7 +68,9 @@ namespace EventStore.Core.Services.Transport.Tcp
                                     IAuthenticationProvider authProvider,
                                     TimeSpan heartbeatInterval,
                                     TimeSpan heartbeatTimeout,
-                                    Action<TcpConnectionManager, SocketError> onConnectionClosed)
+                                    Action<TcpConnectionManager, SocketError> onConnectionClosed,
+                                    int connectionPendingSendBytesThreshold,
+                                    bool limitPendingSendBytes)
         {
             Ensure.NotNull(dispatcher, "dispatcher");
             Ensure.NotNull(publisher, "publisher");
@@ -89,6 +93,8 @@ namespace EventStore.Core.Services.Transport.Tcp
             _weakThisEnvelope = new SendToWeakThisEnvelope(this);
             _heartbeatInterval = heartbeatInterval;
             _heartbeatTimeout = heartbeatTimeout;
+            _connectionPendingSendBytesThreshold = connectionPendingSendBytesThreshold;
+            _limitPendingSendBytes = limitPendingSendBytes;
 
             _connectionClosed = onConnectionClosed;
 
@@ -142,6 +148,8 @@ namespace EventStore.Core.Services.Transport.Tcp
             _weakThisEnvelope = new SendToWeakThisEnvelope(this);
             _heartbeatInterval = heartbeatInterval;
             _heartbeatTimeout = heartbeatTimeout;
+            _connectionPendingSendBytesThreshold = 0;
+            _limitPendingSendBytes = false;
 
             _connectionEstablished = onConnectionEstablished;
             _connectionClosed = onConnectionClosed;
@@ -387,10 +395,19 @@ namespace EventStore.Core.Services.Transport.Tcp
                 return;
 
             int queueSize;
-            if (checkQueueSize && (queueSize = _connection.SendQueueSize) > ConnectionQueueSizeThreshold)
+            int queueSendBytes;
+            if (checkQueueSize)
             {
-                SendBadRequestAndClose(Guid.Empty, string.Format("Connection queue size is too large: {0}.", queueSize));
-                return;
+                if((queueSize = _connection.SendQueueSize) > ConnectionQueueSizeThreshold)
+                {
+                    SendBadRequestAndClose(Guid.Empty, string.Format("Connection queue size is too large: {0}.", queueSize));
+                    return;
+                }
+                if(_limitPendingSendBytes && (queueSendBytes = _connection.PendingSendBytes) > _connectionPendingSendBytesThreshold)
+                {
+                    SendBadRequestAndClose(Guid.Empty, string.Format("Connection pending send bytes is too large: {0}.", queueSendBytes));
+                    return;
+                }
             }
 
             var data = package.AsArraySegment();

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -64,6 +64,9 @@ namespace EventStore.Core.Util
         public const string IntTcpHeartbeatIntervalDescr = "Heartbeat interval for internal TCP sockets";
         public const int IntTcpHeartbeatIntervalDefault = 700;
 
+        public const string ConnectionPendingSendBytesThresholdDescr = "The maximum number of pending send bytes allowed before a connection is closed.";
+        public const int ConnectionPendingSendBytesThresholdDefault = 10 * 1024 * 1024;
+        
         public const string GossipOnSingleNodeDescr = "When enabled tells a single node to run gossip as if it is a cluster";
         public const bool GossipOnSingleNodeDefault = false;
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -91,6 +91,7 @@ namespace EventStore.Core
         protected TimeSpan _intTcpHeartbeatInterval;
         protected TimeSpan _extTcpHeartbeatTimeout;
         protected TimeSpan _extTcpHeartbeatInterval;
+        protected int _connectionPendingSendBytesThreshold;
 
         protected bool _skipVerifyDbHashes;
         protected int _maxMemtableSize;
@@ -188,7 +189,8 @@ namespace EventStore.Core
             _intTcpHeartbeatTimeout = TimeSpan.FromMilliseconds(Opts.IntTcpHeartbeatTimeoutDefault);
             _extTcpHeartbeatInterval = TimeSpan.FromMilliseconds(Opts.ExtTcpHeartbeatIntervalDefault);
             _extTcpHeartbeatTimeout = TimeSpan.FromMilliseconds(Opts.ExtTcpHeartbeatTimeoutDefault);
-
+            _connectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
+            
             _skipVerifyDbHashes = Opts.SkipDbVerifyDefault;
             _maxMemtableSize = Opts.MaxMemtableSizeDefault;
             _subsystems = new List<ISubsystem>();
@@ -734,6 +736,17 @@ namespace EventStore.Core
         public VNodeBuilder WithExternalHeartbeatTimeout(TimeSpan heartbeatTimeout)
         {
             _extTcpHeartbeatTimeout = heartbeatTimeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum number of pending send bytes allowed before a connection is closed.
+        /// </summary>
+        /// <param name="WithConnectionPendingSendBytesThreshold">The number of pending send bytes allowed</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithConnectionPendingSendBytesThreshold(int connectionPendingSendBytesThreshold)
+        {
+            _connectionPendingSendBytesThreshold = connectionPendingSendBytesThreshold;
             return this;
         }
 
@@ -1313,6 +1326,7 @@ namespace EventStore.Core
                     _startStandardProjections,
                     _disableHTTPCaching,
                     _logHttpRequests,
+                    _connectionPendingSendBytesThreshold,
                     _index,
                     _enableHistograms,
                     _indexCacheDepth,

--- a/src/EventStore.Transport.Tcp/ITcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/ITcpConnection.cs
@@ -14,6 +14,7 @@ namespace EventStore.Transport.Tcp
         IPEndPoint RemoteEndPoint { get; }
         IPEndPoint LocalEndPoint { get; }
         int SendQueueSize { get; }
+        int PendingSendBytes { get; }
         bool IsClosed { get; }
 
         void ReceiveAsync(Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> callback);


### PR DESCRIPTION
Re-introduces the changes in #1308.
The ReplicaService was not updated in the previous PR, causing the nodes to drop internal connections. The ReplicaService is now excluded from the pending send threshold.

If pending send bytes grows to be larger than a specified threshold, the connection will be closed.
Adds a new option ConnectionPendingSendBytesThreshold that allows the pending send bytes threshold to be changed.
Tcp messages that are intended for connections that have been closed will now be dropped.