### PR TITLE
Prepare count from master can come last

### DIFF
--- a/src/EventStore.Core/Services/RequestManager/Managers/TwoPhaseRequestManagerBase.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TwoPhaseRequestManagerBase.cs
@@ -173,7 +173,7 @@ namespace EventStore.Core.Services.RequestManager.Managers
 
             _awaitingCommit -= 1;
             if(message.IsSelf) _hadSelf = true;
-            if (_awaitingCommit == 0 && _hadSelf)
+            if (_awaitingCommit <= 0 && _hadSelf)
                 CompleteSuccessRequest(message.FirstEventNumber, message.LastEventNumber, message.LogPosition, message.LogPosition);
         }
 


### PR DESCRIPTION
In the cases where the commit ack from master comes last, the awaiting commit count can drop below 0 because in a 3 node cluster for example, the awaiting commit count is equal to 2. If you get the master ack last, the condition for a successful write won't be hit as the commit count will be lower than 0