### PR TITLE
Fixes #1428

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedEventStorePersistentSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedEventStorePersistentSubscription.cs
@@ -10,7 +10,7 @@ namespace EventStore.ClientAPI.Embedded
 
         internal EmbeddedEventStorePersistentSubscription(
             string subscriptionId, string streamId,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped,
             UserCredentials userCredentials, ILogger log, bool verboseLogging, ConnectionSettings settings,
             EmbeddedSubscriber subscriptions,
@@ -24,7 +24,7 @@ namespace EventStore.ClientAPI.Embedded
 
         internal override Task<PersistentEventStoreSubscription> StartSubscription(
             string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials,
-            Func<EventStoreSubscription, ResolvedEvent, Task> onEventAppeared,
+            Func<EventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> onEventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> onSubscriptionDropped,
             ConnectionSettings settings)
         {

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
@@ -15,21 +15,23 @@ namespace EventStore.ClientAPI.Embedded
         private readonly UserCredentials _userCredentials;
         private readonly IAuthenticationProvider _authenticationProvider;
         private readonly int _bufferSize;
+        private readonly Func<EventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> _eventAppeared;
         private string _subscriptionId;
 
         public EmbeddedPersistentSubscription(
             ILogger log, IPublisher publisher, Guid connectionId,
             TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId,
             UserCredentials userCredentials, IAuthenticationProvider authenticationProvider, int bufferSize,
-            Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
+            Func<EventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> eventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries,
             TimeSpan operationTimeout)
-            : base(log, publisher, connectionId, source, streamId, eventAppeared, subscriptionDropped)
+            : base(log, publisher, connectionId, source, streamId, subscriptionDropped)
         {
             _subscriptionId = subscriptionId;
             _userCredentials = userCredentials;
             _authenticationProvider = authenticationProvider;
             _bufferSize = bufferSize;
+            _eventAppeared = eventAppeared;
         }
 
         protected override PersistentEventStoreSubscription CreateVolatileSubscription(long lastCommitPosition, long? lastEventNumber)
@@ -76,6 +78,14 @@ namespace EventStore.ClientAPI.Embedded
                     new PublishEnvelope(Publisher, true), _subscriptionId, reason,
                     (ClientMessage.PersistentSubscriptionNackEvents.NakAction) action, processedEvents,
                     user));
+        }
+
+        public void EventAppeared(Core.Data.ResolvedEvent resolvedEvent, int? retryCount)
+        {
+            var @event = new PersistentSubscriptionResolvedEvent(resolvedEvent.OriginalPosition == null
+                ? new ResolvedEvent(resolvedEvent.ConvertToClientResolvedIndexEvent())
+                : new ResolvedEvent(resolvedEvent.ConvertToClientResolvedEvent()), retryCount);
+            _eventAppeared(Subscription, @event);
         }
     }
 }

--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -420,7 +420,7 @@ namespace EventStore.ClientAPI.Embedded
 
         public EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(
             string stream, string groupName,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null, int bufferSize = 10,
             bool autoAck = true)
@@ -440,10 +440,11 @@ namespace EventStore.ClientAPI.Embedded
 
         public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
             string stream, string groupName,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null, int bufferSize = 10, bool autoAck = true)
         {
+            Ensure.NotNull(eventAppeared, "eventAppeared");
             var subscription = new EmbeddedEventStorePersistentSubscription(groupName, stream, eventAppeared, subscriptionDropped,
                 GetUserCredentials(_settings, userCredentials), _settings.Log, _settings.VerboseLogging, _settings, _subscriptions, bufferSize,
                 autoAck);

--- a/src/EventStore.ClientAPI.Embedded/IEmbeddedSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/IEmbeddedSubscription.cs
@@ -6,7 +6,6 @@ namespace EventStore.ClientAPI.Embedded
     internal interface IEmbeddedSubscription
     {
         void DropSubscription(EventStore.Core.Services.SubscriptionDropReason reason, Exception ex = null);
-        Task EventAppeared(EventStore.Core.Data.ResolvedEvent resolvedEvent);
         void ConfirmSubscription(long lastCommitPosition, long? lastEventNumber);
         void Unsubscribe();
         void Start(Guid correlationId);

--- a/src/EventStore.ClientAPI/ClientOperations/ConnectToPersistentSubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/ConnectToPersistentSubscriptionOperation.cs
@@ -9,13 +9,13 @@ using EventStore.ClientAPI.Transport.Tcp;
 
 namespace EventStore.ClientAPI.ClientOperations
 {
-    internal class ConnectToPersistentSubscriptionOperation : SubscriptionOperation<PersistentEventStoreSubscription>, IConnectToPersistentSubscriptions
+    internal class ConnectToPersistentSubscriptionOperation : SubscriptionOperation<PersistentEventStoreSubscription, PersistentSubscriptionResolvedEvent>, IConnectToPersistentSubscriptions
     {
         private readonly string _groupName;
         private readonly int _bufferSize;
         private string _subscriptionId;
 
-        public ConnectToPersistentSubscriptionOperation(ILogger log, TaskCompletionSource<PersistentEventStoreSubscription> source, string groupName, int bufferSize, string streamId, UserCredentials userCredentials, Func<PersistentEventStoreSubscription, ResolvedEvent, Task> eventAppeared, Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, bool verboseLogging, Func<TcpPackageConnection> getConnection)
+        public ConnectToPersistentSubscriptionOperation(ILogger log, TaskCompletionSource<PersistentEventStoreSubscription> source, string groupName, int bufferSize, string streamId, UserCredentials userCredentials, Func<PersistentEventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> eventAppeared, Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, bool verboseLogging, Func<TcpPackageConnection> getConnection)
             : base(log, source, streamId, false, userCredentials, eventAppeared, subscriptionDropped, verboseLogging, getConnection)
         {
             _groupName = groupName;
@@ -46,7 +46,7 @@ namespace EventStore.ClientAPI.ClientOperations
             if (package.Command == TcpCommand.PersistentSubscriptionStreamEventAppeared)
             {
                 var dto = package.Data.Deserialize<ClientMessage.PersistentSubscriptionStreamEventAppeared>();
-                EventAppeared(new ResolvedEvent(dto.Event));
+                EventAppeared(new PersistentSubscriptionResolvedEvent(new ResolvedEvent(dto.Event), dto.RetryCount));
                 result = new InspectionResult(InspectionDecision.DoNothing, "StreamEventAppeared");
                 return true;
             }

--- a/src/EventStore.ClientAPI/ClientOperations/VolatileSubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/VolatileSubscriptionOperation.cs
@@ -7,7 +7,7 @@ using EventStore.ClientAPI.Transport.Tcp;
 
 namespace EventStore.ClientAPI.ClientOperations
 {
-    internal class VolatileSubscriptionOperation : SubscriptionOperation<EventStoreSubscription>
+    internal class VolatileSubscriptionOperation : SubscriptionOperation<EventStoreSubscription, ResolvedEvent>
     {
         public VolatileSubscriptionOperation(ILogger log, TaskCompletionSource<EventStoreSubscription> source, string streamId, bool resolveLinkTos, UserCredentials userCredentials, Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared, Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, bool verboseLogging, Func<TcpPackageConnection> getConnection)
             : base(log, source, streamId, resolveLinkTos, userCredentials, eventAppeared, subscriptionDropped, verboseLogging, getConnection)

--- a/src/EventStore.ClientAPI/EventStorePersistentSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscription.cs
@@ -1,10 +1,48 @@
 using System;
 using System.Threading.Tasks;
+using EventStore.ClientAPI.ClientOperations;
 using EventStore.ClientAPI.Internal;
 using EventStore.ClientAPI.SystemData;
 
 namespace EventStore.ClientAPI
 {
+    internal struct PersistentSubscriptionResolvedEvent : IResolvedEvent
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public readonly int? RetryCount;
+        /// <summary>
+        /// 
+        /// </summary>
+        public readonly ResolvedEvent Event;
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="event"></param>
+        /// <param name="retryCount"></param>
+        internal PersistentSubscriptionResolvedEvent(ResolvedEvent @event, int? retryCount)
+        {
+            Event = @event;
+            RetryCount = retryCount;
+        }
+
+        string IResolvedEvent.OriginalStreamId => Event.OriginalStreamId;
+
+        long IResolvedEvent.OriginalEventNumber => Event.OriginalEventNumber;
+
+        RecordedEvent IResolvedEvent.OriginalEvent => Event.OriginalEvent;
+
+        Position? IResolvedEvent.OriginalPosition => Event.OriginalPosition;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="x"></param>
+        /// <returns></returns>
+        public static implicit operator ResolvedEvent(PersistentSubscriptionResolvedEvent x) => x.Event;
+    }
     /// <summary>
     /// Represents a persistent subscription connection.
     /// </summary>
@@ -14,7 +52,7 @@ namespace EventStore.ClientAPI
 
         internal EventStorePersistentSubscription(
             string subscriptionId, string streamId,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped,
             UserCredentials userCredentials, ILogger log, bool verboseLogging, ConnectionSettings settings,
             EventStoreConnectionLogicHandler handler, int bufferSize = 10, bool autoAck = true)
@@ -27,7 +65,7 @@ namespace EventStore.ClientAPI
 
         internal override Task<PersistentEventStoreSubscription> StartSubscription(
             string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials,
-            Func<EventStoreSubscription, ResolvedEvent, Task> onEventAppeared,
+            Func<EventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> onEventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> onSubscriptionDropped, ConnectionSettings settings)
         {
             var source = new TaskCompletionSource<PersistentEventStoreSubscription>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
@@ -21,7 +21,7 @@ namespace EventStore.ClientAPI
 
         private readonly string _subscriptionId;
         private readonly string _streamId;
-        private readonly Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> _eventAppeared;
+        private readonly Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> _eventAppeared;
         private readonly Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> _subscriptionDropped;
         private readonly UserCredentials _userCredentials;
         private readonly ILogger _log;
@@ -30,7 +30,7 @@ namespace EventStore.ClientAPI
         private readonly bool _autoAck;
 
         private PersistentEventStoreSubscription _subscription;
-        private readonly ConcurrentQueue<ResolvedEvent> _queue = new ConcurrentQueue<ResolvedEvent>();
+        private readonly ConcurrentQueue<PersistentSubscriptionResolvedEvent> _queue = new ConcurrentQueue<PersistentSubscriptionResolvedEvent>();
         private int _isProcessing;
         private DropData _dropData;
 
@@ -40,7 +40,7 @@ namespace EventStore.ClientAPI
 
         internal EventStorePersistentSubscriptionBase(string subscriptionId, 
             string streamId,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared, 
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared, 
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped,
             UserCredentials userCredentials,
             ILogger log,
@@ -77,7 +77,7 @@ namespace EventStore.ClientAPI
 
         internal abstract Task<PersistentEventStoreSubscription> StartSubscription(
             string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials,
-            Func<EventStoreSubscription, ResolvedEvent, Task> onEventAppeared,
+            Func<EventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> onEventAppeared,
             Action<EventStoreSubscription, SubscriptionDropReason, Exception> onSubscriptionDropped,
             ConnectionSettings settings);
 
@@ -168,7 +168,7 @@ namespace EventStore.ClientAPI
             var dropData = new DropData(reason, error);
             if (Interlocked.CompareExchange(ref _dropData, dropData, null) == null)
             {
-                Enqueue(DropSubscriptionEvent);
+                Enqueue(new PersistentSubscriptionResolvedEvent(DropSubscriptionEvent, null));
             }
         }
 
@@ -177,13 +177,13 @@ namespace EventStore.ClientAPI
             EnqueueSubscriptionDropNotification(reason, exception);
         }
 
-        private Task OnEventAppeared(EventStoreSubscription subscription, ResolvedEvent resolvedEvent)
+        private Task OnEventAppeared(EventStoreSubscription subscription, PersistentSubscriptionResolvedEvent resolvedEvent)
         {
             Enqueue(resolvedEvent);
             return Task.CompletedTask;
         }
 
-        private void Enqueue(ResolvedEvent resolvedEvent)
+        private void Enqueue(PersistentSubscriptionResolvedEvent resolvedEvent)
         {
             _queue.Enqueue(resolvedEvent);
             if (Interlocked.CompareExchange(ref _isProcessing, 1, 0) == 0)
@@ -200,11 +200,11 @@ namespace EventStore.ClientAPI
                     Thread.Sleep(1);
                 }
                 else
-                { 
-                    ResolvedEvent e;
+                {
+                    PersistentSubscriptionResolvedEvent e;
                     while (_queue.TryDequeue(out e))
                     {
-                        if (e.Equals(DropSubscriptionEvent)) // drop subscription artificial ResolvedEvent
+                        if (e.Event.Equals(DropSubscriptionEvent)) // drop subscription artificial ResolvedEvent
                         {
                             if (_dropData == null) throw new Exception("Drop reason not specified.");
                             DropSubscription(_dropData.Reason, _dropData.Error);
@@ -217,13 +217,13 @@ namespace EventStore.ClientAPI
                         }
                         try
                         {
-                            await _eventAppeared(this, e).ConfigureAwait(false);
+                            await _eventAppeared(this, e, e.RetryCount).ConfigureAwait(false);
                             if (_autoAck)
-                                _subscription.NotifyEventsProcessed(new[] { e.OriginalEvent.EventId });
+                                _subscription.NotifyEventsProcessed(new[] { e.Event.OriginalEvent.EventId });
                             if (_verbose)
                                 _log.Debug("Persistent Subscription to {0}: processed event ({1}, {2}, {3} @ {4}).",
                                           _streamId,
-                                          e.OriginalEvent.EventStreamId, e.OriginalEvent.EventNumber, e.OriginalEvent.EventType, e.OriginalEventNumber);
+                                          e.Event.OriginalEvent.EventStreamId, e.Event.OriginalEvent.EventNumber, e.Event.OriginalEvent.EventType, e.Event.OriginalEventNumber);
                         }
                         catch (Exception exc)
                         {

--- a/src/EventStore.ClientAPI/IEventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnection.cs
@@ -357,7 +357,7 @@ namespace EventStore.ClientAPI
         EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(
             string stream,
             string groupName,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
             int bufferSize = 10,
@@ -384,7 +384,7 @@ namespace EventStore.ClientAPI
         Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
             string stream,
             string groupName,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
             int bufferSize = 10,

--- a/src/EventStore.ClientAPI/IEventStoreConnectionExtensions.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnectionExtensions.cs
@@ -16,7 +16,7 @@ namespace EventStore.ClientAPI
                                 eventAppeared(subscription, e);
                                 return Task.CompletedTask;
                             };
-
+        
         /// <summary>
         /// Asynchronously subscribes to a single event stream. New events
         /// written to the stream while the subscription is active will be
@@ -214,7 +214,44 @@ namespace EventStore.ClientAPI
                 );
 
         /// <summary>
-        /// Asynchronously subscribes to a persistent subscription(competing consumer) on event store
+        /// Subscribes to a persistent subscription(competing consumer) on event store
+        /// </summary>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="groupName">The subscription group to connect to</param>
+        /// <param name="stream">The stream to subscribe to</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="bufferSize">The buffer size to use for the persistent subscription</param>
+        /// <param name="autoAck">Whether the subscription should automatically acknowledge messages processed.
+        /// If not set the receiver is required to explicitly acknowledge messages through the subscription.</param>
+        /// <remarks>This will connect you to a persistent subscription group for a stream. The subscription group
+        /// must first be created with CreatePersistentSubscriptionAsync many connections
+        /// can connect to the same group and they will be treated as competing consumers within the group.
+        /// If one connection dies work will be balanced across the rest of the consumers in the group. If
+        /// you attempt to connect to a group that does not exist you will be given an exception.
+        /// </remarks>
+        /// <returns>An <see cref="EventStorePersistentSubscriptionBase"/> representing the subscription</returns>
+        public static EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(
+                this IEventStoreConnection target,
+                string stream,
+                string groupName,
+                Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+                Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null,
+                int bufferSize = 10,
+                bool autoAck = true) =>
+            target.ConnectToPersistentSubscription(
+                stream,
+                groupName,
+                (s,e, i) => eventAppeared(s,e),
+                subscriptionDropped,
+                userCredentials,
+                bufferSize,
+                autoAck
+                );
+        /// <summary>
+        /// Subscribes to a persistent subscription(competing consumer) on event store
         /// </summary>
         /// <param name="target">The connection to subscribe to</param>
         /// <param name="groupName">The subscription group to connect to</param>
@@ -245,6 +282,44 @@ namespace EventStore.ClientAPI
                 stream,
                 groupName,
                 ToTask(eventAppeared),
+                subscriptionDropped,
+                userCredentials,
+                bufferSize,
+                autoAck
+                );
+
+        /// <summary>
+        /// Subscribes to a persistent subscription(competing consumer) on event store
+        /// </summary>
+        /// <param name="target">The connection to subscribe to</param>
+        /// <param name="groupName">The subscription group to connect to</param>
+        /// <param name="stream">The stream to subscribe to</param>
+        /// <param name="eventAppeared">An action invoked when a new event is received over the subscription</param>
+        /// <param name="subscriptionDropped">An action invoked if the subscription is dropped</param>
+        /// <param name="userCredentials">User credentials to use for the operation</param>
+        /// <param name="bufferSize">The buffer size to use for the persistent subscription</param>
+        /// <param name="autoAck">Whether the subscription should automatically acknowledge messages processed.
+        /// If not set the receiver is required to explicitly acknowledge messages through the subscription.</param>
+        /// <remarks>This will connect you to a persistent subscription group for a stream. The subscription group
+        /// must first be created with CreatePersistentSubscriptionAsync many connections
+        /// can connect to the same group and they will be treated as competing consumers within the group.
+        /// If one connection dies work will be balanced across the rest of the consumers in the group. If
+        /// you attempt to connect to a group that does not exist you will be given an exception.
+        /// </remarks>
+        /// <returns>An <see cref="EventStorePersistentSubscriptionBase"/> representing the subscription</returns>
+        public static Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
+                this IEventStoreConnection target,
+                string stream,
+                string groupName,
+                Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+                Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
+                UserCredentials userCredentials = null,
+                int bufferSize = 10,
+                bool autoAck = true) =>
+            target.ConnectToPersistentSubscriptionAsync(
+                stream,
+                groupName,
+                (s,e, i) => eventAppeared(s,e),
                 subscriptionDropped,
                 userCredentials,
                 bufferSize,

--- a/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
@@ -346,7 +346,7 @@ namespace EventStore.ClientAPI.Internal
         public EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(
             string stream,
             string groupName,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
             int bufferSize = 10,
@@ -367,7 +367,7 @@ namespace EventStore.ClientAPI.Internal
         public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(
             string stream,
             string groupName,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
             Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null,
             UserCredentials userCredentials = null,
             int bufferSize = 10,

--- a/src/EventStore.ClientAPI/Internal/Messages.cs
+++ b/src/EventStore.ClientAPI/Internal/Messages.cs
@@ -136,13 +136,13 @@ namespace EventStore.ClientAPI.Internal
         public readonly string StreamId;
         public readonly int BufferSize;
         public readonly UserCredentials UserCredentials;
-        public readonly Func<PersistentEventStoreSubscription, ResolvedEvent, Task> EventAppeared;
+        public readonly Func<PersistentEventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> EventAppeared;
         public readonly Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> SubscriptionDropped;
            
         public readonly int MaxRetries;
         public readonly TimeSpan Timeout;
 
-        public StartPersistentSubscriptionMessage(TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials, Func<PersistentEventStoreSubscription, ResolvedEvent, Task> eventAppeared, Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries, TimeSpan timeout)
+        public StartPersistentSubscriptionMessage(TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId, int bufferSize, UserCredentials userCredentials, Func<PersistentEventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> eventAppeared, Action<PersistentEventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries, TimeSpan timeout)
         {
             Ensure.NotNull(source, "source");
             Ensure.NotNull(eventAppeared, "eventAppeared");

--- a/src/EventStore.ClientAPI/Messages/ClientMessage.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessage.cs
@@ -1037,11 +1037,15 @@ namespace EventStore.ClientAPI.Messages
     [ProtoMember(1, IsRequired = true, Name=@"event", DataFormat = DataFormat.Default)]
     public readonly ResolvedIndexedEvent Event;
   
+    [ProtoMember(2, IsRequired = false, Name=@"retryCount", DataFormat = DataFormat.TwosComplement)]
+    public readonly int? RetryCount;
+  
     private PersistentSubscriptionStreamEventAppeared() {}
   
-    public PersistentSubscriptionStreamEventAppeared(ResolvedIndexedEvent @event)
+    public PersistentSubscriptionStreamEventAppeared(ResolvedIndexedEvent @event, int? retryCount)
     {
         Event = @event;
+        RetryCount = retryCount;
     }
   }
   

--- a/src/EventStore.ClientAPI/ResolvedEvent.cs
+++ b/src/EventStore.ClientAPI/ResolvedEvent.cs
@@ -1,11 +1,12 @@
-﻿using EventStore.ClientAPI.Messages;
+﻿using EventStore.ClientAPI.ClientOperations;
+using EventStore.ClientAPI.Messages;
 
 namespace EventStore.ClientAPI
 {
     /// <summary>
     /// A structure representing a single event or an resolved link event.
     /// </summary>
-    public struct ResolvedEvent
+    public struct ResolvedEvent : IResolvedEvent
     {
         /// <summary>
         /// The event, or the resolved link event if this <see cref="ResolvedEvent"/> is
@@ -61,5 +62,10 @@ namespace EventStore.ClientAPI
             Link = evnt.Link == null ? null : new RecordedEvent(evnt.Link);
             OriginalPosition = null;
         }
+
+        Position? IResolvedEvent.OriginalPosition => OriginalPosition;
+        RecordedEvent IResolvedEvent.OriginalEvent => OriginalEvent;
+        long IResolvedEvent.OriginalEventNumber=> OriginalEventNumber;
+        string IResolvedEvent.OriginalStreamId => OriginalStreamId;
     }
 }

--- a/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
@@ -575,7 +575,14 @@ namespace EventStore.Core.Tests.ClientAPI
         }
 
         public EventStorePersistentSubscriptionBase ConnectToPersistentSubscription(string stream, string groupName,
-            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared, Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null, int bufferSize = 10,
+            Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared, Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null, int bufferSize = 10,
+            bool autoAck = true)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(string stream, string groupName, Func<EventStorePersistentSubscriptionBase, ResolvedEvent, int?, Task> eventAppeared,
+            Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null, int bufferSize = 10,
             bool autoAck = true)
         {
             throw new NotImplementedException();
@@ -686,11 +693,6 @@ namespace EventStore.Core.Tests.ClientAPI
         {
             var handler = Connected;
             if (handler != null) handler(this, e);
-        }
-
-        public Task<EventStorePersistentSubscriptionBase> ConnectToPersistentSubscriptionAsync(string stream, string groupName, Func<EventStorePersistentSubscriptionBase, ResolvedEvent, Task> eventAppeared, Action<EventStorePersistentSubscriptionBase, SubscriptionDropReason, Exception> subscriptionDropped = null, UserCredentials userCredentials = null, int bufferSize = 10, bool autoAck = true)
-        {
-            throw new NotImplementedException();
         }
     }
 }

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using EventStore.ClientAPI;
@@ -189,6 +188,8 @@ namespace EventStore.Core.Tests.ClientAPI
 
         protected override void Given()
         {
+            
+            
             _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
                 DefaultData.AdminCredentials).Wait();
             _conn.ConnectToPersistentSubscription(
@@ -767,6 +768,63 @@ namespace EventStore.Core.Tests.ClientAPI
             Assert.IsTrue(_resetEvent.WaitOne(TimeSpan.FromSeconds(10)));
             Assert.AreEqual(intMaxValue + 1, _firstEvent.Event.EventNumber);
             Assert.AreEqual(_event1Id, _firstEvent.Event.EventId);
+        }
+    }
+
+    [TestFixture, Category("LongRunning")]
+    public class connect_to_persistent_subscription_with_retries : SpecificationWithMiniNode
+    {
+        private readonly string _stream = Guid.NewGuid().ToString("N");
+        private readonly PersistentSubscriptionSettings _settings = PersistentSubscriptionSettings.Create()
+                                                                .DoNotResolveLinkTos()
+                                                                .StartFromBeginning();
+
+        private readonly AutoResetEvent _resetEvent = new AutoResetEvent(false);
+        private readonly Guid _id = Guid.NewGuid();
+        int? _retryCount;
+        private const string _group = "retries";
+
+        protected override void Given()
+        {
+
+
+            _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
+                DefaultData.AdminCredentials).Wait();
+            _conn.ConnectToPersistentSubscription(
+             _stream,
+             _group,
+             HandleEvent,
+             (sub, reason, ex) => { },
+             DefaultData.AdminCredentials,autoAck:false);
+
+        }
+
+        protected override void When()
+        {
+            _conn.AppendToStreamAsync(_stream, ExpectedVersion.Any, DefaultData.AdminCredentials,
+                new EventData(_id, "test", true, Encoding.UTF8.GetBytes("{'foo' : 'bar'}"), new byte[0])).Wait();
+        }
+
+        private Task HandleEvent(EventStorePersistentSubscriptionBase sub, ResolvedEvent resolvedEvent, int? retryCount)
+        {
+            if (retryCount > 4)
+            {
+                _resetEvent.Set();
+                _retryCount = retryCount;
+                sub.Acknowledge(resolvedEvent);
+            }
+            else
+            {
+                sub.Fail(resolvedEvent, PersistentSubscriptionNakEventAction.Retry, "Not yet tried enough times");
+            }
+            return Task.CompletedTask;
+        }
+
+        [Test]
+        public void events_are_retried_until_success()
+        {
+            Assert.IsTrue(_resetEvent.WaitOne(TimeSpan.FromSeconds(10)));
+            Assert.AreEqual(5, _retryCount);
         }
     }
 

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription_async.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription_async.cs
@@ -193,8 +193,9 @@ namespace EventStore.Core.Tests.ClientAPI
         {
             _conn.CreatePersistentSubscriptionAsync(_stream, _group, _settings,
                 DefaultData.AdminCredentials).Wait();
+
             _conn.ConnectToPersistentSubscriptionAsync(
-             _stream,
+            _stream,
              _group,
              HandleEvent,
              (sub, reason, ex) => { },

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -171,7 +171,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription
             Assert.AreEqual(2, client1Envelope.Replies.Count);
             Assert.AreEqual(2, client2Envelope.Replies.Count);
         }
-
+        
         [Test]
         public void unsubscribed_client_has_assigned_streams_sent_to_another_client()
         {

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -457,7 +457,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
         public void when_wrapping_persistent_subscription_stream_event_appeared_with_deleted_event_should_downgrade_version()
         {
             var msg = new ClientMessage.PersistentSubscriptionStreamEventAppeared(Guid.NewGuid(),
-                                                            ResolvedEvent.ForUnresolvedEvent(CreateDeletedEventRecord(), 0));
+                                                            ResolvedEvent.ForUnresolvedEvent(CreateDeletedEventRecord(), 0), 0);
 
             var package = _dispatcher.WrapMessage(msg, _version);
             Assert.IsNotNull(package, "Package is null");
@@ -467,12 +467,12 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp
             Assert.IsNotNull(dto, "DTO is null");
             Assert.AreEqual(int.MaxValue, dto.Event.Event.EventNumber, "Event Number");
         }
-
+        
         [Test]
         public void when_wrapping_persistent_subscription_stream_event_appeared_with_link_to_deleted_event_should_downgrade_version()
         {
             var msg = new ClientMessage.PersistentSubscriptionStreamEventAppeared(Guid.NewGuid(),
-                                                            ResolvedEvent.ForResolvedLink(CreateLinkEventRecord(), CreateDeletedEventRecord(), 0));
+                                                            ResolvedEvent.ForResolvedLink(CreateLinkEventRecord(), CreateDeletedEventRecord(), 0), 0);
 
             var package = _dispatcher.WrapMessage(msg, _version);
             Assert.IsNotNull(package, "Package is null");

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1337,11 +1337,12 @@ namespace EventStore.Core.Messages
 
             public readonly Guid CorrelationId;
             public readonly ResolvedEvent Event;
-
-            public PersistentSubscriptionStreamEventAppeared(Guid correlationId, ResolvedEvent @event)
+            public readonly int RetryCount;
+            public PersistentSubscriptionStreamEventAppeared(Guid correlationId, ResolvedEvent @event, int retryCount)
             {
                 CorrelationId = correlationId;
                 Event = @event;
+                RetryCount = retryCount;
             }
         }
 

--- a/src/EventStore.Core/Messages/TcpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDto.cs
@@ -15,1296 +15,1300 @@ using ProtoBuf;
 
 namespace EventStore.Core.Messages
 {
-    public static partial class TcpClientMessageDto
+  public static partial class TcpClientMessageDto
+  {
+  [Serializable, ProtoContract(Name=@"NewEvent")]
+  public partial class NewEvent
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event_id", DataFormat = DataFormat.Default)]
+    public readonly byte[] EventId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"event_type", DataFormat = DataFormat.Default)]
+    public readonly string EventType;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"data_content_type", DataFormat = DataFormat.TwosComplement)]
+    public readonly int DataContentType;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"metadata_content_type", DataFormat = DataFormat.TwosComplement)]
+    public readonly int MetadataContentType;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"data", DataFormat = DataFormat.Default)]
+    public readonly byte[] Data;
+  
+    [ProtoMember(6, IsRequired = false, Name=@"metadata", DataFormat = DataFormat.Default)]
+    public readonly byte[] Metadata;
+  
+    private NewEvent() {}
+  
+    public NewEvent(byte[] eventId, string eventType, int dataContentType, int metadataContentType, byte[] data, byte[] metadata)
     {
-        [Serializable, ProtoContract(Name = @"NewEvent")]
-        public partial class NewEvent
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event_id", DataFormat = DataFormat.Default)]
-            public readonly byte[] EventId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"event_type", DataFormat = DataFormat.Default)]
-            public readonly string EventType;
-
-            [ProtoMember(3, IsRequired = true, Name = @"data_content_type", DataFormat = DataFormat.TwosComplement)]
-            public readonly int DataContentType;
-
-            [ProtoMember(4, IsRequired = true, Name = @"metadata_content_type", DataFormat = DataFormat.TwosComplement)]
-            public readonly int MetadataContentType;
-
-            [ProtoMember(5, IsRequired = true, Name = @"data", DataFormat = DataFormat.Default)]
-            public readonly byte[] Data;
-
-            [ProtoMember(6, IsRequired = false, Name = @"metadata", DataFormat = DataFormat.Default)]
-            public readonly byte[] Metadata;
-
-            private NewEvent() { }
-
-            public NewEvent(byte[] eventId, string eventType, int dataContentType, int metadataContentType, byte[] data, byte[] metadata)
-            {
-                EventId = eventId;
-                EventType = eventType;
-                DataContentType = dataContentType;
-                MetadataContentType = metadataContentType;
-                Data = data;
-                Metadata = metadata;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"EventRecord")]
-        public partial class EventRecord
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long EventNumber;
-
-            [ProtoMember(3, IsRequired = true, Name = @"event_id", DataFormat = DataFormat.Default)]
-            public readonly byte[] EventId;
-
-            [ProtoMember(4, IsRequired = true, Name = @"event_type", DataFormat = DataFormat.Default)]
-            public readonly string EventType;
-
-            [ProtoMember(5, IsRequired = true, Name = @"data_content_type", DataFormat = DataFormat.TwosComplement)]
-            public readonly int DataContentType;
-
-            [ProtoMember(6, IsRequired = true, Name = @"metadata_content_type", DataFormat = DataFormat.TwosComplement)]
-            public readonly int MetadataContentType;
-
-            [ProtoMember(7, IsRequired = true, Name = @"data", DataFormat = DataFormat.Default)]
-            public readonly byte[] Data;
-
-            [ProtoMember(8, IsRequired = false, Name = @"metadata", DataFormat = DataFormat.Default)]
-            public readonly byte[] Metadata;
-
-            [ProtoMember(9, IsRequired = false, Name = @"created", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? Created;
-
-            [ProtoMember(10, IsRequired = false, Name = @"created_epoch", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? CreatedEpoch;
-
-            private EventRecord() { }
-
-            public EventRecord(string eventStreamId, long eventNumber, byte[] eventId, string eventType, int dataContentType, int metadataContentType, byte[] data, byte[] metadata, long? created, long? createdEpoch)
-            {
-                EventStreamId = eventStreamId;
-                EventNumber = eventNumber;
-                EventId = eventId;
-                EventType = eventType;
-                DataContentType = dataContentType;
-                MetadataContentType = metadataContentType;
-                Data = data;
-                Metadata = metadata;
-                Created = created;
-                CreatedEpoch = createdEpoch;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ResolvedIndexedEvent")]
-        public partial class ResolvedIndexedEvent
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event", DataFormat = DataFormat.Default)]
-            public readonly EventRecord Event;
-
-            [ProtoMember(2, IsRequired = false, Name = @"link", DataFormat = DataFormat.Default)]
-            public readonly EventRecord Link;
-
-            private ResolvedIndexedEvent() { }
-
-            public ResolvedIndexedEvent(EventRecord @event, EventRecord link)
-            {
-                Event = @event;
-                Link = link;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ResolvedEvent")]
-        public partial class ResolvedEvent
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event", DataFormat = DataFormat.Default)]
-            public readonly EventRecord Event;
-
-            [ProtoMember(2, IsRequired = false, Name = @"link", DataFormat = DataFormat.Default)]
-            public readonly EventRecord Link;
-
-            [ProtoMember(3, IsRequired = true, Name = @"commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long CommitPosition;
-
-            [ProtoMember(4, IsRequired = true, Name = @"prepare_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long PreparePosition;
-
-            private ResolvedEvent() { }
-
-            public ResolvedEvent(EventRecord @event, EventRecord link, long commitPosition, long preparePosition)
-            {
-                Event = @event;
-                Link = link;
-                CommitPosition = commitPosition;
-                PreparePosition = preparePosition;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"WriteEvents")]
-        public partial class WriteEvents
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"expected_version", DataFormat = DataFormat.TwosComplement)]
-            public readonly long ExpectedVersion;
-
-            [ProtoMember(3, Name = @"events", DataFormat = DataFormat.Default)]
-            public readonly NewEvent[] Events;
-
-            [ProtoMember(4, IsRequired = true, Name = @"require_master", DataFormat = DataFormat.Default)]
-            public readonly bool RequireMaster;
-
-            private WriteEvents() { }
-
-            public WriteEvents(string eventStreamId, long expectedVersion, NewEvent[] events, bool requireMaster)
-            {
-                EventStreamId = eventStreamId;
-                ExpectedVersion = expectedVersion;
-                Events = events;
-                RequireMaster = requireMaster;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"WriteEventsCompleted")]
-        public partial class WriteEventsCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly OperationResult Result;
-
-            [ProtoMember(2, IsRequired = false, Name = @"message", DataFormat = DataFormat.Default)]
-            public readonly string Message;
-
-            [ProtoMember(3, IsRequired = true, Name = @"first_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long FirstEventNumber;
-
-            [ProtoMember(4, IsRequired = true, Name = @"last_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long LastEventNumber;
-
-            [ProtoMember(5, IsRequired = false, Name = @"prepare_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? PreparePosition;
-
-            [ProtoMember(6, IsRequired = false, Name = @"commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? CommitPosition;
-
-            [ProtoMember(7, IsRequired = false, Name = @"current_version", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? CurrentVersion;
-
-            private WriteEventsCompleted() { }
-
-            public WriteEventsCompleted(OperationResult result, string message, long firstEventNumber, long lastEventNumber, long? preparePosition, long? commitPosition, long? currentVersion)
-            {
-                Result = result;
-                Message = message;
-                FirstEventNumber = firstEventNumber;
-                LastEventNumber = lastEventNumber;
-                PreparePosition = preparePosition;
-                CommitPosition = commitPosition;
-                CurrentVersion = currentVersion;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"DeleteStream")]
-        public partial class DeleteStream
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"expected_version", DataFormat = DataFormat.TwosComplement)]
-            public readonly long ExpectedVersion;
-
-            [ProtoMember(3, IsRequired = true, Name = @"require_master", DataFormat = DataFormat.Default)]
-            public readonly bool RequireMaster;
-
-            [ProtoMember(4, IsRequired = false, Name = @"hard_delete", DataFormat = DataFormat.Default)]
-            public readonly bool? HardDelete;
-
-            private DeleteStream() { }
-
-            public DeleteStream(string eventStreamId, long expectedVersion, bool requireMaster, bool? hardDelete)
-            {
-                EventStreamId = eventStreamId;
-                ExpectedVersion = expectedVersion;
-                RequireMaster = requireMaster;
-                HardDelete = hardDelete;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"DeleteStreamCompleted")]
-        public partial class DeleteStreamCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly OperationResult Result;
-
-            [ProtoMember(2, IsRequired = false, Name = @"message", DataFormat = DataFormat.Default)]
-            public readonly string Message;
-
-            [ProtoMember(3, IsRequired = false, Name = @"prepare_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? PreparePosition;
-
-            [ProtoMember(4, IsRequired = false, Name = @"commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? CommitPosition;
-
-            private DeleteStreamCompleted() { }
-
-            public DeleteStreamCompleted(OperationResult result, string message, long? preparePosition, long? commitPosition)
-            {
-                Result = result;
-                Message = message;
-                PreparePosition = preparePosition;
-                CommitPosition = commitPosition;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"TransactionStart")]
-        public partial class TransactionStart
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"expected_version", DataFormat = DataFormat.TwosComplement)]
-            public readonly long ExpectedVersion;
-
-            [ProtoMember(3, IsRequired = true, Name = @"require_master", DataFormat = DataFormat.Default)]
-            public readonly bool RequireMaster;
-
-            private TransactionStart() { }
-
-            public TransactionStart(string eventStreamId, long expectedVersion, bool requireMaster)
-            {
-                EventStreamId = eventStreamId;
-                ExpectedVersion = expectedVersion;
-                RequireMaster = requireMaster;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"TransactionStartCompleted")]
-        public partial class TransactionStartCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"transaction_id", DataFormat = DataFormat.TwosComplement)]
-            public readonly long TransactionId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly OperationResult Result;
-
-            [ProtoMember(3, IsRequired = false, Name = @"message", DataFormat = DataFormat.Default)]
-            public readonly string Message;
-
-            private TransactionStartCompleted() { }
-
-            public TransactionStartCompleted(long transactionId, OperationResult result, string message)
-            {
-                TransactionId = transactionId;
-                Result = result;
-                Message = message;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"TransactionWrite")]
-        public partial class TransactionWrite
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"transaction_id", DataFormat = DataFormat.TwosComplement)]
-            public readonly long TransactionId;
-
-            [ProtoMember(2, Name = @"events", DataFormat = DataFormat.Default)]
-            public readonly NewEvent[] Events;
-
-            [ProtoMember(3, IsRequired = true, Name = @"require_master", DataFormat = DataFormat.Default)]
-            public readonly bool RequireMaster;
-
-            private TransactionWrite() { }
-
-            public TransactionWrite(long transactionId, NewEvent[] events, bool requireMaster)
-            {
-                TransactionId = transactionId;
-                Events = events;
-                RequireMaster = requireMaster;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"TransactionWriteCompleted")]
-        public partial class TransactionWriteCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"transaction_id", DataFormat = DataFormat.TwosComplement)]
-            public readonly long TransactionId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly OperationResult Result;
-
-            [ProtoMember(3, IsRequired = false, Name = @"message", DataFormat = DataFormat.Default)]
-            public readonly string Message;
-
-            private TransactionWriteCompleted() { }
-
-            public TransactionWriteCompleted(long transactionId, OperationResult result, string message)
-            {
-                TransactionId = transactionId;
-                Result = result;
-                Message = message;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"TransactionCommit")]
-        public partial class TransactionCommit
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"transaction_id", DataFormat = DataFormat.TwosComplement)]
-            public readonly long TransactionId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"require_master", DataFormat = DataFormat.Default)]
-            public readonly bool RequireMaster;
-
-            private TransactionCommit() { }
-
-            public TransactionCommit(long transactionId, bool requireMaster)
-            {
-                TransactionId = transactionId;
-                RequireMaster = requireMaster;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"TransactionCommitCompleted")]
-        public partial class TransactionCommitCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"transaction_id", DataFormat = DataFormat.TwosComplement)]
-            public readonly long TransactionId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly OperationResult Result;
-
-            [ProtoMember(3, IsRequired = false, Name = @"message", DataFormat = DataFormat.Default)]
-            public readonly string Message;
-
-            [ProtoMember(4, IsRequired = true, Name = @"first_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long FirstEventNumber;
-
-            [ProtoMember(5, IsRequired = true, Name = @"last_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long LastEventNumber;
-
-            [ProtoMember(6, IsRequired = false, Name = @"prepare_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? PreparePosition;
-
-            [ProtoMember(7, IsRequired = false, Name = @"commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? CommitPosition;
-
-            private TransactionCommitCompleted() { }
-
-            public TransactionCommitCompleted(long transactionId, OperationResult result, string message, long firstEventNumber, long lastEventNumber, long? preparePosition, long? commitPosition)
-            {
-                TransactionId = transactionId;
-                Result = result;
-                Message = message;
-                FirstEventNumber = firstEventNumber;
-                LastEventNumber = lastEventNumber;
-                PreparePosition = preparePosition;
-                CommitPosition = commitPosition;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ReadEvent")]
-        public partial class ReadEvent
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long EventNumber;
-
-            [ProtoMember(3, IsRequired = true, Name = @"resolve_link_tos", DataFormat = DataFormat.Default)]
-            public readonly bool ResolveLinkTos;
-
-            [ProtoMember(4, IsRequired = true, Name = @"require_master", DataFormat = DataFormat.Default)]
-            public readonly bool RequireMaster;
-
-            private ReadEvent() { }
-
-            public ReadEvent(string eventStreamId, long eventNumber, bool resolveLinkTos, bool requireMaster)
-            {
-                EventStreamId = eventStreamId;
-                EventNumber = eventNumber;
-                ResolveLinkTos = resolveLinkTos;
-                RequireMaster = requireMaster;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ReadEventCompleted")]
-        public partial class ReadEventCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly ReadEventCompleted.ReadEventResult Result;
-
-            [ProtoMember(2, IsRequired = true, Name = @"event", DataFormat = DataFormat.Default)]
-            public readonly ResolvedIndexedEvent Event;
-
-            [ProtoMember(3, IsRequired = false, Name = @"error", DataFormat = DataFormat.Default)]
-            public readonly string Error;
-
-            [ProtoContract(Name = @"ReadEventResult")]
-            public enum ReadEventResult
-            {
-
-                [ProtoEnum(Name = @"Success", Value = 0)]
-                Success = 0,
-
-                [ProtoEnum(Name = @"NotFound", Value = 1)]
-                NotFound = 1,
-
-                [ProtoEnum(Name = @"NoStream", Value = 2)]
-                NoStream = 2,
-
-                [ProtoEnum(Name = @"StreamDeleted", Value = 3)]
-                StreamDeleted = 3,
-
-                [ProtoEnum(Name = @"Error", Value = 4)]
-                Error = 4,
-
-                [ProtoEnum(Name = @"AccessDenied", Value = 5)]
-                AccessDenied = 5
-            }
-
-            private ReadEventCompleted() { }
-
-            public ReadEventCompleted(ReadEventCompleted.ReadEventResult result, ResolvedIndexedEvent @event, string error)
-            {
-                Result = result;
-                Event = @event;
-                Error = error;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ReadStreamEvents")]
-        public partial class ReadStreamEvents
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"from_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long FromEventNumber;
-
-            [ProtoMember(3, IsRequired = true, Name = @"max_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int MaxCount;
-
-            [ProtoMember(4, IsRequired = true, Name = @"resolve_link_tos", DataFormat = DataFormat.Default)]
-            public readonly bool ResolveLinkTos;
-
-            [ProtoMember(5, IsRequired = true, Name = @"require_master", DataFormat = DataFormat.Default)]
-            public readonly bool RequireMaster;
-
-            private ReadStreamEvents() { }
-
-            public ReadStreamEvents(string eventStreamId, long fromEventNumber, int maxCount, bool resolveLinkTos, bool requireMaster)
-            {
-                EventStreamId = eventStreamId;
-                FromEventNumber = fromEventNumber;
-                MaxCount = maxCount;
-                ResolveLinkTos = resolveLinkTos;
-                RequireMaster = requireMaster;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ReadStreamEventsCompleted")]
-        public partial class ReadStreamEventsCompleted
-        {
-            [ProtoMember(1, Name = @"events", DataFormat = DataFormat.Default)]
-            public readonly ResolvedIndexedEvent[] Events;
-
-            [ProtoMember(2, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly ReadStreamEventsCompleted.ReadStreamResult Result;
-
-            [ProtoMember(3, IsRequired = true, Name = @"next_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long NextEventNumber;
-
-            [ProtoMember(4, IsRequired = true, Name = @"last_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long LastEventNumber;
-
-            [ProtoMember(5, IsRequired = true, Name = @"is_end_of_stream", DataFormat = DataFormat.Default)]
-            public readonly bool IsEndOfStream;
-
-            [ProtoMember(6, IsRequired = true, Name = @"last_commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long LastCommitPosition;
-
-            [ProtoMember(7, IsRequired = false, Name = @"error", DataFormat = DataFormat.Default)]
-            public readonly string Error;
-
-            [ProtoContract(Name = @"ReadStreamResult")]
-            public enum ReadStreamResult
-            {
-
-                [ProtoEnum(Name = @"Success", Value = 0)]
-                Success = 0,
-
-                [ProtoEnum(Name = @"NoStream", Value = 1)]
-                NoStream = 1,
-
-                [ProtoEnum(Name = @"StreamDeleted", Value = 2)]
-                StreamDeleted = 2,
-
-                [ProtoEnum(Name = @"NotModified", Value = 3)]
-                NotModified = 3,
-
-                [ProtoEnum(Name = @"Error", Value = 4)]
-                Error = 4,
-
-                [ProtoEnum(Name = @"AccessDenied", Value = 5)]
-                AccessDenied = 5
-            }
-
-            private ReadStreamEventsCompleted() { }
-
-            public ReadStreamEventsCompleted(ResolvedIndexedEvent[] events, ReadStreamEventsCompleted.ReadStreamResult result, long nextEventNumber, long lastEventNumber, bool isEndOfStream, long lastCommitPosition, string error)
-            {
-                Events = events;
-                Result = result;
-                NextEventNumber = nextEventNumber;
-                LastEventNumber = lastEventNumber;
-                IsEndOfStream = isEndOfStream;
-                LastCommitPosition = lastCommitPosition;
-                Error = error;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ReadAllEvents")]
-        public partial class ReadAllEvents
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long CommitPosition;
-
-            [ProtoMember(2, IsRequired = true, Name = @"prepare_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long PreparePosition;
-
-            [ProtoMember(3, IsRequired = true, Name = @"max_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int MaxCount;
-
-            [ProtoMember(4, IsRequired = true, Name = @"resolve_link_tos", DataFormat = DataFormat.Default)]
-            public readonly bool ResolveLinkTos;
-
-            [ProtoMember(5, IsRequired = true, Name = @"require_master", DataFormat = DataFormat.Default)]
-            public readonly bool RequireMaster;
-
-            private ReadAllEvents() { }
-
-            public ReadAllEvents(long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos, bool requireMaster)
-            {
-                CommitPosition = commitPosition;
-                PreparePosition = preparePosition;
-                MaxCount = maxCount;
-                ResolveLinkTos = resolveLinkTos;
-                RequireMaster = requireMaster;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ReadAllEventsCompleted")]
-        public partial class ReadAllEventsCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long CommitPosition;
-
-            [ProtoMember(2, IsRequired = true, Name = @"prepare_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long PreparePosition;
-
-            [ProtoMember(3, Name = @"events", DataFormat = DataFormat.Default)]
-            public readonly ResolvedEvent[] Events;
-
-            [ProtoMember(4, IsRequired = true, Name = @"next_commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long NextCommitPosition;
-
-            [ProtoMember(5, IsRequired = true, Name = @"next_prepare_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long NextPreparePosition;
-
-            [ProtoMember(6, IsRequired = false, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly ReadAllEventsCompleted.ReadAllResult Result;
-
-            [ProtoMember(7, IsRequired = false, Name = @"error", DataFormat = DataFormat.Default)]
-            public readonly string Error;
-
-            [ProtoContract(Name = @"ReadAllResult")]
-            public enum ReadAllResult
-            {
-
-                [ProtoEnum(Name = @"Success", Value = 0)]
-                Success = 0,
-
-                [ProtoEnum(Name = @"NotModified", Value = 1)]
-                NotModified = 1,
-
-                [ProtoEnum(Name = @"Error", Value = 2)]
-                Error = 2,
-
-                [ProtoEnum(Name = @"AccessDenied", Value = 3)]
-                AccessDenied = 3
-            }
-
-            private ReadAllEventsCompleted() { }
-
-            public ReadAllEventsCompleted(long commitPosition, long preparePosition, ResolvedEvent[] events, long nextCommitPosition, long nextPreparePosition, ReadAllEventsCompleted.ReadAllResult result, string error)
-            {
-                CommitPosition = commitPosition;
-                PreparePosition = preparePosition;
-                Events = events;
-                NextCommitPosition = nextCommitPosition;
-                NextPreparePosition = nextPreparePosition;
-                Result = result;
-                Error = error;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"CreatePersistentSubscription")]
-        public partial class CreatePersistentSubscription
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"subscription_group_name", DataFormat = DataFormat.Default)]
-            public readonly string SubscriptionGroupName;
-
-            [ProtoMember(2, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(3, IsRequired = true, Name = @"resolve_link_tos", DataFormat = DataFormat.Default)]
-            public readonly bool ResolveLinkTos;
-
-            [ProtoMember(4, IsRequired = true, Name = @"start_from", DataFormat = DataFormat.TwosComplement)]
-            public readonly long StartFrom;
-
-            [ProtoMember(5, IsRequired = true, Name = @"message_timeout_milliseconds", DataFormat = DataFormat.TwosComplement)]
-            public readonly int MessageTimeoutMilliseconds;
-
-            [ProtoMember(6, IsRequired = true, Name = @"record_statistics", DataFormat = DataFormat.Default)]
-            public readonly bool RecordStatistics;
-
-            [ProtoMember(7, IsRequired = true, Name = @"live_buffer_size", DataFormat = DataFormat.TwosComplement)]
-            public readonly int LiveBufferSize;
-
-            [ProtoMember(8, IsRequired = true, Name = @"read_batch_size", DataFormat = DataFormat.TwosComplement)]
-            public readonly int ReadBatchSize;
-
-            [ProtoMember(9, IsRequired = true, Name = @"buffer_size", DataFormat = DataFormat.TwosComplement)]
-            public readonly int BufferSize;
-
-            [ProtoMember(10, IsRequired = true, Name = @"max_retry_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int MaxRetryCount;
-
-            [ProtoMember(11, IsRequired = true, Name = @"prefer_round_robin", DataFormat = DataFormat.Default)]
-            public readonly bool PreferRoundRobin;
-
-            [ProtoMember(12, IsRequired = true, Name = @"checkpoint_after_time", DataFormat = DataFormat.TwosComplement)]
-            public readonly int CheckpointAfterTime;
-
-            [ProtoMember(13, IsRequired = true, Name = @"checkpoint_max_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int CheckpointMaxCount;
-
-            [ProtoMember(14, IsRequired = true, Name = @"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int CheckpointMinCount;
-
-            [ProtoMember(15, IsRequired = true, Name = @"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int SubscriberMaxCount;
-
-            [ProtoMember(16, IsRequired = false, Name = @"named_consumer_strategy", DataFormat = DataFormat.Default)]
-            public readonly string NamedConsumerStrategy;
-
-            private CreatePersistentSubscription() { }
-
-            public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, long startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount, string namedConsumerStrategy)
-            {
-                SubscriptionGroupName = subscriptionGroupName;
-                EventStreamId = eventStreamId;
-                ResolveLinkTos = resolveLinkTos;
-                StartFrom = startFrom;
-                MessageTimeoutMilliseconds = messageTimeoutMilliseconds;
-                RecordStatistics = recordStatistics;
-                LiveBufferSize = liveBufferSize;
-                ReadBatchSize = readBatchSize;
-                BufferSize = bufferSize;
-                MaxRetryCount = maxRetryCount;
-                PreferRoundRobin = preferRoundRobin;
-                CheckpointAfterTime = checkpointAfterTime;
-                CheckpointMaxCount = checkpointMaxCount;
-                CheckpointMinCount = checkpointMinCount;
-                SubscriberMaxCount = subscriberMaxCount;
-                NamedConsumerStrategy = namedConsumerStrategy;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"DeletePersistentSubscription")]
-        public partial class DeletePersistentSubscription
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"subscription_group_name", DataFormat = DataFormat.Default)]
-            public readonly string SubscriptionGroupName;
-
-            [ProtoMember(2, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            private DeletePersistentSubscription() { }
-
-            public DeletePersistentSubscription(string subscriptionGroupName, string eventStreamId)
-            {
-                SubscriptionGroupName = subscriptionGroupName;
-                EventStreamId = eventStreamId;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"UpdatePersistentSubscription")]
-        public partial class UpdatePersistentSubscription
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"subscription_group_name", DataFormat = DataFormat.Default)]
-            public readonly string SubscriptionGroupName;
-
-            [ProtoMember(2, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(3, IsRequired = true, Name = @"resolve_link_tos", DataFormat = DataFormat.Default)]
-            public readonly bool ResolveLinkTos;
-
-            [ProtoMember(4, IsRequired = true, Name = @"start_from", DataFormat = DataFormat.TwosComplement)]
-            public readonly long StartFrom;
-
-            [ProtoMember(5, IsRequired = true, Name = @"message_timeout_milliseconds", DataFormat = DataFormat.TwosComplement)]
-            public readonly int MessageTimeoutMilliseconds;
-
-            [ProtoMember(6, IsRequired = true, Name = @"record_statistics", DataFormat = DataFormat.Default)]
-            public readonly bool RecordStatistics;
-
-            [ProtoMember(7, IsRequired = true, Name = @"live_buffer_size", DataFormat = DataFormat.TwosComplement)]
-            public readonly int LiveBufferSize;
-
-            [ProtoMember(8, IsRequired = true, Name = @"read_batch_size", DataFormat = DataFormat.TwosComplement)]
-            public readonly int ReadBatchSize;
-
-            [ProtoMember(9, IsRequired = true, Name = @"buffer_size", DataFormat = DataFormat.TwosComplement)]
-            public readonly int BufferSize;
-
-            [ProtoMember(10, IsRequired = true, Name = @"max_retry_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int MaxRetryCount;
-
-            [ProtoMember(11, IsRequired = true, Name = @"prefer_round_robin", DataFormat = DataFormat.Default)]
-            public readonly bool PreferRoundRobin;
-
-            [ProtoMember(12, IsRequired = true, Name = @"checkpoint_after_time", DataFormat = DataFormat.TwosComplement)]
-            public readonly int CheckpointAfterTime;
-
-            [ProtoMember(13, IsRequired = true, Name = @"checkpoint_max_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int CheckpointMaxCount;
-
-            [ProtoMember(14, IsRequired = true, Name = @"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int CheckpointMinCount;
-
-            [ProtoMember(15, IsRequired = true, Name = @"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
-            public readonly int SubscriberMaxCount;
-
-            [ProtoMember(16, IsRequired = false, Name = @"named_consumer_strategy", DataFormat = DataFormat.Default)]
-            public readonly string NamedConsumerStrategy;
-
-            private UpdatePersistentSubscription() { }
-
-            public UpdatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, long startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount, string namedConsumerStrategy)
-            {
-                SubscriptionGroupName = subscriptionGroupName;
-                EventStreamId = eventStreamId;
-                ResolveLinkTos = resolveLinkTos;
-                StartFrom = startFrom;
-                MessageTimeoutMilliseconds = messageTimeoutMilliseconds;
-                RecordStatistics = recordStatistics;
-                LiveBufferSize = liveBufferSize;
-                ReadBatchSize = readBatchSize;
-                BufferSize = bufferSize;
-                MaxRetryCount = maxRetryCount;
-                PreferRoundRobin = preferRoundRobin;
-                CheckpointAfterTime = checkpointAfterTime;
-                CheckpointMaxCount = checkpointMaxCount;
-                CheckpointMinCount = checkpointMinCount;
-                SubscriberMaxCount = subscriberMaxCount;
-                NamedConsumerStrategy = namedConsumerStrategy;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"UpdatePersistentSubscriptionCompleted")]
-        public partial class UpdatePersistentSubscriptionCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly UpdatePersistentSubscriptionCompleted.UpdatePersistentSubscriptionResult Result;
-
-            [ProtoMember(2, IsRequired = false, Name = @"reason", DataFormat = DataFormat.Default)]
-            public readonly string Reason;
-
-            [ProtoContract(Name = @"UpdatePersistentSubscriptionResult")]
-            public enum UpdatePersistentSubscriptionResult
-            {
-
-                [ProtoEnum(Name = @"Success", Value = 0)]
-                Success = 0,
-
-                [ProtoEnum(Name = @"DoesNotExist", Value = 1)]
-                DoesNotExist = 1,
-
-                [ProtoEnum(Name = @"Fail", Value = 2)]
-                Fail = 2,
-
-                [ProtoEnum(Name = @"AccessDenied", Value = 3)]
-                AccessDenied = 3
-            }
-
-            private UpdatePersistentSubscriptionCompleted() { }
-
-            public UpdatePersistentSubscriptionCompleted(UpdatePersistentSubscriptionCompleted.UpdatePersistentSubscriptionResult result, string reason)
-            {
-                Result = result;
-                Reason = reason;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"CreatePersistentSubscriptionCompleted")]
-        public partial class CreatePersistentSubscriptionCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly CreatePersistentSubscriptionCompleted.CreatePersistentSubscriptionResult Result;
-
-            [ProtoMember(2, IsRequired = false, Name = @"reason", DataFormat = DataFormat.Default)]
-            public readonly string Reason;
-
-            [ProtoContract(Name = @"CreatePersistentSubscriptionResult")]
-            public enum CreatePersistentSubscriptionResult
-            {
-
-                [ProtoEnum(Name = @"Success", Value = 0)]
-                Success = 0,
-
-                [ProtoEnum(Name = @"AlreadyExists", Value = 1)]
-                AlreadyExists = 1,
-
-                [ProtoEnum(Name = @"Fail", Value = 2)]
-                Fail = 2,
-
-                [ProtoEnum(Name = @"AccessDenied", Value = 3)]
-                AccessDenied = 3
-            }
-
-            private CreatePersistentSubscriptionCompleted() { }
-
-            public CreatePersistentSubscriptionCompleted(CreatePersistentSubscriptionCompleted.CreatePersistentSubscriptionResult result, string reason)
-            {
-                Result = result;
-                Reason = reason;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"DeletePersistentSubscriptionCompleted")]
-        public partial class DeletePersistentSubscriptionCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly DeletePersistentSubscriptionCompleted.DeletePersistentSubscriptionResult Result;
-
-            [ProtoMember(2, IsRequired = false, Name = @"reason", DataFormat = DataFormat.Default)]
-            public readonly string Reason;
-
-            [ProtoContract(Name = @"DeletePersistentSubscriptionResult")]
-            public enum DeletePersistentSubscriptionResult
-            {
-
-                [ProtoEnum(Name = @"Success", Value = 0)]
-                Success = 0,
-
-                [ProtoEnum(Name = @"DoesNotExist", Value = 1)]
-                DoesNotExist = 1,
-
-                [ProtoEnum(Name = @"Fail", Value = 2)]
-                Fail = 2,
-
-                [ProtoEnum(Name = @"AccessDenied", Value = 3)]
-                AccessDenied = 3
-            }
-
-            private DeletePersistentSubscriptionCompleted() { }
-
-            public DeletePersistentSubscriptionCompleted(DeletePersistentSubscriptionCompleted.DeletePersistentSubscriptionResult result, string reason)
-            {
-                Result = result;
-                Reason = reason;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ConnectToPersistentSubscription")]
-        public partial class ConnectToPersistentSubscription
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"subscription_id", DataFormat = DataFormat.Default)]
-            public readonly string SubscriptionId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(3, IsRequired = true, Name = @"allowed_in_flight_messages", DataFormat = DataFormat.TwosComplement)]
-            public readonly int AllowedInFlightMessages;
-
-            private ConnectToPersistentSubscription() { }
-
-            public ConnectToPersistentSubscription(string subscriptionId, string eventStreamId, int allowedInFlightMessages)
-            {
-                SubscriptionId = subscriptionId;
-                EventStreamId = eventStreamId;
-                AllowedInFlightMessages = allowedInFlightMessages;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"PersistentSubscriptionAckEvents")]
-        public partial class PersistentSubscriptionAckEvents
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"subscription_id", DataFormat = DataFormat.Default)]
-            public readonly string SubscriptionId;
-
-            [ProtoMember(2, Name = @"processed_event_ids", DataFormat = DataFormat.Default)]
-            public readonly byte[][] ProcessedEventIds;
-
-            private PersistentSubscriptionAckEvents() { }
-
-            public PersistentSubscriptionAckEvents(string subscriptionId, byte[][] processedEventIds)
-            {
-                SubscriptionId = subscriptionId;
-                ProcessedEventIds = processedEventIds;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"PersistentSubscriptionNakEvents")]
-        public partial class PersistentSubscriptionNakEvents
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"subscription_id", DataFormat = DataFormat.Default)]
-            public readonly string SubscriptionId;
-
-            [ProtoMember(2, Name = @"processed_event_ids", DataFormat = DataFormat.Default)]
-            public readonly byte[][] ProcessedEventIds;
-
-            [ProtoMember(3, IsRequired = false, Name = @"message", DataFormat = DataFormat.Default)]
-            public readonly string Message;
-
-            [ProtoMember(4, IsRequired = true, Name = @"action", DataFormat = DataFormat.TwosComplement)]
-            public readonly PersistentSubscriptionNakEvents.NakAction Action;
-
-            [ProtoContract(Name = @"NakAction")]
-            public enum NakAction
-            {
-
-                [ProtoEnum(Name = @"Unknown", Value = 0)]
-                Unknown = 0,
-
-                [ProtoEnum(Name = @"Park", Value = 1)]
-                Park = 1,
-
-                [ProtoEnum(Name = @"Retry", Value = 2)]
-                Retry = 2,
-
-                [ProtoEnum(Name = @"Skip", Value = 3)]
-                Skip = 3,
-
-                [ProtoEnum(Name = @"Stop", Value = 4)]
-                Stop = 4
-            }
-
-            private PersistentSubscriptionNakEvents() { }
-
-            public PersistentSubscriptionNakEvents(string subscriptionId, byte[][] processedEventIds, string message, PersistentSubscriptionNakEvents.NakAction action)
-            {
-                SubscriptionId = subscriptionId;
-                ProcessedEventIds = processedEventIds;
-                Message = message;
-                Action = action;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"PersistentSubscriptionConfirmation")]
-        public partial class PersistentSubscriptionConfirmation
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"last_commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long LastCommitPosition;
-
-            [ProtoMember(2, IsRequired = true, Name = @"subscription_id", DataFormat = DataFormat.Default)]
-            public readonly string SubscriptionId;
-
-            [ProtoMember(3, IsRequired = false, Name = @"last_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? LastEventNumber;
-
-            private PersistentSubscriptionConfirmation() { }
-
-            public PersistentSubscriptionConfirmation(long lastCommitPosition, string subscriptionId, long? lastEventNumber)
-            {
-                LastCommitPosition = lastCommitPosition;
-                SubscriptionId = subscriptionId;
-                LastEventNumber = lastEventNumber;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"PersistentSubscriptionStreamEventAppeared")]
-        public partial class PersistentSubscriptionStreamEventAppeared
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event", DataFormat = DataFormat.Default)]
-            public readonly ResolvedIndexedEvent Event;
-
-            private PersistentSubscriptionStreamEventAppeared() { }
-
-            public PersistentSubscriptionStreamEventAppeared(ResolvedIndexedEvent @event)
-            {
-                Event = @event;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"SubscribeToStream")]
-        public partial class SubscribeToStream
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event_stream_id", DataFormat = DataFormat.Default)]
-            public readonly string EventStreamId;
-
-            [ProtoMember(2, IsRequired = true, Name = @"resolve_link_tos", DataFormat = DataFormat.Default)]
-            public readonly bool ResolveLinkTos;
-
-            private SubscribeToStream() { }
-
-            public SubscribeToStream(string eventStreamId, bool resolveLinkTos)
-            {
-                EventStreamId = eventStreamId;
-                ResolveLinkTos = resolveLinkTos;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"SubscriptionConfirmation")]
-        public partial class SubscriptionConfirmation
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"last_commit_position", DataFormat = DataFormat.TwosComplement)]
-            public readonly long LastCommitPosition;
-
-            [ProtoMember(2, IsRequired = false, Name = @"last_event_number", DataFormat = DataFormat.TwosComplement)]
-            public readonly long? LastEventNumber;
-
-            private SubscriptionConfirmation() { }
-
-            public SubscriptionConfirmation(long lastCommitPosition, long? lastEventNumber)
-            {
-                LastCommitPosition = lastCommitPosition;
-                LastEventNumber = lastEventNumber;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"StreamEventAppeared")]
-        public partial class StreamEventAppeared
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"event", DataFormat = DataFormat.Default)]
-            public readonly ResolvedEvent Event;
-
-            private StreamEventAppeared() { }
-
-            public StreamEventAppeared(ResolvedEvent @event)
-            {
-                Event = @event;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"UnsubscribeFromStream")]
-        public partial class UnsubscribeFromStream
-        {
-            public UnsubscribeFromStream()
-            {
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"SubscriptionDropped")]
-        public partial class SubscriptionDropped
-        {
-            [ProtoMember(1, IsRequired = false, Name = @"reason", DataFormat = DataFormat.TwosComplement)]
-            public readonly SubscriptionDropped.SubscriptionDropReason Reason;
-
-            [ProtoContract(Name = @"SubscriptionDropReason")]
-            public enum SubscriptionDropReason
-            {
-
-                [ProtoEnum(Name = @"Unsubscribed", Value = 0)]
-                Unsubscribed = 0,
-
-                [ProtoEnum(Name = @"AccessDenied", Value = 1)]
-                AccessDenied = 1,
-
-                [ProtoEnum(Name = @"NotFound", Value = 2)]
-                NotFound = 2,
-
-                [ProtoEnum(Name = @"PersistentSubscriptionDeleted", Value = 3)]
-                PersistentSubscriptionDeleted = 3,
-
-                [ProtoEnum(Name = @"SubscriberMaxCountReached", Value = 4)]
-                SubscriberMaxCountReached = 4
-            }
-
-            private SubscriptionDropped() { }
-
-            public SubscriptionDropped(SubscriptionDropped.SubscriptionDropReason reason)
-            {
-                Reason = reason;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"NotHandled")]
-        public partial class NotHandled
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"reason", DataFormat = DataFormat.TwosComplement)]
-            public readonly NotHandled.NotHandledReason Reason;
-
-            [ProtoMember(2, IsRequired = false, Name = @"additional_info", DataFormat = DataFormat.Default)]
-            public readonly byte[] AdditionalInfo;
-
-            [Serializable, ProtoContract(Name = @"MasterInfo")]
-            public partial class MasterInfo
-            {
-                [ProtoMember(1, IsRequired = true, Name = @"external_tcp_address", DataFormat = DataFormat.Default)]
-                public readonly string ExternalTcpAddress;
-
-                [ProtoMember(2, IsRequired = true, Name = @"external_tcp_port", DataFormat = DataFormat.TwosComplement)]
-                public readonly int ExternalTcpPort;
-
-                [ProtoMember(3, IsRequired = true, Name = @"external_http_address", DataFormat = DataFormat.Default)]
-                public readonly string ExternalHttpAddress;
-
-                [ProtoMember(4, IsRequired = true, Name = @"external_http_port", DataFormat = DataFormat.TwosComplement)]
-                public readonly int ExternalHttpPort;
-
-                [ProtoMember(5, IsRequired = false, Name = @"external_secure_tcp_address", DataFormat = DataFormat.Default)]
-                public readonly string ExternalSecureTcpAddress;
-
-                [ProtoMember(6, IsRequired = false, Name = @"external_secure_tcp_port", DataFormat = DataFormat.TwosComplement)]
-                public readonly int? ExternalSecureTcpPort;
-
-                private MasterInfo() { }
-
-                public MasterInfo(string externalTcpAddress, int externalTcpPort, string externalHttpAddress, int externalHttpPort, string externalSecureTcpAddress, int? externalSecureTcpPort)
-                {
-                    ExternalTcpAddress = externalTcpAddress;
-                    ExternalTcpPort = externalTcpPort;
-                    ExternalHttpAddress = externalHttpAddress;
-                    ExternalHttpPort = externalHttpPort;
-                    ExternalSecureTcpAddress = externalSecureTcpAddress;
-                    ExternalSecureTcpPort = externalSecureTcpPort;
-                }
-            }
-
-            [ProtoContract(Name = @"NotHandledReason")]
-            public enum NotHandledReason
-            {
-
-                [ProtoEnum(Name = @"NotReady", Value = 0)]
-                NotReady = 0,
-
-                [ProtoEnum(Name = @"TooBusy", Value = 1)]
-                TooBusy = 1,
-
-                [ProtoEnum(Name = @"NotMaster", Value = 2)]
-                NotMaster = 2
-            }
-
-            private NotHandled() { }
-
-            public NotHandled(NotHandled.NotHandledReason reason, byte[] additionalInfo)
-            {
-                Reason = reason;
-                AdditionalInfo = additionalInfo;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ScavengeDatabase")]
-        public partial class ScavengeDatabase
-        {
-            public ScavengeDatabase()
-            {
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ScavengeDatabaseCompleted")]
-        public partial class ScavengeDatabaseCompleted
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"result", DataFormat = DataFormat.TwosComplement)]
-            public readonly ScavengeDatabaseCompleted.ScavengeResult Result;
-
-            [ProtoMember(2, IsRequired = false, Name = @"error", DataFormat = DataFormat.Default)]
-            public readonly string Error;
-
-            [ProtoMember(3, IsRequired = true, Name = @"total_time_ms", DataFormat = DataFormat.TwosComplement)]
-            public readonly int TotalTimeMs;
-
-            [ProtoMember(4, IsRequired = true, Name = @"total_space_saved", DataFormat = DataFormat.TwosComplement)]
-            public readonly long TotalSpaceSaved;
-
-            [ProtoContract(Name = @"ScavengeResult")]
-            public enum ScavengeResult
-            {
-
-                [ProtoEnum(Name = @"Success", Value = 0)]
-                Success = 0,
-
-                [ProtoEnum(Name = @"InProgress", Value = 1)]
-                InProgress = 1,
-
-                [ProtoEnum(Name = @"Failed", Value = 2)]
-                Failed = 2
-            }
-
-            private ScavengeDatabaseCompleted() { }
-
-            public ScavengeDatabaseCompleted(ScavengeDatabaseCompleted.ScavengeResult result, string error, int totalTimeMs, long totalSpaceSaved)
-            {
-                Result = result;
-                Error = error;
-                TotalTimeMs = totalTimeMs;
-                TotalSpaceSaved = totalSpaceSaved;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"IdentifyClient")]
-        public partial class IdentifyClient
-        {
-            [ProtoMember(1, IsRequired = true, Name = @"version", DataFormat = DataFormat.TwosComplement)]
-            public readonly int Version;
-
-            [ProtoMember(2, IsRequired = false, Name = @"connection_name", DataFormat = DataFormat.Default)]
-            public readonly string ConnectionName;
-
-            private IdentifyClient() { }
-
-            public IdentifyClient(int version, string connectionName)
-            {
-                Version = version;
-                ConnectionName = connectionName;
-            }
-        }
-
-        [Serializable, ProtoContract(Name = @"ClientIdentified")]
-        public partial class ClientIdentified
-        {
-            public ClientIdentified()
-            {
-            }
-        }
-
-        [ProtoContract(Name = @"OperationResult")]
-        public enum OperationResult
-        {
-
-            [ProtoEnum(Name = @"Success", Value = 0)]
-            Success = 0,
-
-            [ProtoEnum(Name = @"PrepareTimeout", Value = 1)]
-            PrepareTimeout = 1,
-
-            [ProtoEnum(Name = @"CommitTimeout", Value = 2)]
-            CommitTimeout = 2,
-
-            [ProtoEnum(Name = @"ForwardTimeout", Value = 3)]
-            ForwardTimeout = 3,
-
-            [ProtoEnum(Name = @"WrongExpectedVersion", Value = 4)]
-            WrongExpectedVersion = 4,
-
-            [ProtoEnum(Name = @"StreamDeleted", Value = 5)]
-            StreamDeleted = 5,
-
-            [ProtoEnum(Name = @"InvalidTransaction", Value = 6)]
-            InvalidTransaction = 6,
-
-            [ProtoEnum(Name = @"AccessDenied", Value = 7)]
-            AccessDenied = 7
-        }
-
+        EventId = eventId;
+        EventType = eventType;
+        DataContentType = dataContentType;
+        MetadataContentType = metadataContentType;
+        Data = data;
+        Metadata = metadata;
     }
+  }
+  
+  [Serializable, ProtoContract(Name=@"EventRecord")]
+  public partial class EventRecord
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long EventNumber;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"event_id", DataFormat = DataFormat.Default)]
+    public readonly byte[] EventId;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"event_type", DataFormat = DataFormat.Default)]
+    public readonly string EventType;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"data_content_type", DataFormat = DataFormat.TwosComplement)]
+    public readonly int DataContentType;
+  
+    [ProtoMember(6, IsRequired = true, Name=@"metadata_content_type", DataFormat = DataFormat.TwosComplement)]
+    public readonly int MetadataContentType;
+  
+    [ProtoMember(7, IsRequired = true, Name=@"data", DataFormat = DataFormat.Default)]
+    public readonly byte[] Data;
+  
+    [ProtoMember(8, IsRequired = false, Name=@"metadata", DataFormat = DataFormat.Default)]
+    public readonly byte[] Metadata;
+  
+    [ProtoMember(9, IsRequired = false, Name=@"created", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? Created;
+  
+    [ProtoMember(10, IsRequired = false, Name=@"created_epoch", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? CreatedEpoch;
+  
+    private EventRecord() {}
+  
+    public EventRecord(string eventStreamId, long eventNumber, byte[] eventId, string eventType, int dataContentType, int metadataContentType, byte[] data, byte[] metadata, long? created, long? createdEpoch)
+    {
+        EventStreamId = eventStreamId;
+        EventNumber = eventNumber;
+        EventId = eventId;
+        EventType = eventType;
+        DataContentType = dataContentType;
+        MetadataContentType = metadataContentType;
+        Data = data;
+        Metadata = metadata;
+        Created = created;
+        CreatedEpoch = createdEpoch;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ResolvedIndexedEvent")]
+  public partial class ResolvedIndexedEvent
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event", DataFormat = DataFormat.Default)]
+    public readonly EventRecord Event;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"link", DataFormat = DataFormat.Default)]
+    public readonly EventRecord Link;
+  
+    private ResolvedIndexedEvent() {}
+  
+    public ResolvedIndexedEvent(EventRecord @event, EventRecord link)
+    {
+        Event = @event;
+        Link = link;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ResolvedEvent")]
+  public partial class ResolvedEvent
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event", DataFormat = DataFormat.Default)]
+    public readonly EventRecord Event;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"link", DataFormat = DataFormat.Default)]
+    public readonly EventRecord Link;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long CommitPosition;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"prepare_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long PreparePosition;
+  
+    private ResolvedEvent() {}
+  
+    public ResolvedEvent(EventRecord @event, EventRecord link, long commitPosition, long preparePosition)
+    {
+        Event = @event;
+        Link = link;
+        CommitPosition = commitPosition;
+        PreparePosition = preparePosition;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"WriteEvents")]
+  public partial class WriteEvents
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"expected_version", DataFormat = DataFormat.TwosComplement)]
+    public readonly long ExpectedVersion;
+  
+    [ProtoMember(3, Name=@"events", DataFormat = DataFormat.Default)]
+    public readonly NewEvent[] Events;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"require_master", DataFormat = DataFormat.Default)]
+    public readonly bool RequireMaster;
+  
+    private WriteEvents() {}
+  
+    public WriteEvents(string eventStreamId, long expectedVersion, NewEvent[] events, bool requireMaster)
+    {
+        EventStreamId = eventStreamId;
+        ExpectedVersion = expectedVersion;
+        Events = events;
+        RequireMaster = requireMaster;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"WriteEventsCompleted")]
+  public partial class WriteEventsCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly OperationResult Result;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = DataFormat.Default)]
+    public readonly string Message;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"first_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long FirstEventNumber;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"last_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long LastEventNumber;
+  
+    [ProtoMember(5, IsRequired = false, Name=@"prepare_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? PreparePosition;
+  
+    [ProtoMember(6, IsRequired = false, Name=@"commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? CommitPosition;
+  
+    [ProtoMember(7, IsRequired = false, Name=@"current_version", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? CurrentVersion;
+  
+    private WriteEventsCompleted() {}
+  
+    public WriteEventsCompleted(OperationResult result, string message, long firstEventNumber, long lastEventNumber, long? preparePosition, long? commitPosition, long? currentVersion)
+    {
+        Result = result;
+        Message = message;
+        FirstEventNumber = firstEventNumber;
+        LastEventNumber = lastEventNumber;
+        PreparePosition = preparePosition;
+        CommitPosition = commitPosition;
+        CurrentVersion = currentVersion;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"DeleteStream")]
+  public partial class DeleteStream
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"expected_version", DataFormat = DataFormat.TwosComplement)]
+    public readonly long ExpectedVersion;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"require_master", DataFormat = DataFormat.Default)]
+    public readonly bool RequireMaster;
+  
+    [ProtoMember(4, IsRequired = false, Name=@"hard_delete", DataFormat = DataFormat.Default)]
+    public readonly bool? HardDelete;
+  
+    private DeleteStream() {}
+  
+    public DeleteStream(string eventStreamId, long expectedVersion, bool requireMaster, bool? hardDelete)
+    {
+        EventStreamId = eventStreamId;
+        ExpectedVersion = expectedVersion;
+        RequireMaster = requireMaster;
+        HardDelete = hardDelete;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"DeleteStreamCompleted")]
+  public partial class DeleteStreamCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly OperationResult Result;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"message", DataFormat = DataFormat.Default)]
+    public readonly string Message;
+  
+    [ProtoMember(3, IsRequired = false, Name=@"prepare_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? PreparePosition;
+  
+    [ProtoMember(4, IsRequired = false, Name=@"commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? CommitPosition;
+  
+    private DeleteStreamCompleted() {}
+  
+    public DeleteStreamCompleted(OperationResult result, string message, long? preparePosition, long? commitPosition)
+    {
+        Result = result;
+        Message = message;
+        PreparePosition = preparePosition;
+        CommitPosition = commitPosition;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"TransactionStart")]
+  public partial class TransactionStart
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"expected_version", DataFormat = DataFormat.TwosComplement)]
+    public readonly long ExpectedVersion;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"require_master", DataFormat = DataFormat.Default)]
+    public readonly bool RequireMaster;
+  
+    private TransactionStart() {}
+  
+    public TransactionStart(string eventStreamId, long expectedVersion, bool requireMaster)
+    {
+        EventStreamId = eventStreamId;
+        ExpectedVersion = expectedVersion;
+        RequireMaster = requireMaster;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"TransactionStartCompleted")]
+  public partial class TransactionStartCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"transaction_id", DataFormat = DataFormat.TwosComplement)]
+    public readonly long TransactionId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly OperationResult Result;
+  
+    [ProtoMember(3, IsRequired = false, Name=@"message", DataFormat = DataFormat.Default)]
+    public readonly string Message;
+  
+    private TransactionStartCompleted() {}
+  
+    public TransactionStartCompleted(long transactionId, OperationResult result, string message)
+    {
+        TransactionId = transactionId;
+        Result = result;
+        Message = message;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"TransactionWrite")]
+  public partial class TransactionWrite
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"transaction_id", DataFormat = DataFormat.TwosComplement)]
+    public readonly long TransactionId;
+  
+    [ProtoMember(2, Name=@"events", DataFormat = DataFormat.Default)]
+    public readonly NewEvent[] Events;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"require_master", DataFormat = DataFormat.Default)]
+    public readonly bool RequireMaster;
+  
+    private TransactionWrite() {}
+  
+    public TransactionWrite(long transactionId, NewEvent[] events, bool requireMaster)
+    {
+        TransactionId = transactionId;
+        Events = events;
+        RequireMaster = requireMaster;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"TransactionWriteCompleted")]
+  public partial class TransactionWriteCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"transaction_id", DataFormat = DataFormat.TwosComplement)]
+    public readonly long TransactionId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly OperationResult Result;
+  
+    [ProtoMember(3, IsRequired = false, Name=@"message", DataFormat = DataFormat.Default)]
+    public readonly string Message;
+  
+    private TransactionWriteCompleted() {}
+  
+    public TransactionWriteCompleted(long transactionId, OperationResult result, string message)
+    {
+        TransactionId = transactionId;
+        Result = result;
+        Message = message;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"TransactionCommit")]
+  public partial class TransactionCommit
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"transaction_id", DataFormat = DataFormat.TwosComplement)]
+    public readonly long TransactionId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"require_master", DataFormat = DataFormat.Default)]
+    public readonly bool RequireMaster;
+  
+    private TransactionCommit() {}
+  
+    public TransactionCommit(long transactionId, bool requireMaster)
+    {
+        TransactionId = transactionId;
+        RequireMaster = requireMaster;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"TransactionCommitCompleted")]
+  public partial class TransactionCommitCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"transaction_id", DataFormat = DataFormat.TwosComplement)]
+    public readonly long TransactionId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly OperationResult Result;
+  
+    [ProtoMember(3, IsRequired = false, Name=@"message", DataFormat = DataFormat.Default)]
+    public readonly string Message;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"first_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long FirstEventNumber;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"last_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long LastEventNumber;
+  
+    [ProtoMember(6, IsRequired = false, Name=@"prepare_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? PreparePosition;
+  
+    [ProtoMember(7, IsRequired = false, Name=@"commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? CommitPosition;
+  
+    private TransactionCommitCompleted() {}
+  
+    public TransactionCommitCompleted(long transactionId, OperationResult result, string message, long firstEventNumber, long lastEventNumber, long? preparePosition, long? commitPosition)
+    {
+        TransactionId = transactionId;
+        Result = result;
+        Message = message;
+        FirstEventNumber = firstEventNumber;
+        LastEventNumber = lastEventNumber;
+        PreparePosition = preparePosition;
+        CommitPosition = commitPosition;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ReadEvent")]
+  public partial class ReadEvent
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long EventNumber;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"resolve_link_tos", DataFormat = DataFormat.Default)]
+    public readonly bool ResolveLinkTos;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"require_master", DataFormat = DataFormat.Default)]
+    public readonly bool RequireMaster;
+  
+    private ReadEvent() {}
+  
+    public ReadEvent(string eventStreamId, long eventNumber, bool resolveLinkTos, bool requireMaster)
+    {
+        EventStreamId = eventStreamId;
+        EventNumber = eventNumber;
+        ResolveLinkTos = resolveLinkTos;
+        RequireMaster = requireMaster;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ReadEventCompleted")]
+  public partial class ReadEventCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly ReadEventCompleted.ReadEventResult Result;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"event", DataFormat = DataFormat.Default)]
+    public readonly ResolvedIndexedEvent Event;
+  
+    [ProtoMember(3, IsRequired = false, Name=@"error", DataFormat = DataFormat.Default)]
+    public readonly string Error;
+  
+    [ProtoContract(Name=@"ReadEventResult")]
+    public enum ReadEventResult
+    {
+            
+      [ProtoEnum(Name=@"Success", Value=0)]
+      Success = 0,
+            
+      [ProtoEnum(Name=@"NotFound", Value=1)]
+      NotFound = 1,
+            
+      [ProtoEnum(Name=@"NoStream", Value=2)]
+      NoStream = 2,
+            
+      [ProtoEnum(Name=@"StreamDeleted", Value=3)]
+      StreamDeleted = 3,
+            
+      [ProtoEnum(Name=@"Error", Value=4)]
+      Error = 4,
+            
+      [ProtoEnum(Name=@"AccessDenied", Value=5)]
+      AccessDenied = 5
+    }
+  
+    private ReadEventCompleted() {}
+  
+    public ReadEventCompleted(ReadEventCompleted.ReadEventResult result, ResolvedIndexedEvent @event, string error)
+    {
+        Result = result;
+        Event = @event;
+        Error = error;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ReadStreamEvents")]
+  public partial class ReadStreamEvents
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"from_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long FromEventNumber;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int MaxCount;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"resolve_link_tos", DataFormat = DataFormat.Default)]
+    public readonly bool ResolveLinkTos;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"require_master", DataFormat = DataFormat.Default)]
+    public readonly bool RequireMaster;
+  
+    private ReadStreamEvents() {}
+  
+    public ReadStreamEvents(string eventStreamId, long fromEventNumber, int maxCount, bool resolveLinkTos, bool requireMaster)
+    {
+        EventStreamId = eventStreamId;
+        FromEventNumber = fromEventNumber;
+        MaxCount = maxCount;
+        ResolveLinkTos = resolveLinkTos;
+        RequireMaster = requireMaster;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ReadStreamEventsCompleted")]
+  public partial class ReadStreamEventsCompleted
+  {
+    [ProtoMember(1, Name=@"events", DataFormat = DataFormat.Default)]
+    public readonly ResolvedIndexedEvent[] Events;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly ReadStreamEventsCompleted.ReadStreamResult Result;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"next_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long NextEventNumber;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"last_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long LastEventNumber;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"is_end_of_stream", DataFormat = DataFormat.Default)]
+    public readonly bool IsEndOfStream;
+  
+    [ProtoMember(6, IsRequired = true, Name=@"last_commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long LastCommitPosition;
+  
+    [ProtoMember(7, IsRequired = false, Name=@"error", DataFormat = DataFormat.Default)]
+    public readonly string Error;
+  
+    [ProtoContract(Name=@"ReadStreamResult")]
+    public enum ReadStreamResult
+    {
+            
+      [ProtoEnum(Name=@"Success", Value=0)]
+      Success = 0,
+            
+      [ProtoEnum(Name=@"NoStream", Value=1)]
+      NoStream = 1,
+            
+      [ProtoEnum(Name=@"StreamDeleted", Value=2)]
+      StreamDeleted = 2,
+            
+      [ProtoEnum(Name=@"NotModified", Value=3)]
+      NotModified = 3,
+            
+      [ProtoEnum(Name=@"Error", Value=4)]
+      Error = 4,
+            
+      [ProtoEnum(Name=@"AccessDenied", Value=5)]
+      AccessDenied = 5
+    }
+  
+    private ReadStreamEventsCompleted() {}
+  
+    public ReadStreamEventsCompleted(ResolvedIndexedEvent[] events, ReadStreamEventsCompleted.ReadStreamResult result, long nextEventNumber, long lastEventNumber, bool isEndOfStream, long lastCommitPosition, string error)
+    {
+        Events = events;
+        Result = result;
+        NextEventNumber = nextEventNumber;
+        LastEventNumber = lastEventNumber;
+        IsEndOfStream = isEndOfStream;
+        LastCommitPosition = lastCommitPosition;
+        Error = error;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ReadAllEvents")]
+  public partial class ReadAllEvents
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long CommitPosition;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"prepare_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long PreparePosition;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int MaxCount;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"resolve_link_tos", DataFormat = DataFormat.Default)]
+    public readonly bool ResolveLinkTos;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"require_master", DataFormat = DataFormat.Default)]
+    public readonly bool RequireMaster;
+  
+    private ReadAllEvents() {}
+  
+    public ReadAllEvents(long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos, bool requireMaster)
+    {
+        CommitPosition = commitPosition;
+        PreparePosition = preparePosition;
+        MaxCount = maxCount;
+        ResolveLinkTos = resolveLinkTos;
+        RequireMaster = requireMaster;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ReadAllEventsCompleted")]
+  public partial class ReadAllEventsCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long CommitPosition;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"prepare_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long PreparePosition;
+  
+    [ProtoMember(3, Name=@"events", DataFormat = DataFormat.Default)]
+    public readonly ResolvedEvent[] Events;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"next_commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long NextCommitPosition;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"next_prepare_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long NextPreparePosition;
+  
+    [ProtoMember(6, IsRequired = false, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly ReadAllEventsCompleted.ReadAllResult Result;
+  
+    [ProtoMember(7, IsRequired = false, Name=@"error", DataFormat = DataFormat.Default)]
+    public readonly string Error;
+  
+    [ProtoContract(Name=@"ReadAllResult")]
+    public enum ReadAllResult
+    {
+            
+      [ProtoEnum(Name=@"Success", Value=0)]
+      Success = 0,
+            
+      [ProtoEnum(Name=@"NotModified", Value=1)]
+      NotModified = 1,
+            
+      [ProtoEnum(Name=@"Error", Value=2)]
+      Error = 2,
+            
+      [ProtoEnum(Name=@"AccessDenied", Value=3)]
+      AccessDenied = 3
+    }
+  
+    private ReadAllEventsCompleted() {}
+  
+    public ReadAllEventsCompleted(long commitPosition, long preparePosition, ResolvedEvent[] events, long nextCommitPosition, long nextPreparePosition, ReadAllEventsCompleted.ReadAllResult result, string error)
+    {
+        CommitPosition = commitPosition;
+        PreparePosition = preparePosition;
+        Events = events;
+        NextCommitPosition = nextCommitPosition;
+        NextPreparePosition = nextPreparePosition;
+        Result = result;
+        Error = error;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"CreatePersistentSubscription")]
+  public partial class CreatePersistentSubscription
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"subscription_group_name", DataFormat = DataFormat.Default)]
+    public readonly string SubscriptionGroupName;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"resolve_link_tos", DataFormat = DataFormat.Default)]
+    public readonly bool ResolveLinkTos;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"start_from", DataFormat = DataFormat.TwosComplement)]
+    public readonly long StartFrom;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"message_timeout_milliseconds", DataFormat = DataFormat.TwosComplement)]
+    public readonly int MessageTimeoutMilliseconds;
+  
+    [ProtoMember(6, IsRequired = true, Name=@"record_statistics", DataFormat = DataFormat.Default)]
+    public readonly bool RecordStatistics;
+  
+    [ProtoMember(7, IsRequired = true, Name=@"live_buffer_size", DataFormat = DataFormat.TwosComplement)]
+    public readonly int LiveBufferSize;
+  
+    [ProtoMember(8, IsRequired = true, Name=@"read_batch_size", DataFormat = DataFormat.TwosComplement)]
+    public readonly int ReadBatchSize;
+  
+    [ProtoMember(9, IsRequired = true, Name=@"buffer_size", DataFormat = DataFormat.TwosComplement)]
+    public readonly int BufferSize;
+  
+    [ProtoMember(10, IsRequired = true, Name=@"max_retry_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int MaxRetryCount;
+  
+    [ProtoMember(11, IsRequired = true, Name=@"prefer_round_robin", DataFormat = DataFormat.Default)]
+    public readonly bool PreferRoundRobin;
+  
+    [ProtoMember(12, IsRequired = true, Name=@"checkpoint_after_time", DataFormat = DataFormat.TwosComplement)]
+    public readonly int CheckpointAfterTime;
+  
+    [ProtoMember(13, IsRequired = true, Name=@"checkpoint_max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int CheckpointMaxCount;
+  
+    [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int CheckpointMinCount;
+  
+    [ProtoMember(15, IsRequired = true, Name=@"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int SubscriberMaxCount;
+  
+    [ProtoMember(16, IsRequired = false, Name=@"named_consumer_strategy", DataFormat = DataFormat.Default)]
+    public readonly string NamedConsumerStrategy;
+  
+    private CreatePersistentSubscription() {}
+  
+    public CreatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, long startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount, string namedConsumerStrategy)
+    {
+        SubscriptionGroupName = subscriptionGroupName;
+        EventStreamId = eventStreamId;
+        ResolveLinkTos = resolveLinkTos;
+        StartFrom = startFrom;
+        MessageTimeoutMilliseconds = messageTimeoutMilliseconds;
+        RecordStatistics = recordStatistics;
+        LiveBufferSize = liveBufferSize;
+        ReadBatchSize = readBatchSize;
+        BufferSize = bufferSize;
+        MaxRetryCount = maxRetryCount;
+        PreferRoundRobin = preferRoundRobin;
+        CheckpointAfterTime = checkpointAfterTime;
+        CheckpointMaxCount = checkpointMaxCount;
+        CheckpointMinCount = checkpointMinCount;
+        SubscriberMaxCount = subscriberMaxCount;
+        NamedConsumerStrategy = namedConsumerStrategy;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"DeletePersistentSubscription")]
+  public partial class DeletePersistentSubscription
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"subscription_group_name", DataFormat = DataFormat.Default)]
+    public readonly string SubscriptionGroupName;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    private DeletePersistentSubscription() {}
+  
+    public DeletePersistentSubscription(string subscriptionGroupName, string eventStreamId)
+    {
+        SubscriptionGroupName = subscriptionGroupName;
+        EventStreamId = eventStreamId;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"UpdatePersistentSubscription")]
+  public partial class UpdatePersistentSubscription
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"subscription_group_name", DataFormat = DataFormat.Default)]
+    public readonly string SubscriptionGroupName;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"resolve_link_tos", DataFormat = DataFormat.Default)]
+    public readonly bool ResolveLinkTos;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"start_from", DataFormat = DataFormat.TwosComplement)]
+    public readonly long StartFrom;
+  
+    [ProtoMember(5, IsRequired = true, Name=@"message_timeout_milliseconds", DataFormat = DataFormat.TwosComplement)]
+    public readonly int MessageTimeoutMilliseconds;
+  
+    [ProtoMember(6, IsRequired = true, Name=@"record_statistics", DataFormat = DataFormat.Default)]
+    public readonly bool RecordStatistics;
+  
+    [ProtoMember(7, IsRequired = true, Name=@"live_buffer_size", DataFormat = DataFormat.TwosComplement)]
+    public readonly int LiveBufferSize;
+  
+    [ProtoMember(8, IsRequired = true, Name=@"read_batch_size", DataFormat = DataFormat.TwosComplement)]
+    public readonly int ReadBatchSize;
+  
+    [ProtoMember(9, IsRequired = true, Name=@"buffer_size", DataFormat = DataFormat.TwosComplement)]
+    public readonly int BufferSize;
+  
+    [ProtoMember(10, IsRequired = true, Name=@"max_retry_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int MaxRetryCount;
+  
+    [ProtoMember(11, IsRequired = true, Name=@"prefer_round_robin", DataFormat = DataFormat.Default)]
+    public readonly bool PreferRoundRobin;
+  
+    [ProtoMember(12, IsRequired = true, Name=@"checkpoint_after_time", DataFormat = DataFormat.TwosComplement)]
+    public readonly int CheckpointAfterTime;
+  
+    [ProtoMember(13, IsRequired = true, Name=@"checkpoint_max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int CheckpointMaxCount;
+  
+    [ProtoMember(14, IsRequired = true, Name=@"checkpoint_min_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int CheckpointMinCount;
+  
+    [ProtoMember(15, IsRequired = true, Name=@"subscriber_max_count", DataFormat = DataFormat.TwosComplement)]
+    public readonly int SubscriberMaxCount;
+  
+    [ProtoMember(16, IsRequired = false, Name=@"named_consumer_strategy", DataFormat = DataFormat.Default)]
+    public readonly string NamedConsumerStrategy;
+  
+    private UpdatePersistentSubscription() {}
+  
+    public UpdatePersistentSubscription(string subscriptionGroupName, string eventStreamId, bool resolveLinkTos, long startFrom, int messageTimeoutMilliseconds, bool recordStatistics, int liveBufferSize, int readBatchSize, int bufferSize, int maxRetryCount, bool preferRoundRobin, int checkpointAfterTime, int checkpointMaxCount, int checkpointMinCount, int subscriberMaxCount, string namedConsumerStrategy)
+    {
+        SubscriptionGroupName = subscriptionGroupName;
+        EventStreamId = eventStreamId;
+        ResolveLinkTos = resolveLinkTos;
+        StartFrom = startFrom;
+        MessageTimeoutMilliseconds = messageTimeoutMilliseconds;
+        RecordStatistics = recordStatistics;
+        LiveBufferSize = liveBufferSize;
+        ReadBatchSize = readBatchSize;
+        BufferSize = bufferSize;
+        MaxRetryCount = maxRetryCount;
+        PreferRoundRobin = preferRoundRobin;
+        CheckpointAfterTime = checkpointAfterTime;
+        CheckpointMaxCount = checkpointMaxCount;
+        CheckpointMinCount = checkpointMinCount;
+        SubscriberMaxCount = subscriberMaxCount;
+        NamedConsumerStrategy = namedConsumerStrategy;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"UpdatePersistentSubscriptionCompleted")]
+  public partial class UpdatePersistentSubscriptionCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly UpdatePersistentSubscriptionCompleted.UpdatePersistentSubscriptionResult Result;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"reason", DataFormat = DataFormat.Default)]
+    public readonly string Reason;
+  
+    [ProtoContract(Name=@"UpdatePersistentSubscriptionResult")]
+    public enum UpdatePersistentSubscriptionResult
+    {
+            
+      [ProtoEnum(Name=@"Success", Value=0)]
+      Success = 0,
+            
+      [ProtoEnum(Name=@"DoesNotExist", Value=1)]
+      DoesNotExist = 1,
+            
+      [ProtoEnum(Name=@"Fail", Value=2)]
+      Fail = 2,
+            
+      [ProtoEnum(Name=@"AccessDenied", Value=3)]
+      AccessDenied = 3
+    }
+  
+    private UpdatePersistentSubscriptionCompleted() {}
+  
+    public UpdatePersistentSubscriptionCompleted(UpdatePersistentSubscriptionCompleted.UpdatePersistentSubscriptionResult result, string reason)
+    {
+        Result = result;
+        Reason = reason;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"CreatePersistentSubscriptionCompleted")]
+  public partial class CreatePersistentSubscriptionCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly CreatePersistentSubscriptionCompleted.CreatePersistentSubscriptionResult Result;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"reason", DataFormat = DataFormat.Default)]
+    public readonly string Reason;
+  
+    [ProtoContract(Name=@"CreatePersistentSubscriptionResult")]
+    public enum CreatePersistentSubscriptionResult
+    {
+            
+      [ProtoEnum(Name=@"Success", Value=0)]
+      Success = 0,
+            
+      [ProtoEnum(Name=@"AlreadyExists", Value=1)]
+      AlreadyExists = 1,
+            
+      [ProtoEnum(Name=@"Fail", Value=2)]
+      Fail = 2,
+            
+      [ProtoEnum(Name=@"AccessDenied", Value=3)]
+      AccessDenied = 3
+    }
+  
+    private CreatePersistentSubscriptionCompleted() {}
+  
+    public CreatePersistentSubscriptionCompleted(CreatePersistentSubscriptionCompleted.CreatePersistentSubscriptionResult result, string reason)
+    {
+        Result = result;
+        Reason = reason;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"DeletePersistentSubscriptionCompleted")]
+  public partial class DeletePersistentSubscriptionCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly DeletePersistentSubscriptionCompleted.DeletePersistentSubscriptionResult Result;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"reason", DataFormat = DataFormat.Default)]
+    public readonly string Reason;
+  
+    [ProtoContract(Name=@"DeletePersistentSubscriptionResult")]
+    public enum DeletePersistentSubscriptionResult
+    {
+            
+      [ProtoEnum(Name=@"Success", Value=0)]
+      Success = 0,
+            
+      [ProtoEnum(Name=@"DoesNotExist", Value=1)]
+      DoesNotExist = 1,
+            
+      [ProtoEnum(Name=@"Fail", Value=2)]
+      Fail = 2,
+            
+      [ProtoEnum(Name=@"AccessDenied", Value=3)]
+      AccessDenied = 3
+    }
+  
+    private DeletePersistentSubscriptionCompleted() {}
+  
+    public DeletePersistentSubscriptionCompleted(DeletePersistentSubscriptionCompleted.DeletePersistentSubscriptionResult result, string reason)
+    {
+        Result = result;
+        Reason = reason;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ConnectToPersistentSubscription")]
+  public partial class ConnectToPersistentSubscription
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"subscription_id", DataFormat = DataFormat.Default)]
+    public readonly string SubscriptionId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"allowed_in_flight_messages", DataFormat = DataFormat.TwosComplement)]
+    public readonly int AllowedInFlightMessages;
+  
+    private ConnectToPersistentSubscription() {}
+  
+    public ConnectToPersistentSubscription(string subscriptionId, string eventStreamId, int allowedInFlightMessages)
+    {
+        SubscriptionId = subscriptionId;
+        EventStreamId = eventStreamId;
+        AllowedInFlightMessages = allowedInFlightMessages;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"PersistentSubscriptionAckEvents")]
+  public partial class PersistentSubscriptionAckEvents
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"subscription_id", DataFormat = DataFormat.Default)]
+    public readonly string SubscriptionId;
+  
+    [ProtoMember(2, Name=@"processed_event_ids", DataFormat = DataFormat.Default)]
+    public readonly byte[][] ProcessedEventIds;
+  
+    private PersistentSubscriptionAckEvents() {}
+  
+    public PersistentSubscriptionAckEvents(string subscriptionId, byte[][] processedEventIds)
+    {
+        SubscriptionId = subscriptionId;
+        ProcessedEventIds = processedEventIds;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"PersistentSubscriptionNakEvents")]
+  public partial class PersistentSubscriptionNakEvents
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"subscription_id", DataFormat = DataFormat.Default)]
+    public readonly string SubscriptionId;
+  
+    [ProtoMember(2, Name=@"processed_event_ids", DataFormat = DataFormat.Default)]
+    public readonly byte[][] ProcessedEventIds;
+  
+    [ProtoMember(3, IsRequired = false, Name=@"message", DataFormat = DataFormat.Default)]
+    public readonly string Message;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"action", DataFormat = DataFormat.TwosComplement)]
+    public readonly PersistentSubscriptionNakEvents.NakAction Action;
+  
+    [ProtoContract(Name=@"NakAction")]
+    public enum NakAction
+    {
+            
+      [ProtoEnum(Name=@"Unknown", Value=0)]
+      Unknown = 0,
+            
+      [ProtoEnum(Name=@"Park", Value=1)]
+      Park = 1,
+            
+      [ProtoEnum(Name=@"Retry", Value=2)]
+      Retry = 2,
+            
+      [ProtoEnum(Name=@"Skip", Value=3)]
+      Skip = 3,
+            
+      [ProtoEnum(Name=@"Stop", Value=4)]
+      Stop = 4
+    }
+  
+    private PersistentSubscriptionNakEvents() {}
+  
+    public PersistentSubscriptionNakEvents(string subscriptionId, byte[][] processedEventIds, string message, PersistentSubscriptionNakEvents.NakAction action)
+    {
+        SubscriptionId = subscriptionId;
+        ProcessedEventIds = processedEventIds;
+        Message = message;
+        Action = action;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"PersistentSubscriptionConfirmation")]
+  public partial class PersistentSubscriptionConfirmation
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"last_commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long LastCommitPosition;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"subscription_id", DataFormat = DataFormat.Default)]
+    public readonly string SubscriptionId;
+  
+    [ProtoMember(3, IsRequired = false, Name=@"last_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? LastEventNumber;
+  
+    private PersistentSubscriptionConfirmation() {}
+  
+    public PersistentSubscriptionConfirmation(long lastCommitPosition, string subscriptionId, long? lastEventNumber)
+    {
+        LastCommitPosition = lastCommitPosition;
+        SubscriptionId = subscriptionId;
+        LastEventNumber = lastEventNumber;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"PersistentSubscriptionStreamEventAppeared")]
+  public partial class PersistentSubscriptionStreamEventAppeared
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event", DataFormat = DataFormat.Default)]
+    public readonly ResolvedIndexedEvent Event;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"retryCount", DataFormat = DataFormat.TwosComplement)]
+    public readonly int? RetryCount;
+  
+    private PersistentSubscriptionStreamEventAppeared() {}
+  
+    public PersistentSubscriptionStreamEventAppeared(ResolvedIndexedEvent @event, int? retryCount)
+    {
+        Event = @event;
+        RetryCount = retryCount;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"SubscribeToStream")]
+  public partial class SubscribeToStream
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event_stream_id", DataFormat = DataFormat.Default)]
+    public readonly string EventStreamId;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"resolve_link_tos", DataFormat = DataFormat.Default)]
+    public readonly bool ResolveLinkTos;
+  
+    private SubscribeToStream() {}
+  
+    public SubscribeToStream(string eventStreamId, bool resolveLinkTos)
+    {
+        EventStreamId = eventStreamId;
+        ResolveLinkTos = resolveLinkTos;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"SubscriptionConfirmation")]
+  public partial class SubscriptionConfirmation
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"last_commit_position", DataFormat = DataFormat.TwosComplement)]
+    public readonly long LastCommitPosition;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"last_event_number", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? LastEventNumber;
+  
+    private SubscriptionConfirmation() {}
+  
+    public SubscriptionConfirmation(long lastCommitPosition, long? lastEventNumber)
+    {
+        LastCommitPosition = lastCommitPosition;
+        LastEventNumber = lastEventNumber;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"StreamEventAppeared")]
+  public partial class StreamEventAppeared
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"event", DataFormat = DataFormat.Default)]
+    public readonly ResolvedEvent Event;
+  
+    private StreamEventAppeared() {}
+  
+    public StreamEventAppeared(ResolvedEvent @event)
+    {
+        Event = @event;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"UnsubscribeFromStream")]
+  public partial class UnsubscribeFromStream
+  {
+    public UnsubscribeFromStream()
+    {
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"SubscriptionDropped")]
+  public partial class SubscriptionDropped
+  {
+    [ProtoMember(1, IsRequired = false, Name=@"reason", DataFormat = DataFormat.TwosComplement)]
+    public readonly SubscriptionDropped.SubscriptionDropReason Reason;
+  
+    [ProtoContract(Name=@"SubscriptionDropReason")]
+    public enum SubscriptionDropReason
+    {
+            
+      [ProtoEnum(Name=@"Unsubscribed", Value=0)]
+      Unsubscribed = 0,
+            
+      [ProtoEnum(Name=@"AccessDenied", Value=1)]
+      AccessDenied = 1,
+            
+      [ProtoEnum(Name=@"NotFound", Value=2)]
+      NotFound = 2,
+            
+      [ProtoEnum(Name=@"PersistentSubscriptionDeleted", Value=3)]
+      PersistentSubscriptionDeleted = 3,
+            
+      [ProtoEnum(Name=@"SubscriberMaxCountReached", Value=4)]
+      SubscriberMaxCountReached = 4
+    }
+  
+    private SubscriptionDropped() {}
+  
+    public SubscriptionDropped(SubscriptionDropped.SubscriptionDropReason reason)
+    {
+        Reason = reason;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"NotHandled")]
+  public partial class NotHandled
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"reason", DataFormat = DataFormat.TwosComplement)]
+    public readonly NotHandled.NotHandledReason Reason;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"additional_info", DataFormat = DataFormat.Default)]
+    public readonly byte[] AdditionalInfo;
+  
+  [Serializable, ProtoContract(Name=@"MasterInfo")]
+  public partial class MasterInfo
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"external_tcp_address", DataFormat = DataFormat.Default)]
+    public readonly string ExternalTcpAddress;
+  
+    [ProtoMember(2, IsRequired = true, Name=@"external_tcp_port", DataFormat = DataFormat.TwosComplement)]
+    public readonly int ExternalTcpPort;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"external_http_address", DataFormat = DataFormat.Default)]
+    public readonly string ExternalHttpAddress;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"external_http_port", DataFormat = DataFormat.TwosComplement)]
+    public readonly int ExternalHttpPort;
+  
+    [ProtoMember(5, IsRequired = false, Name=@"external_secure_tcp_address", DataFormat = DataFormat.Default)]
+    public readonly string ExternalSecureTcpAddress;
+  
+    [ProtoMember(6, IsRequired = false, Name=@"external_secure_tcp_port", DataFormat = DataFormat.TwosComplement)]
+    public readonly int? ExternalSecureTcpPort;
+  
+    private MasterInfo() {}
+  
+    public MasterInfo(string externalTcpAddress, int externalTcpPort, string externalHttpAddress, int externalHttpPort, string externalSecureTcpAddress, int? externalSecureTcpPort)
+    {
+        ExternalTcpAddress = externalTcpAddress;
+        ExternalTcpPort = externalTcpPort;
+        ExternalHttpAddress = externalHttpAddress;
+        ExternalHttpPort = externalHttpPort;
+        ExternalSecureTcpAddress = externalSecureTcpAddress;
+        ExternalSecureTcpPort = externalSecureTcpPort;
+    }
+  }
+  
+    [ProtoContract(Name=@"NotHandledReason")]
+    public enum NotHandledReason
+    {
+            
+      [ProtoEnum(Name=@"NotReady", Value=0)]
+      NotReady = 0,
+            
+      [ProtoEnum(Name=@"TooBusy", Value=1)]
+      TooBusy = 1,
+            
+      [ProtoEnum(Name=@"NotMaster", Value=2)]
+      NotMaster = 2
+    }
+  
+    private NotHandled() {}
+  
+    public NotHandled(NotHandled.NotHandledReason reason, byte[] additionalInfo)
+    {
+        Reason = reason;
+        AdditionalInfo = additionalInfo;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ScavengeDatabase")]
+  public partial class ScavengeDatabase
+  {
+    public ScavengeDatabase()
+    {
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ScavengeDatabaseCompleted")]
+  public partial class ScavengeDatabaseCompleted
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
+    public readonly ScavengeDatabaseCompleted.ScavengeResult Result;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"error", DataFormat = DataFormat.Default)]
+    public readonly string Error;
+  
+    [ProtoMember(3, IsRequired = true, Name=@"total_time_ms", DataFormat = DataFormat.TwosComplement)]
+    public readonly int TotalTimeMs;
+  
+    [ProtoMember(4, IsRequired = true, Name=@"total_space_saved", DataFormat = DataFormat.TwosComplement)]
+    public readonly long TotalSpaceSaved;
+  
+    [ProtoContract(Name=@"ScavengeResult")]
+    public enum ScavengeResult
+    {
+            
+      [ProtoEnum(Name=@"Success", Value=0)]
+      Success = 0,
+            
+      [ProtoEnum(Name=@"InProgress", Value=1)]
+      InProgress = 1,
+            
+      [ProtoEnum(Name=@"Failed", Value=2)]
+      Failed = 2
+    }
+  
+    private ScavengeDatabaseCompleted() {}
+  
+    public ScavengeDatabaseCompleted(ScavengeDatabaseCompleted.ScavengeResult result, string error, int totalTimeMs, long totalSpaceSaved)
+    {
+        Result = result;
+        Error = error;
+        TotalTimeMs = totalTimeMs;
+        TotalSpaceSaved = totalSpaceSaved;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"IdentifyClient")]
+  public partial class IdentifyClient
+  {
+    [ProtoMember(1, IsRequired = true, Name=@"version", DataFormat = DataFormat.TwosComplement)]
+    public readonly int Version;
+  
+    [ProtoMember(2, IsRequired = false, Name=@"connection_name", DataFormat = DataFormat.Default)]
+    public readonly string ConnectionName;
+  
+    private IdentifyClient() {}
+  
+    public IdentifyClient(int version, string connectionName)
+    {
+        Version = version;
+        ConnectionName = connectionName;
+    }
+  }
+  
+  [Serializable, ProtoContract(Name=@"ClientIdentified")]
+  public partial class ClientIdentified
+  {
+    public ClientIdentified()
+    {
+    }
+  }
+  
+    [ProtoContract(Name=@"OperationResult")]
+    public enum OperationResult
+    {
+            
+      [ProtoEnum(Name=@"Success", Value=0)]
+      Success = 0,
+            
+      [ProtoEnum(Name=@"PrepareTimeout", Value=1)]
+      PrepareTimeout = 1,
+            
+      [ProtoEnum(Name=@"CommitTimeout", Value=2)]
+      CommitTimeout = 2,
+            
+      [ProtoEnum(Name=@"ForwardTimeout", Value=3)]
+      ForwardTimeout = 3,
+            
+      [ProtoEnum(Name=@"WrongExpectedVersion", Value=4)]
+      WrongExpectedVersion = 4,
+            
+      [ProtoEnum(Name=@"StreamDeleted", Value=5)]
+      StreamDeleted = 5,
+            
+      [ProtoEnum(Name=@"InvalidTransaction", Value=6)]
+      InvalidTransaction = 6,
+            
+      [ProtoEnum(Name=@"AccessDenied", Value=7)]
+      AccessDenied = 7
+    }
+  
+  }
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DispatchToSinglePersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/DispatchToSinglePersistentSubscriptionConsumerStrategy.cs
@@ -9,11 +9,11 @@ namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
             get { return SystemConsumerStrategies.DispatchToSingle; }
         }
 
-        public override ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        public override ConsumerPushResult PushMessageToClient(ResolvedEvent ev, int retryCount)
         {
             for (int i = 0; i < Clients.Count; i++)
             {
-                if (Clients.Peek().Push(ev))
+                if (Clients.Peek().Push(ev, retryCount))
                 {
                     return ConsumerPushResult.Sent;
                 }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/IPersistentSubscriptionConsumerStrategy.cs
@@ -10,6 +10,6 @@ namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 
         void ClientRemoved(PersistentSubscriptionClient client);
 
-        ConsumerPushResult PushMessageToClient(ResolvedEvent ev);
+        ConsumerPushResult PushMessageToClient(ResolvedEvent ev, int retryCount);
     }
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedPersistentSubscriptionConsumerStrategy.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
             _state.DisconnectNode(nodeId);
         }
 
-        public ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        public ConsumerPushResult PushMessageToClient(ResolvedEvent ev, int retryCount)
         {
             if (_state == null)
             {
@@ -74,7 +74,7 @@ namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
                 _state.AssignBucket(bucket);
             }
 
-            if (!_state.Assignments[bucket].Node.Client.Push(ev))
+            if (!_state.Assignments[bucket].Node.Client.Push(ev, retryCount))
             {
                 return ConsumerPushResult.Skipped;
             }

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/RoundRobinPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/RoundRobinPersistentSubscriptionConsumerStrategy.cs
@@ -35,12 +35,12 @@ namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
             }
         }
 
-        public virtual ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        public virtual ConsumerPushResult PushMessageToClient(ResolvedEvent ev, int retryCount)
         {
             for (int i = 0; i < Clients.Count; i++)
             {
                 var c = Clients.Dequeue();
-                var pushed = c.Push(ev);
+                var pushed = c.Push(ev, retryCount);
                 Clients.Enqueue(c);
                 if (pushed)
                 {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -178,7 +178,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 foreach (StreamBuffer.OutstandingMessagePointer messagePointer in _streamBuffer.Scan())
                 {
                     OutstandingMessage message = messagePointer.Message;
-                    ConsumerPushResult result = _pushClients.PushMessageToClient(message.ResolvedEvent);
+                    ConsumerPushResult result = _pushClients.PushMessageToClient(message.ResolvedEvent, message.RetryCount);
                     if (result == ConsumerPushResult.Sent)
                     {
                         messagePointer.MarkSent();

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClient.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClient.cs
@@ -93,7 +93,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             return removedAny;
         }
 
-        public bool Push(ResolvedEvent evnt)
+        public bool Push(ResolvedEvent evnt, int retryCount)
         {
             if (!CanSend()) { return false; }
             _allowedMessages--;
@@ -101,7 +101,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             if (_extraStatistics != null)
                 _extraStatistics.StartOperation(evnt.OriginalEvent.EventId);
 
-            _envelope.ReplyWith(new ClientMessage.PersistentSubscriptionStreamEventAppeared(CorrelationId, evnt));
+            _envelope.ReplyWith(new ClientMessage.PersistentSubscriptionStreamEventAppeared(CorrelationId, evnt, retryCount));
             if(!_unconfirmedEvents.ContainsKey(evnt.OriginalEvent.EventId)) {
                 _unconfirmedEvents.Add(evnt.OriginalEvent.EventId, evnt);
             }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
@@ -26,9 +26,9 @@ namespace EventStore.Core.Services.PersistentSubscription
             _consumerStrategy.ClientAdded(client);
         }
 
-        public ConsumerPushResult PushMessageToClient(ResolvedEvent ev)
+        public ConsumerPushResult PushMessageToClient(ResolvedEvent ev, int retryCount)
         {
-            return _consumerStrategy.PushMessageToClient(ev);
+            return _consumerStrategy.PushMessageToClient(ev, retryCount);
         }
 
         public IEnumerable<ResolvedEvent> RemoveClientByConnectionId(Guid connectionId)

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -583,7 +583,7 @@ namespace EventStore.Core.Services.Transport.Tcp
 
         private TcpPackage WrapPersistentSubscriptionStreamEventAppeared(ClientMessage.PersistentSubscriptionStreamEventAppeared msg)
         {
-            var dto = new TcpClientMessageDto.PersistentSubscriptionStreamEventAppeared(new TcpClientMessageDto.ResolvedIndexedEvent(msg.Event.Event, msg.Event.Link));
+            var dto = new TcpClientMessageDto.PersistentSubscriptionStreamEventAppeared(new TcpClientMessageDto.ResolvedIndexedEvent(msg.Event.Event, msg.Event.Link), msg.RetryCount);
             return new TcpPackage(TcpCommand.PersistentSubscriptionStreamEventAppeared, msg.CorrelationId, dto.Serialize());
         }
 
@@ -679,7 +679,7 @@ namespace EventStore.Core.Services.Transport.Tcp
 
         private TcpPackage WrapPersistentSubscriptionStreamEventAppearedV1(ClientMessage.PersistentSubscriptionStreamEventAppeared msg)
         {
-            var dto = new TcpClientMessageDto.PersistentSubscriptionStreamEventAppeared(ConvertToResolvedIndexedEventV1(msg.Event));
+            var dto = new TcpClientMessageDto.PersistentSubscriptionStreamEventAppeared(ConvertToResolvedIndexedEventV1(msg.Event), msg.RetryCount);
             return new TcpPackage(TcpCommand.PersistentSubscriptionStreamEventAppeared, msg.CorrelationId, dto.Serialize());
         }
 

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -307,6 +307,7 @@ message PersistentSubscriptionConfirmation {
 
 message PersistentSubscriptionStreamEventAppeared {
 	required ResolvedIndexedEvent event = 1;
+	optional int32 retryCount = 2;
 }
 
 message SubscribeToStream {


### PR DESCRIPTION
Added generic event class to subscription operations and moved
subscription specific handlers into implementation classes.

Updates protos to include optional retry count

Updated connection interface and overloads to allow continued use without retry
count as well as overloads using retry count