### PR TITLE
Persistent subscription bug fix: when reading end of stream and a live event is received

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -59,7 +59,7 @@ namespace EventStore.Core.Services.PersistentSubscription
             Ensure.NotNull(persistentSubscriptionParams.SubscriptionId, "subscriptionId");
             Ensure.NotNull(persistentSubscriptionParams.EventStreamId, "eventStreamId");
             Ensure.NotNull(persistentSubscriptionParams.GroupName, "groupName");
-            _nextEventToPullFrom = 0;            
+            _nextEventToPullFrom = 0;
             _totalTimeWatch = new Stopwatch();
             _settings = persistentSubscriptionParams;
             _totalTimeWatch.Start();
@@ -125,7 +125,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         private void SetLive()
         {
-            //TODO GFY this is hacky and just trying to keep the state at this level when it 
+            //TODO GFY this is hacky and just trying to keep the state at this level when it
             //lives in the streambuffer its for reporting reasons and likely should be revisited
             //at some point.
             _state &= ~PersistentSubscriptionState.Behind;
@@ -159,9 +159,10 @@ namespace EventStore.Core.Services.PersistentSubscription
                 }
                 if (isEndOfStream)
                 {
-                    SetLive();
-                    _streamBuffer.MoveToLive();
-                    return;
+                    if(_streamBuffer.TryMoveToLive()){
+                        SetLive();
+                        return;
+                    }
                 }
                 _nextEventToPullFrom = newposition;
                 TryReadingNewBatch();
@@ -186,7 +187,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                         _lastKnownMessage = Math.Max(_lastKnownMessage, message.ResolvedEvent.OriginalEventNumber);
                     }
                     else if (result == ConsumerPushResult.Skipped)
-                    {                        
+                    {
                         // The consumer strategy skipped the message so leave it in the buffer and continue.
                     }
                     else if (result == ConsumerPushResult.NoMoreCapacity)
@@ -194,7 +195,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                         return;
                     }
                 }
-                
+
             }
         }
 
@@ -402,7 +403,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 lock (_lock)
                 {
                     _outstandingMessages.Remove(e.OriginalEvent.EventId);
-                    _pushClients.RemoveProcessingMessage(e.OriginalEvent.EventId); 
+                    _pushClients.RemoveProcessingMessage(e.OriginalEvent.EventId);
                     TryPushingMessagesToClients();
                 }
             });
@@ -463,7 +464,7 @@ namespace EventStore.Core.Services.PersistentSubscription
                 }
                 else
                 {
-                    TryReadingParkedMessagesFrom(newposition, stopAt);                    
+                    TryReadingParkedMessagesFrom(newposition, stopAt);
                 }
             }
         }
@@ -474,9 +475,9 @@ namespace EventStore.Core.Services.PersistentSubscription
 
             if (result == StartMessageResult.SkippedDuplicate)
             {
-                Log.Warn("Skipping message {0}/{1} with duplicate eventId {2}", 
+                Log.Warn("Skipping message {0}/{1} with duplicate eventId {2}",
                     message.ResolvedEvent.OriginalStreamId,
-                    message.ResolvedEvent.OriginalEventNumber, 
+                    message.ResolvedEvent.OriginalEventNumber,
                     message.EventId);
             }
         }

--- a/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
@@ -133,9 +133,13 @@ namespace EventStore.Core.Services.PersistentSubscription
             }
         }
 
-        public void MoveToLive()
+        public bool TryMoveToLive()
         {
-            if (_liveBuffer.Count == 0) Live = true;
+            if (_liveBuffer.Count == 0){
+                Live = true;
+                return true;
+            }
+            return false;
         }
 
         public long GetLowestRetry()


### PR DESCRIPTION
## Issue
In persistent subscriptions, when reaching the end of a stream, the current behaviour is to set the _state to `Live` and return immediately. `TryReadingNewBatch` will not be called again.
https://github.com/EventStore/EventStore/blob/daddeca886f43e40489efd7d9f45cb6ddd4aed8a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs#L160-L165

There may have been live events that have come in during the time window that a read is started and completed.
Example sequence of events:
```
1. ClientMessage.ReadStreamEventsForward (TryReadingNewBatch)
2. StorageMessage.EventCommitted (NotifyLiveSubscriptionMessage)
3. ClientMessage.ReadStreamEventsForwardCompleted (HandleReadCompleted)
```

Since `TryReadingNewBatch` is not being called again, the new message will stay in the `_liveBuffer` in `_streamBuffer` and will not be pushed out to clients until another live message is received.

## Impact
This will cause the live event that has been received to be **held by the subscription and not be pushed out to clients until another live event is received.**

The bug only occurs when transitioning from a `Behind` state to `Live` which is possible during:

1. Checkpoint loading procedure on startup (OnCheckpointLoaded)
2. When the live buffer is full which will bring the _state from [Live to Behind](https://github.com/EventStore/EventStore/blob/release-v4.1.1/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs#L213)
and cause reads to happen on the [next NotifyClockTick](https://github.com/EventStore/EventStore/blob/release-v4.1.1/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs#L520)