### PR TITLE
Fix bug where a forwarded request's Content-Type was omitted if Content-Length is 0

### DIFF
--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -179,6 +179,7 @@ namespace EventStore.Core.Services
             request.RequestUri = forwardUri;
             request.Method = new System.Net.Http.HttpMethod(srcReq.HttpMethod);
 
+            var hasContentLength = false;
             // Copy unrestricted headers (including cookies, if any)
             foreach (var headerKey in srcReq.Headers.AllKeys)
             {
@@ -188,7 +189,7 @@ namespace EventStore.Core.Services
                         case "accept":            request.Headers.Accept.ParseAdd(srcReq.Headers[headerKey]); break;
                         case "connection":        break;
                         case "content-type":      break;
-                        case "content-length":    break;
+                        case "content-length":    hasContentLength = true; break;
                         case "date":              request.Headers.Date = DateTime.Parse(srcReq.Headers[headerKey]); break;
                         case "expect":            break;
                         case "host":              request.Headers.Host = forwardUri.Host; break;
@@ -217,7 +218,7 @@ namespace EventStore.Core.Services
             // Copy content (if content body is allowed)
             if (!string.Equals(srcReq.HttpMethod, "GET", StringComparison.OrdinalIgnoreCase)
                 && !string.Equals(srcReq.HttpMethod, "HEAD", StringComparison.OrdinalIgnoreCase)
-                && srcReq.HasEntityBody)
+                && hasContentLength)
             {
                 var streamContent = new StreamContent(srcReq.InputStream);
                 streamContent.Headers.ContentType = MediaTypeHeaderValue.Parse(srcReq.ContentType);


### PR DESCRIPTION
Fixes #1509 which is one particular case of this bug

According to [RFC 2616 (HTTP/1.1)](https://tools.ietf.org/html/rfc2616#section-14.13):
`Any Content-Length greater than or equal to zero is a valid value.`

but [`HasEntityBody`](https://msdn.microsoft.com/en-us/library/system.net.httplistenerrequest.hasentitybody(v=vs.110).aspx) returns true only if Content-Length > 0