### PR TITLE
added traverse in scavenge to count the new chunk size in memory

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -174,45 +174,48 @@ namespace EventStore.Core.TransactionLog.Chunks
                 foreach (var oldChunk in oldChunks)
                 {
                     TraverseChunk(oldChunk,
-                                  prepare => { /* NOOP */ },
-                                  commit =>
+                                  (prepare, _) => { /* NOOP */ },
+                                  (commit, _) =>
                                   {
                                       if (commit.TransactionPosition >= chunkStartPos)
                                           commits.Add(commit.TransactionPosition, new CommitInfo(commit));
                                   },
-                                  system => { /* NOOP */ });
+                                  (system, _) => { /* NOOP */ });
                 }
 
-                var positionMapping = new List<PosMap>();
+                int newSize = 0;
+                int positionMapCount = 0;
+
                 foreach (var oldChunk in oldChunks)
                 {
                     TraverseChunk(oldChunk,
-                                  prepare =>
+                                  (prepare, len) =>
                                   {
                                       if (ShouldKeepPrepare(prepare, commits, chunkStartPos, chunkEndPos))
-                                          positionMapping.Add(WriteRecord(newChunk, prepare));
+                                      {
+                                          newSize += len + 8;
+                                          positionMapCount++;
+                                      }
                                   },
-                                  commit =>
+                                  (commit, len) =>
                                   {
                                       if (ShouldKeepCommit(commit, commits))
-                                          positionMapping.Add(WriteRecord(newChunk, commit));
+                                      {
+                                          newSize += len + 8;
+                                          positionMapCount++;
+                                      }
                                   },
-                                  // we always keep system log records for now
-                                  system => positionMapping.Add(WriteRecord(newChunk, system)));
+                                  (system, len) =>
+                                  {
+                                      newSize += len + 8;
+                                      positionMapCount++;
+                                  });
                 }
-                newChunk.CompleteScavenge(positionMapping);
 
-                var oldSize = oldChunks.Sum(x => (long)x.PhysicalDataSize + x.ChunkFooter.MapSize + ChunkHeader.Size + ChunkFooter.Size);
-                var newSize = (long)newChunk.PhysicalDataSize + PosMap.FullSize * positionMapping.Count + ChunkHeader.Size + ChunkFooter.Size;
-
-                if(_unsafeIgnoreHardDeletes) {
-                    Log.Trace("Forcing scavenge chunk to be kept even if bigger.");
-                }
+                newSize += positionMapCount * PosMap.FullSize + ChunkHeader.Size + ChunkFooter.Size;
 
                 var oldVersion = oldChunks.Any(x => x.ChunkHeader.Version != 3);
-                if(oldVersion) {
-                    Log.Trace("Forcing scavenged chunk to be kept as old chunk is a previous version.");
-                }
+                var oldSize = oldChunks.Sum(x => (long)x.PhysicalDataSize + x.ChunkFooter.MapSize + ChunkHeader.Size + ChunkFooter.Size);
 
                 if (oldSize <= newSize && !alwaysKeepScavenged && !_unsafeIgnoreHardDeletes && !oldVersion)
                 {
@@ -227,6 +230,34 @@ namespace EventStore.Core.TransactionLog.Chunks
                     PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, spaceSaved);
                     return false;
                 }
+
+                var positionMapping = new List<PosMap>();
+                foreach (var oldChunk in oldChunks)
+                {
+                    TraverseChunk(oldChunk,
+                                  (prepare, _) =>
+                                  {
+                                      if (ShouldKeepPrepare(prepare, commits, chunkStartPos, chunkEndPos))
+                                          positionMapping.Add(WriteRecord(newChunk, prepare));
+                                  },
+                                  (commit, _) =>
+                                  {
+                                      if (ShouldKeepCommit(commit, commits))
+                                          positionMapping.Add(WriteRecord(newChunk, commit));
+                                  },
+                                  // we always keep system log records for now
+                                  (system, _) => positionMapping.Add(WriteRecord(newChunk, system)));
+                }
+                newChunk.CompleteScavenge(positionMapping);
+
+                if(_unsafeIgnoreHardDeletes) {
+                    Log.Trace("Forcing scavenge chunk to be kept even if bigger.");
+                }
+
+                if(oldVersion) {
+                    Log.Trace("Forcing scavenged chunk to be kept as old chunk is a previous version.");
+                }
+
                 var chunk = _db.Manager.SwitchChunk(newChunk, verifyHash: false, removeChunksWithGreaterNumbers: false);
                 if (chunk != null)
                 {
@@ -472,9 +503,9 @@ namespace EventStore.Core.TransactionLog.Chunks
         }
 
         private void TraverseChunk(TFChunk.TFChunk chunk,
-                                   Action<PrepareLogRecord> processPrepare,
-                                   Action<CommitLogRecord> processCommit,
-                                   Action<SystemLogRecord> processSystem)
+                                   Action<PrepareLogRecord, int> processPrepare,
+                                   Action<CommitLogRecord, int> processCommit,
+                                   Action<SystemLogRecord, int> processSystem)
         {
             var result = chunk.TryReadFirst();
             while (result.Success)
@@ -485,19 +516,19 @@ namespace EventStore.Core.TransactionLog.Chunks
                     case LogRecordType.Prepare:
                     {
                         var prepare = (PrepareLogRecord)record;
-                        processPrepare(prepare);
+                        processPrepare(prepare, result.RecordLength);
                         break;
                     }
                     case LogRecordType.Commit:
                     {
                         var commit = (CommitLogRecord)record;
-                        processCommit(commit);
+                        processCommit(commit, result.RecordLength);
                         break;
                     }
                     case LogRecordType.System:
                     {
                         var system = (SystemLogRecord)record;
-                        processSystem(system);
+                        processSystem(system, result.RecordLength);
                         break;
                     }
                     default:

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -183,7 +183,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                                   (system, _) => { /* NOOP */ });
                 }
 
-                int newSize = 0;
+                long newSize = 0;
                 int positionMapCount = 0;
 
                 foreach (var oldChunk in oldChunks)
@@ -193,7 +193,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                                   {
                                       if (ShouldKeepPrepare(prepare, commits, chunkStartPos, chunkEndPos))
                                       {
-                                          newSize += len + 8;
+                                          newSize += len + 2 * sizeof(int);
                                           positionMapCount++;
                                       }
                                   },
@@ -201,13 +201,13 @@ namespace EventStore.Core.TransactionLog.Chunks
                                   {
                                       if (ShouldKeepCommit(commit, commits))
                                       {
-                                          newSize += len + 8;
+                                          newSize += len + 2 * sizeof(int);
                                           positionMapCount++;
                                       }
                                   },
                                   (system, len) =>
                                   {
-                                      newSize += len + 8;
+                                      newSize += len + 2 * sizeof(int);
                                       positionMapCount++;
                                   });
                 }


### PR DESCRIPTION
Faster rescavange and more accurate inmemory precalculation of chunk size. Fixes #1399

scavenge stops on shutting down the node
![image](https://user-images.githubusercontent.com/121181/30745918-9aff069e-9fb0-11e7-8f64-d5b762a616a2.png)

and when restarted

- current speed when dealing with "no chunks scavenged"
![image](https://user-images.githubusercontent.com/121181/30734765-428a3270-9f85-11e7-938e-11b59c68c655.png)

- optimized
![image](https://user-images.githubusercontent.com/121181/30734352-760c4be4-9f83-11e7-880f-28fc724714a6.png)
