### PR TITLE
Use current epoch (epoch-0) when starting up projections instead of (epoch-1)

### DIFF
--- a/src/EventStore.Core.Tests/Integration/when_a_master_is_shutdown.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_master_is_shutdown.cs
@@ -12,45 +12,66 @@ namespace EventStore.Core.Tests.Integration
     public class when_a_master_is_shutdown : specification_with_cluster
     {
         private List<Guid> _epochIds = new List<Guid>();
-        private CountdownEvent _expectedNumberOfRoleAssignments;
+        private List<string> _roleAssignments = new List<string>();
+        private CountdownEvent _expectedNumberOfEvents;
+
         protected override void BeforeNodesStart()
         {
-            _nodes.ToList().ForEach(x =>
-                x.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.StateChangeMessage>(Handle)));
-            _expectedNumberOfRoleAssignments = new CountdownEvent(3);
+            _nodes.ToList().ForEach(x => {
+                x.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.BecomeMaster>(Handle));
+                x.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.BecomeSlave>(Handle));
+                x.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(Handle));
+            });
+
+            _expectedNumberOfEvents = new CountdownEvent(3 /*role assignments*/+ 1 /*epoch write*/);
             base.BeforeNodesStart();
         }
 
         protected override void Given()
         {
-            _expectedNumberOfRoleAssignments.Wait(5000);
+            _expectedNumberOfEvents.Wait(5000);
             var master = _nodes.First(x => x.NodeState == Data.VNodeState.Master);
             ShutdownNode(master.DebugIndex);
-            _expectedNumberOfRoleAssignments = new CountdownEvent(2);
-            _expectedNumberOfRoleAssignments.Wait(5000);
+            _expectedNumberOfEvents = new CountdownEvent(2 /*role assignments*/ + 1 /*epoch write*/);
+            _expectedNumberOfEvents.Wait(5000);
             base.Given();
         }
 
-        private void Handle(SystemMessage.StateChangeMessage msg)
+        private void Handle(SystemMessage.BecomeMaster msg)
         {
-            switch (msg.State)
-            {
-                case Data.VNodeState.Master:
-                    _expectedNumberOfRoleAssignments?.Signal();
-                    _epochIds.Add(((SystemMessage.BecomeMaster)msg).EpochId);
-                    break;
-                case Data.VNodeState.Slave:
-                    _expectedNumberOfRoleAssignments?.Signal();
-                    _epochIds.Add(((SystemMessage.BecomeSlave)msg).EpochId);
-                    break;
-            }
+            _roleAssignments.Add("master");
+            _expectedNumberOfEvents?.Signal();
+        }
+
+        private void Handle(SystemMessage.BecomeSlave msg)
+        {
+            _roleAssignments.Add("slave");
+            _expectedNumberOfEvents?.Signal();
+        }
+
+        private void Handle(SystemMessage.EpochWritten msg)
+        {
+            _epochIds.Add(msg.Epoch.EpochId);
+            _expectedNumberOfEvents?.Signal();
         }
 
         [Test]
-        public void should_use_the_same_epochIds()
+        public void should_assign_master_and_slave_roles_correctly()
         {
-            Assert.AreEqual(1, _epochIds.Take(3).Distinct().Count());
-            Assert.AreEqual(1, _epochIds.Skip(3).Take(2).Distinct().Count());
+            Assert.AreEqual(5, _roleAssignments.Count());
+            
+            Assert.AreEqual(1, _roleAssignments.Take(3).Where(x => x.Equals("master")).Count());
+            Assert.AreEqual(2, _roleAssignments.Take(3).Where(x => x.Equals("slave")).Count());
+            
+            //after shutting down
+            Assert.AreEqual(1, _roleAssignments.Skip(3).Take(2).Where(x => x.Equals("master")).Count());
+            Assert.AreEqual(1, _roleAssignments.Skip(3).Take(2).Where(x => x.Equals("slave")).Count());
+        } 
+
+        [Test]
+        public void should_have_two_unique_epoch_writes()
+        {
+            Assert.AreEqual(2, _epochIds.Distinct().Count());
         } 
     }
 }

--- a/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Integration
         private const int _numberOfNodeStarts = 5;
         protected override void BeforeNodeStarts()
         {
-            _node.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.StateChangeMessage>(Handle));
+            _node.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(Handle));
             base.BeforeNodeStarts();
         }
 
@@ -29,14 +29,9 @@ namespace EventStore.Core.Tests.Integration
             base.Given();
         }
 
-        private void Handle(SystemMessage.StateChangeMessage msg)
+        private void Handle(SystemMessage.EpochWritten msg)
         {
-            switch (msg.State)
-            {
-                case Data.VNodeState.Master:
-                    _epochIds.Add(((SystemMessage.BecomeMaster)msg).EpochId);
-                    break;
-            }
+            _epochIds.Add(msg.Epoch.EpochId);
         }
 
         [Test]

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -186,7 +186,8 @@ namespace EventStore.Core
                                           vNodeSettings.HashCollisionReadLimit,
                                           vNodeSettings.SkipIndexScanOnReads);
             var writer = new TFChunkWriter(db);
-            var epochManager = new EpochManager(ESConsts.CachedEpochCount,
+            var epochManager = new EpochManager(_mainQueue,
+                                                ESConsts.CachedEpochCount,
                                                 db.Config.EpochCheckpoint,
                                                 writer,
                                                 initialReaderCount: 1,

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.Messages
 {
@@ -97,11 +98,9 @@ namespace EventStore.Core.Messages
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
             public override int MsgTypeId { get { return TypeId; } }
-            public readonly Guid EpochId;
 
-            public BecomeMaster(Guid correlationId, Guid epochId): base(correlationId, VNodeState.Master)
+            public BecomeMaster(Guid correlationId): base(correlationId, VNodeState.Master)
             {
-                EpochId = epochId;
             }
         }
 
@@ -191,11 +190,9 @@ namespace EventStore.Core.Messages
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
             public override int MsgTypeId { get { return TypeId; } }
-            public readonly Guid EpochId;
 
-            public BecomeSlave(Guid correlationId, Guid epochId, VNodeInfo master): base(correlationId, VNodeState.Slave, master)
+            public BecomeSlave(Guid correlationId, VNodeInfo master): base(correlationId, VNodeState.Slave, master)
             {
-                EpochId = epochId;
             }
         }
 
@@ -298,5 +295,19 @@ namespace EventStore.Core.Messages
 		    private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 		    public override int MsgTypeId { get { return TypeId; } }
 	    }
+
+        public class EpochWritten: Message
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly EpochRecord Epoch;
+
+            public EpochWritten(EpochRecord epoch)
+            {
+                Ensure.NotNull(epoch,"epoch");
+                Epoch = epoch;
+            }            
+        }           
     }
 }

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -32,7 +32,6 @@ namespace EventStore.Core.Services.VNode
         private VNodeInfo _master;
         private Guid _stateCorrelationId = Guid.NewGuid();
         private Guid _subscriptionId = Guid.Empty;
-        private Guid _lastEpochId = Guid.Empty;
 
         private IQueuedHandler _mainQueue;
         private IEnvelope _publishEnvelope;
@@ -428,7 +427,6 @@ namespace EventStore.Core.Services.VNode
             }
 
             _master = VNodeInfoHelper.FromMemberInfo(message.Master);
-            _lastEpochId = message.Master.EpochId;
             _subscriptionId = Guid.NewGuid();
             _stateCorrelationId = Guid.NewGuid();
             _outputBus.Publish(message);
@@ -723,7 +721,7 @@ namespace EventStore.Core.Services.VNode
                 return;
 
             _outputBus.Publish(message);
-            _fsm.Handle(new SystemMessage.BecomeMaster(_stateCorrelationId, _lastEpochId));
+            _fsm.Handle(new SystemMessage.BecomeMaster(_stateCorrelationId));
         }
 
         private void HandleAsPreReplica(SystemMessage.ChaserCaughtUp message)
@@ -788,7 +786,7 @@ namespace EventStore.Core.Services.VNode
                          _master.InternalTcp, _master.InternalSecureTcp == null ? "n/a" : _master.InternalSecureTcp.ToString(),
                          message.MasterId);
                 _outputBus.Publish(message);
-                _fsm.Handle(new SystemMessage.BecomeSlave(_stateCorrelationId, _lastEpochId, _master));
+                _fsm.Handle(new SystemMessage.BecomeSlave(_stateCorrelationId, _master));
             }
         }
 

--- a/src/EventStore.Projections.Core.Tests/Integration/parallel_query/when_running_from_catalog_stream_query_twice.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/parallel_query/when_running_from_catalog_stream_query_twice.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
@@ -38,7 +39,8 @@ fromStreamCatalog('catalog').foreachStream().when({
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
@@ -4,6 +4,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -87,7 +88,8 @@ namespace EventStore.Projections.Core.Tests.Integration
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             if (_startSystemProjections)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/command_reader_response_reader_integration/when_a_node_becomes_master.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/command_reader_response_reader_integration/when_a_node_becomes_master.cs
@@ -1,6 +1,7 @@
 ﻿using EventStore.Core.Messages;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Tests.Services.projections_manager;
+using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -19,8 +20,12 @@ namespace EventStore.Projections.Core.Tests.Services.command_reader_response_rea
 
         protected override IEnumerable<WhenStep> When()
         {
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            
             _uniqueId = Guid.NewGuid();
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), _uniqueId);
+            EpochRecord epochRecord = new EpochRecord(0L,0,_uniqueId,0L,DateTime.Now);
+
+            yield return new SystemMessage.EpochWritten(epochRecord);
             yield return new SystemMessage.SystemCoreReady();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -104,6 +104,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _bus.Subscribe<ClientMessage.DeleteStreamCompleted>(_manager);
             _bus.Subscribe<SystemMessage.StateChangeMessage>(_manager);
             _bus.Subscribe<SystemMessage.SystemCoreReady>(_manager);
+            _bus.Subscribe<SystemMessage.EpochWritten>(_manager);
             _bus.Subscribe<ProjectionManagementMessage.ReaderReady>(_manager);
             _bus.Subscribe(
                 CallbackSubscriber.Create<ProjectionManagementMessage.Starting>(
@@ -111,6 +112,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
             _bus.Subscribe<SystemMessage.StateChangeMessage>(_coordinator);
             _bus.Subscribe<SystemMessage.SystemCoreReady>(_coordinator);
+            _bus.Subscribe<SystemMessage.EpochWritten>(_coordinator);
 
             if (GetInputQueue() != _processingQueues.First().Item2)
             {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
@@ -6,6 +6,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Tests.Services.core_projection;
@@ -42,7 +43,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
 
             protected override IEnumerable<WhenStep> When()
             {
-                yield return(new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+                yield return(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+                yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
                 yield return(new SystemMessage.SystemCoreReady());
                 yield return
                     (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -46,7 +47,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
 
             protected override IEnumerable<WhenStep> When()
             {
-                yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+                yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+                yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
                 yield return (new SystemMessage.SystemCoreReady());
                 yield return (
                     new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -39,7 +40,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
 
             protected override IEnumerable<WhenStep> When()
             {
-                yield return(new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+                yield return(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+                yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
                 yield return(new SystemMessage.SystemCoreReady());
                 yield return
                     (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
@@ -8,6 +8,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
 using System.Linq;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 {
@@ -34,7 +35,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 
             protected override IEnumerable<WhenStep> When()
             {
-                yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+                yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+                yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
                 yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
@@ -89,7 +91,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 
             protected override IEnumerable<WhenStep> When()
             {
-                yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+                yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+                yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
                 yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
@@ -132,7 +135,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 
             protected override IEnumerable<WhenStep> PreWhen()
             {
-                yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+                yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+                yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
                 yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -8,6 +8,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
 using System.Linq;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 {
@@ -35,7 +36,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 
             protected override IEnumerable<WhenStep> When()
             {
-                yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+                yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+                yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
                 yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(
@@ -90,7 +92,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas
 
             protected override IEnumerable<WhenStep> When()
             {
-                yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+                yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+                yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
                 yield return new SystemMessage.SystemCoreReady();
                 yield return
                     new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/slave_projection/specification_with_slave_projection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.UserManagement;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Messages.ParallelQueryProcessingMessages;
 using EventStore.Projections.Core.Services;
@@ -28,7 +29,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.slave_p
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new CoreProjectionManagementMessage.CreateAndPrepareSlave(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_a_disabled_projection_has_been_loaded.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_a_disabled_projection_has_been_loaded.cs
@@ -8,6 +8,7 @@ using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -42,7 +43,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             _projectionName = "test-projection";
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_faulted_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_faulted_persistent_projection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
@@ -26,7 +27,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
@@ -26,7 +27,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
@@ -26,7 +27,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_emitted_streams_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_emitted_streams_stream.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
@@ -25,7 +26,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
@@ -24,7 +25,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
@@ -24,7 +25,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_system_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_system_projection.cs
@@ -9,6 +9,7 @@ using EventStore.ClientAPI.Common.Utils;
 using System.Collections;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -47,7 +48,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Disable(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
@@ -5,6 +5,7 @@ using System.Text;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -26,7 +27,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_registration_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_registration_write_fails.cs
@@ -9,6 +9,7 @@ using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
 using EventStore.Projections.Core.Services.Processing;
 using System.Collections;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -45,7 +46,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             _projectionName = "test-projection";
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -27,7 +28,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             _projectionName = "test-projection";
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_an_onetime_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_an_onetime_projection.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using NUnit.Framework;
 
@@ -18,7 +19,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using EventStore.Projections.Core.Services.Processing;
 using System.Collections.Generic;
 using EventStore.Projections.Core.Services;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.when_reading_registered_projections
 {
@@ -19,7 +20,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.when_re
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream_and_intialize_system_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream_and_intialize_system_projections.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections;
 using EventStore.Common.Utils;
 using EventStore.Projections.Core.Services;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.when_reading_registered_projections
 {
@@ -28,7 +29,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.when_re
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using NUnit.Framework;
@@ -24,7 +25,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
             yield return
                 new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_requesting_partition_state_from_a_stopped_foreach_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_requesting_partition_state_from_a_stopped_foreach_projection.cs
@@ -7,6 +7,7 @@ using EventStore.Projections.Core.Messages;
 using NUnit.Framework;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Services;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -40,7 +41,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             // when
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_duplicate_projection_created.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_duplicate_projection_created.cs
@@ -49,7 +49,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);
-            _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
             _manager.Handle(new ProjectionManagementMessage.ReaderReady());
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_partially_created_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_partially_created_projection.cs
@@ -48,7 +48,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);
-            _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
             _manager.Handle(new ProjectionManagementMessage.ReaderReady());
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projection.cs
@@ -48,7 +48,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);
-            _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            _manager.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
             _manager.Handle(new ProjectionManagementMessage.ReaderReady());
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_onetime_projection_has_been_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_onetime_projection_has_been_posted.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using NUnit.Framework;
 
@@ -22,7 +23,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             _projectionQuery = @"fromAll(); on_any(function(){});log(1);";
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_projections_initialized_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_the_projections_initialized_write_fails.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using EventStore.Projections.Core.Services.Processing;
 using System.Collections;
 using EventStore.Projections.Core.Services;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager
 {
@@ -41,7 +42,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
 
         protected override IEnumerable<WhenStep> When()
         {
-            yield return new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid());
+            yield return new SystemMessage.BecomeMaster(Guid.NewGuid());
+            yield return new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now));
             yield return new SystemMessage.SystemCoreReady();
         }
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -29,7 +30,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             _projectionName = "test-projection";
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -30,7 +31,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             _projectionName = "test-projection";
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -31,7 +32,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         {
             _projectionName = "test-projection";
             _source = @"fromAll(); on_any(function(){});log(1);";
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -29,7 +30,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             _projectionName = "test-projection";
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -71,7 +72,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
         protected override IEnumerable<WhenStep> When()
         {
             _projectionName = "test-projection";
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return
                 (new ProjectionManagementMessage.Command.Post(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
@@ -41,13 +41,13 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
             [Test]
             public void core_readers_should_use_the_unique_id_provided_by_the_state_change_message()
             {
-                var becomeMaster = _consumer.HandledMessages.OfType<SystemMessage.BecomeMaster>().First();
+                var epochWrittenMessages = _consumer.HandledMessages.OfType<SystemMessage.EpochWritten>().First();
                 var startCoreMessages = _consumer.HandledMessages.OfType<ProjectionCoreServiceMessage.StartCore>();
                 var startingMessage = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Starting>().First();
 
                 Assert.AreEqual(1, startCoreMessages.Select(x => x.EpochId).Distinct().Count());
-                Assert.AreEqual(becomeMaster.EpochId, startCoreMessages.First().EpochId);
-                Assert.AreEqual(becomeMaster.EpochId, startingMessage.EpochId);
+                Assert.AreEqual(epochWrittenMessages.Epoch.EpochId, startCoreMessages.First().EpochId);
+                Assert.AreEqual(epochWrittenMessages.Epoch.EpochId, startingMessage.EpochId);
             }
         }
 
@@ -56,7 +56,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
         {
             protected override IEnumerable<WhenStep> PreWhen()
             {
-                yield return (new SystemMessage.BecomeSlave(Guid.NewGuid(), Guid.NewGuid(),
+                yield return (new SystemMessage.BecomeSlave(Guid.NewGuid(),
                     new EventStore.Core.Data.VNodeInfo(Guid.NewGuid(), 1,
                         new IPEndPoint(IPAddress.Loopback, 1111),
                         new IPEndPoint(IPAddress.Loopback, 1112),

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projections_subsystem.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projections_subsystem.cs
@@ -5,6 +5,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Tests.Services.projections_manager;
 using System.Linq;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_system
 {
@@ -33,7 +34,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
 
         protected override IEnumerable<WhenStep> PreWhen()
         {
-            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid(), Guid.NewGuid()));
+            yield return (new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            yield return (new SystemMessage.EpochWritten(new EpochRecord(0L,0,Guid.NewGuid(),0L,DateTime.Now)));
             yield return (new SystemMessage.SystemCoreReady());
             yield return Yield;
             if (_startSystemProjections)

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -80,6 +80,7 @@ namespace EventStore.Projections.Core
         {
             mainBus.Subscribe<SystemMessage.StateChangeMessage>(projectionManager);
             mainBus.Subscribe<SystemMessage.SystemCoreReady>(projectionManager);
+            mainBus.Subscribe<SystemMessage.EpochWritten>(projectionManager);
             if (runProjections >= ProjectionType.System)
             {
                 mainBus.Subscribe<ProjectionManagementMessage.Command.Post>(projectionManager);
@@ -165,6 +166,8 @@ namespace EventStore.Projections.Core
                 Forwarder.Create<SystemMessage.StateChangeMessage>(projectionsStandardComponents.MasterInputQueue));
             standardComponents.MainBus.Subscribe(
                 Forwarder.Create<SystemMessage.SystemCoreReady>(projectionsStandardComponents.MasterInputQueue));
+            standardComponents.MainBus.Subscribe(
+                Forwarder.Create<SystemMessage.EpochWritten>(projectionsStandardComponents.MasterInputQueue));            
             projectionsStandardComponents.MasterMainBus.Subscribe(new UnwrapEnvelopeHandler());
         }
     }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -22,6 +22,7 @@ namespace EventStore.Projections.Core.Services.Management
         : IDisposable,
             IHandle<SystemMessage.StateChangeMessage>,
             IHandle<SystemMessage.SystemCoreReady>,
+            IHandle<SystemMessage.EpochWritten>,
             IHandle<ClientMessage.ReadStreamEventsBackwardCompleted>,
             IHandle<ClientMessage.ReadStreamEventsForwardCompleted>,
             IHandle<ClientMessage.WriteEventsCompleted>,
@@ -92,6 +93,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         private int _lastUsedQueue = 0;
         private bool _started;
+        private bool _projectionsStarted;
         private readonly PublishEnvelope _publishEnvelope;
 
         private readonly
@@ -177,6 +179,9 @@ namespace EventStore.Projections.Core.Services.Management
 
         private void Start()
         {
+            if(_started)
+                throw new InvalidOperationException();
+            _started = true;
             _publisher.Publish(new ProjectionManagementMessage.Starting(_epochId));
         }
 
@@ -186,7 +191,7 @@ namespace EventStore.Projections.Core.Services.Management
                 StartExistingProjections(
                     () =>
                     {
-                        _started = true;
+                        _projectionsStarted = true;
                         ScheduleExpire();
                         _publisher.Publish(new SystemMessage.SubSystemInitialized("Projections"));
                     });
@@ -195,7 +200,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         private void ScheduleExpire()
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             _publisher.Publish(
                 TimerMessage.Schedule.Create(
@@ -207,6 +212,7 @@ namespace EventStore.Projections.Core.Services.Management
         private void Stop()
         {
             _started = false;
+            _projectionsStarted = false;
 
             _writeDispatcher.CancelAll();
             _readDispatcher.CancelAll();
@@ -217,7 +223,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.Post message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
 
             if (
@@ -249,7 +255,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.Delete message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             var projection = GetProjection(message.Name);
             if (projection == null)
@@ -282,7 +288,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.GetQuery message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             var projection = GetProjection(message.Name);
             if (projection == null)
@@ -296,7 +302,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.UpdateQuery message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             _logger.Info(
                 "Updating '{0}' projection source to '{1}' (Requested type is: '{2}')",
@@ -315,7 +321,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.Disable message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             _logger.Info("Disabling '{0}' projection", message.Name);
 
@@ -331,7 +337,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.Enable message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             _logger.Info("Enabling '{0}' projection", message.Name);
 
@@ -350,7 +356,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.Abort message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             _logger.Info("Aborting '{0}' projection", message.Name);
 
@@ -366,7 +372,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.SetRunAs message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             _logger.Info("Setting RunAs1 account for '{0}' projection", message.Name);
 
@@ -389,7 +395,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.Reset message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             _logger.Info("Resetting '{0}' projection", message.Name);
 
@@ -408,7 +414,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.GetStatistics message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             if (!string.IsNullOrEmpty(message.Name))
             {
@@ -436,7 +442,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.GetState message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             var projection = GetProjection(message.Name);
             if (projection == null)
@@ -447,7 +453,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.GetResult message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             var projection = GetProjection(message.Name);
             if (projection == null)
@@ -458,7 +464,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.GetConfig message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             var projection = GetProjection(message.Name);
             if (projection == null)
@@ -472,7 +478,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Command.UpdateConfig message)
         {
-            if (!_started)
+            if (!_projectionsStarted)
                 return;
             var projection = GetProjection(message.Name);
             if (projection == null)
@@ -594,6 +600,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         private VNodeState _currentState = VNodeState.Unknown;
         private bool _systemIsReady = false;
+        private bool _ready = false;        
         private Guid _epochId = Guid.Empty;
         public void Handle(SystemMessage.SystemCoreReady message)
         {
@@ -604,30 +611,30 @@ namespace EventStore.Projections.Core.Services.Management
         public void Handle(SystemMessage.StateChangeMessage message)
         {
             _currentState = message.State;
-            _epochId = GetEpochIdFromStateChange(message);
+            if(_currentState != VNodeState.Master)
+                _ready = false;            
+            
             StartWhenConditionsAreMet();
         }
 
-        private Guid GetEpochIdFromStateChange(SystemMessage.StateChangeMessage message)
+        public void Handle(SystemMessage.EpochWritten message)
         {
-            Guid epochId = Guid.Empty;
-            switch (message.State)
-            {
-                case VNodeState.Master:
-                    epochId = ((SystemMessage.BecomeMaster)message).EpochId;
-                    break;
-                case VNodeState.Slave:
-                    epochId = ((SystemMessage.BecomeSlave)message).EpochId;
-                    break;
+            if(_ready) return;
+            
+            if(_currentState == VNodeState.Master){
+                _epochId = message.Epoch.EpochId;
+                _ready = true;
             }
-            return epochId;
+
+            StartWhenConditionsAreMet(); 
         }
 
         private void StartWhenConditionsAreMet()
         {
-            if (_currentState == VNodeState.Master)
+            //run if and only if these conditions are met
+            if (_systemIsReady && _ready)
             {
-                if (!_started && _systemIsReady)
+                if (!_started)
                 {
                     _logger.Debug("PROJECTIONS: Starting Projections Manager. (Node State : {0})", _currentState);
                     Start();


### PR DESCRIPTION
The epoch id is used to create the $projections-$control-{guid} streams which should be unique per projection run.

The previous epoch id (the one obtained before latest elections: epoch-1) was being used but under certain circumstances it is possible for two nodes to end up using the same epoch id which causes projections to behave abnormally (they get stuck on start up).

Example:
```
Node 1 is master with Epoch E1
Node 2,3 update their epoch state to E1
Node 3 is stopped
Node 2 becomes master and updates epoch to E2
Node 1 updates epoch state to E2 (Node 3 doesn't update because it's stopped)
Node 2 is stopped
Node 3 is started
Since StorageChaser (which updates the epoch) and Elections run in 'parallel', it's possible that Node 3 becomes master and uses Epoch E1 when starting up projections
```

**Resolution** - Start Projections only when we are master and the epoch has been written, that is use epoch-0 instead of epoch-1.

- Added a new message: SystemMessage.EpochWritten
- Change and improve the start up logic in ProjectionManager and ProjectionCoreCoordinator
- Removed EpochId from BecomeMaster / BecomeSlave messages since we are now obtaining it from EpochWritten
- Fix tests, removing epoch id parameter from BecomeSlave/BecomeMaster
- Fix tests to obtain the epoch id from SystemMessage.EpochWritten
- Fix tests to send EpochWritten message before projections start