### PR TITLE
Limit the number of inflight writes per projection to 1

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -228,6 +228,9 @@
     <Compile Include="Hashes\SMHasher.cs" />
     <Compile Include="Hashes\xxhash_hash_should.cs" />
     <Compile Include="Helpers\ClientApiLoggerBridge.cs" />
+    <Compile Include="Helpers\IODispatcherTests\QueueWriteEventsTests\when_a_write_completes.cs" />
+    <Compile Include="Helpers\IODispatcherTests\QueueWriteEventsTests\when_requesting_multiple_writes_with_different_keys.cs" />
+    <Compile Include="Helpers\IODispatcherTests\QueueWriteEventsTests\when_requesting_multiple_writes_with_the_same_key.cs" />
     <Compile Include="Helpers\LengthPrefixSuffixFramer.cs" />
     <Compile Include="Helpers\ManualQueue.cs" />
     <Compile Include="Helpers\MiniClusterNode.cs" />

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/QueueWriteEventsTests/when_a_write_completes.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/QueueWriteEventsTests/when_a_write_completes.cs
@@ -1,0 +1,28 @@
+﻿using EventStore.Core.Data;
+using EventStore.Core.Services.UserManagement;
+using NUnit.Framework;
+using System;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.QueueWriteEventsTests
+{
+    [TestFixture]
+    public class when_a_write_completes : TestFixtureWithExistingEvents
+    {
+        private bool _completed = false;
+        protected override void Given()
+        {
+            AllWritesQueueUp();
+
+            _ioDispatcher.QueueWriteEvents(Guid.NewGuid(), $"stream-{Guid.NewGuid()}", ExpectedVersion.Any, new Event[] { new Event(Guid.NewGuid(), "event-type", false, string.Empty, string.Empty) }, SystemAccount.Principal, (msg) => {
+                _completed = true;
+            });
+            OneWriteCompletes();
+        }
+
+        [Test]
+        public void should_invoke_callback_when_write_completes()
+        {
+            Assert.IsTrue(_completed);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/QueueWriteEventsTests/when_requesting_multiple_writes_with_different_keys.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/QueueWriteEventsTests/when_requesting_multiple_writes_with_different_keys.cs
@@ -1,0 +1,25 @@
+﻿using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.UserManagement;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.QueueWriteEventsTests
+{
+    [TestFixture]
+    public class when_requesting_multiple_writes_with_different_keys : TestFixtureWithExistingEvents
+    {
+        protected override void Given()
+        {
+            _ioDispatcher.QueueWriteEvents(Guid.NewGuid(), $"stream-{Guid.NewGuid()}", ExpectedVersion.Any, new Event[] { new Event(Guid.NewGuid(), "event-type", false, string.Empty, string.Empty) }, SystemAccount.Principal, (msg) => { });
+            _ioDispatcher.QueueWriteEvents(Guid.NewGuid(), $"stream-{Guid.NewGuid()}", ExpectedVersion.Any, new Event[] { new Event(Guid.NewGuid(), "event-type", false, string.Empty, string.Empty) }, SystemAccount.Principal, (msg) => { });
+        }
+
+        [Test]
+        public void should_have_as_many_writes_in_flight_as_unique_keys()
+        {
+            Assert.AreEqual(2, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Count());
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/QueueWriteEventsTests/when_requesting_multiple_writes_with_the_same_key.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/QueueWriteEventsTests/when_requesting_multiple_writes_with_the_same_key.cs
@@ -1,0 +1,50 @@
+﻿using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.UserManagement;
+using NUnit.Framework;
+using System;
+using System.Linq;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.QueueWriteEventsTests
+{
+    [TestFixture]
+    public class when_requesting_multiple_writes_with_the_same_key : TestFixtureWithExistingEvents
+    {
+        protected override void Given()
+        {
+            AllWritesQueueUp();
+
+            var key = Guid.NewGuid();
+            _ioDispatcher.QueueWriteEvents(key, $"stream-{Guid.NewGuid()}", ExpectedVersion.Any, new Event[] { new Event(Guid.NewGuid(), "event-type", false, string.Empty, string.Empty) }, SystemAccount.Principal, (msg) => { });
+            _ioDispatcher.QueueWriteEvents(key, $"stream-{Guid.NewGuid()}", ExpectedVersion.Any, new Event[] { new Event(Guid.NewGuid(), "event-type", false, string.Empty, string.Empty) }, SystemAccount.Principal, (msg) => { });
+            _ioDispatcher.QueueWriteEvents(key, $"stream-{Guid.NewGuid()}", ExpectedVersion.Any, new Event[] { new Event(Guid.NewGuid(), "event-type", false, string.Empty, string.Empty) }, SystemAccount.Principal, (msg) => { });
+        }
+
+        [Test]
+        public void should_only_have_a_single_write_in_flight()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Count());
+        }
+
+        [Test]
+        public void should_continue_to_only_have_a_single_write_in_flight_as_writes_complete()
+        {
+            var writeRequests = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>();
+
+            //first write
+            _consumer.HandledMessages.Clear();
+            OneWriteCompletes();
+            Assert.AreEqual(1, writeRequests.Count());
+
+            //second write
+            _consumer.HandledMessages.Clear();
+            OneWriteCompletes();
+            Assert.AreEqual(1, writeRequests.Count());
+
+            //third write completes, no more writes left in the queue
+            _consumer.HandledMessages.Clear();
+            OneWriteCompletes();
+            Assert.AreEqual(0, writeRequests.Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_correct_order_the_started_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_correct_order_the_started_projection_checkpoint.cs
@@ -50,6 +50,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
                         new EmittedDataEvent(
                             "stream1", Guid.NewGuid(), "type4", true, "data", null, CheckpointTag.FromPosition(0, 140, 130), null))
                 });
+            OneWriteCompletes(); //stream2
+            OneWriteCompletes(); //stream3
         }
 
         [Test]
@@ -85,7 +87,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         }
 
         [Test]
-        public void should_not_write_a_secong_group_until_the_first_write_completes()
+        public void should_not_write_a_second_group_until_the_first_write_completes()
         {
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCheckpoint.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCheckpoint.cs
@@ -33,6 +33,8 @@ namespace EventStore.Projections.Core.Services.Processing
 
         private List<IEnvelope> _awaitingStreams;
 
+        private Guid _instanceId;
+
         public ProjectionCheckpoint(
             IPublisher publisher,
             IODispatcher ioDispatcher,
@@ -59,6 +61,7 @@ namespace EventStore.Projections.Core.Services.Processing
             _from = _last = from;
             _maxWriteBatchLength = maxWriteBatchLength;
             _logger = logger;
+            _instanceId = Guid.NewGuid();
         }
 
         public void Start()
@@ -142,7 +145,7 @@ namespace EventStore.Projections.Core.Services.Processing
                     streamMetadata, _runAs, maxWriteBatchLength: _maxWriteBatchLength, logger: _logger);
 
                 stream = new EmittedStream(
-                    streamId, writerConfiguration, _projectionVersion, _positionTagger, _from, _publisher, _ioDispatcher, this);
+                    _instanceId, streamId, writerConfiguration, _projectionVersion, _positionTagger, _from, _publisher, _ioDispatcher, this);
 
                 if (_started)
                     stream.Start();


### PR DESCRIPTION
In an Event Store under significant load, the projections that write events to streams could flood the node with writes. This will result in quite a number of write timeouts.

This is because a projection can have a write in flight for each unique stream it writes to.

This PR allows a projection to only have a single write in flight regardless of the number of unique streams it writes to. This significantly reduces the chances of a commit timeout and have each projection act like a well behaved client.

**Todo:**
We could look at making this a configuration option and let the user configure how many writes in flight a projection is allowed to have.