### PR TITLE
Prevent 2 instances of ProjectionCoreCoordinator & its subcomponents from running in parallel

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -563,6 +563,15 @@
     <Compile Include="Services\event_reader\stream_reader\when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs" />
     <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_reader_starting_at_event_zero.cs" />
     <Compile Include="Services\event_reader\multi_stream_reader\when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs" />
+    <Compile Include="Services\core_coordinator\when_starting_with_projection_type_none.cs" />
+    <Compile Include="Services\core_coordinator\when_starting_with_projection_type_system.cs" />
+    <Compile Include="Services\core_coordinator\when_starting_with_projection_type_all.cs" />
+    <Compile Include="Services\core_coordinator\when_stopping_with_projection_type_none.cs" />
+    <Compile Include="Services\core_coordinator\when_stopping_with_projection_type_system.cs" />
+    <Compile Include="Services\core_coordinator\when_stopping_with_projection_type_all.cs" />
+    <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_none.cs" />
+    <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_system.cs" />
+    <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_all.cs" />    
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_restarting_with_projection_type_all.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_restarting_with_projection_type_all.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_restarting_with_projection_type_all
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.All,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+
+            //force stop
+            _coordinator.Handle(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+
+            //clear queues for clearer testing
+            queues[0].Messages.Clear();
+        }
+
+        private void BecomeReady(){
+            //become ready
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+        }
+
+        private void AllSubComponentsStarted(){
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("EventReaderCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreServiceCommandReader"));
+        }
+
+        private void AllSubComponentsStopped(){
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreServiceCommandReader"));
+        }
+
+        [Test]
+        public void should_not_start_if_subcomponents_not_stopped()
+        {
+            AllSubComponentsStarted();
+
+            BecomeReady();
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_not_start_if_only_some_subcomponents_stopped()
+        {
+            AllSubComponentsStarted();
+
+            /*Only some subcomponents stopped*/
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
+
+            BecomeReady();
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_stopped_before_becoming_ready()
+        {
+            AllSubComponentsStarted();
+
+            AllSubComponentsStopped();
+            BecomeReady();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_stopped_after_becoming_ready()
+        {
+            AllSubComponentsStarted();
+
+            BecomeReady();
+            AllSubComponentsStopped();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_some_subcomponents_stopped_before_becoming_ready_and_some_after_becoming_ready()
+        {
+            AllSubComponentsStarted();
+
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
+
+            BecomeReady();
+
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreServiceCommandReader"));
+
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_started_and_stopped_late_after_becoming_ready()
+        {
+            BecomeReady();
+            AllSubComponentsStarted();
+            AllSubComponentsStopped();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_started_and_stopped_in_a_different_random_order()
+        {
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("EventReaderCoreService"));
+            BecomeReady();
+
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
+            
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreServiceCommandReader"));
+          
+
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreServiceCommandReader"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+            
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_restarting_with_projection_type_none.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_restarting_with_projection_type_none.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_restarting_with_projection_type_none
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.None,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+
+            //force stop
+            _coordinator.Handle(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+
+            //clear queues for clearer testing
+            queues[0].Messages.Clear();
+        }
+
+        private void BecomeReady(){
+            //become ready
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+        }
+
+        private void AllSubComponentsStarted(){
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("EventReaderCoreService"));
+        }
+
+        private void AllSubComponentsStopped(){
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+        }
+
+        [Test]
+        public void should_not_start_if_subcomponents_not_stopped()
+        {
+            AllSubComponentsStarted();
+
+            BecomeReady();
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_stopped_before_becoming_ready()
+        {
+            AllSubComponentsStarted();
+
+            AllSubComponentsStopped();
+            BecomeReady();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_stopped_after_becoming_ready()
+        {
+            AllSubComponentsStarted();
+
+            BecomeReady();
+            AllSubComponentsStopped();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_started_and_stopped_late_after_becoming_ready()
+        {
+            BecomeReady();
+            AllSubComponentsStarted();
+            AllSubComponentsStopped();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_restarting_with_projection_type_system.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_restarting_with_projection_type_system.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_restarting_with_projection_type_system
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.System,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+
+            //force stop
+            _coordinator.Handle(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+
+            //clear queues for clearer testing
+            queues[0].Messages.Clear();
+        }
+
+        private void BecomeReady(){
+            //become ready
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+        }
+
+        private void AllSubComponentsStarted(){
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("EventReaderCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreServiceCommandReader"));
+        }
+
+        private void AllSubComponentsStopped(){
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreServiceCommandReader"));
+        }
+
+        [Test]
+        public void should_not_start_if_subcomponents_not_stopped()
+        {
+            AllSubComponentsStarted();
+
+            BecomeReady();
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_not_start_if_only_some_subcomponents_stopped()
+        {
+            AllSubComponentsStarted();
+
+            /*Only some subcomponents stopped*/
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
+
+            BecomeReady();
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(0,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_stopped_before_becoming_ready()
+        {
+            AllSubComponentsStarted();
+
+            AllSubComponentsStopped();
+            BecomeReady();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_stopped_after_becoming_ready()
+        {
+            AllSubComponentsStarted();
+
+            BecomeReady();
+            AllSubComponentsStopped();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_some_subcomponents_stopped_before_becoming_ready_and_some_after_becoming_ready()
+        {
+            AllSubComponentsStarted();
+
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
+
+            BecomeReady();
+
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreServiceCommandReader"));
+
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_started_and_stopped_late_after_becoming_ready()
+        {
+            BecomeReady();
+            AllSubComponentsStarted();
+            AllSubComponentsStopped();
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+
+        [Test]
+        public void should_start_if_subcomponents_started_and_stopped_in_a_different_random_order()
+        {
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("EventReaderCoreService"));
+            BecomeReady();
+
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreService"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
+            
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreServiceCommandReader"));
+          
+
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreServiceCommandReader"));
+            _coordinator.Handle(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));
+            
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+            Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ProjectionCoreServiceMessage.StartCore).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_starting_with_projection_type_all.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_starting_with_projection_type_all.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_starting_with_projection_type_all
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.All,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+        }
+
+        [Test]
+        public void should_publish_start_reader_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+        }
+
+        [Test]
+        public void should_publish_start_core_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x.GetType() == typeof(ProjectionCoreServiceMessage.StartCore)).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_starting_with_projection_type_none.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_starting_with_projection_type_none.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_starting_with_projection_type_none
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.None,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+        }
+
+        [Test]
+        public void should_publish_start_reader_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+        }
+
+        [Test]
+        public void should_not_publish_start_core_messages()
+        {
+         Assert.AreEqual(0,queues[0].Messages.FindAll(x => x.GetType() == typeof(ProjectionCoreServiceMessage.StartCore)).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_starting_with_projection_type_system.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_starting_with_projection_type_system.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_starting_with_projection_type_system
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.System,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+        }
+
+        [Test]
+        public void should_publish_start_reader_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StartReader).Count);
+        }
+
+        [Test]
+        public void should_publish_start_core_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x.GetType() == typeof(ProjectionCoreServiceMessage.StartCore)).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_stopping_with_projection_type_all.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_stopping_with_projection_type_all.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_stopping_with_projection_type_all
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.All,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+
+            //force stop
+            _coordinator.Handle(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+        }
+
+        [Test]
+        public void should_publish_stop_reader_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StopReader).Count);
+        }
+
+        [Test]
+        public void should_publish_stop_core_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x.GetType() == typeof(ProjectionCoreServiceMessage.StopCore)).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_stopping_with_projection_type_none.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_stopping_with_projection_type_none.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_stopping_with_projection_type_none
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.None,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+
+            //force stop
+            _coordinator.Handle(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+        }
+
+        [Test]
+        public void should_publish_stop_reader_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StopReader).Count);
+        }
+
+        [Test]
+        public void should_not_publish_stop_core_messages()
+        {
+         Assert.AreEqual(0,queues[0].Messages.FindAll(x => x.GetType() == typeof(ProjectionCoreServiceMessage.StopCore)).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_stopping_with_projection_type_system.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_coordinator/when_stopping_with_projection_type_system.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Common.Options;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.Replication;
+using System.Collections.Generic;
+
+namespace EventStore.Projections.Core.Tests.Services.core_coordinator
+{
+    [TestFixture]
+    public class when_stopping_with_projection_type_system
+    {
+        private FakePublisher[] queues;
+        private FakePublisher publisher;
+        private ProjectionCoreCoordinator _coordinator;
+        private TimeoutScheduler[] timeoutScheduler = {};
+        private FakeEnvelope envelope = new FakeEnvelope();
+        [SetUp]
+        public void Setup()
+        {
+            queues = new List<FakePublisher>(){new FakePublisher()}.ToArray();
+            publisher = new FakePublisher();
+
+            _coordinator = new ProjectionCoreCoordinator(ProjectionType.System,timeoutScheduler,queues,publisher,envelope);
+            _coordinator.Handle(new SystemMessage.BecomeMaster(Guid.NewGuid()));
+            _coordinator.Handle(new SystemMessage.SystemCoreReady());
+            _coordinator.Handle(new SystemMessage.EpochWritten(new EpochRecord(0,0,Guid.NewGuid(),0,DateTime.Now)));
+
+            //force stop
+            _coordinator.Handle(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+        }
+
+        [Test]
+        public void should_publish_stop_reader_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x is ReaderCoreServiceMessage.StopReader).Count);
+        }
+
+        [Test]
+        public void should_publish_stop_core_messages()
+        {
+         Assert.AreEqual(1,queues[0].Messages.FindAll(x => x.GetType() == typeof(ProjectionCoreServiceMessage.StopCore)).Count);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Messages/ProjectionCoreServiceMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionCoreServiceMessage.cs
@@ -59,5 +59,27 @@ namespace EventStore.Projections.Core.Messages
             }
         }
 
+        public class SubComponentStarted : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+            public readonly string SubComponent;
+            public SubComponentStarted(string subComponent)
+            {
+                SubComponent = subComponent;
+            }            
+        }
+
+        public class SubComponentStopped : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+            public readonly string SubComponent;
+            public SubComponentStopped(string subComponent)
+            {
+                SubComponent = subComponent;
+            }          
+        }                
+
     }
 }

--- a/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
@@ -54,7 +54,8 @@ namespace EventStore.Projections.Core
                 coreOutput.Subscribe<ClientMessage.ReadAllEventsForward>(forwarder);
                 coreOutput.Subscribe<ClientMessage.WriteEvents>(forwarder);
                 coreOutput.Subscribe<ClientMessage.DeleteStream>(forwarder);
-
+                coreOutput.Subscribe<ProjectionCoreServiceMessage.SubComponentStarted>(forwarder);
+                coreOutput.Subscribe<ProjectionCoreServiceMessage.SubComponentStopped>(forwarder);
 
                 if (projectionsStandardComponents.RunProjections >= ProjectionType.System)
                 {

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -167,7 +167,11 @@ namespace EventStore.Projections.Core
             standardComponents.MainBus.Subscribe(
                 Forwarder.Create<SystemMessage.SystemCoreReady>(projectionsStandardComponents.MasterInputQueue));
             standardComponents.MainBus.Subscribe(
-                Forwarder.Create<SystemMessage.EpochWritten>(projectionsStandardComponents.MasterInputQueue));            
+                Forwarder.Create<SystemMessage.EpochWritten>(projectionsStandardComponents.MasterInputQueue));
+            standardComponents.MainBus.Subscribe(
+                Forwarder.Create<ProjectionCoreServiceMessage.SubComponentStarted>(projectionsStandardComponents.MasterInputQueue));
+            standardComponents.MainBus.Subscribe(
+                Forwarder.Create<ProjectionCoreServiceMessage.SubComponentStopped>(projectionsStandardComponents.MasterInputQueue));                                
             projectionsStandardComponents.MasterMainBus.Subscribe(new UnwrapEnvelopeHandler());
         }
     }

--- a/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
@@ -349,14 +349,14 @@ namespace EventStore.Projections.Core.Services.Processing
         public void Handle(ReaderCoreServiceMessage.StartReader message)
         {
             StartReaders();
+            _publisher.Publish(new ProjectionCoreServiceMessage.SubComponentStarted("EventReaderCoreService"));
         }
 
         public void Handle(ReaderCoreServiceMessage.StopReader message)
         {
             StopReaders();
+            _publisher.Publish(new ProjectionCoreServiceMessage.SubComponentStopped("EventReaderCoreService"));            
         }
-
-
         public void Handle(ReaderCoreServiceMessage.ReaderTick message)
         {
             message.Action();

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -83,11 +83,13 @@ namespace EventStore.Projections.Core.Services.Processing
 
         public void Handle(ProjectionCoreServiceMessage.StartCore message)
         {
+            _publisher.Publish(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreService"));            
         }
 
         public void Handle(ProjectionCoreServiceMessage.StopCore message)
         {
             StopProjections();
+            _publisher.Publish(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreService"));
         }
 
         private void StopProjections()

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreServiceCommandReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreServiceCommandReader.cs
@@ -47,6 +47,7 @@ namespace EventStore.Projections.Core.Services.Processing
             Log.Debug("PROJECTIONS: Stopping Projection Core Reader ({0})", _coreServiceId);
             _cancellationScope.Cancel();
             _stopped = true;
+            _publisher.Publish(new ProjectionCoreServiceMessage.SubComponentStopped("ProjectionCoreServiceCommandReader"));            
         }
 
         private IEnumerable<IODispatcherAsync.Step> ControlSteps(Guid epochId)
@@ -147,6 +148,7 @@ namespace EventStore.Projections.Core.Services.Processing
             }
 
             Log.Debug("PROJECTIONS: Finished Starting Projection Core Reader (reads from $projections-${0})", _coreServiceId);
+            _publisher.Publish(new ProjectionCoreServiceMessage.SubComponentStarted("ProjectionCoreServiceCommandReader"));            
 
             ControlSteps(startCoreMessage.EpochId).Run();
 

--- a/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -1,5 +1,6 @@
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
+using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Messaging;
 
 namespace EventStore.Projections.Core.Services.Processing
@@ -10,7 +11,9 @@ namespace EventStore.Projections.Core.Services.Processing
                                                  IHandle<ClientMessage.ReadAllEventsForward>,
                                                  IHandle<ClientMessage.WriteEvents>,
                                                  IHandle<ClientMessage.DeleteStream>,
-                                                 IHandle<SystemMessage.SubSystemInitialized>
+                                                 IHandle<SystemMessage.SubSystemInitialized>,
+                                                 IHandle<ProjectionCoreServiceMessage.SubComponentStarted>,
+                                                 IHandle<ProjectionCoreServiceMessage.SubComponentStopped>
     {
         private readonly IPublisher _externalRequestQueue;
         private readonly IPublisher _inputQueue;
@@ -77,5 +80,19 @@ namespace EventStore.Projections.Core.Services.Processing
             _externalRequestQueue.Publish(
                 new SystemMessage.SubSystemInitialized(msg.SubSystemName));
         }
+
+        void IHandle<ProjectionCoreServiceMessage.SubComponentStarted>.Handle(ProjectionCoreServiceMessage.SubComponentStarted message)
+        {
+            _externalRequestQueue.Publish(
+                new ProjectionCoreServiceMessage.SubComponentStarted(message.SubComponent)
+            );
+        }
+
+        void IHandle<ProjectionCoreServiceMessage.SubComponentStopped>.Handle(ProjectionCoreServiceMessage.SubComponentStopped message)
+        {
+            _externalRequestQueue.Publish(
+                new ProjectionCoreServiceMessage.SubComponentStopped(message.SubComponent)
+            );
+        }        
     }
 }


### PR DESCRIPTION
It is possible for 2 instances of Projection Core Coordinator subcomponents (EventReaderCoreService/ProjectionCoreService/ProjectionCoreServiceCommandReader) to be running in parallel if a node goes from Master to Unknown state and quickly back to Master state.
If the subcomponents have not been stopped in time when the node moves to Unknown state, there will be 2 instances of the subcomponent running when the node moves back to master.

This can cause problems where projections gets stuck after an election

**Example:**
If a second instance of the command reader starts running (when receiving ProjectionCoreServiceMessage.StartCore message with another Epoch ID) before the first one is stopped, the command reader is stopped when the StopCore message for the first instance arrives.

```
[PID:18392:012 2017.10.11 16:20:24.644 INFO  ClusterVNodeControll] === NO QUORUM EMERGED WITHIN TIMEOUT... RETIRING...
[PID:18392:012 2017.10.11 16:20:24.644 INFO  ClusterVNodeControll] ========== [127.0.0.1:2112] IS UNKNOWN...
[PID:18392:012 2017.10.11 16:20:24.644 DEBUG ElectionsService    ] ELECTIONS: STARTING ELECTIONS.
[PID:18392:012 2017.10.11 16:20:24.644 DEBUG ElectionsService    ] ELECTIONS: (V=4) SHIFT TO LEADER ELECTION.
[PID:18392:012 2017.10.11 16:20:24.644 DEBUG ElectionsService    ] ELECTIONS: (V=4) VIEWCHANGE FROM [127.0.0.1:2112, {26650f98-b103-4fec-ac03-34673619413a}].
[PID:18392:018 2017.10.11 16:20:24.644 DEBUG ProjectionCoreCoordi] PROJECTIONS: Stopping Projections Core Coordinator. (Node State : Unknown)
---
Stopping projection manager
[PID:18392:018 2017.10.11 16:20:24.645 DEBUG ProjectionManager   ] PROJECTIONS: Stopping Projections Manager. (Node State : Unknown)
---
[PID:18392:015 2017.10.11 16:20:24.648 DEBUG PersistentSubscripti] Subscriptions received state change to Unknown stopping listening.
[PID:18392:012 2017.10.11 16:20:24.665 DEBUG ElectionsService    ] ELECTIONS: (V=4) VIEWCHANGE FROM [127.0.0.1:2122, {df52b02e-e51c-4941-9e2d-0db5cd2bed76}].
[PID:18392:012 2017.10.11 16:20:24.665 DEBUG ElectionsService    ] ELECTIONS: (V=4) MAJORITY OF VIEWCHANGE.
[PID:18392:012 2017.10.11 16:20:24.670 DEBUG ElectionsService    ] ELECTIONS: (V=4) PREPARE FROM [127.0.0.1:2122, {df52b02e-e51c-4941-9e2d-0db5cd2bed76}].
[PID:18392:012 2017.10.11 16:20:24.670 DEBUG ElectionsService    ] ELECTIONS: (V=4) SHIFT TO REG_NONLEADER.
[PID:18392:012 2017.10.11 16:20:24.693 DEBUG ElectionsService    ] ELECTIONS: (V=4) PROPOSAL FROM [127.0.0.1:2122,{df52b02e-e51c-4941-9e2d-0db5cd2bed76}] M=[127.0.0.1:2112,{26650f98-b103-4fec-ac03-34673619413a}](L=108911,W=109516,C=109516,E6@63525:{958f8051-057a-4b49-b126-f3f237b6abbb}). ME=[127.0.0.1:2112,{26650f98-b103-4fec-ac03-34673619413a}](L=108911,W=109516,C=109516,E6@63525:{958f8051-057a-4b49-b126-f3f237b6abbb}).
[PID:18392:012 2017.10.11 16:20:24.693 DEBUG ElectionsService    ] ELECTIONS: (V=4) ACCEPT FROM [127.0.0.1:2122,{df52b02e-e51c-4941-9e2d-0db5cd2bed76}] M=[127.0.0.1:2112,{26650f98-b103-4fec-ac03-34673619413a}]).
[PID:18392:012 2017.10.11 16:20:24.693 DEBUG ElectionsService    ] ELECTIONS: (V=4) ACCEPT FROM [127.0.0.1:2112,{26650f98-b103-4fec-ac03-34673619413a}] M=[127.0.0.1:2112,{26650f98-b103-4fec-ac03-34673619413a}]).
[PID:18392:012 2017.10.11 16:20:24.693 INFO  ElectionsService    ] ELECTIONS: (V=4) DONE. ELECTED MASTER = [127.0.0.1:2112,{26650f98-b103-4fec-ac03-34673619413a}](L=108911,W=109516,C=109516,E6@63525:{958f8051-057a-4b49-b126-f3f237b6abbb}). ME=[127.0.0.1:2112,{26650f98-b103-4fec-ac03-34673619413a}](L=108911,W=109516,C=109516,E6@63525:{958f8051-057a-4b49-b126-f3f237b6abbb}).
[PID:18392:012 2017.10.11 16:20:24.693 INFO  ClusterVNodeControll] ========== [127.0.0.1:2112] PRE-MASTER STATE, WAITING FOR CHASER TO CATCH UP...
[PID:18392:022 2017.10.11 16:20:24.694 DEBUG PersistentSubscripti] Subscriptions received state change to PreMaster stopping listening.
[PID:18392:012 2017.10.11 16:20:24.699 INFO  ClusterVNodeControll] ========== [127.0.0.1:2112] IS MASTER... SPARTA!
[PID:18392:009 2017.10.11 16:20:24.699 DEBUG EpochManager        ] === Writing E7@109516:{53449de7-e378-45f8-902a-b73a392597be} (previous epoch at 63525).
[PID:18392:006 2017.10.11 16:20:24.699 DEBUG PersistentSubscripti] Subscriptions Became Master so now handling subscriptions
[PID:18392:009 2017.10.11 16:20:24.705 DEBUG EpochManager        ] === Update Last Epoch E7@109516:{53449de7-e378-45f8-902a-b73a392597be} (previous epoch at 63525).
[PID:18392:018 2017.10.11 16:20:24.705 DEBUG ProjectionCoreCoordi] PROJECTIONS: Starting Projections Core Coordinator. (Node State : Master)
[PID:18392:018 2017.10.11 16:20:24.705 DEBUG ProjectionManager   ] PROJECTIONS: Starting Projections Manager. (Node State : Master)
[PID:18392:018 2017.10.11 16:20:24.705 DEBUG ProjectionManagerRes] PROJECTIONS: There was an active cancellation scope, cancelling now
[PID:18392:018 2017.10.11 16:20:24.705 DEBUG ProjectionManagerRes] PROJECTIONS: Starting Projection Manager Response Reader (reads from $projections-$master)
[PID:18392:018 2017.10.11 16:20:24.705 DEBUG MultiStreamMessageWr] PROJECTIONS: Resetting Worker Writer
[PID:18392:021 2017.10.11 16:20:24.714 INFO  ProjectionCoreServic] _projections is not empty after all the projections have been killed
[PID:18392:021 2017.10.11 16:20:24.714 TRACE InMemoryBus         ] SLOW BUS MSG [bus]: StopCore - 68ms. Handler: ProjectionCoreService.
[PID:18392:021 2017.10.11 16:20:24.714 DEBUG ProjectionCoreServic] PROJECTIONS: Stopping Projection Core Reader (34d3170a1d1b4d4bb2481bc0999924d0)
[PID:18392:021 2017.10.11 16:20:24.714 TRACE QueuedHandlerAutoRes] SLOW QUEUE MSG [Projection Core #2]: StopCore - 68ms. Q: 1/4.
[PID:18392:020 2017.10.11 16:20:24.715 INFO  ProjectionCoreServic] _projections is not empty after all the projections have been killed
[PID:18392:020 2017.10.11 16:20:24.715 TRACE InMemoryBus         ] SLOW BUS MSG [bus]: StopCore - 68ms. Handler: ProjectionCoreService.
[PID:18392:020 2017.10.11 16:20:24.715 DEBUG ProjectionCoreServic] PROJECTIONS: Stopping Projection Core Reader (d614795683174951b061bfee08f63ae5)
[PID:18392:020 2017.10.11 16:20:24.715 TRACE QueuedHandlerAutoRes] SLOW QUEUE MSG [Projection Core #1]: StopCore - 68ms. Q: 1/7.
[PID:18392:020 2017.10.11 16:20:24.715 INFO  ProjectionCoreServic] _subscriptions is not empty after all the projections have been killed
[PID:18392:020 2017.10.11 16:20:24.716 INFO  ProjectionCoreServic] _eventReaders is not empty after all the projections have been killed
[PID:18392:020 2017.10.11 16:20:24.716 INFO  ProjectionCoreServic] _subscriptionEventReaders is not empty after all the projections have been killed
[PID:18392:020 2017.10.11 16:20:24.718 DEBUG ResponseWriter      ] PROJECTIONS: Scheduling the writing of $stopped to $projections-$master. Current status of Writer: Busy: True
[PID:18392:021 2017.10.11 16:20:24.718 INFO  ProjectionCoreServic] _eventReaders is not empty after all the projections have been killed
---
New instances of Projection Core Reader started:
[PID:18392:021 2017.10.11 16:20:24.718 DEBUG ProjectionCoreServic] PROJECTIONS: Starting Projection Core Reader (reads from $projections-$34d3170a1d1b4d4bb2481bc0999924d0)
[PID:18392:021 2017.10.11 16:20:24.718 DEBUG ResponseWriter      ] PROJECTIONS: Resetting Master Writer
[PID:18392:020 2017.10.11 16:20:24.718 DEBUG ProjectionCoreServic] PROJECTIONS: Starting Projection Core Reader (reads from $projections-$d614795683174951b061bfee08f63ae5)
[PID:18392:020 2017.10.11 16:20:24.719 DEBUG ResponseWriter      ] PROJECTIONS: Resetting Master Writer
---
[PID:18392:019 2017.10.11 16:20:24.719 INFO  ProjectionCoreServic] _projections is not empty after all the projections have been killed
[PID:18392:019 2017.10.11 16:20:24.719 TRACE InMemoryBus         ] SLOW BUS MSG [bus]: StopCore - 73ms. Handler: ProjectionCoreService.
---
StopCore message received after other instances started :
[PID:18392:019 2017.10.11 16:20:24.720 DEBUG ProjectionCoreServic] PROJECTIONS: Stopping Projection Core Reader (025c5717850c452c971a73761d394851)
[PID:18392:019 2017.10.11 16:20:24.720 TRACE QueuedHandlerAutoRes] SLOW QUEUE MSG [Projection Core #0]: StopCore - 73ms. Q: 1/4.
---
[PID:18392:019 2017.10.11 16:20:24.720 INFO  ProjectionCoreServic] _eventReaders is not empty after all the projections have been killed
[PID:18392:019 2017.10.11 16:20:24.720 DEBUG ProjectionCoreServic] PROJECTIONS: Starting Projection Core Reader (reads from $projections-$025c5717850c452c971a73761d394851)
[PID:18392:019 2017.10.11 16:20:24.721 DEBUG ResponseWriter      ] PROJECTIONS: Resetting Master Writer
[PID:18392:017 2017.10.11 16:20:24.726 INFO  TcpService          ] Internal TCP connection accepted: [Normal, 127.0.0.1:34427, L127.0.0.1:2110, {dea512e1-81fd-425a-a7b4-c8216607e01a}].
[PID:18392:012 2017.10.11 16:20:24.792 TRACE GossipServiceBase   ] CLUSTER HAS CHANGED (gossip received from [127.0.0.1:2122])

Projections get stuck at this point
```

**Resolution:**
Keep track of subcomponent starts and stops.
During a node transition to Master, only start the ProjectionCoreCoordinator when all subcomponents (from the previous running instance) have been stopped.
