### PR TITLE
Fix projections getting stuck in preparing when a node becomes master

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/specification_with_projection_core_service_command_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/specification_with_projection_core_service_command_reader.cs
@@ -53,11 +53,6 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
             _bus.Subscribe<ProjectionCoreServiceMessage.StopCore>(_commandReader);
         }
 
-        protected override IEnumerable<WhenStep> PreWhen()
-        {
-            yield return CreateWriteEvent("$projections-$control", "$response-reader-started", "{}");
-        }
-
         [SetUp]
         public new void SetUp()
         {

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/specification_with_projection_core_service_command_reader_started.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/specification_with_projection_core_service_command_reader_started.cs
@@ -43,8 +43,9 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
 
         protected override IEnumerable<WhenStep> PreWhen()
         {
-            foreach (var m in base.PreWhen()) yield return m;
-            yield return new ProjectionCoreServiceMessage.StartCore();
+            var startCore = new ProjectionCoreServiceMessage.StartCore();
+            var startReader = CreateWriteEvent("$projections-$control", "$response-reader-started", "{}");
+            yield return new WhenStep(startCore, startReader);
             List<EventRecord> stream;
             _streams.TryGetValue("$projections-$master", out stream);
             Assume.That(stream != null);

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_starting.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_starting.cs
@@ -37,7 +37,9 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
     {
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new ProjectionCoreServiceMessage.StartCore();
+            var startCore = new ProjectionCoreServiceMessage.StartCore();
+            var startReader = CreateWriteEvent("$projections-$control", "$response-reader-started", "{}");
+            yield return new WhenStep(startCore, startReader);
         }
 
         [Test]

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreServiceCommandReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreServiceCommandReader.cs
@@ -80,65 +80,56 @@ namespace EventStore.Projections.Core.Services.Processing
 
             Log.Debug("PROJECTIONS: Starting read control from {0}", fromEventNumber);
 
-            //TODO: handle shutdown here and in other readers
             long subscribeFrom = 0;
-            var doWriteRegistration = true;
             while (!_stopped)
             {
-                if (doWriteRegistration)
-                {
-                    var events = new[]
-                    {
-                        new Event(
-                            Guid.NewGuid(),
-                            "$projection-worker-started",
-                            true,
-                            "{\"id\":\"" + _coreServiceId + "\"}",
-                            null)
-                    };
-                    yield return
-                        _ioDispatcher.BeginWriteEvents(
-                        _cancellationScope,
-                            ProjectionNamesBuilder._projectionsMasterStream,
-                            ExpectedVersion.Any,
-                            SystemAccount.Principal,
-                            events,
-                            r => { });
-                }
-                do
-                {
-                    ClientMessage.ReadStreamEventsForwardCompleted readResultForward = null;
-                    yield return
-                        _ioDispatcher.BeginReadForward(
-                        _cancellationScope,
-                            ProjectionNamesBuilder._projectionsControlStream,
-                            fromEventNumber,
-                            1,
-                            false,
-                            SystemAccount.Principal,
-                            completed => readResultForward = completed);
+                ClientMessage.ReadStreamEventsForwardCompleted readResultForward = null;
+                yield return
+                    _ioDispatcher.BeginReadForward(
+                    _cancellationScope,
+                        ProjectionNamesBuilder._projectionsControlStream,
+                        fromEventNumber,
+                        1,
+                        false,
+                        SystemAccount.Principal,
+                        completed => readResultForward = completed);
 
-                    if (readResultForward.Result != ReadStreamResult.Success
-                        && readResultForward.Result != ReadStreamResult.NoStream)
-                        throw new Exception("Control reader failed. Read result: " + readResultForward.Result);
-                    if (readResultForward.Events != null && readResultForward.Events.Length > 0)
+                if (readResultForward.Result != ReadStreamResult.Success
+                    && readResultForward.Result != ReadStreamResult.NoStream)
+                    throw new Exception("Control reader failed. Read result: " + readResultForward.Result);
+                if (readResultForward.Events != null && readResultForward.Events.Length > 0)
+                {
+                    var doWriteRegistration =
+                        readResultForward.Events.Any(v => v.Event.EventType == "$response-reader-started");
+                    fromEventNumber = readResultForward.NextEventNumber;
+                    subscribeFrom = readResultForward.TfLastCommitPosition;
+                    if (doWriteRegistration)
                     {
-                        doWriteRegistration =
-                            readResultForward.Events.Any(v => v.Event.EventType == "$response-reader-started");
-                        fromEventNumber = readResultForward.NextEventNumber;
-                        subscribeFrom = readResultForward.TfLastCommitPosition;
-                        break;
+                        var events = new[]
+                        {
+                            new Event(
+                                Guid.NewGuid(), "$projection-worker-started", true, "{\"id\":\"" + _coreServiceId + "\"}", null)
+                        };
+                        yield return
+                            _ioDispatcher.BeginWriteEvents(
+                            _cancellationScope,
+                                ProjectionNamesBuilder._projectionsMasterStream,
+                                ExpectedVersion.Any,
+                                SystemAccount.Principal,
+                                events,
+                                r => { });
                     }
-                    if (readResultForward.Result == ReadStreamResult.Success)
-                        subscribeFrom = readResultForward.TfLastCommitPosition;
+                    break;
+                }
+                if (readResultForward.Result == ReadStreamResult.Success)
+                    subscribeFrom = readResultForward.TfLastCommitPosition;
 
-                    yield return
-                        _ioDispatcher.BeginSubscribeAwake(
-                        _cancellationScope,
-                            ProjectionNamesBuilder._projectionsControlStream,
-                            new TFPos(subscribeFrom, subscribeFrom),
-                            message => { });
-                } while (!_stopped);
+                yield return
+                    _ioDispatcher.BeginSubscribeAwake(
+                    _cancellationScope,
+                        ProjectionNamesBuilder._projectionsControlStream,
+                        new TFPos(subscribeFrom, subscribeFrom),
+                        message => { });
             }
         }
 


### PR DESCRIPTION
Re-introduces changes from #1349 
This PR was reverted because the tests were failing intermittently. These failures were caused by a possible infinite loop in the tests caused by the `StartCore` message waiting for the `$response-reader-started` event to be written. This was resolved by sending both messages in the same test step.

Don't write projection worker started events until projection worker has actually been started.
Also remove log about handling shutdown as this is handled.

This fixes projections getting stuck in preparing when a master node gets re-elected as master.
Reproduction steps:

1. Start 2 nodes configured to be in a 3 node cluster and to have system projections running.
2. Write a bunch of events.
3. Kill the slave node while events are still being written.
4. Bring the slave node back up after a short while.

The projections should now be stuck in preparing.