### PR TITLE
Ensure c++ compiler before building V8

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The list of precompiled projections libraries can be found in `src/libs/x64`
 ### Linux
 **Prerequisites**
 - git
+- a c++ compiler (e.g `sudo apt-get install g++`)
 
 The scripts attempts to do it's best to have no dependencies from the user's point of view. If you do encounter any issues, please don't hesitate to raise an issue.
 


### PR DESCRIPTION
I needed to run `sudo apt-get install g++` for `scripts/build-js1/build-js1-linux.sh` to successfully run.

This is perhaps a little debian-centric (using `apt-get`) I'm open to suggestions.

This helped: https://groups.google.com/forum/#!topic/v8-users/Tt56ucRG3Tk