### PR TITLE
Allow the user to skip verification of index integrity on startup

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -199,6 +199,9 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.UnsafeIgnoreHardDeleteDescr, Opts.DbGroup)]
         public bool UnsafeIgnoreHardDelete { get; set; }
 
+        [ArgDescription(Opts.SkipIndexVerifyDescr, Opts.DbGroup)]
+        public bool SkipIndexVerify { get; set; }
+
         [ArgDescription(Opts.IndexCacheDepthDescr, Opts.DbGroup)]
         public int IndexCacheDepth { get; set; }
 
@@ -319,6 +322,7 @@ namespace EventStore.ClusterNode
             GossipAllowedDifferenceMs = Opts.GossipAllowedDifferenceMsDefault;
             GossipTimeoutMs = Opts.GossipTimeoutMsDefault;
             IndexCacheDepth = Opts.IndexCacheDepthDefault;
+            SkipIndexVerify = Opts.SkipIndexVerifyDefault;
             EnableHistograms = Opts.HistogramEnabledDefault;
             ReaderThreadsCount = Opts.ReaderThreadsCountDefault;
 

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -198,6 +198,7 @@ namespace EventStore.ClusterNode
                         .WithNodePriority(options.NodePriority)
                         .WithScavengeHistoryMaxAge(options.ScavengeHistoryMaxAge)
                         .WithIndexPath(options.Index)
+                        .WithIndexVerification(options.SkipIndexVerify)
                         .WithIndexCacheDepth(options.IndexCacheDepth)
                         .WithSslTargetHost(options.SslTargetHost)
                         .RunProjections(options.RunProjections, options.ProjectionThreads)
@@ -236,7 +237,7 @@ namespace EventStore.ClusterNode
             foreach(var prefix in options.ExtHttpPrefixes) {
                 builder.AddExternalHttpPrefix(prefix);
             }
-            
+
             if(options.EnableTrustedAuth)
                 builder.EnableTrustedAuth();
             if(options.StartStandardProjections)
@@ -277,7 +278,7 @@ namespace EventStore.ClusterNode
                 builder.EnableWriteThrough();
             if (options.SkipIndexScanOnReads)
                 builder.SkipIndexScanOnReads();
-               
+
             if (options.IntSecureTcpPort > 0 || options.ExtSecureTcpPort > 0)
             {
                 if (!string.IsNullOrWhiteSpace(options.CertificateStoreLocation))
@@ -304,7 +305,7 @@ namespace EventStore.ClusterNode
             var authenticationProviderFactory = GetAuthenticationProviderFactory(options.AuthenticationType, authenticationConfig, plugInContainer);
             var consumerStrategyFactories = GetPlugInConsumerStrategyFactories(plugInContainer);
             builder.WithAuthenticationProvider(authenticationProviderFactory);
-            
+
             return builder.Build(options, consumerStrategyFactories);
         }
 

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -681,6 +681,9 @@
     <Compile Include="Services\Transport\Tcp\TcpClientDispatcherTests.cs" />
     <Compile Include="Services\Storage\Scavenge\when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1.cs" />
     <Compile Include="ClientAPI\ExpectedVersion64Bit\read_stream_with_link_to_event_with_event_number_greater_than_int_maxvalue.cs" />
+    <Compile Include="Index\IndexV1\when_a_ptable_is_loaded_from_disk.cs" />
+    <Compile Include="Index\IndexV2\when_a_ptable_is_loaded_from_disk.cs" />
+    <Compile Include="Index\IndexV3\when_a_ptable_is_loaded_from_disk.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj">

--- a/src/EventStore.Core.Tests/Index/IndexV1/opening_a_ptable_with_more_than_32bits_of_records.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/opening_a_ptable_with_more_than_32bits_of_records.cs
@@ -5,6 +5,7 @@ using System.IO;
 using NUnit.Framework;
 using EventStore.Core.Index;
 using EventStore.Common.Utils;
+using EventStore.Common.Options;
 
 namespace EventStore.Core.Tests.Index.IndexV1
 {
@@ -28,7 +29,7 @@ namespace EventStore.Core.Tests.Index.IndexV1
             _size = _ptableCount * (long)indexEntrySize + PTableHeader.Size + PTable.MD5Size;
             Console.WriteLine("Creating PTable at {0}. Size of PTable: {1}", Filename, _size);
             CreatePTableFile(Filename, _size, indexEntrySize);
-            _ptable = PTable.FromFile(Filename, 22);
+            _ptable = PTable.FromFile(Filename, 22, false);
         }
 
         public static void CreatePTableFile(string filename, long ptableSize, int indexEntrySize, int cacheDepth = 16)

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_header_is_corrupt_on_disk.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_header_is_corrupt_on_disk.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using EventStore.Common.Options;
 using EventStore.Core.Exceptions;
 using EventStore.Core.Index;
 using NUnit.Framework;
@@ -35,8 +36,16 @@ namespace EventStore.Core.Tests.Index.IndexV1
         [Test]
         public void the_hash_is_invalid()
         {
-            var exc = Assert.Throws<CorruptIndexException>(() => _table = PTable.FromFile(_copiedfilename, 16));
+            var exc = Assert.Throws<CorruptIndexException>(() => _table = PTable.FromFile(_copiedfilename, 16, false));
             Assert.IsInstanceOf<HashValidationException>(exc.InnerException);
+        }
+
+        [Test]
+        public void no_error_if_index_verification_disabled()
+        {
+            Assert.DoesNotThrow(
+                () => _table = PTable.FromFile(_copiedfilename, 16, true)
+            );
         }
 
         [TearDown]

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_is_corrupt_on_disk.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_is_corrupt_on_disk.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using EventStore.Common.Options;
 using EventStore.Core.Exceptions;
 using EventStore.Core.Index;
 using NUnit.Framework;
@@ -46,7 +47,7 @@ namespace EventStore.Core.Tests.Index.IndexV1
         [Test]
         public void the_hash_is_invalid()
         {
-            var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(_copiedfilename, 16));
+            var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(_copiedfilename, 16, false));
             Assert.IsInstanceOf<HashValidationException>(exc.InnerException);
         }
     }

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_is_loaded_from_disk.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_is_loaded_from_disk.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using EventStore.Common.Options;
+using EventStore.Core.Exceptions;
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Index.IndexV1
+{
+    [TestFixture]
+    public class when_a_ptable_is_loaded_from_disk: SpecificationWithDirectory
+    {
+        private string _filename;
+        private PTable _table;
+        private string _copiedfilename;
+        protected byte _ptableVersion = PTableVersions.IndexV1;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            _filename = GetTempFilePath();
+            _copiedfilename = GetTempFilePath();
+            var mtable = new HashListMemTable(_ptableVersion, maxSize: 1024);
+            
+            long logPosition = 0;
+            long eventNumber = 1;
+            ulong streamId = 0x010100000000;
+
+            for(var i=0;i<1337;i++){
+                logPosition++;
+
+                if(i%37 == 0){
+                    streamId -= 0x1337;
+                    eventNumber = 1;
+                }
+                else
+                    eventNumber++;
+                mtable.Add(streamId , eventNumber, logPosition);
+            }
+            _table = PTable.FromMemtable(mtable, _filename);
+            _table.Dispose();
+            File.Copy(_filename, _copiedfilename);
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            base.TearDown();
+        }
+
+        [Test]
+        public void same_midpoints_are_loaded_when_enabling_or_disabling_index_verification()
+        {
+            for(int depth = 2; depth <= 20; depth++){
+                var ptableWithMD5Verification = PTable.FromFile(_copiedfilename, depth, false);
+                var ptableWithoutVerification = PTable.FromFile(_copiedfilename, depth, true);
+                var midPoints1 = ptableWithMD5Verification.GetMidPoints();
+                var midPoints2 = ptableWithoutVerification.GetMidPoints();
+
+                Assert.AreEqual(midPoints1.Length, midPoints2.Length);
+                for(var i=0;i<midPoints1.Length;i++){
+                    Assert.AreEqual(midPoints1[i].ItemIndex, midPoints2[i].ItemIndex);
+                    Assert.AreEqual(midPoints1[i].Key.Stream, midPoints2[i].Key.Stream);
+                    Assert.AreEqual(midPoints1[i].Key.Version, midPoints2[i].Key.Version);
+                }
+
+                ptableWithMD5Verification.Dispose();
+                ptableWithoutVerification.Dispose();
+            }
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_opening_ptable_without_right_flag_in_header.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_opening_ptable_without_right_flag_in_header.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using EventStore.Common.Options;
 using EventStore.Core.Exceptions;
 using EventStore.Core.Index;
 using NUnit.Framework;
@@ -23,7 +24,7 @@ namespace EventStore.Core.Tests.Index.IndexV1
         [Test]
         public void the_invalid_file_exception_is_thrown()
         {
-            var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(Filename, 16));
+            var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(Filename, 16, false));
             Assert.IsInstanceOf<InvalidFileException>(exc.InnerException);
         }
     }

--- a/src/EventStore.Core.Tests/Index/IndexV2/when_a_ptable_is_loaded_from_disk.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/when_a_ptable_is_loaded_from_disk.cs
@@ -1,0 +1,14 @@
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Index.IndexV2
+{
+    [TestFixture]
+    public class when_a_ptable_is_loaded_from_disk: IndexV1.when_a_ptable_is_loaded_from_disk
+    {
+        public when_a_ptable_is_loaded_from_disk()
+        {
+            _ptableVersion = PTableVersions.IndexV2;
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Index/IndexV3/when_a_ptable_is_loaded_from_disk.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV3/when_a_ptable_is_loaded_from_disk.cs
@@ -1,0 +1,14 @@
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Index.IndexV3
+{
+    [TestFixture]
+    public class when_a_ptable_is_loaded_from_disk: IndexV1.when_a_ptable_is_loaded_from_disk
+    {
+        public when_a_ptable_is_loaded_from_disk()
+        {
+            _ptableVersion = PTableVersions.IndexV3;
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/SpecificationWithDirectory.cs
+++ b/src/EventStore.Core.Tests/SpecificationWithDirectory.cs
@@ -30,7 +30,17 @@ namespace EventStore.Core.Tests
         public virtual void TearDown()
         {
             //kill whole tree
-            Directory.Delete(PathName, true);
+            ForceDeleteDirectory(PathName);
+        }
+
+        private static void ForceDeleteDirectory(string path)
+        {
+            var directory = new DirectoryInfo(path) { Attributes = FileAttributes.Normal };
+            foreach (var info in directory.GetFileSystemInfos("*", SearchOption.AllDirectories))
+            {
+                info.Attributes = FileAttributes.Normal;
+            }
+            directory.Delete(true);
         }
     }
 }

--- a/src/EventStore.Core.Tests/SpecificationWithDirectoryPerTestFixture.cs
+++ b/src/EventStore.Core.Tests/SpecificationWithDirectoryPerTestFixture.cs
@@ -31,7 +31,17 @@ namespace EventStore.Core.Tests
         public virtual void TestFixtureTearDown()
         {
             //kill whole tree
-            Directory.Delete(PathName, true);
+            ForceDeleteDirectory(PathName);
+        }
+
+        private static void ForceDeleteDirectory(string path)
+        {
+            var directory = new DirectoryInfo(path) { Attributes = FileAttributes.Normal };
+            foreach (var info in directory.GetFileSystemInfos("*", SearchOption.AllDirectories))
+            {
+                info.Attributes = FileAttributes.Normal;
+            }
+            directory.Delete(true);
         }
     }
 }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -64,6 +64,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly bool VerifyDbHash;
         public readonly int MaxMemtableEntryCount;
         public readonly int HashCollisionReadLimit;
+        public readonly bool SkipIndexVerify;
         public readonly int IndexCacheDepth;
         public readonly byte IndexBitnessVersion;
 
@@ -126,6 +127,7 @@ namespace EventStore.Core.Cluster.Settings
                                     bool logHttpRequests,
                                     int connectionPendingSendBytesThreshold,
                                     string index = null, bool enableHistograms = false,
+                                    bool skipIndexVerify = false,
                                     int indexCacheDepth = 16,
                                     byte indexBitnessVersion = 2,
                                     IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null,
@@ -216,6 +218,7 @@ namespace EventStore.Core.Cluster.Settings
             HashCollisionReadLimit = hashCollisionReadLimit;
 
             EnableHistograms = enableHistograms;
+            SkipIndexVerify = skipIndexVerify;
             IndexCacheDepth = indexCacheDepth;
             IndexBitnessVersion = indexBitnessVersion;
             Index = index;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -176,6 +176,7 @@ namespace EventStore.Core
                                             maxSizeForMemory: vNodeSettings.MaxMemtableEntryCount,
                                             maxTablesPerLevel: 2,
                                             inMem: db.Config.InMemDb,
+                                            skipIndexVerify: vNodeSettings.SkipIndexVerify,
                                             indexCacheDepth: vNodeSettings.IndexCacheDepth);
 			var readIndex = new ReadIndex(_mainQueue,
                                           readerPool,

--- a/src/EventStore.Core/Index/IndexMap.cs
+++ b/src/EventStore.Core/Index/IndexMap.cs
@@ -108,7 +108,7 @@ namespace EventStore.Core.Index
             return new IndexMap(IndexMapVersion, new List<List<PTable>>(), -1, -1, maxTablesPerLevel);
         }
 
-        public static IndexMap FromFile(string filename, int maxTablesPerLevel = 4, bool loadPTables = true, int cacheDepth = 16)
+        public static IndexMap FromFile(string filename, int maxTablesPerLevel = 4, bool loadPTables = true, int cacheDepth = 16, bool skipIndexVerify = false)
         {
             if (!File.Exists(filename))
                 return CreateEmpty(maxTablesPerLevel);
@@ -130,7 +130,7 @@ namespace EventStore.Core.Index
                     var prepareCheckpoint = checkpoints.PreparePosition;
                     var commitCheckpoint = checkpoints.CommitPosition;
 
-                    var tables = loadPTables ? LoadPTables(reader, filename, checkpoints, cacheDepth) : new List<List<PTable>>();
+                    var tables = loadPTables ? LoadPTables(reader, filename, checkpoints, cacheDepth, skipIndexVerify) : new List<List<PTable>>();
 
                     if (!loadPTables && reader.ReadLine() != null)
                         throw new CorruptIndexException(
@@ -208,7 +208,7 @@ namespace EventStore.Core.Index
             }
         }
 
-        private static List<List<PTable>> LoadPTables(StreamReader reader, string indexmapFilename, TFPos checkpoints, int cacheDepth)
+        private static List<List<PTable>> LoadPTables(StreamReader reader, string indexmapFilename, TFPos checkpoints, int cacheDepth, bool skipIndexVerify)
         {
             var tables = new List<List<PTable>>();
 
@@ -230,7 +230,7 @@ namespace EventStore.Core.Index
                     var path = Path.GetDirectoryName(indexmapFilename);
                     var ptablePath = Path.Combine(path, file);
 
-                    ptable = PTable.FromFile(ptablePath, cacheDepth);
+                    ptable = PTable.FromFile(ptablePath, cacheDepth, skipIndexVerify);
 
                     CreateIfNeeded(level, tables);
                     tables[level].Insert(position, ptable);

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -6,15 +6,16 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using EventStore.Common.Options;
 using EventStore.Common.Utils;
 
 namespace EventStore.Core.Index
 {
     public unsafe partial class PTable
     {
-        public static PTable FromFile(string filename, int cacheDepth)
+        public static PTable FromFile(string filename, int cacheDepth, bool skipIndexVerify)
         {
-            return new PTable(filename, Guid.NewGuid(), depth: cacheDepth);
+            return new PTable(filename, Guid.NewGuid(), depth: cacheDepth, skipIndexVerify: skipIndexVerify);
         }
 
         public static PTable FromMemtable(IMemTable table, string filename, int cacheDepth = 16)

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -28,6 +28,7 @@ namespace EventStore.Core.Index
         private readonly int _maxTablesPerLevel;
         private readonly bool _additionalReclaim;
         private readonly bool _inMem;
+        private readonly bool _skipIndexVerify;
         private readonly int _indexCacheDepth;
         private readonly byte _ptableVersion;
         private readonly string _directory;
@@ -60,6 +61,7 @@ namespace EventStore.Core.Index
                           int maxTablesPerLevel = 4,
                           bool additionalReclaim = false,
                           bool inMem = false,
+                          bool skipIndexVerify = false,
                           int indexCacheDepth = 16)
         {
             Ensure.NotNullOrEmpty(directory, "directory");
@@ -79,6 +81,7 @@ namespace EventStore.Core.Index
             _maxTablesPerLevel = maxTablesPerLevel;
             _additionalReclaim = additionalReclaim;
             _inMem = inMem;
+            _skipIndexVerify = skipIndexVerify;
             _indexCacheDepth = indexCacheDepth;
             _ptableVersion = ptableVersion;
             _awaitingMemTables = new List<TableItem> { new TableItem(_memTableFactory(), -1, -1) };
@@ -112,7 +115,7 @@ namespace EventStore.Core.Index
             // this can happen (very unlikely, though) on master crash
             try
             {
-                _indexMap = IndexMap.FromFile(indexmapFile, maxTablesPerLevel: _maxTablesPerLevel, cacheDepth: _indexCacheDepth);
+                _indexMap = IndexMap.FromFile(indexmapFile, maxTablesPerLevel: _maxTablesPerLevel, cacheDepth: _indexCacheDepth, skipIndexVerify: _skipIndexVerify);
                 if (_indexMap.CommitCheckpoint >= chaserCheckpoint)
                 {
                     _indexMap.Dispose(TimeSpan.FromMilliseconds(5000));
@@ -125,7 +128,7 @@ namespace EventStore.Core.Index
                 LogIndexMapContent(indexmapFile);
                 DumpAndCopyIndex();
                 File.Delete(indexmapFile);
-                _indexMap = IndexMap.FromFile(indexmapFile, maxTablesPerLevel: _maxTablesPerLevel, cacheDepth: _indexCacheDepth);
+                _indexMap = IndexMap.FromFile(indexmapFile, maxTablesPerLevel: _maxTablesPerLevel, cacheDepth: _indexCacheDepth, skipIndexVerify: _skipIndexVerify);
             }
             _prepareCheckpoint = _indexMap.PrepareCheckpoint;
             _commitCheckpoint = _indexMap.CommitCheckpoint;

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -66,7 +66,7 @@ namespace EventStore.Core.Util
 
         public const string ConnectionPendingSendBytesThresholdDescr = "The maximum number of pending send bytes allowed before a connection is closed.";
         public const int ConnectionPendingSendBytesThresholdDefault = 10 * 1024 * 1024;
-        
+
         public const string GossipOnSingleNodeDescr = "When enabled tells a single node to run gossip as if it is a cluster";
         public const bool GossipOnSingleNodeDefault = false;
 
@@ -327,7 +327,9 @@ namespace EventStore.Core.Util
         public const string HistogramDescr =
             "Enables the tracking of various histograms in the backend, typically only used for debugging etc";
         public static readonly bool HistogramEnabledDefault = false;
-
+        public const string SkipIndexVerifyDescr =
+            "Bypasses the checking of file hashes of indexes during startup (allows for faster startup).";
+        public static readonly bool SkipIndexVerifyDefault = false;
         public const string IndexCacheDepthDescr = "Sets the depth to cache for the mid point cache in index.";
         public static int IndexCacheDepthDefault = 16;
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -103,6 +103,7 @@ namespace EventStore.Core
         protected bool _writethrough;
 
         protected string _index;
+        protected bool _skipIndexVerify;
         protected int _indexCacheDepth;
         protected bool _unsafeIgnoreHardDelete;
         protected bool _unsafeDisableFlushToDisk;
@@ -202,6 +203,7 @@ namespace EventStore.Core
             _logHttpRequests = Opts.LogHttpRequestsDefault;
             _enableHistograms = Opts.LogHttpRequestsDefault;
             _index = null;
+            _skipIndexVerify = Opts.SkipIndexVerifyDefault;
             _indexCacheDepth = Opts.IndexCacheDepthDefault;
             _indexBitnessVersion = Opts.IndexBitnessVersionDefault;
             _unsafeIgnoreHardDelete = Opts.UnsafeIgnoreHardDeleteDefault;
@@ -928,6 +930,17 @@ namespace EventStore.Core
         }
 
         /// <summary>
+        /// Verifies the index integrity using the specified method on startup
+        /// </summary>
+        /// <param name="indexVerification">The index verification method</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithIndexVerification(bool skipIndexVerify)
+        {
+            _skipIndexVerify = skipIndexVerify;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the depth to cache for the mid point cache in index
         /// </summary>
         /// <param name="indexCacheDepth">The index cache depth</param>
@@ -1342,6 +1355,7 @@ namespace EventStore.Core
                     _connectionPendingSendBytesThreshold,
                     _index,
                     _enableHistograms,
+                    _skipIndexVerify,
                     _indexCacheDepth,
                     _indexBitnessVersion,
                     consumerStrategies,


### PR DESCRIPTION
While loading midpoints from PTable index files during start up, the whole PTable file is read to also verify its integrity using an MD5 checksum. This can take a long time for very large databases/indexes.

This change allows the user to skip this verification by specifying a command line argument:
`EventStore.ClusterNode.exe --skip-index-verify`

Specifying that parameter will not read the whole file but will only read the midpoints by seeking directly to the midpoint locations in the file.