### PR TITLE
Add option to set initial reader count on TFChunk

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -140,6 +140,9 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.UnbufferedDescr, Opts.DbGroup)]
         public bool Unbuffered { get; set; }
 
+        [ArgDescription(Opts.ChunkInitialReaderCountDescr, Opts.DbGroup)]
+        public int ChunkInitialReaderCount { get; set; }
+
 
         [ArgDescription(Opts.RunProjectionsDescr, Opts.ProjectionsGroup)]
         public ProjectionType RunProjections { get; set; }
@@ -340,6 +343,7 @@ namespace EventStore.ClusterNode
             SkipIndexScanOnReads = Opts.SkipIndexScanOnReadsDefault;
 
             ConnectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
+            ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
         }
     }
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -215,7 +215,8 @@ namespace EventStore.ClusterNode
                         .AdvertiseInternalSecureTCPPortAs(options.IntSecureTcpPortAdvertiseAs)
                         .AdvertiseExternalSecureTCPPortAs(options.ExtSecureTcpPortAdvertiseAs)
                         .HavingReaderThreads(options.ReaderThreadsCount)
-                        .WithConnectionPendingSendBytesThreshold(options.ConnectionPendingSendBytesThreshold);
+                        .WithConnectionPendingSendBytesThreshold(options.ConnectionPendingSendBytesThreshold)
+                        .WithChunkInitialReaderCount(options.ChunkInitialReaderCount);
 
             if(options.GossipSeed.Length > 0)
                 builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -71,7 +71,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit
                 ChaserCheckpoint = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
             }
 
-            Db = new TFChunkDb(TFChunkDbConfigHelper.Create(dbPath, WriterCheckpoint, ChaserCheckpoint, TFConsts.ChunkSize));
+            Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(dbPath, WriterCheckpoint, ChaserCheckpoint, TFConsts.ChunkSize));
             Db.Open();
 
             // create DB

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -626,7 +626,7 @@
     <Compile Include="Services\Transport\Tcp\TcpClientDispatcherTests.cs" />
     <Compile Include="Services\Storage\Scavenge\when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1.cs" />
     <Compile Include="ClientAPI\ExpectedVersion64Bit\read_stream_with_link_to_event_with_event_number_greater_than_int_maxvalue.cs" />
-    <Compile Include="TransactionLog\TFChunkDbConfigHelper.cs" />
+    <Compile Include="TransactionLog\TFChunkHelper.cs" />
     <Compile Include="Index\IndexV1\when_a_ptable_is_loaded_from_disk.cs" />
     <Compile Include="Index\IndexV4\ptable_midpoint_calculations_should.cs" />
     <Compile Include="Index\IndexV4\when_merging_ptables_with_entries_to_nonexisting_record.cs" />

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -102,7 +102,7 @@ namespace EventStore.Core.Tests.Helpers
                 intTcpHeartbeatTimeout: TimeSpan.FromSeconds(2), intTcpHeartbeatInterval: TimeSpan.FromSeconds(2),
                 verifyDbHash: false, maxMemtableEntryCount: memTableSize, hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
                 startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false,
-                connectionPendingSendBytesThreshold: Opts.ConnectionPendingSendBytesThresholdDefault);
+                connectionPendingSendBytesThreshold: Opts.ConnectionPendingSendBytesThresholdDefault, chunkInitialReaderCount: Opts.ChunkInitialReaderCountDefault);
 
             Log.Info(
                 "\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"
@@ -222,7 +222,7 @@ namespace EventStore.Core.Tests.Helpers
             }
             var nodeConfig = new TFChunkDbConfig(
                 dbPath, new VersionedPatternFileNamingStrategy(dbPath, "chunk-"), chunkSize, chunksCacheSize, writerChk,
-                chaserChk, epochChk, truncateChk, replicationCheckpoint, inMemDb);
+                chaserChk, epochChk, truncateChk, replicationCheckpoint, Opts.ChunkInitialReaderCountDefault, inMemDb);
             return nodeConfig;
         }
     }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10),
                 TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false, false, false,
-                Opts.ConnectionPendingSendBytesThresholdDefault);
+                Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ChunkInitialReaderCountDefault);
 
             return vnode;
         }

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -105,7 +105,7 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex
             var bus = new InMemoryBus("bus");
             new IODispatcher(bus, new PublishEnvelope(bus));
 
-            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerCheckpoint, chaserCheckpoint));
+            _db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerCheckpoint, chaserCheckpoint));
 
             _db.Open();
             // create db

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Tests.Services.Storage
             Bus = new InMemoryBus("bus");
             IODispatcher = new IODispatcher(Bus, new PublishEnvelope(Bus));
 
-            Db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, WriterCheckpoint, ChaserCheckpoint, replicationCheckpoint: ReplicationCheckpoint));
+            Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, WriterCheckpoint, ChaserCheckpoint, replicationCheckpoint: ReplicationCheckpoint));
 
             Db.Open();
             // create db

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -47,7 +47,7 @@ namespace EventStore.Core.Tests.Services.Storage
                 DbRes.Db.Close();
             }
 
-            var dbConfig = TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 1024 * 1024);
+            var dbConfig = TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 1024 * 1024);
             var dbHelper = new TFChunkDbCreationHelper(dbConfig);
 
             DbRes = dbHelper.Chunk(records).CreateDb();

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.Services.Storage
         {
             base.TestFixtureSetUp();
 
-            var dbConfig = TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 1024 * 1024);
+            var dbConfig = TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 1024 * 1024);
             var dbCreationHelper = new TFChunkDbCreationHelper(dbConfig);
             
             DbRes = CreateDb(dbCreationHelper);

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -45,7 +45,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
         {
             base.TestFixtureSetUp();
 
-            var dbConfig = TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 1024 * 1024);
+            var dbConfig = TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 1024 * 1024);
             var dbCreationHelper = new TFChunkDbCreationHelper(dbConfig);
             _dbResult = CreateDb(dbCreationHelper);
             _keptRecords = KeptRecords(_dbResult);

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging
         public void is_fully_resident_in_memory_when_cached()
         {
             var map = new List<PosMap>();
-            var chunk = TFChunk.CreateNew(Filename, 1024*1024, 0, 0, true, false, false, false);
+            var chunk = TFChunk.CreateNew(Filename, 1024*1024, 0, 0, true, false, false, false, 5);
             long logPos = 0;
             for (int i = 0, n = ChunkFooter.Size/PosMap.FullSize + 1; i < n; ++i)
             {

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -1,12 +1,14 @@
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog
 {
-    public static class TFChunkDbConfigHelper
+    public static class TFChunkHelper
     {
-        public static TFChunkDbConfig Create(string pathName, long writerCheckpointPosition, long chaserCheckpointPosition = 0,
+        public static TFChunkDbConfig CreateDbConfig(string pathName, long writerCheckpointPosition, long chaserCheckpointPosition = 0,
             long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000)
         {
             return new TFChunkDbConfig(pathName,
@@ -17,10 +19,11 @@ namespace EventStore.Core.Tests.TransactionLog
                                              new InMemoryCheckpoint(chaserCheckpointPosition),
                                              new InMemoryCheckpoint(epochCheckpointPosition),
                                              new InMemoryCheckpoint(truncateCheckpoint),
-                                             new InMemoryCheckpoint(-1));
+                                             new InMemoryCheckpoint(-1),
+                                             Opts.ChunkInitialReaderCountDefault);
         }
 
-        public static TFChunkDbConfig Create(string pathName, ICheckpoint writerCheckpoint, ICheckpoint chaserCheckpoint, int chunkSize = 10000, ICheckpoint replicationCheckpoint = null)
+        public static TFChunkDbConfig CreateDbConfig(string pathName, ICheckpoint writerCheckpoint, ICheckpoint chaserCheckpoint, int chunkSize = 10000, ICheckpoint replicationCheckpoint = null)
         {
             if(replicationCheckpoint == null) replicationCheckpoint = new InMemoryCheckpoint(-1);
             return new TFChunkDbConfig(pathName,
@@ -31,7 +34,15 @@ namespace EventStore.Core.Tests.TransactionLog
                                              chaserCheckpoint,
                                              new InMemoryCheckpoint(-1),
                                              new InMemoryCheckpoint(-1),
-                                             replicationCheckpoint);
+                                             replicationCheckpoint,
+                                             Opts.ChunkInitialReaderCountDefault);
+        }
+
+        public static TFChunk CreateNewChunk(string fileName, int chunkSize = 4096, bool isScavenged = false)
+        {
+            return TFChunk.CreateNew(fileName, chunkSize, 0, 0, 
+                                     isScavenged: isScavenged, inMem: false, unbuffered: false, 
+                                     writethrough: false, initialReaderCount: 5);
         }
     }
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
 
         private void ReOpenDb()
         {
-            Db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, WriterCheckpoint, ChaserCheckpoint));
+            Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, WriterCheckpoint, ChaserCheckpoint));
 
             Db.Open();
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = TFChunkDbConfigHelper.Create(PathName, 1711, 5500, 5500, 1111, 1000);
+            _config = TFChunkHelper.CreateDbConfig(PathName, 1711, 5500, 5500, 1111, 1000);
 
             var rnd = new Random();
             _file1Contents = new byte[_config.ChunkSize];

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = TFChunkDbConfigHelper.Create(PathName, 11111, 5500, 5500, 5757, 1000);
+            _config = TFChunkHelper.CreateDbConfig(PathName, 11111, 5500, 5500, 5757, 1000);
 
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = TFChunkDbConfigHelper.Create(PathName, 1711, 5500, 5500, 1111, 1000);
+            _config = TFChunkHelper.CreateDbConfig(PathName, 1711, 5500, 5500, 1111, 1000);
 
             var rnd = new Random();
             _file1Contents = new byte[_config.ChunkSize];

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = TFChunkDbConfigHelper.Create(PathName, 13500, 5500, 5500, 11000, 1000);
+            _config = TFChunkHelper.CreateDbConfig(PathName, 13500, 5500, 5500, 11000, 1000);
 
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation
         {
             base.TestFixtureSetUp();
 
-            _config = TFChunkDbConfigHelper.Create(PathName, 11111, 5500, 5500, 0, 1000);
+            _config = TFChunkHelper.CreateDbConfig(PathName, 11111, 5500, 5500, 0, 1000);
 
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
             DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_file_of_wrong_size_database_corruption_is_detected()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 500);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 500);
             using (var db = new TFChunkDb(config))
             {
                 File.WriteAllText(GetFilePathFor("chunk-000000.000000"), "this is just some test blahbydy blah");
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_not_enough_files_to_reach_checksum_throws()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 15000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 15000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_with_exactly_enough_file_to_reach_checksum()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -50,7 +50,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void does_not_allow_not_completed_not_last_chunks()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 4000, chunkSize: 1000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 4000, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -66,7 +66,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_next_new_chunk_when_checksum_is_exactly_in_between_two_chunks()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -78,7 +78,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Due to truncation such situation can happen, so must be considered valid.")]
         public void does_not_allow_next_new_completed_chunk_when_checksum_is_exactly_in_between_two_chunks()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -92,7 +92,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_last_chunk_to_be_not_completed_when_checksum_is_exactly_in_between_two_chunks_and_no_next_chunk_exists()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -103,7 +103,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void does_not_allow_pre_last_chunk_to_be_not_completed_when_checksum_is_exactly_in_between_two_chunks_and_next_chunk_exists()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -117,7 +117,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Not valid test now after disabling size validation on ongoing TFChunk ")]
         public void with_wrong_size_file_less_than_checksum_throws()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 15000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 15000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -131,7 +131,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_in_first_extraneous_files_throws_corrupt_database_exception()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 9000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 9000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -145,7 +145,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_in_multiple_extraneous_files_throws_corrupt_database_exception()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 15000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 15000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -160,7 +160,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_in_brand_new_extraneous_files_throws_corrupt_database_exception()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 0);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 0);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 4, GetFilePathFor("chunk-000004.000000"));
@@ -173,7 +173,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_a_chaser_checksum_is_ahead_of_writer_checksum_throws_corrupt_database_exception()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 0, 11);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 0, 11);
             using (var db = new TFChunkDb(config))
             {
                 Assert.That(() => db.Open(verifyHash: false),
@@ -185,7 +185,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_an_epoch_checksum_is_ahead_of_writer_checksum_throws_corrupt_database_exception()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 0, 0, 11);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 0, 0, 11);
             using (var db = new TFChunkDb(config))
             {
                 Assert.That(() => db.Open(verifyHash: false),
@@ -197,7 +197,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_no_files_when_checkpoint_is_zero()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 0);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 0);
             using (var db = new TFChunkDb(config))
             {
                 Assert.DoesNotThrow(() => db.Open(verifyHash: false));
@@ -208,7 +208,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_first_correct_ongoing_chunk_when_checkpoint_is_zero()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 0);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 0);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -219,7 +219,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Due to truncation such situation can happen, so must be considered valid.")]
         public void does_not_allow_first_completed_chunk_when_checkpoint_is_zero()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 0);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 0);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -232,7 +232,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_checkpoint_to_point_into_the_middle_of_completed_chunk_when_enough_actual_data_in_chunk()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 1500, chunkSize: 1000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 1500, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -249,7 +249,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("We do not check this as it is too erroneous to read ChunkFooter from ongoing chunk...")]
         public void does_not_allow_checkpoint_to_point_into_the_middle_of_completed_chunk_when_not_enough_actual_data()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 1500);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 1500);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -264,7 +264,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void does_not_allow_checkpoint_to_point_into_the_middle_of_scavenged_chunk()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 1500, chunkSize: 1000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 1500, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -282,7 +282,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
             File.Create(GetFilePathFor("foo")).Close();
             File.Create(GetFilePathFor("bla")).Close();
 
-            var config = TFChunkDbConfigHelper.Create(PathName, 350, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 350, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -309,7 +309,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_on_boundary_of_chunk_last_chunk_is_preserved()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -328,7 +328,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_on_boundary_of_new_chunk_last_chunk_is_preserved_and_excessive_versions_are_removed_if_present()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -348,7 +348,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_not_present_but_should_be_created()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -367,7 +367,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_present()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -387,7 +387,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_no_exception_is_thrown()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -406,7 +406,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Not valid test now after disabling size validation on ongoing TFChunk ")]
         public void when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_but_not_completed_exception_is_thrown()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -421,7 +421,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void temporary_files_are_removed()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 150, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 150, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db_with_multi_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db_with_multi_chunks.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_not_enough_files_to_reach_checksum_throws()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 25000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 25000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_checksum_inside_multi_chunk_throws()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 25000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 25000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 2, GetFilePathFor("chunk-000000.000000"));
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_with_exactly_enough_file_to_reach_checksum_while_last_is_multi_chunk()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 30000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 30000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -56,7 +56,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_next_new_chunk_when_checksum_is_exactly_in_between_two_chunks_if_last_is_ongoing_chunk()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 20000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 20000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
@@ -72,7 +72,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test, Ignore("Due to truncation such situation can happen, so must be considered valid.")]
         public void does_not_allow_next_new_chunk_when_checksum_is_exactly_in_between_two_chunks_and_last_is_multi_chunk()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 10000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 10000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -90,7 +90,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
             File.Create(GetFilePathFor("foo")).Close();
             File.Create(GetFilePathFor("bla")).Close();
 
-            var config = TFChunkDbConfigHelper.Create(PathName, 350, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 350, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -116,7 +116,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_not_present_but_should_be_created()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
@@ -133,7 +133,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_present()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 200, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
@@ -151,7 +151,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_no_exception_is_thrown()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 300, chunkSize: 100);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 300, chunkSize: 100);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -170,7 +170,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void does_not_allow_checkpoint_to_point_into_the_middle_of_multichunk_chunk()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 1500, chunkSize: 1000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 1500, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
@@ -185,7 +185,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void allows_last_chunk_to_be_multichunk_when_checkpoint_point_at_the_start_of_next_chunk()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 4000, chunkSize: 1000);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 4000, chunkSize: 1000);
             using (var db = new TFChunkDb(config))
             {
                 DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunkdb_without_previous_files.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunkdb_without_previous_files.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_a_writer_checksum_of_nonzero_and_no_files_a_corrupted_database_exception_is_thrown()
         {
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 500));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 500));
             var exc = Assert.Throws<CorruptDatabaseException>(() => db.Open());
             Assert.IsInstanceOf<ChunkNotFoundException>(exc.InnerException);
             db.Dispose();
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation
         [Test]
         public void with_a_writer_checksum_of_zero_and_no_files_is_valid()
         {
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
             Assert.DoesNotThrow(() => db.Open());
             db.Dispose();
         }

--- a/src/EventStore.Core.Tests/TransactionLog/when_appending_past_end_of_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_appending_past_end_of_a_tfchunk.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.TransactionLog
             base.SetUp();
             var record = new PrepareLogRecord(15556, _corrId, _eventId, 15556, 0, "test", 1, new DateTime(2000, 1, 1, 12, 0, 0),
                                               PrepareFlags.None, "Foo", new byte[12], new byte[15]);
-            _chunk = TFChunk.CreateNew(Filename, 20, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename, 20);
             _written = _chunk.TryAppend(record).Success;
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_appending_to_a_tfchunk_and_flushing.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_appending_to_a_tfchunk_and_flushing.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog
             base.TestFixtureSetUp();
             _record = new PrepareLogRecord(0, _corrId, _eventId, 0, 0, "test", 1, new DateTime(2000, 1, 1, 12, 0, 0),
                                            PrepareFlags.None, "Foo", new byte[12], new byte[15]);
-            _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename);
             _result = _chunk.TryAppend(_record);
             _chunk.Flush();
         }

--- a/src/EventStore.Core.Tests/TransactionLog/when_appending_to_a_tfchunk_without_flush.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_appending_to_a_tfchunk_without_flush.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog
             base.TestFixtureSetUp();
             _record = new PrepareLogRecord(0, _corrId, _eventId, 0, 0, "test", 1, new DateTime(2000, 1, 1, 12, 0, 0),
                                            PrepareFlags.None, "Foo", new byte[12], new byte[15]);
-            _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename);
             _result = _chunk.TryAppend(_record);
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             var writerchk = new InMemoryCheckpoint(0);
             var chaserchk = new InMemoryCheckpoint();
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
 
             var chaser = new TFChunkChaser(db, writerchk, new InMemoryCheckpoint());
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             var writerchk = new InMemoryCheckpoint();
             var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
             writerchk.Write(12);
             writerchk.Flush();
@@ -84,7 +84,7 @@ namespace EventStore.Core.Tests.TransactionLog
             
             var writerchk = new InMemoryCheckpoint(128);
             var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
 
             var chaser = new TFChunkChaser(db, writerchk, chaserchk);
@@ -108,7 +108,7 @@ namespace EventStore.Core.Tests.TransactionLog
             var writerchk = new InMemoryCheckpoint(0);
             var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
             
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
 
             var recordToWrite = new PrepareLogRecord(logPosition: 0,
@@ -150,7 +150,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             var writerchk = new InMemoryCheckpoint(0);
             var chaserchk = new InMemoryCheckpoint(Checkpoint.Chaser, 0);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
 
             var recordToWrite = new PrepareLogRecord(logPosition: 0,

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_chaser.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_chaser.cs
@@ -21,14 +21,14 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_null_writer_checksum_throws_argument_null_exception()
         {
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
             Assert.Throws<ArgumentNullException>(() => new TFChunkChaser(db, null, new InMemoryCheckpoint()));
         }
 
         [Test]
         public void a_null_chaser_checksum_throws_argument_null_exception()
         {
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
             Assert.Throws<ArgumentNullException>(() => new TFChunkChaser(db, new InMemoryCheckpoint(), null));
         }
     }

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_file_reader.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_file_reader.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_null_checkpoint_throws_argument_null_exception()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 0);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 0);
             var db = new TFChunkDb(config);
             Assert.Throws<ArgumentNullException>(() => new TFChunkReader(db, null));
         }

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_tfchunk_from_empty_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_tfchunk_from_empty_file.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void SetUp()
         {
             base.SetUp();
-            _chunk = TFChunk.CreateNew(Filename, 1024, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename, 1024);
         }
 
         [TearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void SetUp()
         {
             base.SetUp();
-            _chunk = TFChunk.CreateNew(Filename, 1000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename, 1000);
             _chunk.MarkForDeletion();
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void SetUp()
         {
             base.SetUp();
-            _chunk = TFChunk.CreateNew(Filename, 1000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename, 1000);
             _reader = _chunk.AcquireReader();
             _chunk.MarkForDeletion();
         }

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
 
-            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 16 * 1024));
+            _db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 16 * 1024));
             _db.Open();
 
             var chunk = _db.Manager.GetChunkFor(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_marking_for_deletion_a_tfchunk_that_has_been_locked_and_unlocked.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void SetUp()
         {
             base.SetUp();
-            _chunk = TFChunk.CreateNew(Filename, 1000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename, 1000);
             var reader = _chunk.AcquireReader();
             _chunk.MarkForDeletion();
             reader.Release();

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_chunked_transaction_file_db_without_previous_files.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_chunked_transaction_file_db_without_previous_files.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void with_a_writer_checksum_of_zero_the_first_chunk_is_created_with_correct_name_and_is_aligned()
         {
-            var config = TFChunkDbConfigHelper.Create(PathName, 0);
+            var config = TFChunkHelper.CreateDbConfig(PathName, 0);
             var db = new TFChunkDb(config);
             db.Open();
             db.Dispose();

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -15,9 +15,9 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void TestFixtureSetUp()
         {
             base.TestFixtureSetUp();
-            _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename);
             _chunk.Complete();
-            _testChunk = TFChunk.FromCompletedFile(Filename, true, false);
+            _testChunk = TFChunk.FromCompletedFile(Filename, true, false, 5);
         }
 
         [TearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -10,7 +10,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void it_should_throw_a_file_not_found_exception()
         {
-            Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false));
+            Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5));
         }
     }
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
@@ -21,15 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void TestFixtureSetUp()
         {
             base.TestFixtureSetUp();
-            _db = new TFChunkDb(new TFChunkDbConfig(PathName,
-                                                    new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
-                                                    4096,
-                                                    0,
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1),
-                                                    new InMemoryCheckpoint(-1)));
+            _db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 4096));
             _db.Open();
 
             var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_an_empty_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_an_empty_chunked_transaction_log.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             var writerchk = new InMemoryCheckpoint(0);
             var chaserchk = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
 
             var reader = new TFChunkReader(db, writerchk, 0);
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             var writerchk = new InMemoryCheckpoint(0);
             var chaserchk = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, writerchk, chaserchk));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
 
             var writer = new TFChunkWriter(db);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_cached_empty_scavenged_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_cached_empty_scavenged_tfchunk.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void TestFixtureSetUp()
         {
             base.TestFixtureSetUp();
-            _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename, isScavenged: true);
             _chunk.CompleteScavenge(new PosMap[0]);
             _chunk.CacheInMemory();
         }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -22,11 +22,11 @@ namespace EventStore.Core.Tests.TransactionLog
             base.TestFixtureSetUp();
             _record = new PrepareLogRecord(0, _corrId, _eventId, 0, 0, "test", 1, new DateTime(2000, 1, 1, 12, 0, 0),
                                            PrepareFlags.None, "Foo", new byte[12], new byte[15]);
-            _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename);
             _result = _chunk.TryAppend(_record);
             _chunk.Flush();
             _chunk.Complete();
-            _cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false);
+            _cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5);
             _cachedChunk.CacheInMemory();
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void the_file_will_not_be_deleted_until_reader_released()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 2000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
             using (var reader = chunk.AcquireReader())
             {
                 chunk.MarkForDeletion();
@@ -25,7 +25,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_read_on_new_file_can_be_performed_but_returns_nothing()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 2000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
             using(var reader = chunk.AcquireReader())
             {
                 var buffer = new byte[1024];
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_read_past_end_of_completed_chunk_does_not_include_footer()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 300, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
             chunk.Complete(); // chunk has 0 bytes of actual data
             using (var reader = chunk.AcquireReader())
             {
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_read_on_scavenged_chunk_does_not_include_map()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("afile"), 200, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("afile"), 200, isScavenged: true);
             chunk.CompleteScavenge(new[] { new PosMap(0, 0), new PosMap(1, 1) });
             using (var reader = chunk.AcquireReader())
             {
@@ -73,7 +73,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test] 
         public void if_asked_for_more_than_buffer_size_will_only_read_buffer_size()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 3000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 3000);
 
             var rec = LogRecord.Prepare(0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "ES", -1, PrepareFlags.None, "ET", new byte[2000], null);
             Assert.IsTrue(chunk.TryAppend(rec).Success, "Record was not appended");
@@ -92,7 +92,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_read_past_eof_doesnt_return_eof_if_chunk_is_not_yet_completed()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 300, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
             var rec = LogRecord.Commit(0, Guid.NewGuid(), 0, 0);
             Assert.IsTrue(chunk.TryAppend(rec).Success, "Record was not appended");
             using (var reader = chunk.AcquireReader())
@@ -110,7 +110,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_read_past_eof_returns_eof_if_chunk_is_completed()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 300, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
 
             var rec = LogRecord.Commit(0, Guid.NewGuid(), 0, 0);
             Assert.IsTrue(chunk.TryAppend(rec).Success, "Record was not appended");

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_physical_bytes_bulk_from_a_chunk.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void the_file_will_not_be_deleted_until_reader_released()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 2000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
             using (var reader = chunk.AcquireReader())
             {
                 chunk.MarkForDeletion();
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_read_on_new_file_can_be_performed()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 2000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 2000);
             using (var reader = chunk.AcquireReader())
             {
                 var buffer = new byte[1024];
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void if_asked_for_more_than_buffer_size_will_only_read_buffer_size()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 3000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 3000);
             using (var reader = chunk.AcquireReader())
             {
                 var buffer = new byte[1024];
@@ -89,7 +89,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void a_read_past_eof_returns_eof_and_no_footer()
         {
-            var chunk = TFChunk.CreateNew(GetFilePathFor("file1"), 300, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 300);
             using (var reader = chunk.AcquireReader())
             {
                 var buffer = new byte[8092];

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_uncached_empty_scavenged_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_uncached_empty_scavenged_tfchunk.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void TestFixtureSetUp()
         {
             base.TestFixtureSetUp();
-            _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: true, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename, isScavenged: true);
             _chunk.CompleteScavenge(new PosMap[0]);
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
 
-            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 4096));
+            _db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 4096));
             _db.Open();
 
             var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             base.TestFixtureSetUp();
 
-            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 4096));
+            _db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 4096));
             _db.Open();
             
             var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Tests.TransactionLog
             base.TestFixtureSetUp();
 
             _db = new TFChunkDb(
-                    TFChunkDbConfigHelper.Create(PathName, 0, chunkSize: 4096));
+                    TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 4096));
             _db.Open();
 
             var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -22,11 +22,11 @@ namespace EventStore.Core.Tests.TransactionLog
             base.TestFixtureSetUp();
             _record = new PrepareLogRecord(0, _corrId, _eventId, 0, 0, "test", 1, new DateTime(2000, 1, 1, 12, 0, 0),
                                            PrepareFlags.None, "Foo", new byte[12], new byte[15]);
-            _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename);
             _result = _chunk.TryAppend(_record);
             _chunk.Flush();
             _chunk.Complete();
-            _uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false);
+            _uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5);
             _uncachedChunk.CacheInMemory();
             _uncachedChunk.UnCacheFromMemory();
         }

--- a/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_unlocking_a_tfchunk_that_has_been_marked_for_deletion.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void SetUp()
         {
             base.SetUp();
-            _chunk = TFChunk.CreateNew(Filename, 1000, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename, 1000);
             var reader = _chunk.AcquireReader();
             _chunk.MarkForDeletion();
             reader.Release();

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_a_new_chunked_transaction_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_a_new_chunked_transaction_file.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public void a_record_can_be_written()
         {
             _checkpoint = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _checkpoint, new InMemoryCheckpoint()));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, _checkpoint, new InMemoryCheckpoint()));
             db.Open();
             var tf = new TFChunkWriter(db);
             tf.Open();

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.TransactionLog
             File.WriteAllBytes(filename, bytes);
 
             _checkpoint = new InMemoryCheckpoint(137);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _checkpoint, new InMemoryCheckpoint()));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, _checkpoint, new InMemoryCheckpoint()));
             db.Open();
             var tf = new TFChunkWriter(db);
             var record = new PrepareLogRecord(logPosition: _checkpoint.Read(),

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum_and_data_bigger_than_buffer.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum_and_data_bigger_than_buffer.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.TransactionLog
             File.WriteAllBytes(filename, buf);
 
             _checkpoint = new InMemoryCheckpoint(137);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _checkpoint, new InMemoryCheckpoint(), chunkSize: chunkHeader.ChunkSize));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, _checkpoint, new InMemoryCheckpoint(), chunkSize: chunkHeader.ChunkSize));
             db.Open();
 
             var bytes = new byte[3994]; // this gives exactly 4097 size of record, with 3993 (rec size 4096) everything works fine!

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_not_enough_space_in_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_not_enough_space_in_chunk.cs
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.TransactionLog
             File.WriteAllBytes(filename1, bytes);
 
             _checkpoint = new InMemoryCheckpoint(0);
-            var db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _checkpoint, new InMemoryCheckpoint()));
+            var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, _checkpoint, new InMemoryCheckpoint()));
             db.Open();
             var tf = new TFChunkWriter(db);
             long pos;

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public void SetUp()
         {
             _writerCheckpoint = new InMemoryCheckpoint();
-            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _writerCheckpoint, new InMemoryCheckpoint(), 1024));
+            _db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, _writerCheckpoint, new InMemoryCheckpoint(), 1024));
             _db.Open();
             _writer = new TFChunkWriter(_db);
             _writer.Open();

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_multiple_records_to_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_multiple_records_to_a_tfchunk.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public override void TestFixtureSetUp()
         {
             base.TestFixtureSetUp();
-            _chunk = TFChunk.CreateNew(Filename, 4096, 0, 0, isScavenged: false, inMem: false, unbuffered: false, writethrough: false);
+            _chunk = TFChunkHelper.CreateNewChunk(Filename);
 
             _prepare1 = new PrepareLogRecord(0, _corrId, _eventId, 0, 0, "test", 1, new DateTime(2000, 1, 1, 12, 0, 0),
                                              PrepareFlags.None, "Foo", new byte[12], new byte[15]);

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public void SetUp()
         {
             _writerCheckpoint = new InMemoryCheckpoint();
-            _db = new TFChunkDb(TFChunkDbConfigHelper.Create(PathName, _writerCheckpoint, new InMemoryCheckpoint(), 1024));
+            _db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, _writerCheckpoint, new InMemoryCheckpoint(), 1024));
             _db.Open();
             _writer = new TFChunkWriter(_db);
             _writer.Open();

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -67,6 +67,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly bool SkipIndexVerify;
         public readonly int IndexCacheDepth;
         public readonly byte IndexBitnessVersion;
+        public readonly int ChunkInitialReaderCount;
 
         public readonly bool BetterOrdering;
         public readonly string Index;
@@ -126,6 +127,7 @@ namespace EventStore.Core.Cluster.Settings
                                     bool disableHTTPCaching,
                                     bool logHttpRequests,
                                     int connectionPendingSendBytesThreshold,
+                                    int chunkInitialReaderCount,
                                     string index = null, bool enableHistograms = false,
                                     bool skipIndexVerify = false,
                                     int indexCacheDepth = 16,
@@ -212,6 +214,7 @@ namespace EventStore.Core.Cluster.Settings
             ExtTcpHeartbeatTimeout = extTcpHeartbeatTimeout;
             ExtTcpHeartbeatInterval = extTcpHeartbeatInterval;
             ConnectionPendingSendBytesThreshold = connectionPendingSendBytesThreshold;
+            ChunkInitialReaderCount = chunkInitialReaderCount;
 
             VerifyDbHash = verifyDbHash;
             MaxMemtableEntryCount = maxMemtableEntryCount;
@@ -268,7 +271,8 @@ namespace EventStore.Core.Cluster.Settings
                                  + "HTTPCachingDisabled: {33}\n"
                                  + "IndexPath: {34}\n"
                                  + "ScavengeHistoryMaxAge: {35}\n"
-                                 + "ConnectionPendingSendBytesThreshold: {36}\n",
+                                 + "ConnectionPendingSendBytesThreshold: {36}\n"
+                                 + "ChunkInitialReaderCount: {37}\n",
                                  NodeInfo.InstanceId,
                                  NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
                                  NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -286,7 +290,7 @@ namespace EventStore.Core.Cluster.Settings
                                  StatsPeriod, StatsStorage, AuthenticationProviderFactory.GetType(),
                                  NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout,
                                  EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge,
-                                 ConnectionPendingSendBytesThreshold);
+                                 ConnectionPendingSendBytesThreshold, ChunkInitialReaderCount);
         }
     }
 }

--- a/src/EventStore.Core/Settings/ESConsts.cs
+++ b/src/EventStore.Core/Settings/ESConsts.cs
@@ -15,7 +15,6 @@ namespace EventStore.Core.Settings
                                               + StorageReaderThreadCount
                                               + 5 /* just in case reserve :) */;
 
-        public const int TFChunkInitialReaderCount = 5;
         public const int TFChunkMaxReaderCount = PTableMaxReaderCount 
                                                + 2 /* for caching/uncaching, populating midpoints */
                                                + 1 /* for epoch manager usage of elections/replica service */

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -117,9 +117,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
             FreeCachedData();
         }
 
-        public static TFChunk FromCompletedFile(string filename, bool verifyHash, bool unbufferedRead)
+        public static TFChunk FromCompletedFile(string filename, bool verifyHash, bool unbufferedRead, int initialReaderCount)
         {
-            var chunk = new TFChunk(filename, ESConsts.TFChunkInitialReaderCount, ESConsts.TFChunkMaxReaderCount,
+            var chunk = new TFChunk(filename, initialReaderCount, ESConsts.TFChunkMaxReaderCount,
                                     TFConsts.MidpointsDepth, false, unbufferedRead, false);
             try
             {
@@ -133,10 +133,10 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
             return chunk;
         }
 
-        public static TFChunk FromOngoingFile(string filename, int writePosition, bool checkSize, bool unbuffered, bool writethrough)
+        public static TFChunk FromOngoingFile(string filename, int writePosition, bool checkSize, bool unbuffered, bool writethrough, int initialReaderCount)
         {
             var chunk = new TFChunk(filename,
-                                    ESConsts.TFChunkInitialReaderCount,
+                                    initialReaderCount,
                                     ESConsts.TFChunkMaxReaderCount,
                                     TFConsts.MidpointsDepth,
                                     false,
@@ -161,11 +161,12 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                                         bool isScavenged,
                                         bool inMem,
                                         bool unbuffered,
-                                        bool writethrough)
+                                        bool writethrough,
+                                        int initialReaderCount)
         {
             var size = GetAlignedSize(chunkSize + ChunkHeader.Size + ChunkFooter.Size);
             var chunkHeader = new ChunkHeader(CurrentChunkVersion, chunkSize, chunkStartNumber, chunkEndNumber, isScavenged, Guid.NewGuid());
-            return CreateWithHeader(filename, chunkHeader, size, inMem, unbuffered, writethrough);
+            return CreateWithHeader(filename, chunkHeader, size, inMem, unbuffered, writethrough, initialReaderCount);
         }
 
         public static TFChunk CreateWithHeader(string filename,
@@ -173,10 +174,11 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk
                                                int fileSize,
                                                bool inMem,
                                                bool unbuffered,
-                                               bool writethrough)
+                                               bool writethrough,
+                                               int initialReaderCount)
         {
             var chunk = new TFChunk(filename,
-                                    ESConsts.TFChunkInitialReaderCount,
+                                    initialReaderCount,
                                     ESConsts.TFChunkMaxReaderCount,
                                     TFConsts.MidpointsDepth,
                                     inMem,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -52,10 +52,10 @@ namespace EventStore.Core.TransactionLog.Chunks
                     // but the actual last chunk is (lastChunkNum-1) one and it could be not completed yet -- perfectly valid situation.
                     var footer = ReadChunkFooter(versions[0]);
                     if (footer.IsCompleted)
-                        chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered);
+                        chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount);
                     else
                     {
-                        chunk = TFChunk.TFChunk.FromOngoingFile(versions[0], Config.ChunkSize, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough);
+                        chunk = TFChunk.TFChunk.FromOngoingFile(versions[0], Config.ChunkSize, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough, initialReaderCount:Config.InitialReaderCount);
                         // chunk is full with data, we should complete it right here
                         if (!readOnly)
                             chunk.Complete();
@@ -63,7 +63,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 }
                 else
                 {
-                    chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered);
+                    chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount);
                 }
                 Manager.AddChunk(chunk);
                 chunkNum = chunk.ChunkHeader.ChunkEndNumber + 1;
@@ -84,7 +84,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 var chunkLocalPos = chunkHeader.GetLocalLogPosition(checkpoint);
                 if (chunkHeader.IsScavenged)
                 {
-                    var lastChunk = TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false, unbufferedRead:Config.Unbuffered);
+                    var lastChunk = TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount);
                     if (lastChunk.ChunkFooter.LogicalDataSize != chunkLocalPos)
                     {
                         lastChunk.Dispose();
@@ -106,7 +106,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 }
                 else
                 {
-                    var lastChunk = TFChunk.TFChunk.FromOngoingFile(chunkFileName, (int)chunkLocalPos, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough);
+                    var lastChunk = TFChunk.TFChunk.FromOngoingFile(chunkFileName, (int)chunkLocalPos, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough, initialReaderCount:Config.InitialReaderCount);
                     Manager.AddChunk(lastChunk);
                 }
             }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -18,6 +18,7 @@ namespace EventStore.Core.TransactionLog.Chunks
         public readonly bool InMemDb;
         public readonly bool Unbuffered;
         public readonly bool WriteThrough;
+        public readonly int InitialReaderCount;
 
         public TFChunkDbConfig(string path, 
                                IFileNamingStrategy fileNamingStrategy, 
@@ -28,6 +29,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                                ICheckpoint epochCheckpoint,
                                ICheckpoint truncateCheckpoint,
                                ICheckpoint replicationCheckpoint,
+                               int initialReaderCount,
                                bool inMemDb = false,
                                bool unbuffered = false,
                                bool writethrough = false)
@@ -41,6 +43,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             Ensure.NotNull(epochCheckpoint, "epochCheckpoint");
             Ensure.NotNull(truncateCheckpoint, "truncateCheckpoint");
             Ensure.NotNull(replicationCheckpoint, "replicationCheckpoint");
+            Ensure.Positive(initialReaderCount, "initialReaderCount");
             
             Path = path;
             ChunkSize = chunkSize;
@@ -54,22 +57,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             InMemDb = inMemDb;
             Unbuffered = unbuffered;
             WriteThrough = writethrough;
-        }
-
-         public TFChunkDbConfig(string path, 
-                               IFileNamingStrategy fileNamingStrategy, 
-                               int chunkSize,
-                               long maxChunksCacheSize,
-                               ICheckpoint writerCheckpoint, 
-                               ICheckpoint chaserCheckpoint,
-                               ICheckpoint epochCheckpoint,
-                               ICheckpoint truncateCheckpoint,
-                               bool inMemDb = false,
-                               bool unbuffered = false,
-                               bool writethrough = false)
-        : this(path, fileNamingStrategy, chunkSize, maxChunksCacheSize, writerCheckpoint, chaserCheckpoint,
-               epochCheckpoint, truncateCheckpoint, new InMemoryCheckpoint(-1), inMemDb, unbuffered, writethrough)
-        {
+            InitialReaderCount = initialReaderCount;
         }
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -105,7 +105,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                                     fileSize, 
                                                     _config.InMemDb,
                                                     _config.Unbuffered,
-                                                    _config.WriteThrough);
+                                                    _config.WriteThrough,
+                                                    _config.InitialReaderCount);
         }
 
         public TFChunk.TFChunk AddNewChunk()
@@ -121,7 +122,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                                       isScavenged: false, 
                                                       inMem: _config.InMemDb,
                                                       unbuffered: _config.Unbuffered,
-                                                      writethrough: _config.WriteThrough);
+                                                      writethrough: _config.WriteThrough,
+                                                      initialReaderCount: _config.InitialReaderCount);
                 AddChunk(chunk);
                 return chunk;
             }
@@ -144,7 +146,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                                              fileSize, 
                                                              _config.InMemDb,
                                                              unbuffered: _config.Unbuffered,
-                                                             writethrough: _config.WriteThrough);
+                                                             writethrough: _config.WriteThrough,
+                                                             initialReaderCount: _config.InitialReaderCount);
                 AddChunk(chunk);
                 return chunk;
             }
@@ -195,7 +198,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 var newFileName = _config.FileNamingStrategy.DetermineBestVersionFilenameFor(chunkHeader.ChunkStartNumber);
                 Log.Info("File {0} will be moved to file {1}", Path.GetFileName(oldFileName), Path.GetFileName(newFileName));
                 File.Move(oldFileName, newFileName);
-                newChunk = TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered);
+                newChunk = TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered, _config.InitialReaderCount);
             }
 
             lock (_chunksLocker)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -159,7 +159,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                                      isScavenged: true,
                                                      inMem: _db.Config.InMemDb,
                                                      unbuffered: _db.Config.Unbuffered,
-                                                     writethrough: _db.Config.WriteThrough);
+                                                     writethrough: _db.Config.WriteThrough,
+                                                     initialReaderCount: _db.Config.InitialReaderCount);
             }
             catch (IOException exc)
             {

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -115,6 +115,9 @@ namespace EventStore.Core.Util
         public const string WriteThroughDescr = "Enables Write Through when writing to the file system, this bypasses filesystem caches.";
         public const bool WriteThroughDefault = false;
 
+        public const string ChunkInitialReaderCountDescr = "The initial number of readers to start when opening a TFChunk";
+        public const int ChunkInitialReaderCountDefault  = 5;
+
         public const string UnbufferedDescr = "Enables Unbuffered/DirectIO when writing to the file system, this bypasses filesystem caches.";
         public const bool UnbufferedDefault = false;
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -101,6 +101,7 @@ namespace EventStore.Core
         protected int _readerThreadsCount;
         protected bool _unbuffered;
         protected bool _writethrough;
+        protected int _chunkInitialReaderCount;
 
         protected string _index;
         protected bool _skipIndexVerify;
@@ -212,7 +213,7 @@ namespace EventStore.Core
             _unsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
             _alwaysKeepScavenged = Opts.AlwaysKeepScavengedDefault;
             _skipIndexScanOnReads = Opts.SkipIndexScanOnReadsDefault;
-
+            _chunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
             _projectionsQueryExpiry = TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault);
         }
 
@@ -1037,6 +1038,16 @@ namespace EventStore.Core
             return this;
         }
 
+        /// <summary>
+        /// Sets the initial number of readers to open per TFChunk
+        /// </summary>
+        /// <param name="chunkInitialReaderCount">The initial number of readers to open per TFChunk</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithChunkInitialReaderCount(int chunkInitialReaderCount)
+        {
+            _chunkInitialReaderCount = chunkInitialReaderCount;
+            return this;
+        }
 
         /// <summary>
         /// Sets the Server SSL Certificate
@@ -1313,6 +1324,7 @@ namespace EventStore.Core
                                        _inMemoryDb, 
                                        _unbuffered,
                                        _writethrough,
+                                       _chunkInitialReaderCount,
                                        _log);
             FileStreamExtensions.ConfigureFlush(disableFlushToDisk: _unsafeDisableFlushToDisk);
 
@@ -1368,6 +1380,7 @@ namespace EventStore.Core
                     _disableHTTPCaching,
                     _logHttpRequests,
                     _connectionPendingSendBytesThreshold,
+                    _chunkInitialReaderCount,
                     _index,
                     _enableHistograms,
                     _skipIndexVerify,
@@ -1422,6 +1435,7 @@ namespace EventStore.Core
                                                       bool inMemDb,
                                                       bool unbuffered,
                                                       bool writethrough,
+                                                      int chunkInitialReaderCount,
                                                       ILogger log)
         {
             ICheckpoint writerChk;
@@ -1491,6 +1505,7 @@ namespace EventStore.Core
                                                  epochChk,
                                                  truncateChk,
                                                  replicationChk,
+                                                 chunkInitialReaderCount,
                                                  inMemDb,
                                                  unbuffered,
                                                  writethrough);


### PR DESCRIPTION
Adds an option, `chunk-initial-reader-count` to allow the user to set the initial number of readers to open per TFChunk.
By default, 5 readers are opened initially per chunk. If this is on a large database with old chunks that may never be read, this can cause many unnecessary file streams to be open at startup.

Also changes the test helper, `TFChunkDbConfigHelper`, to just `TFChunkHelper` and includes a constructor for creating a new chunk.
This makes updating the constructors for `TFChunk` and `TFChunkDb` much easier, as most of the code using these constructors belonged to tests.

