### PR TITLE
Expose config options for projections

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_event_type_index_positions_when_updating.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_phase.cs" />
     <Compile Include="Services\checkpoint_tag\checkpoint_tag_by_catalog_stream.cs" />
+    <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_maximum_allowed_writes_in_flight_set.cs" />
     <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_null_streamId.cs" />
     <Compile Include="Services\core_service\when_a_subscribed_projection_handler_throws.cs" />
     <Compile Include="Services\emitted_stream\when_a_read_completes_before_a_timeout_in_recovery.cs" />
@@ -548,6 +549,7 @@
     <Compile Include="Services\projections_manager\projection_manager_response_reader\when_read_times_out.cs" />
     <Compile Include="Services\projections_manager\projection_manager_response_reader\when_timeout_received_after_read_succeeds.cs" />
     <Compile Include="Services\projections_manager\projection_manager_response_reader\when_read_results_in_an_error.cs" />
+    <Compile Include="Services\projections_manager\managed_projection\when_updating_projection_config.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services
             _node.Node.MainBus.Subscribe(_ioDispatcher.Awaker);
             _node.Node.MainBus.Subscribe(_ioDispatcher);
             _projectionNamesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
-            _emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher, new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, false, _trackEmittedStreams, 10000), _projectionNamesBuilder);
+            _emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher, new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, false, _trackEmittedStreams, 10000, 1), _projectionNamesBuilder);
             _emittedStreamsDeleter = new EmittedStreamsDeleter(_ioDispatcher, _projectionNamesBuilder.GetEmittedStreamsName(), _projectionNamesBuilder.GetEmittedStreamsCheckpointName());
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
@@ -104,7 +104,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             return new ProjectionConfig(
                 null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold, GivenPendingEventsThreshold(),
                 GivenMaxWriteBatchLength(), GivenEmitEventEnabled(), GivenCheckpointsEnabled(), _createTempStreams,
-                GivenStopOnEof(), GivenIsSlaveProjection(), GivenTrackEmittedStreams(), GivenCheckpointAfterMs());
+                GivenStopOnEof(), GivenIsSlaveProjection(), GivenTrackEmittedStreams(), GivenCheckpointAfterMs(), GivenMaximumAllowedWritesInFlight());
         }
 
         protected virtual bool GivenIsSlaveProjection()
@@ -145,6 +145,11 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         protected virtual int GivenCheckpointAfterMs()
         {
             return 10000;
+        }
+
+        protected virtual int GivenMaximumAllowedWritesInFlight()
+        {
+            return 1;
         }
 
         protected virtual FakeProjectionStateHandler GivenProjectionStateHandler()

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -19,6 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
         protected bool _checkpointsEnabled;
         protected bool _trackEmittedStreams;
         protected int _checkpointAfterMs;
+        protected int _maximumAllowedWritesInFlight;
         protected bool _producesResults;
         protected bool _definesFold = true;
         protected Guid _projectionCorrelationId;
@@ -38,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
             _namingBuilder = ProjectionNamesBuilder.CreateForTest("projection");
             _config = new ProjectionConfig(null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold,
                 _pendingEventsThreshold, _maxWriteBatchLength, _emitEventEnabled,
-                _checkpointsEnabled, _createTempStreams, _stopOnEof, false, _trackEmittedStreams, _checkpointAfterMs);
+                _checkpointsEnabled, _createTempStreams, _stopOnEof, false, _trackEmittedStreams, _checkpointAfterMs, _maximumAllowedWritesInFlight);
             When();
         }
 
@@ -87,6 +88,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
             _checkpointUnhandledBytesThreshold = 5;
             _pendingEventsThreshold = 5;
             _maxWriteBatchLength = 5;
+            _maximumAllowedWritesInFlight = 1;
             _emitEventEnabled = true;
             _checkpointsEnabled = true;
             _producesResults = true;

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/the_non_started_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/the_non_started_checkpoint.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/the_started_checkpoint_with_some_events_emitted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/the_started_checkpoint_with_some_events_emitted.cs
@@ -18,7 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();;
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             _checkpoint.Start();
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_creating_a_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_creating_a_projection_checkpoint.cs
@@ -31,7 +31,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             Assert.Throws<ArgumentNullException>(() => {
             new ProjectionCheckpoint(
                 null, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             });
         }
 
@@ -41,7 +41,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             Assert.Throws<ArgumentNullException>(() => {
             new ProjectionCheckpoint(
                 _fakePublisher, null, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             });
         }
 
@@ -51,7 +51,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             Assert.Throws<ArgumentNullException>(() => {
             new ProjectionCheckpoint(
                 _fakePublisher, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, null,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             });
         }
 
@@ -61,7 +61,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             Assert.Throws<ArgumentException>(() => {
             new ProjectionCheckpoint(
                 _fakePublisher, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 101), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 101), new TransactionFilePositionTagger(0), 250, 1);
             });
         }
 
@@ -70,7 +70,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
         {
             new ProjectionCheckpoint(
                 _fakePublisher, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_before_from_position_the_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_before_from_position_the_projection_checkpoint.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             try
             {
                 _checkpoint.ValidateOrderAndEmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_backward_order_to_the_same_stream_the_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_backward_order_to_the_same_stream_the_projection_checkpoint.cs
@@ -19,7 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             try
             {
                 _checkpoint.ValidateOrderAndEmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_correct_order_the_started_projection_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_in_correct_order_the_started_projection_checkpoint.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             _checkpoint.Start();
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_the_non_started_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_the_non_started_checkpoint.cs
@@ -18,7 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]
                 {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_maximum_allowed_writes_in_flight_set.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_maximum_allowed_writes_in_flight_set.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using System.Collections;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_checkpoint
+{
+    public class NumberOfMessagesInFlightSource : IEnumerable
+    {
+        public IEnumerator GetEnumerator()
+        {
+            return Enumerable.Range(1, 3).Select(x => x)
+                .GetEnumerator();
+        }
+    }
+
+    [TestFixture, TestFixtureSource(typeof(NumberOfMessagesInFlightSource))]
+    public class when_emitting_events_with_maximum_allowed_writes_in_flight_set : TestFixtureWithExistingEvents
+    {
+        private ProjectionCheckpoint _checkpoint;
+        private TestCheckpointManagerMessageHandler _readyHandler;
+
+        private int _maximumNumberOfAllowedWritesInFlight;
+        public when_emitting_events_with_maximum_allowed_writes_in_flight_set(int maximumNumberOfAllowedWritesInFlight)
+        {
+            _maximumNumberOfAllowedWritesInFlight = maximumNumberOfAllowedWritesInFlight;
+        }
+
+        protected override void Given()
+        {
+            AllWritesQueueUp();
+            AllWritesToSucceed("$$stream1");
+            AllWritesToSucceed("$$stream2");
+            AllWritesToSucceed("$$stream3");
+            NoOtherStreams();
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            _readyHandler = new TestCheckpointManagerMessageHandler();
+            _checkpoint = new ProjectionCheckpoint(
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, _maximumNumberOfAllowedWritesInFlight);
+            _checkpoint.Start();
+            _checkpoint.ValidateOrderAndEmitEvents(
+                new[]
+                {
+                    new EmittedEventEnvelope(
+                        new EmittedDataEvent(
+                            "stream1", Guid.NewGuid(), "type1", true, "data1", null, CheckpointTag.FromPosition(0, 120, 110), null)),
+                    new EmittedEventEnvelope(
+                        new EmittedDataEvent(
+                            "stream2", Guid.NewGuid(), "type2", true, "data2", null, CheckpointTag.FromPosition(0, 120, 110), null)),
+                    new EmittedEventEnvelope(
+                        new EmittedDataEvent(
+                            "stream3", Guid.NewGuid(), "type3", true, "data3", null, CheckpointTag.FromPosition(0, 120, 110), null)),
+                });
+        }
+
+        [Test]
+        public void should_have_the_same_number_writes_in_flight_as_configured()
+        {
+            var writeEvents =
+                _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+                         .ExceptOfEventType(SystemEventTypes.StreamMetadata);
+            Assert.AreEqual(_maximumNumberOfAllowedWritesInFlight, writeEvents.Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_null_streamId.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_null_streamId.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             try
             {
                 _checkpoint.ValidateOrderAndEmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_handling_stream_awaiting_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_handling_stream_awaiting_message.cs
@@ -18,7 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
 
             _fakeEnvelope = new FakeEnvelope();
             _checkpoint.Handle(new CoreProjectionProcessingMessage.EmittedStreamAwaiting("awaiting_stream", _fakeEnvelope));

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_requesting_checkpoint_after_all_writes_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_requesting_checkpoint_after_all_writes_completed.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             _checkpoint.Start();
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_requesting_checkpoint_before_all_writes_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_requesting_checkpoint_before_all_writes_completed.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             _checkpoint.Start();
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_starting_the_projection_checkpoint_with_some_events_already_emitted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_starting_the_projection_checkpoint_with_some_events_already_emitted.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]
                 {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_the_projection_checkpoint_has_been_started.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_the_projection_checkpoint_has_been_started.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 0, -1), new TransactionFilePositionTagger(0), 250);
+                CheckpointTag.FromPosition(0, 0, -1), new TransactionFilePositionTagger(0), 250, 1);
             _checkpoint.Start();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
@@ -24,7 +24,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
         }
 
         private readonly ProjectionConfig _defaultProjectionConfig = new ProjectionConfig(
-            null, 5, 10, 1000, 250, true, true, true, true, false, true, 10000);
+            null, 5, 10, 1000, 250, true, true, true, true, false, true, 10000, 1);
 
         private IODispatcher _ioDispatcher;
 
@@ -39,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             Assert.Throws<ArgumentException>(() => {
                 IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
                 var version = new ProjectionVersion(1, 0, 0);
-                var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false, false, true, 10000);
+                var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false, false, true, 10000, 1);
                 new ContinuousProjectionProcessingStrategy(
                     "projection",
                     version,
@@ -65,7 +65,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             Assert.Throws<ArgumentOutOfRangeException>(() => {
                 IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
                 var version = new ProjectionVersion(1, 0, 0);
-                var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false, false, true, 10000);
+                var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false, false, true, 10000, 1);
                 new ContinuousProjectionProcessingStrategy(
                     "projection",
                     version,
@@ -264,7 +264,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             Assert.Throws<ArgumentOutOfRangeException>(() => {
                 IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
                 var version = new ProjectionVersion(1, 0, 0);
-                var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false, false, true, 10000);
+                var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false, false, true, 10000, 1);
                 new ContinuousProjectionProcessingStrategy(
                     "projection",
                     version,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection
             _bus.Subscribe(_ioDispatcher.Writer);
             _bus.Subscribe(_ioDispatcher);
             IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
-            _projectionConfig = new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, false, true, 10000);
+            _projectionConfig = new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, false, true, 10000, 1);
             var version = new ProjectionVersion(1, 0, 0);
             var projectionProcessingStrategy = new ContinuousProjectionProcessingStrategy(
                 "projection", version, projectionStateHandler, _projectionConfig,

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_receiving_create_and_prepare_command.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_receiving_create_and_prepare_command.cs
@@ -28,6 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
                              ""checkpointUnhandledBytesThreshold"":10000,
                              ""pendingEventsThreshold"":5000, 
                              ""maxWriteBatchLength"":100,
+                             ""maximumAllowedWritesInFlight"":1,
                              ""emitEventEnabled"":true,
                              ""checkpointsEnabled"":true,
                              ""createTempStreams"":true,
@@ -60,6 +61,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
             Assert.AreEqual(10000, createPrepare.Config.CheckpointUnhandledBytesThreshold);
             Assert.AreEqual(5000, createPrepare.Config.PendingEventsThreshold);
             Assert.AreEqual(100, createPrepare.Config.MaxWriteBatchLength);
+            Assert.AreEqual(1, createPrepare.Config.MaximumAllowedWritesInFlight);
             Assert.AreEqual(true, createPrepare.Config.EmitEventEnabled);
             Assert.AreEqual(true, createPrepare.Config.CheckpointsEnabled);
             Assert.AreEqual(true, createPrepare.Config.CreateTempStreams);

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_receiving_create_and_prepare_slave_command.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_receiving_create_and_prepare_slave_command.cs
@@ -28,6 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
                              ""checkpointUnhandledBytesThreshold"":10000,
                              ""pendingEventsThreshold"":5000, 
                              ""maxWriteBatchLength"":100,
+                             ""maximumAllowedWritesInFlight"":1,
                              ""emitEventEnabled"":true,
                              ""checkpointsEnabled"":true,
                              ""createTempStreams"":true,
@@ -62,6 +63,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
             Assert.AreEqual(10000, createPrepareSlave.Config.CheckpointUnhandledBytesThreshold);
             Assert.AreEqual(5000, createPrepareSlave.Config.PendingEventsThreshold);
             Assert.AreEqual(100, createPrepareSlave.Config.MaxWriteBatchLength);
+            Assert.AreEqual(1, createPrepareSlave.Config.MaximumAllowedWritesInFlight);
             Assert.AreEqual(true, createPrepareSlave.Config.EmitEventEnabled);
             Assert.AreEqual(true, createPrepareSlave.Config.CheckpointsEnabled);
             Assert.AreEqual(true, createPrepareSlave.Config.CreateTempStreams);

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_receiving_create_prepared_command.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_receiving_create_prepared_command.cs
@@ -28,6 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
                              ""checkpointUnhandledBytesThreshold"":10000,
                              ""pendingEventsThreshold"":5000, 
                              ""maxWriteBatchLength"":100,
+                             ""maximumAllowedWritesInFlight"":1,
                              ""emitEventEnabled"":true,
                              ""checkpointsEnabled"":true,
                              ""createTempStreams"":true,
@@ -85,6 +86,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service_com
             Assert.AreEqual(10000, createPrepared.Config.CheckpointUnhandledBytesThreshold);
             Assert.AreEqual(5000, createPrepared.Config.PendingEventsThreshold);
             Assert.AreEqual(100, createPrepared.Config.MaxWriteBatchLength);
+            Assert.AreEqual(1, createPrepared.Config.MaximumAllowedWritesInFlight);
             Assert.AreEqual(true, createPrepared.Config.EmitEventEnabled);
             Assert.AreEqual(true, createPrepared.Config.CheckpointsEnabled);
             Assert.AreEqual(true, createPrepared.Config.CreateTempStreams);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_message.cs
@@ -39,7 +39,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
-                10000);
+                10000,
+                1);
 
         }
 
@@ -79,6 +80,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
             Assert.AreEqual(_config.IsSlaveProjection, command.Config.IsSlaveProjection);
             Assert.AreEqual(_config.MaxWriteBatchLength, command.Config.MaxWriteBatchLength);
             Assert.AreEqual(_config.PendingEventsThreshold, command.Config.PendingEventsThreshold);
+            Assert.AreEqual(_config.MaximumAllowedWritesInFlight, command.Config.MaximumAllowedWritesInFlight);
             Assert.AreEqual(_config.RunAs.Identity.Name, command.Config.RunAs);
             Assert.AreEqual(_config.StopOnEof, command.Config.StopOnEof);
         }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_slave_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_and_prepare_slave_message.cs
@@ -43,7 +43,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
-                10000);
+                10000,
+                1);
 
         }
 
@@ -85,6 +86,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
             Assert.AreEqual(_config.IsSlaveProjection, command.Config.IsSlaveProjection);
             Assert.AreEqual(_config.MaxWriteBatchLength, command.Config.MaxWriteBatchLength);
             Assert.AreEqual(_config.PendingEventsThreshold, command.Config.PendingEventsThreshold);
+            Assert.AreEqual(_config.MaximumAllowedWritesInFlight, command.Config.MaximumAllowedWritesInFlight);
             Assert.AreEqual(_config.RunAs.Identity.Name, command.Config.RunAs);
             Assert.AreEqual(_config.StopOnEof, command.Config.StopOnEof);
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_prepared_message.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/command_writer/when_handling_create_prepared_message.cs
@@ -40,7 +40,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
                 true,
                 true,
                 true,
-                10000);
+                10000,
+                1);
 
             var builder = new SourceDefinitionBuilder();
             builder.FromStream("s1");
@@ -89,6 +90,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.command
             Assert.AreEqual(_config.IsSlaveProjection, command.Config.IsSlaveProjection);
             Assert.AreEqual(_config.MaxWriteBatchLength, command.Config.MaxWriteBatchLength);
             Assert.AreEqual(_config.PendingEventsThreshold, command.Config.PendingEventsThreshold);
+            Assert.AreEqual(_config.MaximumAllowedWritesInFlight, command.Config.MaximumAllowedWritesInFlight);
             Assert.AreEqual(_config.RunAs.Identity.Name, command.Config.RunAs);
             Assert.AreEqual(_config.StopOnEof, command.Config.StopOnEof);
             Assert.AreEqual(_definition.AllEvents, command.SourceDefinition.AllEvents);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
@@ -1,0 +1,274 @@
+using System;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed_projection
+{
+    [TestFixture]
+    public class when_getting_config : projection_config_test_base
+    {
+        private ManagedProjection _mp;
+        private Guid _projectionId = Guid.NewGuid();
+        private ProjectionManagementMessage.ProjectionConfig _config;
+
+        private ManagedProjection.PersistedState _persistedState = new ManagedProjection.PersistedState
+        {
+            Enabled = true,
+            HandlerType = "JS",
+            Query = "fromAll().when({});",
+            Mode = ProjectionMode.Continuous,
+            CheckpointsDisabled = false,
+            Epoch = -1,
+            Version = -1,
+            RunAs = SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous),
+            EmitEnabled = false,
+            TrackEmittedStreams = true,
+            CheckpointAfterMs = 1,
+            CheckpointHandledThreshold = 2,
+            CheckpointUnhandledBytesThreshold = 3,
+            PendingEventsThreshold = 4,
+            MaxWriteBatchLength = 5,
+            MaxAllowedWritesInFlight = 6
+        };
+
+        public when_getting_config()
+        {
+            AllWritesQueueUp();
+        }
+
+        protected override void Given()
+        {
+            _timeProvider = new FakeTimeProvider();
+            _mp = CreateManagedProjection();
+
+            _mp.InitializeNew(
+                _persistedState,
+                null);
+            _mp.Handle(new CoreProjectionStatusMessage.Prepared(_projectionId, new ProjectionSourceDefinition()));
+
+            // Complete write of persisted state to start projection
+            OneWriteCompletes();
+            _config = GetProjectionConfig(_mp);
+        }
+
+        [Test]
+        public void config_should_be_same_as_persisted_state()
+        {
+            Assert.IsNotNull(_config);
+            Assert.AreEqual(_persistedState.EmitEnabled, _config.EmitEnabled, "EmitEnabled");
+            Assert.AreEqual(_persistedState.TrackEmittedStreams, _config.TrackEmittedStreams, "TrackEmittedStreams");
+            Assert.AreEqual(_persistedState.CheckpointAfterMs, _config.CheckpointAfterMs, "CheckpointAfterMs");
+            Assert.AreEqual(_persistedState.CheckpointHandledThreshold, _config.CheckpointHandledThreshold, "CheckpointHandledThreshold");
+            Assert.AreEqual(_persistedState.CheckpointUnhandledBytesThreshold, _config.CheckpointUnhandledBytesThreshold, "CheckpointUnhandledBytesThreshold");
+            Assert.AreEqual(_persistedState.PendingEventsThreshold, _config.PendingEventsThreshold, "PendingEventsThreshold");
+            Assert.AreEqual(_persistedState.MaxWriteBatchLength, _config.MaxWriteBatchLength, "MaxWriteBatchLength");
+            Assert.AreEqual(_persistedState.MaxAllowedWritesInFlight, _config.MaxAllowedWritesInFlight, "MaxAllowedWritesInFlight");
+        }
+    }
+
+    [TestFixture]
+    public class when_updating_projection_config_of_faulted_projection : projection_config_test_base
+    {
+        private ManagedProjection _mp;
+        private Guid _projectionId = Guid.NewGuid();
+        private Exception _thrownException;
+        private ProjectionManagementMessage.Command.UpdateConfig _updateConfig;
+
+        public when_updating_projection_config_of_faulted_projection()
+        {
+            AllWritesQueueUp();
+        }
+
+        protected override void Given()
+        {
+            _timeProvider = new FakeTimeProvider();
+            _mp = CreateManagedProjection();
+             _mp.InitializeNew(
+                new ManagedProjection.PersistedState
+                {
+                    Enabled = false,
+                    HandlerType = "JS",
+                    Query = "fromAll().when({});",
+                    Mode = ProjectionMode.Continuous,
+                    EmitEnabled = true,
+                    CheckpointsDisabled = false,
+                    Epoch = -1,
+                    Version = -1,
+                    RunAs = SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous),
+                },
+                null);
+
+            _mp.Handle(new CoreProjectionStatusMessage.Prepared(_projectionId, new ProjectionSourceDefinition()));
+            OneWriteCompletes();
+            _consumer.HandledMessages.Clear();
+
+            _mp.Handle(new CoreProjectionStatusMessage.Faulted(
+                _projectionId,
+                "test"));
+
+            _updateConfig = CreateConfig();
+            try {
+                _mp.Handle(_updateConfig);
+            } catch(Exception ex) {
+                _thrownException = ex;
+            }
+        }
+
+        [Test]
+        public void persisted_state_is_written()
+        {
+            var writeEvents = _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().ToList();
+            Assert.AreEqual(1, writeEvents.Count());
+            Assert.AreEqual("$projections-name", writeEvents[0].EventStreamId);
+        }
+
+        [Test]
+        public void config_update_does_not_throw_exception()
+        {
+            Assert.IsNull(_thrownException);
+        }
+
+        [Test]
+        public void config_is_updated()
+        {
+            var getConfigResult = GetProjectionConfig(_mp);
+
+            Assert.IsNotNull(getConfigResult);
+            Assert.AreEqual(_updateConfig.EmitEnabled, getConfigResult.EmitEnabled);
+            Assert.AreEqual(_updateConfig.TrackEmittedStreams, getConfigResult.TrackEmittedStreams);
+            Assert.AreEqual(_updateConfig.CheckpointAfterMs, getConfigResult.CheckpointAfterMs);
+            Assert.AreEqual(_updateConfig.CheckpointHandledThreshold, getConfigResult.CheckpointHandledThreshold);
+            Assert.AreEqual(_updateConfig.CheckpointUnhandledBytesThreshold, getConfigResult.CheckpointUnhandledBytesThreshold);
+            Assert.AreEqual(_updateConfig.PendingEventsThreshold, getConfigResult.PendingEventsThreshold);
+            Assert.AreEqual(_updateConfig.MaxWriteBatchLength, getConfigResult.MaxWriteBatchLength);
+            Assert.AreEqual(_updateConfig.MaxAllowedWritesInFlight, getConfigResult.MaxAllowedWritesInFlight);
+        }
+    }
+
+    [TestFixture]
+    public class when_updating_projection_config_of_running_projection : projection_config_test_base
+    {
+        private ManagedProjection _mp;
+        private Guid _projectionId = Guid.NewGuid();
+        private ManagedProjection.PersistedState _persistedState = new ManagedProjection.PersistedState
+        {
+            Enabled = true,
+            HandlerType = "JS",
+            Query = "fromAll().when({});",
+            Mode = ProjectionMode.Continuous,
+            CheckpointsDisabled = false,
+            Epoch = -1,
+            Version = -1,
+            RunAs = SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous),
+            EmitEnabled = false,
+            TrackEmittedStreams = true,
+            CheckpointAfterMs = 1,
+            CheckpointHandledThreshold = 2,
+            CheckpointUnhandledBytesThreshold = 3,
+            PendingEventsThreshold = 4,
+            MaxWriteBatchLength = 5,
+            MaxAllowedWritesInFlight = 6
+        };
+        private InvalidOperationException _thrownException;
+
+        public when_updating_projection_config_of_running_projection()
+        {
+            AllWritesQueueUp();
+        }
+
+        protected override void Given()
+        {
+            _timeProvider = new FakeTimeProvider();
+            _mp = CreateManagedProjection();
+
+            _mp.InitializeNew(
+                _persistedState,
+                null);
+            _mp.Handle(new CoreProjectionStatusMessage.Prepared(_projectionId, new ProjectionSourceDefinition()));
+
+            // Complete write of persisted state to start projection
+            OneWriteCompletes();
+
+            try {
+                _mp.Handle(CreateConfig());
+            } catch(InvalidOperationException ex) {
+                _thrownException = ex;
+            }
+        }
+
+        [Test]
+        public void should_throw_exception_when_trying_to_update_config()
+        {
+            Assert.IsNotNull(_thrownException);
+        }
+
+        [Test]
+        public void config_should_remain_unchanged()
+        {
+            var getConfigResult = GetProjectionConfig(_mp);
+
+            Assert.IsNotNull(getConfigResult);
+            Assert.AreEqual(_persistedState.EmitEnabled, getConfigResult.EmitEnabled, "EmitEnabled");
+            Assert.AreEqual(_persistedState.TrackEmittedStreams, getConfigResult.TrackEmittedStreams, "TrackEmittedStreams");
+            Assert.AreEqual(_persistedState.CheckpointAfterMs, getConfigResult.CheckpointAfterMs, "CheckpointAfterMs");
+            Assert.AreEqual(_persistedState.CheckpointHandledThreshold, getConfigResult.CheckpointHandledThreshold, "CheckpointHandledThreshold");
+            Assert.AreEqual(_persistedState.CheckpointUnhandledBytesThreshold, getConfigResult.CheckpointUnhandledBytesThreshold, "CheckpointUnhandledBytesThreshold");
+            Assert.AreEqual(_persistedState.PendingEventsThreshold, getConfigResult.PendingEventsThreshold, "PendingEventsThreshold");
+            Assert.AreEqual(_persistedState.MaxWriteBatchLength, getConfigResult.MaxWriteBatchLength, "MaxWriteBatchLength");
+            Assert.AreEqual(_persistedState.MaxAllowedWritesInFlight, getConfigResult.MaxAllowedWritesInFlight, "MaxAllowedWritesInFlight");
+        }
+    }
+
+    public class projection_config_test_base : TestFixtureWithExistingEvents
+    {
+        protected ManagedProjection CreateManagedProjection()
+        {
+            return new ManagedProjection(
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                1,
+                "name",
+                true,
+                null,
+                _streamDispatcher,
+                _writeDispatcher,
+                _readDispatcher,
+                _bus,
+                _timeProvider, new RequestResponseDispatcher
+                    <CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
+                    _bus, 
+                    v => v.CorrelationId,
+                    v => v.CorrelationId,
+                    new PublishEnvelope(_bus)), new RequestResponseDispatcher
+                        <CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
+                        _bus, 
+                        v => v.CorrelationId,
+                        v => v.CorrelationId,
+                        new PublishEnvelope(_bus)),
+                _ioDispatcher);
+        }
+
+        protected ProjectionManagementMessage.Command.UpdateConfig CreateConfig()
+        {
+            return new ProjectionManagementMessage.Command.UpdateConfig(
+                new NoopEnvelope(), "name", true, false, 100, 200, 300, 400, 500, 600, ProjectionManagementMessage.RunAs.Anonymous);
+        }
+
+        protected ProjectionManagementMessage.ProjectionConfig GetProjectionConfig(ManagedProjection mp)
+        {
+            ProjectionManagementMessage.ProjectionConfig getConfigResult = null;
+            mp.Handle(new ProjectionManagementMessage.Command.GetConfig(
+                new CallbackEnvelope(m => getConfigResult = (ProjectionManagementMessage.ProjectionConfig)m), "name",
+                SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous)));
+            return getConfigResult;
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
@@ -48,7 +48,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.slave_p
                         true,
                         true,
                         true,
-                        10000),
+                        10000,
+                        1),
                     _masterWorkerId,
                     _coreProjectionCorrelationId,
                     //(handlerType, query) => new FakeProjectionStateHandler(

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -214,6 +214,7 @@
     <Compile Include="Services\Management\ManagedProjectionStates\StoppedState.cs" />
     <Compile Include="Services\Management\ManagedProjectionStates\StoppingState.cs" />
     <Compile Include="Services\Management\ProjectionBalancer.cs" />
+    <Compile Include="Services\Management\ProjectionConsts.cs" />
     <Compile Include="Services\Management\ProjectionCoreCoordinator.cs" />
     <Compile Include="Services\Management\ProjectionCoreResponseWriter.cs" />
     <Compile Include="Services\Management\ProjectionManagerResponseReader.cs" />

--- a/src/EventStore.Projections.Core/Messages/Persisted/Commands/PersistedProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Messages/Persisted/Commands/PersistedProjectionConfig.cs
@@ -20,6 +20,7 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
         public bool IsSlaveProjection;
         public bool TrackEmittedStreams;
         public int CheckpointAfterMs;
+        public int MaximumAllowedWritesInFlight;
 
         public PersistedProjectionConfig()
         {
@@ -43,6 +44,7 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
             IsSlaveProjection = config.IsSlaveProjection;
             TrackEmittedStreams = config.TrackEmittedStreams;
             CheckpointAfterMs = config.CheckpointAfterMs;
+            MaximumAllowedWritesInFlight = config.MaximumAllowedWritesInFlight;
         }
 
         public ProjectionConfig ToConfig()
@@ -62,7 +64,8 @@ namespace EventStore.Projections.Core.Messages.Persisted.Commands
                     StopOnEof,
                     IsSlaveProjection,
                     TrackEmittedStreams,
-                    CheckpointAfterMs);
+                    CheckpointAfterMs,
+                    MaximumAllowedWritesInFlight);
         }
     }
 }

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -350,6 +350,102 @@ namespace EventStore.Projections.Core.Messages
                 }
             }
 
+            public class GetConfig : ControlMessage
+            {
+                private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+                public override int MsgTypeId { get { return TypeId; } }
+
+                private readonly string _name;
+
+                public GetConfig(IEnvelope envelope, string name, RunAs runAs):
+                    base(envelope, runAs)
+                {
+                    _name = name;
+                }
+
+                public string Name
+                {
+                    get { return _name; }
+                }
+            }
+
+            public class UpdateConfig : ControlMessage
+            {
+                private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+                public override int MsgTypeId { get { return TypeId; } }
+
+                private readonly string _name;
+                private readonly bool _emitEnabled;
+                private readonly bool _trackEmittedStreams;
+                private readonly int _checkpointAfterMs;
+                private readonly int _checkpointHandledThreshold;
+                private readonly int _checkpointUnhandledBytesThreshold;
+                private readonly int _pendingEventsThreshold;
+                private readonly int _maxWriteBatchLength;
+                private readonly int _maxAllowedWritesInFlight;
+
+                public UpdateConfig(IEnvelope envelope, string name, bool emitEnabled, bool trackEmittedStreams, int checkpointAfterMs,
+                    int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold, int pendingEventsThreshold,
+                    int maxWriteBatchLength, int maxAllowedWritesInFlight, RunAs runAs):
+                    base(envelope, runAs)
+                {
+                    _name = name;
+                    _emitEnabled = emitEnabled;
+                    _trackEmittedStreams = trackEmittedStreams;
+                    _checkpointAfterMs = checkpointAfterMs;
+                    _checkpointHandledThreshold = checkpointHandledThreshold;
+                    _checkpointUnhandledBytesThreshold = checkpointUnhandledBytesThreshold;
+                    _pendingEventsThreshold = pendingEventsThreshold;
+                    _maxWriteBatchLength = maxWriteBatchLength;
+                    _maxAllowedWritesInFlight = maxAllowedWritesInFlight;
+                }
+
+                public string Name
+                {
+                    get { return _name; }
+                }
+
+                public bool EmitEnabled
+                {
+                    get { return _emitEnabled; }
+                }
+
+                public bool TrackEmittedStreams
+                {
+                    get { return _trackEmittedStreams; }
+                }
+
+                public int CheckpointAfterMs
+                {
+                    get { return _checkpointAfterMs; }
+                }
+
+                public int CheckpointHandledThreshold
+                {
+                    get { return _checkpointHandledThreshold; }
+                }
+
+                public int CheckpointUnhandledBytesThreshold
+                {
+                    get { return _checkpointUnhandledBytesThreshold; }
+                }
+
+                public int PendingEventsThreshold
+                {
+                    get { return _pendingEventsThreshold; }
+                }
+
+                public int MaxWriteBatchLength
+                {
+                    get { return _maxWriteBatchLength; }
+                }
+
+                public int MaxAllowedWritesInFlight
+                {
+                    get { return _maxAllowedWritesInFlight; }
+                }
+            }
+
             public class StartSlaveProjections : ControlMessage
             {
                 private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
@@ -941,5 +1037,76 @@ namespace EventStore.Projections.Core.Messages
             }
         }
 
+        public class ProjectionConfig : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId
+            {
+                get
+                { return TypeId; }
+            }
+
+            private readonly bool _emitEnabled;
+            private readonly bool _trackEmittedStreams;
+            private readonly int _checkpointAfterMs;
+            private readonly int _checkpointHandledThreshold;
+            private readonly int _checkpointUnhandledBytesThreshold;
+            private readonly int _pendingEventsThreshold;
+            private readonly int _maxWriteBatchLength;
+            private readonly int _maxAllowedWritesInFlight;
+
+            public ProjectionConfig(bool emitEnabled, bool trackEmittedStreams, int checkpointAfterMs, int checkpointHandledThreshold,
+                int checkpointUnhandledBytesThreshold, int pendingEventsThreshold, int maxWriteBatchLength, int maxAllowedWritesInFlight)
+            {
+                _emitEnabled = emitEnabled;
+                _trackEmittedStreams = trackEmittedStreams;
+                _checkpointAfterMs = checkpointAfterMs;
+                _checkpointHandledThreshold = checkpointHandledThreshold;
+                _checkpointUnhandledBytesThreshold = checkpointUnhandledBytesThreshold;
+                _pendingEventsThreshold = pendingEventsThreshold;
+                _maxWriteBatchLength = maxWriteBatchLength;
+                _maxAllowedWritesInFlight = maxAllowedWritesInFlight;
+            }
+
+            public bool EmitEnabled
+            {
+                get { return _emitEnabled; }
+            }
+
+            public bool TrackEmittedStreams
+            {
+                get { return _trackEmittedStreams; }
+            }
+
+            public int CheckpointAfterMs
+            {
+                get { return _checkpointAfterMs; }
+            }
+
+            public int CheckpointHandledThreshold
+            {
+                get { return _checkpointHandledThreshold; }
+            }
+
+            public int CheckpointUnhandledBytesThreshold
+            {
+                get { return _checkpointUnhandledBytesThreshold; }
+            }
+
+            public int PendingEventsThreshold
+            {
+                get { return _pendingEventsThreshold; }
+            }
+
+            public int MaxWriteBatchLength
+            {
+                get { return _maxWriteBatchLength; }
+            }
+
+            public int MaxAllowedWritesInFlight
+            {
+                get { return _maxAllowedWritesInFlight; }
+            }
+        }
     }
 }

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -95,6 +95,8 @@ namespace EventStore.Projections.Core
                 mainBus.Subscribe<ProjectionManagementMessage.Command.SetRunAs>(projectionManager);
                 mainBus.Subscribe<ProjectionManagementMessage.Command.Reset>(projectionManager);
                 mainBus.Subscribe<ProjectionManagementMessage.Command.StartSlaveProjections>(projectionManager);
+                mainBus.Subscribe<ProjectionManagementMessage.Command.GetConfig>(projectionManager);
+                mainBus.Subscribe<ProjectionManagementMessage.Command.UpdateConfig>(projectionManager);
                 mainBus.Subscribe<ProjectionManagementMessage.RegisterSystemProjection>(projectionManager);
                 mainBus.Subscribe<ProjectionManagementMessage.Internal.CleanupExpired>(projectionManager);
                 mainBus.Subscribe<ProjectionManagementMessage.Internal.Deleted>(projectionManager);

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionConsts.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionConsts.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventStore.Projections.Core.Services.Management
+{
+    public static class ProjectionConsts
+    {
+        public const int CheckpointHandledThreshold = 4000;
+        public const int PendingEventsThreshold = 5000;
+        public const int MaxWriteBatchLength = 500;
+        public const int CheckpointUnhandledBytesThreshold = 10 * 1000 * 1000;
+        public const int MaxAllowedWritesInFlight = 1;
+        public static TimeSpan CheckpointAfterMs = TimeSpan.FromSeconds(5);
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/DefaultCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/DefaultCheckpointManager.cs
@@ -27,7 +27,6 @@ namespace EventStore.Projections.Core.Services.Processing
         private readonly CoreProjectionCheckpointWriter _coreProjectionCheckpointWriter;
         private PartitionStateUpdateManager _partitionStateUpdateManager;
 
-
         public DefaultCheckpointManager(
             IPublisher publisher, Guid projectionCorrelationId, ProjectionVersion projectionVersion, IPrincipal runAs,
             IODispatcher ioDispatcher, ProjectionConfig projectionConfig, string name, PositionTagger positionTagger,
@@ -155,7 +154,7 @@ namespace EventStore.Projections.Core.Services.Processing
         {
             return new ProjectionCheckpoint(
                 _publisher, _ioDispatcher, _projectionVersion, _runAs, this, checkpointPosition, _positionTagger,
-                _projectionConfig.MaxWriteBatchLength, _logger);
+                _projectionConfig.MaxWriteBatchLength, _projectionConfig.MaximumAllowedWritesInFlight, _logger);
         }
 
         public void Handle(CoreProjectionCheckpointWriterMessage.CheckpointWritten message)


### PR DESCRIPTION
Create http endpoints for getting and updating projection config.
Allow updating of config options such as checkpoint threshold on projections.