### PR TITLE
Add ResponseUrl to HttpEntity to allow prefixes to be used

### DIFF
--- a/src/EventStore.Common/Utils/HostName.cs
+++ b/src/EventStore.Common/Utils/HostName.cs
@@ -5,11 +5,11 @@ namespace EventStore.Common.Utils
 {
     public class HostName
     {
-        public static string Combine(Uri requestedUrl, string relativeUri, params object[] arg)
+        public static string Combine(Uri responseUrl, string relativeUri, params object[] arg)
         {
             try
             {
-                return CombineHostNameAndPath(requestedUrl, relativeUri, arg);
+                return CombineHostNameAndPath(responseUrl, relativeUri, arg);
             }
             catch (Exception e)
             {
@@ -18,13 +18,14 @@ namespace EventStore.Common.Utils
             }
         }
 
-        private static string CombineHostNameAndPath(Uri requestedUrl,
+        private static string CombineHostNameAndPath(Uri responseUrl,
                                                      string relativeUri,
                                                      object[] arg)
         {
             //TODO: encode???
             var path = string.Format(relativeUri, arg);
-            return new UriBuilder(requestedUrl.Scheme, requestedUrl.Host, requestedUrl.Port, path).Uri.AbsoluteUri;
+            if(path.Length > 0 && path[0] == '/') path = path.Substring(1);
+            return new UriBuilder(responseUrl.Scheme, responseUrl.Host, responseUrl.Port, responseUrl.LocalPath + path).Uri.AbsoluteUri;
         }
     }
 }

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -119,6 +119,61 @@ namespace EventStore.Core.Tests.Http.Streams
             }
         }
 
+        [TestFixture, Category("LongRunning")]
+        public class when_retrieving_feed_head_with_forwarded_prefix : SpecificationWithLongFeed
+        {
+            private JObject _feed;
+            private string _prefix;
+
+            protected override void When()
+            {
+                _prefix = "testprefix";
+                var headers = new NameValueCollection();
+                headers.Add("X-Forwarded-Prefix", _prefix);
+                _feed = GetJson<JObject>(TestStream, ContentType.AtomJson, headers: headers);
+            }
+
+            [Test]
+            public void returns_ok_status_code()
+            {
+                Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+            }
+
+            [Test]
+            public void contains_a_link_rel_previous_with_prefix()
+            {
+                var rel = GetLink(_feed, "previous");
+                Assert.AreEqual(MakeUrl("/" + _prefix + TestStream + "/25/forward/20"), new Uri(rel));
+            }
+
+            [Test]
+            public void contains_a_link_rel_next_with_prefix()
+            {
+                var rel = GetLink(_feed, "next");
+                Assert.AreEqual(MakeUrl("/" + _prefix + TestStream + "/4/backward/20"), new Uri(rel));
+            }
+
+            [Test]
+            public void contains_a_link_rel_self_with_prefix()
+            {
+                var rel = GetLink(_feed, "self");
+                Assert.AreEqual(MakeUrl("/" + _prefix + TestStream), new Uri(rel));
+            }
+
+            [Test]
+            public void contains_a_link_rel_first_with_prefix()
+            {
+                var rel = GetLink(_feed, "first");
+                Assert.AreEqual(MakeUrl("/" + _prefix + TestStream + "/head/backward/20"), new Uri(rel));
+            }
+
+            [Test]
+            public void contains_a_link_rel_last_with_prefix()
+            {
+                var rel = GetLink(_feed, "last");
+                Assert.AreEqual(MakeUrl("/" + _prefix + TestStream + "/0/forward/20"), new Uri(rel));
+            }
+        }
 
         [TestFixture, Category("LongRunning")]
         public class when_retrieving_the_previous_link_of_the_feed_head: SpecificationWithLongFeed

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -305,7 +305,7 @@ namespace EventStore.Core.Services.Transport.Http
                 switch (msg.Result)
                 {
                     case OperationResult.Success:
-                        var location = HostName.Combine(entity.RequestedUrl, "/streams/{0}/{1}",
+                        var location = HostName.Combine(entity.ResponseUrl, "/streams/{0}/{1}",
                                                         Uri.EscapeDataString(eventStreamId), msg.FirstEventNumber);
                         return new ResponseConfiguration(HttpStatusCode.Created, "Created", "text/plain", Helper.UTF8NoBom,
                                                          new KeyValuePair<string, string>("Location", location));

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -82,8 +82,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
         protected static string MakeUrl(HttpEntityManager http, string path)
         {
-            var hostUri = http.RequestedUrl;
-            return new UriBuilder(hostUri.Scheme, hostUri.Host, hostUri.Port, path).Uri.AbsoluteUri;
+            var builder = new UriBuilder(http.ResponseUrl);
+            if(path.Length > 0 && path[0] == '/') path = path.Substring(1);
+            builder.Path = builder.Path + path;
+            return builder.Uri.AbsoluteUri;
         }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Services.Transport.Http
                 case ContentType.Atom:
                 case ContentType.AtomJson:
                 case ContentType.Html:
-                    return entity.ResponseCodec.To(Convert.ToEntry(msg.Record, entity.RequestedUrl, embed, singleEntry: true));
+                    return entity.ResponseCodec.To(Convert.ToEntry(msg.Record, entity.ResponseUrl, embed, singleEntry: true));
                 default:
                     return AutoEventConverter.SmartFormat(msg.Record, entity.ResponseCodec);
             }
@@ -40,7 +40,7 @@ namespace EventStore.Core.Services.Transport.Http
             if (msg == null || msg.Result != ReadStreamResult.Success)
                 return String.Empty;
 
-            return entity.ResponseCodec.To(Convert.ToStreamEventBackwardFeed(msg, entity.RequestedUrl, embed, headOfStream));
+            return entity.ResponseCodec.To(Convert.ToStreamEventBackwardFeed(msg, entity.ResponseUrl, embed, headOfStream));
         }
 
         public static string GetStreamEventsForward(HttpResponseFormatterArgs entity, Message message, EmbedLevel embed)
@@ -49,7 +49,7 @@ namespace EventStore.Core.Services.Transport.Http
             if (msg == null || msg.Result != ReadStreamResult.Success)
                 return String.Empty;
                 
-            return entity.ResponseCodec.To(Convert.ToStreamEventForwardFeed(msg, entity.RequestedUrl, embed));
+            return entity.ResponseCodec.To(Convert.ToStreamEventForwardFeed(msg, entity.ResponseUrl, embed));
         }
 
         public static string ReadAllEventsBackwardCompleted(HttpResponseFormatterArgs entity, Message message, EmbedLevel embed)
@@ -58,7 +58,7 @@ namespace EventStore.Core.Services.Transport.Http
             if (msg == null || msg.Result != ReadAllResult.Success)
                 return String.Empty;
 
-            return entity.ResponseCodec.To(Convert.ToAllEventsBackwardFeed(msg, entity.RequestedUrl, embed));
+            return entity.ResponseCodec.To(Convert.ToAllEventsBackwardFeed(msg, entity.ResponseUrl, embed));
         }
 
         public static string ReadAllEventsForwardCompleted(HttpResponseFormatterArgs entity, Message message, EmbedLevel embed)
@@ -67,7 +67,7 @@ namespace EventStore.Core.Services.Transport.Http
             if (msg == null || msg.Result != ReadAllResult.Success)
                 return String.Empty;
 
-            return entity.ResponseCodec.To(Convert.ToAllEventsForwardFeed(msg, entity.RequestedUrl, embed)); 
+            return entity.ResponseCodec.To(Convert.ToAllEventsForwardFeed(msg, entity.ResponseUrl, embed)); 
         }
 
         public static string WriteEventsCompleted(HttpResponseFormatterArgs entity, Message message)
@@ -127,7 +127,7 @@ namespace EventStore.Core.Services.Transport.Http
             if (msg == null || msg.Result != ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Success)
                 return String.Empty;
 
-            return entity.ResponseCodec.To(Convert.ToNextNPersistentMessagesFeed(msg, entity.RequestedUrl, streamId, groupName, count, embed));
+            return entity.ResponseCodec.To(Convert.ToNextNPersistentMessagesFeed(msg, entity.ResponseUrl, streamId, groupName, count, embed));
         }
 
         public static string GetDescriptionDocument(HttpResponseFormatterArgs entity, string streamId, string[] persistentSubscriptionStats)

--- a/src/EventStore.Core/Services/Transport/Http/SendToHttpEnvelope.cs
+++ b/src/EventStore.Core/Services/Transport/Http/SendToHttpEnvelope.cs
@@ -11,35 +11,39 @@ namespace EventStore.Core.Services.Transport.Http
 {
     public class HttpResponseConfiguratorArgs
     {
+        public readonly Uri ResponseUrl;
         public readonly Uri RequestedUrl;
         public readonly ICodec ResponseCodec;
 
-        public HttpResponseConfiguratorArgs(Uri requestedUrl, ICodec responseCodec)
+        public HttpResponseConfiguratorArgs(Uri responseUrl, Uri requestedUrl, ICodec responseCodec)
         {
+            ResponseUrl = responseUrl;
             RequestedUrl = requestedUrl;
             ResponseCodec = responseCodec;
         }
 
         public static implicit operator HttpResponseConfiguratorArgs(HttpEntityManager entity)
         {
-            return new HttpResponseConfiguratorArgs(entity.RequestedUrl, entity.ResponseCodec);
+            return new HttpResponseConfiguratorArgs(entity.ResponseUrl, entity.RequestedUrl, entity.ResponseCodec);
         }
     }
 
     public class HttpResponseFormatterArgs
     {
+        public readonly Uri ResponseUrl;
         public readonly Uri RequestedUrl;
         public readonly ICodec ResponseCodec;
 
-        public HttpResponseFormatterArgs(Uri requestedUrl, ICodec responseCodec)
+        public HttpResponseFormatterArgs(Uri responseUrl, Uri requestedUrl, ICodec responseCodec)
         {
+            ResponseUrl = responseUrl;
             RequestedUrl = requestedUrl;
             ResponseCodec = responseCodec;
         }
 
         public static implicit operator HttpResponseFormatterArgs(HttpEntityManager entity)
         {
-            return new HttpResponseFormatterArgs(entity.RequestedUrl, entity.ResponseCodec);
+            return new HttpResponseFormatterArgs(entity.ResponseUrl, entity.RequestedUrl, entity.ResponseCodec);
         }
     }
 

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntity.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntity.cs
@@ -12,6 +12,7 @@ namespace EventStore.Transport.Http.EntityManagement
     {
         private readonly bool _logHttpRequests;
         public readonly Uri RequestedUrl;
+        public readonly Uri ResponseUrl;
 
         public readonly HttpListenerRequest Request;
         internal readonly HttpListenerResponse Response;
@@ -24,14 +25,20 @@ namespace EventStore.Transport.Http.EntityManagement
 
             _logHttpRequests = logHttpRequests;
             RequestedUrl = BuildRequestedUrl(request.Url, request.Headers, advertiseAsAddress, advertiseAsPort);
+            ResponseUrl = BuildRequestedUrl(request.Url, request.Headers, advertiseAsAddress, advertiseAsPort, true);
             Request = request;
             Response = response;
             User = user;
         }
 
-        public static Uri BuildRequestedUrl(Uri requestUrl, NameValueCollection requestHeaders, IPAddress advertiseAsAddress, int advertiseAsPort)
+        public static Uri BuildRequestedUrl(Uri requestUrl, NameValueCollection requestHeaders,
+                                            IPAddress advertiseAsAddress, int advertiseAsPort, bool overridePath = false)
         {
             var uriBuilder = new UriBuilder(requestUrl);
+            if (overridePath)
+            {
+                uriBuilder.Path = string.Empty;
+            }
 
             if(advertiseAsAddress != null)
             {
@@ -78,12 +85,14 @@ namespace EventStore.Transport.Http.EntityManagement
             {
                 uriBuilder.Path = forwardedPrefixHeaderValue + uriBuilder.Path;
             }
+            
             return uriBuilder.Uri;
         }
 
         private HttpEntity(IPrincipal user, bool logHttpRequests)
         {
             RequestedUrl = null;
+            ResponseUrl = null;
 
             Request = null;
             Response = null;
@@ -94,6 +103,7 @@ namespace EventStore.Transport.Http.EntityManagement
         private HttpEntity(HttpEntity httpEntity, IPrincipal user, bool logHttpRequests)
         {
             RequestedUrl = httpEntity.RequestedUrl;
+            ResponseUrl = httpEntity.ResponseUrl;
 
             Request = httpEntity.Request;
             Response = httpEntity.Response;

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -34,6 +34,7 @@ namespace EventStore.Transport.Http.EntityManagement
         private AsyncQueuedBufferWriter _asyncWriter;
         private readonly ICodec _requestCodec;
         private readonly ICodec _responseCodec;
+        private readonly Uri _responseUrl;
         private readonly Uri _requestedUrl;
         private readonly string _responseContentEncoding;
         private static readonly string[] SupportedCompressionAlgorithms = { CompressionAlgorithms.Gzip, CompressionAlgorithms.Deflate };
@@ -58,6 +59,7 @@ namespace EventStore.Transport.Http.EntityManagement
             _onRequestSatisfied = onRequestSatisfied;
             _requestCodec = requestCodec;
             _responseCodec = responseCodec;
+            _responseUrl = httpEntity.ResponseUrl;
             _requestedUrl = httpEntity.RequestedUrl;
             _responseContentEncoding = GetRequestedContentEncoding(httpEntity);
             _logHttpRequests = logHttpRequests;
@@ -70,6 +72,7 @@ namespace EventStore.Transport.Http.EntityManagement
 
         public ICodec RequestCodec { get { return _requestCodec; } }
         public ICodec ResponseCodec { get { return _responseCodec; } }
+        public Uri ResponseUrl { get { return _responseUrl; } }
         public Uri RequestedUrl { get { return _requestedUrl; } }
         public IPrincipal User { get { return HttpEntity.User; } }
 


### PR DESCRIPTION
ResponseUrl is the same as the RequestedUrl, but with the path replaced with the X-Forwarded-Prefix.
Use ResponseUrl when generating feed and response urls so that the forwarded path is included correctly.
Use RequestedUrl when returning errors or locations that require the original url.