### PR TITLE
Don't fail if there are duplicate projection created events

### DIFF
--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/projectionsManagerTests.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/projectionsManagerTests.cs
@@ -230,7 +230,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
 
 	[TestFixture]
 	[Category("ProjectionsManager")]
-	public class when_listing_all_projections : SpecificationWithNodeAndProjectionsManager
+	public class when_listing_the_projections : SpecificationWithNodeAndProjectionsManager
 	{
 		private List<ProjectionDetails> _result;
 		public override void Given()

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -554,6 +554,7 @@
     <Compile Include="Services\projections_manager\projection_manager_response_reader\when_timeout_received_after_read_succeeds.cs" />
     <Compile Include="Services\projections_manager\projection_manager_response_reader\when_read_results_in_an_error.cs" />
     <Compile Include="Services\projections_manager\managed_projection\when_updating_projection_config.cs" />
+    <Compile Include="Services\projections_manager\when_starting_the_projection_manager_with_duplicate_projection_created.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_duplicate_projection_created.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_duplicate_projection_created.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Services;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager
+{
+
+    [TestFixture]
+    public class when_starting_the_projection_manager_with_duplicate_projection_created : TestFixtureWithExistingEvents
+    {
+        private new ITimeProvider _timeProvider;
+        private ProjectionManager _manager;
+        private Guid _workerId;
+
+        protected override void Given()
+        {
+            _workerId = Guid.NewGuid();
+            ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, ProjectionEventTypes.ProjectionCreated, null, "projection1");
+            ExistingEvent(ProjectionNamesBuilder.ProjectionsRegistrationStream, ProjectionEventTypes.ProjectionCreated, null, "projection1");
+            ExistingEvent(
+                "$projections-projection1", ProjectionEventTypes.ProjectionUpdated, null,
+                @"{""Query"":""fromAll(); on_any(function(){});log('hello-from-projection-definition');"", ""Mode"":""3"", ""Enabled"":true, ""HandlerType"":""JS""}");
+        }
+
+        [SetUp]
+        public void setup()
+        {
+            _timeProvider = new FakeTimeProvider();
+            var queues = new Dictionary<Guid, IPublisher>{{_workerId, _bus}};
+            _manager = new ProjectionManager(
+                _bus,
+                _bus,
+                queues,
+                _timeProvider,
+                ProjectionType.All,
+                _ioDispatcher);
+            _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);
+            _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            _manager.Handle(new ProjectionManagementMessage.ReaderReady());
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _manager.Dispose();
+        }
+
+        [Test]
+        public void projection_status_is_preparing()
+        {
+            _manager.Handle(
+                new ProjectionManagementMessage.Command.GetStatistics(new PublishEnvelope(_bus), null, "projection1", true));
+            Assert.AreEqual(
+                ManagedProjectionState.Preparing,
+                _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>().SingleOrDefault(
+                    v => v.Projections[0].Name == "projection1").Projections[0].MasterStatus);
+        }
+
+        [Test]
+        public void projection_id_is_latest()
+        {
+            _manager.Handle(
+                new ProjectionManagementMessage.Command.GetStatistics(new PublishEnvelope(_bus), null, "projection1", true));
+            Assert.AreEqual(
+                1,
+                _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>().SingleOrDefault(
+                    v => v.Projections[0].Name == "projection1").Projections[0].ProjectionId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -276,6 +276,7 @@ namespace EventStore.Projections.Core.Services.Management
                 status = new ProjectionStatistics
                     {
                         Name = _name,
+                        ProjectionId = _projectionId,
                         Epoch = -1,
                         Version = -1,
                         Mode = Mode,
@@ -288,6 +289,7 @@ namespace EventStore.Projections.Core.Services.Management
                 status = _lastReceivedStatistics.Clone();
                 status.Mode = Mode;
                 status.Name = _name;
+                status.ProjectionId = _projectionId;
                 var enabledSuffix = ((_state == ManagedProjectionState.Stopped || _state == ManagedProjectionState.Faulted) && Enabled ? " (Enabled)" : "");
                 status.Status = (status.Status == "Stopped" && _state == ManagedProjectionState.Completed
                                     ? _state.EnumValueName()

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -750,6 +750,12 @@ namespace EventStore.Projections.Core.Services.Management
                         }
                         if (evnt.Event.EventType == ProjectionEventTypes.ProjectionCreated)
                         {
+                            if(registeredProjections.ContainsKey(projectionName))
+                            {
+                                registeredProjections[projectionName] = projectionId;
+                                _logger.Warn("PROJECTIONS: The following projection: {0} has a duplicate created event. Using projection Id {1}", projectionName, projectionId);
+                                continue;
+                            }
                             registeredProjections.Add(projectionName, projectionId);
                         }
                         else if(evnt.Event.EventType == ProjectionEventTypes.ProjectionDeleted)


### PR DESCRIPTION
Fixes #1401 

Log out if there are duplicate projection created events, and use the id of the latest one.
Duplicate events can be created if the writes for creating a projection are slowed and the create request is issued multiple times.

Also added the projection id to the statistics returned when listing all projections so that it can be used in tests.

Note: Do we want to add a similar check for deleted events as well?