### PR TITLE
#1051: Remove Thread.Sleep from ClientAPI

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -455,7 +455,7 @@ namespace EventStore.ClientAPI
                 : slice.NextPosition >= new Position(lastCommitPosition.Value, lastCommitPosition.Value);
 
             if (!done && slice.IsEndOfStream)
-                Thread.Sleep(1); // we are waiting for server to flush its data
+                await Task.Delay(1).ConfigureAwait(false); // we are awaiting the server to flush its data
             return done;
         }
 
@@ -595,7 +595,7 @@ namespace EventStore.ClientAPI
             }
 
             if (!done && slice.IsEndOfStream)
-                Thread.Sleep(1); // we are waiting for server to flush its data
+                await Task.Delay(1).ConfigureAwait(false); // we are awaiting the server to flush its data
             return done;
         }
 

--- a/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
@@ -197,7 +197,7 @@ namespace EventStore.ClientAPI
             {
                 if (_subscription == null)
                 {
-                    Thread.Sleep(1);
+                    await Task.Delay(1).ConfigureAwait(false);
                 }
                 else
                 {


### PR DESCRIPTION
This prevents a threadpool starvation described in #1051. Instead of blocking the thread when trying to enqueue more operations than MaxQueueSize the thread is released letting other operations to continue.