### PR TITLE
Set number of writes in flight to unlimited

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_maximum_allowed_writes_in_flight_set.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_emitting_events_with_maximum_allowed_writes_in_flight_set.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Services;
 using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 using System.Collections;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_checkpoint
 {
@@ -68,6 +69,53 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
                 _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
                          .ExceptOfEventType(SystemEventTypes.StreamMetadata);
             Assert.AreEqual(_maximumNumberOfAllowedWritesInFlight, writeEvents.Count());
+        }
+    }
+
+    public class when_emitting_events_with_maximum_allowed_writes_in_flight_set_to_unlimited : TestFixtureWithExistingEvents
+    {
+        private ProjectionCheckpoint _checkpoint;
+        private TestCheckpointManagerMessageHandler _readyHandler;
+
+        protected override void Given()
+        {
+            AllWritesQueueUp();
+            AllWritesToSucceed("$$stream1");
+            AllWritesToSucceed("$$stream2");
+            AllWritesToSucceed("$$stream3");
+            NoOtherStreams();
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            _readyHandler = new TestCheckpointManagerMessageHandler();
+            _checkpoint = new ProjectionCheckpoint(
+                _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, AllowedWritesInFlight.Unlimited);
+            _checkpoint.Start();
+            _checkpoint.ValidateOrderAndEmitEvents(
+                new[]
+                {
+                    new EmittedEventEnvelope(
+                        new EmittedDataEvent(
+                            "stream1", Guid.NewGuid(), "type1", true, "data1", null, CheckpointTag.FromPosition(0, 120, 110), null)),
+                    new EmittedEventEnvelope(
+                        new EmittedDataEvent(
+                            "stream2", Guid.NewGuid(), "type2", true, "data2", null, CheckpointTag.FromPosition(0, 120, 110), null)),
+                    new EmittedEventEnvelope(
+                        new EmittedDataEvent(
+                            "stream3", Guid.NewGuid(), "type3", true, "data3", null, CheckpointTag.FromPosition(0, 120, 110), null)),
+                });
+        }
+
+        [Test]
+        public void should_have_as_many_writes_in_flight_as_requested()
+        {
+            var writeEvents =
+                _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>()
+                         .ExceptOfEventType(SystemEventTypes.StreamMetadata);
+            Assert.AreEqual(3, writeEvents.Count());
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_starting_the_projection_checkpoint_with_some_events_already_emitted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint/when_starting_the_projection_checkpoint_with_some_events_already_emitted.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_checkpoint
 {
@@ -26,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _checkpoint = new ProjectionCheckpoint(
                 _bus, _ioDispatcher, new ProjectionVersion(1, 0, 0), null, _readyHandler,
-                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, 1);
+                CheckpointTag.FromPosition(0, 100, 50), new TransactionFilePositionTagger(0), 250, AllowedWritesInFlight.Unlimited);
             _checkpoint.ValidateOrderAndEmitEvents(
                 new[]
                 {

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/a_checkpoint_requested_on_a_non_started_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/a_checkpoint_requested_on_a_non_started_stream.cs
@@ -19,7 +19,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             ;
             _stream = new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             try
             {

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoc
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_emits_with_previously_written_events_at_the_same_position.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_emits_with_previously_written_events_at_the_same_position.cs
@@ -52,7 +52,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoc
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher), new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 100, 50),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_emits_with_previously_written_events_in_different_epochs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_epoch/when_handling_emits_with_previously_written_events_in_different_epochs.cs
@@ -46,7 +46,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoc
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 20, 10),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_projection/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/another_projection/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
@@ -23,7 +23,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_proj
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_a_read_completes_before_a_timeout_in_recovery.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_a_read_completes_before_a_timeout_in_recovery.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                TestStreamId, new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                TestStreamId, new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_a_read_times_out_in_recovery.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_a_read_times_out_in_recovery.cs
@@ -28,7 +28,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                TestStreamId, new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                TestStreamId, new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             ;
             _stream = new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.Checkpoint();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_but_disabled.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_but_disabled.cs
@@ -18,7 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _exception = null;
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler,
                 noCheckpoints: true);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_with_all_writes_already_completed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_with_all_writes_already_completed.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_with_pending_writes.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_checkpoint_requested_with_pending_writes.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             ;
             _stream = new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();
             _stream.EmitEvents(

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_creating_an_emitted_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_creating_an_emitted_stream.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
-                null, new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                null, new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher,
                 new TestCheckpointManagerMessageHandler());
             });
@@ -49,7 +49,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
-                "", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher,
                 new TestCheckpointManagerMessageHandler());
             });
@@ -60,7 +60,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
-                "", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), null, _fakePublisher, _ioDispatcher, new TestCheckpointManagerMessageHandler());
             });
         }
@@ -70,7 +70,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), null, _ioDispatcher,
                 new TestCheckpointManagerMessageHandler());
             });
@@ -81,7 +81,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, null,
                 new TestCheckpointManagerMessageHandler());
             });
@@ -92,7 +92,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             Assert.Throws<ArgumentNullException>(() => {
             new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher, null);
             });
         }
@@ -101,7 +101,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         public void it_can_be_created()
         {
             new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _fakePublisher, _ioDispatcher,
                 new TestCheckpointManagerMessageHandler());
         }

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_a_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_a_timeout.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream.another_epoc
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 2, 2), new TransactionFilePositionTagger(0), CheckpointTag.Empty,
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_the_not_started_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_the_not_started_stream.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             ;
             _stream = new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.EmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_the_started_in_recovery_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_the_started_in_recovery_stream.cs
@@ -24,7 +24,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_to_the_nonexisting_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_to_the_nonexisting_stream.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_caused_by_and_correlation_id.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_caused_by_and_correlation_id.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
 
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_committed_callback.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_committed_callback.cs
@@ -22,7 +22,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_expected_tag_the_started_in_recovery_stream.cs
@@ -23,7 +23,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_extra_metadata.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_extra_metadata.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_not_ready_event.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_not_ready_event.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_stream_metadata.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_stream_metadata.cs
@@ -20,7 +20,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             AllWritesQueueUp();
             NoStream("test_stream");
             _streamMetadata = new EmittedStream.WriterConfiguration.StreamMetadata(maxCount: 10);
-            _writerConfiguration = new EmittedStream.WriterConfiguration(_streamMetadata, null, maxWriteBatchLength: 50);
+            _writerConfiguration = new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),_streamMetadata, null, maxWriteBatchLength: 50);
         }
 
         [SetUp]

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_write_as_configured.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_an_emit_with_write_as_configured.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _writeAs = new OpenGenericPrincipal("test-user");
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), _writeAs, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), _writeAs, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_in_invalid_order.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_in_invalid_order.cs
@@ -21,7 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 40, 30),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_with_previously_written_events.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_with_previously_written_events.cs
@@ -26,7 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0),
                 CheckpointTag.FromPosition(0, 100, 50), _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_with_previously_written_events_at_the_same_position.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_handling_emits_with_previously_written_events_at_the_same_position.cs
@@ -45,7 +45,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
+                "test_stream", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, maxWriteBatchLength: 50),
                 new ProjectionVersion(1, 0, 0), new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 20, 10),
                 _bus, _ioDispatcher, _readyHandler);
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_the_stream_is_started.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_the_stream_is_started.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
         {
             _readyHandler = new TestCheckpointManagerMessageHandler();
             _stream = new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             ;
             _stream.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_the_stream_is_started_with_already_emitted_events.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_stream/when_the_stream_is_started_with_already_emitted_events.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.emitted_stream
             _readyHandler = new TestCheckpointManagerMessageHandler();
             ;
             _stream = new EmittedStream(
-                "test", new EmittedStream.WriterConfiguration(new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
+                "test", new EmittedStream.WriterConfiguration(new EmittedStreamsWriter(_ioDispatcher),new EmittedStream.WriterConfiguration.StreamMetadata(), null, 50), new ProjectionVersion(1, 0, 0),
                 new TransactionFilePositionTagger(0), CheckpointTag.FromPosition(0, 0, -1), _bus, _ioDispatcher, _readyHandler);
             _stream.EmitEvents(
                 new[]

--- a/src/EventStore.Projections.Core/Common/AllowedWritesInFlight.cs
+++ b/src/EventStore.Projections.Core/Common/AllowedWritesInFlight.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventStore.Projections.Core.Common
+{
+    public static class AllowedWritesInFlight
+    {
+        public const int Unlimited = 0;
+    }
+}

--- a/src/EventStore.Projections.Core/Common/ProjectionConsts.cs
+++ b/src/EventStore.Projections.Core/Common/ProjectionConsts.cs
@@ -1,10 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EventStore.Projections.Core.Services.Management
+namespace EventStore.Projections.Core.Common
 {
     public static class ProjectionConsts
     {
@@ -12,7 +8,7 @@ namespace EventStore.Projections.Core.Services.Management
         public const int PendingEventsThreshold = 5000;
         public const int MaxWriteBatchLength = 500;
         public const int CheckpointUnhandledBytesThreshold = 10 * 1000 * 1000;
-        public const int MaxAllowedWritesInFlight = 1;
-        public static TimeSpan CheckpointAfterMs = TimeSpan.FromSeconds(5);
+        public const int MaxAllowedWritesInFlight = AllowedWritesInFlight.Unlimited;
+        public static TimeSpan CheckpointAfterMs = TimeSpan.FromSeconds(0);
     }
 }

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -122,6 +122,8 @@
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Common\AllowedWritesInFlight.cs" />
+    <Compile Include="Common\ProjectionConsts.cs" />
     <Compile Include="EventReaders\Feeds\FeedReader.cs" />
     <Compile Include="EventReaders\Feeds\FeedReaderService.cs" />
     <Compile Include="Messages\CoreProjectionManagementMessage.cs" />
@@ -214,7 +216,6 @@
     <Compile Include="Services\Management\ManagedProjectionStates\StoppedState.cs" />
     <Compile Include="Services\Management\ManagedProjectionStates\StoppingState.cs" />
     <Compile Include="Services\Management\ProjectionBalancer.cs" />
-    <Compile Include="Services\Management\ProjectionConsts.cs" />
     <Compile Include="Services\Management\ProjectionCoreCoordinator.cs" />
     <Compile Include="Services\Management\ProjectionCoreResponseWriter.cs" />
     <Compile Include="Services\Management\ProjectionManagerResponseReader.cs" />
@@ -248,6 +249,7 @@
     <Compile Include="Services\Processing\EmittedLinkTo.cs" />
     <Compile Include="Services\Processing\EmittedStreamsDeleter.cs" />
     <Compile Include="Services\Processing\EmittedStreamsTracker.cs" />
+    <Compile Include="Services\Processing\EmittedStreamsWriter.cs" />
     <Compile Include="Services\Processing\EventByTypeIndexEventFilter.cs" />
     <Compile Include="Services\Processing\EventByTypeIndexEventReader.cs" />
     <Compile Include="Services\Processing\EventByTypeIndexPositionTagger.cs" />
@@ -261,6 +263,7 @@
     <Compile Include="Services\Processing\GetStateWorkItem.cs" />
     <Compile Include="Services\Processing\ICoreProjectionCheckpointManager.cs" />
     <Compile Include="Services\Processing\ICoreProjectionForProcessingPhase.cs" />
+    <Compile Include="Services\Processing\IEmittedStreamsWriter.cs" />
     <Compile Include="Services\Processing\IEventReader.cs" />
     <Compile Include="Services\Processing\IEventWriter.cs" />
     <Compile Include="Services\Processing\IEventProcessingPhase.cs" />
@@ -304,6 +307,7 @@
     <Compile Include="Services\Processing\ProjectionOutputConfig.cs" />
     <Compile Include="Services\Processing\ProjectionProcessingStrategy.cs" />
     <Compile Include="Services\Processing\ProjectionSourceDefinition.cs" />
+    <Compile Include="Services\Processing\QueuedEmittedStreamsWriter.cs" />
     <Compile Include="Services\Processing\ReaderSubscriptionBase.cs" />
     <Compile Include="Services\Processing\ProjectionVersion.cs" />
     <Compile Include="Services\Processing\QueryProcessingStrategy.cs" />

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -16,6 +16,7 @@ using EventStore.Projections.Core.Utils;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 using System.Threading;
 using EventStore.Core.Helpers;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Services.Management
 {

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -14,7 +14,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Core.Helpers;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Standard;
-using EventStore.Core.Services;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Services.Management
 {

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -64,7 +64,6 @@ namespace EventStore.Projections.Core.Services.Processing
         private Event _submittedWriteMetaStreamEvent;
         private const int MaxRetryCount = 5;
         private Guid _pendingRequestCorrelationId;
-        private Guid _instanceId;
 
         public class WriterConfiguration
         {
@@ -74,6 +73,8 @@ namespace EventStore.Projections.Core.Services.Processing
 
             private readonly int? maxCount;
             private readonly TimeSpan? maxAge;
+
+            private readonly IEmittedStreamsWriter _writer;
 
             public class StreamMetadata
             {
@@ -98,8 +99,9 @@ namespace EventStore.Projections.Core.Services.Processing
             }
 
             public WriterConfiguration(
-                StreamMetadata streamMetadata, IPrincipal writeAs, int maxWriteBatchLength, ILogger logger = null)
+                IEmittedStreamsWriter writer, StreamMetadata streamMetadata, IPrincipal writeAs, int maxWriteBatchLength, ILogger logger = null)
             {
+                _writer = writer;
                 _writeAs = writeAs;
                 _maxWriteBatchLength = maxWriteBatchLength;
                 _logger = logger;
@@ -134,19 +136,15 @@ namespace EventStore.Projections.Core.Services.Processing
             {
                 get { return maxAge; }
             }
+
+            public IEmittedStreamsWriter Writer
+            {
+                get { return _writer; }
+            }
         }
 
         public EmittedStream(
             string streamId, WriterConfiguration writerConfiguration, ProjectionVersion projectionVersion,
-            PositionTagger positionTagger, CheckpointTag fromCheckpointPosition, IPublisher publisher, IODispatcher ioDispatcher,
-            IEmittedStreamContainer readyHandler, bool noCheckpoints = false) : 
-            this(Guid.NewGuid(), streamId, writerConfiguration, projectionVersion,
-                 positionTagger, fromCheckpointPosition, publisher, ioDispatcher, readyHandler, noCheckpoints)
-        {
-        }
-
-        public EmittedStream(
-            Guid instanceId, string streamId, WriterConfiguration writerConfiguration, ProjectionVersion projectionVersion,
             PositionTagger positionTagger, CheckpointTag fromCheckpointPosition, IPublisher publisher, IODispatcher ioDispatcher,
             IEmittedStreamContainer readyHandler, bool noCheckpoints = false)
         {
@@ -157,7 +155,6 @@ namespace EventStore.Projections.Core.Services.Processing
             if (publisher == null) throw new ArgumentNullException("publisher");
             if (ioDispatcher == null) throw new ArgumentNullException("ioDispatcher");
             if (readyHandler == null) throw new ArgumentNullException("readyHandler");
-            _instanceId = instanceId;
             _streamId = streamId;
             _metadataStreamId = SystemStreams.MetastreamOf(streamId);
             _writerConfiguration = writerConfiguration;
@@ -480,15 +477,15 @@ namespace EventStore.Projections.Core.Services.Processing
             var delayInSeconds = MaxRetryCount - retryCount;
             if (delayInSeconds == 0)
             {
-                _ioDispatcher.WriteEvent(
-                    _metadataStreamId, ExpectedVersion.Any, _submittedWriteMetaStreamEvent, _writeAs,
+                _writerConfiguration.Writer.WriteEvents(
+                    _metadataStreamId, ExpectedVersion.Any, new Event[] { _submittedWriteMetaStreamEvent }, _writeAs,
                     m => HandleMetadataWriteCompleted(m, retryCount));
             }
             else
             {
                 _ioDispatcher.Delay(TimeSpan.FromSeconds(delayInSeconds),
-                    () => _ioDispatcher.WriteEvent(
-                            _metadataStreamId, ExpectedVersion.Any, _submittedWriteMetaStreamEvent, _writeAs,
+                    () => _writerConfiguration.Writer.WriteEvents(
+                            _metadataStreamId, ExpectedVersion.Any, new Event[] { _submittedWriteMetaStreamEvent }, _writeAs,
                             m => HandleMetadataWriteCompleted(m, retryCount)));
             }
         }
@@ -638,14 +635,14 @@ namespace EventStore.Projections.Core.Services.Processing
             var delayInSeconds = MaxRetryCount - retryCount;
             if (delayInSeconds == 0)
             {
-                _ioDispatcher.QueueWriteEvents(_instanceId,
+                _writerConfiguration.Writer.WriteEvents(
                     _streamId, _lastKnownEventNumber, _submittedToWriteEvents, _writeAs,
                     m => HandleWriteEventsCompleted(m, retryCount));
             }
             else
             {
-                _ioDispatcher.Delay(TimeSpan.FromSeconds(delayInSeconds), 
-                    () => _ioDispatcher.QueueWriteEvents(_instanceId,
+                _ioDispatcher.Delay(TimeSpan.FromSeconds(delayInSeconds),
+                    () => _writerConfiguration.Writer.WriteEvents(
                         _streamId, _lastKnownEventNumber, _submittedToWriteEvents, _writeAs,
                         m => HandleWriteEventsCompleted(m, retryCount)));
             }

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsWriter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Security.Principal;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+
+namespace EventStore.Projections.Core.Services.Processing
+{
+    public class EmittedStreamsWriter : IEmittedStreamsWriter
+    {
+        private IODispatcher _ioDispatcher;
+
+        public EmittedStreamsWriter(IODispatcher ioDispatcher)
+        {
+            _ioDispatcher = ioDispatcher;
+        }
+
+        public void WriteEvents(string streamId, long expectedVersion, Event[] events, IPrincipal writeAs, Action<ClientMessage.WriteEventsCompleted> complete)
+        {
+            _ioDispatcher.WriteEvents(streamId, expectedVersion, events, writeAs, complete);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/IEmittedStreamsWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/IEmittedStreamsWriter.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Security.Principal;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+
+namespace EventStore.Projections.Core.Services.Processing
+{
+    public interface IEmittedStreamsWriter
+    {
+        void WriteEvents(string streamId, long expectedVersion, Event[] events, IPrincipal writeAs, Action<ClientMessage.WriteEventsCompleted> complete);
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
@@ -76,7 +76,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 /* MUST NEVER SEND READY MESSAGE */
                 _namingBuilder.GetOrderStreamName(),
                 new EmittedStream.WriterConfiguration(
-                    new EmittedStream.WriterConfiguration.StreamMetadata(), SystemAccount.Principal, 100, _logger),
+                    new EmittedStreamsWriter(_ioDispatcher), new EmittedStream.WriterConfiguration.StreamMetadata(), SystemAccount.Principal, 100, _logger),
                 _projectionVersion, _positionTagger, @from, _publisher, _ioDispatcher, this, noCheckpoints: true);
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCheckpoint.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCheckpoint.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Helpers;
 using EventStore.Core.Messaging;
 using EventStore.Projections.Core.Messages;
 using EventStore.Core.Bus;
+using EventStore.Projections.Core.Common;
 
 namespace EventStore.Projections.Core.Services.Processing
 {
@@ -33,7 +34,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
         private List<IEnvelope> _awaitingStreams;
 
-        private Guid[] _writeKeys;
+        private Guid[] _writeQueueIds;
         private int _maximumAllowedWritesInFlight;
 
         public ProjectionCheckpoint(
@@ -64,7 +65,7 @@ namespace EventStore.Projections.Core.Services.Processing
             _from = _last = from;
             _maxWriteBatchLength = maxWriteBatchLength;
             _logger = logger;
-            _writeKeys = Enumerable.Range(0, _maximumAllowedWritesInFlight).Select(x => Guid.NewGuid()).ToArray();
+            _writeQueueIds = Enumerable.Range(0, _maximumAllowedWritesInFlight).Select(x => Guid.NewGuid()).ToArray();
         }
 
         public void Start()
@@ -144,11 +145,20 @@ namespace EventStore.Projections.Core.Services.Processing
             {
                 var streamMetadata = emittedEvents.Length > 0 ? emittedEvents[0].StreamMetadata : null;
 
-                var writerConfiguration = new EmittedStream.WriterConfiguration(
-                    streamMetadata, _runAs, maxWriteBatchLength: _maxWriteBatchLength, logger: _logger);
+                var writeQueueId = _maximumAllowedWritesInFlight == AllowedWritesInFlight.Unlimited 
+                    ? (Guid?)null 
+                    :_writeQueueIds[_emittedStreams.Count % _maximumAllowedWritesInFlight];
 
-                stream = new EmittedStream(
-                    _writeKeys[_emittedStreams.Count % _maximumAllowedWritesInFlight], streamId, writerConfiguration, _projectionVersion, _positionTagger, _from, _publisher, _ioDispatcher, this);
+                IEmittedStreamsWriter writer;
+                if (writeQueueId == null)
+                    writer = new EmittedStreamsWriter(_ioDispatcher);
+                else
+                    writer = new QueuedEmittedStreamsWriter(_ioDispatcher, writeQueueId.Value);
+
+                var writerConfiguration = new EmittedStream.WriterConfiguration(
+                    writer, streamMetadata, _runAs, maxWriteBatchLength: _maxWriteBatchLength, logger: _logger);
+
+                stream = new EmittedStream(streamId, writerConfiguration, _projectionVersion, _positionTagger, _from, _publisher, _ioDispatcher, this);
 
                 if (_started)
                     stream.Start();

--- a/src/EventStore.Projections.Core/Services/Processing/QueuedEmittedStreamsWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/QueuedEmittedStreamsWriter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Security.Principal;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+
+namespace EventStore.Projections.Core.Services.Processing
+{
+    public class QueuedEmittedStreamsWriter : IEmittedStreamsWriter
+    {
+        private IODispatcher _ioDispatcher;
+        private Guid _writeQueueId;
+
+        public QueuedEmittedStreamsWriter(IODispatcher ioDispatcher, Guid writeQueueId)
+        {
+            _ioDispatcher = ioDispatcher;
+            _writeQueueId = writeQueueId;
+        }
+
+        public void WriteEvents(string streamId, long expectedVersion, Event[] events, IPrincipal writeAs, Action<ClientMessage.WriteEventsCompleted> complete)
+        {
+            _ioDispatcher.QueueWriteEvents(_writeQueueId, streamId, expectedVersion, events, writeAs, complete);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
@@ -1,3 +1,4 @@
+using EventStore.Projections.Core.Common;
 using System;
 using System.Security.Principal;
 
@@ -37,9 +38,9 @@ namespace EventStore.Projections.Core.Services
                 if (checkpointUnhandledBytesThreshold != 0)
                     throw new ArgumentException("checkpointUnhandledBytesThreshold must be 0");
             }
-            if(maximumAllowedWritesInFlight <= 0)
+            if(maximumAllowedWritesInFlight < AllowedWritesInFlight.Unlimited)
             {
-                throw new ArgumentException("The Maximum Number of Allowed Writes in Flight cannot be less or equal to 0");
+                throw new ArgumentException($"The Maximum Number of Allowed Writes in Flight cannot be less than {AllowedWritesInFlight.Unlimited}");
             }
             _runAs = runAs;
             _checkpointHandledThreshold = checkpointHandledThreshold;


### PR DESCRIPTION
Extract Emitted Streams Writer into the Writer Configuration which is supplied to the Emitted Stream so that it doesn't need to care about how writes are being handled. That's the responsibility of the Projection Checkpoint which sets up the Writer Configuration supplied to the Emitted Stream