### PR TITLE
AsyncWrapper Log fix

### DIFF
--- a/src/EventStore.Common/Log/log.config
+++ b/src/EventStore.Common/Log/log.config
@@ -8,26 +8,36 @@
   <variable name="VerboseLayout" value="[PID:${processid:padCharacter=0:padding=5}:${threadid:padCharacter=0:padding=3} ${date:universalTime=true:format=yyyy\.MM\.dd HH\:mm\:ss\.fff} ${level:padding=-5:uppercase=true} ${logger:padding=-20:fixedLength=true}] ${message}${onexception:${newline}EXCEPTION OCCURRED:${newline}${exception:format=tostring:innerFormat=tostring:maxInnerExceptionLevel=20}}"/>
   <variable name="ConsoleLayout" value="[${processid:padCharacter=0:padding=5},${threadid:padCharacter=0:padding=2},${date:universalTime=true:format=HH\:mm\:ss\.fff}] ${message}${onexception:${newline}EXCEPTION OCCURRED:${newline}${exception:format=message}}"/>
   <variable name="LogFileNameBase" value="${logsdir}/${shortdate:universalTime=true}/${environment:variable=EVENTSTORE_INT-COMPONENT-NAME}"/>
-  
-  <targets async="true">
-    <target name="fileLog" xsi:type="File" fileName="${LogFileNameBase}.log" layout="${VerboseLayout}"/>
-   
-    <target name="errorFileLog" xsi:type="FilteringWrapper" condition="length('${exception}')>0 || level==LogLevel.Error || level==LogLevel.Fatal">
-      <target xsi:type="File" fileName="${LogFileNameBase}-err.log" layout="${VerboseLayout}"/>
+
+  <targets>
+    <target name="asyncWrapper" xsi:Type="AsyncWrapper" overflowAction="Grow">
+      <target name="fileLog" xsi:type="File" fileName="${LogFileNameBase}.log" layout="${VerboseLayout}"/>
     </target>
-    
-    <target name="coloredConsoleLog" xsi:type="ColoredConsole" layout="${ConsoleLayout}" useDefaultRowHighlightingRules="true">
-      <highlight-row condition="level == LogLevel.Info" foregroundColor="Green" backgroundColor="NoChange"/>
+
+    <target name="asyncWrapper" xsi:Type="AsyncWrapper" overflowAction="Grow">
+      <target name="errorFileLog" xsi:type="FilteringWrapper" condition="length('${exception}')>0 || level==LogLevel.Error || level==LogLevel.Fatal">
+        <target xsi:type="File" fileName="${LogFileNameBase}-err.log" layout="${VerboseLayout}"/>
+      </target>
     </target>
-    
-    <target name="plainConsoleLog" xsi:type="Console" layout="${ConsoleLayout}"/>
-    
-    <target name="statsFileLog" xsi:type="File" fileName="${LogFileNameBase}-stats.csv" layout="${message}"/>
+
+    <target name="asyncWrapper" xsi:Type="AsyncWrapper" overflowAction="Grow">
+      <target name="coloredConsoleLog" xsi:type="ColoredConsole" layout="${ConsoleLayout}" useDefaultRowHighlightingRules="true">
+        <highlight-row condition="level == LogLevel.Info" foregroundColor="Green" backgroundColor="NoChange"/>
+      </target>
+    </target>
+
+    <target name="asyncWrapper" xsi:Type="AsyncWrapper" overflowAction="Grow">
+      <target name="plainConsoleLog" xsi:type="Console" layout="${ConsoleLayout}"/>
+    </target>
+
+    <target name="asyncWrapper" xsi:Type="AsyncWrapper" overflowAction="Grow">
+      <target name="statsFileLog" xsi:type="File" fileName="${LogFileNameBase}-stats.csv" layout="${message}"/>
+    </target>
   </targets>
 
   <rules>
     <logger name="REGULAR-STATS-LOGGER" minlevel="Trace" writeTo="statsFileLog" final="true" />
-    
+
     <logger name="*" minlevel="Trace" writeTo="fileLog, errorFileLog"/>
 
     <logger name="*" minlevel="Trace" writeTo="plainConsoleLog">
@@ -40,6 +50,6 @@
         <when condition="is-mono()" action="Ignore"/>
       </filters>
     </logger>
-   
+
   </rules>
 </nlog>


### PR DESCRIPTION
Log fix based on [https://github.com/nlog/NLog/wiki/AsyncWrapper-target#async-attribute-will-discard-by-default](https://github.com/nlog/NLog/wiki/AsyncWrapper-target#async-attribute-will-discard-by-default)
async="true" will Discard items by default when the queue overflows