### PR TITLE
Remove Thread.Sleep from ClientAPI

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -455,7 +455,7 @@ namespace EventStore.ClientAPI
                 : slice.NextPosition >= new Position(lastCommitPosition.Value, lastCommitPosition.Value);
 
             if (!done && slice.IsEndOfStream)
-                Thread.Sleep(1); // we are waiting for server to flush its data
+                await Task.Delay(1).ConfigureAwait(false); // we are awaiting the server to flush its data
             return done;
         }
 
@@ -595,7 +595,7 @@ namespace EventStore.ClientAPI
             }
 
             if (!done && slice.IsEndOfStream)
-                Thread.Sleep(1); // we are waiting for server to flush its data
+                await Task.Delay(1).ConfigureAwait(false); // we are awaiting the server to flush its data
             return done;
         }
 

--- a/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
@@ -197,7 +197,7 @@ namespace EventStore.ClientAPI
             {
                 if (_subscription == null)
                 {
-                    Thread.Sleep(1);
+                    await Task.Delay(1).ConfigureAwait(false);
                 }
                 else
                 {

--- a/src/EventStore.Core.Tests/ClientAPI/read_all_events_backward_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_all_events_backward_should.cs
@@ -86,7 +86,7 @@ namespace EventStore.Core.Tests.ClientAPI
         public void throw_when_got_int_max_value_as_maxcount()
         {
 
-            Assert.Throws<ArgumentException>(
+            Assert.ThrowsAsync<ArgumentException>(
                 () => _conn.ReadAllEventsBackwardAsync(Position.Start, int.MaxValue, resolveLinkTos: false));
         }
     }

--- a/src/EventStore.Core.Tests/ClientAPI/read_all_events_forward_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_all_events_forward_should.cs
@@ -87,7 +87,7 @@ namespace EventStore.Core.Tests.ClientAPI
         [Category("Network")]
         public void throw_when_got_int_max_value_as_maxcount()
         {
-            Assert.Throws<ArgumentException>(
+            Assert.ThrowsAsync<ArgumentException>(
                 () => _conn.ReadAllEventsForwardAsync(Position.Start, int.MaxValue, resolveLinkTos: false));
 
         }

--- a/src/EventStore.Core.Tests/ClientAPI/read_event_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_event_should.cs
@@ -26,19 +26,19 @@ namespace EventStore.Core.Tests.ClientAPI
         [Test, Category("Network")]
         public void throw_if_stream_id_is_null()
         {
-            Assert.Throws<ArgumentNullException>(() => _conn.ReadEventAsync(null, 0, resolveLinkTos: false));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _conn.ReadEventAsync(null, 0, resolveLinkTos: false));
         }
 
         [Test, Category("Network")]
         public void throw_if_stream_id_is_empty()
         {
-            Assert.Throws<ArgumentNullException>(() => _conn.ReadEventAsync("", 0, resolveLinkTos: false));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _conn.ReadEventAsync("", 0, resolveLinkTos: false));
         }
 
         [Test, Category("Network")]
         public void throw_if_event_number_is_less_than_minus_one()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => _conn.ReadEventAsync("stream", -2, resolveLinkTos: false));
+            Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => _conn.ReadEventAsync("stream", -2, resolveLinkTos: false));
         }
 
         [Test, Category("Network")]

--- a/src/EventStore.Core.Tests/ClientAPI/read_event_stream_backward_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_event_stream_backward_should.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.ClientAPI
             using (var store = BuildConnection(_node))
             {
                 store.ConnectAsync().Wait();
-                Assert.Throws<ArgumentOutOfRangeException>(() => store.ReadStreamEventsBackwardAsync(stream, 0, 0, resolveLinkTos: false));
+                Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => store.ReadStreamEventsBackwardAsync(stream, 0, 0, resolveLinkTos: false));
             }
         }
 
@@ -223,7 +223,7 @@ namespace EventStore.Core.Tests.ClientAPI
             {
                 store.ConnectAsync().Wait();
 
-                Assert.Throws<ArgumentException>(() => store.ReadStreamEventsBackwardAsync("foo", StreamPosition.Start, int.MaxValue, resolveLinkTos: false));
+                Assert.ThrowsAsync<ArgumentException>(() => store.ReadStreamEventsBackwardAsync("foo", StreamPosition.Start, int.MaxValue, resolveLinkTos: false));
 
             }
         }

--- a/src/EventStore.Core.Tests/ClientAPI/read_event_stream_forward_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_event_stream_forward_should.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.ClientAPI
             using (var store = BuildConnection(_node))
             {
                 store.ConnectAsync().Wait();
-                Assert.Throws<ArgumentOutOfRangeException>(() => store.ReadStreamEventsForwardAsync(stream, 0, 0, resolveLinkTos: false));
+                Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => store.ReadStreamEventsForwardAsync(stream, 0, 0, resolveLinkTos: false));
             }
         }
 
@@ -53,7 +53,7 @@ namespace EventStore.Core.Tests.ClientAPI
             using (var store = BuildConnection(_node))
             {
                 store.ConnectAsync().Wait();
-                Assert.Throws<ArgumentOutOfRangeException>(() => store.ReadStreamEventsForwardAsync(stream, -1, 1, resolveLinkTos: false));
+                Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => store.ReadStreamEventsForwardAsync(stream, -1, 1, resolveLinkTos: false));
             }
         }
 
@@ -156,7 +156,7 @@ namespace EventStore.Core.Tests.ClientAPI
             {
                 store.ConnectAsync().Wait();
 
-                Assert.Throws<ArgumentException>(() => store.ReadStreamEventsForwardAsync("foo", StreamPosition.Start, int.MaxValue, resolveLinkTos: false));
+                Assert.ThrowsAsync<ArgumentException>(() => store.ReadStreamEventsForwardAsync("foo", StreamPosition.Start, int.MaxValue, resolveLinkTos: false));
 
             }
         }


### PR DESCRIPTION
This prevents a threadpool starvation described in #1051. Instead of blocking the thread when trying to enqueue more operations than MaxQueueSize the thread is released letting other operations to continue.

PR is a dublicate of PR 1566 but with fixed tests