### PR TITLE
Make PasswordChangeNotificationReader try again in case of a read error

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/Authentication/PasswordChangeNotificationReader.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/PasswordChangeNotificationReader.cs
@@ -65,8 +65,10 @@ namespace EventStore.Core.Services.Transport.Http.Authentication
                             case ReadStreamResult.AccessDenied:
                             case ReadStreamResult.Error:
                             case ReadStreamResult.NotModified:
-                                throw new Exception(
-                                    "Failed to read: " + UserManagementService.UserPasswordNotificationsStreamId);
+                                _log.Error("Failed to read: " + UserManagementService.UserPasswordNotificationsStreamId + " completed.Result=" + completed.Result.ToString());
+                                _ioDispatcher.Delay(
+                                    TimeSpan.FromSeconds(10), () => ReadNotificationsFrom(fromEventNumber));
+                                break;
                             case ReadStreamResult.NoStream:
                             case ReadStreamResult.StreamDeleted:
                                 _ioDispatcher.Delay(


### PR DESCRIPTION
Retry when getting ReadStreamResult.Error/AccessDenied/NotModified