### PR TITLE
Resize the stream when writing the chunk footer

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -3,10 +3,8 @@ using System.Collections.Generic;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
-using EventStore.Core.Index.Hashes;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Services.Storage;
-using EventStore.Core.Tests.Fakes;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -22,6 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog
     {
         private TFChunkDb _db;
         private TFChunk _scavengedChunk;
+        private int _originalFileSize;
         private PrepareLogRecord _p1, _p2, _p3;
         private CommitLogRecord _c1, _c2, _c3;
         private RecordWriteResult _res1, _res2, _res3;
@@ -44,7 +43,7 @@ namespace EventStore.Core.Tests.TransactionLog
             var chunk = _db.Manager.GetChunkFor(0);
 
             _p1 = LogRecord.SingleWrite(0, Guid.NewGuid(), Guid.NewGuid(), "es-to-scavenge", ExpectedVersion.Any, "et1",
-                                          new byte[] { 0, 1, 2 }, new byte[] { 5, 7 });
+                                          new byte[2048], new byte[] { 5, 7 });
             _res1 = chunk.TryAppend(_p1);
 
             _c1 = LogRecord.Commit(_res1.NewPosition, Guid.NewGuid(), _p1.LogPosition, 0);
@@ -52,7 +51,7 @@ namespace EventStore.Core.Tests.TransactionLog
 
             _p2 = LogRecord.SingleWrite(_cres1.NewPosition,
                                         Guid.NewGuid(), Guid.NewGuid(), "es-to-scavenge", ExpectedVersion.Any, "et1",
-                                        new byte[] { 0, 1, 2 }, new byte[] { 5, 7 });
+                                        new byte[2048], new byte[] { 5, 7 });
             _res2 = chunk.TryAppend(_p2);
 
             _c2 = LogRecord.Commit(_res2.NewPosition, Guid.NewGuid(), _p2.LogPosition, 1);
@@ -60,13 +59,14 @@ namespace EventStore.Core.Tests.TransactionLog
             
             _p3 = LogRecord.SingleWrite(_cres2.NewPosition,
                                         Guid.NewGuid(), Guid.NewGuid(), "es-to-scavenge", ExpectedVersion.Any, "et1",
-                                        new byte[] { 0, 1, 2 }, new byte[] { 5, 7 });
+                                        new byte[2048], new byte[] { 5, 7 });
             _res3 = chunk.TryAppend(_p3);
 
             _c3 = LogRecord.Commit(_res3.NewPosition, Guid.NewGuid(), _p3.LogPosition, 2);
             _cres3 = chunk.TryAppend(_c3);
 
             chunk.Complete();
+            _originalFileSize = chunk.FileSize;
 
             _db.Config.WriterCheckpoint.Write(chunk.ChunkHeader.ChunkEndPosition);
             _db.Config.WriterCheckpoint.Flush();
@@ -163,6 +163,19 @@ namespace EventStore.Core.Tests.TransactionLog
                 res = _scavengedChunk.TryReadClosestForward((int)res.NextPosition);
             }
             Assert.AreEqual(0, records.Count);
+        }
+
+        [Test]
+        public void scavenged_chunk_should_have_saved_space()
+        {
+            Assert.IsTrue(_scavengedChunk.FileSize < _originalFileSize,
+                String.Format("Expected scavenged file size ({0}) to be less than original file size ({1})", _scavengedChunk.FileSize, _originalFileSize));
+        }
+
+        [Test]
+        public void scavenged_chunk_should_be_aligned()
+        {
+            Assert.IsTrue(_scavengedChunk.FileSize % 4096 == 0);
         }
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -857,6 +857,12 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
         private ChunkFooter WriteFooter(ICollection<PosMap> mapping)
         {
             var workItem = _writerWorkItem;
+
+            var alignedSize = GetAlignedSize(ChunkHeader.Size + _physicalDataSize);
+            if(_chunkHeader.Version >= (byte)ChunkVersions.Aligned && workItem.StreamLength != alignedSize)
+            {
+                workItem.ResizeStream(alignedSize);
+            }
             int mapSize = 0;
             if (mapping != null)
             {
@@ -901,8 +907,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                 //TODO GFY this is dead code as all chunks are now Aligned.
                 Log.Debug("Resizing stream as header is unaligned");
                 workItem.ResizeStream(fileSize);
-                _fileSize = fileSize;
             }
+            _fileSize = fileSize;
 
             return footerWithHash;
         }


### PR DESCRIPTION
Resize the FileStream to the aligned size of the data in the chunk before the footer is written.

Fixes an issue where the chunks are not resized when they are scavenged, forcing them to be exactly 256mb, and preventing the scavenge from saving space unless a merge happens.

Update scavenge TFChunk test to ensure scavenged chunk is smaller than original.