### PR TITLE
Optimize existAt calls on scavenged chunks using bloom filters for faster index merges

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -210,6 +210,9 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.IndexCacheDepthDescr, Opts.DbGroup)]
         public int IndexCacheDepth { get; set; }
 
+        [ArgDescription(Opts.OptimizeIndexMergeDescr, Opts.DbGroup)]
+        public bool OptimizeIndexMerge { get; set; }
+
         [ArgDescription(Opts.GossipIntervalMsDescr, Opts.ClusterGroup)]
         public int GossipIntervalMs { get; set; }
         [ArgDescription(Opts.GossipAllowedDifferenceMsDescr, Opts.ClusterGroup)]
@@ -328,6 +331,7 @@ namespace EventStore.ClusterNode
             GossipTimeoutMs = Opts.GossipTimeoutMsDefault;
             IndexCacheDepth = Opts.IndexCacheDepthDefault;
             SkipIndexVerify = Opts.SkipIndexVerifyDefault;
+            OptimizeIndexMerge = Opts.OptimizeIndexMergeDefault;
             EnableHistograms = Opts.HistogramEnabledDefault;
             ReaderThreadsCount = Opts.ReaderThreadsCountDefault;
 

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -200,6 +200,7 @@ namespace EventStore.ClusterNode
                         .WithIndexPath(options.Index)
                         .WithIndexVerification(options.SkipIndexVerify)
                         .WithIndexCacheDepth(options.IndexCacheDepth)
+                        .WithIndexMergeOptimization(options.OptimizeIndexMerge)
                         .WithSslTargetHost(options.SslTargetHost)
                         .RunProjections(options.RunProjections, options.ProjectionThreads)
                         .WithProjectionQueryExpirationOf(TimeSpan.FromMinutes(options.ProjectionsQueryExpiry))

--- a/src/EventStore.Core.Tests/DataStructures/bloom_filter_should.cs
+++ b/src/EventStore.Core.Tests/DataStructures/bloom_filter_should.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Core.DataStructures;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.DataStructures
+{
+    [TestFixture]
+    public class bloom_filter_should
+    {
+        [Test]
+        public void always_return_true_if_an_item_was_added()
+        {
+            for(int n=1;n<=1000;n++){
+                for(double p=0.1;p>1.0e-7;p/=10.0){
+                    BloomFilter filter = new BloomFilter(n,p);
+
+                    //no items added yet
+                    for(int i=0;i<=n;i++){
+                        Assert.IsFalse(filter.MayExist(i));
+                    }
+
+                    //add the items
+                    for(int i=0;i<=n;i++){
+                        filter.Add(i);
+                    }
+
+                    //all the items should exist
+                    for(int i=0;i<=n;i++){
+                        Assert.IsTrue(filter.MayExist(i));
+                    }
+                }
+            }
+        }
+
+        [Test, Category("LongRunning")]
+        public void always_return_true_if_an_item_was_added_for_large_n()
+        {
+            int n = 1234567;
+            double p = 1.0e-6;
+
+            BloomFilter filter = new BloomFilter(n,p);
+
+            //no items added yet
+            for(int i=0;i<=n;i++){
+                Assert.IsFalse(filter.MayExist(i));
+            }
+
+            //add the items
+            for(int i=0;i<=n;i++){
+                filter.Add(i);
+            }
+
+            //all the items should exist
+            for(int i=0;i<=n;i++){
+                Assert.IsTrue(filter.MayExist(i));
+            }
+        }
+
+        [Test]
+        public void support_adding_large_values()
+        {
+            int n = 1234567;
+            double p = 1.0e-6;
+
+            BloomFilter filter = new BloomFilter(n,p);
+            long[] items = {192389123812L,286928492L,27582928698L,72669175482L,1738996371L,939342020387L,37253255484L,346536436L,123921398432L,8324982394329432L,183874782348723874L, long.MaxValue};
+
+            //no items added yet
+            for(int i=0;i<items.Length;i++){
+                Assert.IsFalse(filter.MayExist(items[i]));
+            }
+
+            //add the items
+            for(int i=0;i<items.Length;i++){
+                filter.Add(items[i]);
+            }
+
+            //all the items should exist
+            for(int i=0;i<items.Length;i++){
+                Assert.IsTrue(filter.MayExist(items[i]));
+            }
+
+            //all the neighbouring items should probably not exist
+            for(int i=0;i<items.Length;i++){
+                Assert.IsFalse(filter.MayExist(items[i]-1));
+                Assert.IsFalse(filter.MayExist(items[i]+1));
+            }
+        }
+
+        [Test]
+        public void have_false_positives_with_probability_p()
+        {
+            for(int n=1;n<=1000;n++){
+                for(double p=0.1;p>1.0e-7;p/=10.0){
+                    BloomFilter filter = new BloomFilter(n,p);
+
+                    //add only odd numbers
+                    for(int i=1;i<=n;i+=2){
+                        filter.Add(i);
+                    }
+
+                    //expected number of false positives
+                    int expectedFalsePositives = (int) Math.Ceiling(n * p / 2.0);
+
+                    //none of these items should exist but there may be some false positives
+                    int falsePositives = 0;
+                    for(int i=2;i<=n;i+=2){
+                        if(filter.MayExist(i)){
+                            falsePositives++;
+                        }
+                    }
+
+                    if(falsePositives>0)
+                        Console.Out.WriteLine("n: {0}, p:{1}. Found {2} false positives. Expected false positives: {3}", n, p, falsePositives, expectedFalsePositives);
+
+                    Assert.LessOrEqual(falsePositives, expectedFalsePositives);
+                }
+            }
+        }
+
+        [Test]
+        public void have_false_positives_with_probability_p_for_large_n()
+        {
+            int n = 1234567;
+
+            for(double p=0.1;p>1.0e-7;p/=10.0){
+                BloomFilter filter = new BloomFilter(n,p);
+
+                //add only odd numbers
+                for(int i=1;i<=n;i+=2){
+                    filter.Add(i);
+                }
+
+                //expected number of false positives
+                int expectedFalsePositives = (int) Math.Ceiling(n * p / 2.0);
+
+                //none of these items should exist but there may be some false positives
+                int falsePositives = 0;
+                for(int i=2;i<=n;i+=2){
+                    if(filter.MayExist(i)){
+                        falsePositives++;
+                    }
+                }
+
+                if(falsePositives>0)
+                    Console.Out.WriteLine("n: {0}, p:{1}. Found {2} false positives. Expected false positives: {3}", n, p, falsePositives, expectedFalsePositives);
+                Assert.LessOrEqual(falsePositives, expectedFalsePositives);
+            }
+        }
+
+        [Test]
+        public void throw_argumentoutofrangeexception_when_given_non_positive_n()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter(0, 0.1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter(-1, 0.1));
+        }
+
+        [Test]
+        public void throw_argumentoutofrangeexception_when_given_non_positive_p()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter(1, 0.0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter(1, -0.1));
+        }
+
+        [Test]
+        public void throw_argumentoutofrangeexception_when_number_of_bits_too_large()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => new BloomFilter(123456789, 0.0000000001));
+        }
+
+        [Test]
+        public void correctly_convert_long_to_bytes()
+        {
+            for(long i=-1000;i<=1000;i++){
+                byte[] bytes = BloomFilter.toBytes(i);
+                Assert.AreEqual(8, bytes.Length);
+                long v = 0;
+
+                for(int j=7;j>=0;j--){
+                    v <<= 8;
+                    v |= bytes[j];
+                }
+                Assert.AreEqual(i, v);
+            }
+
+            long [] nums = { long.MaxValue, long.MinValue, 0, 192389123812L,286928492L,27582928698L,72669175482L,1738996371L,939342020387L,37253255484L,346536436L,123921398432L,8324982394329432L,183874782348723874L};
+            for(long i=0;i<nums.Length;i++){
+                byte[] bytes = BloomFilter.toBytes(nums[i]);
+                Assert.AreEqual(8, bytes.Length);
+                long v = 0;
+                for(int j=7;j>=0;j--){
+                    v <<= 8;
+                    v |= bytes[j];
+                }
+                Assert.AreEqual(nums[i], v);
+            }
+        }
+
+    }
+}

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -654,6 +654,8 @@
     <Compile Include="Services\Replication\CommitReplication\with_index_committer_service.cs" />
     <Compile Include="Services\Replication\CommitReplication\when_single_node_cluster_receives_commit_ack_for_multiple_prepares.cs" />
     <Compile Include="Services\Replication\CommitReplication\when_constructing_index_committer_service.cs" />
+    <Compile Include="DataStructures\bloom_filter_should.cs" />
+    <Compile Include="TransactionLog\Optimization\tfchunkreader_existsat_optimizer_should.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj">

--- a/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Optimization
+{
+    [TestFixture]
+    public class tfchunkreader_existsat_optimizer_should: SpecificationWithDirectoryPerTestFixture
+    {
+        [Test]
+        public void have_a_single_instance()
+        {
+            var instance1 = TFChunkReaderExistsAtOptimizer.Instance;
+            var instance2 = TFChunkReaderExistsAtOptimizer.Instance;
+            Assert.AreEqual(instance1, instance2);
+        }
+
+        [Test]
+        public void optimize_only_maxcached_items_at_a_time()
+        {
+            int maxCached = 3;
+            List<TFChunk> chunks = new List<TFChunk>();
+            TFChunkReaderExistsAtOptimizer _existsAtOptimizer = new TFChunkReaderExistsAtOptimizer(maxCached);
+
+            for(int i=0;i<7;i++){
+                var chunk = CreateChunk(i, true);
+                chunks.Add(chunk);
+                Assert.IsFalse(_existsAtOptimizer.IsOptimized(chunk));
+                _existsAtOptimizer.Optimize(chunk);
+            }
+
+
+            //only the last maxCached chunks should still be optimized
+            int cached = maxCached;
+            for(int i=7-1;i>=0;i--){
+                if(cached > 0){
+                    Assert.AreEqual(true, _existsAtOptimizer.IsOptimized(chunks[i]));
+                    cached--;
+                }
+                else{
+                    Assert.AreEqual(false, _existsAtOptimizer.IsOptimized(chunks[i]));
+                }
+            }
+
+            foreach(var chunk in chunks){
+                chunk.MarkForDeletion();
+                chunk.WaitForDestroy(5000);
+            }
+        }
+
+        [Test]
+        public void optimize_only_scavenged_chunks()
+        {
+            TFChunkReaderExistsAtOptimizer _existsAtOptimizer = new TFChunkReaderExistsAtOptimizer(3);
+            var chunk = CreateChunk(0, false);
+            _existsAtOptimizer.Optimize(chunk);
+            Assert.AreEqual(false, _existsAtOptimizer.IsOptimized(chunk));
+
+            chunk.MarkForDeletion();
+            chunk.WaitForDestroy(5000);
+        }
+
+        [Test]
+        public void posmap_items_should_exist_in_chunk()
+        {
+            TFChunkReaderExistsAtOptimizer _existsAtOptimizer = new TFChunkReaderExistsAtOptimizer(3);
+            List<PosMap> posmap;
+            var chunk = CreateChunk(0, true, out posmap);
+
+            //before optimization
+            Assert.AreEqual(false, _existsAtOptimizer.IsOptimized(chunk));
+            foreach(var p in posmap){
+                Assert.AreEqual(true, chunk.ExistsAt(p.LogPos));
+            }
+
+            //after optimization
+            _existsAtOptimizer.Optimize(chunk);
+            Assert.AreEqual(true, _existsAtOptimizer.IsOptimized(chunk));
+            foreach(var p in posmap){
+                Assert.AreEqual(true, chunk.ExistsAt(p.LogPos));
+            }
+
+            chunk.MarkForDeletion();
+            chunk.WaitForDestroy(5000);
+        }
+
+        private TFChunk CreateChunk(int chunkNumber, bool scavenged){
+            List<PosMap> posmap;
+            return CreateChunk(chunkNumber, scavenged, out posmap);
+        }
+
+        private TFChunk CreateChunk(int chunkNumber, bool scavenged, out List<PosMap> posmap){
+            var map = new List<PosMap>();
+            var chunk = TFChunk.CreateNew(GetFilePathFor("chunk-"+chunkNumber+"-"+Guid.NewGuid()), 1024*1024, chunkNumber, chunkNumber, scavenged, false, false, false, 5);
+            long offset = chunkNumber * 1024 * 1024;
+            long logPos = 0 + offset;
+            for (int i = 0, n = ChunkFooter.Size/PosMap.FullSize + 1; i < n; ++i)
+            {
+                if(scavenged)
+                    map.Add(new PosMap(logPos, (int)logPos));
+
+                var res = chunk.TryAppend(LogRecord.Commit(logPos, Guid.NewGuid(), logPos, 0));
+                Assert.IsTrue(res.Success);
+                logPos = res.NewPosition + offset;
+            }
+
+            if(scavenged){
+                posmap = map;
+                chunk.CompleteScavenge(map);
+            }
+            else{
+                posmap = null;
+                chunk.Complete();
+            }
+            return chunk;
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog
             var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
 
-            var chaser = new TFChunkChaser(db, writerchk, new InMemoryCheckpoint());
+            var chaser = new TFChunkChaser(db, writerchk, new InMemoryCheckpoint(), false);
             chaser.Open();
 
             LogRecord record;
@@ -45,7 +45,7 @@ namespace EventStore.Core.Tests.TransactionLog
             chaserchk.Write(12);
             chaserchk.Flush();
 
-            var chaser = new TFChunkChaser(db, writerchk, chaserchk);
+            var chaser = new TFChunkChaser(db, writerchk, chaserchk, false);
             chaser.Open();
 
             LogRecord record;
@@ -87,7 +87,7 @@ namespace EventStore.Core.Tests.TransactionLog
             var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, writerchk, chaserchk));
             db.Open();
 
-            var chaser = new TFChunkChaser(db, writerchk, chaserchk);
+            var chaser = new TFChunkChaser(db, writerchk, chaserchk, false);
             chaser.Open();
 
             LogRecord record;
@@ -131,7 +131,7 @@ namespace EventStore.Core.Tests.TransactionLog
 
             writerchk.Write(recordToWrite.GetSizeWithLengthPrefixAndSuffix());
 
-            var reader = new TFChunkChaser(db, writerchk, chaserchk);
+            var reader = new TFChunkChaser(db, writerchk, chaserchk, false);
             reader.Open();
 
             LogRecord record;
@@ -173,7 +173,7 @@ namespace EventStore.Core.Tests.TransactionLog
 
             writerchk.Write(recordToWrite.GetSizeWithLengthPrefixAndSuffix());
 
-            var chaser = new TFChunkChaser(db, writerchk, chaserchk);
+            var chaser = new TFChunkChaser(db, writerchk, chaserchk, false);
             chaser.Open();
 
             LogRecord record;

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_chaser.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_chunked_transaction_chaser.cs
@@ -15,21 +15,21 @@ namespace EventStore.Core.Tests.TransactionLog
         public void a_null_file_config_throws_argument_null_exception()
         {
             Assert.Throws<ArgumentNullException>(
-                () => new TFChunkChaser(null, new InMemoryCheckpoint(0), new InMemoryCheckpoint(0)));
+                () => new TFChunkChaser(null, new InMemoryCheckpoint(0), new InMemoryCheckpoint(0), false));
         }
 
         [Test]
         public void a_null_writer_checksum_throws_argument_null_exception()
         {
             var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
-            Assert.Throws<ArgumentNullException>(() => new TFChunkChaser(db, null, new InMemoryCheckpoint()));
+            Assert.Throws<ArgumentNullException>(() => new TFChunkChaser(db, null, new InMemoryCheckpoint(), false));
         }
 
         [Test]
         public void a_null_chaser_checksum_throws_argument_null_exception()
         {
             var db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
-            Assert.Throws<ArgumentNullException>(() => new TFChunkChaser(db, new InMemoryCheckpoint(), null));
+            Assert.Throws<ArgumentNullException>(() => new TFChunkChaser(db, new InMemoryCheckpoint(), null, false));
         }
     }
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
@@ -46,7 +46,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void the_data_is_written()
         {
-            using (var reader = new TFChunkChaser(_db, _writerCheckpoint, _db.Config.ChaserCheckpoint))
+            using (var reader = new TFChunkChaser(_db, _writerCheckpoint, _db.Config.ChaserCheckpoint, false))
             {
                 reader.Open();
                 LogRecord r;

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
@@ -55,7 +55,7 @@ namespace EventStore.Core.Tests.TransactionLog
         public void the_data_is_written()
         {
             //TODO MAKE THIS ACTUALLY ASSERT OFF THE FILE AND READER FROM KNOWN FILE
-            using (var reader = new TFChunkChaser(_db, _writerCheckpoint, _db.Config.ChaserCheckpoint))
+            using (var reader = new TFChunkChaser(_db, _writerCheckpoint, _db.Config.ChaserCheckpoint, false))
             {
                 reader.Open();
                 LogRecord r;

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -67,6 +67,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly bool SkipIndexVerify;
         public readonly int IndexCacheDepth;
         public readonly byte IndexBitnessVersion;
+        public readonly bool OptimizeIndexMerge;
         public readonly int ChunkInitialReaderCount;
 
         public readonly bool BetterOrdering;
@@ -132,6 +133,7 @@ namespace EventStore.Core.Cluster.Settings
                                     bool skipIndexVerify = false,
                                     int indexCacheDepth = 16,
                                     byte indexBitnessVersion = 4,
+                                    bool optimizeIndexMerge = false,
                                     IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null,
                                     bool unsafeIgnoreHardDeletes = false,
                                     bool betterOrdering = false,
@@ -224,6 +226,7 @@ namespace EventStore.Core.Cluster.Settings
             SkipIndexVerify = skipIndexVerify;
             IndexCacheDepth = indexCacheDepth;
             IndexBitnessVersion = indexBitnessVersion;
+            OptimizeIndexMerge = optimizeIndexMerge;
             Index = index;
             UnsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
             BetterOrdering = betterOrdering;

--- a/src/EventStore.Core/DataStructures/BloomFilter.cs
+++ b/src/EventStore.Core/DataStructures/BloomFilter.cs
@@ -1,0 +1,85 @@
+using System;
+using EventStore.Common.Utils;
+using EventStore.Core.Index.Hashes;
+
+namespace EventStore.Core.DataStructures
+{
+    public class BloomFilter
+    {
+        /*
+            Bloom filter implementation based on the following paper by Adam Kirsch and Michael Mitzenmacher:
+            "Less Hashing, Same Performance: Building a Better Bloom Filter"
+            https://www.eecs.harvard.edu/~michaelm/postscripts/rsa2008.pdf
+
+            Only two 32-bit hash functions can be used to simulate additional hash functions of the form g(x) = h1(x) + i*h2(x)
+        */
+        int m; //number of bits
+        int k; //number of hash functions
+        ulong []bits; //bit array
+        const int LONG_SIZE = sizeof(long); //64 bits
+        public int NumBits { get {return m; }}
+        public int NumHashFunctions { get {return k; }}
+        private static IHasher hasher1 = new XXHashUnsafe(), hasher2 = new Murmur3AUnsafe();
+
+        public BloomFilter(int n, double p){
+            Ensure.Positive(n,"n");
+            if(p<=0.0 || p>=0.5)
+                throw new ArgumentOutOfRangeException("p", "p should be between 0 and 0.5 exclusive");
+
+            //calculate number of hash functions to use
+            k = (int) Math.Ceiling(- Math.Log(p) / Math.Log(2));
+            k = Math.Max(2, k);
+
+            //calculate number of bits required
+            long m = (long) Math.Ceiling(- n * Math.Log(p) / Math.Log(2) / Math.Log(2));
+            long buckets = m / LONG_SIZE;
+            if(m % LONG_SIZE != 0) buckets++;
+            if(m > Int32.MaxValue) {
+                throw new ArgumentOutOfRangeException("p", "calculated number of bits, m, is too large: "+m+". please choose a larger value of p.");
+            }
+            this.m = (int) m;
+            bits = new ulong[ buckets ];
+        }
+
+        public void Add(long item){
+            byte[] bytes = toBytes(item);
+            int hash1 = (int)hasher1.Hash(bytes);
+            int hash2 = (int)hasher2.Hash(bytes);
+
+            int hash = hash1;
+            for(int i=0;i<k;i++){
+                hash += hash2;
+                hash &= Int32.MaxValue; //make positive
+                int idx = (hash%m);
+                bits[idx / LONG_SIZE] |= (1UL << (idx % LONG_SIZE));
+            }
+        }
+
+        public bool MayExist(long item){
+            byte[] bytes = toBytes(item);
+            int hash1 = (int)hasher1.Hash(bytes);
+            int hash2 = (int)hasher2.Hash(bytes);
+
+            int hash = hash1;
+            for(int i=0;i<k;i++){
+                hash += hash2;
+                hash &= Int32.MaxValue; //make positive
+                int idx = (hash%m);
+                if((bits[idx / LONG_SIZE] & (1UL << (idx % LONG_SIZE))) == 0)
+                    return false;
+            }
+
+            return true;
+        }
+
+        public static byte[] toBytes(long value){
+            byte []bytes = new byte[8];
+            for(int i=0;i<8;i++){
+                bytes[i] |= (byte) (value & 0xFF);
+                value >>= 8;
+            }
+
+            return bytes;
+        }
+    }
+}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -430,6 +430,8 @@
     <Compile Include="Helpers\StreamVersionConverter.cs" />
     <Compile Include="Exceptions\MaybeCorruptIndexException.cs" />
     <Compile Include="Services\Storage\IndexCommitterService.cs" />
+    <Compile Include="DataStructures\BloomFilter.cs" />
+    <Compile Include="TransactionLog\Chunks\TFChunkReaderExistsAtOptimizer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj">

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkChaser.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkChaser.cs
@@ -11,14 +11,14 @@ namespace EventStore.Core.TransactionLog.Chunks
         private readonly ICheckpoint _chaserCheckpoint;
         private readonly TFChunkReader _reader;
 
-        public TFChunkChaser(TFChunkDb db, ICheckpoint writerCheckpoint, ICheckpoint chaserCheckpoint)
+        public TFChunkChaser(TFChunkDb db, ICheckpoint writerCheckpoint, ICheckpoint chaserCheckpoint, bool optimizeReadSideCache)
         {
             Ensure.NotNull(db, "dbConfig");
             Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
             Ensure.NotNull(chaserCheckpoint, "chaserCheckpoint");
 
             _chaserCheckpoint = chaserCheckpoint;
-            _reader = new TFChunkReader(db, writerCheckpoint, _chaserCheckpoint.Read());
+            _reader = new TFChunkReader(db, writerCheckpoint, _chaserCheckpoint.Read(), optimizeReadSideCache);
         }
 
         public void Open()

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -52,7 +52,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                     // but the actual last chunk is (lastChunkNum-1) one and it could be not completed yet -- perfectly valid situation.
                     var footer = ReadChunkFooter(versions[0]);
                     if (footer.IsCompleted)
-                        chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount);
+                        chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache: Config.OptimizeReadSideCache);
                     else
                     {
                         chunk = TFChunk.TFChunk.FromOngoingFile(versions[0], Config.ChunkSize, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough, initialReaderCount:Config.InitialReaderCount);
@@ -63,7 +63,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 }
                 else
                 {
-                    chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount);
+                    chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache: Config.OptimizeReadSideCache);
                 }
                 Manager.AddChunk(chunk);
                 chunkNum = chunk.ChunkHeader.ChunkEndNumber + 1;
@@ -84,7 +84,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 var chunkLocalPos = chunkHeader.GetLocalLogPosition(checkpoint);
                 if (chunkHeader.IsScavenged)
                 {
-                    var lastChunk = TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount);
+                    var lastChunk = TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache: Config.OptimizeReadSideCache);
                     if (lastChunk.ChunkFooter.LogicalDataSize != chunkLocalPos)
                     {
                         lastChunk.Dispose();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -19,6 +19,7 @@ namespace EventStore.Core.TransactionLog.Chunks
         public readonly bool Unbuffered;
         public readonly bool WriteThrough;
         public readonly int InitialReaderCount;
+        public readonly bool OptimizeReadSideCache;
 
         public TFChunkDbConfig(string path, 
                                IFileNamingStrategy fileNamingStrategy, 
@@ -32,7 +33,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                int initialReaderCount,
                                bool inMemDb = false,
                                bool unbuffered = false,
-                               bool writethrough = false)
+                               bool writethrough = false,
+                               bool optimizeReadSideCache = false)
         {
             Ensure.NotNullOrEmpty(path, "path");
             Ensure.NotNull(fileNamingStrategy, "fileNamingStrategy");
@@ -58,6 +60,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             Unbuffered = unbuffered;
             WriteThrough = writethrough;
             InitialReaderCount = initialReaderCount;
+            OptimizeReadSideCache = optimizeReadSideCache;
         }
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -198,7 +198,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 var newFileName = _config.FileNamingStrategy.DetermineBestVersionFilenameFor(chunkHeader.ChunkStartNumber);
                 Log.Info("File {0} will be moved to file {1}", Path.GetFileName(oldFileName), Path.GetFileName(newFileName));
                 File.Move(oldFileName, newFileName);
-                newChunk = TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered, _config.InitialReaderCount);
+                newChunk = TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered, _config.InitialReaderCount, _config.OptimizeReadSideCache);
             }
 
             lock (_chunksLocker)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkReaderExistsAtOptimizer.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkReaderExistsAtOptimizer.cs
@@ -1,0 +1,59 @@
+using System;
+using EventStore.Common.Log;
+using EventStore.Core.DataStructures;
+
+namespace EventStore.Core.TransactionLog.Chunks
+{
+    public class TFChunkReaderExistsAtOptimizer
+    {
+        private static TFChunkReaderExistsAtOptimizer _instance;
+        public static TFChunkReaderExistsAtOptimizer Instance {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new TFChunkReaderExistsAtOptimizer(MaxBloomFiltersCached);
+                }
+                return _instance;
+            }
+        }
+
+        //Least-Recently-Used cache to keep track of scavenged TFChunks that have cached bloom filters
+        private LRUCache<string, TFChunk.TFChunk> _cache;
+        private const int MaxBloomFiltersCached = 10000; //around 5GB RAM max if we consider 200,000 log positions/chunk and 20 bits/log position
+        private static readonly ILogger Log = LogManager.GetLoggerFor<TFChunkReaderExistsAtOptimizer>();
+
+
+        public TFChunkReaderExistsAtOptimizer(int maxCached){
+            Func<object, bool> onPut = (o) => {
+                var chunk = (TFChunk.TFChunk) o;
+                if(chunk == null)
+                    return false;
+                Log.Debug("Optimizing chunk "+chunk.FileName+" for fast merge...");
+                chunk.OptimizeExistsAt();
+                return true;
+            };
+
+            Func<object, bool> onRemove = (o) => {
+                var chunk = (TFChunk.TFChunk) o;
+                if(chunk == null)
+                    return false;
+                Log.Debug("Clearing fast merge optimizations from chunk "+chunk.FileName+"...");
+                chunk.DeOptimizeExistsAt();
+                return true;
+            };
+
+            _cache = new LRUCache<string, TFChunk.TFChunk>(maxCached, onPut, onRemove);
+        }
+
+        public void Optimize(TFChunk.TFChunk chunk){
+            if(!chunk.ChunkHeader.IsScavenged) return;
+            _cache.Put(chunk.FileName, chunk);
+        }
+
+        public bool IsOptimized(TFChunk.TFChunk chunk){
+            TFChunk.TFChunk value;
+            return _cache.TryGet(chunk.FileName, out value);
+        }
+    }
+}

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -341,6 +341,9 @@ namespace EventStore.Core.Util
 
         public const string IndexBitnessVersionDescr = "Sets the bitness version for the indexes to use";
         public const byte IndexBitnessVersionDefault = EventStore.Core.Index.PTableVersions.IndexV4;
+        public const string OptimizeIndexMergeDescr =
+            "Makes index merges faster and reduces disk pressure during merges.";
+        public static readonly bool OptimizeIndexMergeDefault = false;
 		/*
 		 * Authentication Options
 		 */

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -106,6 +106,8 @@ namespace EventStore.Core
         protected string _index;
         protected bool _skipIndexVerify;
         protected int _indexCacheDepth;
+        protected bool _optimizeIndexMerge;
+
         protected bool _unsafeIgnoreHardDelete;
         protected bool _unsafeDisableFlushToDisk;
         protected bool _betterOrdering;
@@ -194,7 +196,7 @@ namespace EventStore.Core
             _extTcpHeartbeatInterval = TimeSpan.FromMilliseconds(Opts.ExtTcpHeartbeatIntervalDefault);
             _extTcpHeartbeatTimeout = TimeSpan.FromMilliseconds(Opts.ExtTcpHeartbeatTimeoutDefault);
             _connectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
-            
+
             _skipVerifyDbHashes = Opts.SkipDbVerifyDefault;
             _maxMemtableSize = Opts.MaxMemtableSizeDefault;
             _subsystems = new List<ISubsystem>();
@@ -208,6 +210,7 @@ namespace EventStore.Core
             _skipIndexVerify = Opts.SkipIndexVerifyDefault;
             _indexCacheDepth = Opts.IndexCacheDepthDefault;
             _indexBitnessVersion = Opts.IndexBitnessVersionDefault;
+            _optimizeIndexMerge = Opts.OptimizeIndexMergeDefault;
             _unsafeIgnoreHardDelete = Opts.UnsafeIgnoreHardDeleteDefault;
             _betterOrdering = Opts.BetterOrderingDefault;
             _unsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
@@ -327,7 +330,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets up the Internal IP that would be advertised 
+        /// Sets up the Internal IP that would be advertised
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder AdvertiseInternalIPAs(IPAddress intIpAdvertiseAs)
@@ -337,7 +340,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets up the External IP that would be advertised 
+        /// Sets up the External IP that would be advertised
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder AdvertiseExternalIPAs(IPAddress extIpAdvertiseAs)
@@ -347,7 +350,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets up the Internal Http Port that would be advertised 
+        /// Sets up the Internal Http Port that would be advertised
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder AdvertiseInternalHttpPortAs(int intHttpPortAdvertiseAs)
@@ -370,7 +373,7 @@ namespace EventStore.Core
 
 
         /// <summary>
-        /// Sets up the External Http Port that would be advertised 
+        /// Sets up the External Http Port that would be advertised
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder AdvertiseExternalHttpPortAs(int extHttpPortAdvertiseAs)
@@ -380,7 +383,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets up the Internal Secure TCP Port that would be advertised 
+        /// Sets up the Internal Secure TCP Port that would be advertised
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder AdvertiseInternalSecureTCPPortAs(int intSecureTcpPortAdvertiseAs)
@@ -390,7 +393,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets up the External Secure TCP Port that would be advertised 
+        /// Sets up the External Secure TCP Port that would be advertised
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder AdvertiseExternalSecureTCPPortAs(int extSecureTcpPortAdvertiseAs)
@@ -400,7 +403,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets up the Internal TCP Port that would be advertised 
+        /// Sets up the Internal TCP Port that would be advertised
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder AdvertiseInternalTCPPortAs(int intTcpPortAdvertiseAs)
@@ -421,7 +424,7 @@ namespace EventStore.Core
 
 
         /// <summary>
-        /// Sets up the External TCP Port that would be advertised 
+        /// Sets up the External TCP Port that would be advertised
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder AdvertiseExternalTCPPortAs(int extTcpPortAdvertiseAs)
@@ -529,7 +532,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets the target host of the server's SSL certificate. 
+        /// Sets the target host of the server's SSL certificate.
         /// </summary>
         /// <param name="targetHost">The target host of the server's SSL certificate</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
@@ -540,7 +543,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets whether to validate that the server's certificate is trusted.  
+        /// Sets whether to validate that the server's certificate is trusted.
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder ValidateSslServer()
@@ -692,7 +695,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Don't add the interface prefixes (e.g. If the External IP is set to the Loopback address, we'll add http://localhost:2113/ as a prefix) 
+        /// Don't add the interface prefixes (e.g. If the External IP is set to the Loopback address, we'll add http://localhost:2113/ as a prefix)
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder DontAddInterfacePrefixes()
@@ -804,7 +807,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets the minimum flush delay 
+        /// Sets the minimum flush delay
         /// </summary>
         /// <param name="minFlushDelay">The minimum flush delay</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
@@ -815,7 +818,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets the prepare timeout 
+        /// Sets the prepare timeout
         /// </summary>
         /// <param name="prepareTimeout">The prepare timeout</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
@@ -826,7 +829,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets the commit timeout 
+        /// Sets the commit timeout
         /// </summary>
         /// <param name="commitTimeout">The commit timeout</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
@@ -859,7 +862,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets the number of nodes which must acknowledge prepares. 
+        /// Sets the number of nodes which must acknowledge prepares.
         /// The minimum allowed value is one greater than half the cluster size.
         /// </summary>
         /// <param name="prepareCount">The number of nodes which must acknowledge prepares</param>
@@ -871,7 +874,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Sets the number of nodes which must acknowledge commits before acknowledging to a client.  
+        /// Sets the number of nodes which must acknowledge commits before acknowledging to a client.
         /// The minimum allowed value is one greater than half the cluster size.
         /// </summary>
         /// <param name="commitCount">The number of nodes which must acknowledge commits</param>
@@ -894,7 +897,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Disables the merging of chunks when scavenge is running 
+        /// Disables the merging of chunks when scavenge is running
         /// </summary>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder DisableScavengeMerging()
@@ -946,9 +949,9 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// Verifies the index integrity using the specified method on startup
+        /// Skips verification of indexes on startup
         /// </summary>
-        /// <param name="skipIndexVerify">The index verification method</param>
+        /// <param name="skipIndexVerify">Skips verification of indexes on startup</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
         public VNodeBuilder WithIndexVerification(bool skipIndexVerify)
         {
@@ -964,6 +967,17 @@ namespace EventStore.Core
         public VNodeBuilder WithIndexCacheDepth(int indexCacheDepth)
         {
             _indexCacheDepth = indexCacheDepth;
+            return this;
+        }
+
+        /// <summary>
+        /// Optimizes index merges
+        /// </summary>
+        /// <param name="optimizeIndexMerge">Optimizes index merges</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithIndexMergeOptimization(bool optimizeIndexMerge)
+        {
+            _optimizeIndexMerge = optimizeIndexMerge;
             return this;
         }
 
@@ -1156,7 +1170,7 @@ namespace EventStore.Core
         }
 
         /// <summary>
-        /// The number of chunks to cache in unmanaged memory.        
+        /// The number of chunks to cache in unmanaged memory.
         /// </summary>
         /// <param name="cachedChunks">The number of chunks to cache</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
@@ -1278,7 +1292,7 @@ namespace EventStore.Core
                 var extSecureTcpEndPoint = new IPEndPoint(extIpAddressToAdvertise, extSecureTcpPort);
 
                 var intHttpPort = _advertiseInternalHttpPortAs > 0 ? _advertiseInternalHttpPortAs : _internalHttp.Port;
-                var extHttpPort = _advertiseExternalHttpPortAs > 0 ? _advertiseExternalHttpPortAs : _externalHttp.Port; 
+                var extHttpPort = _advertiseExternalHttpPortAs > 0 ? _advertiseExternalHttpPortAs : _externalHttp.Port;
 
                 var intHttpEndPoint = new IPEndPoint(intIpAddressToAdvertise, intHttpPort);
                 var extHttpEndPoint = new IPEndPoint(extIpAddressToAdvertise, extHttpPort);
@@ -1291,7 +1305,7 @@ namespace EventStore.Core
             }
             return _gossipAdvertiseInfo;
         }
-        
+
         protected abstract void SetUpProjectionsIfNeeded();
 
         /// <summary>
@@ -1316,15 +1330,15 @@ namespace EventStore.Core
             SetUpProjectionsIfNeeded();
             _gossipAdvertiseInfo = EnsureGossipAdvertiseInfo();
 
-
-            _dbConfig = CreateDbConfig(_chunkSize, 
-                                       _cachedChunks, 
-                                       _dbPath, 
+            _dbConfig = CreateDbConfig(_chunkSize,
+                                       _cachedChunks,
+                                       _dbPath,
                                        _chunksCacheSize,
-                                       _inMemoryDb, 
+                                       _inMemoryDb,
                                        _unbuffered,
                                        _writethrough,
                                        _chunkInitialReaderCount,
+                                       _optimizeIndexMerge?true:false,
                                        _log);
             FileStreamExtensions.ConfigureFlush(disableFlushToDisk: _unsafeDisableFlushToDisk);
 
@@ -1386,6 +1400,7 @@ namespace EventStore.Core
                     _skipIndexVerify,
                     _indexCacheDepth,
                     _indexBitnessVersion,
+                    _optimizeIndexMerge,
                     consumerStrategies,
                     _unsafeIgnoreHardDelete,
                     _betterOrdering,
@@ -1428,14 +1443,15 @@ namespace EventStore.Core
             return gossipSeedSource;
         }
 
-        private static TFChunkDbConfig CreateDbConfig(int chunkSize, 
-                                                      int cachedChunks, 
-                                                      string dbPath, 
-                                                      long chunksCacheSize, 
+        private static TFChunkDbConfig CreateDbConfig(int chunkSize,
+                                                      int cachedChunks,
+                                                      string dbPath,
+                                                      long chunksCacheSize,
                                                       bool inMemDb,
                                                       bool unbuffered,
                                                       bool writethrough,
                                                       int chunkInitialReaderCount,
+                                                      bool optimizeReadSideCache,
                                                       ILogger log)
         {
             ICheckpoint writerChk;
@@ -1508,7 +1524,8 @@ namespace EventStore.Core
                                                  chunkInitialReaderCount,
                                                  inMemDb,
                                                  unbuffered,
-                                                 writethrough);
+                                                 writethrough,
+                                                 optimizeReadSideCache);
 
             return nodeConfig;
         }


### PR DESCRIPTION
# Problem/Solution description
PTable merges of index entries related to scavenged chunks are around 10x slower than merges of index entries related to non-scavenged chunks as shown below:

```
Merge with non-scavenged chunk:
[PID:30978:007 2018.01.08 09:50:48.759 TRACE PTable              ] PTables merge finished in 00:00:01.8044394 ([2048000, 2048000] entries merged into 4096000).
Merge with scavenged chunk:
[PID:32224:007 2018.01.08 10:13:22.025 TRACE PTable              ] PTables merge finished in 00:00:25.2660264 ([2048000, 2048000] entries merged into 4096000).
```
The slowness is due to the [existAt call](https://github.com/EventStore/EventStore/blob/release-v4.1.1/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs#L212) that verifies if an index entry exists in the chunk file by doing a binary search look up on the Posmap. The disk seeks done during the binary search add a significant amount of time.

The proposed solution is to add an option **--optimize-index-merge** that uses bloom filters to keep the posmap in memory for as many scavenged chunks as possible. This reduces the time for PTable merges and also decreases the disk pressure which is already high during PTable merges **(Full description of the solution in commit message)**

# Results:
## Test 1 (index rebuild of ~4M records on local machine/SSD with all chunks scavenged)
**Merge with scavenged chunk without optimization:**
 ```
PTables merge finished in 00:00:23.1940588 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:20.1107664 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:35.5952172 ([2000000, 2000000] entries merged into 4000000).
```
**Total merge time: 78s**

**Merge with scavenged chunk with --optimize-index-merge**
 ```
PTables merge finished in 00:00:03.1470243 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:03.1325550 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:04.3924874 ([2000000, 2000000] entries merged into 4000000).
```
**Total merge time: 10s (around 7-8x speedup)**

## Test 2 (index rebuild of ~20M records on AWS gp2/3000 iops from around 100 scavenged chunks)
**Merge with scavenged chunk without optimization:**
 ```
PTables merge finished in 00:00:26.1488981 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:26.3401015 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:54.1679085 ([2000000, 2000000] entries merged into 4000000).
PTables merge finished in 00:00:25.5928785 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:24.9906702 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:50.9753001 ([2000000, 2000000] entries merged into 4000000).
PTables merge finished in 00:01:53.2629083 ([4000000, 4000000] entries merged into 8000000).
PTables merge finished in 00:00:26.2846765 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:26.0847349 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:53.6072441 ([2000000, 2000000] entries merged into 4000000).
PTables merge finished in 00:00:26.0905945 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:26.4107351 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:54.8803166 ([2000000, 2000000] entries merged into 4000000).
PTables merge finished in 00:02:00.7227806 ([4000000, 4000000] entries merged into 8000000).
PTables merge finished in 00:03:56.1719077 ([8000000, 8000000] entries merged into 16000000).
PTables merge finished in 00:00:26.7429373 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:24.8559697 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:51.3573719 ([2000000, 2000000] entries merged into 4000000).
```
**Total merge time: ~986s**

**Merge with scavenged chunk with --optimize-index-merge**
 ```
PTables merge finished in 00:00:03.0629760 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:03.6487620 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:04.6183743 ([2000000, 2000000] entries merged into 4000000).
PTables merge finished in 00:00:02.8651277 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:03.2199336 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:04.9969473 ([2000000, 2000000] entries merged into 4000000).
PTables merge finished in 00:00:16.7856282 ([4000000, 4000000] entries merged into 8000000).
PTables merge finished in 00:00:03.1933536 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:02.8766726 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:04.6630766 ([2000000, 2000000] entries merged into 4000000).
PTables merge finished in 00:00:02.7591681 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:03.7337959 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:05.2891856 ([2000000, 2000000] entries merged into 4000000).
PTables merge finished in 00:00:16.9391175 ([4000000, 4000000] entries merged into 8000000).
PTables merge finished in 00:00:34.3026239 ([8000000, 8000000] entries merged into 16000000).
PTables merge finished in 00:00:03.1081373 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:03.0633281 ([1000000, 1000000] entries merged into 2000000).
PTables merge finished in 00:00:04.9363529 ([2000000, 2000000] entries merged into 4000000).
```
**Total merge time: ~122s (8x speedup)**

**For the optimized runs, the above tests also includes the time taken to create and populate the bloom filters which is done on the fly when calls are made to existAt.**

# Verification of data integrity
Verification of data integrity was done by:
- checking if the md5 hashes of the PTables and the checkpoints in `indexmap` match for the above 2 tests after the index rebuild
- doing index rebuilds with a few small --max-mem-table-size values (to generate many merges) with and without --optimize-index-merge and then checking if the md5 hashes of the final PTables match

