### PR TITLE
Remove RandomAccess option from TFChunk file access.

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -366,7 +366,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                             FileAccess.Read,
                             FileShare.ReadWrite,
                             ReadBufferSize,
-                            FileOptions.RandomAccess);
+                            FileOptions.None);
             }
             var reader = new BinaryReader(stream);
             return new ReaderWorkItem(stream, reader, false);


### PR DESCRIPTION
I've done this as a PR but I'm just looking for a discussion at this point.

We've been having major performance issues related to projection throughput. Those inside the ES support team will be aware. It can be summed up as; system projection throughput drops to ~600 events/s from a normal range of ~6000 events/s. 

We've finally tracked this down to a low memory scenario. In particular when the windows file cache has filled up the RAM with **active** memory mapped file pages to where there is less then 4GB of "free" RAM. Over time this scenario is always hit due to the way the Windows file cache behaves.

See https://support.microsoft.com/en-gb/help/2549369/performance-degrades-when-accessing-large-files-with-file-flag-random

As mentioned in the Microsoft article, the fix is to not use the RandomAccess option on file access. The result of this is files are still cached in all available RAM, but they are marked as standby. This means they are more likely to be evicted; possibly bad for read performance, but fixes the mentioned performance issue.

I've done some basic testing and read performance seems comparable (if not better!) without the option. I can also see (using RamMap.exe) that Windows is correctly treating the file cache as standby pages. I'm not sure of any other implications, such as on mono/Linux. There may also be a need to configure this for people who prefer random read performance. 

So to start; any thoughts?
