### PR TITLE
Add timeout functionality to IODispatcher.

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -656,6 +656,14 @@
     <Compile Include="Services\Replication\CommitReplication\when_constructing_index_committer_service.cs" />
     <Compile Include="DataStructures\bloom_filter_should.cs" />
     <Compile Include="TransactionLog\Optimization\tfchunkreader_existsat_optimizer_should.cs" />
+    <Compile Include="Helpers\IODispatcherTests\ReadEventsTests\with_read_io_dispatcher.cs" />
+    <Compile Include="Helpers\IODispatcherTests\ReadEventsTests\async_read_stream_events_forward_with_cancelled_read.cs" />
+    <Compile Include="Helpers\IODispatcherTests\ReadEventsTests\read_stream_events_forward_with_successful_read.cs" />
+    <Compile Include="Helpers\IODispatcherTests\ReadEventsTests\read_stream_events_forward_with_timeout_on_read.cs" />
+    <Compile Include="Helpers\IODispatcherTests\ReadEventsTests\read_stream_events_backward_with_successful_read.cs" />
+    <Compile Include="Helpers\IODispatcherTests\ReadEventsTests\read_stream_events_backward_with_timeout_on_read.cs" />
+    <Compile Include="Helpers\IODispatcherTests\ReadEventsTests\async_read_stream_events_backward_with_cancelled_read.cs" />
+    <Compile Include="Helpers\IODispatcherTests\IODispatcherTestHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj">

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/IODispatcherTestHelpers.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/IODispatcherTestHelpers.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Text;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Bus;
+using EventStore.Core.TransactionLog.LogRecords;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests
+{
+    public static class IODispatcherTestHelpers
+    {
+        public static ResolvedEvent[] CreateResolvedEvent(string streamId, string eventType, string data, string metadata = "", long eventNumber = 0)
+        {
+            var record = new EventRecord(eventNumber, LogRecord.Prepare(0, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+                streamId, eventNumber, PrepareFlags.None, eventType, Encoding.UTF8.GetBytes(data), Encoding.UTF8.GetBytes(metadata)));
+            return new ResolvedEvent[] {
+                ResolvedEvent.ForUnresolvedEvent(record, 0)
+            };
+        }
+
+        public static void SubscribeIODispatcher(IODispatcher ioDispatcher, IBus bus)
+        {
+            bus.Subscribe(ioDispatcher);
+            bus.Subscribe(ioDispatcher.ForwardReader);
+            bus.Subscribe(ioDispatcher.BackwardReader);
+            bus.Subscribe(ioDispatcher.Writer);
+            bus.Subscribe(ioDispatcher.Awaker);
+            bus.Subscribe(ioDispatcher.StreamDeleter);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/async_read_stream_events_backward_with_cancelled_read.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/async_read_stream_events_backward_with_cancelled_read.cs
@@ -1,0 +1,43 @@
+using EventStore.Core.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.ReadEventsTests
+{
+    [TestFixture]
+    public class async_read_stream_events_backward_with_cancelled_read : with_read_io_dispatcher
+    {
+        private bool _hasTimedOut;
+        private bool _hasRead;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var step = _ioDispatcher.BeginReadBackward(
+                _cancellationScope, _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _hasRead = true,
+                () => _hasTimedOut = true
+            );
+            
+            IODispatcherAsync.Run(step);
+            _cancellationScope.Cancel();
+        }
+
+        [Test]
+        public void should_ignore_read()
+        {
+            Assert.IsFalse(_hasRead, "Should not have completed read before replying on read message");
+            _readBackward.Envelope.ReplyWith(CreateReadStreamEventsBackwardCompleted(_readBackward));
+            Assert.IsFalse(_hasRead);
+        }
+
+        [Test]
+        public void should_ignore_timeout_message()
+        {
+            Assert.IsFalse(_hasTimedOut, "Should not have timed out before replying on timeout message");
+            _timeoutMessage.Reply();
+            Assert.IsFalse(_hasTimedOut);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/async_read_stream_events_forward_with_cancelled_read.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/async_read_stream_events_forward_with_cancelled_read.cs
@@ -1,0 +1,43 @@
+using EventStore.Core.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.ReadEventsTests
+{
+    [TestFixture]
+    public class async_read_stream_events_forward_with_cancelled_read : with_read_io_dispatcher
+    {
+        private bool _hasTimedOut;
+        private bool _hasRead;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var step = _ioDispatcher.BeginReadForward(
+                _cancellationScope, _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _hasRead = true,
+                () => _hasTimedOut = true
+            );
+            
+            IODispatcherAsync.Run(step);
+            _cancellationScope.Cancel();
+        }
+
+        [Test]
+        public void should_ignore_read()
+        {
+            Assert.IsFalse(_hasRead, "Should not have completed read before replying on read message");
+            _readForward.Envelope.ReplyWith(CreateReadStreamEventsForwardCompleted(_readForward));
+            Assert.IsFalse(_hasRead);
+        }
+
+        [Test]
+        public void should_ignore_timeout_message()
+        {
+            Assert.IsFalse(_hasTimedOut, "Should not have timed out before replying on timeout message");
+            _timeoutMessage.Reply();
+            Assert.IsFalse(_hasTimedOut);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/read_stream_events_backward_with_successful_read.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/read_stream_events_backward_with_successful_read.cs
@@ -1,0 +1,86 @@
+using System;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.ReadEventsTests
+{
+    [TestFixture]
+    public class async_read_stream_events_backward_with_successful_read : with_read_io_dispatcher
+    {
+        private ClientMessage.ReadStreamEventsBackwardCompleted _result;
+        private bool _hasTimedOut;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var step = _ioDispatcher.BeginReadBackward(
+                _cancellationScope, _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _result = res,
+                () => _hasTimedOut = true
+            );
+            
+            IODispatcherAsync.Run(step);
+
+            _readBackward.Envelope.ReplyWith(CreateReadStreamEventsBackwardCompleted(_readBackward));
+        }
+
+        [Test]
+        public void should_get_read_result()
+        {
+            Assert.IsNotNull(_result);
+            Assert.AreEqual(_maxCount, _result.Events.Length, "Event count");
+            Assert.AreEqual(_eventStreamId, _result.Events[0].OriginalStreamId, "Stream Id");
+            Assert.AreEqual(_fromEventNumber, _result.Events[_maxCount - 1].OriginalEventNumber, "From event number");
+        }
+
+        [Test]
+        public void should_ignore_timeout_message()
+        {
+            Assert.IsFalse(_hasTimedOut, "Should not have timed out before replying on timeout message");
+            _timeoutMessage.Reply();
+            Assert.IsFalse(_hasTimedOut);
+        }
+    }
+
+    [TestFixture]
+    public class read_stream_events_backward_with_successful_read: with_read_io_dispatcher
+    {
+        private ClientMessage.ReadStreamEventsBackwardCompleted _result;
+        private bool _hasTimedOut;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            _ioDispatcher.ReadBackward(
+                _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _result = res,
+                () => _hasTimedOut = true,
+                Guid.NewGuid()
+            );
+
+            _readBackward.Envelope.ReplyWith(CreateReadStreamEventsBackwardCompleted(_readBackward));
+        }
+
+        [Test]
+        public void should_get_read_result()
+        {
+            Assert.IsNotNull(_result);
+            Assert.AreEqual(_maxCount, _result.Events.Length, "Event count");
+            Assert.AreEqual(_eventStreamId, _result.Events[0].OriginalStreamId, "Stream Id");
+            Assert.AreEqual(_fromEventNumber, _result.Events[_maxCount - 1].OriginalEventNumber, "From event number");
+        }
+
+        [Test]
+        public void should_ignore_timeout_message()
+        {
+            Assert.IsFalse(_hasTimedOut, "Should not have timed out before replying on timeout message");
+            _timeoutMessage.Reply();
+            Assert.IsFalse(_hasTimedOut);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/read_stream_events_backward_with_timeout_on_read.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/read_stream_events_backward_with_timeout_on_read.cs
@@ -1,0 +1,80 @@
+using System;
+using EventStore.Core.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.ReadEventsTests
+{
+    [TestFixture]
+    public class async_read_stream_events_backward_with_timeout_on_read : with_read_io_dispatcher
+    {
+        private bool _didTimeout;
+        private bool _didReceiveRead;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var step = _ioDispatcher.BeginReadBackward(
+                _cancellationScope, _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _didReceiveRead = true,
+                () => _didTimeout = true
+            );
+            IODispatcherAsync.Run(step);
+            Assert.IsNotNull(_timeoutMessage, "Expected TimeoutMessage to not be null");
+
+            _timeoutMessage.Reply();
+        }
+
+        [Test]
+        public void should_call_timeout_handler()
+        {
+            Assert.IsTrue(_didTimeout);
+        }
+
+        [Test]
+        public void should_ignore_read_complete()
+        {
+            Assert.IsFalse(_didReceiveRead, "Should not have received read completed before replying on message");
+            _readBackward.Envelope.ReplyWith(CreateReadStreamEventsBackwardCompleted(_readBackward));
+            Assert.IsFalse(_didReceiveRead);
+        }
+    }
+
+    [TestFixture]
+    public class read_stream_events_backward_with_timeout_on_read : with_read_io_dispatcher
+    {
+        private bool _didTimeout;
+        private bool _didReceiveRead;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            _ioDispatcher.ReadBackward(
+                _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _didReceiveRead = true,
+                () => _didTimeout = true,
+                Guid.NewGuid()
+            );
+            Assert.IsNotNull(_timeoutMessage, "Expected TimeoutMessage to not be null");
+
+            _timeoutMessage.Reply();
+        }
+
+        [Test]
+        public void should_call_timeout_handler()
+        {
+            Assert.IsTrue(_didTimeout);
+        }
+
+        [Test]
+        public void should_ignore_read_complete()
+        {
+            Assert.IsFalse(_didReceiveRead, "Should not have received read completed before replying on message");
+            _readBackward.Envelope.ReplyWith(CreateReadStreamEventsBackwardCompleted(_readBackward));
+            Assert.IsFalse(_didReceiveRead);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/read_stream_events_forward_with_successful_read.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/read_stream_events_forward_with_successful_read.cs
@@ -1,0 +1,86 @@
+using System;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.ReadEventsTests
+{
+    [TestFixture]
+    public class async_read_stream_events_forward_with_successful_read : with_read_io_dispatcher
+    {
+        private ClientMessage.ReadStreamEventsForwardCompleted _result;
+        private bool _hasTimedOut;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var step = _ioDispatcher.BeginReadForward(
+                _cancellationScope, _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _result = res,
+                () => _hasTimedOut = true
+            );
+            
+            IODispatcherAsync.Run(step);
+
+            _readForward.Envelope.ReplyWith(CreateReadStreamEventsForwardCompleted(_readForward));
+        }
+
+        [Test]
+        public void should_get_read_result()
+        {
+            Assert.IsNotNull(_result);
+            Assert.AreEqual(_maxCount, _result.Events.Length, "Event count");
+            Assert.AreEqual(_eventStreamId, _result.Events[0].OriginalStreamId, "Stream Id");
+            Assert.AreEqual(_fromEventNumber, _result.Events[0].OriginalEventNumber, "From event number");
+        }
+
+        [Test]
+        public void should_ignore_timeout_message()
+        {
+            Assert.IsFalse(_hasTimedOut, "Should not have timed out before replying on timeout message");
+            _timeoutMessage.Reply();
+            Assert.IsFalse(_hasTimedOut);
+        }
+    }
+
+    [TestFixture]
+    public class read_stream_events_forward_with_successful_read : with_read_io_dispatcher
+    {
+        private ClientMessage.ReadStreamEventsForwardCompleted _result;
+        private bool _hasTimedOut;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            _ioDispatcher.ReadForward(
+                _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _result = res,
+                () => _hasTimedOut = true,
+                Guid.NewGuid()
+            );
+            
+            _readForward.Envelope.ReplyWith(CreateReadStreamEventsForwardCompleted(_readForward));
+        }
+
+        [Test]
+        public void should_get_read_result()
+        {
+            Assert.IsNotNull(_result);
+            Assert.AreEqual(_maxCount, _result.Events.Length, "Event count");
+            Assert.AreEqual(_eventStreamId, _result.Events[0].OriginalStreamId, "Stream Id");
+            Assert.AreEqual(_fromEventNumber, _result.Events[0].OriginalEventNumber, "From event number");
+        }
+
+        [Test]
+        public void should_ignore_timeout_message()
+        {
+            Assert.IsFalse(_hasTimedOut, "Should not have timed out before replying on timeout message");
+            _timeoutMessage.Reply();
+            Assert.IsFalse(_hasTimedOut);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/read_stream_events_forward_with_timeout_on_read.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/read_stream_events_forward_with_timeout_on_read.cs
@@ -1,0 +1,79 @@
+using EventStore.Core.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.ReadEventsTests
+{
+    [TestFixture]
+    public class async_read_stream_events_forward_with_timeout_on_read : with_read_io_dispatcher
+    {
+        private bool _didTimeout;
+        private bool _didReceiveRead;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var step = _ioDispatcher.BeginReadForward(
+                _cancellationScope, _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _didReceiveRead = true,
+                () => _didTimeout = true
+            );
+            IODispatcherAsync.Run(step);
+            Assert.IsNotNull(_timeoutMessage, "Expected TimeoutMessage to not be null");
+
+            _timeoutMessage.Reply();
+        }
+
+        [Test]
+        public void should_call_timeout_handler()
+        {
+            Assert.IsTrue(_didTimeout);
+        }
+
+        [Test]
+        public void should_ignore_read_complete()
+        {
+            Assert.IsFalse(_didReceiveRead, "Should not have received read completed before replying on message");
+            _readForward.Envelope.ReplyWith(CreateReadStreamEventsForwardCompleted(_readForward));
+            Assert.IsFalse(_didReceiveRead);
+        }
+    }
+
+    [TestFixture]
+    public class read_stream_events_forward_with_timeout_on_read : with_read_io_dispatcher
+    {
+        private bool _didTimeout;
+        private bool _didReceiveRead;
+
+        [OneTimeSetUp]
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var step = _ioDispatcher.BeginReadForward(
+                _cancellationScope, _eventStreamId, _fromEventNumber, _maxCount, true, _principal,
+                res => _didReceiveRead = true,
+                () => _didTimeout = true
+            );
+            IODispatcherAsync.Run(step);
+            Assert.IsNotNull(_timeoutMessage, "Expected TimeoutMessage to not be null");
+
+            _timeoutMessage.Reply();
+        }
+
+        [Test]
+        public void should_call_timeout_handler()
+        {
+            Assert.IsTrue(_didTimeout);
+        }
+
+        [Test]
+        public void should_ignore_read_complete()
+        {
+            Assert.IsFalse(_didReceiveRead, "Should not have received read completed before replying on message");
+            _readForward.Envelope.ReplyWith(CreateReadStreamEventsForwardCompleted(_readForward));
+            Assert.IsFalse(_didReceiveRead);
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/with_read_io_dispatcher.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/with_read_io_dispatcher.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Security.Principal;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Helpers.IODispatcherTests.ReadEventsTests
+{
+    public abstract class with_read_io_dispatcher : IHandle<ClientMessage.ReadStreamEventsForward>,
+                                                    IHandle<ClientMessage.ReadStreamEventsBackward>,
+                                                    IHandle<TimerMessage.Schedule>
+    {
+        protected IODispatcher _ioDispatcher;
+        protected readonly IPrincipal _principal = SystemAccount.Principal;
+        protected readonly InMemoryBus _bus = InMemoryBus.CreateTest();
+        protected readonly IODispatcherAsync.CancellationScope _cancellationScope = new IODispatcherAsync.CancellationScope();
+
+        protected ClientMessage.ReadStreamEventsForward _readForward;
+        protected ClientMessage.ReadStreamEventsBackward _readBackward;
+        protected TimerMessage.Schedule _timeoutMessage;
+
+        protected readonly int _maxCount = 1;
+        protected readonly int _fromEventNumber = 10;
+        protected readonly string _eventStreamId = "test";
+
+        [OneTimeSetUp]
+        public virtual void TestFixtureSetUp()
+        {
+            _ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_bus));
+            IODispatcherTestHelpers.SubscribeIODispatcher(_ioDispatcher, _bus);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsForward>(this);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsBackward>(this);
+            _bus.Subscribe<TimerMessage.Schedule>(this);
+        }
+
+        public virtual void Handle(ClientMessage.ReadStreamEventsForward message)
+        {
+            _readForward = message;
+        }
+        
+        public virtual void Handle(ClientMessage.ReadStreamEventsBackward message)
+        {
+            _readBackward = message;
+        }
+
+        public virtual void Handle(TimerMessage.Schedule message)
+        {
+            _timeoutMessage = message;
+        }
+
+        public ClientMessage.ReadStreamEventsForwardCompleted CreateReadStreamEventsForwardCompleted(ClientMessage.ReadStreamEventsForward msg)
+        {
+            var lastEventNumber = msg.FromEventNumber + 1;
+            var nextEventNumber = lastEventNumber + 1;
+            var events = IODispatcherTestHelpers.CreateResolvedEvent(msg.EventStreamId, "event_type", "test", eventNumber: 10);
+            var res = new ClientMessage.ReadStreamEventsForwardCompleted(msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber,
+                msg.MaxCount, ReadStreamResult.Success, events, null, false, String.Empty, nextEventNumber, lastEventNumber, false, 0);
+            return res;
+        }
+
+        public ClientMessage.ReadStreamEventsBackwardCompleted CreateReadStreamEventsBackwardCompleted(ClientMessage.ReadStreamEventsBackward msg)
+        {
+            var startEventNumber = msg.FromEventNumber;
+            var nextEventNumber = startEventNumber - 1;
+            var events = IODispatcherTestHelpers.CreateResolvedEvent(msg.EventStreamId, "event_type", "test", eventNumber: 10);
+            var res = new ClientMessage.ReadStreamEventsBackwardCompleted(msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber,
+                msg.MaxCount, ReadStreamResult.Success, events, null, false, String.Empty, nextEventNumber, startEventNumber, false, 0);
+            return res;
+        }
+    }
+}

--- a/src/EventStore.Core/Helpers/IODispatcherDelayedMessage.cs
+++ b/src/EventStore.Core/Helpers/IODispatcherDelayedMessage.cs
@@ -10,11 +10,19 @@ namespace EventStore.Core.Helpers
 
         private readonly Guid _correlationId;
         private readonly Action _action;
+        private readonly Guid? _messageCorrelationId;
 
         public IODispatcherDelayedMessage(Guid correlationId, Action action)
         {
             _action = action;
             _correlationId = correlationId;
+        }
+
+        public IODispatcherDelayedMessage(Guid correlationId, Action action, Guid? messageCorrelationId)
+        {
+            _action = action;
+            _correlationId = correlationId;
+            _messageCorrelationId = messageCorrelationId;
         }
 
         public Action Action
@@ -25,6 +33,11 @@ namespace EventStore.Core.Helpers
         public Guid CorrelationId
         {
             get { return _correlationId; }
+        }
+
+        public Guid? MessageCorrelationId
+        {
+            get { return _messageCorrelationId; }
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -573,6 +573,22 @@
     <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_system.cs" />
     <Compile Include="Services\core_coordinator\when_restarting_with_projection_type_all.cs" />
     <Compile Include="Services\core_projection\when_stopping_a_projection_with_existing_state_without_updating_the_state.cs" />
+    <Compile Include="Services\command_reader_response_reader_integration\when_command_reader_times_out_reading_control_stream_on_startup.cs" />
+    <Compile Include="Services\command_reader_response_reader_integration\when_command_reader_times_out_reading_projection_core_stream_on_startup.cs" />
+    <Compile Include="Services\master_core_projection_response_reader\with_master_core_response_reader.cs" />
+    <Compile Include="Services\master_core_projection_response_reader\when_response_reader_has_read_timeout.cs" />
+    <Compile Include="Services\master_core_projection_response_reader\when_response_reader_starts_up_successfully.cs" />
+    <Compile Include="Services\core_projection\projection_checkpoint_reader\with_projection_checkpoint_reader.cs" />
+    <Compile Include="Services\core_projection\projection_checkpoint_reader\when_projection_reader_reads_successfully.cs" />
+    <Compile Include="Services\core_projection\projection_checkpoint_reader\when_projection_reader_times_out_on_read.cs" />
+    <Compile Include="Services\core_projection\checkpoint_manager\multi_stream\when_starting_and_read_prerecorded_events_times_out.cs" />
+    <Compile Include="Services\core_projection\checkpoint_manager\multi_stream\with_multi_stream_checkpoint_manager.cs" />
+    <Compile Include="Services\core_projection\checkpoint_manager\multi_stream\when_starting_and_read_prerecorded_events_successfully.cs" />
+    <Compile Include="Services\core_projection\checkpoint_manager\multi_stream\when_starting_and_enqueue_prerecorded_events_read_times_out.cs" />
+    <Compile Include="Services\emitted_streams_deleter\when_deleting\with_emitted_stream_deleter.cs" />
+    <Compile Include="Services\emitted_streams_deleter\when_deleting\when_delete_stream_succeeds.cs" />
+    <Compile Include="Services\emitted_streams_deleter\when_deleting\when_checkpoint_read_times_out.cs" />
+    <Compile Include="Services\emitted_streams_deleter\when_deleting\when_emitted_streams_read_times_out.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj">

--- a/src/EventStore.Projections.Core.Tests/Services/command_reader_response_reader_integration/specification_with_command_reader_and_response_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/command_reader_response_reader_integration/specification_with_command_reader_and_response_reader.cs
@@ -14,6 +14,7 @@ namespace EventStore.Projections.Core.Tests.Services.command_reader_response_rea
         protected ProjectionCoreServiceCommandReader _commandReader;
         protected ProjectionManagerResponseReader _responseReader;
         protected int _numberOfWorkers;
+        protected string _coreServiceId;
 
         protected override void Given()
         {
@@ -21,7 +22,9 @@ namespace EventStore.Projections.Core.Tests.Services.command_reader_response_rea
             AllWritesSucceed();
             NoOtherStreams();
 
-            _commandReader = new ProjectionCoreServiceCommandReader(_bus, _ioDispatcher, Guid.NewGuid().ToString("N"));
+            if (String.IsNullOrEmpty(_coreServiceId))_coreServiceId = Guid.NewGuid().ToString("N");
+            
+            _commandReader = new ProjectionCoreServiceCommandReader(_bus, _ioDispatcher, _coreServiceId);
             _responseReader = new ProjectionManagerResponseReader(_bus, _ioDispatcher, _numberOfWorkers);
 
             _bus.Subscribe<ProjectionCoreServiceMessage.StartCore>(_commandReader);

--- a/src/EventStore.Projections.Core.Tests/Services/command_reader_response_reader_integration/when_command_reader_times_out_reading_control_stream_on_startup.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/command_reader_response_reader_integration/when_command_reader_times_out_reading_control_stream_on_startup.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Services.TimerService;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.command_reader_response_reader_integration
+{
+    [TestFixture]
+    public class when_command_reader_times_out_reading_control_stream_on_startup : specification_with_command_reader_and_response_reader
+    {
+        private Guid _epochId = Guid.NewGuid();
+
+        protected override void Given()
+        {
+            _numberOfWorkers = 1;
+            var controlStream = ProjectionNamesBuilder.BuildControlStreamName(_epochId);
+            TimeOutReadToStreamOnce(controlStream);
+
+            int timeoutCount = 0;
+            _bus.Subscribe(new AdHocHandler<TimerMessage.Schedule>(msg => {
+                if (msg.ReplyMessage is IODispatcherDelayedMessage && timeoutCount <= 1)
+                {
+                    // Only the second read should time out as the first is of the control stream
+                    if(timeoutCount == 1)
+                    {
+                        msg.Reply();
+                    }
+                    timeoutCount++;
+                }
+            }));
+            base.Given();
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            yield return new WhenStep(
+                new ProjectionCoreServiceMessage.StartCore(_epochId), 
+                new ProjectionManagementMessage.Starting(_epochId));
+        }
+
+        [Test]
+        public void should_send_reader_ready()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ProjectionManagementMessage.ReaderReady>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/command_reader_response_reader_integration/when_command_reader_times_out_reading_projection_core_stream_on_startup.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/command_reader_response_reader_integration/when_command_reader_times_out_reading_projection_core_stream_on_startup.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Services.TimerService;
+using EventStore.Projections.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.command_reader_response_reader_integration
+{
+    [TestFixture]
+    public class when_command_reader_times_out_reading_projection_core_stream_on_startup : specification_with_command_reader_and_response_reader
+    {
+        private Guid _epochId = Guid.NewGuid();
+
+        protected override void Given()
+        {
+            _coreServiceId = Guid.NewGuid().ToString("N");
+            _numberOfWorkers = 1;
+
+            var projectionCoreStream = "$projections-$" + _coreServiceId;
+            TimeOutReadToStreamOnce(projectionCoreStream);
+
+            var hasTimedOut = false;
+            _bus.Subscribe(new AdHocHandler<TimerMessage.Schedule>(msg => {
+                var delay = msg.ReplyMessage as IODispatcherDelayedMessage;
+                if (delay != null && !hasTimedOut)
+                {
+                    hasTimedOut = true;
+                    msg.Reply();
+                }
+            }));
+
+            // Start up reader
+            base.Given();
+        }
+
+        protected override IEnumerable<WhenStep> When()
+        {
+            yield return new WhenStep(
+                new ProjectionCoreServiceMessage.StartCore(_epochId), 
+                new ProjectionManagementMessage.Starting(_epochId));
+        }
+
+        [Test]
+        public void should_send_reader_ready()
+        {
+            Assert.AreEqual(1, _consumer.HandledMessages.OfType<ProjectionManagementMessage.ReaderReady>().Count());
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_and_enqueue_prerecorded_events_read_times_out.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_and_enqueue_prerecorded_events_read_times_out.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager.multi_stream
+{
+    [TestFixture]
+    public class when_starting_and_enqueue_prerecorded_events_read_times_out : with_multi_stream_checkpoint_manager,
+                                                                                IHandle<TimerMessage.Schedule>,
+                                                                                IHandle<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>
+    {
+        private bool _hasTimedOut;
+        private Guid _timeoutCorrelationId;
+        private ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private CoreProjectionProcessingMessage.PrerecordedEventsLoaded _eventsLoadedMessage;
+
+        public override void When()
+        {
+            _bus.Subscribe<TimerMessage.Schedule>(this);
+            _bus.Subscribe<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>(this);
+
+            _checkpointManager.Initialize();
+            var positions = new Dictionary<string, long> { { "a", 1 }, { "b", 1 }, { "c", 1 } };
+            _checkpointManager.BeginLoadPrerecordedEvents(CheckpointTag.FromStreamPositions(0, positions));
+
+            if(!_mre.Wait(10000))
+            {
+                Assert.Fail("Timed out waiting for pre recorded events loaded message");
+            }
+        }
+
+        public override void Handle(ClientMessage.ReadStreamEventsBackward message)
+        {
+            if(!_hasTimedOut && message.EventStreamId == "a")
+            {
+                _hasTimedOut = true;
+                _timeoutCorrelationId = message.CorrelationId;
+                return;
+            }
+            base.Handle(message);
+        }
+
+        public void Handle(TimerMessage.Schedule message)
+        {
+            var delay = message.ReplyMessage as IODispatcherDelayedMessage;
+            if (delay != null && delay.MessageCorrelationId == _timeoutCorrelationId)
+            {
+                message.Reply();
+            }
+        }
+
+        public void Handle(CoreProjectionProcessingMessage.PrerecordedEventsLoaded message)
+        {
+            _eventsLoadedMessage = message;
+            _mre.Set();
+        }
+
+        [Test]
+        public void should_send_prerecorded_events_message()
+        {
+            Assert.IsNotNull(_eventsLoadedMessage);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_and_read_prerecorded_events_successfully.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_and_read_prerecorded_events_successfully.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager.multi_stream
+{
+    [TestFixture]
+    public class when_starting_and_read_prerecorded_events_successfully : with_multi_stream_checkpoint_manager,
+                                                                          IHandle<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>
+    {
+        private ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private CoreProjectionProcessingMessage.PrerecordedEventsLoaded _eventsLoadedMessage;
+
+        public override void When()
+        {
+            _bus.Subscribe<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>(this);
+
+            _checkpointManager.Initialize();
+            var positions = new Dictionary<string, long> { { "a", 1 }, { "b", 1 }, { "c", 1 } };
+            _checkpointManager.BeginLoadPrerecordedEvents(CheckpointTag.FromStreamPositions(0, positions));
+
+            if(!_mre.Wait(10000))
+            {
+                Assert.Fail("Timed out waiting for pre recorded events loaded message");
+            }
+        }
+
+        public void Handle(CoreProjectionProcessingMessage.PrerecordedEventsLoaded message)
+        {
+            _eventsLoadedMessage = message;
+            _mre.Set();
+        }
+
+        [Test]
+        public void should_send_prerecorded_events_message()
+        {
+            Assert.IsNotNull(_eventsLoadedMessage);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_and_read_prerecorded_events_times_out.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_and_read_prerecorded_events_times_out.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager.multi_stream
+{
+    [TestFixture]
+    public class when_starting_and_read_prerecorded_events_times_out : with_multi_stream_checkpoint_manager,
+                                                                       IHandle<TimerMessage.Schedule>,
+                                                                       IHandle<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>
+    {
+        private bool _hasTimedOut;
+        private Guid _timeoutCorrelationId;
+        private ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private CoreProjectionProcessingMessage.PrerecordedEventsLoaded _eventsLoadedMessage;
+
+        public override void When()
+        {
+            _bus.Subscribe<TimerMessage.Schedule>(this);
+            _bus.Subscribe<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>(this);
+
+            _checkpointManager.Initialize();
+            var positions = new Dictionary<string, long> { { "a", 1 }, { "b", 1 }, { "c", 1 } };
+            _checkpointManager.BeginLoadPrerecordedEvents(CheckpointTag.FromStreamPositions(0, positions));
+
+            if(!_mre.Wait(10000))
+            {
+                Assert.Fail("Timed out waiting for pre recorded events loaded message");
+            }
+        }
+
+        public override void Handle(ClientMessage.ReadStreamEventsBackward message)
+        {
+            if(!_hasTimedOut)
+            {
+                _hasTimedOut = true;
+                _timeoutCorrelationId = message.CorrelationId;
+                return;
+            }
+            base.Handle(message);
+        }
+
+        public void Handle(TimerMessage.Schedule message)
+        {
+            var delay = message.ReplyMessage as IODispatcherDelayedMessage;
+            if (delay != null && delay.MessageCorrelationId == _timeoutCorrelationId)
+            {
+                message.Reply();
+            }
+        }
+
+        public void Handle(CoreProjectionProcessingMessage.PrerecordedEventsLoaded message)
+        {
+            _eventsLoadedMessage = message;
+            _mre.Set();
+        }
+
+        [Test]
+        public void should_send_prerecorded_events_message()
+        {
+            Assert.IsNotNull(_eventsLoadedMessage);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.UserManagement;
+using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_manager.multi_stream
+{
+    public abstract class with_multi_stream_checkpoint_manager : IHandle<ClientMessage.ReadStreamEventsBackward>
+    {
+        protected readonly InMemoryBus _bus = InMemoryBus.CreateTest();
+        protected readonly Guid _projectionId = Guid.NewGuid();
+        protected readonly string[] _streams = new string[]{ "a", "b", "c" };
+        protected readonly string _projectionName = "test_projection";
+
+        protected IODispatcher _ioDispatcher;
+        protected ProjectionVersion _projectionVersion;
+        protected ProjectionConfig _projectionConfig;
+        protected PositionTagger _positionTagger;
+        protected ProjectionNamesBuilder _namingBuilder;
+        protected CoreProjectionCheckpointWriter _coreProjectionCheckpointWriter;
+        protected MultiStreamMultiOutputCheckpointManager _checkpointManager;
+
+        private bool _hasRead;
+
+        [OneTimeSetUp]
+        public void TestFixtureSetUp()
+        {
+            _ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_bus));
+            _projectionVersion = new ProjectionVersion(3, 1, 2);
+            _projectionConfig = new ProjectionConfig(SystemAccount.Principal, 10, 1000, 1000, 10, true, true, true, false,
+                false, false, 5000, 10);
+            _positionTagger = new MultiStreamPositionTagger(3, _streams);
+            _positionTagger.AdjustTag(CheckpointTag.FromStreamPositions(3, new Dictionary<string, long> {{ "a", 0 }, { "b", 0 }, { "c", 0 }}));
+            _namingBuilder = ProjectionNamesBuilder.CreateForTest("projection");
+
+            IODispatcherTestHelpers.SubscribeIODispatcher(_ioDispatcher, _bus);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsBackward>(this);
+
+            _coreProjectionCheckpointWriter = new CoreProjectionCheckpointWriter(_namingBuilder.MakeCheckpointStreamName(), _ioDispatcher,
+                _projectionVersion, _projectionName);
+
+            _checkpointManager = new MultiStreamMultiOutputCheckpointManager(_bus, _projectionId, _projectionVersion, SystemAccount.Principal,
+                _ioDispatcher, _projectionConfig, _projectionName, _positionTagger, _namingBuilder, true, true, false,
+                _coreProjectionCheckpointWriter);
+
+            When();
+        }
+
+        public abstract void When();
+
+        public virtual void Handle(ClientMessage.ReadStreamEventsBackward message)
+        {
+            if (message.EventStreamId == _namingBuilder.GetOrderStreamName())
+                message.Envelope.ReplyWith(ReadOrderStream(message));
+            if (message.EventStreamId == "a")
+                message.Envelope.ReplyWith(ReadTestStream(message));
+        }
+
+        public ClientMessage.ReadStreamEventsBackwardCompleted ReadOrderStream(ClientMessage.ReadStreamEventsBackward message)
+        {
+            ResolvedEvent[] events;
+            if(!_hasRead)
+            {
+                var checkpoint = CheckpointTag.FromStreamPositions(0, new Dictionary<string, long> {{"a", 5}, {"b", 5}, {"c", 5}});
+                events = IODispatcherTestHelpers.CreateResolvedEvent(message.EventStreamId, "$>",
+                "10@a", checkpoint.ToJsonString(new ProjectionVersion(3, 0, 1)));
+                _hasRead = true;
+            }
+            else
+            {
+                events = new ResolvedEvent[0] {};
+            }
+            return new ClientMessage.ReadStreamEventsBackwardCompleted(message.CorrelationId, message.EventStreamId, message.FromEventNumber,
+                message.MaxCount, ReadStreamResult.Success, events, null, true, "", message.FromEventNumber - events.Length, message.FromEventNumber, true, 10000);
+        }
+
+        public ClientMessage.ReadStreamEventsBackwardCompleted ReadTestStream(ClientMessage.ReadStreamEventsBackward message)
+        {
+            var events = IODispatcherTestHelpers.CreateResolvedEvent(message.EventStreamId, "testevent", "{ \"data\":1 }");
+            return new ClientMessage.ReadStreamEventsBackwardCompleted(message.CorrelationId, message.EventStreamId, message.FromEventNumber,
+                message.MaxCount, ReadStreamResult.Success, events, null, true, "", message.FromEventNumber - 1, message.FromEventNumber, true, 10000);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint_reader/when_projection_reader_reads_successfully.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint_reader/when_projection_reader_reads_successfully.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using EventStore.Core.Bus;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_checkpoint_reader
+{
+    [TestFixture]
+    public class when_projection_reader_reads_successfully : with_projection_checkpoint_reader,
+                                                            IHandle<CoreProjectionProcessingMessage.CheckpointLoaded>
+    {
+        private ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private CoreProjectionProcessingMessage.CheckpointLoaded _checkpointLoaded;
+
+        public override void When()
+        {
+            _bus.Subscribe<CoreProjectionProcessingMessage.CheckpointLoaded>(this);
+
+            _reader.Initialize();
+            _reader.BeginLoadState();
+            if(!_mre.Wait(10000))
+            {
+                Assert.Fail("Timed out waiting for checkpoint to load");
+            }
+        }
+
+        public void Handle(CoreProjectionProcessingMessage.CheckpointLoaded message)
+        {
+            _checkpointLoaded = message;
+            _mre.Set();
+        }
+
+        [Test]
+        public void should_load_checkpoint()
+        {
+            Assert.IsNotNull(_checkpointLoaded);
+            Assert.AreEqual(_checkpointLoaded.ProjectionId, _projectionId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint_reader/when_projection_reader_times_out_on_read.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint_reader/when_projection_reader_times_out_on_read.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using EventStore.Projections.Core.Services;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_checkpoint_reader
+{
+    [TestFixture]
+    public class when_projection_reader_times_out_on_read :  with_projection_checkpoint_reader,
+                                                            IHandle<CoreProjectionProcessingMessage.CheckpointLoaded>,
+                                                            IHandle<TimerMessage.Schedule>
+    {
+        private ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private CoreProjectionProcessingMessage.CheckpointLoaded _checkpointLoaded;
+        private bool _hasTimedOut;
+        private Guid _timeoutCorrelationId;
+
+        public override void When()
+        {
+            _bus.Subscribe<CoreProjectionProcessingMessage.CheckpointLoaded>(this);
+            _bus.Subscribe<TimerMessage.Schedule>(this);
+
+            _reader.Initialize();
+            _reader.BeginLoadState();
+            if(!_mre.Wait(10000))
+            {
+                Assert.Fail("Timed out waiting for checkpoint to load");
+            }
+        }
+
+        public override void Handle(ClientMessage.ReadStreamEventsBackward message)
+        {
+            if(!_hasTimedOut)
+            {
+                _timeoutCorrelationId = message.CorrelationId;
+                _hasTimedOut = true;
+                return;
+            }
+            var evnts = IODispatcherTestHelpers.CreateResolvedEvent(message.EventStreamId, ProjectionEventTypes.ProjectionCheckpoint, "[]",
+                @"{
+                    ""$v"": ""1:-1:3:3"",
+                    ""$c"": 269728,
+                    ""$p"": 269728
+                }");
+            var reply = new ClientMessage.ReadStreamEventsBackwardCompleted(message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount, ReadStreamResult.Success,
+                evnts, null, true, "", 0, 0, true, 10000);
+            message.Envelope.ReplyWith(reply);
+        }
+
+        public void Handle(TimerMessage.Schedule message)
+        {
+            var delay = message.ReplyMessage as IODispatcherDelayedMessage;
+            if (delay != null && delay.MessageCorrelationId == _timeoutCorrelationId)
+            {
+                message.Reply();
+            }
+        }
+
+        public void Handle(CoreProjectionProcessingMessage.CheckpointLoaded message)
+        {
+            _checkpointLoaded = message;
+            _mre.Set();
+        }
+
+        [Test]
+        public void should_load_checkpoint()
+        {
+            Assert.IsNotNull(_checkpointLoaded);
+            Assert.AreEqual(_checkpointLoaded.ProjectionId, _projectionId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint_reader/with_projection_checkpoint_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/projection_checkpoint_reader/with_projection_checkpoint_reader.cs
@@ -1,0 +1,50 @@
+using System;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection.projection_checkpoint_reader
+{
+    public abstract class with_projection_checkpoint_reader : IHandle<ClientMessage.ReadStreamEventsBackward>
+    {
+        protected readonly string _projectionCheckpointStreamId = "projection-checkpoint-stream";
+        protected readonly Guid _projectionId = Guid.NewGuid();
+
+        protected InMemoryBus _bus = InMemoryBus.CreateTest();
+        protected IODispatcher _ioDispatcher;
+        protected ProjectionVersion _projectionVersion;
+        protected CoreProjectionCheckpointReader _reader;
+
+        [OneTimeSetUp]
+        public void TestFixtureSetUp()
+        {
+            _ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_bus));
+            IODispatcherTestHelpers.SubscribeIODispatcher(_ioDispatcher, _bus);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsBackward>(this);
+            _projectionVersion = new ProjectionVersion(1, 2, 3);
+            _reader = new CoreProjectionCheckpointReader(_bus, _projectionId, _ioDispatcher, _projectionCheckpointStreamId, _projectionVersion, true);
+            When();
+        }
+
+        public abstract void When();
+
+        public virtual void Handle(ClientMessage.ReadStreamEventsBackward message)
+        {
+            var evnts = IODispatcherTestHelpers.CreateResolvedEvent(message.EventStreamId, ProjectionEventTypes.ProjectionCheckpoint, "[]",
+                @"{
+                    ""$v"": ""1:-1:3:3"",
+                    ""$c"": 269728,
+                    ""$p"": 269728
+                }");
+            var reply = new ClientMessage.ReadStreamEventsBackwardCompleted(message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount, ReadStreamResult.Success,
+                evnts, null, true, "", 0, 0, true, 10000);
+            message.Envelope.ReplyWith(reply);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/when_checkpoint_read_times_out.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/when_checkpoint_read_times_out.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
+{
+    [TestFixture]
+    public class when_checkpoint_read_times_out : with_emitted_stream_deleter,
+                                                  IHandle<TimerMessage.Schedule>
+    {
+        protected Action _onDeleteStreamCompleted;
+        private ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private List<ClientMessage.DeleteStream> _deleteMessages = new List<ClientMessage.DeleteStream>();
+        private bool _hasTimerTimedOut;
+
+        private Guid _timedOutCorrelationId;
+
+        public override void When()
+        {
+            _bus.Subscribe<TimerMessage.Schedule>(this);
+            _onDeleteStreamCompleted = () =>
+            {
+                _mre.Set();
+            };
+
+            _deleter.DeleteEmittedStreams(_onDeleteStreamCompleted);
+        }
+
+        public override void Handle(ClientMessage.ReadStreamEventsBackward message)
+        {
+            if(message.CorrelationId == _timedOutCorrelationId)
+            {
+                return;
+            }
+            else
+            {
+                base.Handle(message);
+            }
+        }
+
+        public override void Handle(ClientMessage.DeleteStream message)
+        {
+            _deleteMessages.Add(message);
+            message.Envelope.ReplyWith(new ClientMessage.DeleteStreamCompleted(
+                message.CorrelationId, OperationResult.Success, String.Empty));
+        }
+
+        public void Handle(TimerMessage.Schedule message)
+        {
+            if(!_hasTimerTimedOut)
+            {
+                var delay = message.ReplyMessage as IODispatcherDelayedMessage;
+                if(delay != null)
+                {
+                    _timedOutCorrelationId = delay.MessageCorrelationId.Value;
+                    _hasTimerTimedOut = true;
+                    message.Reply();
+                }
+            }
+        }
+
+        [Test]
+        public void should_have_deleted_the_tracked_emitted_stream()
+        {
+            if(!_mre.Wait(10000))
+            {
+                Assert.Fail("Timed out waiting for event to be deleted");
+            }
+            Assert.AreEqual(_testStreamName, _deleteMessages[0].EventStreamId);
+            Assert.AreEqual(_checkpointName, _deleteMessages[1].EventStreamId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/when_delete_stream_succeeds.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/when_delete_stream_succeeds.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
+{
+    [TestFixture]
+    public class when_delete_stream_succeeds : with_emitted_stream_deleter
+    {
+        protected Action _onDeleteStreamCompleted;
+        private readonly ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private readonly List<ClientMessage.DeleteStream> _deleteMessages = new List<ClientMessage.DeleteStream>();
+
+        public override void When()
+        {
+            _onDeleteStreamCompleted = () =>
+            {
+                _mre.Set();
+            };
+
+            _deleter.DeleteEmittedStreams(_onDeleteStreamCompleted);
+        }
+
+        public override void Handle(ClientMessage.DeleteStream message)
+        {
+            _deleteMessages.Add(message);
+            message.Envelope.ReplyWith(new ClientMessage.DeleteStreamCompleted(
+                message.CorrelationId, OperationResult.Success, String.Empty));
+        }
+
+        [Test]
+        public void should_have_deleted_the_tracked_emitted_stream()
+        {
+            if(!_mre.Wait(10000))
+            {
+                Assert.Fail("Timed out waiting for event to be deleted");
+            }
+            Assert.AreEqual(_testStreamName, _deleteMessages[0].EventStreamId);
+            Assert.AreEqual(_checkpointName, _deleteMessages[1].EventStreamId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/when_emitted_streams_read_times_out.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/when_emitted_streams_read_times_out.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
+{
+    [TestFixture]
+    public class when_emitted_streams_read_times_out : with_emitted_stream_deleter,
+                                                       IHandle<TimerMessage.Schedule>
+    {
+        protected Action _onDeleteStreamCompleted;
+        private ManualResetEventSlim _mre = new ManualResetEventSlim();
+        private List<ClientMessage.DeleteStream> _deleteMessages = new List<ClientMessage.DeleteStream>();
+        private bool _hasTimedOut;
+
+        private Guid _timedOutCorrelationId;
+
+        public override void When()
+        {
+            _bus.Subscribe<TimerMessage.Schedule>(this);
+            _onDeleteStreamCompleted = () =>
+            {
+                _mre.Set();
+            };
+
+            _deleter.DeleteEmittedStreams(_onDeleteStreamCompleted);
+        }
+
+        public override void Handle(ClientMessage.ReadStreamEventsForward message)
+        {
+            if(!_hasTimedOut)
+            {
+                _hasTimedOut = true;
+                _timedOutCorrelationId = message.CorrelationId;
+                return;
+            }
+            else
+            {
+                base.Handle(message);
+            }
+        }
+
+        public override void Handle(ClientMessage.DeleteStream message)
+        {
+            _deleteMessages.Add(message);
+            message.Envelope.ReplyWith(new ClientMessage.DeleteStreamCompleted(
+                message.CorrelationId, OperationResult.Success, String.Empty));
+        }
+
+        public void Handle(TimerMessage.Schedule message)
+        {
+            var delay = message.ReplyMessage as IODispatcherDelayedMessage;
+            if(delay != null && delay.MessageCorrelationId.Value == _timedOutCorrelationId)
+            {
+                message.Reply();
+            }
+        }
+
+        [Test]
+        public void should_have_deleted_the_tracked_emitted_stream()
+        {
+            if(!_mre.Wait(10000))
+            {
+                Assert.Fail("Timed out waiting for event to be deleted");
+            }
+            Assert.AreEqual(_testStreamName, _deleteMessages[0].EventStreamId);
+            Assert.AreEqual(_checkpointName, _deleteMessages[1].EventStreamId);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_emitted_stream_deleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/emitted_streams_deleter/when_deleting/with_emitted_stream_deleter.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.emitted_streams_deleter.when_deleting
+{
+    public abstract class with_emitted_stream_deleter : IHandle<ClientMessage.ReadStreamEventsForward>,
+                                                            IHandle<ClientMessage.ReadStreamEventsBackward>,
+                                                            IHandle<ClientMessage.DeleteStream>
+    {
+        protected InMemoryBus _bus = InMemoryBus.CreateTest();
+        protected IODispatcher _ioDispatcher;
+        protected EmittedStreamsDeleter _deleter;
+        protected ProjectionNamesBuilder _projectionNamesBuilder;
+        protected string _projectionName = "test_projection";
+        protected string _checkpointName;
+        protected string _testStreamName = "test_stream";
+        private bool _hasReadForward;
+
+        [OneTimeSetUp]
+        protected virtual void SetUp()
+        {
+            _ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_bus));
+            _projectionNamesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
+            _checkpointName = _projectionNamesBuilder.GetEmittedStreamsCheckpointName();
+
+            _deleter = new EmittedStreamsDeleter(_ioDispatcher,
+                _projectionNamesBuilder.GetEmittedStreamsName(),
+                _checkpointName);
+
+            IODispatcherTestHelpers.SubscribeIODispatcher(_ioDispatcher, _bus);
+
+            _bus.Subscribe<ClientMessage.ReadStreamEventsForward>(this);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsBackward>(this);
+            _bus.Subscribe<ClientMessage.DeleteStream>(this);
+
+            When();
+        }
+
+        public abstract void When();
+
+        public virtual void Handle(ClientMessage.ReadStreamEventsBackward message)
+        {
+            var events = IODispatcherTestHelpers.CreateResolvedEvent(message.EventStreamId, ProjectionEventTypes.ProjectionCheckpoint, "0");
+            var reply = new ClientMessage.ReadStreamEventsBackwardCompleted(message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount,
+                ReadStreamResult.Success, events, null, false, String.Empty, 0, message.FromEventNumber, true, 1000);
+
+            message.Envelope.ReplyWith(reply);
+        }
+
+        public virtual void Handle(ClientMessage.ReadStreamEventsForward message)
+        {
+            ClientMessage.ReadStreamEventsForwardCompleted reply;
+
+            if(!_hasReadForward)
+            {
+                _hasReadForward = true;
+                var events = IODispatcherTestHelpers.CreateResolvedEvent(message.EventStreamId, ProjectionEventTypes.ProjectionCheckpoint, _testStreamName);
+                reply = new ClientMessage.ReadStreamEventsForwardCompleted(message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount,
+                    ReadStreamResult.Success, events, null, false, String.Empty, message.FromEventNumber + 1, message.FromEventNumber, true, 1000);
+            }
+            else
+            {
+                reply = new ClientMessage.ReadStreamEventsForwardCompleted(message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount,
+                    ReadStreamResult.Success, new ResolvedEvent[]{}, null, false, String.Empty, message.FromEventNumber, message.FromEventNumber, true, 1000);
+            }
+            message.Envelope.ReplyWith(reply);
+        }
+
+        public abstract void Handle(ClientMessage.DeleteStream message);
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/master_core_projection_response_reader/when_response_reader_has_read_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/master_core_projection_response_reader/when_response_reader_has_read_timeout.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Projections.Core.Messages.ParallelQueryProcessingMessages;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.master_core_projection_response_reader
+{
+    [TestFixture]
+    public class when_response_reader_has_read_timeout : with_master_core_response_reader,
+                                                         IHandle<PartitionProcessingResult>,
+                                                         IHandle<TimerMessage.Schedule>
+    {
+        private bool _hasTimedOut;
+        public ManualResetEventSlim _mre = new ManualResetEventSlim();
+
+        [OneTimeSetUp]
+        protected override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            _bus.Subscribe<PartitionProcessingResult>(this);
+            _bus.Subscribe<TimerMessage.Schedule>(this);
+
+            _reader.Start();
+            
+        }
+
+        public void Handle(TimerMessage.Schedule message)
+        {
+            if (!_hasTimedOut && message.ReplyMessage as IODispatcherDelayedMessage != null)
+            {
+                _hasTimedOut = true;
+                message.Reply();
+            }
+        }
+
+        public override void Handle(ClientMessage.ReadStreamEventsForward message)
+        {
+            if(!_hasTimedOut)
+                return;
+            message.Envelope.ReplyWith(CreateResultCommandReadResponse(message));
+        }
+
+        public void Handle(PartitionProcessingResult message)
+        {
+            _mre.Set();
+        }
+
+        [Test]
+        public void should_publish_command()
+        {
+            Assert.IsTrue(_mre.Wait(10000));
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/master_core_projection_response_reader/when_response_reader_starts_up_successfully.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/master_core_projection_response_reader/when_response_reader_starts_up_successfully.cs
@@ -1,0 +1,40 @@
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Projections.Core.Messages.ParallelQueryProcessingMessages;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.master_core_projection_response_reader
+{
+    [TestFixture]
+    public class when_response_reader_starts_up_successfully : with_master_core_response_reader,
+                                                               IHandle<PartitionProcessingResult>
+    {
+        public ManualResetEventSlim _mre = new ManualResetEventSlim();
+
+        [OneTimeSetUp]
+        protected override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+            _bus.Subscribe<PartitionProcessingResult>(this);
+
+            _reader.Start();
+        }
+
+        public override void Handle(ClientMessage.ReadStreamEventsForward message)
+        {
+            message.Envelope.ReplyWith(CreateResultCommandReadResponse(message));
+        }
+
+        public void Handle(PartitionProcessingResult message)
+        {
+            _mre.Set();
+        }
+
+        [Test]
+        public void should_publish_command()
+        {
+            Assert.IsTrue(_mre.Wait(10000));
+        }
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/master_core_projection_response_reader/with_master_core_response_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/master_core_projection_response_reader/with_master_core_response_reader.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Text;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Helpers.IODispatcherTests;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Projections.Core.Messages.Persisted.Responses.Slave;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Projections.Core.Services.Processing;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.master_core_projection_response_reader
+{
+    public abstract class with_master_core_response_reader : IHandle<ClientMessage.WriteEvents>,
+                                                             IHandle<ClientMessage.ReadStreamEventsForward>
+    {
+        protected Guid _workerId = Guid.NewGuid();
+        protected Guid _masterProjectionId = Guid.NewGuid();
+        protected string _streamId;
+
+        protected MasterCoreProjectionResponseReader _reader;
+        protected InMemoryBus _bus;
+        protected IODispatcher _ioDispatcher;
+
+        [OneTimeSetUp]
+        protected virtual void TestFixtureSetUp()
+        {
+            _streamId = "$projection-$" + _masterProjectionId.ToString("N");
+
+            _bus = InMemoryBus.CreateTest();
+            _bus.Subscribe<ClientMessage.WriteEvents>(this);
+            _bus.Subscribe<ClientMessage.ReadStreamEventsForward>(this);
+
+            _ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_bus));
+            IODispatcherTestHelpers.SubscribeIODispatcher(_ioDispatcher, _bus);
+
+            _reader = new MasterCoreProjectionResponseReader(_bus, _ioDispatcher, _workerId, _masterProjectionId);
+        }
+
+        public abstract void Handle(ClientMessage.ReadStreamEventsForward message);
+
+        public virtual void Handle(ClientMessage.WriteEvents message)
+        {
+            var response = new ClientMessage.WriteEventsCompleted(message.CorrelationId, 0, 0, 1000, 1000);
+            message.Envelope.ReplyWith(response);
+        }
+
+        public ClientMessage.ReadStreamEventsForwardCompleted CreateResultCommandReadResponse(ClientMessage.ReadStreamEventsForward message)
+        {
+            var result = new PartitionProcessingResultResponse
+            {
+                SubscriptionId = Guid.NewGuid().ToString("N"),
+                Partition = "teststream",
+                CausedBy = Guid.NewGuid().ToString("N"),
+                Position = CheckpointTag.Empty,
+                Result = "result"
+            };
+            var data = JsonConvert.SerializeObject(result);
+
+            var evnts = IODispatcherTestHelpers.CreateResolvedEvent(_streamId, "$result", data);
+            return new ClientMessage.ReadStreamEventsForwardCompleted(message.CorrelationId, message.EventStreamId, message.FromEventNumber, message.MaxCount,
+            ReadStreamResult.Success, evnts, null, false, String.Empty, message.FromEventNumber + 1, message.FromEventNumber, true, 10000);
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Services/Management/MasterCoreProjectionResponseReader.cs
+++ b/src/EventStore.Projections.Core/Services/Management/MasterCoreProjectionResponseReader.cs
@@ -100,7 +100,8 @@ namespace EventStore.Projections.Core.Services.Management
                                             PublishCommand(e);
                                     }
                                 }
-                            });
+                            },
+                            () => Log.Warn("Read forward of stream {0} timed out. Retrying", _streamId));
                 } while (!eof);
                 _lastAwakeCorrelationId = Guid.NewGuid();
                 yield return

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManagerResponseReader.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManagerResponseReader.cs
@@ -118,6 +118,10 @@ namespace EventStore.Projections.Core.Services.Management
                     false,
                     SystemAccount.Principal,
                     ReadForwardCompleted,
+                    () => {
+                        Log.Warn("Read forward of stream {0} timed out. Retrying", ProjectionNamesBuilder._projectionsMasterStream);
+                        ReadForward();
+                    },
                     _correlationId)
             );
             _publisher.Publish(TimerMessage.Schedule.Create(


### PR DESCRIPTION
This allows us to handle timeouts on reads for projections in a single place.

Update the projection command/response readers, checkpoint managers and emitted streams tracker/deleter to handle timeouts. This is to prevent projections from getting stuck in the event of a timeout.