### PR TITLE
Prevent reads of events that have not been replicated

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -2,6 +2,7 @@ using System;
 using EventStore.ClientAPI;
 using EventStore.Core.Tests.ClientAPI.Helpers;
 using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.TransactionLog;
 using NUnit.Framework;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
@@ -70,16 +71,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
                 ChaserCheckpoint = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
             }
 
-            Db = new TFChunkDb(new TFChunkDbConfig(dbPath,
-                                                   new VersionedPatternFileNamingStrategy(dbPath, "chunk-"),
-                                                   TFConsts.ChunkSize,
-                                                   0,
-                                                   WriterCheckpoint,
-                                                   ChaserCheckpoint,
-                                                   new InMemoryCheckpoint(-1),
-                                                   new InMemoryCheckpoint(-1),
-                                                   inMemDb: false));
-
+            Db = new TFChunkDb(TFChunkDbConfigHelper.Create(dbPath, WriterCheckpoint, ChaserCheckpoint, TFConsts.ChunkSize));
             Db.Open();
 
             // create DB

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -681,6 +681,24 @@
     <Compile Include="Services\Transport\Tcp\TcpClientDispatcherTests.cs" />
     <Compile Include="Services\Storage\Scavenge\when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1.cs" />
     <Compile Include="ClientAPI\ExpectedVersion64Bit\read_stream_with_link_to_event_with_event_number_greater_than_int_maxvalue.cs" />
+    <Compile Include="Services\Replication\CheckpointFilter\when_processing_event_committed_and_commit_position_is_less_than_replication.cs" />
+    <Compile Include="Services\Replication\MasterReplication\with_master_replication_service.cs" />
+    <Compile Include="Services\Replication\MasterReplication\when_3_node_cluster_receives_1_commit_ack.cs" />
+    <Compile Include="Services\Replication\MasterReplication\when_3_node_cluster_receives_2_commit_acks.cs" />
+    <Compile Include="Services\Replication\MasterReplication\when_3_node_cluster_receives_2_commit_acks_for_positions_lower_than_checkpoint.cs" />
+    <Compile Include="Services\Replication\MasterReplication\when_3_node_cluster_receives_multiple_acks_for_different_positions.cs" />
+    <Compile Include="Services\Replication\CheckpointFilter\with_replication_checkpoint_filter.cs" />
+    <Compile Include="Services\Replication\CheckpointFilter\when_processing_event_committed_and_commit_position_is_greater_than_checkpoint.cs" />
+    <Compile Include="Services\Replication\CheckpointFilter\when_processing_multiple_event_committed_messages.cs" />
+    <Compile Include="Services\Replication\CheckpointFilter\when_processing_multiple_event_committed_messages_for_the_same_positions.cs" />
+    <Compile Include="Services\Replication\ReplicationTestHelper.cs" />
+    <Compile Include="Services\Replication\ReadStream\when_reading_an_event_from_a_single_node.cs" />
+    <Compile Include="Services\Replication\ReadStream\when_reading_an_event_committed_on_master_and_on_slaves.cs" />
+    <Compile Include="Services\Replication\ReadStream\when_reading_events_from_cluster_with_replication_checkpoint_not_set.cs" />
+    <Compile Include="Services\Replication\Subscriptions\TestSubscription.cs" />
+    <Compile Include="Services\Replication\Subscriptions\when_subscribed_to_stream_on_master_and_event_is_replicated_to_slaves.cs" />
+    <Compile Include="TransactionLog\when_reading_a_single_record.cs" />
+    <Compile Include="Services\Storage\AllReader\when_reading_all_with_replication_checkpoint_set.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj">

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -699,6 +699,7 @@
     <Compile Include="Services\Replication\Subscriptions\when_subscribed_to_stream_on_master_and_event_is_replicated_to_slaves.cs" />
     <Compile Include="TransactionLog\when_reading_a_single_record.cs" />
     <Compile Include="Services\Storage\AllReader\when_reading_all_with_replication_checkpoint_set.cs" />
+    <Compile Include="TransactionLog\TFChunkDbConfigHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj">

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -188,6 +188,7 @@ namespace EventStore.Core.Tests.Helpers
             ICheckpoint chaserChk;
             ICheckpoint epochChk;
             ICheckpoint truncateChk;
+            ICheckpoint replicationCheckpoint = new InMemoryCheckpoint(-1);
             if (inMemDb)
             {
                 writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
@@ -221,7 +222,7 @@ namespace EventStore.Core.Tests.Helpers
             }
             var nodeConfig = new TFChunkDbConfig(
                 dbPath, new VersionedPatternFileNamingStrategy(dbPath, "chunk-"), chunkSize, chunksCacheSize, writerChk,
-                chaserChk, epochChk, truncateChk, inMemDb);
+                chaserChk, epochChk, truncateChk, replicationCheckpoint, inMemDb);
             return nodeConfig;
         }
     }

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace EventStore.Core.Tests.Integration
 {
@@ -131,6 +132,16 @@ namespace EventStore.Core.Tests.Integration
         protected static void WaitIdle()
         {
             QueueStatsCollector.WaitIdle();
+        }
+
+        protected MiniClusterNode GetMaster()
+        {
+            return _nodes.First(x => x.NodeState == Data.VNodeState.Master);
+        }
+
+        protected MiniClusterNode[] GetSlaves()
+        {
+            return _nodes.Where(x => x.NodeState != Data.VNodeState.Master).ToArray();
         }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/when_processing_event_committed_and_commit_position_is_greater_than_checkpoint.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/when_processing_event_committed_and_commit_position_is_greater_than_checkpoint.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.CheckpointFilter
+{
+    [TestFixture]
+    public class when_processing_event_committed_and_commit_position_is_greater_than_checkpoint : with_replication_checkpoint_filter
+    {
+        private TimerMessage.Schedule _scheduledMessage;
+
+        public override void When()
+        {
+            _replicationChk.Write(2000);
+            var msg = new StorageMessage.EventCommitted(3000, CreateDummyEventRecord(3000), false);
+            _scheduledMessage = _publishConsumer.HandledMessages.OfType<TimerMessage.Schedule>().SingleOrDefault();
+
+            _filter.Handle(msg);
+        }
+
+        [Test]
+        public void should_not_publish_event_committed_message()
+        {
+            Assert.AreEqual(0, _outputConsumer.HandledMessages.OfType<StorageMessage.EventCommitted>().Count());
+        }
+
+        [Test]
+        public void should_schedule_a_replication_checkpoint_check_message()
+        {
+            Assert.IsNotNull(_scheduledMessage);
+            Assert.IsInstanceOf<ReplicationMessage.ReplicationCheckTick>(_scheduledMessage.ReplyMessage);
+        }
+
+        [Test]
+        public void should_publish_event_committed_message_on_tick_after_checkpoint_increases()
+        {
+            _replicationChk.Write(4000);
+            _filter.Handle((ReplicationMessage.ReplicationCheckTick)_scheduledMessage.ReplyMessage);
+            Assert.AreEqual(1, _outputConsumer.HandledMessages.OfType<StorageMessage.EventCommitted>().Count());
+        }
+    }
+
+}

--- a/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/when_processing_event_committed_and_commit_position_is_less_than_replication.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/when_processing_event_committed_and_commit_position_is_less_than_replication.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.CheckpointFilter
+{
+    [TestFixture]
+    public class when_processing_event_committed_and_commit_position_is_less_than_replication : with_replication_checkpoint_filter
+    {
+        public override void When()
+        {
+            _replicationChk.Write(2000);
+            var msg = new StorageMessage.EventCommitted(1000, CreateDummyEventRecord(1000), false);
+
+            _filter.Handle(msg);
+        }
+
+        [Test]
+        public void should_publish_event_committed_message()
+        {
+            Assert.AreEqual(1, _outputConsumer.HandledMessages.OfType<StorageMessage.EventCommitted>().Count());
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/when_processing_multiple_event_committed_messages.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/when_processing_multiple_event_committed_messages.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.CheckpointFilter
+{
+    [TestFixture]
+    public class when_processing_multiple_event_committed_messages : with_replication_checkpoint_filter
+    {
+        private TimerMessage.Schedule _scheduledMessage;
+
+        public override void When()
+        {
+            _scheduledMessage = _publishConsumer.HandledMessages.OfType<TimerMessage.Schedule>().SingleOrDefault();
+            _replicationChk.Write(-1);
+
+            var msg1 = new StorageMessage.EventCommitted(1000, CreateDummyEventRecord(1000), false);
+            var msg2 = new StorageMessage.EventCommitted(2000, CreateDummyEventRecord(2000), false);
+            var msg3 = new StorageMessage.EventCommitted(3000, CreateDummyEventRecord(3000), false);
+            _filter.Handle(msg1);
+            _filter.Handle(msg2);
+            _filter.Handle(msg3);
+
+            _replicationChk.Write(2000);
+            _filter.Handle((ReplicationMessage.ReplicationCheckTick)_scheduledMessage.ReplyMessage);
+        }
+
+        [Test]
+        public void should_publish_event_committed_message_on_tick_for_first_two_messages()
+        {
+            var messages = _outputConsumer.HandledMessages.OfType<StorageMessage.EventCommitted>().ToList();
+            Assert.AreEqual(2, messages.Count);
+            Assert.IsTrue(messages.Any(x=> ((StorageMessage.EventCommitted)x).CommitPosition == 1000));
+            Assert.IsTrue(messages.Any(x=> ((StorageMessage.EventCommitted)x).CommitPosition == 2000));
+        }
+
+        [Test]
+        public void should_publish_third_event_on_tick_after_checkpoint_increases()
+        {
+            _outputConsumer.HandledMessages.Clear();
+            _replicationChk.Write(3000);
+            _filter.Handle((ReplicationMessage.ReplicationCheckTick)_scheduledMessage.ReplyMessage);
+            Assert.AreEqual(1, _outputConsumer.HandledMessages.OfType<StorageMessage.EventCommitted>().Count());
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/when_processing_multiple_event_committed_messages_for_the_same_positions.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/when_processing_multiple_event_committed_messages_for_the_same_positions.cs
@@ -1,0 +1,34 @@
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.CheckpointFilter
+{
+    [TestFixture]
+    public class when_processing_multiple_event_committed_messages_for_the_same_positions : with_replication_checkpoint_filter
+    {
+        private TimerMessage.Schedule _scheduledMessage;
+
+        public override void When()
+        {
+            _scheduledMessage = _publishConsumer.HandledMessages.OfType<TimerMessage.Schedule>().SingleOrDefault();
+            _replicationChk.Write(-1);
+
+            var msg1 = new StorageMessage.EventCommitted(1000, CreateDummyEventRecord(1000), false);
+            var msg2 = new StorageMessage.EventCommitted(1000, CreateDummyEventRecord(1000), false);
+            _filter.Handle(msg1);
+            _filter.Handle(msg2);
+
+            _replicationChk.Write(2000);
+            _filter.Handle((ReplicationMessage.ReplicationCheckTick)_scheduledMessage.ReplyMessage);
+        }
+
+        [Test]
+        public void should_publish_event_committed_message_for_both_messages()
+        {
+            var messages = _outputConsumer.HandledMessages.OfType<StorageMessage.EventCommitted>().ToList();
+            Assert.AreEqual(2, messages.Count);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/with_replication_checkpoint_filter.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CheckpointFilter/with_replication_checkpoint_filter.cs
@@ -1,0 +1,49 @@
+using System;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Replication;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Bus.Helpers;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.CheckpointFilter
+{
+     public abstract class with_replication_checkpoint_filter
+    {
+        protected ReplicationCheckpointFilter _filter;
+        protected InMemoryBus _outputBus;
+        protected InMemoryBus _publisher;
+        protected ICheckpoint _replicationChk;
+
+        protected TestHandler<Message> _outputConsumer;
+        protected TestHandler<Message> _publishConsumer;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            _outputBus = new InMemoryBus("OutputBus");
+            _publisher = new InMemoryBus("Publisher");
+            _replicationChk = new InMemoryCheckpoint();
+
+            _outputConsumer = new TestHandler<Message>();
+            _outputBus.Subscribe(_outputConsumer);
+
+            _publishConsumer = new TestHandler<Message>();
+            _publisher.Subscribe(_publishConsumer);
+
+            _filter = new ReplicationCheckpointFilter(_outputBus, _publisher, _replicationChk);
+
+            When();
+        }
+
+        public abstract void When();
+
+        protected EventRecord CreateDummyEventRecord(long logPosition)
+        {
+            return new EventRecord(1, logPosition, Guid.NewGuid(), Guid.NewGuid(), logPosition, 0, "test-stream",
+                                   0, DateTime.Now, PrepareFlags.Data, "testEvent", new byte[0], new byte[0]);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/MasterReplication/when_3_node_cluster_receives_1_commit_ack.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/MasterReplication/when_3_node_cluster_receives_1_commit_ack.cs
@@ -1,0 +1,25 @@
+using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.MasterReplication
+{
+    [TestFixture]
+    public class when_3_node_cluster_receives_1_commit_ack : with_master_replication_service
+    {
+        private Guid _correlationId = Guid.NewGuid();
+        private long _logPosition;
+
+        public override void When()
+        {
+            _logPosition = 4000;
+            Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPosition, _logPosition, 0, 0));
+        }
+
+        [Test]
+        public void replication_checkpoint_should_not_be_updated()
+        {
+            Assert.AreEqual(-1, Db.Config.ReplicationCheckpoint.ReadNonFlushed());
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/MasterReplication/when_3_node_cluster_receives_2_commit_acks.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/MasterReplication/when_3_node_cluster_receives_2_commit_acks.cs
@@ -1,0 +1,25 @@
+using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.MasterReplication
+{
+    [TestFixture]
+    public class when_3_node_cluster_receives_2_commit_acks : with_master_replication_service
+    {
+        private long _logPosition = 5000;
+        private Guid _correlationId = Guid.NewGuid();
+
+        public override void When()
+        {
+            Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPosition, _logPosition, 0, 0));
+            Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPosition, _logPosition, 0, 0));
+        }
+
+        [Test]
+        public void replication_checkpoint_should_have_been_updated()
+        {
+            Assert.AreEqual(_logPosition, Db.Config.ReplicationCheckpoint.ReadNonFlushed());
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/MasterReplication/when_3_node_cluster_receives_2_commit_acks_for_positions_lower_than_checkpoint.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/MasterReplication/when_3_node_cluster_receives_2_commit_acks_for_positions_lower_than_checkpoint.cs
@@ -1,0 +1,27 @@
+using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.MasterReplication
+{
+    [TestFixture]
+    public class when_3_node_cluster_receives_2_commit_acks_for_positions_lower_than_checkpoint : with_master_replication_service
+    {
+        private long _checkpointPosition = 6000;
+        private long _logPosition = 3000;
+        private Guid _correlationId = Guid.NewGuid();
+
+        public override void When()
+        {
+            Db.Config.ReplicationCheckpoint.Write(_checkpointPosition);
+            Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPosition, _logPosition, 0, 0));
+            Service.Handle(new StorageMessage.CommitAck(_correlationId, _logPosition, _logPosition, 0, 0));
+        }
+
+        [Test]
+        public void replication_checkpoint_should_remain_at_higher_value()
+        {
+            Assert.AreEqual(_checkpointPosition, Db.Config.ReplicationCheckpoint.ReadNonFlushed());
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/MasterReplication/when_3_node_cluster_receives_multiple_acks_for_different_positions.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/MasterReplication/when_3_node_cluster_receives_multiple_acks_for_different_positions.cs
@@ -1,0 +1,41 @@
+using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.MasterReplication
+{
+    [TestFixture]
+    public class when_3_node_cluster_receives_multiple_acks_for_different_positions : with_master_replication_service
+    {
+        private Guid _correlationId1 = Guid.NewGuid();
+        private Guid _correlationId2 = Guid.NewGuid();
+        private Guid _correlationId3 = Guid.NewGuid();
+
+        private long _logPosition1 = 1000;
+        private long _logPosition2 = 2000;
+        private long _logPosition3 = 3000;
+
+        public override void When()
+        {
+            Service.Handle(new StorageMessage.CommitAck(_correlationId1, _logPosition1, _logPosition1, 0, 0));
+            Service.Handle(new StorageMessage.CommitAck(_correlationId2, _logPosition2, _logPosition2, 0, 0));
+            Service.Handle(new StorageMessage.CommitAck(_correlationId3, _logPosition3, _logPosition3, 0, 0));
+
+            // Reach quorum for middle commit
+            Service.Handle(new StorageMessage.CommitAck(_correlationId2, _logPosition2, _logPosition2, 0, 0));
+        }
+
+        [Test]
+        public void replication_checkpoint_should_be_updated()
+        {
+            Assert.AreEqual(_logPosition2, Db.Config.ReplicationCheckpoint.ReadNonFlushed());
+        }
+
+        [Test]
+        public void replication_checkpoint_should_update_if_next_commit_is_acked()
+        {
+            Service.Handle(new StorageMessage.CommitAck(_correlationId3, _logPosition3, _logPosition3, 0, 0));
+            Assert.AreEqual(_logPosition3, Db.Config.ReplicationCheckpoint.ReadNonFlushed());
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/MasterReplication/with_master_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/MasterReplication/with_master_replication_service.cs
@@ -1,0 +1,58 @@
+using System;
+using System.IO;
+using EventStore.Core.Bus;
+using EventStore.Core.Services.Replication;
+using EventStore.Core.Tests.Services.ElectionsService;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.MasterReplication
+{
+    public abstract class with_master_replication_service : SpecificationWithDirectoryPerTestFixture
+    {
+        protected MasterReplicationService Service;
+        protected TFChunkDb Db;
+
+        protected Guid MasterId = Guid.NewGuid();
+        protected int ClusterSize = 3;
+
+        protected InMemoryBus Publisher;
+        protected InMemoryBus TcpSendPublisher;
+
+        [OneTimeSetUp]
+        public void SetUp()
+        {
+            CreateDb();
+            Publisher = new InMemoryBus("publisher");
+            TcpSendPublisher = new InMemoryBus("tcpSendPublisher");
+            Service = new MasterReplicationService(Publisher, MasterId, Db, TcpSendPublisher, new FakeEpochManager(), ClusterSize);
+
+            When();
+        }
+
+        private void CreateDb()
+        {
+            string dbPath = Path.Combine(PathName, string.Format("mini-node-db-{0}", Guid.NewGuid()));
+
+            var writerCheckpoint = new InMemoryCheckpoint();
+            var chaserCheckpoint = new InMemoryCheckpoint();
+            var replicationCheckpoint = new InMemoryCheckpoint(-1);
+            Db = new TFChunkDb(new TFChunkDbConfig(dbPath,
+                                                   new VersionedPatternFileNamingStrategy(dbPath, "chunk-"),
+                                                   TFConsts.ChunkSize,
+                                                   0,
+                                                   writerCheckpoint,
+                                                   chaserCheckpoint,
+                                                   new InMemoryCheckpoint(-1),
+                                                   new InMemoryCheckpoint(-1),
+                                                   replicationCheckpoint,
+                                                   inMemDb: true));
+
+            Db.Open();
+        }
+
+        public abstract void When();
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/ReadStream/when_reading_an_event_committed_on_master_and_on_slaves.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReadStream/when_reading_an_event_committed_on_master_and_on_slaves.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Linq;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+using EventStore.Core.Tests.Integration;
+using EventStore.Core.Messages;
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Tests.Replication.ReadStream
+{
+    [TestFixture]
+    [Category("LongRunning")]
+    public class when_reading_an_event_committed_on_master_and_on_slaves : specification_with_cluster
+    {
+        private CountdownEvent _expectedNumberOfRoleAssignments;
+        private string _streamId = "when_reading_an_event_committed_on_master_and_on_slaves-" + Guid.NewGuid().ToString();
+        private long _commitPosition;
+
+        protected override void BeforeNodesStart()
+        {
+            _nodes.ToList().ForEach(x =>
+                x.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.StateChangeMessage>(Handle)));
+            _expectedNumberOfRoleAssignments = new CountdownEvent(3);
+            base.BeforeNodesStart();
+        }
+
+        private void Handle(SystemMessage.StateChangeMessage msg)
+        {
+            switch (msg.State)
+            {
+                case Data.VNodeState.Master:
+                    _expectedNumberOfRoleAssignments.Signal();
+                    break;
+                case Data.VNodeState.Slave:
+                    _expectedNumberOfRoleAssignments.Signal();
+                    break;
+            }
+        }
+
+        protected override void Given()
+        {
+            _expectedNumberOfRoleAssignments.Wait(5000);
+
+            var master = GetMaster();
+            Assert.IsNotNull(master, "Could not get master node");
+
+            // Set the checkpoint so the check is not skipped
+            master.Db.Config.ReplicationCheckpoint.Write(0);
+
+            var events = new Event[]{new Event(Guid.NewGuid(), "test-type", false, new byte[10], new byte[0]) };
+            var writeResult = ReplicationTestHelper.WriteEvent(master, events, _streamId);
+            Assert.AreEqual(OperationResult.Success, writeResult.Result);
+            _commitPosition = writeResult.CommitPosition;
+
+            Assert.IsTrue(_commitPosition <= GetMaster().Db.Config.ReplicationCheckpoint.ReadNonFlushed(),
+                "Replication checkpoint should be greater than event commit position");
+            base.Given();
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_all_forward_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadAllEventsForward(GetMaster(), _commitPosition);
+            Assert.AreEqual(1, readResult.Events.Where(x=>x.OriginalStreamId == _streamId).Count());
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_all_backward_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadAllEventsBackward(GetMaster(), _commitPosition);
+            Assert.AreEqual(1, readResult.Events.Where(x=>x.OriginalStreamId == _streamId).Count());
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_stream_forward_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadStreamEventsForward(GetMaster(), _streamId);
+            Assert.AreEqual(1, readResult.Events.Count());
+            Assert.AreEqual(ReadStreamResult.Success, readResult.Result);
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_stream_backward_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadStreamEventsBackward(GetMaster(), _streamId);
+            Assert.AreEqual(ReadStreamResult.Success, readResult.Result);
+            Assert.AreEqual(1, readResult.Events.Count());
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadEvent(GetMaster(), _streamId, 0);
+            Assert.AreEqual(ReadEventResult.Success, readResult.Result);
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_all_forward_on_slaves()
+        {
+            var slaves = GetSlaves();
+            foreach(var s in slaves)
+            {
+                var readResult = ReplicationTestHelper.ReadAllEventsForward(s, _commitPosition);
+                Assert.AreEqual(1, readResult.Events.Where(x=>x.OriginalStreamId == _streamId).Count());
+            }
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_all_backward_on_slaves()
+        {
+            var slaves = GetSlaves();
+            foreach(var s in slaves)
+            {
+                var readResult = ReplicationTestHelper.ReadAllEventsBackward(s, _commitPosition);
+                Assert.AreEqual(1, readResult.Events.Where(x=>x.OriginalStreamId == _streamId).Count());
+            }
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_stream_forward_on_slaves()
+        {
+            var slaves = GetSlaves();
+            foreach(var s in slaves)
+            {
+                var readResult = ReplicationTestHelper.ReadStreamEventsForward(s, _streamId);
+                Assert.AreEqual(1, readResult.Events.Count());
+                Assert.AreEqual(ReadStreamResult.Success, readResult.Result);
+            }
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_stream_backward_on_slaves()
+        {
+            var slaves = GetSlaves();
+            foreach(var s in slaves)
+            {
+                var readResult = ReplicationTestHelper.ReadStreamEventsBackward(s, _streamId);
+                Assert.AreEqual(1, readResult.Events.Count());
+                Assert.AreEqual(ReadStreamResult.Success, readResult.Result);
+            }
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_on_slaves()
+        {
+            var slaves = GetSlaves();
+            foreach(var s in slaves)
+            {
+                var readResult = ReplicationTestHelper.ReadEvent(s, _streamId, 0);
+                Assert.AreEqual(ReadEventResult.Success, readResult.Result);
+            }
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/ReadStream/when_reading_an_event_from_a_single_node.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReadStream/when_reading_an_event_from_a_single_node.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+using EventStore.Core.Tests.Integration;
+using EventStore.Core.Messages;
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Tests.Replication.ReadStream
+{
+    [TestFixture]
+    [Category("LongRunning")]
+    public class when_reading_an_event_from_a_single_node : specification_with_cluster
+    {
+        private CountdownEvent _expectedNumberOfRoleAssignments;
+        private string _streamId = "test-stream";
+        private long _commitPosition;
+
+        private MiniClusterNode _liveNode;
+
+        protected override void BeforeNodesStart()
+        {
+            _nodes.ToList().ForEach(x =>
+                x.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.StateChangeMessage>(Handle)));
+            _expectedNumberOfRoleAssignments = new CountdownEvent(3);
+            base.BeforeNodesStart();
+        }
+
+        private void Handle(SystemMessage.StateChangeMessage msg)
+        {
+            switch (msg.State)
+            {
+                case Data.VNodeState.Master:
+                    _expectedNumberOfRoleAssignments.Signal();
+                    break;
+                case Data.VNodeState.Slave:
+                    _expectedNumberOfRoleAssignments.Signal();
+                    break;
+            }
+        }
+
+        protected override void Given()
+        {
+            _expectedNumberOfRoleAssignments.Wait(5000);
+
+            _liveNode = GetMaster();
+            Assert.IsNotNull(_liveNode, "Could not get master node");
+
+            var events = new Event[]{new Event(Guid.NewGuid(), "test-type", false, new byte[10], new byte[0]) };
+            var writeResult = ReplicationTestHelper.WriteEvent(_liveNode, events, _streamId);
+            Assert.AreEqual(OperationResult.Success, writeResult.Result);
+            _commitPosition = writeResult.CommitPosition;
+
+            var slaves = GetSlaves();
+            foreach(var s in slaves)
+            {
+                ShutdownNode(s.DebugIndex);
+            }
+
+            base.Given();
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_all_forward()
+        {
+            var readResult = ReplicationTestHelper.ReadAllEventsForward(_liveNode, _commitPosition);
+            Assert.AreEqual(1, readResult.Events.Where(x=>x.OriginalStreamId == _streamId).Count());
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_all_backward()
+        {
+            var readResult = ReplicationTestHelper.ReadAllEventsBackward(_liveNode, _commitPosition);
+            Assert.AreEqual(1, readResult.Events.Where(x=>x.OriginalStreamId == _streamId).Count());
+        }
+
+        [Test]
+        public void should_not_be_able_to_read_event_from_stream_forward()
+        {
+            
+            var readResult = ReplicationTestHelper.ReadStreamEventsForward(_liveNode, _streamId);
+            Assert.AreEqual(1, readResult.Events.Count());
+            Assert.AreEqual(ReadStreamResult.Success, readResult.Result);
+        }
+
+        [Test]
+        public void should_not_be_able_to_read_event_from_stream_backward()
+        {
+            var readResult = ReplicationTestHelper.ReadStreamEventsBackward(_liveNode, _streamId);
+            Assert.AreEqual(1, readResult.Events.Count());
+            Assert.AreEqual(ReadStreamResult.Success, readResult.Result);
+        }
+
+        [Test]
+        public void should_not_be_able_to_read_event()
+        {
+            var readResult = ReplicationTestHelper.ReadEvent(_liveNode, _streamId, 0);
+            Assert.AreEqual(ReadEventResult.Success, readResult.Result);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/ReadStream/when_reading_events_from_cluster_with_replication_checkpoint_not_set.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReadStream/when_reading_events_from_cluster_with_replication_checkpoint_not_set.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using System.Threading;
+using EventStore.Core.Bus;
+using NUnit.Framework;
+using EventStore.Core.Tests.Integration;
+using EventStore.Core.Messages;
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Tests.Replication.ReadStream
+{
+    [TestFixture]
+    [Category("LongRunning")]
+    public class when_reading_events_from_cluster_with_replication_checkpoint_not_set : specification_with_cluster
+    {
+        private CountdownEvent _expectedNumberOfRoleAssignments;
+        private string _streamId = "when_reading_events_from_cluster_with_replication_checkpoint_not_set-" + Guid.NewGuid().ToString();
+        private long _commitPosition;
+
+        protected override void BeforeNodesStart()
+        {
+            _nodes.ToList().ForEach(x =>
+                x.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.StateChangeMessage>(Handle)));
+            _expectedNumberOfRoleAssignments = new CountdownEvent(3);
+            base.BeforeNodesStart();
+        }
+
+        private void Handle(SystemMessage.StateChangeMessage msg)
+        {
+            switch (msg.State)
+            {
+                case Data.VNodeState.Master:
+                    _expectedNumberOfRoleAssignments.Signal();
+                    break;
+                case Data.VNodeState.Slave:
+                    _expectedNumberOfRoleAssignments.Signal();
+                    break;
+            }
+        }
+
+        protected override void Given()
+        {
+            _expectedNumberOfRoleAssignments.Wait(5000);
+
+            var master = GetMaster();
+            Assert.IsNotNull(master, "Could not get master node");
+
+            var events = new Event[]{new Event(Guid.NewGuid(), "test-type", false, new byte[10], new byte[0]) };
+            var writeResult = ReplicationTestHelper.WriteEvent(master, events, _streamId);
+            Assert.AreEqual(OperationResult.Success, writeResult.Result);
+            _commitPosition = writeResult.CommitPosition;
+
+            // Set checkpoint to starting value
+            master.Db.Config.ReplicationCheckpoint.Write(-1);
+            base.Given();
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_all_forward_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadAllEventsForward(GetMaster(), _commitPosition);
+            Assert.AreEqual(1, readResult.Events.Where(x=>x.OriginalStreamId == _streamId).Count());
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_all_backward_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadAllEventsBackward(GetMaster(), _commitPosition);
+            Assert.AreEqual(1, readResult.Events.Where(x=>x.OriginalStreamId == _streamId).Count());
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_stream_forward_on_master()
+        {
+            
+            var readResult = ReplicationTestHelper.ReadStreamEventsForward(GetMaster(), _streamId);
+            Assert.AreEqual(1, readResult.Events.Count());
+            Assert.AreEqual(ReadStreamResult.Success, readResult.Result);
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_from_stream_backward_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadStreamEventsBackward(GetMaster(), _streamId);
+            Assert.AreEqual(ReadStreamResult.Success, readResult.Result);
+            Assert.AreEqual(1, readResult.Events.Count());
+        }
+
+        [Test]
+        public void should_be_able_to_read_event_on_master()
+        {
+            var readResult = ReplicationTestHelper.ReadEvent(GetMaster(), _streamId, 0);
+            Assert.AreEqual(ReadEventResult.Success, readResult.Result);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/ReplicationTestHelper.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReplicationTestHelper.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Threading;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services;
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Tests.Replication.ReadStream
+{
+    public static class ReplicationTestHelper
+    {
+        private static TimeSpan _timeout = TimeSpan.FromSeconds(8);
+
+        public static ClientMessage.WriteEventsCompleted WriteEvent(MiniClusterNode node, Event[] events, string streamId)
+        {
+            var resetEvent = new ManualResetEventSlim();
+            ClientMessage.WriteEventsCompleted writeResult = null;
+            node.Node.MainQueue.Publish(new ClientMessage.WriteEvents(Guid.NewGuid(), Guid.NewGuid(), 
+                                          new CallbackEnvelope(msg =>
+                                          {
+                                              writeResult = (ClientMessage.WriteEventsCompleted)msg;
+                                              resetEvent.Set();
+                                          }), false, streamId, -1, events, 
+                                          SystemAccount.Principal, SystemUsers.Admin, SystemUsers.DefaultAdminPassword));
+            if(!resetEvent.Wait(_timeout))
+            {
+                Assert.Fail("Timed out waiting for event to be written");
+                return null;
+            }
+            return writeResult;
+        }
+
+        public static ClientMessage.ReadAllEventsForwardCompleted ReadAllEventsForward(MiniClusterNode node, long position)
+        {
+            ClientMessage.ReadAllEventsForwardCompleted readResult = null;
+            var readEvent = new ManualResetEventSlim();
+            var done = false;
+            while(!done)
+            {
+                var read = new ClientMessage.ReadAllEventsForward(Guid.NewGuid(), Guid.NewGuid(), new CallbackEnvelope(msg =>
+                {
+                    readResult = (ClientMessage.ReadAllEventsForwardCompleted)msg;
+                    readEvent.Set();
+                }),
+                0, 0, 100, false, false, null, SystemAccount.Principal);
+                node.Node.MainQueue.Publish(read);
+
+                if(!readEvent.Wait(_timeout))
+                {
+                    Assert.Fail("Timed out waiting for events to be read forward");
+                    return null;
+                }
+                if(readResult.Result == ReadAllResult.Error)
+                {
+                    Assert.Fail("Failed to read forwards. Read result error: {0}", readResult.Error);
+                    return null;
+                }
+                done = readResult.NextPos.CommitPosition > position;
+                readEvent.Reset();
+            }
+            return readResult;
+        }
+
+        public static ClientMessage.ReadAllEventsBackwardCompleted ReadAllEventsBackward(MiniClusterNode node, long position)
+        {
+            ClientMessage.ReadAllEventsBackwardCompleted readResult = null;
+            var resetEvent = new ManualResetEventSlim();
+            var done = false;
+            while(!done)
+            {
+                resetEvent.Reset();
+                var read = new ClientMessage.ReadAllEventsBackward(Guid.NewGuid(), Guid.NewGuid(), new CallbackEnvelope(msg =>
+                {
+                    readResult = (ClientMessage.ReadAllEventsBackwardCompleted)msg;
+                    resetEvent.Set();
+                }),
+                -1, -1, 100, false, false, null, SystemAccount.Principal);
+                node.Node.MainQueue.Publish(read);
+
+                if(!resetEvent.Wait(_timeout))
+                {
+                    Assert.Fail("Timed out waiting for events to be read backward");
+                    return null;
+                }
+                if(readResult.Result == ReadAllResult.Error)
+                {
+                    Assert.Fail("Failed to read backwards. Read result error: {0}", readResult.Error);
+                    return null;
+                }
+                done = readResult.NextPos.CommitPosition < position;
+            }
+            return readResult;
+        }
+
+        public static ClientMessage.ReadStreamEventsForwardCompleted ReadStreamEventsForward(MiniClusterNode node, string streamId)
+        {
+            ClientMessage.ReadStreamEventsForwardCompleted readResult = null;
+            var resetEvent = new ManualResetEventSlim();
+            var read = new ClientMessage.ReadStreamEventsForward(Guid.NewGuid(), Guid.NewGuid(), new CallbackEnvelope(msg =>
+            {
+                readResult = (ClientMessage.ReadStreamEventsForwardCompleted)msg;
+                resetEvent.Set();
+            }), streamId, 0, 10,
+            false, false, null, SystemAccount.Principal);
+            node.Node.MainQueue.Publish(read);
+
+            if(!resetEvent.Wait(_timeout))
+            {
+                Assert.Fail("Timed out waiting for the stream to be read forward");
+                return null;
+            }
+            return readResult;
+        }
+
+        public static ClientMessage.ReadStreamEventsBackwardCompleted ReadStreamEventsBackward(MiniClusterNode node, string streamId)
+        {
+            ClientMessage.ReadStreamEventsBackwardCompleted readResult = null;
+            var resetEvent = new ManualResetEventSlim();
+            var read = new ClientMessage.ReadStreamEventsBackward(Guid.NewGuid(), Guid.NewGuid(), new CallbackEnvelope(msg =>
+            {
+                readResult = (ClientMessage.ReadStreamEventsBackwardCompleted)msg;
+                resetEvent.Set();
+            }), streamId, 9, 10,
+            false, false, null, SystemAccount.Principal);
+            node.Node.MainQueue.Publish(read);
+
+            if(!resetEvent.Wait(_timeout))
+            {
+                Assert.Fail("Timed out waiting for the stream to be read backward");
+                return null;
+            }
+            return readResult;
+        }
+
+        public static ClientMessage.ReadEventCompleted ReadEvent(MiniClusterNode node, string streamId, long eventNumber)
+        {
+            ClientMessage.ReadEventCompleted readResult = null;
+            var resetEvent = new ManualResetEventSlim();
+            var read = new ClientMessage.ReadEvent(Guid.NewGuid(), Guid.NewGuid(), new CallbackEnvelope(msg =>
+            {
+                readResult = (ClientMessage.ReadEventCompleted)msg;
+                resetEvent.Set();
+            }), streamId, eventNumber,
+            false, false, SystemAccount.Principal);
+            node.Node.MainQueue.Publish(read);
+
+            if(!resetEvent.Wait(_timeout))
+            {
+                Assert.Fail("Timed out waiting for the event to be read");
+                return null;
+            }
+            return readResult;
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/Subscriptions/TestSubscription.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/Subscriptions/TestSubscription.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Collections.Generic;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.UserManagement;
+
+namespace EventStore.Core.Tests.Replication.ReadStream
+{
+    public class TestSubscription
+    {
+        public MiniClusterNode Node;
+        public CountdownEvent SubscriptionsConfirmed;
+        public CountdownEvent EventAppeared;
+        public List<ClientMessage.StreamEventAppeared> StreamEvents;
+        public string StreamId;
+
+        public TestSubscription(MiniClusterNode node, int expectedEvents, string streamId, CountdownEvent subscriptionsConfirmed)
+        {
+            Node = node;
+            SubscriptionsConfirmed = subscriptionsConfirmed;
+            EventAppeared = new CountdownEvent(expectedEvents);
+            StreamId = streamId;
+        }
+
+        public void CreateSubscription()
+        {
+            var subscribeMsg = new ClientMessage.SubscribeToStream(Guid.NewGuid(), Guid.NewGuid(),
+                new CallbackEnvelope(x => 
+                {
+                    switch(x.GetType().Name)
+                    {
+                        case "SubscriptionConfirmation":
+                            SubscriptionsConfirmed.Signal();
+                            break;
+                        case "StreamEventAppeared":
+                            EventAppeared.Signal();
+                            break;
+                        case "SubscriptionDropped":
+                            break;
+                        default :
+                            Assert.Fail("Unexpected message type :" + x.GetType().Name);
+                            break;
+                    }
+                }), Guid.NewGuid(), StreamId, false, SystemAccount.Principal);
+            Node.Node.MainQueue.Publish(subscribeMsg);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Replication/Subscriptions/when_subscribed_to_stream_on_master_and_event_is_replicated_to_slaves.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/Subscriptions/when_subscribed_to_stream_on_master_and_event_is_replicated_to_slaves.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Collections.Generic;
+using EventStore.Core.Bus;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+using EventStore.Core.Tests.Integration;
+using EventStore.Core.Messages;
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Tests.Replication.ReadStream
+{
+    [TestFixture, Category("LongRunning")]
+    public class when_subscribed_to_stream_on_master_and_event_is_replicated_to_slaves : specification_with_cluster
+    {
+        private const string _streamId = "test-stream";
+        private CountdownEvent _expectedNumberOfRoleAssignments;
+        private CountdownEvent _subscriptionsConfirmed;
+        private TestSubscription _masterSubscription;
+        private List<TestSubscription> _slaveSubscriptions;
+
+        private TimeSpan _timeout = TimeSpan.FromSeconds(5);
+
+        protected override void BeforeNodesStart()
+        {
+            _nodes.ToList().ForEach(x =>
+                x.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.StateChangeMessage>(Handle)));
+            _expectedNumberOfRoleAssignments = new CountdownEvent(3);
+            base.BeforeNodesStart();
+        }
+
+        private void Handle(SystemMessage.StateChangeMessage msg)
+        {
+            switch (msg.State)
+            {
+                case Data.VNodeState.Master:
+                    _expectedNumberOfRoleAssignments.Signal();
+                    break;
+                case Data.VNodeState.Slave:
+                    _expectedNumberOfRoleAssignments.Signal();
+                    break;
+            }
+        }
+
+        protected override void Given()
+        {
+            _expectedNumberOfRoleAssignments.Wait(5000);
+
+            var master = GetMaster();
+            Assert.IsNotNull(master, "Could not get master node");
+            
+            // Set the checkpoint so the check is not skipped
+            master.Db.Config.ReplicationCheckpoint.Write(0);
+
+            _subscriptionsConfirmed = new CountdownEvent(3);
+            _masterSubscription = new TestSubscription(master, 1, _streamId, _subscriptionsConfirmed);
+            _masterSubscription.CreateSubscription();
+
+            _slaveSubscriptions = new List<TestSubscription>();
+            var slaves = GetSlaves();
+            foreach(var s in slaves)
+            {
+                var slaveSubscription = new TestSubscription(s, 1, _streamId, _subscriptionsConfirmed);
+                _slaveSubscriptions.Add(slaveSubscription);
+                slaveSubscription.CreateSubscription();
+            }
+
+            if(!_subscriptionsConfirmed.Wait(_timeout))
+            {
+                Assert.Fail("Timed out waiting for subscriptions to confirm");
+            }
+
+            var events = new Event[]{new Event(Guid.NewGuid(), "test-type", false, new byte[10], new byte[0]) };
+            var writeResult = ReplicationTestHelper.WriteEvent(master, events, _streamId);
+            Assert.AreEqual(OperationResult.Success, writeResult.Result);
+
+            base.Given();
+        }
+
+        [Test]
+        public void should_receive_event_on_master()
+        {
+            Assert.IsTrue(_masterSubscription.EventAppeared.Wait(2000));
+        }
+
+        [Test]
+        public void should_receive_event_on_slaves()
+        {
+            if(!(_slaveSubscriptions[0].EventAppeared.Wait(2000) && _slaveSubscriptions[1].EventAppeared.Wait(2000)))
+            {
+                Assert.Fail("Timed out waiting for slave subscriptions to get events");
+            } 
+            else
+            {
+                Assert.Pass();
+            }
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_replication_checkpoint_set.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_replication_checkpoint_set.cs
@@ -1,0 +1,89 @@
+using System;
+using NUnit.Framework;
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Tests.Services.Storage.AllReader
+{
+    [TestFixture]
+    public class when_reading_all_with_replication_checkpoint_set 
+        : ReadIndexTestScenario
+    {
+        long _commitPosition;
+
+        protected override void WriteTestScenario()
+        {
+            var res = WritePrepare("ES1", 0, Guid.NewGuid(), "event-type", new string('.', 3000));
+            WriteCommit(res.LogPosition, "ES1", 0);
+
+            res = WritePrepare("ES2", 0, Guid.NewGuid(), "event-type", new string('.', 3000));
+            var commit = WriteCommit(res.LogPosition, "ES2", 0);
+            _commitPosition = commit.LogPosition;
+
+            res = WritePrepare("ES2", 1, Guid.NewGuid(), "event-type", new string('.', 3000));
+            WriteCommit(res.LogPosition, "ES2", 1);
+
+            ReplicationCheckpoint.Write(_commitPosition);
+        }
+
+        [Test]
+        public void should_be_able_to_read_replicated_stream_backwards()
+        {
+            var result = ReadIndex.ReadStreamEventsBackward("ES1", 9, 10);
+            Assert.AreEqual(1, result.Records.Length);
+        }
+
+        [Test]
+        public void should_be_able_to_read_replicated_stream_forwards()
+        {
+            var result = ReadIndex.ReadStreamEventsForward("ES1", 0, 10);
+            Assert.AreEqual(1, result.Records.Length);
+        }
+
+        [Test]
+        public void should_be_able_to_read_events_before_replication_checkpoint_backwards()
+        {
+            var result = ReadIndex.ReadStreamEventsBackward("ES2", 9, 10);
+            Assert.AreEqual(1, result.Records.Length);
+            Assert.AreEqual(0, result.Records[0].EventNumber);
+        }
+        
+        [Test]
+        public void should_be_able_to_read_events_before_replication_checkpoint_forward()
+        {
+            var result = ReadIndex.ReadStreamEventsForward("ES2", 0, 10);
+            Assert.AreEqual(1, result.Records.Length);
+            Assert.AreEqual(0, result.Records[0].EventNumber);
+        }
+
+        [Test]
+        public void should_be_able_to_read_single_event_before_replication_checkpoint()
+        {
+            var result = ReadIndex.ReadEvent("ES2", 0);
+            Assert.AreEqual(ReadEventResult.Success, result.Result);
+        }
+
+        [Test]
+        public void should_not_be_able_to_read_single_event_after_replication_checkpoint()
+        {
+            var result = ReadIndex.ReadEvent("ES2", 1);
+            Assert.AreEqual(ReadEventResult.NotFound, result.Result);
+        }
+
+
+        [Test]
+        public void should_be_able_to_read_all_backwards_and_get_events_before_replication_checkpoint()
+        {
+            var checkpoint = WriterCheckpoint.Read();
+            var pos = new TFPos(checkpoint, checkpoint);
+            var result = ReadIndex.ReadAllEventsBackward(pos, 10);
+            Assert.AreEqual(2, result.Records.Count);
+        }
+
+        [Test]
+        public void should_be_able_to_read_all_forwards_and_get_events_before_replication_checkpoint()
+        {
+            var result = ReadIndex.ReadAllEventsForward(new TFPos(0,0), 10);
+            Assert.AreEqual(2, result.Records.Count);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Helpers;
 using EventStore.Core.Index;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -104,14 +105,7 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex
             var bus = new InMemoryBus("bus");
             new IODispatcher(bus, new PublishEnvelope(bus));
 
-            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                   new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                   10000,
-                                                   0,
-                                                   writerCheckpoint,
-                                                   chaserCheckpoint,
-                                                   new InMemoryCheckpoint(-1),
-                                                   new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerCheckpoint, chaserCheckpoint));
 
             _db.Open();
             // create db

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -141,7 +141,8 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex
                                       additionalCommitChecks: PerformAdditionalCommitChecks,
                                       metastreamMaxCount: MetastreamMaxCount,
                                       hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
-                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault);
+                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
+                                      replicationCheckpoint: _db.Config.ReplicationCheckpoint);
 
 
             ReadIndex.Init(chaserCheckpoint.Read());
@@ -171,7 +172,8 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex
                                       additionalCommitChecks: PerformAdditionalCommitChecks,
                                       metastreamMaxCount: MetastreamMaxCount,
                                       hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
-                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault);
+                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
+                                      replicationCheckpoint: _db.Config.ReplicationCheckpoint);
 
             ReadIndex.Init(chaserCheckpoint.Read());
         }

--- a/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
 using EventStore.Core.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services.Storage.ReaderIndex;
 
@@ -40,7 +41,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions
                                          maxSizeForMemory: _maxMemTableSize,
                                          maxTablesPerLevel: 2);
             _tableIndex.Initialize(long.MaxValue);
-            _indexReader = new IndexReader(_indexBackend, _tableIndex, new EventStore.Core.Data.StreamMetadata(), _hashCollisionReadLimit, skipIndexScanOnRead: false);
+            _indexReader = new IndexReader(_indexBackend, _tableIndex, new EventStore.Core.Data.StreamMetadata(), _hashCollisionReadLimit, false, new InMemoryCheckpoint(-1));
 
             when();
             //wait for the mem table to be dumped
@@ -211,7 +212,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions
                                          maxSizeForMemory: _maxMemTableSize,
                                          maxTablesPerLevel: 2);
             _tableIndex.Initialize(long.MaxValue);
-            _indexReader = new IndexReader(_indexBackend, _tableIndex, new EventStore.Core.Data.StreamMetadata(), _hashCollisionReadLimit, skipIndexScanOnRead: false);
+            _indexReader = new IndexReader(_indexBackend, _tableIndex, new EventStore.Core.Data.StreamMetadata(), _hashCollisionReadLimit, false, new InMemoryCheckpoint(-1));
             //memtable with 64bit indexes
             _tableIndex.Add(1, streamId, 0, 8);
         }

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Services;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -4,6 +4,7 @@ using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -46,15 +47,7 @@ namespace EventStore.Core.Tests.Services.Storage
                 DbRes.Db.Close();
             }
 
-            var dbConfig = new TFChunkDbConfig(PathName,
-                                   new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                   1024 * 1024,
-                                   0,
-                                   new InMemoryCheckpoint(0),
-                                   new InMemoryCheckpoint(0),
-                                   new InMemoryCheckpoint(-1),
-                                   new InMemoryCheckpoint(-1),
-                                   inMemDb: true);
+            var dbConfig = TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 1024 * 1024);
             var dbHelper = new TFChunkDbCreationHelper(dbConfig);
 
             DbRes = dbHelper.Chunk(records).CreateDb();

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -81,7 +81,8 @@ namespace EventStore.Core.Tests.Services.Storage
                                       additionalCommitChecks: true,
                                       metastreamMaxCount: _metastreamMaxCount,
                                       hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
-                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault);
+                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
+                                      replicationCheckpoint: DbRes.Db.Config.ReplicationCheckpoint);
 
             ReadIndex.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
         }

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -4,6 +4,7 @@ using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -38,14 +39,7 @@ namespace EventStore.Core.Tests.Services.Storage
         {
             base.TestFixtureSetUp();
 
-            var dbConfig = new TFChunkDbConfig(PathName,
-                                               new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                               1024*1024,
-                                               0,
-                                               new InMemoryCheckpoint(0),
-                                               new InMemoryCheckpoint(0),
-                                               new InMemoryCheckpoint(-1),
-                                               new InMemoryCheckpoint(-1));
+            var dbConfig = TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 1024 * 1024);
             var dbCreationHelper = new TFChunkDbCreationHelper(dbConfig);
             
             DbRes = CreateDb(dbCreationHelper);

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -72,7 +72,8 @@ namespace EventStore.Core.Tests.Services.Storage
                                       additionalCommitChecks: true,
                                       metastreamMaxCount: _metastreamMaxCount,
                                       hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
-                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault);
+                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
+                                      replicationCheckpoint: DbRes.Db.Config.ReplicationCheckpoint);
 
             ReadIndex.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
         }

--- a/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
@@ -47,7 +47,8 @@ namespace EventStore.Core.Tests.Services.Storage.Transactions
                                       additionalCommitChecks: true, 
                                       metastreamMaxCount: 1,
                                       hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
-                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault);
+                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
+                                      replicationCheckpoint: Db.Config.ReplicationCheckpoint);
             ReadIndex.Init(ChaserCheckpoint.Read());
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -10,6 +10,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Settings;
 using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -44,14 +45,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
         {
             base.TestFixtureSetUp();
 
-            var dbConfig = new TFChunkDbConfig(PathName,
-                                               new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                               1024*1024,
-                                               0,
-                                               new InMemoryCheckpoint(0),
-                                               new InMemoryCheckpoint(0),
-                                               new InMemoryCheckpoint(-1),
-                                               new InMemoryCheckpoint(-1));
+            var dbConfig = TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 1024 * 1024);
             var dbCreationHelper = new TFChunkDbCreationHelper(dbConfig);
             _dbResult = CreateDb(dbCreationHelper);
             _keptRecords = KeptRecords(_dbResult);

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -72,7 +72,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
                                             PTableVersions.IndexV3,
                                             maxSizeForMemory: 100,
                                             maxTablesPerLevel: 2);
-            ReadIndex = new ReadIndex(new NoopPublisher(), readerPool, tableIndex, 100, true, _metastreamMaxCount, Opts.HashCollisionReadLimitDefault, Opts.SkipIndexScanOnReadsDefault);
+            ReadIndex = new ReadIndex(new NoopPublisher(), readerPool, tableIndex, 100, true, _metastreamMaxCount, Opts.HashCollisionReadLimitDefault, Opts.SkipIndexScanOnReadsDefault, _dbResult.Db.Config.ReplicationCheckpoint);
             ReadIndex.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 
             //var scavengeReadIndex = new ScavengeReadIndex(_dbResult.Streams, _metastreamMaxCount);

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkDbConfigHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkDbConfigHelper.cs
@@ -1,0 +1,37 @@
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+
+namespace EventStore.Core.Tests.TransactionLog
+{
+    public static class TFChunkDbConfigHelper
+    {
+        public static TFChunkDbConfig Create(string pathName, long writerCheckpointPosition, long chaserCheckpointPosition = 0,
+            long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000)
+        {
+            return new TFChunkDbConfig(pathName,
+                                             new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
+                                             chunkSize,
+                                             0,
+                                             new InMemoryCheckpoint(writerCheckpointPosition),
+                                             new InMemoryCheckpoint(chaserCheckpointPosition),
+                                             new InMemoryCheckpoint(epochCheckpointPosition),
+                                             new InMemoryCheckpoint(truncateCheckpoint),
+                                             new InMemoryCheckpoint(-1));
+        }
+
+        public static TFChunkDbConfig Create(string pathName, ICheckpoint writerCheckpoint, ICheckpoint chaserCheckpoint, int chunkSize = 10000, ICheckpoint replicationCheckpoint = null)
+        {
+            if(replicationCheckpoint == null) replicationCheckpoint = new InMemoryCheckpoint(-1);
+            return new TFChunkDbConfig(pathName,
+                                             new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
+                                             chunkSize,
+                                             0,
+                                             writerCheckpoint,
+                                             chaserCheckpoint,
+                                             new InMemoryCheckpoint(-1),
+                                             new InMemoryCheckpoint(-1),
+                                             replicationCheckpoint);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -4,6 +4,7 @@ using EventStore.Core.Index;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Services.Storage;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -29,14 +30,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
         private void ReOpenDb()
         {
-            Db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                   new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                   10000,
-                                                   0,
-                                                   WriterCheckpoint,
-                                                   ChaserCheckpoint,
-                                                   new InMemoryCheckpoint(-1),
-                                                   new InMemoryCheckpoint(-1)));
+            Db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, WriterCheckpoint, ChaserCheckpoint));
 
             Db.Open();
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -55,7 +55,8 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
                                       additionalCommitChecks: true,
                                       metastreamMaxCount: MetastreamMaxCount,
                                       hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
-                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault);
+                                      skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
+                                      replicationCheckpoint: Db.Config.ReplicationCheckpoint);
             ReadIndex.Init(ChaserCheckpoint.Read());
         }
     }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -21,14 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = new TFChunkDbConfig(PathName,
-                                          new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                          1000,
-                                          0,
-                                          new InMemoryCheckpoint(1711),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(1111));
+            _config = TFChunkDbConfigHelper.Create(PathName, 1711, 5500, 5500, 1111, 1000);
 
             var rnd = new Random();
             _file1Contents = new byte[_config.ChunkSize];

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -17,14 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = new TFChunkDbConfig(PathName,
-                                          new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                          1000,
-                                          0,
-                                          new InMemoryCheckpoint(11111),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(5757));
+            _config = TFChunkDbConfigHelper.Create(PathName, 11111, 5500, 5500, 5757, 1000);
 
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -21,14 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = new TFChunkDbConfig(PathName,
-                                          new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                          1000,
-                                          0,
-                                          new InMemoryCheckpoint(1711),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(1111));
+            _config = TFChunkDbConfigHelper.Create(PathName, 1711, 5500, 5500, 1111, 1000);
 
             var rnd = new Random();
             _file1Contents = new byte[_config.ChunkSize];

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -17,14 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = new TFChunkDbConfig(PathName,
-                                          new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                          1000,
-                                          0,
-                                          new InMemoryCheckpoint(13500),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(11000));
+            _config = TFChunkDbConfigHelper.Create(PathName, 13500, 5500, 5500, 11000, 1000);
 
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.Tests.TransactionLog.Validation;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -17,14 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = new TFChunkDbConfig(PathName,
-                                          new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                          1000,
-                                          0,
-                                          new InMemoryCheckpoint(11111),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(5500),
-                                          new InMemoryCheckpoint(0));
+            _config = TFChunkDbConfigHelper.Create(PathName, 11111, 5500, 5500, 0, 1000);
 
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
@@ -13,14 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_file_of_wrong_size_database_corruption_is_detected()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(500),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 500);
             using (var db = new TFChunkDb(config))
             {
                 File.WriteAllText(GetFilePathFor("chunk-000000.000000"), "this is just some test blahbydy blah");
@@ -33,14 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_not_enough_files_to_reach_checksum_throws()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(15000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 15000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -53,14 +39,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_with_exactly_enough_file_to_reach_checksum()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(10000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -71,14 +50,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void does_not_allow_not_completed_not_last_chunks()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"), 
-                                             1000,
-                                             0,
-                                             new InMemoryCheckpoint(4000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 4000, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -94,14 +66,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_next_new_chunk_when_checksum_is_exactly_in_between_two_chunks()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(10000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -113,14 +78,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Due to truncation such situation can happen, so must be considered valid.")]
         public void does_not_allow_next_new_completed_chunk_when_checksum_is_exactly_in_between_two_chunks()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(10000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -134,14 +92,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_last_chunk_to_be_not_completed_when_checksum_is_exactly_in_between_two_chunks_and_no_next_chunk_exists()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(10000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -152,14 +103,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void does_not_allow_pre_last_chunk_to_be_not_completed_when_checksum_is_exactly_in_between_two_chunks_and_next_chunk_exists()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(10000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -173,14 +117,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Not valid test now after disabling size validation on ongoing TFChunk ")]
         public void with_wrong_size_file_less_than_checksum_throws()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(15000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 15000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -194,14 +131,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_in_first_extraneous_files_throws_corrupt_database_exception()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(9000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 9000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -215,15 +145,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_in_multiple_extraneous_files_throws_corrupt_database_exception()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(15000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
-
+            var config = TFChunkDbConfigHelper.Create(PathName, 15000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -238,14 +160,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_in_brand_new_extraneous_files_throws_corrupt_database_exception()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(0),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 0);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 4, GetFilePathFor("chunk-000004.000000"));
@@ -258,14 +173,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_a_chaser_checksum_is_ahead_of_writer_checksum_throws_corrupt_database_exception()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(0),
-                                             new InMemoryCheckpoint(11),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 0, 11);
             using (var db = new TFChunkDb(config))
             {
                 Assert.That(() => db.Open(verifyHash: false),
@@ -277,14 +185,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_an_epoch_checksum_is_ahead_of_writer_checksum_throws_corrupt_database_exception()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(0),
-                                             new InMemoryCheckpoint(0),
-                                             new InMemoryCheckpoint(11),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 0, 0, 11);
             using (var db = new TFChunkDb(config))
             {
                 Assert.That(() => db.Open(verifyHash: false),
@@ -296,14 +197,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_no_files_when_checkpoint_is_zero()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 0);
             using (var db = new TFChunkDb(config))
             {
                 Assert.DoesNotThrow(() => db.Open(verifyHash: false));
@@ -314,14 +208,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_first_correct_ongoing_chunk_when_checkpoint_is_zero()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 0);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -332,14 +219,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Due to truncation such situation can happen, so must be considered valid.")]
         public void does_not_allow_first_completed_chunk_when_checkpoint_is_zero()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 0);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -352,14 +232,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_checkpoint_to_point_into_the_middle_of_completed_chunk_when_enough_actual_data_in_chunk()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             1000,
-                                             0,
-                                             new InMemoryCheckpoint(1500),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 1500, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -376,14 +249,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("We do not check this as it is too erroneous to read ChunkFooter from ongoing chunk...")]
         public void does_not_allow_checkpoint_to_point_into_the_middle_of_completed_chunk_when_not_enough_actual_data()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             1000,
-                                             0,
-                                             new InMemoryCheckpoint(1500),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 1500);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -398,14 +264,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void does_not_allow_checkpoint_to_point_into_the_middle_of_scavenged_chunk()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             1000,
-                                             0,
-                                             new InMemoryCheckpoint(1500),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 1500, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -423,14 +282,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
             File.Create(GetFilePathFor("foo")).Close();
             File.Create(GetFilePathFor("bla")).Close();
 
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(350),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 350, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -457,14 +309,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_on_boundary_of_chunk_last_chunk_is_preserved()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(200),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -483,14 +328,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_on_boundary_of_new_chunk_last_chunk_is_preserved_and_excessive_versions_are_removed_if_present()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(200),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -510,14 +348,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_not_present_but_should_be_created()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(200),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -536,14 +367,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_present()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(200),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -563,14 +387,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_no_exception_is_thrown()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(200),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -589,14 +406,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Not valid test now after disabling size validation on ongoing TFChunk ")]
         public void when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_but_not_completed_exception_is_thrown()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(200),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -611,14 +421,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void temporary_files_are_removed()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(150),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 150, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db_with_multi_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db_with_multi_chunks.cs
@@ -13,14 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_not_enough_files_to_reach_checksum_throws()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(25000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 25000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
@@ -33,14 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_checksum_inside_multi_chunk_throws()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(25000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 25000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 2, GetFilePathFor("chunk-000000.000000"));
@@ -53,14 +39,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_with_exactly_enough_file_to_reach_checksum_while_last_is_multi_chunk()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(30000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 30000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -77,14 +56,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_next_new_chunk_when_checksum_is_exactly_in_between_two_chunks_if_last_is_ongoing_chunk()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(20000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 20000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
@@ -100,14 +72,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Due to truncation such situation can happen, so must be considered valid.")]
         public void does_not_allow_next_new_chunk_when_checksum_is_exactly_in_between_two_chunks_and_last_is_multi_chunk()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(10000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -125,14 +90,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
             File.Create(GetFilePathFor("foo")).Close();
             File.Create(GetFilePathFor("bla")).Close();
 
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(350),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 350, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -158,14 +116,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_not_present_but_should_be_created()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(200),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
@@ -182,14 +133,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_present()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(200),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
@@ -207,14 +151,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_no_exception_is_thrown()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             100,
-                                             0,
-                                             new InMemoryCheckpoint(300),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 300, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -233,14 +170,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void does_not_allow_checkpoint_to_point_into_the_middle_of_multichunk_chunk()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             1000,
-                                             0,
-                                             new InMemoryCheckpoint(1500),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 1500, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -255,14 +185,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_last_chunk_to_be_multichunk_when_checkpoint_point_at_the_start_of_next_chunk()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             1000,
-                                             0,
-                                             new InMemoryCheckpoint(4000),
-                                             new InMemoryCheckpoint(),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 4000, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunkdb_without_previous_files.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunkdb_without_previous_files.cs
@@ -1,4 +1,5 @@
 using EventStore.Core.Exceptions;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
@@ -12,14 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_a_writer_checksum_of_nonzero_and_no_files_a_corrupted_database_exception_is_thrown()
         {
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       new InMemoryCheckpoint(500),
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 500));
             var exc = Assert.Throws<CorruptDatabaseException>(() => db.Open());
             Assert.IsInstanceOf<ChunkNotFoundException>(exc.InnerException);
             db.Dispose();
@@ -28,14 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_a_writer_checksum_of_zero_and_no_files_is_valid()
         {
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       new InMemoryCheckpoint(0),
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0));
             Assert.DoesNotThrow(() => db.Open());
             db.Dispose();
         }

--- a/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
@@ -19,14 +19,8 @@ namespace EventStore.Core.Tests.TransactionLog
         public void try_read_returns_false_when_writer_checkpoint_is_zero()
         {
             var writerchk = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       writerchk,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var chaserchk = new InMemoryCheckpoint();
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
             db.Open();
 
             var chaser = new TFChunkChaser(db, writerchk, new InMemoryCheckpoint());
@@ -44,14 +38,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             var writerchk = new InMemoryCheckpoint();
             var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       writerchk,
-                                                       chaserchk,
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
             db.Open();
             writerchk.Write(12);
             writerchk.Flush();
@@ -97,14 +84,7 @@ namespace EventStore.Core.Tests.TransactionLog
             
             var writerchk = new InMemoryCheckpoint(128);
             var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       writerchk,
-                                                       chaserchk,
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
             db.Open();
 
             var chaser = new TFChunkChaser(db, writerchk, chaserchk);
@@ -128,14 +108,7 @@ namespace EventStore.Core.Tests.TransactionLog
             var writerchk = new InMemoryCheckpoint(0);
             var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
             
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       writerchk,
-                                                       chaserchk,
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
             db.Open();
 
             var recordToWrite = new PrepareLogRecord(logPosition: 0,
@@ -177,14 +150,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             var writerchk = new InMemoryCheckpoint(0);
             var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       writerchk,
-                                                       chaserchk,
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
             db.Open();
 
             var recordToWrite = new PrepareLogRecord(logPosition: 0,

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_chaser.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_chaser.cs
@@ -21,28 +21,14 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_null_writer_checksum_throws_argument_null_exception()
         {
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0));
             Assert.Throws<ArgumentNullException>(() => new TFChunkChaser(db, null, new InMemoryCheckpoint()));
         }
 
         [Test]
         public void a_null_chaser_checksum_throws_argument_null_exception()
         {
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0));
             Assert.Throws<ArgumentNullException>(() => new TFChunkChaser(db, new InMemoryCheckpoint(), null));
         }
     }

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_file_reader.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_file_reader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -20,14 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_null_checkpoint_throws_argument_null_exception()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(0),
-                                             new InMemoryCheckpoint(0),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 0);
             var db = new TFChunkDb(config);
             Assert.Throws<ArgumentNullException>(() => new TFChunkReader(db, null));
         }

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Index.Hashes;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Services.Storage;
 using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -31,14 +32,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
 
-            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                    new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                    16 * 1024,
-                                                    0,
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 16 * 1024));
             _db.Open();
 
             var chunk = _db.Manager.GetChunkFor(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_chunked_transaction_file_db_without_previous_files.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_chunked_transaction_file_db_without_previous_files.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -13,14 +14,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void with_a_writer_checksum_of_zero_the_first_chunk_is_created_with_correct_name_and_is_aligned()
         {
-            var config = new TFChunkDbConfig(PathName,
-                                             new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                             10000,
-                                             0,
-                                             new InMemoryCheckpoint(0),
-                                             new InMemoryCheckpoint(0),
-                                             new InMemoryCheckpoint(-1),
-                                             new InMemoryCheckpoint(-1));
+            var config = TFChunkDbConfigHelper.Create(PathName, 0);
             var db = new TFChunkDb(config);
             db.Open();
             db.Dispose();

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
@@ -1,0 +1,108 @@
+using System;
+using EventStore.Core.Data;
+using EventStore.Core.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog
+{
+    [TestFixture]
+    public class when_reading_a_single_record : SpecificationWithDirectoryPerTestFixture
+    {
+        private const int RecordsCount = 8;
+
+        private TFChunkDb _db;
+        private LogRecord[] _records;
+        private RecordWriteResult[] _results;
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
+                                                    new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
+                                                    4096,
+                                                    0,
+                                                    new InMemoryCheckpoint(),
+                                                    new InMemoryCheckpoint(),
+                                                    new InMemoryCheckpoint(-1),
+                                                    new InMemoryCheckpoint(-1),
+                                                    new InMemoryCheckpoint(-1)));
+            _db.Open();
+
+            var chunk = _db.Manager.GetChunk(0);
+
+            _records = new LogRecord[RecordsCount];
+            _results = new RecordWriteResult[RecordsCount];
+
+            var pos = 0;
+            for (int i = 0; i < RecordsCount; ++i)
+            {
+                if (i > 0 && i % 3 == 0)
+                {
+                    pos = i/3 * _db.Config.ChunkSize;
+                    chunk.Complete();
+                    chunk = _db.Manager.AddNewChunk();
+                }
+
+                _records[i] = LogRecord.SingleWrite(pos,
+                                                    Guid.NewGuid(), Guid.NewGuid(), "es1", ExpectedVersion.Any, "et1",
+                                                    new byte[1200], new byte[] { 5, 7 });
+                _results[i] = chunk.TryAppend(_records[i]);
+
+                pos += _records[i].GetSizeWithLengthPrefixAndSuffix();
+            }
+
+            chunk.Flush();
+            _db.Config.WriterCheckpoint.Write((RecordsCount / 3) * _db.Config.ChunkSize + _results[RecordsCount - 1].NewPosition);
+            _db.Config.WriterCheckpoint.Flush();
+        }
+
+        public override void TestFixtureTearDown()
+        {
+            _db.Dispose();
+
+            base.TestFixtureTearDown();
+        }
+
+        private TFChunkReader GetTFChunkReader(long from)
+        {
+            return new TFChunkReader(_db, _db.Config.WriterCheckpoint, from);
+        }
+
+        [Test]
+        public void all_records_were_written()
+        {
+            var pos = 0;
+            for (int i = 0; i < RecordsCount; ++i)
+            {
+                if (i % 3 == 0)
+                    pos = 0;
+
+                Assert.IsTrue(_results[i].Success);
+                Assert.AreEqual(pos, _results[i].OldPosition);
+
+                pos += _records[i].GetSizeWithLengthPrefixAndSuffix();
+                Assert.AreEqual(pos, _results[i].NewPosition);
+            }
+        }
+
+        [Test]
+        public void all_records_can_be_read()
+        {
+            var reader = GetTFChunkReader(0);
+
+            RecordReadResult res;
+            for(var i = 0; i < RecordsCount; i++)
+            {
+                var rec = _records[i];
+                res = reader.TryReadAt(rec.LogPosition);
+
+                Assert.IsTrue(res.Success);
+                Assert.AreEqual(rec, res.LogRecord);
+            }
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
@@ -1,9 +1,8 @@
 using System;
 using EventStore.Core.Data;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
-using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
 
@@ -21,15 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void TestFixtureSetUp()
         {
             base.TestFixtureSetUp();
-            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                    new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                    4096,
-                                                    0,
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0));
             _db.Open();
 
             var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_an_empty_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_an_empty_chunked_transaction_log.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -15,14 +16,8 @@ namespace EventStore.Core.Tests.TransactionLog
         public void try_read_returns_false_when_writer_checksum_is_zero()
         {
             var writerchk = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       writerchk,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var chaserchk = new InMemoryCheckpoint(0);
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
             db.Open();
 
             var reader = new TFChunkReader(db, writerchk, 0);
@@ -35,14 +30,8 @@ namespace EventStore.Core.Tests.TransactionLog
         public void try_read_does_not_cache_anything_and_returns_record_once_it_is_written_later()
         {
             var writerchk = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       writerchk,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var chaserchk = new InMemoryCheckpoint(0);
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
             db.Open();
 
             var writer = new TFChunkWriter(db);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Core.Data;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -22,14 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
 
-            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                    new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                    4096,
-                                                    0,
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 4096));
             _db.Open();
 
             var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Core.Data;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -22,14 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
 
-            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                    new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                    4096,
-                                                    0,
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 4096));
             _db.Open();
             
             var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Core.Data;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -23,17 +24,8 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
 
-            _db =
-                new TFChunkDb(
-                    new TFChunkDbConfig(
-                        PathName,
-                        new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                        4096,
-                        0,
-                        new InMemoryCheckpoint(),
-                        new InMemoryCheckpoint(),
-                        new InMemoryCheckpoint(-1),
-                        new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(
+                    TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 4096));
             _db.Open();
 
             var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_a_new_chunked_transaction_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_a_new_chunked_transaction_file.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
@@ -19,14 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public void a_record_can_be_written()
         {
             _checkpoint = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       1000,
-                                                       0,
-                                                       _checkpoint,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _checkpoint, new InMemoryCheckpoint()));
             db.Open();
             var tf = new TFChunkWriter(db);
             tf.Open();

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -27,14 +28,7 @@ namespace EventStore.Core.Tests.TransactionLog
             File.WriteAllBytes(filename, bytes);
 
             _checkpoint = new InMemoryCheckpoint(137);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       _checkpoint,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _checkpoint, new InMemoryCheckpoint()));
             db.Open();
             var tf = new TFChunkWriter(db);
             var record = new PrepareLogRecord(logPosition: _checkpoint.Read(),

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum_and_data_bigger_than_buffer.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum_and_data_bigger_than_buffer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -27,14 +28,7 @@ namespace EventStore.Core.Tests.TransactionLog
             File.WriteAllBytes(filename, buf);
 
             _checkpoint = new InMemoryCheckpoint(137);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       chunkHeader.ChunkSize,
-                                                       0,
-                                                       _checkpoint,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _checkpoint, new InMemoryCheckpoint(), chunkSize: chunkHeader.ChunkSize));
             db.Open();
 
             var bytes = new byte[3994]; // this gives exactly 4097 size of record, with 3993 (rec size 4096) everything works fine!

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_not_enough_space_in_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_not_enough_space_in_chunk.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -29,14 +30,7 @@ namespace EventStore.Core.Tests.TransactionLog
             File.WriteAllBytes(filename1, bytes);
 
             _checkpoint = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                       new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                       10000,
-                                                       0,
-                                                       _checkpoint,
-                                                       new InMemoryCheckpoint(),
-                                                       new InMemoryCheckpoint(-1),
-                                                       new InMemoryCheckpoint(-1)));
+            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _checkpoint, new InMemoryCheckpoint()));
             db.Open();
             var tf = new TFChunkWriter(db);
             long pos;

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -21,14 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public void SetUp()
         {
             _writerCheckpoint = new InMemoryCheckpoint();
-            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                    new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                    1024,
-                                                    0,
-                                                    _writerCheckpoint,
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _writerCheckpoint, new InMemoryCheckpoint(), 1024));
             _db.Open();
             _writer = new TFChunkWriter(_db);
             _writer.Open();

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -22,14 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public void SetUp()
         {
             _writerCheckpoint = new InMemoryCheckpoint();
-            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                    new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                    1024,
-                                                    0,
-                                                    _writerCheckpoint,
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _writerCheckpoint, new InMemoryCheckpoint(), 1024));
             _db.Open();
             _writer = new TFChunkWriter(_db);
             _writer.Open();

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -427,6 +427,7 @@
     <Compile Include="VNodeBuilder.cs" />
     <Compile Include="Index\IndexEntryV2.cs" />
     <Compile Include="Helpers\StreamVersionConverter.cs" />
+    <Compile Include="Services\Replication\ReplicationCheckpointFilter.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj">

--- a/src/EventStore.Core/Messages/ReplicationMessage.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessage.cs
@@ -425,6 +425,16 @@ namespace EventStore.Core.Messages
             }
         }
 
+        public class ReplicationCheckTick : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public ReplicationCheckTick()
+            {
+            }
+        }
+
         public class ReplicationStats
         {
             public Guid SubscriptionId { get; private set; }

--- a/src/EventStore.Core/Services/Replication/ReplicationCheckpointFilter.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicationCheckpointFilter.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Common.Log;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.Checkpoint;
+
+namespace EventStore.Core.Services.Replication
+{
+    public class ReplicationCheckpointFilter : IHandle<ReplicationMessage.ReplicationCheckTick>
+    {
+        public ILogger Log = LogManager.GetLoggerFor<ReplicationCheckpointFilter>();
+        private readonly IPublisher _outputBus;
+        private readonly IPublisher _publisher;
+        private readonly IEnvelope _busEnvelope;
+        private readonly ICheckpoint _replicationCheckpoint;
+        private readonly TimeSpan TimeoutPeriod = new TimeSpan(1000);
+
+        private SortedDictionary<long, List<Message>> _messages;
+
+        public ReplicationCheckpointFilter(IPublisher outputBus, IPublisher publisher, ICheckpoint replicationCheckpoint)
+        {
+            _outputBus = outputBus;
+            _publisher = publisher;
+            _replicationCheckpoint = replicationCheckpoint;
+            _busEnvelope = new PublishEnvelope(_publisher);
+            _messages = new SortedDictionary<long, List<Message>>();
+            _publisher.Publish(TimerMessage.Schedule.Create(TimeoutPeriod, _busEnvelope, new ReplicationMessage.ReplicationCheckTick()));
+        }
+
+        public void Handle(StorageMessage.EventCommitted message)
+        {
+            var replChk = _replicationCheckpoint.ReadNonFlushed();
+            if(message.CommitPosition > replChk)
+            {
+                Enqueue(message, message.CommitPosition);
+            }
+            else
+            {
+                _outputBus.Publish(message);
+            }
+        }
+
+        public void Handle(ReplicationMessage.ReplicationCheckTick message)
+        {
+            HandleMessages();
+            _publisher.Publish(TimerMessage.Schedule.Create(TimeoutPeriod, _busEnvelope, message));
+        }
+
+        private void Enqueue(Message message, long commitPosition)
+        {
+            if(_messages.ContainsKey(commitPosition))
+            {
+                _messages[commitPosition].Add(message);
+            }
+            else
+            {
+                _messages.Add(commitPosition, new List<Message>{ message });
+            }
+        }
+
+        private void HandleMessages()
+        {
+            var replChk = _replicationCheckpoint.ReadNonFlushed();
+            var messagesToHandle = _messages.Where(x => x.Key <= replChk).ToList();
+            foreach(var m in messagesToHandle)
+            {
+                foreach(var i in m.Value)
+                {
+                    _outputBus.Publish(i);
+                }
+                _messages.Remove(m.Key);
+            }
+        }
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -13,6 +13,7 @@ namespace EventStore.Core.TransactionLog.Chunks
         public readonly ICheckpoint ChaserCheckpoint;
         public readonly ICheckpoint EpochCheckpoint;
         public readonly ICheckpoint TruncateCheckpoint;
+        public readonly ICheckpoint ReplicationCheckpoint;
         public readonly IFileNamingStrategy FileNamingStrategy;
         public readonly bool InMemDb;
         public readonly bool Unbuffered;
@@ -26,6 +27,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                                ICheckpoint chaserCheckpoint,
                                ICheckpoint epochCheckpoint,
                                ICheckpoint truncateCheckpoint,
+                               ICheckpoint replicationCheckpoint,
                                bool inMemDb = false,
                                bool unbuffered = false,
                                bool writethrough = false)
@@ -38,6 +40,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             Ensure.NotNull(chaserCheckpoint, "chaserCheckpoint");
             Ensure.NotNull(epochCheckpoint, "epochCheckpoint");
             Ensure.NotNull(truncateCheckpoint, "truncateCheckpoint");
+            Ensure.NotNull(replicationCheckpoint, "replicationCheckpoint");
             
             Path = path;
             ChunkSize = chunkSize;
@@ -46,10 +49,27 @@ namespace EventStore.Core.TransactionLog.Chunks
             ChaserCheckpoint = chaserCheckpoint;
             EpochCheckpoint = epochCheckpoint;
             TruncateCheckpoint = truncateCheckpoint;
+            ReplicationCheckpoint = replicationCheckpoint;
             FileNamingStrategy = fileNamingStrategy;
             InMemDb = inMemDb;
             Unbuffered = unbuffered;
             WriteThrough = writethrough;
+        }
+
+         public TFChunkDbConfig(string path, 
+                               IFileNamingStrategy fileNamingStrategy, 
+                               int chunkSize,
+                               long maxChunksCacheSize,
+                               ICheckpoint writerCheckpoint, 
+                               ICheckpoint chaserCheckpoint,
+                               ICheckpoint epochCheckpoint,
+                               ICheckpoint truncateCheckpoint,
+                               bool inMemDb = false,
+                               bool unbuffered = false,
+                               bool writethrough = false)
+        : this(path, fileNamingStrategy, chunkSize, maxChunksCacheSize, writerCheckpoint, chaserCheckpoint,
+               epochCheckpoint, truncateCheckpoint, new InMemoryCheckpoint(-1), inMemDb, unbuffered, writethrough)
+        {
         }
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -55,21 +55,5 @@ namespace EventStore.Core.TransactionLog.Chunks
             Unbuffered = unbuffered;
             WriteThrough = writethrough;
         }
-
-         public TFChunkDbConfig(string path, 
-                               IFileNamingStrategy fileNamingStrategy, 
-                               int chunkSize,
-                               long maxChunksCacheSize,
-                               ICheckpoint writerCheckpoint, 
-                               ICheckpoint chaserCheckpoint,
-                               ICheckpoint epochCheckpoint,
-                               ICheckpoint truncateCheckpoint,
-                               bool inMemDb = false,
-                               bool unbuffered = false,
-                               bool writethrough = false)
-        : this(path, fileNamingStrategy, chunkSize, maxChunksCacheSize, writerCheckpoint, chaserCheckpoint,
-               epochCheckpoint, truncateCheckpoint, new InMemoryCheckpoint(-1), inMemDb, unbuffered, writethrough)
-        {
-        }
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkReader.cs
@@ -45,6 +45,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             while (true)
             {
                 var pos = _curPos;
+
                 var writerChk = _writerCheckpoint.Read();
                 if (pos >= writerChk)
                     return SeqReadResult.Failure;

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1399,6 +1399,7 @@ namespace EventStore.Core
             ICheckpoint chaserChk;
             ICheckpoint epochChk;
             ICheckpoint truncateChk;
+            ICheckpoint replicationChk = new InMemoryCheckpoint(-1);
             if (inMemDb)
             {
                 writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
@@ -1460,6 +1461,7 @@ namespace EventStore.Core
                                                  chaserChk,
                                                  epochChk,
                                                  truncateChk,
+                                                 replicationChk,
                                                  inMemDb,
                                                  unbuffered,
                                                  writethrough);


### PR DESCRIPTION
Don't allow reads or subscriptions to get events that have not been replicated to the quorum.

Introduce a `ReplicationCheckpoint` that tracks the latest commit that has been acknowledged by the nodes in the cluster.

Reads are gated by the replication checkpoint in the `TFChunkReader`.
`EventCommitted` messages which are used to update subscriptions and projections are gated by a filter that hooks into the `ClusterVNodeController`. The filter queues `EventCommitted` messages and waits until the replication checkpoint is greater than their commit positions before publishing them internally.

Only master will gate reads according to the replication checkpoint. Slaves and other nodes will be able to read events immediately.

Also refactored tests using `TFChunkDbConfig` to use a constructor from a helper method to make future constructor updates easier.


