### PR TITLE
Fix bug in StreamEventReader / MultiStreamEventReader causing projections to get stuck

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -556,6 +556,10 @@
     <Compile Include="Services\projections_manager\managed_projection\when_updating_projection_config.cs" />
     <Compile Include="Services\projections_manager\when_starting_the_projection_manager_with_duplicate_projection_created.cs" />
     <Compile Include="Services\core_projection\when_killing_a_projection_and_an_event_is_received.cs" />
+    <Compile Include="Services\event_reader\stream_reader\when_handling_streams_with_deleted_events_and_starting_at_event_zero.cs" />
+    <Compile Include="Services\event_reader\stream_reader\when_handling_streams_with_deleted_events_and_starting_after_event_zero.cs" />
+    <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_starting_at_event_zero.cs" />
+    <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_starting_after_event_zero.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_streams_with_deleted_events_and_starting_after_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_streams_with_deleted_events_and_starting_after_event_zero.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.AwakeReaderService;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_reader
+{
+    [TestFixture]
+    public class when_handling_streams_with_deleted_events_and_starting_after_event_zero : TestFixtureWithExistingEvents
+    {
+        private MultiStreamEventReader _edp;
+        private int _fromSequenceNumber;
+        private string[] _streamNames;
+        private Dictionary<string,long> _streamPositions;
+        private Guid _distibutionPointCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+            _fromSequenceNumber = 10;
+            _streamNames = new[] {"stream1","stream2"};
+            _streamPositions = new Dictionary<string, long> {{"stream1", _fromSequenceNumber}, {"stream2", 100}};
+        }
+
+        [SetUp]
+        public new void When()
+        {
+            _distibutionPointCorrelationId = Guid.NewGuid();
+            
+            _edp = new MultiStreamEventReader(
+                _ioDispatcher, _bus, _distibutionPointCorrelationId, null, 0, _streamNames, _streamPositions, false,
+                new RealTimeProvider());
+                
+            _edp.Resume();
+        }
+
+        private void HandleEvents(string stream, long[] eventNumbers){
+            string eventType = "event_type";
+            List<ResolvedEvent> events = new List<ResolvedEvent>();
+
+            foreach(long eventNumber in eventNumbers){
+                events.Add(
+                    ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            eventNumber, 50*(eventNumber+1), Guid.NewGuid(), Guid.NewGuid(), 50*(eventNumber+1), 0, stream, ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            eventType, new byte[] {0}, new byte[] {0}
+                        )
+                    )
+                );
+            }
+
+            long start, end;
+            if(eventNumbers.Length > 0){
+                start = eventNumbers[0];
+                end = eventNumbers[eventNumbers.Length-1];
+            }
+            else{
+                start = _fromSequenceNumber;
+                end = _fromSequenceNumber;
+            }
+
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == stream).CorrelationId;            
+
+            _edp.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, stream, start, 100, ReadStreamResult.Success,events.ToArray(), null, false, "", start+1, end, true, 200)
+            );            
+        }
+
+        private void HandleEvents(string stream,long start,long end){
+            List<long> eventNumbers = new List<long>();
+            for(long i=start;i<=end;i++) eventNumbers.Add(i);
+            HandleEvents(stream,eventNumbers.ToArray());
+        }
+
+        [Test]
+        public void allows_first_event_to_be_equal_to_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber;
+
+            Assert.DoesNotThrow(() => {
+                HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
+                //to trigger event delivery:
+                HandleEvents(_streamNames[1],100,101);                
+            });
+        }
+
+        [Test]
+        public void allows_first_event_to_be_greater_than_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber+5;
+
+            Assert.DoesNotThrow(() => {
+                HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
+                //to trigger event delivery:
+                HandleEvents(_streamNames[1],100,101);    
+            });
+        }
+
+        [Test]
+        public void does_not_allow_first_event_to_be_less_than_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber-1;
+
+            Assert.Throws<InvalidOperationException>(() => {
+                HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
+                //to trigger event delivery:
+                HandleEvents(_streamNames[1],100,101);                 
+            });
+        }
+
+        [Test]
+        public void events_after_first_event_should_be_in_sequence()
+        {            
+            Assert.Throws<InvalidOperationException>(() => {
+                //_fromSequenceNumber+2 has been omitted
+                HandleEvents(_streamNames[0],new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
+                //to trigger event delivery:
+                HandleEvents(_streamNames[1],100,101);                  
+            });        
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_streams_with_deleted_events_and_starting_at_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_streams_with_deleted_events_and_starting_at_event_zero.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.AwakeReaderService;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_reader
+{
+    [TestFixture]
+    public class when_handling_streams_with_deleted_events_and_starting_at_event_zero : TestFixtureWithExistingEvents
+    {
+        private MultiStreamEventReader _edp;
+        private int _fromSequenceNumber;
+        private string[] _streamNames;
+        private Dictionary<string,long> _streamPositions;
+        private Guid _distibutionPointCorrelationId;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+            _fromSequenceNumber = 0;
+            _streamNames = new[] {"stream1","stream2"};
+            _streamPositions = new Dictionary<string, long> {{"stream1", _fromSequenceNumber}, {"stream2", 100}};
+        }
+
+        [SetUp]
+        public new void When()
+        {
+            _distibutionPointCorrelationId = Guid.NewGuid();
+            
+            _edp = new MultiStreamEventReader(
+                _ioDispatcher, _bus, _distibutionPointCorrelationId, null, 0, _streamNames, _streamPositions, false,
+                new RealTimeProvider());
+                
+            _edp.Resume();
+        }
+
+        private void HandleEvents(string stream, long[] eventNumbers){
+            string eventType = "event_type";
+            List<ResolvedEvent> events = new List<ResolvedEvent>();
+
+            foreach(long eventNumber in eventNumbers){
+                events.Add(
+                    ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            eventNumber, 50*(eventNumber+1), Guid.NewGuid(), Guid.NewGuid(), 50*(eventNumber+1), 0, stream, ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            eventType, new byte[] {0}, new byte[] {0}
+                        )
+                    )
+                );
+            }            
+
+            long start, end;
+            if(eventNumbers.Length > 0){
+                start = eventNumbers[0];
+                end = eventNumbers[eventNumbers.Length-1];
+            }
+            else{
+                start = _fromSequenceNumber;
+                end = _fromSequenceNumber;
+            }
+
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == stream).CorrelationId;
+
+            _edp.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, stream, start, 100, ReadStreamResult.Success,events.ToArray(), null, false, "", start+1, end, true, 200)
+            );    
+        }
+
+        private void HandleEvents(string stream,long start,long end){
+            List<long> eventNumbers = new List<long>();
+            for(long i=start;i<=end;i++) eventNumbers.Add(i);
+            HandleEvents(stream,eventNumbers.ToArray());
+        }
+
+        [Test]
+        public void allows_first_event_to_be_equal_to_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber;
+
+            Assert.DoesNotThrow(() => {
+                HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
+                //to trigger event delivery:
+                HandleEvents(_streamNames[1],100,101);
+            });
+        }
+
+        [Test]
+        public void allows_first_event_to_be_greater_than_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber+5;
+
+            Assert.DoesNotThrow(() => {
+                HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
+                //to trigger event delivery:
+                HandleEvents(_streamNames[1],100,101);
+            });
+        }
+
+        [Test]
+        public void events_after_first_event_should_be_in_sequence()
+        {            
+            Assert.Throws<InvalidOperationException>(() => {
+                //_fromSequenceNumber+2 has been omitted
+                HandleEvents(_streamNames[0],new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
+                //to trigger event delivery:
+                HandleEvents(_streamNames[1],100,101);
+            });        
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_starting_after_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_starting_after_event_zero.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.AwakeReaderService;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
+{
+    [TestFixture]
+    public class when_handling_streams_with_deleted_events_and_starting_after_event_zero : TestFixtureWithExistingEvents
+    {
+        private StreamEventReader _edp;
+        private int _fromSequenceNumber;
+        const string _streamName = "stream";
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+            _fromSequenceNumber = 10;
+        }
+
+        [SetUp]
+        public new void When()
+        {
+            _edp = new StreamEventReader(_bus, Guid.NewGuid(), null, _streamName, _fromSequenceNumber, new RealTimeProvider(), false,
+                produceStreamDeletes: false);
+            _edp.Resume();
+        }
+
+        private void HandleEvents(long[] eventNumbers){
+            string eventType = "event_type";
+            List<ResolvedEvent> events = new List<ResolvedEvent>();
+
+            foreach(long eventNumber in eventNumbers){
+                events.Add(
+                    ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            eventNumber, 50*(eventNumber+1), Guid.NewGuid(), Guid.NewGuid(), 50*(eventNumber+1), 0, _streamName, ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            eventType, new byte[] {0}, new byte[] {0}
+                        )
+                    )
+                );
+            }
+
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
+
+            long start, end;
+            if(eventNumbers.Length > 0){
+                start = eventNumbers[0];
+                end = eventNumbers[eventNumbers.Length-1];
+            }
+            else{
+                start = _fromSequenceNumber;
+                end = _fromSequenceNumber;
+            }
+
+            _edp.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, _streamName, start, 100, ReadStreamResult.Success,events.ToArray(), null, false, "", start+1, end, true, 200)
+            );            
+        }
+
+        private void HandleEvents(long start,long end){
+            List<long> eventNumbers = new List<long>();
+            for(long i=start;i<=end;i++) eventNumbers.Add(i);
+            HandleEvents(eventNumbers.ToArray());
+        }
+
+        [Test]
+        public void allows_first_event_to_be_equal_to_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber;
+
+            Assert.DoesNotThrow(() => {
+                HandleEvents(eventSequenceNumber,eventSequenceNumber);
+            });
+        }
+
+        [Test]
+        public void allows_first_event_to_be_greater_than_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber+5;
+
+            Assert.DoesNotThrow(() => {
+                HandleEvents(eventSequenceNumber,eventSequenceNumber);
+            });
+        }
+
+        [Test]
+        public void does_not_allow_first_event_to_be_less_than_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber-1;
+
+            Assert.Throws<InvalidOperationException>(() => {
+                HandleEvents(eventSequenceNumber,eventSequenceNumber);
+            });
+        }
+
+        [Test]
+        public void events_after_first_event_should_be_in_sequence()
+        {            
+            Assert.Throws<InvalidOperationException>(() => {
+                //_fromSequenceNumber+2 has been omitted
+                HandleEvents(new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
+            });        
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_starting_at_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_starting_at_event_zero.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.AwakeReaderService;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
+{
+    [TestFixture]
+    public class when_handling_streams_with_deleted_events_and_starting_at_event_zero : TestFixtureWithExistingEvents
+    {
+        private StreamEventReader _edp;
+        private int _fromSequenceNumber;
+        const string _streamName = "stream";
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+            _fromSequenceNumber = 0;
+        }
+
+        [SetUp]
+        public new void When()
+        {
+            _edp = new StreamEventReader(_bus, Guid.NewGuid(), null, _streamName, _fromSequenceNumber, new RealTimeProvider(), false,
+                produceStreamDeletes: false);
+            _edp.Resume();
+        }
+
+        private void HandleEvents(long[] eventNumbers){
+            string eventType = "event_type";
+            List<ResolvedEvent> events = new List<ResolvedEvent>();
+
+            foreach(long eventNumber in eventNumbers){
+                events.Add(
+                    ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            eventNumber, 50*(eventNumber+1), Guid.NewGuid(), Guid.NewGuid(), 50*(eventNumber+1), 0, _streamName, ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            eventType, new byte[] {0}, new byte[] {0}
+                        )
+                    )
+                );
+            }
+
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
+
+            long start, end;
+            if(eventNumbers.Length > 0){
+                start = eventNumbers[0];
+                end = eventNumbers[eventNumbers.Length-1];
+            }
+            else{
+                start = _fromSequenceNumber;
+                end = _fromSequenceNumber;
+            }
+
+            _edp.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, _streamName, start, 100, ReadStreamResult.Success,events.ToArray(), null, false, "", start+1, end, true, 200)
+            );            
+        }
+
+        private void HandleEvents(long start,long end){
+            List<long> eventNumbers = new List<long>();
+            for(long i=start;i<=end;i++) eventNumbers.Add(i);
+            HandleEvents(eventNumbers.ToArray());
+        }
+
+        [Test]
+        public void allows_first_event_to_be_equal_to_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber;
+
+            Assert.DoesNotThrow(() => {
+                HandleEvents(eventSequenceNumber,eventSequenceNumber);
+            });
+        }
+
+        [Test]
+        public void allows_first_event_to_be_greater_than_sequence_number()
+        {
+            long eventSequenceNumber = _fromSequenceNumber+5;
+
+            Assert.DoesNotThrow(() => {
+                HandleEvents(eventSequenceNumber,eventSequenceNumber);
+            });
+        }
+
+        [Test]
+        public void events_after_first_event_should_be_in_sequence()
+        {            
+            Assert.Throws<InvalidOperationException>(() => {
+                //_fromSequenceNumber+2 has been omitted
+                HandleEvents(new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
+            });        
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
@@ -18,6 +18,7 @@ namespace EventStore.Projections.Core.Services.Processing
     {
         private readonly string _streamName;
         private long _fromSequenceNumber;
+        private bool _firstEventProcessed = false;
         private readonly ITimeProvider _timeProvider;
         private readonly bool _resolveLinkTos;
         private readonly bool _produceStreamDeletes;
@@ -143,11 +144,17 @@ namespace EventStore.Projections.Core.Services.Processing
 
         private long StartFrom(ClientMessage.ReadStreamEventsForwardCompleted message, long fromSequenceNumber)
         {
-            if (fromSequenceNumber != 0) return fromSequenceNumber;
-            if(message.Events.Length > 0)
-            {
-                return message.Events[0].OriginalEventNumber;
+            if(!_firstEventProcessed){
+                if(message.Events.Length>0){
+                    _firstEventProcessed = true;
+
+                    if(message.Events[0].OriginalEventNumber > fromSequenceNumber)
+                        return message.Events[0].OriginalEventNumber;
+                    else
+                        return fromSequenceNumber;
+                }
             }
+
             return fromSequenceNumber;
         }
 


### PR DESCRIPTION
Fix bug in EventStreamReader/MultiStreamEventReader causing projections to stop processing (gets stuck at position -1 or at the last event processed) when events have been removed from the beginning of a stream (e.g. through $maxAge, $maxCount)

Fixes #1333, #1412 

**The following error is thrown out in logs:**
System.InvalidOperationException: Event number [x] was expected in the stream [streamname], but event number [y] was received

x is usually 0, but it is possible for it to also be equal to the last event processed+1.

**Steps to reproduce (use files below):**
[event.txt](https://github.com/EventStore/EventStore/files/1292541/event.txt)
[event0.txt](https://github.com/EventStore/EventStore/files/1292543/event0.txt)
[maxcountmetadata.txt](https://github.com/EventStore/EventStore/files/1295932/maxcountmetadata.txt)

```
1. Create streams stream1 and stream2 (writing 3 events to each one):
curl -i -d @event.txt -H "Content-Type:application/vnd.eventstore.events+json" "http://127.0.0.1:2113/streams/stream1"
curl -i -d @event.txt -H "Content-Type:application/vnd.eventstore.events+json" "http://127.0.0.1:2113/streams/stream2"

2. Create a projection 'multistream':
fromStreams(['stream1','stream2']).
when({
    '$any':function(s,e){

    }
})

3. Run it, Position should be: stream1: 2; stream2: 2;

4. Create a projection 'singlestream':
fromStreams(['stream1']).
when({
    '$any':function(s,e){

    }
})

5. Run it, Position should be: stream1: 2

6. Stop both projections

7. Write $maxCount for stream1 to 2 events:
curl -i -d@maxcountmetadata.txt http://127.0.0.1:2113/streams/stream1/metadata --user admin:changeit -H "Content-Type: application/vnd.eventstore.events+json"

8. Write 3 more events to stream1:
curl -i -d @event0.txt -H "Content-Type:application/vnd.eventstore.events+json" "http://127.0.0.1:2113/streams/stream1"

9. stream1 should now contain event numbers 4,5 only (0,1,2,3 should be deleted because of maxCount=2)

10. Start both projections => Both multistream and singlestream are stuck at event 2 on stream1 and log errors like:
[PID:11003:022 2017.09.11 10:19:45.322 ERROR QueuedHandlerMRES   ] Error while processing message EventStore.Projections.Core.Messaging.UnwrapEnvelopeMessage in queued handler 'Projection Core #1'.
System.InvalidOperationException: Event number 3 was expected in the stream stream1, but event number 4 was received

11. Stop, Reset and Start both projections =>
The problem stays the same for multistream (stuck at -1)
singlestream works fine and moves to position stream1: 5
```

**Resolution:**
When  starting to read from a stream, we can expect the first event to have an event number greater than the last event processed.

After we have read in the first event, next messages are expected to be in sequence (Assuming that events are not removed from the stream faster than they are processed by projections)