### PR TITLE
Stop reading the order stream once the checkpoint has passed.

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Services\command_reader_response_reader_integration\specification_with_command_reader_and_response_reader.cs" />
     <Compile Include="Services\command_reader_response_reader_integration\when_response_reader_starts_before_command_reader.cs" />
     <Compile Include="Services\command_reader_response_reader_integration\when_command_reader_starts_before_response_reader.cs" />
+    <Compile Include="Services\core_projection\checkpoint_manager\multi_stream\when_starting_with_prerecorded_events_before_the_last_checkpoint.cs" />
     <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_maximum_allowed_writes_in_flight_set.cs" />
     <Compile Include="Services\core_projection\projection_checkpoint\when_emitting_events_with_null_streamId.cs" />
     <Compile Include="Services\core_service\when_a_subscribed_projection_handler_throws.cs" />
@@ -561,7 +562,7 @@
     <Compile Include="Services\event_reader\stream_reader\when_handling_streams_with_deleted_events_and_reader_starting_at_event_zero.cs" />
     <Compile Include="Services\event_reader\stream_reader\when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs" />
     <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_reader_starting_at_event_zero.cs" />
-    <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs" />    
+    <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_with_prerecorded_events_before_the_last_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_with_prerecorded_events_before_the_last_checkpoint.cs
@@ -1,0 +1,58 @@
+﻿using System.Linq;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+using EventStore.Projections.Core.Services;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager.multi_stream
+{
+    [TestFixture]
+    public class when_starting_with_prerecorded_events_before_the_last_checkpoint :
+        TestFixtureWithMultiStreamCheckpointManager
+    {
+        protected override void Given()
+        {
+            base.Given();
+            ExistingEvent(
+                "$projections-projection-checkpoint", ProjectionEventTypes.ProjectionCheckpoint,
+                @"{""s"": {""a"": 0, ""b"": 1, ""c"": 0}}", "{}");
+            ExistingEvent("a", "StreamCreated", "", "");
+            ExistingEvent("b", "StreamCreated", "", "");
+            ExistingEvent("c", "StreamCreated", "", "");
+            ExistingEvent("d", "StreamCreated", "", "");
+
+            ExistingEvent("a", "Event", "", @"{""data"":""a""");
+            ExistingEvent("b", "Event", "bb", @"{""data"":""b""");
+            ExistingEvent("c", "$>", "{$o:\"org\"}", @"1@d");
+            ExistingEvent("d", "Event", "dd", @"{""data"":""d""");
+
+            // Lots of pre-recorded events before the checkpoint.
+            for (int i = 0; i < 1000; i++)
+            {
+                
+                ExistingEvent(
+                    "$projections-projection-order", "$>", @"{""s"": {""a"": 0, ""b"": 0, ""c"": 0}}", "0@c");
+            }
+            // Pre-recorded event at checkpoint 
+            ExistingEvent(
+                "$projections-projection-order", "$>", @"{""s"": {""a"": 0, ""b"": 1, ""c"": 0}}", "1@b");
+        }
+
+        protected override void When()
+        {
+            base.When();
+            _checkpointReader.BeginLoadState();
+            var checkpointLoaded =
+                _consumer.HandledMessages.OfType<CoreProjectionProcessingMessage.CheckpointLoaded>().First();
+            _checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
+            _manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
+
+        }
+
+        [Test]
+        public void stops_reading_prerecorded_events_after_found_checkpoint()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsBackward>().Count(_ => _.EventStreamId == "$projections-projection-order"));
+        }
+
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
@@ -131,7 +131,7 @@ namespace EventStore.Projections.Core.Services.Processing
                                 if (tag <= checkpointTag)
                                 {
                                     SetOrderStreamReadCompleted();
-                                    break;
+                                    return;
                                 }
                                 EnqueuePrerecordedEvent(@event.Event, tag);
                             }


### PR DESCRIPTION
Looking at the Windows file caching I noticed one of our event store clusters was always loading the entire database into the file cache. This turned out to be a multi-stream projection causing the projection system to read an entire stream all the way backwards during initialization. In particular the "order" stream. This takes about 2 hours and blows out the file cache...

It looks like the **break** was attempting to break out the **switch** but was actually breaking out the **foreach**.

Test included.