### PR TITLE
Convert timeout of 0 to no timeout when loading config on startup.

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -171,8 +171,6 @@ namespace EventStore.Core.Services.PersistentSubscription
                 return;
             }
 
-            var msgTimeout = message.MessageTimeoutMilliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(message.MessageTimeoutMilliseconds);
-            var checkPointAfter = message.CheckPointAfterMilliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(message.CheckPointAfterMilliseconds);
             CreateSubscriptionGroup(message.EventStreamId,
                                     message.GroupName,
                                     message.ResolveLinkTos,
@@ -182,12 +180,12 @@ namespace EventStore.Core.Services.PersistentSubscription
                                     message.LiveBufferSize,
                                     message.BufferSize,
                                     message.ReadBatchSize,
-                                    checkPointAfter,
+                                    ToTimeout(message.CheckPointAfterMilliseconds),
                                     message.MinCheckPointCount,
                                     message.MaxCheckPointCount,
                                     message.MaxSubscriberCount,
                                     message.NamedConsumerStrategy,
-                                    msgTimeout
+                                    ToTimeout(message.MessageTimeoutMilliseconds)
                                     );
             Log.Debug("New persistent subscription {0}.", message.GroupName);
             _config.Updated = DateTime.Now;
@@ -247,8 +245,6 @@ namespace EventStore.Core.Services.PersistentSubscription
 
             RemoveSubscription(message.EventStreamId, message.GroupName);
             RemoveSubscriptionConfig(message.User.Identity.Name, message.EventStreamId, message.GroupName);
-            var msgTimeout = message.MessageTimeoutMilliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(message.MessageTimeoutMilliseconds);
-            var checkPointAfter = message.CheckPointAfterMilliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(message.CheckPointAfterMilliseconds);
             CreateSubscriptionGroup(message.EventStreamId,
                                     message.GroupName,
                                     message.ResolveLinkTos,
@@ -258,12 +254,12 @@ namespace EventStore.Core.Services.PersistentSubscription
                                     message.LiveBufferSize,
                                     message.BufferSize,
                                     message.ReadBatchSize,
-                                    checkPointAfter,
+                                    ToTimeout(message.CheckPointAfterMilliseconds),
                                     message.MinCheckPointCount,
                                     message.MaxCheckPointCount,
                                     message.MaxSubscriberCount,
                                     message.NamedConsumerStrategy,
-                                    msgTimeout
+                                    ToTimeout(message.MessageTimeoutMilliseconds)
                                     );
             _config.Updated = DateTime.Now;
             _config.UpdatedBy = message.User.Identity.Name;
@@ -668,12 +664,12 @@ namespace EventStore.Core.Services.PersistentSubscription
                                                     entry.LiveBufferSize,
                                                     entry.HistoryBufferSize,
                                                     entry.ReadBatchSize,
-                                                    TimeSpan.FromMilliseconds(entry.CheckPointAfter),
+                                                    ToTimeout(entry.CheckPointAfter),
                                                     entry.MinCheckPointCount,
                                                     entry.MaxCheckPointCount,
                                                     entry.MaxSubscriberCount,
                                                     entry.NamedConsumerStrategy,
-                                                    TimeSpan.FromMilliseconds(entry.MessageTimeout));
+                                                    ToTimeout(entry.MessageTimeout));
                         }
                         continueWith();
                     }
@@ -713,31 +709,6 @@ namespace EventStore.Core.Services.PersistentSubscription
                     break;
                 default:
                     throw new Exception(obj.Result + " is an unexpected result writing subscription configuration.");
-            }
-        }
-
-        public void LoadSubscriptionsFromConfig()
-        {
-            Log.Debug("Loading subscriptions from persisted config.");
-            InitToEmpty();
-            if(_config.Entries == null) throw new Exception("Subscription Entries should never be null.");
-            foreach (var sub in _config.Entries)
-            {
-                CreateSubscriptionGroup(sub.Stream,
-                                        sub.Group,
-                                        sub.ResolveLinkTos,
-                                        sub.StartFrom,
-                                        sub.ExtraStatistics,
-                                        sub.MaxRetryCount,
-                                        sub.LiveBufferSize,
-                                        sub.HistoryBufferSize,
-                                        sub.ReadBatchSize,
-                                        TimeSpan.FromMilliseconds(sub.CheckPointAfter),
-                                        sub.MinCheckPointCount,
-                                        sub.MaxCheckPointCount,
-                                        sub.MaxSubscriberCount,
-                                        sub.NamedConsumerStrategy,
-                                        TimeSpan.FromMilliseconds(sub.MessageTimeout));
             }
         }
 
@@ -834,6 +805,11 @@ namespace EventStore.Core.Services.PersistentSubscription
             {
                 subscription.NotifyClockTick(now);
             }
+        }
+
+        private TimeSpan ToTimeout(int milliseconds)
+        {
+            return milliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(milliseconds);
         }
     }
 }


### PR DESCRIPTION
A timeout of 0 milliseconds is used to indicate that messages on the subscription should not time out, and was converted to `TimeSpan.MaxValue` when it was set.

However, this same conversion did not happen when loading the config for the subscription.
This means that if a subscription with `DoNotTimeout()` is restarted, messages would timeout immediately after being sent.

Also removed unused block of code for loading config. 