### PR TITLE
Disable expired projections rather than deleting them

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
@@ -52,9 +52,10 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
             }
 
             [Test]
-            public void projection_is_not_found()
+            public void projection_is_disabled()
             {
-                Assert.IsTrue(_consumer.HandledMessages.OfType<ProjectionManagementMessage.NotFound>().Any());
+                var res = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>().First();
+                Assert.AreEqual("Stopped", res.Projections[0].Status);
             }
         }
     }

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -555,14 +555,12 @@ namespace EventStore.Projections.Core.Services.Management
                     // NOTE: workaround for stop not working on creating state (just ignore them)
                     return;
                 }
+                _logger.Warn("Projection {0} has expired and will be disabled. Last accessed at {1}", _name, _lastAccessed);
                 Handle(
-                    new ProjectionManagementMessage.Command.Delete(
+                    new ProjectionManagementMessage.Command.Disable(
                         new NoopEnvelope(),
                         _name,
-                        ProjectionManagementMessage.RunAs.System,
-                        false,
-                        false,
-                        false));
+                        ProjectionManagementMessage.RunAs.System));
             }
         }
 


### PR DESCRIPTION
Previously, if a projection hadn't responded after 5 minutes, the projection was deleted.
This updates it so that the expiry is logged and the projection is disabled instead, as it is very difficult to recover from a delete.