### PR TITLE
Additional fixes for MonoPosixHelper

### DIFF
--- a/scripts/package-mono/package-linux.sh
+++ b/scripts/package-mono/package-linux.sh
@@ -99,6 +99,9 @@ mkdir "$PACKAGEDIRECTORY"
 
 pushd "$SCRIPTDIR/../../bin/clusternode/"
 
+# Update the global DllMap config file to avoid a hard coded location for libMonoPosixHelper
+sed -i '/libMonoPosixHelper\.so/c\\	<dllmap dll=\"MonoPosixHelper\" target=\"libMonoPosixHelper\.so\" os=\"!windows\" \/\>' "$MONOCONFIG"
+
 # There is an issue with mkbundled packages in mono
 # https://bugzilla.xamarin.com/show_bug.cgi?id=33483
 # https://bugzilla.xamarin.com/show_bug.cgi?id=42735
@@ -107,8 +110,6 @@ pushd "$SCRIPTDIR/../../bin/clusternode/"
 # The fix for now would be to just remove this prefix path
 cp "$MONOCONFIG" "$MONOCONFIG.custom"
 sed -e 's/$mono_libdir\///g' -i "$MONOCONFIG.custom"
-# Update the DllMap config file to avoid a hard coded location for libMonoPosixHelper
-sed -i '/libMonoPosixHelper\.dylib/c\\<dllmap dll=\"MonoPosixHelper\" target=\"libMonoPosixHelper\.dylib\" os=\"!windows\" \/\>' "$MONOCONFIG.custom"
 MONOCONFIG="$MONOCONFIG.custom"
 
 # mkbundle -c -o clusternode.c -oo clusternode.a \


### PR DESCRIPTION
- Change .dylib extension to .so for linux
- Update global config Dllmap for `MonoPosixHelper` instead of only for the current assembly:
GzipStream/DeflateStream (requiring MonoPosixHelper) in System.IO.Compression is present in the System.dll assembly, not the EventStore.ClusterNode.exe assembly. Thus adding the `dllmap` to `config.custom` and using it with `mkbundle` does not have any effect. There are two ways around this:
  - Update the dll map in the global mono config (/etc/mono/config) (current solution proposed in this PR)
  - Add a `System.dll.config` file with the dllmap configuration in the same folder as the `System.dll` file (more complex: we need to locate the file in the GAC + we would need to do this for all assemblies requiring `MonoPosixHelper`)

