### PR TITLE
Fixed ProjectionsManager's GetResultAsync and GetPartitionResultAsync

### DIFF
--- a/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
@@ -227,7 +227,7 @@ namespace EventStore.ClientAPI.Projections
         public Task<string> GetResultAsync(string name, UserCredentials userCredentials = null)
         {
             Ensure.NotNullOrEmpty(name, "name");
-            return _client.GetState(_httpEndPoint, name, userCredentials);
+            return _client.GetResult(_httpEndPoint, name, userCredentials);
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace EventStore.ClientAPI.Projections
         {
             Ensure.NotNullOrEmpty(name, "name");
             Ensure.NotNullOrEmpty(partitionId, "partitionId");
-            return _client.GetPartitionStateAsync(_httpEndPoint, name, partitionId, userCredentials);
+            return _client.GetPartitionResultAsync(_httpEndPoint, name, partitionId, userCredentials);
         }
 
         /// <summary>


### PR DESCRIPTION
The ProjectionsManager's GetResultAsync and GetPartitionResultAsync were calling the wrong methods on ProjectionsClient.

I think this was a copy&paste bug