### PR TITLE
Parked stream persistent subscription fixes

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading.Tasks;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.Services.PersistentSubscription
 {
@@ -437,26 +439,29 @@ namespace EventStore.Core.Services.PersistentSubscription
             _settings.StreamReader.BeginReadEvents(_settings.ParkedMessageStream, position, count,_settings.ReadBatchSize, true, (events, newposition, isstop) => HandleParkedReadCompleted(events, newposition, isstop, stopAt));
         }
 
-        public void HandleParkedReadCompleted(ResolvedEvent[] events, long newposition, bool isEndofStrem, long stopAt)
+        public void HandleParkedReadCompleted(ResolvedEvent[] parkedEvents, long newposition, bool isEndofStream, long stopAt)
         {
             lock (_lock)
             {
                 if ((_state & PersistentSubscriptionState.ReplayingParkedMessages) == 0) return;
 
-                foreach (var ev in events)
+                foreach (var parkedEvent in parkedEvents)
                 {
-                    if (ev.OriginalEventNumber == stopAt)
+                    if (parkedEvent.OriginalEventNumber == stopAt)
                     {
                         break;
                     }
 
-                    Log.Debug("Retrying event {0} on subscription {1}", ev.OriginalEvent.EventId, _settings.SubscriptionId);
-                    _streamBuffer.AddRetry(new OutstandingMessage(ev.OriginalEvent.EventId, null, ev, 0));
+                    GetOriginalEventFromParkedEvent(parkedEvent,(ev)=>{
+                        Log.Debug("Retrying event {0} on subscription {1}", ev.OriginalEvent.EventId, _settings.SubscriptionId);
+                        _streamBuffer.AddRetry(new OutstandingMessage(ev.OriginalEvent.EventId, null, ev, 0));
+                        return true;
+                    });
                 }
 
                 TryPushingMessagesToClients();
 
-                if (isEndofStrem || stopAt <= newposition)
+                if (isEndofStream || stopAt <= newposition)
                 {
                     var replayedEnd = newposition == -1 ? stopAt : Math.Min(stopAt, newposition);
                     _settings.MessageParker.BeginMarkParkedMessagesReprocessed(replayedEnd);
@@ -467,6 +472,39 @@ namespace EventStore.Core.Services.PersistentSubscription
                     TryReadingParkedMessagesFrom(newposition, stopAt);
                 }
             }
+        }
+
+        private void GetOriginalEventFromParkedEvent(ResolvedEvent parkedEvent,Func<ResolvedEvent,bool> onEventReceived)
+        {
+            var eventRecord = parkedEvent.Event;
+
+            long? commitPosition = null;
+            if(eventRecord.Flags.HasFlag(PrepareFlags.IsCommitted)) //we do not have the commit position for transactions
+                commitPosition = eventRecord.LogPosition;
+
+            if (_settings.ResolveLinkTos && eventRecord.EventType == SystemEventTypes.LinkTo)
+            {
+                try
+                {
+                    _settings.StreamReader.BeginReadEvents(eventRecord.EventStreamId,eventRecord.EventNumber,1,_settings.ReadBatchSize,true,
+                    (events,newPosition,isEndOfStream)=>{
+                        if(events.Length==1 && events[0].ResolveResult == ReadEventResult.Success){
+                            onEventReceived(ResolvedEvent.ForResolvedLink(events[0].Event, eventRecord, commitPosition));
+                        }
+                        else{
+                            Log.Error("Could not resolve link for event record: {0}. Resolve result: {1}", eventRecord.ToString(), events[0].ResolveResult);
+                            onEventReceived(ResolvedEvent.ForFailedResolvedLink(eventRecord, events[0].ResolveResult, commitPosition));
+                        }
+                    });
+                }
+                catch (Exception exc)
+                {
+                    Log.ErrorException(exc, "Error while resolving link for event record: {0}", eventRecord.ToString());
+                    onEventReceived(ResolvedEvent.ForFailedResolvedLink(eventRecord, ReadEventResult.Error, commitPosition));
+                }
+            }
+            else
+                onEventReceived(ResolvedEvent.ForUnresolvedEvent(eventRecord, commitPosition));
         }
 
         private void StartMessage(OutstandingMessage message, DateTime expires)

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -54,12 +54,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         private string GetLinkToFor(ResolvedEvent ev)
         {
-            if (ev.Event == null) // Unresolved link so just use the bad/deleted link data.
-            {
-                return Encoding.UTF8.GetString(ev.Link.Data);
-            }
-
-            return string.Format("{0}@{1}", ev.Event.EventNumber, ev.Event.EventStreamId);
+            return string.Format("{0}@{1}", ev.OriginalEventNumber, ev.OriginalStreamId);
         }
 
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -578,7 +578,7 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         public void Handle(ClientMessage.ReplayAllParkedMessages message)
         {
-            Log.Debug("Replying parked messages.");
+            Log.Debug("Replaying parked messages.");
             PersistentSubscription subscription;
             var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
                         var streamAccess = _readIndex.CheckStreamAccess(SystemStreams.SettingsStream, StreamAccessType.Write, message.User);


### PR DESCRIPTION
This commit fixes two issues in parked streams:

**1) When replaying events from parked streams, the parked event is returned in the "Original" part of the ResolvedEvent (instead of the actual original event)**
The change ensures that the actual original event is now returned in the "Original" part.
If the event is a linkTo, the "Event" part is also resolved according to _settings.ResolveLinkTos_

**2) When writing an event to parked streams, and the Original event is a linkTo, the linked event is written to the parked stream instead of the Original event (basically the Original event information is lost)**
The change ensures that we always write the Original event to the parked stream instead of the linked event

Basically the change makes sure that _"Replaying parked messages" makes the subscriptions receive events exactly the same way they are received normally in the "EventAppeared" handler_

**Configuration affected # 1:** Clients using the "Original" part of the event
This configuration was not working correctly previously when replayed from parked streams - the parked event was returned as the "Original" part of the _ResolvedEvent_

**Configuration affected # 2:** _Events with links_ + _DoNotResolveLinkTos_
This configuration was not working correctly previously when replayed from parked streams - the linked event was returned instead of the original event as the "Event" part of the _ResolvedEvent_

_**Issue with existing parked streams for configuration # 2:**_
Replaying messages from existing parked streams will continue to return the **Linked event** instead of the **Original event** until the stream is completely replayed and truncated (because the parked stream contains the linked event)