### PR TITLE
Bug fix: Initial projection state was not set in the checkpoint manager

### DIFF
--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -571,7 +571,8 @@
     <Compile Include="Services\core_coordinator\when_stopping_with_projection_type_all.cs" />
     <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_none.cs" />
     <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_system.cs" />
-    <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_all.cs" />    
+    <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_all.cs" />
+    <Compile Include="Services\core_projection\when_stopping_a_projection_with_existing_state_without_updating_the_state.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_prerecording_event_order.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_prerecording_event_order.cs
@@ -47,7 +47,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
             _checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
             _manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
 
-            _manager.Start(CheckpointTag.FromStreamPositions(0, new Dictionary<string, long> { { "pa", -1 }, { "pb", -1 } }));
+            _manager.Start(CheckpointTag.FromStreamPositions(0, new Dictionary<string, long> { { "pa", -1 }, { "pb", -1 } }), null);
             _manager.RecordEventOrder(_event1, CheckpointTag.FromStreamPositions(0, new Dictionary<string, long>{{"pa", 1},{"pb", -1}}), committed: noop);
             _manager.RecordEventOrder(_event2, CheckpointTag.FromStreamPositions(0, new Dictionary<string, long>{{"pa", 1},{"pb", 1}}), committed: noop);
         }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_a_checkpoint_has_been_completed_and_requesting_checkpoint_to_stop.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_a_checkpoint_has_been_completed_and_requesting_checkpoint_to_stop.cs
@@ -31,7 +31,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
                 _checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
                 _manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
 
-                _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10));
+                _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10),null);
 //                _manager.StateUpdated("", @"{""state"":""state1""}");
                 _manager.EventProcessed(CheckpointTag.FromStreamPosition(0, "stream", 11), 77.7f);
 //                _manager.StateUpdated("", @"{""state"":""state2""}");

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_a_core_projection_checkpoint_manager_has_been_created.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_a_core_projection_checkpoint_manager_has_been_created.cs
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
         [Test]
         public void can_be_started()
         {
-            _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10));
+            _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10),null);
         }
 
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_a_default_checkpoint_manager_has_been_reinitialized.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_a_default_checkpoint_manager_has_been_reinitialized.cs
@@ -32,7 +32,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
                 _checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
                 _manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
 
-                _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10));
+                _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10),null);
 //                _manager.StateUpdated("", @"{""state"":""state1""}");
                 _manager.EventProcessed(CheckpointTag.FromStreamPosition(0, "stream", 11), 77.7f);
 //                _manager.StateUpdated("", @"{""state"":""state2""}");
@@ -87,7 +87,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
         [Test]
         public void can_be_started()
         {
-            _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10));
+            _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10),null);
         }
 
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_beginning_to_load_state_the_core_projection_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_beginning_to_load_state_the_core_projection_checkpoint_manager.cs
@@ -71,14 +71,14 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
         [Test]
         public void can_be_started()
         {
-            _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10));
+            _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10),null);
         }
 
         [Test]
         public void cannot_be_started_from_incompatible_checkpoint_tag()
         {
             //TODO: move to when loaded
-            Assert.Throws<InvalidOperationException>(()=> { _manager.Start(CheckpointTag.FromStreamPosition(0, "stream1", 10)); });
+            Assert.Throws<InvalidOperationException>(()=> { _manager.Start(CheckpointTag.FromStreamPosition(0, "stream1", 10),null); });
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_multiple_event_processed_received_the_core_projection_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_multiple_event_processed_received_the_core_projection_checkpoint_manager.cs
@@ -33,7 +33,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
                 _checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
                 _manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
 
-                _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10));
+                _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10),null);
 //                _manager.StateUpdated("", @"{""state"":""state1""}");
                 _manager.EventProcessed(CheckpointTag.FromStreamPosition(0, "stream", 11), 77.7f);
 //                _manager.StateUpdated("", @"{""state"":""state2""}");

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_starting_the_core_projection_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/when_starting_the_core_projection_checkpoint_manager.cs
@@ -30,7 +30,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
                 _checkpointWriter.StartFrom(checkpointLoaded.CheckpointTag, checkpointLoaded.CheckpointEventNumber);
                 _manager.BeginLoadPrerecordedEvents(checkpointLoaded.CheckpointTag);
 
-                _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10));
+                _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10),null);
             }
             catch (Exception ex)
             {
@@ -47,7 +47,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
         [Test]
         public void start_throws_invalid_operation_exception()
         {
-            Assert.Throws<InvalidOperationException>(()=> { _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10)); });
+            Assert.Throws<InvalidOperationException>(()=> { _manager.Start(CheckpointTag.FromStreamPosition(0, "stream", 10),null); });
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/multi_phase/specification_with_multi_phase_core_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/multi_phase/specification_with_multi_phase_core_projection.cs
@@ -261,7 +261,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.multi_phase
             {
             }
 
-            public void Start(CheckpointTag checkpointTag)
+            public void Start(CheckpointTag checkpointTag, PartitionState rootPartitionState)
             {
                 _started = true;
                 _startedAt = checkpointTag;

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_stopping_a_projection_with_existing_state_without_updating_the_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_stopping_a_projection_with_existing_state_without_updating_the_state.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Linq;
+using EventStore.Projections.Core.Messages;
+using NUnit.Framework;
+using EventStore.Projections.Core.Services;
+using ResolvedEvent = EventStore.Projections.Core.Services.Processing.ResolvedEvent;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Processing;
+using System.Text;
+using EventStore.Common.Utils;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection
+{
+    [TestFixture]
+    public class when_stopping_a_projection_with_existing_state_without_updating_the_state : TestFixtureWithCoreProjectionStarted
+    {
+        private string _testProjectionState = @"{""test"":1}";
+
+        protected override void Given()
+        {   
+            //write existing checkpoint
+            ExistingEvent(
+                "$projections-projection-checkpoint", ProjectionEventTypes.ProjectionCheckpoint,
+                @"{""c"": 100, ""p"": 50}", _testProjectionState);
+
+            AllWritesQueueUp();
+        }
+
+        protected override void When()
+        {
+            //force write of another checkpoint
+            _bus.Publish(
+                new EventReaderSubscriptionMessage.CheckpointSuggested(
+                    _subscriptionId, CheckpointTag.FromPosition(0, 160, 150), 77.7f, 0));
+
+            _coreProjection.Stop();
+        }
+
+        [Test]
+        public void a_projection_checkpoint_event_is_published()
+        {
+            AllWriteComplete();
+            Assert.AreEqual(
+                1,
+                _writeEventHandler.HandledMessages.Count(v => v.Events.Any(e => e.EventType == ProjectionEventTypes.ProjectionCheckpoint)));
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<CoreProjectionStatusMessage.Stopped>().Count());
+        }
+
+        [Test]
+        public void previous_state_is_saved_in_checkpoint_event()
+        {
+            AllWriteComplete();
+            Assert.AreEqual(
+                1,
+                _writeEventHandler.HandledMessages.Count(
+                    v => v.Events.Any(
+                        e => e.EventType == ProjectionEventTypes.ProjectionCheckpoint
+                        && Helper.UTF8NoBom.GetString(e.Data).Equals("["+_testProjectionState+"]")
+                    )
+                )
+            );
+        }
+
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjection.cs
@@ -123,7 +123,7 @@ namespace EventStore.Projections.Core.Services.Processing
 
             _projectionProcessingPhases = projectionProcessingStrategy.CreateProcessingPhases(
                 publisher,
-                inputQueue, 
+                inputQueue,
                 projectionCorrelationId,
                 partitionStateCache,
                 UpdateStatistics,
@@ -146,14 +146,14 @@ namespace EventStore.Projections.Core.Services.Processing
             GoToState(State.Initial);
         }
 
-        private void BeginPhase(IProjectionProcessingPhase processingPhase, CheckpointTag startFrom)
+        private void BeginPhase(IProjectionProcessingPhase processingPhase, CheckpointTag startFrom, PartitionState rootPartitionState)
         {
             _projectionProcessingPhase = processingPhase;
             _projectionProcessingPhase.SetProjectionState(PhaseState.Starting);
             _checkpointManager = processingPhase.CheckpointManager;
 
              _projectionProcessingPhase.InitializeFromCheckpoint(startFrom);
-            _checkpointManager.Start(startFrom);
+            _checkpointManager.Start(startFrom,rootPartitionState);
         }
 
         private void UpdateStatistics()
@@ -222,14 +222,14 @@ namespace EventStore.Projections.Core.Services.Processing
             {
                 info.Progress = -2.0f;
             }
-            info.Status = _state.EnumValueName() + info.Status; 
+            info.Status = _state.EnumValueName() + info.Status;
             info.Name = _name;
             info.EffectiveName = _name;
             info.ProjectionId = _version.ProjectionId;
             info.Epoch = _version.Epoch;
             info.Version = _version.Version;
             info.StateReason = "";
-            info.BufferedEvents = 0; 
+            info.BufferedEvents = 0;
             info.PartitionsCached = _partitionStateCache.CachedItemCount;
             _enrichStatistics(info);
             if (_projectionProcessingPhase != null)
@@ -301,9 +301,13 @@ namespace EventStore.Projections.Core.Services.Processing
                 //TODO: write test to ensure projection state is correctly loaded from a checkpoint and posted back when enough empty records processed
                 //TODO: handle errors
                 _coreProjectionCheckpointWriter.StartFrom(checkpointTag, message.CheckpointEventNumber);
-                if (_requiresRootPartition)
-                    _partitionStateCache.CacheAndLockPartitionState("", PartitionState.Deserialize(message.CheckpointData, checkpointTag), null);
-                BeginPhase(projectionProcessingPhase, checkpointTag);
+
+                PartitionState rootPartitionState = null;
+                if (_requiresRootPartition){
+                    rootPartitionState = PartitionState.Deserialize(message.CheckpointData, checkpointTag);
+                    _partitionStateCache.CacheAndLockPartitionState("", rootPartitionState, null);
+                }
+                BeginPhase(projectionProcessingPhase, checkpointTag, rootPartitionState);
                 GoToState(State.StateLoaded);
                 if (_startOnLoad)
                 {
@@ -350,10 +354,10 @@ namespace EventStore.Projections.Core.Services.Processing
             //
             CompleteCheckpointSuggestedWorkItem();
             EnsureUnsubscribed();
-            StopSlaveProjections(); 
+            StopSlaveProjections();
             GoToState(State.Initial);
             Start();
-            
+
         }
 
         public void Handle(CoreProjectionProcessingMessage.Failed message)
@@ -573,7 +577,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private void EnterStopped()
         {
             EnsureUnsubscribed();
-            StopSlaveProjections(); 
+            StopSlaveProjections();
             _publisher.Publish(new CoreProjectionStatusMessage.Stopped(_projectionCorrelationId, _name, _completed));
         }
 
@@ -585,7 +589,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private void EnterFaulted()
         {
             EnsureUnsubscribed();
-            StopSlaveProjections(); 
+            StopSlaveProjections();
             _publisher.Publish(
                 new CoreProjectionStatusMessage.Faulted(_projectionCorrelationId, _faultedReason));
         }
@@ -605,7 +609,7 @@ namespace EventStore.Projections.Core.Services.Processing
             {
                 var nextPhase = _projectionProcessingPhases[completedPhaseIndex + 1];
                 var nextPhaseZeroPosition = nextPhase.MakeZeroCheckpointTag();
-                BeginPhase(nextPhase, nextPhaseZeroPosition);
+                BeginPhase(nextPhase, nextPhaseZeroPosition,null);
                 if (_slaveProjections != null)
                     _projectionProcessingPhase.AssignSlaves(_slaveProjections);
                 _projectionProcessingPhase.Subscribe(nextPhaseZeroPosition, fromCheckpoint: false);
@@ -661,7 +665,7 @@ namespace EventStore.Projections.Core.Services.Processing
         public void EnsureTickPending()
         {
             // ticks are requested when an async operation is completed or when an item is being processed
-            // thus, the tick message is removed from the queue when it does not process any work item (and 
+            // thus, the tick message is removed from the queue when it does not process any work item (and
             // it is renewed therefore)
             if (_tickPending)
                 return;
@@ -694,7 +698,7 @@ namespace EventStore.Projections.Core.Services.Processing
         private void CheckpointCompleted(CheckpointTag lastCompletedCheckpointPosition)
         {
             CompleteCheckpointSuggestedWorkItem();
-            // all emitted events caused by events before the checkpoint position have been written  
+            // all emitted events caused by events before the checkpoint position have been written
             // unlock states, so the cache can be clean up as they can now be safely reloaded from the ES
             _partitionStateCache.Unlock(lastCompletedCheckpointPosition);
 
@@ -726,7 +730,7 @@ namespace EventStore.Projections.Core.Services.Processing
             var workItem = _checkpointSuggestedWorkItem;
             if (workItem != null)
             {
-                _checkpointSuggestedWorkItem = null; 
+                _checkpointSuggestedWorkItem = null;
                 workItem.CheckpointCompleted();
                 EnsureTickPending();
             }

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointManager.cs
@@ -101,12 +101,16 @@ namespace EventStore.Projections.Core.Services.Processing
 
         }
 
-        public virtual void Start(CheckpointTag checkpointTag)
+        public virtual void Start(CheckpointTag checkpointTag, PartitionState rootPartitionState)
         {
             Contract.Requires(_currentCheckpoint == null);
             if (_started)
                 throw new InvalidOperationException("Already started");
             _started = true;
+
+            if(rootPartitionState != null)
+                _currentProjectionState = rootPartitionState;
+
             _lastProcessedEventPosition.UpdateByCheckpointTagInitial(checkpointTag);
             _lastProcessedEventProgress = -1;
             _lastCompletedCheckpointPosition = checkpointTag;

--- a/src/EventStore.Projections.Core/Services/Processing/ICoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ICoreProjectionCheckpointManager.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Services.Processing
     public interface ICoreProjectionCheckpointManager
     {
         void Initialize();
-        void Start(CheckpointTag checkpointTag);
+        void Start(CheckpointTag checkpointTag,PartitionState rootPartitionState);
         void Stopping();
         void Stopped();
         void GetStatistics(ProjectionStatistics info);

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
@@ -42,9 +42,9 @@ namespace EventStore.Projections.Core.Services.Processing
             _orderStream = null;
         }
 
-        public override void Start(CheckpointTag checkpointTag)
+        public override void Start(CheckpointTag checkpointTag, PartitionState rootPartitionState)
         {
-            base.Start(checkpointTag);
+            base.Start(checkpointTag,rootPartitionState);
             _orderStream = CreateOrderStream(checkpointTag);
             _orderStream.Start();
         }

--- a/src/EventStore.Projections.Core/Services/Processing/NoopCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/NoopCheckpointManager.cs
@@ -59,7 +59,7 @@ namespace EventStore.Projections.Core.Services.Processing
             _stopped = false;
         }
 
-        public void Start(CheckpointTag checkpointTag)
+        public void Start(CheckpointTag checkpointTag, PartitionState rootPartitionState)
         {
             if (_started)
                 throw new InvalidOperationException("Already started");


### PR DESCRIPTION
Fixes #1517 

**Issue:**
Initial state (root partition) of a projection was not being set in the checkpoint manager.
If a projection processes enough events to create a checkpoint without updating the state, the previous state is lost.

**Reproduction Steps:**

```
1. Create a projection named test:
fromStream('x')
.when({
    '$init':function(){
      return {state: 0};
    },
    '$any':function(s,e){
        if(s.state==0){
            s.state = new Date();
        }
    }
})
2. Stop the projection and edit the config, set the max checkpoint threshold to a small value (3 for example)

3. Write a few events (e.g. 10) to stream 'x'

4. Stop the projection, check $projections-test-checkpoint, there should be two events with data containing the state : [{"state":"2017-12-12T11:23:36.512Z"},{"state":"2017-12-12T11:23:36.512Z"}]

5. Start the projection again

6. Write a few more events to trigger another checkpoint.

7. Check $projections-test-checkpoint again, the newly generated checkpoint's data should be : []

8. Stop the projection and start it again

9. Write a few events

10. Check $projections-test-checkpoint again. The previous state is lost and the newly generated checkpoint's data should have different dates : [{"state":"2017-12-12T11:25:43.655Z"},{"state":"2017-12-12T11:25:43.655Z"}]
```

**Resolution:**
Pass the root partition state to the checkpoint manager when loading the checkpoint.