### PR TITLE
Allow changing of custom metadata properties in the client StreamMetadataBuilder

### DIFF
--- a/src/EventStore.ClientAPI/StreamMetadataBuilder.cs
+++ b/src/EventStore.ClientAPI/StreamMetadataBuilder.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EventStore.ClientAPI.Common.Utils;
 using Newtonsoft.Json.Linq;
-
 namespace EventStore.ClientAPI
 {
     /// <summary>
@@ -19,8 +19,15 @@ namespace EventStore.ClientAPI
         private string[] _aclDelete;
         private string[] _aclMetaRead;
         private string[] _aclMetaWrite;
+        private readonly IDictionary<string, JToken> _customMetadata;
 
-        private readonly IDictionary<string, JToken> _customMetadata = new Dictionary<string, JToken>();
+        /// <summary>
+        /// All existing custom property keys.
+        /// </summary>
+        /// <remarks>
+        /// Returns a copy of the key list so it's safe to enumerate whilst removing custom properties.
+        /// </remarks>
+        public IEnumerable<string> CustomPropertyKeys => _customMetadata.Keys.ToList();
 
         internal StreamMetadataBuilder(
             long? maxCount = null,
@@ -45,7 +52,6 @@ namespace EventStore.ClientAPI
             _aclMetaWrite = aclMetaWrite;
             _customMetadata = customMetadata == null ? new Dictionary<string, JToken>() : new Dictionary<string, JToken>(customMetadata);
         }
-
         /// <summary>
         /// Builds a <see cref="StreamMetadata"/> from a <see cref="StreamMetadataBuilder"/>.
         /// </summary>
@@ -55,21 +61,20 @@ namespace EventStore.ClientAPI
         {
             return builder.Build();
         }
-
         /// <summary>
         /// Builds a <see cref="StreamMetadata"/> from a <see cref="StreamMetadataBuilder"/>.
         /// </summary>
-        public StreamMetadata Build() {
+        public StreamMetadata Build()
+        {
             var acl = this._aclRead == null
-                      && this._aclWrite == null 
-                      && this._aclDelete == null 
+                      && this._aclWrite == null
+                      && this._aclDelete == null
                       && this._aclMetaRead == null
                       && this._aclMetaWrite == null
                 ? null
                 : new StreamAcl(this._aclRead, this._aclWrite, this._aclDelete, this._aclMetaRead, this._aclMetaWrite);
             return new StreamMetadata(this._maxCount, this._maxAge, this._truncateBefore, this._cacheControl, acl, this._customMetadata);
         }
-
         /// <summary>
         /// Sets the maximum number of events allowed in the stream.
         /// </summary>
@@ -81,7 +86,6 @@ namespace EventStore.ClientAPI
             _maxCount = maxCount;
             return this;
         }
-
         /// <summary>
         /// Sets the maximum age of events allowed in the stream.
         /// </summary>
@@ -93,7 +97,6 @@ namespace EventStore.ClientAPI
             _maxAge = maxAge;
             return this;
         }
-
         /// <summary>
         /// Sets the event number from which previous events can be scavenged.
         /// </summary>
@@ -105,7 +108,6 @@ namespace EventStore.ClientAPI
             _truncateBefore = truncateBefore;
             return this;
         }
-
         /// <summary>
         /// Sets the amount of time for which the stream head is cachable.
         /// </summary>
@@ -117,7 +119,6 @@ namespace EventStore.ClientAPI
             _cacheControl = cacheControl;
             return this;
         }
-
         /// <summary>
         /// Sets a single role name with read permission for the stream.
         /// </summary>
@@ -128,7 +129,6 @@ namespace EventStore.ClientAPI
             _aclRead = role == null ? null : new[] { role };
             return this;
         }
-
         /// <summary>
         /// Sets role names with read permission for the stream.
         /// </summary>
@@ -139,7 +139,6 @@ namespace EventStore.ClientAPI
             _aclRead = roles;
             return this;
         }
-
         /// <summary>
         /// Sets a single role name with write permission for the stream.
         /// </summary>
@@ -150,7 +149,6 @@ namespace EventStore.ClientAPI
             _aclWrite = role == null ? null : new[] { role };
             return this;
         }
-
         /// <summary>
         /// Sets role names with write permission for the stream.
         /// </summary>
@@ -161,7 +159,6 @@ namespace EventStore.ClientAPI
             _aclWrite = roles;
             return this;
         }
-
         /// <summary>
         /// Sets a single role name with delete permission for the stream.
         /// </summary>
@@ -172,7 +169,6 @@ namespace EventStore.ClientAPI
             _aclDelete = role == null ? null : new[] { role };
             return this;
         }
-
         /// <summary>
         /// Sets role names with delete permission for the stream.
         /// </summary>
@@ -183,7 +179,6 @@ namespace EventStore.ClientAPI
             _aclDelete = roles;
             return this;
         }
-
         /// <summary>
         /// Sets a single role name with metadata read permission for the stream.
         /// </summary>
@@ -194,7 +189,6 @@ namespace EventStore.ClientAPI
             _aclMetaRead = role == null ? null : new[] { role };
             return this;
         }
-
         /// <summary>
         /// Sets role names with metadata read permission for the stream.
         /// </summary>
@@ -205,7 +199,6 @@ namespace EventStore.ClientAPI
             _aclMetaRead = roles;
             return this;
         }
-
         /// <summary>
         /// Sets a single role name with metadata write permission for the stream.
         /// </summary>
@@ -216,7 +209,6 @@ namespace EventStore.ClientAPI
             _aclMetaWrite = role == null ? null : new[] { role };
             return this;
         }
-
         /// <summary>
         /// Sets role names with metadata write permission for the stream.
         /// </summary>
@@ -227,7 +219,6 @@ namespace EventStore.ClientAPI
             _aclMetaWrite = roles;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -236,10 +227,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, string value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -248,10 +238,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, int value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -260,10 +249,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, int? value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -272,10 +260,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, long value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -284,10 +271,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, long? value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -296,10 +282,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, float value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -308,10 +293,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, float? value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -320,10 +304,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, double value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -332,10 +315,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, double? value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -344,10 +326,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, decimal value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -356,10 +337,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, decimal? value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -368,10 +348,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, bool value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property.
         /// </summary>
@@ -380,10 +359,9 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomProperty(string key, bool? value)
         {
-            _customMetadata.Add(key, value);
+            _customMetadata[key] = value;
             return this;
         }
-
         /// <summary>
         /// Sets a custom metadata property to a string of raw JSON.
         /// </summary>
@@ -392,8 +370,20 @@ namespace EventStore.ClientAPI
         /// <returns>The builder.</returns>
         public StreamMetadataBuilder SetCustomPropertyWithValueAsRawJsonString(string key, string rawJson)
         {
-            _customMetadata.Add(key, JToken.Parse(rawJson));
+            _customMetadata[key] = JToken.Parse(rawJson);
             return this;
         }
+
+        /// <summary>
+        /// Removes a custom property.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns>The builder.</returns>
+        public StreamMetadataBuilder RemoveCustomProperty(string key)
+        {
+            _customMetadata.Remove(key);
+            return this;
+        }
+
     }
 }


### PR DESCRIPTION
Currently you can't modify a custom property if already set. Also added ways to enumerate and remove custom properties.