### PR TITLE
Allow connecting with SSL when using the testclient

### DIFF
--- a/src/EventStore.TestClient/ClientOptions.cs
+++ b/src/EventStore.TestClient/ClientOptions.cs
@@ -40,6 +40,10 @@ namespace EventStore.TestClient
         public string[] Command { get; set; }
         public bool Reconnect { get; set; }
 
+        public bool UseSsl { get; set; }
+        public string TargetHost { get; set; }
+        public bool ValidateServer { get; set; }
+
         public ClientOptions()
         {
             Config = "";
@@ -58,6 +62,9 @@ namespace EventStore.TestClient
             PingWindow = 2000;
             Force = false;
             Reconnect = true;
+            UseSsl = false;
+            TargetHost = "";
+            ValidateServer = false;
         }
     }
 }


### PR DESCRIPTION
Adds new options to the testclient to run with SSL

For example:
```
./EventStore.TestClient.exe --use-ssl --target-host=eventstore.org --tcp-port=1115
```