### PR TITLE
Expire long-running queries and make expiration configurable

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
@@ -38,7 +38,8 @@ namespace EventStore.ClientAPI.Embedded
         /// </summary>
         protected override void SetUpProjectionsIfNeeded()
         {
-            _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType, _startStandardProjections));
+            _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType,
+                            _startStandardProjections, _projectionsQueryExpiry));
         }
     }
 }

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -147,6 +147,8 @@ namespace EventStore.ClusterNode
         public int ProjectionThreads { get; set; }
         [ArgDescription(Opts.WorkerThreadsDescr, Opts.AppGroup)]
         public int WorkerThreads { get; set; }
+        [ArgDescription(Opts.ProjectionsQueryExpiryDescr, Opts.ProjectionsGroup)]
+        public int ProjectionsQueryExpiry { get; set; }
 
         [ArgDescription(Opts.IntHttpPrefixesDescr, Opts.InterfacesGroup)]
         public string[] IntHttpPrefixes { get; set; }

--- a/src/EventStore.ClusterNode/ClusterVNodeBuilder.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeBuilder.cs
@@ -35,7 +35,8 @@ namespace EventStore.ClusterNode
         
         protected override void SetUpProjectionsIfNeeded()
         {
-            _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType, _startStandardProjections));
+            _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType,
+                            _startStandardProjections, _projectionsQueryExpiry));
         }
     }
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -201,6 +201,7 @@ namespace EventStore.ClusterNode
                         .WithIndexCacheDepth(options.IndexCacheDepth)
                         .WithSslTargetHost(options.SslTargetHost)
                         .RunProjections(options.RunProjections, options.ProjectionThreads)
+                        .WithProjectionQueryExpirationOf(TimeSpan.FromMinutes(options.ProjectionsQueryExpiry))
                         .WithTfCachedChunks(options.CachedChunks)
                         .WithTfChunksCacheSize(options.ChunksCacheSize)
                         .WithStatsStorage(StatsStorage.StreamAndCsv)

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -127,6 +127,9 @@ namespace EventStore.Core.Util
         public const string ProjectionThreadsDescr = "The number of threads to use for projections.";
         public const int    ProjectionThreadsDefault = 3;
 
+        public const string ProjectionsQueryExpiryDescr = "The number of minutes a query can be idle before it expires";
+        public const int    ProjectionsQueryExpiryDefault = 5;
+
         public const string WorkerThreadsDescr = "The number of threads to use for pool of worker services.";
         public const int    WorkerThreadsDefault = 5;
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -109,6 +109,7 @@ namespace EventStore.Core
         protected bool _betterOrdering;
         protected ProjectionType _projectionType;
         protected int _projectionsThreads;
+        protected TimeSpan _projectionsQueryExpiry;
 
         protected TFChunkDb _db;
         protected ClusterVNodeSettings _vNodeSettings;
@@ -209,6 +210,8 @@ namespace EventStore.Core
             _unsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
             _alwaysKeepScavenged = Opts.AlwaysKeepScavengedDefault;
             _skipIndexScanOnReads = Opts.SkipIndexScanOnReadsDefault;
+
+            _projectionsQueryExpiry = TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault);
         }
 
         protected VNodeBuilder WithSingleNodeSettings()
@@ -260,6 +263,18 @@ namespace EventStore.Core
             _projectionsThreads = numberOfThreads;
             return this;
         }
+
+        /// <summary>
+        /// Sets how long a projection query can be idle before it expires.
+        /// </summary>
+        /// <param name="projectionQueryExpiry">The length of time a projection query can be idle before it expires.</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithProjectionQueryExpirationOf(TimeSpan projectionQueryExpiry)
+        {
+            _projectionsQueryExpiry = projectionQueryExpiry;
+            return this;
+        }
+
 
         /// <summary>
         /// Adds a custom subsystem to the builder. NOTE: This is an advanced use case that most people will never need!

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -12,6 +12,7 @@ using EventStore.Core;
 using EventStore.Core.Bus;
 using EventStore.Core.Tests;
 using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 using ResolvedEvent = EventStore.ClientAPI.ResolvedEvent;
@@ -110,7 +111,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
 
         private MiniClusterNode CreateNode(int index, Endpoints endpoints, IPEndPoint[] gossipSeeds)
         {
-            _projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All, startStandardProjections: false);
+            _projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
+                            startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             var node = new MiniClusterNode(
                 PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp, endpoints.ExternalTcp,
                 endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false,

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/ProjectionsManagerTestSuiteMarkerBase.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/ProjectionsManagerTestSuiteMarkerBase.cs
@@ -5,6 +5,7 @@ using EventStore.Common.Options;
 using EventStore.Core;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.ClientAPI.Helpers;
+using EventStore.Core.Util;
 using System.IO;
 
 namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
@@ -43,7 +44,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
 
         protected void CreateNode()
 		{
-            var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All, startStandardProjections: false);
+            var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
+                    startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             Node = new MiniNode(
                 PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { projections });
             Node.Start();

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
@@ -11,6 +11,7 @@ using EventStore.Core.Tests;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.ClientAPI.Helpers;
 using EventStore.Core.Services;
+using EventStore.Core.Util;
 
 namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
 {
@@ -94,7 +95,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
 
         protected MiniNode CreateNode()
         {
-            var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All, startStandardProjections: false);
+            var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
+                                startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             return new MiniNode(
             PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { projections });
         }

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -10,6 +10,7 @@ using EventStore.Core;
 using EventStore.Core.Bus;
 using EventStore.Core.Tests;
 using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 using ResolvedEvent = EventStore.ClientAPI.ResolvedEvent;
@@ -88,7 +89,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
         private void CreateNode()
         {
             var projectionWorkerThreadCount = GivenWorkerThreadCount();
-            _projections = new ProjectionsSubsystem(projectionWorkerThreadCount, runProjections: ProjectionType.All, startStandardProjections: false);
+            _projections = new ProjectionsSubsystem(projectionWorkerThreadCount, runProjections: ProjectionType.All,
+                            startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             _node = new MiniNode(
                 PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { _projections });
             _node.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -65,6 +65,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 _timeProvider,
                 ProjectionType.All,
                 _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
                 _initializeSystemProjections);
 
             _coordinator = new ProjectionCoreCoordinator(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
@@ -9,6 +9,7 @@ using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
+using EventStore.Core.Services.TimerService;
 using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.continuous
@@ -165,6 +166,60 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
                              .Single()
                              .Projections.Single()
                              .MasterStatus);
+            }
+        }
+    }
+
+    public class an_expired_projection
+    {
+        public abstract class Base : a_new_posted_projection.Base
+        {
+            protected Guid _reader;
+
+            protected override void Given()
+            {
+                AllWritesSucceed();
+                base.Given();
+            }
+
+            protected override IEnumerable<WhenStep> When()
+            {
+                foreach (var m in base.When()) yield return m;
+                var readerAssignedMessage =
+                    _consumer.HandledMessages.OfType<EventReaderSubscriptionMessage.ReaderAssignedReader>().LastOrDefault();
+                Assert.IsNotNull(readerAssignedMessage);
+                _reader = readerAssignedMessage.ReaderId;
+
+                yield return
+                    (ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+                        _reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false, Guid.NewGuid(),
+                        "type", false, new byte[0], new byte[0], 100, 33.3f));
+                _timeProvider.AddTime(TimeSpan.FromMinutes(6));
+                yield return Yield;
+                foreach (var m in _consumer.HandledMessages.OfType<TimerMessage.Schedule>().ToArray())
+                    m.Envelope.ReplyWith(m.ReplyMessage);
+            }
+        }
+
+        [TestFixture]
+        public class when_retrieving_statistics : Base
+        {
+            protected override IEnumerable<WhenStep> When()
+            {
+                foreach (var s in base.When()) yield return s;
+                _consumer.HandledMessages.Clear();
+                yield return (
+                    new ProjectionManagementMessage.Command.GetStatistics(
+                        new PublishEnvelope(_bus), null, _projectionName, false));
+            }
+
+            [Test]
+            public void projection_is_not_deleted()
+            {
+                Assert.IsFalse(_consumer.HandledMessages.OfType<ProjectionManagementMessage.NotFound>().Any());
+                var res = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>()
+                                        .First(x => x.Projections.Any(y => y.Name == _projectionName));
+                Assert.AreEqual("Running", res.Projections.First(x => x.Name == _projectionName).Status);
             }
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_creating_a_managed_projection.cs
@@ -3,6 +3,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
@@ -63,7 +64,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                 _timeProvider,
                 _getStateDispatcher,
                 _getResultDispatcher,
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             });
         }
 
@@ -95,7 +97,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     v => v.CorrelationId,
                     v => v.CorrelationId,
                     new PublishEnvelope(_bus)),
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             });
         }
 
@@ -127,7 +130,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     v => v.CorrelationId,
                     v => v.CorrelationId,
                     new PublishEnvelope(_bus)),
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             });
         }
 
@@ -159,7 +163,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     v => v.CorrelationId,
                     v => v.CorrelationId,
                     new PublishEnvelope(_bus)),
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             });
         }
 
@@ -191,7 +196,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     v => v.CorrelationId,
                     v => v.CorrelationId,
                     new PublishEnvelope(_bus)),
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             });
         }
 
@@ -223,7 +229,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     v => v.CorrelationId,
                     v => v.CorrelationId,
                     new PublishEnvelope(_bus)),
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             });
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
@@ -3,6 +3,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -43,7 +44,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                         v => v.CorrelationId,
                         v => v.CorrelationId,
                         new PublishEnvelope(_bus)),
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
@@ -3,6 +3,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -75,12 +76,15 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                     _bus,
                     v => v.CorrelationId,
                     v => v.CorrelationId,
-                    new PublishEnvelope(_bus)), new RequestResponseDispatcher
+                    new PublishEnvelope(_bus)),
+                new RequestResponseDispatcher
                         <CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
                         _bus,
                         v => v.CorrelationId,
                         v => v.CorrelationId,
-                        new PublishEnvelope(_bus)), _ioDispatcher);
+                        new PublishEnvelope(_bus)),
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
         }
 
         protected override IEnumerable<WhenStep> When()

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_slave_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_slave_projections.cs
@@ -9,6 +9,7 @@ using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
 using EventStore.Projections.Core.Services.Processing;
+using EventStore.Core.Util;
 using NUnit.Framework;
 using TestFixtureWithExistingEvents =
     EventStore.Projections.Core.Tests.Services.core_projection.TestFixtureWithExistingEvents;
@@ -63,7 +64,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                         _bus, 
                         v => v.CorrelationId,
                         v => v.CorrelationId,
-                        new PublishEnvelope(_bus)), _ioDispatcher);
+                        new PublishEnvelope(_bus)), _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
         }
 
         protected override IEnumerable<WhenStep> When()

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services;
 using EventStore.Projections.Core.Services.Management;
@@ -253,7 +254,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
                         v => v.CorrelationId,
                         v => v.CorrelationId,
                         new PublishEnvelope(_bus)),
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
         }
 
         protected ProjectionManagementMessage.Command.UpdateConfig CreateConfig()

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
 using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
@@ -46,16 +47,17 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query
             protected override IEnumerable<WhenStep> When()
             {
                 foreach (var s in base.When()) yield return s;
+                _consumer.HandledMessages.Clear();
                 yield return (
                     new ProjectionManagementMessage.Command.GetStatistics(
                         new PublishEnvelope(_bus), null, _projectionName, false));
             }
 
             [Test]
-            public void projection_is_disabled()
+            public void projection_is_not_found()
             {
-                var res = _consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>().First();
-                Assert.AreEqual("Stopped", res.Projections[0].Status);
+                Assert.AreEqual(1, _consumer.HandledMessages.OfType<ProjectionManagementMessage.NotFound>().Count());
+                Assert.IsFalse(_consumer.HandledMessages.OfType<ProjectionManagementMessage.Statistics>().Any());
             }
         }
     }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.AwakeReaderService;
 using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Messages.ParallelQueryProcessingMessages;
 using EventStore.Projections.Core.Services.Management;
@@ -59,6 +60,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 _timeProvider,
                 ProjectionType.All,
                 _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
                 _initializeSystemProjections);
 
             IPublisher inputQueue = GetInputQueue();

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_creating_projection_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_creating_projection_manager.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Services.Management;
 using NUnit.Framework;
 using EventStore.Core.Helpers;
@@ -47,7 +48,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     _queues,
                     _timeProvider,
                     ProjectionType.All,
-                    _ioDispatcher))
+                    _ioDispatcher,
+                    TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault)))
             {
             }
 
@@ -64,7 +66,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     _queues,
                     _timeProvider,
                     ProjectionType.All,
-                    _ioDispatcher))
+                    _ioDispatcher,
+                    TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault)))
             {
             }
             });
@@ -81,7 +84,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     _queues,
                     _timeProvider,
                     ProjectionType.All,
-                    _ioDispatcher))
+                    _ioDispatcher,
+                    TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault)))
             {
             }
             });
@@ -98,7 +102,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     null,
                     _timeProvider,
                     ProjectionType.All,
-                    _ioDispatcher))
+                    _ioDispatcher,
+                    TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault)))
             {
             }
             });
@@ -115,7 +120,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                     new Dictionary<Guid, IPublisher>(),
                     _timeProvider,
                     ProjectionType.All,
-                    _ioDispatcher))
+                    _ioDispatcher,
+                    TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault)))
             {
             }
             });

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_duplicate_projection_created.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_duplicate_projection_created.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Management;
 using EventStore.Projections.Core.Tests.Services.core_projection;
@@ -45,7 +46,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 queues,
                 _timeProvider,
                 ProjectionType.All,
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_partially_created_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_partially_created_projection.cs
@@ -44,7 +44,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 queues,
                 _timeProvider,
                 ProjectionType.All,
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_starting_the_projection_manager_with_existing_projection.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Util;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Services.Management;
 using EventStore.Projections.Core.Tests.Services.core_projection;
@@ -44,7 +45,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 queues,
                 _timeProvider,
                 ProjectionType.All,
-                _ioDispatcher);
+                _ioDispatcher,
+                TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
             _bus.Subscribe<ClientMessage.WriteEventsCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_manager);
             _bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_manager);

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -22,7 +22,8 @@ namespace EventStore.Projections.Core
         public static void CreateManagerService(
             StandardComponents standardComponents,
             ProjectionsStandardComponents projectionsStandardComponents,
-            IDictionary<Guid, IPublisher> queues)
+            IDictionary<Guid, IPublisher> queues,
+            TimeSpan projectionQueryExpiry)
         {
             IQueuedHandler inputQueue = projectionsStandardComponents.MasterInputQueue;
             InMemoryBus outputBus = projectionsStandardComponents.MasterOutputBus;
@@ -56,7 +57,8 @@ namespace EventStore.Projections.Core
                 queues,
                 new RealTimeProvider(),
                 projectionsStandardComponents.RunProjections,
-                ioDispatcher);
+                ioDispatcher,
+                projectionQueryExpiry);
 
             SubscribeMainBus(
                 projectionsStandardComponents.MasterMainBus,

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -97,6 +97,7 @@ namespace EventStore.Projections.Core.Services.Management
         private readonly bool _enabledToRun;
         private ManagedProjectionState _state;
         internal PersistedState PersistedProjectionState = new PersistedState();
+        private bool _persistedStateLoaded = false;
         //private int _version;
 
         private string _faultedReason;
@@ -113,6 +114,7 @@ namespace EventStore.Projections.Core.Services.Management
         internal bool Prepared;
         internal bool Created;
         private bool _pendingWritePersistedState;
+        private readonly TimeSpan _projectionsQueryExpiry;
 
         private ManagedProjectionStateBase _stateHandler;
         private IEnvelope _lastReplyEnvelope;
@@ -139,6 +141,7 @@ namespace EventStore.Projections.Core.Services.Management
                 <CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>
                 getResultDispatcher,
             IODispatcher ioDispatcher,
+            TimeSpan projectionQueryExpiry,
             bool isSlave = false,
             Guid slaveMasterWorkerId = default(Guid),
             Guid slaveMasterCorrelationId = default(Guid))
@@ -167,6 +170,7 @@ namespace EventStore.Projections.Core.Services.Management
             _getResultDispatcher = getResultDispatcher;
             _lastAccessed = _timeProvider.Now;
             _ioDispatcher = ioDispatcher;
+            _projectionsQueryExpiry = projectionQueryExpiry;
         }
 
         private string HandlerType
@@ -547,7 +551,6 @@ namespace EventStore.Projections.Core.Services.Management
 
         public void Handle(ProjectionManagementMessage.Internal.CleanupExpired message)
         {
-            //TODO: configurable expiration
             if (IsExpiredProjection())
             {
                 if (_state == ManagedProjectionState.Creating)
@@ -555,12 +558,15 @@ namespace EventStore.Projections.Core.Services.Management
                     // NOTE: workaround for stop not working on creating state (just ignore them)
                     return;
                 }
-                _logger.Warn("Projection {0} has expired and will be disabled. Last accessed at {1}", _name, _lastAccessed);
+                _logger.Warn("Transient projection {0} has expired and will be deleted. Last accessed at {1}", _name, _lastAccessed);
                 Handle(
-                    new ProjectionManagementMessage.Command.Disable(
+                    new ProjectionManagementMessage.Command.Delete(
                         new NoopEnvelope(),
                         _name,
-                        ProjectionManagementMessage.RunAs.System));
+                        ProjectionManagementMessage.RunAs.System,
+                        false,
+                        false,
+                        false));
             }
         }
 
@@ -620,7 +626,7 @@ namespace EventStore.Projections.Core.Services.Management
 
         private bool IsExpiredProjection()
         {
-            return Mode == ProjectionMode.Transient && !_isSlave && _lastAccessed.AddMinutes(5) < _timeProvider.Now;
+            return Mode == ProjectionMode.Transient && !_isSlave && _lastAccessed.Add(_projectionsQueryExpiry) < _timeProvider.Now && _persistedStateLoaded;
         }
 
         public void InitializeNew(PersistedState persistedState, IEnvelope replyEnvelope)
@@ -724,6 +730,7 @@ namespace EventStore.Projections.Core.Services.Management
 
             PersistedProjectionState = persistedState;
             _runAs = SerializedRunAs.DeserializePrincipal(persistedState.RunAs);
+            _persistedStateLoaded = true;
         }
 
         internal void WriteStartOrLoadStopped()

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -66,6 +66,7 @@ namespace EventStore.Projections.Core.Services.Management
         private readonly IPublisher _publisher;
         private readonly Tuple<Guid, IPublisher>[] _queues;
         private readonly Guid[] _workers;
+        private readonly TimeSpan _projectionsQueryExpiry;
 
         private readonly ITimeProvider _timeProvider;
         private readonly ProjectionType _runProjections;
@@ -114,6 +115,7 @@ namespace EventStore.Projections.Core.Services.Management
             ITimeProvider timeProvider,
             ProjectionType runProjections,
             IODispatcher ioDispatcher,
+            TimeSpan projectionQueryExpiry,
             bool initializeSystemProjections = true)
         {
             if (inputQueue == null) throw new ArgumentNullException("inputQueue");
@@ -130,6 +132,7 @@ namespace EventStore.Projections.Core.Services.Management
             _runProjections = runProjections;
             _initializeSystemProjections = initializeSystemProjections;
             _ioDispatcher = ioDispatcher;
+            _projectionsQueryExpiry = projectionQueryExpiry;
 
             _writeDispatcher =
                 new RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted>(
@@ -1081,6 +1084,7 @@ namespace EventStore.Projections.Core.Services.Management
                 _getStateDispatcher,
                 _getResultDispatcher,
                 _ioDispatcher,
+                _projectionsQueryExpiry,
                 isSlave,
                 slaveMasterWorkerId,
                 slaveMasterCorrelationId);


### PR DESCRIPTION
Related to #1480 

Also prevent projections from being expired if they have not had a chance to load their persisted state yet. As the default ProjectionMode is Transient, this was what was causing continuous projections to be deleted when they took more than 5 minutes to start up.