### PR TITLE
Fix slave-to-master forwarding issues when a header has the wrong formatting

### DIFF
--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -182,25 +182,30 @@ namespace EventStore.Core.Services
             // Copy unrestricted headers (including cookies, if any)
             foreach (var headerKey in srcReq.Headers.AllKeys)
             {
-                switch (headerKey.ToLower())
-                {
-                    case "accept":            request.Headers.Accept.ParseAdd(srcReq.Headers[headerKey]); break;
-                    case "connection":        break;
-                    case "content-type":      break;
-                    case "content-length":    break;
-                    case "date":              request.Headers.Date = DateTime.Parse(srcReq.Headers[headerKey]); break;
-                    case "expect":            break;
-                    case "host":              request.Headers.Host = forwardUri.Host; break;
-                    case "if-modified-since": request.Headers.IfModifiedSince = DateTime.Parse(srcReq.Headers[headerKey]); break;
-                    case "proxy-connection":  break;
-                    case "range":             break;
-                    case "referer":           request.Headers.Referrer = new Uri(srcReq.Headers[headerKey]); break;
-                    case "transfer-encoding": request.Headers.TransferEncoding.ParseAdd(srcReq.Headers[headerKey]); break;
-                    case "user-agent":        request.Headers.UserAgent.ParseAdd(srcReq.Headers[headerKey]); break;
+                try{
+                    switch (headerKey.ToLower())
+                    {
+                        case "accept":            request.Headers.Accept.ParseAdd(srcReq.Headers[headerKey]); break;
+                        case "connection":        break;
+                        case "content-type":      break;
+                        case "content-length":    break;
+                        case "date":              request.Headers.Date = DateTime.Parse(srcReq.Headers[headerKey]); break;
+                        case "expect":            break;
+                        case "host":              request.Headers.Host = forwardUri.Host; break;
+                        case "if-modified-since": request.Headers.IfModifiedSince = DateTime.Parse(srcReq.Headers[headerKey]); break;
+                        case "proxy-connection":  break;
+                        case "range":             break;
+                        case "referer":           request.Headers.Referrer = new Uri(srcReq.Headers[headerKey]); break;
+                        case "transfer-encoding": request.Headers.TransferEncoding.ParseAdd(srcReq.Headers[headerKey]); break;
+                        case "user-agent":        request.Headers.UserAgent.ParseAdd(srcReq.Headers[headerKey]); break;
 
-                    default:
-                        request.Headers.Add(headerKey, srcReq.Headers[headerKey]);
-                        break;
+                        default:
+                            request.Headers.Add(headerKey, srcReq.Headers[headerKey]);
+                            break;
+                    }
+                }
+                catch(System.FormatException){
+                    request.Headers.TryAddWithoutValidation(headerKey,srcReq.Headers[headerKey]);
                 }
             }
 


### PR DESCRIPTION
If there's a wrongly or slightly wrongly formatted header, the request will be rejected by the slave when trying to forward a request (results in a 500 internal error)

**Resolution:** 
If **System.FormatException** is thrown, try to add the header without validating it.
The request will handled and validated by the master anyway, so it doesn't affect the end result.

**Test examples:**
curl -H "Accept: application/json;" -v localhost:2113/users/admin
(The semicolon at the end is invalid)

curl -H "Via: abcd" -v localhost:2113/users/admin
(Correct format: "Via: 1.1 abcd")
