### PR TITLE
Handle stream deletions in MultiStreamEventReader

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -560,6 +560,8 @@
     <Compile Include="Services\event_reader\stream_reader\when_handling_streams_with_deleted_events_and_starting_after_event_zero.cs" />
     <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_starting_at_event_zero.cs" />
     <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_starting_after_event_zero.cs" />
+    <Compile Include="Services\event_reader\multi_stream_reader\when_handling_deleted_streams.cs" />
+    <Compile Include="Services\event_reader\stream_reader\when_handling_deleted_streams.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_deleted_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_deleted_streams.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_reader
+{
+    [TestFixture]
+    public class when_handling_deleted_streams : TestFixtureWithExistingEvents
+    {
+        private MultiStreamEventReader _edp;
+        private string[] _streamNames;
+        private Dictionary<string,long> _streamPositions;
+        private Guid _distibutionPointCorrelationId;
+        private long _fromSequenceNumber = 10;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+            _streamNames = new[] {"stream1","stream2"};
+            _streamPositions = new Dictionary<string, long> {{"stream1", 10}, {"stream2", _fromSequenceNumber}};
+        }
+
+        [SetUp]
+        public new void When()
+        {
+            _distibutionPointCorrelationId = Guid.NewGuid();
+            
+            _edp = new MultiStreamEventReader(
+                _ioDispatcher, _bus, _distibutionPointCorrelationId, null, 0, _streamNames, _streamPositions, false,
+                new RealTimeProvider());
+                
+            _edp.Resume();
+        }
+
+       private void HandleEvents(string stream, long[] eventNumbers){
+            string eventType = "event_type";
+            List<ResolvedEvent> events = new List<ResolvedEvent>();
+
+            foreach(long eventNumber in eventNumbers){
+                events.Add(
+                    ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            eventNumber, 50*(eventNumber+1), Guid.NewGuid(), Guid.NewGuid(), 50*(eventNumber+1), 0, stream, ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            eventType, new byte[] {0}, new byte[] {0}
+                        )
+                    )
+                );
+            }
+
+            long start, end;
+            if(eventNumbers.Length > 0){
+                start = eventNumbers[0];
+                end = eventNumbers[eventNumbers.Length-1];
+            }
+            else{
+                start = _fromSequenceNumber;
+                end = _fromSequenceNumber;
+            }
+
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == stream).CorrelationId;            
+
+            _edp.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, stream, start, 100, ReadStreamResult.Success,events.ToArray(), null, false, "", start+1, end, true, 200)
+            );            
+        
+        }
+        private void HandleEvents(string stream,long start,long end){
+            List<long> eventNumbers = new List<long>();
+            for(long i=start;i<=end;i++) eventNumbers.Add(i);
+            HandleEvents(stream,eventNumbers.ToArray());
+        }
+
+        private void HandleDeletedStream(string stream, long sequenceNumber, ReadStreamResult result){
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == stream).CorrelationId;            
+
+            _edp.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, stream, sequenceNumber, 100, result,new ResolvedEvent[]{}, null, false, "", -1, sequenceNumber, true, 200)
+            );            
+        }
+
+        [Test]
+        public void when_no_stream_and_sequence_num_equal_to_minus_one_should_not_publish_partition_deleted_message()
+        {
+         HandleDeletedStream(_streamNames[0],-1,ReadStreamResult.NoStream);
+         //trigger event delivery:
+         HandleEvents(_streamNames[1],_fromSequenceNumber,_fromSequenceNumber);
+
+         Assert.AreEqual(0,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().Count());
+        }
+
+        [Test]
+        public void when_no_stream_and_sequence_num_equal_to_zero_should_publish_partition_deleted_message()
+        {
+         HandleDeletedStream(_streamNames[0],0,ReadStreamResult.NoStream);
+         //trigger event delivery:
+         HandleEvents(_streamNames[1],_fromSequenceNumber,_fromSequenceNumber);
+
+         Assert.AreEqual(1,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().Count());
+         Assert.AreEqual(_streamNames[0],_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().First().Partition);
+        }
+
+        [Test]
+        public void when_no_stream_and_sequence_num_greater_than_zero_should_publish_partition_deleted_message()
+        {
+         HandleDeletedStream(_streamNames[0],100,ReadStreamResult.NoStream);
+         //trigger event delivery:
+         HandleEvents(_streamNames[1],_fromSequenceNumber,_fromSequenceNumber);
+
+         Assert.AreEqual(1,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().Count());
+         Assert.AreEqual(_streamNames[0],_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().First().Partition);
+        }
+
+        [Test]
+        public void when_stream_deleted_should_publish_partition_deleted_message()
+        {
+         HandleDeletedStream(_streamNames[0],0,ReadStreamResult.StreamDeleted);
+         //trigger event delivery:
+         HandleEvents(_streamNames[1],_fromSequenceNumber,_fromSequenceNumber);
+
+         Assert.AreEqual(1,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().Count());
+         Assert.AreEqual(_streamNames[0],_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().First().Partition);
+        }
+        
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_deleted_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_deleted_streams.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
+{
+    [TestFixture]
+    public class when_handling_deleted_streams : TestFixtureWithExistingEvents
+    {
+        private StreamEventReader _edp;
+        private string _streamName;
+        private Guid _distibutionPointCorrelationId;
+        private long _fromSequenceNumber = 10;
+        private FakeTimeProvider _fakeTimeProvider;
+
+        protected override void Given()
+        {
+            TicksAreHandledImmediately();
+            _streamName = "stream1";
+            _fromSequenceNumber = 10;
+        }
+
+        [SetUp]
+        public new void When()
+        {
+            _distibutionPointCorrelationId = Guid.NewGuid();
+            _fakeTimeProvider = new FakeTimeProvider();
+            _edp = new StreamEventReader(_bus, _distibutionPointCorrelationId, null, _streamName, _fromSequenceNumber, _fakeTimeProvider, false, produceStreamDeletes: false);               
+            _edp.Resume();
+        }
+
+       private void HandleEvents(string stream, long[] eventNumbers){
+            string eventType = "event_type";
+            List<ResolvedEvent> events = new List<ResolvedEvent>();
+
+            foreach(long eventNumber in eventNumbers){
+                events.Add(
+                    ResolvedEvent.ForUnresolvedEvent(
+                        new EventRecord(
+                            eventNumber, 50*(eventNumber+1), Guid.NewGuid(), Guid.NewGuid(), 50*(eventNumber+1), 0, stream, ExpectedVersion.Any, DateTime.UtcNow,
+                            PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
+                            eventType, new byte[] {0}, new byte[] {0}
+                        )
+                    )
+                );
+            }
+
+            long start, end;
+            if(eventNumbers.Length > 0){
+                start = eventNumbers[0];
+                end = eventNumbers[eventNumbers.Length-1];
+            }
+            else{
+                start = _fromSequenceNumber;
+                end = _fromSequenceNumber;
+            }
+
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == stream).CorrelationId;            
+
+            _edp.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, stream, start, 100, ReadStreamResult.Success,events.ToArray(), null, false, "", start+1, end, true, 200)
+            );            
+        
+        }
+        private void HandleEvents(string stream,long start,long end){
+            List<long> eventNumbers = new List<long>();
+            for(long i=start;i<=end;i++) eventNumbers.Add(i);
+            HandleEvents(stream,eventNumbers.ToArray());
+        }
+
+        private void HandleDeletedStream(string stream, long sequenceNumber, ReadStreamResult result){
+            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last(x => x.EventStreamId == stream).CorrelationId;            
+
+            _edp.Handle(
+                new ClientMessage.ReadStreamEventsForwardCompleted(
+                    correlationId, stream, sequenceNumber, 100, result,new ResolvedEvent[]{}, null, false, "", -1, sequenceNumber, true, 200)
+            );            
+        }
+
+        [Test]
+        public void when_no_stream_and_sequence_num_equal_to_minus_one_should_not_publish_partition_deleted_message()
+        {
+         HandleDeletedStream(_streamName,-1,ReadStreamResult.NoStream);
+         Assert.AreEqual(0,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().Count());
+        }
+
+        [Test]
+        public void when_no_stream_and_sequence_num_equal_to_zero_should_publish_partition_deleted_message()
+        {
+         HandleDeletedStream(_streamName,0,ReadStreamResult.NoStream);
+         Assert.AreEqual(1,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().Count());
+         Assert.AreEqual(_streamName,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().First().Partition);
+        }
+
+        [Test]
+        public void when_no_stream_and_sequence_num_greater_than_zero_should_publish_partition_deleted_message()
+        {
+         HandleDeletedStream(_streamName,100,ReadStreamResult.NoStream);
+         Assert.AreEqual(1,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().Count());
+         Assert.AreEqual(_streamName,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().First().Partition);
+        }
+
+        [Test]
+        public void when_stream_deleted_should_publish_partition_deleted_message()
+        {
+         HandleDeletedStream(_streamName,0,ReadStreamResult.StreamDeleted);
+         Assert.AreEqual(1,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().Count());
+         Assert.AreEqual(_streamName,_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderPartitionDeleted>().First().Partition);
+        }
+        
+    }
+}


### PR DESCRIPTION
MultiStreamEventReader was not handling stream deletions properly.
A "null" item was being enqueued but not processed in ProcessBuffers() causing a null reference exception to be thrown.

When seeing a ReadStreamResult.StreamDeleted result, the null item was also not being added to the queue.

Possibly fixes #1413

**Steps to reproduce (use files below):**
[event.txt](https://github.com/EventStore/EventStore/files/1301887/event.txt)
```
1. Create streams stream1 and stream2 (writing 3 events to each one):
curl -i -d @event.txt -H "Content-Type:application/vnd.eventstore.events+json" "http://127.0.0.1:2113/streams/stream1"
curl -i -d @event.txt -H "Content-Type:application/vnd.eventstore.events+json" "http://127.0.0.1:2113/streams/stream2"

2. Create a projection 'multistream':
fromStreams(['stream1','stream2']).
when({
    '$any':function(s,e){

    }
})

3. Run it, Position should be: stream1: 2; stream2: 2;

4. Create a projection 'singlestream':
fromStreams(['stream1']).
when({
    '$any':function(s,e){

    }
})

5. Run it, Position should be: stream1: 2

6. Stop both projections

7. Soft delete stream1:
curl -v -X DELETE http://127.0.0.1:2113/streams/stream1

8. Start both projections:
singlestream starts without errors
multistream throws out errors in log:
[PID:09908:022 2017.09.12 04:29:06.772 ERROR QueuedHandlerMRES   ] Error while processing message EventStore.Projections.Core.Messaging.UnwrapEnvelopeMessage in queued handler 'Projection Core #1'.
System.NullReferenceException: Object reference not set to an instance of an object
  at EventStore.Projections.Core.Services.Processing.MultiStreamEventReader.GetItemPosition (System.Tuple`2[T1,T2] head) [0x00002] in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Projections.Core/Services/Processing/MultiStreamEventReader.cs:353
...
```

**Resolution:**
Handle null items in ProcessBuffers() and publish the partition deleted message.