### PR TITLE
Bugfixes for index upgrade from PTable V1 to V2 or later

### DIFF
--- a/src/EventStore.Core.Tests/Index/IndexV3/table_index_hash_collision_when_upgrading_to_64bit.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV3/table_index_hash_collision_when_upgrading_to_64bit.cs
@@ -3,10 +3,13 @@ using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Index.IndexV3
 {
-    [TestFixture, Category("LongRunning")]
+    [TestFixture(0,0)]
+    [TestFixture(10,0)]
+    [TestFixture(0,10)]
+    [TestFixture(10,10)]
     public class table_index_hash_collision_when_upgrading_to_64bit : IndexV2.table_index_hash_collision_when_upgrading_to_64bit
     {
-        public table_index_hash_collision_when_upgrading_to_64bit()
+        public table_index_hash_collision_when_upgrading_to_64bit(int extraStreamHashesAtBeginning, int extraStreamHashesAtEnd) : base(extraStreamHashesAtBeginning, extraStreamHashesAtEnd)
         {
             _ptableVersion = PTableVersions.IndexV3;
         }


### PR DESCRIPTION
Thanks to @lscpike for finding these bugs :+1: 

**i) Bugfix that may cause PTable enumeration to end earlier when upgrading hashes (failing test provided by @lscpike in #1501):**

If an empty list is returned in ReadUntilDifferentHashes(), the list enumerator in MoveNext() will return false and PTable enumeration will stop earlier than it should.

**ii) Bugfix that may cause PTable entries with collision to become out of order (test added in `table_index_hash_collision_when_upgrading_to_64bit`):**
The last IndexEntry in the list returned by ReadUntilDifferentHashes() corresponds to the next stream hash group. Thus, that IndexEntry will be returned earlier during enumeration and will be merged earlier.
If that IndexEntry corresponds to a stream hash which has collisions, it might not be at the correct position after merge (if it should be later in the file after sorting index entries)