### PR TITLE
Fix case where master node may crash after 2 consecutive elections

### DIFF
--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -198,6 +198,8 @@ namespace EventStore.Core.Services.Storage
 
         void IHandle<SystemMessage.WriteEpoch>.Handle(SystemMessage.WriteEpoch message)
         {
+            if(_vnodeState == VNodeState.PreMaster)
+                return;
             if (_vnodeState != VNodeState.Master)
                 throw new Exception(string.Format("New Epoch request not in master state. State: {0}.", _vnodeState));
             EpochManager.WriteNewEpoch();

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -421,8 +421,11 @@ namespace EventStore.Core.Services.VNode
         {
             if (_master != null && _master.InstanceId == message.Master.InstanceId)
             {
-                if (_master.InstanceId == _nodeInfo.InstanceId)
+                //if the master hasn't changed, we skip state changes through PreMaster or PreReplica
+                if (_master.InstanceId == _nodeInfo.InstanceId && _state == VNodeState.Master){
+                    //transitioning from master to master, we just write a new epoch
                     _fsm.Handle(new SystemMessage.WriteEpoch());
+                }
                 return;
             }
 


### PR DESCRIPTION
**Bug description**
When two elections occur quickly resulting in the same master being elected, the master node may crash.

**Sample case (data has been anonymized):**

```
1. INFO  ElectionsService    ] ELECTIONS: (V=1) DONE. ELECTED MASTER = [192.168.1.5:2112...
2. INFO  ClusterVNodeControll] ========== [192.168.1.5:2112] PRE-MASTER STATE, WAITING FOR CHASER TO CATCH UP...
...
3. INFO  ElectionsService    ] ELECTIONS: (V=2) DONE. ELECTED MASTER = [192.168.1.5:2112...
4. INFO  ClusterVNodeControll] ========== [192.168.1.5:2112] IS MASTER... SPARTA!
...
5. INFO  ElectionsService    ] ELECTIONS: (V=3) DONE. ELECTED MASTER = [192.168.1.5:2112...
6. FATAL StorageWriterService] Unexpected error in StorageWriterService. Terminating the process...
System.Exception: New Epoch request not in master state. State: PreMaster.
   at EventStore.Core.Services.Storage.StorageWriterService.EventStore.Core.Bus.IHandle<EventStore.Core.Messages.SystemMessage.WriteEpoch>.Handle(WriteEpoch message)...
```

**It looks like the following sequence of events is occuring:**

```
ClusterVNodeController                  StorageWriterService
======================                  ====================
ElectionMessage.ElectionsDone (#1)
SystemMessage.BecomePreMaster (#2)
                                        SystemMessage.BecomePreMaster (#2, _vnodeState = PreMaster)
ElectionMessage.ElectionsDone (#3)
Outputs SystemMessage.WriteEpoch here
SystemMessage.BecomeMaster (#4)
ElectionMessage.ElectionsDone (#5)
                                        Receives SystemMessage.WriteEpoch (_vnodeState = PreMaster) and crashes
                                        SystemMessage.BecomeMaster (#4) has not yet been received here

```

Getting a second **ElectionMessage.ElectionsDone** message before **SystemMessage.BecomeMaster** is published doesn't give the chance to the **StorageWriterService** to become **Master** and it's still in the **PreMaster** state when the **WriteEpoch** message is received.


**Resolution**
1. Ensure we're in the **Master** state before publishing **SystemMessage.WriteEpoch**. Otherwise that means we're still in **PreMaster** state (the master info matches the node info, there is no other possible state) and will soon transition to **Master** where an epoch will be written.
2. Drop **WriteEpoch** message if we're still in **PreMaster** state. After the **StorageWriterService's** state change to **Master** occurs soon after, the epoch will be written anyway.
