### PR TITLE
Fix for scavenged files remaining at 256MB

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -214,9 +214,11 @@ namespace EventStore.Core.TransactionLog.Chunks
                 }
 
                 newSize += positionMapCount * PosMap.FullSize + ChunkHeader.Size + ChunkFooter.Size;
+                if(newChunk.ChunkHeader.Version >= (byte) TFChunk.TFChunk.ChunkVersions.Aligned)
+                    newSize = TFChunk.TFChunk.GetAlignedSize((int)newSize);
 
                 var oldVersion = oldChunks.Any(x => x.ChunkHeader.Version != 3);
-                var oldSize = oldChunks.Sum(x => (long)x.PhysicalDataSize + x.ChunkFooter.MapSize + ChunkHeader.Size + ChunkFooter.Size);
+                var oldSize = oldChunks.Sum(x => (long)x.FileSize);
 
                 if (oldSize <= newSize && !alwaysKeepScavenged && !_unsafeIgnoreHardDeletes && !oldVersion)
                 {


### PR DESCRIPTION
Resize the stream before writing the chunk footer
Compare old chunk file sizes instead of calculating them to ensure padding/alignment is also included
Update scavenge tfchunk test to ensure scavenged chunk is smaller than original