### PR TITLE
Start Projections Core Coordinator only when Master

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
@@ -84,13 +84,11 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
             }
 
             [Test]
-            public void core_readers_should_use_the_unique_id_provided_by_the_state_change_message()
+            public void projections_core_coordinator_should_not_publish_start_core_message()
             {
-                var becomeMaster = _consumer.HandledMessages.OfType<SystemMessage.BecomeSlave>().First();
+                //projections are not allowed (yet) to run on slaves
                 var startCoreMessages = _consumer.HandledMessages.OfType<ProjectionCoreServiceMessage.StartCore>();
-
-                Assert.AreEqual(1, startCoreMessages.Select(x => x.EpochId).Distinct().Count());
-                Assert.AreEqual(becomeMaster.EpochId, startCoreMessages.First().EpochId);
+                Assert.AreEqual(0, startCoreMessages.Select(x => x.EpochId).Distinct().Count());
             }
         }
     }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionCoreCoordinator.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionCoreCoordinator.cs
@@ -78,7 +78,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         private void StartWhenConditionsAreMet()
         {
-            if (_systemReady && (_currentState == VNodeState.Master || _currentState == VNodeState.Slave))
+            if (_systemReady && (_currentState == VNodeState.Master))
             {
                 if (!_started)
                 {


### PR DESCRIPTION
In certain conditions, it can happen that projections core coordinator is running on both a master and slave. This leads to inconsistencies like projections getting stuck since projections are currently designed to run only on the master node.

**When  it happens (cluster of size 3 example):**
1. Node 1 is master with projections running and Node 2 is slave
2. Node 2 is stopped and restarted and during the elections, Node 2 becomes master and Node 1 slave.
(This can happen if Node 2 is leader of last attempted view and Node 2's serverId >  Node 1's serverId. Node 2 doesn't have lastElectedMaster info since it was just restarted)
3. Projection core coordinator will run on both node 1 and node 2

**Steps to reproduce it:**
Command to start node 1: 
```
mono ./bin/clusternode/EventStore.ClusterNode.exe --int-ip 127.0.0.1 --ext-ip 127.0.0.1 --int-tcp-port=2110 --ext-tcp-port=2111 --int-http-port=2112 --ext-http-port=2113 --cluster-size=3 --discover-via-dns=false --gossip-seed=127.0.0.1:2122,127.0.0.1:2132 --log ../logs/0 --db ../db/0 --run-projections=All
```
Command to start node 2:
```
mono ./bin/clusternode/EventStore.ClusterNode.exe --int-ip 127.0.0.1 --ext-ip 127.0.0.1 --int-tcp-port=2120 --ext-tcp-port=2121 --int-http-port=2122 --ext-http-port=2123 --cluster-size=3 --discover-via-dns=false --gossip-seed=127.0.0.1:2112,127.0.0.1:2132 --log ../logs/1 --db ../db/1 --run-projections=All
```

1. Start node 1
Note: To make the bug happen much more quickly, node 1 should have a GUID starting with a middle character between 0 to f (for e.g. 8 or 9). Restart node 1 as long as this is not satisfied.

Example, in this case 9ab96f3f... starts with 9.
```
[14731,16,11:47:13.290] VND {9ab96f3f-a329-48b9-b257-ca4aa9ec77c0} <LIVE> [Unknown, 127.0.0.1:2110, 127.0.0.1:0, 127.0.0.1:2111, 127.0.0.1:0, 127.0.0.1:2112, 127.0.0.1:2113] 1373618/1374098/1374098/E30@1357715:{a3e78964-32ef-425d-9c71-f2d34caac0a5} | 2017-09-25 11:47:13.221
```

2. Start node 2. If node 1 is master and projections are running on it, then good. Otherwise repeat step 2 until satisfied.

3. Stop node 2. Start node 2 again when you see the elections attempted view is an even number on Node 1. For example, here it's V=6:
```
[10734,15,11:16:26.680] ELECTIONS: (V=6) SHIFT TO LEADER ELECTION.
[10734,15,11:16:26.680] ELECTIONS: (V=6) VIEWCHANGE FROM [127.0.0.1:2112, {15bb35a6-5847-4b77-928b-221e092b2334}].

```
Note: This requires some keyboard kung-fu. If done correctly, you should see something like this on node 2, where V=6 is even:
```
[11265,15,11:20:50.344] ELECTIONS: (V=6) SHIFT TO REG_LEADER.
```

4. If in step 3, node 2 is luckily assigned a GUID > than node 1's GUID (50% chance) , then node 2 will become master and projections core coordinator will start running on both of them. (If not satisfied, repeat step 3)
In this example, Node 2 has a greater GUID (e6cb57ac...) than Node 1's GUID(9ab96f3f...):
```
[15371,16,11:51:00.381] VND {e6cb57ac-2ae8-46ba-b839-5fff9c00869e} <LIVE> [CatchingUp, 127.0.0.1:2120, 127.0.0.1:0, 127.0.0.1:2121, 127.0.0.1:0, 127.0.0.1:2122, 127.0.0.1:2123] 1542623/1559847/1559847/E49@1526066:{ec8b5df8-2b41-4c79-a193-c2bd027ecf73} | 2017-09-25 11:51:00.381
[15371,16,11:51:00.381] VND {9ab96f3f-a329-48b9-b257-ca4aa9ec77c0} <LIVE> [Master, 127.0.0.1:2110, n/a, 127.0.0.1:2111, n/a, 127.0.0.1:2112, 127.0.0.1:2113] 1560862/1561036/1561036/E50@1559847:{033022aa-a826-4502-a5b7-5a2b41884731} | 2017-09-25 11:51:00.380

```
