### PR TITLE
Set MaxDiscoverAttempts for KeepReconnecting

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -180,6 +180,7 @@ namespace EventStore.ClientAPI
         public ConnectionSettingsBuilder KeepReconnecting()
         {
             _maxReconnections = -1;
+            _maxDiscoverAttempts = -1;
             return this;
         }
 


### PR DESCRIPTION
Currently, `MaxDiscoverAttempts` doesn't have a value that matches `KeepReconnecting` (-1)
This sets the values to match.

fixes #1478