### PR TITLE
Ability to disable index merges during busy periods.

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -201,6 +201,8 @@ namespace EventStore.ClusterNode
 
         [ArgDescription(Opts.IndexCacheDepthDescr, Opts.DbGroup)]
         public int IndexCacheDepth { get; set; }
+        [ArgDescription(Opts.DisableIndexMergingDescr, Opts.DbGroup)]
+        public bool DisableIndexMerging { get; set; }
 
         [ArgDescription(Opts.GossipIntervalMsDescr, Opts.ClusterGroup)]
         public int GossipIntervalMs { get; set; }
@@ -319,6 +321,7 @@ namespace EventStore.ClusterNode
             GossipAllowedDifferenceMs = Opts.GossipAllowedDifferenceMsDefault;
             GossipTimeoutMs = Opts.GossipTimeoutMsDefault;
             IndexCacheDepth = Opts.IndexCacheDepthDefault;
+            DisableIndexMerging = Opts.DisableIndexMergingDefault;
             EnableHistograms = Opts.HistogramEnabledDefault;
             ReaderThreadsCount = Opts.ReaderThreadsCountDefault;
 

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -223,6 +223,9 @@ namespace EventStore.ClusterNode
             else
                 builder.DisableDnsDiscovery();
 
+            if (options.DisableIndexMerging)
+                builder.WithIndexMergingDisabled();
+
             if (!options.AddInterfacePrefixes){
                 builder.DontAddInterfacePrefixes();
             }

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
@@ -680,6 +680,21 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building
     }
 
     [TestFixture]
+    public class with_index_merging_disabled : SingleNodeScenario
+    {
+        public override void Given()
+        {
+            _builder.WithIndexMergingDisabled();
+        }
+
+        [Test]
+        public void should_set_index_cache_depth()
+        {
+            Assert.AreEqual(false, _settings.IndexMerging);
+        }
+    }
+
+    [TestFixture]
     public class with_custom_authentication_provider_factory : SingleNodeScenario
     {
         public override void Given()

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -24,7 +24,8 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile></DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -272,8 +273,11 @@
     <Compile Include="Http\Users\users.cs" />
     <Compile Include="Index\FakeIndexHasher.cs" />
     <Compile Include="Index\FakeIndexReader.cs" />
+    <Compile Include="Index\IndexV1\merging_doesnt_occur_when_merging_is_disabled.cs" />
     <Compile Include="Index\IndexV1\when_merging_ptables.cs" />
+    <Compile Include="Index\IndexV2\merging_doesnt_occur_when_merging_is_disabled.cs" />
     <Compile Include="Index\IndexV2\table_index_hash_collision_when_upgrading_to_64bit.cs" />
+    <Compile Include="Index\IndexV3\merging_doesnt_occur_when_merging_is_disabled.cs" />
     <Compile Include="Index\MemTableTests.cs" />
     <Compile Include="Index\IndexV2\adding_four_items_to_empty_index_map_with_four_tables_per_level_causes_merge.cs" />
     <Compile Include="Index\IndexV2\adding_four_items_to_empty_index_map_with_two_tables_per_level_causes_double_merge.cs" />

--- a/src/EventStore.Core.Tests/Index/IndexV1/merging_doesnt_occur_when_merging_is_disabled.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/merging_doesnt_occur_when_merging_is_disabled.cs
@@ -1,0 +1,88 @@
+using System.IO;
+using System.Linq;
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Index.IndexV1
+{
+    [TestFixture]
+    public class merging_doesnt_occur_when_merging_is_disabled : SpecificationWithDirectoryPerTestFixture
+    {
+        private string _filename;
+        private IndexMap _map;
+        private MergeResult _result;
+        protected byte _ptableVersion = PTableVersions.IndexV1;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            _filename = GetTempFilePath();
+
+            _map = IndexMap.FromFile(_filename, maxTablesPerLevel: 4);
+            var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
+            memtable.Add(0, 1, 0);
+
+            _result = _map.AddPTable(PTable.FromMemtable(memtable, GetTempFilePath()), 1, 2,
+                (streamId, hash) => hash,
+                _ => true, _ => new System.Tuple<string, bool>("", true), new GuidFilenameProvider(PathName), _ptableVersion, mergeIfNecessary: false);
+            _result.ToDelete.ForEach(x => x.MarkForDestruction());
+
+            _result = _result.MergedMap.AddPTable(PTable.FromMemtable(memtable, GetTempFilePath()), 3, 4,
+                (streamId, hash) => hash,
+                _ => true, _ => new System.Tuple<string, bool>("", true), new GuidFilenameProvider(PathName), _ptableVersion, mergeIfNecessary: false);
+            _result.ToDelete.ForEach(x => x.MarkForDestruction());
+
+            _result = _result.MergedMap.AddPTable(PTable.FromMemtable(memtable, GetTempFilePath()), 4, 5,
+                (streamId, hash) => hash,
+                _ => true, _ => new System.Tuple<string, bool>("", true), new GuidFilenameProvider(PathName), _ptableVersion, mergeIfNecessary: false);
+            _result.ToDelete.ForEach(x => x.MarkForDestruction());
+
+            _result = _result.MergedMap.AddPTable(PTable.FromMemtable(memtable, GetTempFilePath()), 0, 1,
+                (streamId, hash) => hash,
+                _ => true, _ => new System.Tuple<string, bool>("", true), new GuidFilenameProvider(PathName), _ptableVersion, mergeIfNecessary: false);
+            _result.ToDelete.ForEach(x => x.MarkForDestruction());
+        }
+
+        [OneTimeTearDown]
+        public override void TestFixtureTearDown()
+        {
+            _result.MergedMap.InOrder().ToList().ForEach(x => x.MarkForDestruction());
+            File.Delete(_filename);
+
+            base.TestFixtureTearDown();
+        }
+
+        [Test]
+        public void the_prepare_checkpoint_is_taken_from_the_latest_added_table()
+        {
+            Assert.AreEqual(0, _result.MergedMap.PrepareCheckpoint);
+        }
+
+        [Test]
+        public void the_commit_checkpoint_is_taken_from_the_latest_added_table()
+        {
+            Assert.AreEqual(1, _result.MergedMap.CommitCheckpoint);
+        }
+
+        [Test]
+        public void there_are_no_items_to_delete()
+        {
+            Assert.AreEqual(0, _result.ToDelete.Count);
+        }
+
+        [Test]
+        public void the_map_has_four_files()
+        {
+            Assert.AreEqual(4, _result.MergedMap.GetAllFilenames().Count());
+        }
+
+        [Test]
+        public void the_original_map_did_not_change()
+        {
+            Assert.AreEqual(0, _map.InOrder().Count());
+            Assert.AreEqual(0, _map.GetAllFilenames().Count());
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Index/IndexV2/merging_doesnt_occur_when_merging_is_disabled.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/merging_doesnt_occur_when_merging_is_disabled.cs
@@ -1,0 +1,14 @@
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Index.IndexV2
+{
+    [TestFixture]
+    public class merging_doesnt_occur_when_merging_is_disabled : IndexV1.merging_doesnt_occur_when_merging_is_disabled
+    {
+        public merging_doesnt_occur_when_merging_is_disabled()
+        {
+            _ptableVersion = PTableVersions.IndexV2;
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Index/IndexV3/merging_doesnt_occur_when_merging_is_disabled.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV3/merging_doesnt_occur_when_merging_is_disabled.cs
@@ -1,0 +1,14 @@
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Index.IndexV3
+{
+    [TestFixture]
+    public class merging_doesnt_occur_when_merging_is_disabled : IndexV1.merging_doesnt_occur_when_merging_is_disabled
+    {
+        public merging_doesnt_occur_when_merging_is_disabled()
+        {
+            _ptableVersion = PTableVersions.IndexV3;
+        }
+    }
+}

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -65,6 +65,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly int MaxMemtableEntryCount;
         public readonly int HashCollisionReadLimit;
         public readonly int IndexCacheDepth;
+        public readonly bool IndexMerging;
         public readonly byte IndexBitnessVersion;
 
         public readonly bool BetterOrdering;
@@ -127,6 +128,7 @@ namespace EventStore.Core.Cluster.Settings
                                     int connectionPendingSendBytesThreshold,
                                     string index = null, bool enableHistograms = false,
                                     int indexCacheDepth = 16,
+                                    bool indexMergingEnabled = true,
                                     byte indexBitnessVersion = 2,
                                     IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null,
                                     bool unsafeIgnoreHardDeletes = false,
@@ -217,6 +219,7 @@ namespace EventStore.Core.Cluster.Settings
 
             EnableHistograms = enableHistograms;
             IndexCacheDepth = indexCacheDepth;
+            IndexMerging = indexMergingEnabled;
             IndexBitnessVersion = indexBitnessVersion;
             Index = index;
             UnsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -167,6 +167,7 @@ namespace EventStore.Core
             var readerPool = new ObjectPool<ITransactionFileReader>(
                 "ReadIndex readers pool", ESConsts.PTableInitialReaderCount, ESConsts.PTableMaxReaderCount,
                 () => new TFChunkReader(db, db.Config.WriterCheckpoint));
+
             var tableIndex = new TableIndex(indexPath,
                                             new XXHashUnsafe(),
                                             new Murmur3AUnsafe(),
@@ -177,7 +178,12 @@ namespace EventStore.Core
                                             maxTablesPerLevel: 2,
                                             inMem: db.Config.InMemDb,
                                             indexCacheDepth: vNodeSettings.IndexCacheDepth);
-			var readIndex = new ReadIndex(_mainQueue,
+
+            // ReSharper disable RedundantTypeArgumentsOfMethod
+            _mainBus.Subscribe<ClientMessage.SetIndexMerging>(tableIndex);
+            // ReSharper enable RedundantTypeArgumentsOfMethod
+
+            var readIndex = new ReadIndex(_mainQueue,
                                           readerPool,
                                           tableIndex,
                                           ESConsts.StreamInfoCacheCapacity,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -177,7 +177,8 @@ namespace EventStore.Core
                                             maxSizeForMemory: vNodeSettings.MaxMemtableEntryCount,
                                             maxTablesPerLevel: 2,
                                             inMem: db.Config.InMemDb,
-                                            indexCacheDepth: vNodeSettings.IndexCacheDepth);
+                                            indexCacheDepth: vNodeSettings.IndexCacheDepth,
+                                            mergingEnabled: vNodeSettings.IndexMerging);
 
             // ReSharper disable RedundantTypeArgumentsOfMethod
             _mainBus.Subscribe<ClientMessage.SetIndexMerging>(tableIndex);

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -6,14 +6,16 @@ using System.Text;
 using System.Threading;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
+using EventStore.Core.Bus;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.Util;
 using EventStore.Core.Index.Hashes;
+using EventStore.Core.Messages;
 
 namespace EventStore.Core.Index
 {
-    public class TableIndex : ITableIndex
+    public class TableIndex : ITableIndex, IHandle<ClientMessage.SetIndexMerging>
     {
         public const string IndexMapFilename = "indexmap";
         private const int MaxMemoryTables = 1;
@@ -38,6 +40,7 @@ namespace EventStore.Core.Index
         private readonly object _awaitingTablesLock = new object();
 
         private IndexMap _indexMap;
+        private bool _mergingEnabled;
         private List<TableItem> _awaitingMemTables;
         private long _commitCheckpoint = -1;
         private long _prepareCheckpoint = -1;
@@ -60,7 +63,8 @@ namespace EventStore.Core.Index
                           int maxTablesPerLevel = 4,
                           bool additionalReclaim = false,
                           bool inMem = false,
-                          int indexCacheDepth = 16)
+                          int indexCacheDepth = 16,
+                          bool mergingEnabled = true)
         {
             Ensure.NotNullOrEmpty(directory, "directory");
             Ensure.NotNull(memTableFactory, "memTableFactory");
@@ -80,6 +84,7 @@ namespace EventStore.Core.Index
             _additionalReclaim = additionalReclaim;
             _inMem = inMem;
             _indexCacheDepth = indexCacheDepth;
+            _mergingEnabled = mergingEnabled;
             _ptableVersion = ptableVersion;
             _awaitingMemTables = new List<TableItem> { new TableItem(_memTableFactory(), -1, -1) };
 
@@ -267,7 +272,11 @@ namespace EventStore.Core.Index
                         mergeResult = _indexMap.AddPTable(ptable, tableItem.PrepareCheckpoint, tableItem.CommitCheckpoint,
                                                           (streamId, currentHash) => UpgradeHash(streamId, currentHash),
                                                           entry => reader.ExistsAt(entry.Position),
-                                                          entry => ReadEntry(reader, entry.Position), _fileNameProvider, _ptableVersion, _indexCacheDepth);
+                                                          entry => ReadEntry(reader, entry.Position), 
+                                                          _fileNameProvider, 
+                                                          _ptableVersion, 
+                                                          _indexCacheDepth,
+                                                          _mergingEnabled);
                     }
                     _indexMap = mergeResult.MergedMap;
                     _indexMap.SaveToFile(indexmapFile);
@@ -597,6 +606,11 @@ namespace EventStore.Core.Index
                 PrepareCheckpoint = prepareCheckpoint;
                 CommitCheckpoint = commitCheckpoint;
             }
+        }
+
+        public void Handle(ClientMessage.SetIndexMerging message)
+        {
+            _mergingEnabled = message.MergingEnabled;
         }
     }
 }

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1450,5 +1450,18 @@ namespace EventStore.Core.Messages
                 CorrelationId = correlationId;
             }
         }
+
+        public class SetIndexMerging : Message
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly bool MergingEnabled;
+
+            public SetIndexMerging(bool mergingEnabled)
+            {
+                MergingEnabled = mergingEnabled;
+            }
+        }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -23,11 +23,37 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
         {
             service.RegisterAction(new ControllerAction("/admin/shutdown", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs), OnPostShutdown);
             service.RegisterAction(new ControllerAction("/admin/scavenge", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs), OnPostScavenge);
+
+            service.RegisterAction(new ControllerAction("/admin/indexMerging?enabled={enabled}", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs), OnPostSetIndexMerging);
+        }
+        
+
+        private void OnPostSetIndexMerging(HttpEntityManager entity, UriTemplateMatch match)
+        {
+            if (IsAuthorized(entity))
+            {
+                bool mergingEnabled;
+                if (bool.TryParse(match.BoundVariables["enabled"], out mergingEnabled))
+                {
+                    Log.Info(
+                        $"Request set index merging={mergingEnabled} because {nameof(OnPostSetIndexMerging)} has been triggered.");
+                    Publish(new ClientMessage.SetIndexMerging(mergingEnabled));
+                    entity.ReplyStatus(HttpStatusCode.OK, "OK", LogReplyError);
+                }
+                else
+                {
+                    entity.ReplyStatus(HttpStatusCode.BadRequest, "enabled should be bool parsable", LogReplyError);
+                }
+            }
+            else
+            {
+                entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
+            }
         }
 
         private void OnPostShutdown(HttpEntityManager entity, UriTemplateMatch match)
         {
-            if (entity.User != null && (entity.User.IsInRole(SystemRoles.Admins) || entity.User.IsInRole(SystemRoles.Operations)))
+            if (IsAuthorized(entity))
             {
                 Log.Info("Request shut down of node because shutdown command has been received.");
                 Publish(new ClientMessage.RequestShutdown(exitProcess: true, shutdownHttp: true));
@@ -41,7 +67,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
         private void OnPostScavenge(HttpEntityManager entity, UriTemplateMatch match)
         {
-            if (entity.User != null && (entity.User.IsInRole(SystemRoles.Admins) || entity.User.IsInRole(SystemRoles.Operations)))
+            if (IsAuthorized(entity))
             {
                 Log.Info("Request scavenging because /admin/scavenge request has been received.");
                 Publish(new ClientMessage.ScavengeDatabase(new NoopEnvelope(), Guid.Empty, entity.User));
@@ -51,6 +77,11 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             {
                 entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
             }
+        }
+
+        private static bool IsAuthorized(HttpEntityManager entity)
+        {
+            return entity.User != null && (entity.User.IsInRole(SystemRoles.Admins) || entity.User.IsInRole(SystemRoles.Operations));
         }
 
         private void LogReplyError(Exception exc)

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -331,6 +331,9 @@ namespace EventStore.Core.Util
         public const string IndexCacheDepthDescr = "Sets the depth to cache for the mid point cache in index.";
         public static int IndexCacheDepthDefault = 16;
 
+        public const string DisableIndexMergingDescr = "Whether or not to disable on-the-fly index merges.  Only disable if you plan on enabling it via the admin http request during quiet periods.";
+        public static bool DisableIndexMergingDefault = false;
+
         public const string IndexBitnessVersionDescr = "Sets the bitness version for the indexes to use";
         public const byte IndexBitnessVersionDefault = EventStore.Core.Index.PTableVersions.IndexV3;
 		/*

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -104,6 +104,7 @@ namespace EventStore.Core
 
         protected string _index;
         protected int _indexCacheDepth;
+        protected bool _disableIndexMerging;
         protected bool _unsafeIgnoreHardDelete;
         protected bool _unsafeDisableFlushToDisk;
         protected bool _betterOrdering;
@@ -203,6 +204,7 @@ namespace EventStore.Core
             _enableHistograms = Opts.LogHttpRequestsDefault;
             _index = null;
             _indexCacheDepth = Opts.IndexCacheDepthDefault;
+            _disableIndexMerging = Opts.DisableIndexMergingDefault;
             _indexBitnessVersion = Opts.IndexBitnessVersionDefault;
             _unsafeIgnoreHardDelete = Opts.UnsafeIgnoreHardDeleteDefault;
             _betterOrdering = Opts.BetterOrderingDefault;
@@ -939,6 +941,16 @@ namespace EventStore.Core
         }
 
         /// <summary>
+        /// Disabled on-the-fly index merges.
+        /// </summary>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithIndexMergingDisabled()
+        {
+            _disableIndexMerging = true;
+            return this;
+        }
+
+        /// <summary>
         /// Disables Hard Deletes (UNSAFE: use to remove hard deletes)
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
@@ -1343,6 +1355,7 @@ namespace EventStore.Core
                     _index,
                     _enableHistograms,
                     _indexCacheDepth,
+                    !_disableIndexMerging,
                     _indexBitnessVersion,
                     consumerStrategies,
                     _unsafeIgnoreHardDelete,


### PR DESCRIPTION
This is mainly a discussion point but if agreed, this is almost ready to go.
A few weeks ago we had an outage during a peak load period due to an index merge that was occurring on all the nodes within that particular cluster.  We saw SLOW MSG BUS messages stacking up in the logs and had no way to prevent the merge from occurring or to stop the merge once in progress.  

We feel the probability of merges occurring during peak periods is naturally higher (in terms of when they are likely to occur) due to the fact that the index is under more pressure due to the increased amount of events being added.  We discussed this internally and decided that the biggest win would be to suspend any index merges until after the peak period has passed.

I have exposed an admin POST endpoint to enable and disable the on-the-fly index merging.  The proposed setup we have discussed is that index merging is to be disabled during peak hours (we see this as 4 - 5 hours) and then re-enabled afterwards.  The toggle back to enabled would likely trigger a full merge soon afterwards.

This is a first effort that this.  Comments, suggestions, queries all welcome.