### PR TITLE
Bugfix: An event emitted in recovery differs from the originally emitted event

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointManager.cs
@@ -129,6 +129,12 @@ namespace EventStore.Projections.Core.Services.Processing
             EnsureStarted();
             _started = false;
             _stopped = true;
+
+            if(_currentCheckpoint!=null) _currentCheckpoint.Dispose();
+            _currentCheckpoint = null;
+
+            if(_closingCheckpoint!=null) _closingCheckpoint.Dispose();
+            _closingCheckpoint = null;
         }
 
         public virtual void GetStatistics(ProjectionStatistics info)
@@ -280,7 +286,7 @@ namespace EventStore.Projections.Core.Services.Processing
             if (_inCheckpoint) // checkpoint in progress.  no other writes will happen, so we can stop here.
                 return;
             // do not request checkpoint if no events were processed since last checkpoint
-            //NOTE: we ignore _usePersistentCheckpoints flag as we need to flush final writes before query object 
+            //NOTE: we ignore _usePersistentCheckpoints flag as we need to flush final writes before query object
             // has been disposed
             if (/* _usePersistentCheckpoints && */ _lastCompletedCheckpointPosition < _lastProcessedEventPosition.LastTag)
             {
@@ -339,7 +345,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 Guid.Empty, new ResolvedEvent(pair, null), null, -1, source: this.GetType());
             _publisher.Publish(
                 EventReaderSubscriptionMessage.CommittedEventReceived.FromCommittedEventDistributed(
-                    committedEvent, positionTag, null, _projectionCorrelationId, 
+                    committedEvent, positionTag, null, _projectionCorrelationId,
                     prerecordedEventMessageSequenceNumber));
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -97,8 +97,9 @@ namespace EventStore.Projections.Core.Services.Processing
             _ioDispatcher.Writer.CancelAll();
 
             var allProjections = _projections.Values;
-            //foreach (var projection in allProjections)
-                //projection.Kill();
+            foreach (var projection in allProjections)
+                projection.Kill();
+
             if (_projections.Count > 0)
             {
                 _logger.Info("_projections is not empty after all the projections have been killed");
@@ -201,7 +202,7 @@ namespace EventStore.Projections.Core.Services.Processing
                         projectionConfig,
                         stateHandler,
                         message.MasterWorkerId,
-                        _publisher, 
+                        _publisher,
                         message.MasterCoreProjectionId,
                         this);
                 CreateCoreProjection(message.ProjectionId, projectionConfig.RunAs, projectionProcessingStrategy);


### PR DESCRIPTION
Kill projections and dispose ProjectionCheckpoint objects when stopping projections

This would sometimes cause projections to go in a Faulted State with the error message 'An event emitted in recovery differs from the originally emitted event'. When projections are stopped (for example during Elections), the _checkpointManager was not being properly stopped. "ProjectionCheckpoint" objects were thus not being disposed properly and consequently "EmittedStream" objects were not being disposed too. If an event was received just before Projections are stopped and it managed to slip in to the "EmittedStream" (before the dispatcher stops), the latter would stay alive. When Projections are started again (on the same or another node), we would now have two instances of "EmittedStream" reading/writing events at the same time. This would result in an inconsistent state.