### PR TITLE
Update TaskCompletionSource to use TaskCreationOptions.RunContinuationsAsynchronously

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedEventStorePersistentSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedEventStorePersistentSubscription.cs
@@ -28,7 +28,7 @@ namespace EventStore.ClientAPI.Embedded
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> onSubscriptionDropped,
             ConnectionSettings settings)
         {
-            var source = new TaskCompletionSource<PersistentEventStoreSubscription>();
+            var source = new TaskCompletionSource<PersistentEventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _subscriptions.StartPersistentSubscription(Guid.NewGuid(), source, subscriptionId, streamId, userCredentials, bufferSize, onEventAppeared,
                 onSubscriptionDropped, settings.MaxRetries, settings.OperationTimeout);

--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -109,7 +109,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public Task ConnectAsync()
         {
-            var source = new TaskCompletionSource<object>();
+            var source = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             source.SetResult(null);
 
@@ -136,7 +136,7 @@ namespace EventStore.ClientAPI.Embedded
         {
             Ensure.NotNullOrEmpty(stream, "stream");
 
-            var source = new TaskCompletionSource<DeleteResult>();
+            var source = new TaskCompletionSource<DeleteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.DeleteStream(source, stream, expectedVersion));
 
@@ -170,7 +170,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNull(events, "events");
 
-            var source = new TaskCompletionSource<WriteResult>();
+            var source = new TaskCompletionSource<WriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.AppendToStream(source, stream, expectedVersion));
 
@@ -190,7 +190,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNull(events, "events");
 
-            var source = new TaskCompletionSource<ConditionalWriteResult>();
+            var source = new TaskCompletionSource<ConditionalWriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.ConditionalAppendToStream(source, stream));
 
@@ -207,7 +207,7 @@ namespace EventStore.ClientAPI.Embedded
         {
             Ensure.NotNullOrEmpty(stream, "stream");
 
-            var source = new TaskCompletionSource<EventStoreTransaction>();
+            var source = new TaskCompletionSource<EventStoreTransaction>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.TransactionStart(source, this, stream, expectedVersion));
 
@@ -231,7 +231,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNull(transaction, "transaction");
             Ensure.NotNull(events, "events");
 
-            var source = new TaskCompletionSource<EventStoreTransaction>();
+            var source = new TaskCompletionSource<EventStoreTransaction>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.TransactionWrite(source, this));
 
@@ -249,7 +249,7 @@ namespace EventStore.ClientAPI.Embedded
         {
             Ensure.NotNull(transaction, "transaction");
 
-            var source = new TaskCompletionSource<WriteResult>();
+            var source = new TaskCompletionSource<WriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.TransactionCommit(source));
 
@@ -266,7 +266,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNullOrEmpty(stream, "stream");
             if (eventNumber < -1) throw new ArgumentOutOfRangeException("eventNumber");
 
-            var source = new TaskCompletionSource<EventReadResult>();
+            var source = new TaskCompletionSource<EventReadResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.ReadEvent(source, stream, eventNumber));
 
@@ -284,7 +284,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.Nonnegative(start, "start");
             Ensure.Positive(count, "count");
             if (count > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
-            var source = new TaskCompletionSource<StreamEventsSlice>();
+            var source = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.ReadStreamForwardEvents(source, stream, start));
 
@@ -301,7 +301,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.Positive(count, "count");
             if (count > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
-            var source = new TaskCompletionSource<StreamEventsSlice>();
+            var source = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.ReadStreamEventsBackward(source, stream, start));
 
@@ -317,7 +317,7 @@ namespace EventStore.ClientAPI.Embedded
         {
             Ensure.Positive(maxCount, "maxCount");
             if (maxCount > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
-            var source = new TaskCompletionSource<AllEventsSlice>();
+            var source = new TaskCompletionSource<AllEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.ReadAllEventsForward(source));
 
@@ -334,7 +334,7 @@ namespace EventStore.ClientAPI.Embedded
         {
             Ensure.Positive(maxCount, "maxCount");
             if (maxCount > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
-            var source = new TaskCompletionSource<AllEventsSlice>();
+            var source = new TaskCompletionSource<AllEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.ReadAllEventsBackward(source));
 
@@ -356,7 +356,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNull(eventAppeared, "eventAppeared");
 
-            var source = new TaskCompletionSource<EventStoreSubscription>();
+            var source = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Guid corrId = Guid.NewGuid();
 
@@ -408,7 +408,7 @@ namespace EventStore.ClientAPI.Embedded
         {
             Ensure.NotNull(eventAppeared, "eventAppeared");
 
-            var source = new TaskCompletionSource<EventStoreSubscription>();
+            var source = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Guid corrId = Guid.NewGuid();
 
@@ -491,7 +491,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNullOrEmpty(groupName, "groupName");
             Ensure.NotNull(settings, "settings");
 
-            var source = new TaskCompletionSource<PersistentSubscriptionCreateResult>();
+            var source = new TaskCompletionSource<PersistentSubscriptionCreateResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.CreatePersistentSubscription(source, stream, groupName));
 
@@ -530,7 +530,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
 
-            var source = new TaskCompletionSource<PersistentSubscriptionUpdateResult>();
+            var source = new TaskCompletionSource<PersistentSubscriptionUpdateResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(new EmbeddedResponders.UpdatePersistentSubscription(source, stream, groupName));
 
@@ -569,7 +569,7 @@ namespace EventStore.ClientAPI.Embedded
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
 
-            var source = new TaskCompletionSource<PersistentSubscriptionDeleteResult>();
+            var source = new TaskCompletionSource<PersistentSubscriptionDeleteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(
                 new EmbeddedResponders.DeletePersistentSubscription(source, stream, groupName));
@@ -601,7 +601,7 @@ namespace EventStore.ClientAPI.Embedded
             var metaevent = new EventData(Guid.NewGuid(), SystemEventTypes.StreamMetadata, true, metadata ?? Empty.ByteArray, null);
             var metastream = SystemStreams.MetastreamOf(stream);
 
-            var source = new TaskCompletionSource<WriteResult>();
+            var source = new TaskCompletionSource<WriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(
                 new EmbeddedResponders.AppendToStream(source, metastream, expectedMetastreamVersion));
@@ -687,7 +687,7 @@ namespace EventStore.ClientAPI.Embedded
         public Task TransactionalWriteAsync(EventStoreTransaction transaction, IEnumerable<EventData> events,
             UserCredentials userCredentials = null)
         {
-            var source = new TaskCompletionSource<EventStoreTransaction>();
+            var source = new TaskCompletionSource<EventStoreTransaction>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(
                 new EmbeddedResponders.TransactionWrite(source, this));
@@ -702,7 +702,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public Task<WriteResult> CommitTransactionAsync(EventStoreTransaction transaction, UserCredentials userCredentials = null)
         {
-            var source = new TaskCompletionSource<WriteResult>();
+            var source = new TaskCompletionSource<WriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var envelope = new EmbeddedResponseEnvelope(
                 new EmbeddedResponders.TransactionCommit(source));

--- a/src/EventStore.ClientAPI/Common/Utils/Threading/ManualResetEventSlimExtensions.cs
+++ b/src/EventStore.ClientAPI/Common/Utils/Threading/ManualResetEventSlimExtensions.cs
@@ -12,7 +12,7 @@ namespace EventStore.ClientAPI.Common.Utils.Threading
 
         public static Task AsTask(this ManualResetEventSlim resetEvent, int timeoutMs)
         {
-            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             RegisteredWaitHandle registration = ThreadPool.RegisterWaitForSingleObject(resetEvent.WaitHandle, (state, timedOut) =>
             {

--- a/src/EventStore.ClientAPI/EventStorePersistentSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscription.cs
@@ -30,7 +30,7 @@ namespace EventStore.ClientAPI
             Func<EventStoreSubscription, ResolvedEvent, Task> onEventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> onSubscriptionDropped, ConnectionSettings settings)
         {
-            var source = new TaskCompletionSource<PersistentEventStoreSubscription>();
+            var source = new TaskCompletionSource<PersistentEventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
             _handler.EnqueueMessage(new StartPersistentSubscriptionMessage(source, subscriptionId, streamId, bufferSize,
                 userCredentials, onEventAppeared,
                 onSubscriptionDropped, settings.MaxRetries, settings.OperationTimeout));

--- a/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
@@ -61,7 +61,7 @@ namespace EventStore.ClientAPI.Internal
 
         public Task ConnectAsync()
         {
-            var source = new TaskCompletionSource<object>();
+            var source = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             _handler.EnqueueMessage(new StartConnectionMessage(source, _endPointDiscoverer));
             return source.Task;
         }
@@ -85,7 +85,7 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.NotNullOrEmpty(stream, "stream");
 
-            var source = new TaskCompletionSource<DeleteResult>();
+            var source = new TaskCompletionSource<DeleteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new DeleteStreamOperation(Settings.Log, source, Settings.RequireMaster,
                                                        stream, expectedVersion, hardDelete, userCredentials));
             return source.Task;
@@ -113,7 +113,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNull(events, "events");
 
-            var source = new TaskCompletionSource<WriteResult>();
+            var source = new TaskCompletionSource<WriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new AppendToStreamOperation(Settings.Log, source, Settings.RequireMaster,
                                                          stream, expectedVersion, events, userCredentials));
             return source.Task;
@@ -127,7 +127,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNull(events, "events");
 
-            var source = new TaskCompletionSource<ConditionalWriteResult>();
+            var source = new TaskCompletionSource<ConditionalWriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new ConditionalAppendToStreamOperation(Settings.Log, source, Settings.RequireMaster,
                                                          stream, expectedVersion, events, userCredentials));
             return source.Task;
@@ -138,7 +138,7 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.NotNullOrEmpty(stream, "stream");
 
-            var source = new TaskCompletionSource<EventStoreTransaction>();
+            var source = new TaskCompletionSource<EventStoreTransaction>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new StartTransactionOperation(Settings.Log, source, Settings.RequireMaster,
                                                            stream, expectedVersion, this, userCredentials));
             return source.Task;
@@ -156,7 +156,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(transaction, "transaction");
             Ensure.NotNull(events, "events");
 
-            var source = new TaskCompletionSource<object>();
+            var source = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new TransactionalWriteOperation(Settings.Log, source, Settings.RequireMaster,
                                                              transaction.TransactionId, events, userCredentials));
             return source.Task;
@@ -167,7 +167,7 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.NotNull(transaction, "transaction");
 
-            var source = new TaskCompletionSource<WriteResult>();
+            var source = new TaskCompletionSource<WriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new CommitTransactionOperation(Settings.Log, source, Settings.RequireMaster,
                                                             transaction.TransactionId, userCredentials));
             return source.Task;
@@ -178,7 +178,7 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.NotNullOrEmpty(stream, "stream");
             if (eventNumber < -1) throw new ArgumentOutOfRangeException(nameof(eventNumber));
-            var source = new TaskCompletionSource<EventReadResult>();
+            var source = new TaskCompletionSource<EventReadResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             var operation = new ReadEventOperation(Settings.Log, source, stream, eventNumber, resolveLinkTos,
                                                    Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
@@ -191,7 +191,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.Nonnegative(start, "start");
             Ensure.Positive(count, "count");
             if(count > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
-            var source = new TaskCompletionSource<StreamEventsSlice>();
+            var source = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
             var operation = new ReadStreamEventsForwardOperation(Settings.Log, source, stream, start, count,
                                                                  resolveLinkTos, Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
@@ -203,7 +203,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.Positive(count, "count");
             if (count > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
-            var source = new TaskCompletionSource<StreamEventsSlice>();
+            var source = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
             var operation = new ReadStreamEventsBackwardOperation(Settings.Log, source, stream, start, count,
                                                                   resolveLinkTos, Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
@@ -214,7 +214,7 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.Positive(maxCount, "maxCount");
             if (maxCount > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
-            var source = new TaskCompletionSource<AllEventsSlice>();
+            var source = new TaskCompletionSource<AllEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
             var operation = new ReadAllEventsForwardOperation(Settings.Log, source, position, maxCount,
                                                               resolveLinkTos, Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
@@ -225,7 +225,7 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.Positive(maxCount, "maxCount");
             if (maxCount > Consts.MaxReadSize) throw new ArgumentException(string.Format("Count should be less than {0}. For larger reads you should page.", Consts.MaxReadSize));
-            var source = new TaskCompletionSource<AllEventsSlice>();
+            var source = new TaskCompletionSource<AllEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
             var operation = new ReadAllEventsBackwardOperation(Settings.Log, source, position, maxCount,
                                                                resolveLinkTos, Settings.RequireMaster, userCredentials);
             EnqueueOperation(operation);
@@ -251,7 +251,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNull(eventAppeared, "eventAppeared");
 
-            var source = new TaskCompletionSource<EventStoreSubscription>();
+            var source = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
             _handler.EnqueueMessage(new StartSubscriptionMessage(source, stream, resolveLinkTos, userCredentials,
                                                                  eventAppeared, subscriptionDropped,
                                                                  Settings.MaxRetries, Settings.OperationTimeout));
@@ -303,7 +303,7 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.NotNull(eventAppeared, "eventAppeared");
 
-            var source = new TaskCompletionSource<EventStoreSubscription>();
+            var source = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
             _handler.EnqueueMessage(new StartSubscriptionMessage(source, string.Empty, resolveLinkTos, userCredentials,
                                                                  eventAppeared, subscriptionDropped,
                                                                  Settings.MaxRetries, Settings.OperationTimeout));
@@ -408,7 +408,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
             Ensure.NotNull(settings, "settings");
-            var source = new TaskCompletionSource<PersistentSubscriptionCreateResult>();
+            var source = new TaskCompletionSource<PersistentSubscriptionCreateResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new CreatePersistentSubscriptionOperation(Settings.Log, source, stream, groupName, settings, credentials));
             return source.Task;
         }
@@ -418,7 +418,7 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
             Ensure.NotNull(settings, "settings");
-            var source = new TaskCompletionSource<PersistentSubscriptionUpdateResult>();
+            var source = new TaskCompletionSource<PersistentSubscriptionUpdateResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new UpdatePersistentSubscriptionOperation(Settings.Log, source, stream, groupName, settings, credentials));
             return source.Task;
         }
@@ -428,7 +428,7 @@ namespace EventStore.ClientAPI.Internal
         {
             Ensure.NotNullOrEmpty(groupName, "groupName");
             Ensure.NotNull(settings, "settings");
-            var source = new TaskCompletionSource<PersistentSubscriptionCreateResult>();
+            var source = new TaskCompletionSource<PersistentSubscriptionCreateResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new CreatePersistentSubscriptionOperation(_settings.Log, source, SystemStreams.AllStream, groupName, settings, userCredentials));
             return source.Task;
         }
@@ -437,7 +437,7 @@ namespace EventStore.ClientAPI.Internal
         public Task DeletePersistentSubscriptionAsync(string stream, string groupName, UserCredentials userCredentials = null) {
             Ensure.NotNullOrEmpty(stream, "stream");
             Ensure.NotNullOrEmpty(groupName, "groupName");
-            var source = new TaskCompletionSource<PersistentSubscriptionDeleteResult>();
+            var source = new TaskCompletionSource<PersistentSubscriptionDeleteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new DeletePersistentSubscriptionOperation(Settings.Log, source, stream, groupName, userCredentials));
             return source.Task;
         }
@@ -446,7 +446,7 @@ namespace EventStore.ClientAPI.Internal
         public Task<PersistentSubscriptionDeleteResult> DeletePersistentSubscriptionForAllAsync(string groupName, UserCredentials userCredentials = null)
         {
             Ensure.NotNullOrEmpty(groupName, "groupName");
-            var source = new TaskCompletionSource<PersistentSubscriptionDeleteResult>();
+            var source = new TaskCompletionSource<PersistentSubscriptionDeleteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
             EnqueueOperation(new DeletePersistentSubscriptionOperation(_settings.Log, source, SystemStreams.AllStream, groupName, userCredentials));
             return source.Task;
         }
@@ -464,7 +464,7 @@ namespace EventStore.ClientAPI.Internal
             if (SystemStreams.IsMetastream(stream))
                 throw new ArgumentException(string.Format("Setting metadata for metastream '{0}' is not supported.", stream), nameof(stream));
 
-            var source = new TaskCompletionSource<WriteResult>();
+            var source = new TaskCompletionSource<WriteResult>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             var metaevent = new EventData(Guid.NewGuid(), SystemEventTypes.StreamMetadata, true, metadata ?? Empty.ByteArray, null);
             EnqueueOperation(new AppendToStreamOperation(Settings.Log,

--- a/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
@@ -154,7 +154,7 @@ namespace EventStore.ClientAPI.Projections
 
         private Task<string> SendGet(string url, UserCredentials userCredentials, int expectedCode)
         {
-            var source = new TaskCompletionSource<string>();
+            var source = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             _client.Get(url,
                         userCredentials,
                         response =>
@@ -176,7 +176,7 @@ namespace EventStore.ClientAPI.Projections
 
         private Task<string> SendDelete(string url, UserCredentials userCredentials, int expectedCode)
         {
-            var source = new TaskCompletionSource<string>();
+            var source = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             _client.Delete(url,
                            userCredentials,
                            response =>
@@ -198,7 +198,7 @@ namespace EventStore.ClientAPI.Projections
 
         private Task SendPut(string url, string content, UserCredentials userCredentials, int expectedCode)
         {
-            var source = new TaskCompletionSource<object>();
+            var source = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             _client.Put(url,
                         content,
                         "application/json",
@@ -222,7 +222,7 @@ namespace EventStore.ClientAPI.Projections
 
         private Task SendPost(string url, string content, UserCredentials userCredentials, int expectedCode)
         {
-            var source = new TaskCompletionSource<object>();
+            var source = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             _client.Post(url,
                          content,
                          "application/json",

--- a/src/EventStore.ClientAPI/UserManagement/UsersClient.cs
+++ b/src/EventStore.ClientAPI/UserManagement/UsersClient.cs
@@ -98,7 +98,7 @@ namespace EventStore.ClientAPI.UserManagement
 
         private Task<string> SendGet(string url, UserCredentials userCredentials, int expectedCode)
         {
-            var source = new TaskCompletionSource<string>();
+            var source = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             _client.Get(url,
                 userCredentials,
                 response =>
@@ -120,7 +120,7 @@ namespace EventStore.ClientAPI.UserManagement
 
         private Task<string> SendDelete(string url, UserCredentials userCredentials, int expectedCode)
         {
-            var source = new TaskCompletionSource<string>();
+            var source = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
             _client.Delete(url,
                 userCredentials,
                 response =>
@@ -142,7 +142,7 @@ namespace EventStore.ClientAPI.UserManagement
 
         private Task SendPut(string url, string content, UserCredentials userCredentials, int expectedCode)
         {
-            var source = new TaskCompletionSource<object>();
+            var source = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             _client.Put(url,
                 content,
                 "application/json",
@@ -166,7 +166,7 @@ namespace EventStore.ClientAPI.UserManagement
 
         private Task SendPost(string url, string content, UserCredentials userCredentials, int expectedCode)
         {
-            var source = new TaskCompletionSource<object>();
+            var source = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             _client.Post(url,
                 content,
                 "application/json",

--- a/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
@@ -100,7 +100,7 @@ namespace EventStore.Core.Tests.ClientAPI
             var expectedException = new ApplicationException("Test");
             _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
             {
-                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                 Assert.That(stream, Is.EqualTo(StreamId));
                 Assert.That(start, Is.EqualTo(0));
                 Assert.That(max, Is.EqualTo(1));
@@ -126,7 +126,7 @@ namespace EventStore.Core.Tests.ClientAPI
                 if (callCount++ == 0)
                 {
                     Assert.That(start, Is.EqualTo(0));
-                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                     taskCompletionSource.SetResult(CreateStreamEventsSlice());
                     return taskCompletionSource.Task;
 
@@ -157,14 +157,14 @@ namespace EventStore.Core.Tests.ClientAPI
                 if (callCount++ == 0)
                 {
                     Assert.That(start, Is.EqualTo(0));
-                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                     taskCompletionSource.SetResult(CreateStreamEventsSlice());
                     return taskCompletionSource.Task;
                 }
                 else
                 {
                     Assert.That(start, Is.EqualTo(1));
-                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                     taskCompletionSource.SetException(expectedException);
                     return taskCompletionSource.Task;
                 }
@@ -181,7 +181,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
             _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
             {
-                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                 taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
                 return taskCompletionSource.Task;
             });
@@ -203,14 +203,14 @@ namespace EventStore.Core.Tests.ClientAPI
 
             _connection.HandleReadStreamEventsForwardAsync((stream, start, max) =>
             {
-                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                 taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
                 return taskCompletionSource.Task;
             });
 
             _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
             {
-                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
                 taskCompletionSource.SetException(expectedException);
                 return taskCompletionSource.Task;
             });
@@ -229,7 +229,7 @@ namespace EventStore.Core.Tests.ClientAPI
             {
                 if (callCount++ == 0)
                 {
-                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                     taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
                     return taskCompletionSource.Task;
                 }
@@ -242,7 +242,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
             _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
             {
-                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
                 taskCompletionSource.SetResult(CreateVolatileSubscription(raise, drop, 1));
                 return taskCompletionSource.Task;
             });
@@ -262,14 +262,14 @@ namespace EventStore.Core.Tests.ClientAPI
             {
                 if (callCount++ == 0)
                 {
-                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                     taskCompletionSource.SetResult(CreateStreamEventsSlice(isEnd: true));
                     return taskCompletionSource.Task;
                 }
                 else
                 {
                     Assert.That(start, Is.EqualTo(1));
-                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                    var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                     taskCompletionSource.SetException(expectedException);
                     return taskCompletionSource.Task;
                 }
@@ -277,7 +277,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
             _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
             {
-                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
                 taskCompletionSource.SetResult(CreateVolatileSubscription(raise, drop, 1));
                 return taskCompletionSource.Task;
             });
@@ -330,7 +330,7 @@ namespace EventStore.Core.Tests.ClientAPI
             {
                 callCount++;
 
-                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                 if (callCount == 1)
                 {
                     taskCompletionSource.SetResult(CreateStreamEventsSlice(fromEvent: 0, count: 0, isEnd: true));
@@ -348,7 +348,7 @@ namespace EventStore.Core.Tests.ClientAPI
             _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
             {
                 innerSubscriptionDrop = drop;
-                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
                 volatileEventStoreSubscription = CreateVolatileSubscription(raise, drop, null);
                 taskCompletionSource.SetResult(volatileEventStoreSubscription);
                 return taskCompletionSource.Task;
@@ -369,7 +369,7 @@ namespace EventStore.Core.Tests.ClientAPI
             {
                 callCount++;
 
-                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>();
+                var taskCompletionSource = new TaskCompletionSource<StreamEventsSlice>(TaskCreationOptions.RunContinuationsAsynchronously);
                 if (callCount == 1)
                 {
                     taskCompletionSource.SetResult(CreateStreamEventsSlice(fromEvent: 0, count:0, isEnd: true));
@@ -387,7 +387,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
             _connection.HandleSubscribeToStreamAsync((stream, raise, drop) =>
             {
-                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>();
+                var taskCompletionSource = new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);
                 VolatileEventStoreSubscription volatileEventStoreSubscription2 = CreateVolatileSubscription(raise, drop, null);
                 taskCompletionSource.SetResult(volatileEventStoreSubscription);
 
@@ -417,7 +417,7 @@ namespace EventStore.Core.Tests.ClientAPI
 
         private static VolatileEventStoreSubscription CreateVolatileSubscription(Func<EventStoreSubscription, ResolvedEvent, Task> raise, Action<EventStoreSubscription, SubscriptionDropReason, Exception> drop, int? lastEventNumber)
         {
-            return new VolatileEventStoreSubscription(new VolatileSubscriptionOperation(new NoopLogger(), new TaskCompletionSource<EventStoreSubscription>(), StreamId, false, null, raise, drop, false, () => null), StreamId, -1, lastEventNumber);
+            return new VolatileEventStoreSubscription(new VolatileSubscriptionOperation(new NoopLogger(), new TaskCompletionSource<EventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously), StreamId, false, null, raise, drop, false, () => null), StreamId, -1, lastEventNumber);
         }
 
         private static StreamEventsSlice CreateStreamEventsSlice(int fromEvent = 0, int count = 1, bool isEnd = false)

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -603,7 +603,7 @@ namespace EventStore.Core
 
         public Task<ClusterVNode> StartAndWaitUntilReady()
         {
-            var tcs = new TaskCompletionSource<ClusterVNode>();
+            var tcs = new TaskCompletionSource<ClusterVNode>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             _mainBus.Subscribe(new AdHocHandler<SystemMessage.SystemReady>(
                     _ => tcs.TrySetResult(this)));

--- a/src/EventStore.TestClient/Commands/RunTestScenarios/LoopingProjTranWriteScenario.cs
+++ b/src/EventStore.TestClient/Commands/RunTestScenarios/LoopingProjTranWriteScenario.cs
@@ -178,7 +178,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
         {
             Log.Info("Starting to write {0} events in tran {1}", eventCount, transaction.TransactionId);
 
-            var resSource = new TaskCompletionSource<object>();
+            var resSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Action<Task> fail = prevTask =>
             {
@@ -211,7 +211,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
 
         private Task<object> CommitTransaction(EventStoreTransaction transaction)
         {
-            var resSource = new TaskCompletionSource<object>();
+            var resSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Action<Task> fail = prevTask =>
             {

--- a/src/EventStore.TestClient/Commands/RunTestScenarios/ScenarioBase.cs
+++ b/src/EventStore.TestClient/Commands/RunTestScenarios/ScenarioBase.cs
@@ -465,7 +465,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
 
         private Task WriteSingleEventAtTime(string stream, int events, Func<int, EventData> createEvent)
         {
-            var resSource = new TaskCompletionSource<object>();
+            var resSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             Log.Info("Starting to write {0} events to [{1}]", events, stream);
             var store = GetConnection();
@@ -507,7 +507,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
             const int bucketSize = 25;
             Log.Info("Starting to write {0} events to [{1}] ({2} events at once)", eventCount, stream, bucketSize);
 
-            var resSource = new TaskCompletionSource<object>();
+            var resSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var store = GetConnection();
             int writtenCount = 0;
 
@@ -549,7 +549,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
         {
             Log.Info("Starting to write {0} events to [{1}] (in single transaction)", eventCount, stream);
 
-            var resSource = new TaskCompletionSource<object>();
+            var resSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var store = GetConnection();
 
             Action<Task> fail = prevTask =>
@@ -598,7 +598,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
         private Task ReadStream(string stream, int from, int count)
         {
             Log.Info("Reading [{0}] from {1,-10} count {2,-10}", stream, from, count);
-            var resSource = new TaskCompletionSource<object>();
+            var resSource = new TaskCompletionSource<object>(TaskCreationOptions.RunContinuationsAsynchronously);
             var store = GetConnection();
 
             Action<Task> fail = prevTask =>


### PR DESCRIPTION
Referencing #1179, this updates TaskCompletionSource constructors to use the TaskCreationOptions.RunContinuationsAsynchronously option. This will prevent ClientAPI from running synchronous user code when setting the result, which can result in deadlocks and also heartbeat timeouts if the user's synchronous operation takes too long.

See https://blogs.msdn.microsoft.com/pfxteam/2015/02/02/new-task-apis-in-net-4-6/ for a great discussion on why this should be included.