### PR TITLE
Add PreferSlaveNode to Connection Builder

### DIFF
--- a/src/EventStore.ClientAPI/ClusterSettings.cs
+++ b/src/EventStore.ClientAPI/ClusterSettings.cs
@@ -43,7 +43,7 @@ namespace EventStore.ClientAPI
         /// <summary>
         /// Prefer a randomly selected node. 
         /// </summary>
-        public bool PreferRandomNode;
+        public NodePreference NodePreference;
 
         /// <summary>
         /// Used if connecting with gossip seeds.
@@ -51,15 +51,15 @@ namespace EventStore.ClientAPI
         /// <param name="gossipSeeds">Endpoints for seeding gossip</param>.
         /// <param name="maxDiscoverAttempts">Maximum number of attempts to discover the cluster</param>.
         /// <param name="gossipTimeout">Timeout for cluster gossip</param>.
-        /// <param name="preferRandomNode">Whether to prefer a random node selection or master</param>.
-        internal ClusterSettings(GossipSeed[] gossipSeeds, int maxDiscoverAttempts, TimeSpan gossipTimeout, bool preferRandomNode)
+        /// <param name="nodePreference">Whether to prefer slave, random, or master node selection</param>.
+        internal ClusterSettings(GossipSeed[] gossipSeeds, int maxDiscoverAttempts, TimeSpan gossipTimeout, NodePreference nodePreference)
         {
             ClusterDns = "";
             MaxDiscoverAttempts = maxDiscoverAttempts;
             ExternalGossipPort = 0;
             GossipTimeout = gossipTimeout;
             GossipSeeds = gossipSeeds;
-            PreferRandomNode = preferRandomNode;
+            NodePreference = nodePreference;
         }
 
         /// <summary>
@@ -69,8 +69,8 @@ namespace EventStore.ClientAPI
         /// <param name="maxDiscoverAttempts">The maximum number of attempts for discovering endpoints</param>.
         /// <param name="externalGossipPort">The well-known endpoint on which cluster managers are running</param>.
         /// <param name="gossipTimeout">Timeout for cluster gossip</param>.
-        /// <param name="preferRandomNode">Whether to prefer a random node selection or master</param>.
-        internal ClusterSettings(string clusterDns, int maxDiscoverAttempts, int externalGossipPort, TimeSpan gossipTimeout, bool preferRandomNode)
+        /// <param name="nodePreference">Whether to prefer slave, random, or master node selection</param>.
+        internal ClusterSettings(string clusterDns, int maxDiscoverAttempts, int externalGossipPort, TimeSpan gossipTimeout, NodePreference nodePreference)
         {
             Ensure.NotNullOrEmpty(clusterDns, "clusterDns");
             if (maxDiscoverAttempts < -1)
@@ -82,7 +82,7 @@ namespace EventStore.ClientAPI
             ExternalGossipPort = externalGossipPort;
             GossipTimeout = gossipTimeout;
             GossipSeeds = new GossipSeed[0];
-            PreferRandomNode = preferRandomNode;
+            NodePreference = nodePreference;
         }
     }
 }

--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -124,7 +124,7 @@ namespace EventStore.ClientAPI
         /// <summary>
         /// Whether to randomly choose a node that's alive from the known nodes. 
         /// </summary>
-        public readonly bool PreferRandomNode;
+        public readonly NodePreference NodePreference;
 
         /// <summary>
         /// The interval after which a client will time out during connection.
@@ -154,7 +154,7 @@ namespace EventStore.ClientAPI
                                     int maxDiscoverAttempts, 
                                     int externalGossipPort, 
                                     TimeSpan gossipTimeout,
-                                    bool preferRandomNode)
+                                    NodePreference nodePreference)
         {
             Ensure.NotNull(log, "log");
             Ensure.Positive(maxQueueSize, "maxQueueSize");
@@ -189,7 +189,7 @@ namespace EventStore.ClientAPI
             MaxDiscoverAttempts = maxDiscoverAttempts;
             ExternalGossipPort = externalGossipPort;
             GossipTimeout = gossipTimeout;
-            PreferRandomNode = preferRandomNode;
+            NodePreference = nodePreference;
         }
     }
 }

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -40,7 +40,7 @@ namespace EventStore.ClientAPI
         private int _gossipExternalHttpPort = Consts.DefaultClusterManagerExternalHttpPort;
         private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
         private GossipSeed[] _gossipSeeds;
-        private bool _preferRandomNode = false;
+        private NodePreference _nodePreference = NodePreference.Master;
 
 
         internal ConnectionSettingsBuilder()
@@ -350,7 +350,17 @@ namespace EventStore.ClientAPI
         /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
         public ConnectionSettingsBuilder PreferRandomNode()
         {
-            _preferRandomNode = true;
+            _nodePreference = NodePreference.Random;
+            return this;
+        }
+
+        /// <summary>
+        /// Whether to prioritize choosing a slave node that's alive from the known nodes. 
+        /// </summary>
+        /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        public ConnectionSettingsBuilder PreferSlaveNode()
+        {
+            _nodePreference = NodePreference.Slave;
             return this;
         }
 
@@ -454,7 +464,7 @@ namespace EventStore.ClientAPI
                                           _maxDiscoverAttempts,
                                           _gossipExternalHttpPort,
                                           _gossipTimeout,
-                                          _preferRandomNode);
+                                          _nodePreference);
         }
     }
 }

--- a/src/EventStore.ClientAPI/DnsClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/DnsClusterSettingsBuilder.cs
@@ -14,7 +14,7 @@ namespace EventStore.ClientAPI
         private int _maxDiscoverAttempts = Consts.DefaultMaxClusterDiscoverAttempts;
         private int _managerExternalHttpPort = Consts.DefaultClusterManagerExternalHttpPort;
         private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
-        private bool _preferRandomNode = false;
+        private NodePreference _nodePreference = NodePreference.Master;
 
         /// <summary>
         /// Sets the DNS name under which cluster nodes are listed.
@@ -60,7 +60,17 @@ namespace EventStore.ClientAPI
         /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
         public DnsClusterSettingsBuilder PreferRandomNode()
         {
-            _preferRandomNode = true;
+            _nodePreference = NodePreference.Random;
+            return this;
+        }
+
+        /// <summary>
+        /// Whether to prioritize choosing a slave node that's alive from the known nodes. 
+        /// </summary>
+        /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        public DnsClusterSettingsBuilder PreferSlaveNode()
+        {
+            _nodePreference = NodePreference.Slave;
             return this;
         }
 
@@ -103,7 +113,7 @@ namespace EventStore.ClientAPI
                 this._maxDiscoverAttempts,
                 this._managerExternalHttpPort,
                 this._gossipTimeout,
-                this._preferRandomNode); 
+                this._nodePreference); 
         }
     }
 }

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Internal\PersistentSubscriptionUpdateResult.cs" />
     <Compile Include="Internal\PersistentSubscriptionUpdateStatus.cs" />
     <Compile Include="Internal\VolatileEventStoreSubscription.cs" />
+    <Compile Include="NodePreference.cs" />
     <Compile Include="PersistentEventStoreSubscription.cs" />
     <Compile Include="PersistentSubscriptionNakEventAction.cs" />
     <Compile Include="PersistentSubscriptionSettings.cs" />

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -100,12 +100,12 @@ namespace EventStore.ClientAPI
                         connectionSettings.ClientConnectionTimeout, connectionSettings.ClusterDns,
                         connectionSettings.GossipSeeds, connectionSettings.MaxDiscoverAttempts,
                         connectionSettings.ExternalGossipPort, connectionSettings.GossipTimeout,
-                        connectionSettings.PreferRandomNode);
+                        connectionSettings.NodePreference);
                 }
                 if (scheme == "discover")
                 {
                     var clusterSettings = new ClusterSettings(uri.Host, connectionSettings.MaxDiscoverAttempts, uri.Port,
-                        connectionSettings.GossipTimeout, connectionSettings.PreferRandomNode);
+                        connectionSettings.GossipTimeout, connectionSettings.NodePreference);
                     Ensure.NotNull(connectionSettings, "connectionSettings");
                     Ensure.NotNull(clusterSettings, "clusterSettings");
 
@@ -115,7 +115,7 @@ namespace EventStore.ClientAPI
                         clusterSettings.ExternalGossipPort,
                         clusterSettings.GossipSeeds,
                         clusterSettings.GossipTimeout,
-                        clusterSettings.PreferRandomNode);
+                        clusterSettings.NodePreference);
 
                     return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
                         connectionName);
@@ -134,7 +134,7 @@ namespace EventStore.ClientAPI
                 var clusterSettings = new ClusterSettings(connectionSettings.GossipSeeds,
                     connectionSettings.MaxDiscoverAttempts,
                     connectionSettings.GossipTimeout,
-                    connectionSettings.PreferRandomNode);
+                    connectionSettings.NodePreference);
                 Ensure.NotNull(connectionSettings, "connectionSettings");
                 Ensure.NotNull(clusterSettings, "clusterSettings");
 
@@ -144,7 +144,7 @@ namespace EventStore.ClientAPI
                     clusterSettings.ExternalGossipPort,
                     clusterSettings.GossipSeeds,
                     clusterSettings.GossipTimeout,
-                    clusterSettings.PreferRandomNode);
+                    clusterSettings.NodePreference);
 
                 return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
                     connectionName);
@@ -226,7 +226,7 @@ namespace EventStore.ClientAPI
                                                                       clusterSettings.ExternalGossipPort,
                                                                       clusterSettings.GossipSeeds,
                                                                       clusterSettings.GossipTimeout,
-                                                                      clusterSettings.PreferRandomNode);
+                                                                      clusterSettings.NodePreference);
 
             return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer, connectionName);
         }

--- a/src/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
@@ -13,7 +13,7 @@ namespace EventStore.ClientAPI
         private GossipSeed[] _gossipSeeds;
         private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
         private int _maxDiscoverAttempts = Consts.DefaultMaxClusterDiscoverAttempts;
-        private bool _preferRandomNode = false;
+        private NodePreference _nodePreference = NodePreference.Master;
 
         /// <summary>
         /// Sets gossip seed endpoints for the client.
@@ -82,7 +82,17 @@ namespace EventStore.ClientAPI
         /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
         public GossipSeedClusterSettingsBuilder PreferRandomNode()
         {
-            _preferRandomNode = true;
+            _nodePreference = NodePreference.Random;
+            return this;
+        }
+
+        /// <summary>
+        /// Whether to prioritize choosing a slave node that's alive from the known nodes. 
+        /// </summary>
+        /// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+        public GossipSeedClusterSettingsBuilder PreferSlaveNode()
+        {
+            _nodePreference = NodePreference.Slave;
             return this;
         }
 
@@ -100,7 +110,7 @@ namespace EventStore.ClientAPI
         /// Builds a <see cref="ClusterSettings"/> object from a <see cref="GossipSeedClusterSettingsBuilder"/>.
         /// </summary>
         public ClusterSettings Build() {
-            return new ClusterSettings(this._gossipSeeds, this._maxDiscoverAttempts, this._gossipTimeout, this._preferRandomNode);
+            return new ClusterSettings(this._gossipSeeds, this._maxDiscoverAttempts, this._gossipTimeout, this._nodePreference);
         }
     }
 }

--- a/src/EventStore.ClientAPI/NodePreference.cs
+++ b/src/EventStore.ClientAPI/NodePreference.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventStore.ClientAPI
+{
+    /// <summary>
+    /// Indicates which order of preferred nodes for connecting to.
+    /// </summary>
+    public enum NodePreference
+    {
+        /// <summary>
+        /// When attempting connnection, prefers master node.
+        /// </summary>
+        Master,
+        /// <summary>
+        /// When attempting connnection, prefers slave node.
+        /// </summary>
+        Slave,
+        /// <summary>
+        /// When attempting connnection, has no node preference.
+        /// </summary>
+        Random
+    }
+}


### PR DESCRIPTION
This adds the option to prefer Slave nodes in the ClientAPI connection builder (similar to PreferRandom). No breaking changes to the public API, simply adds a PreferSlaveNode() to the fluent syntax connection builder, similar to PreferRandomNode(). 

The use case is that my company has many services that UseMaster along with several services that are read-only and use PreferRandom. The issue is that best case, a third of our read only services are still loading down the master which already has a disproportionate number of the connections. We'd like to shift as much read-only load to the slaves when possible.