### PR TITLE
Allow event data/metadata to be stored as JSON array through HTTP API

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
@@ -175,7 +175,7 @@ namespace EventStore.Core.Services.Transport.Http
 
         private static byte[] AsBytes(object obj, out bool isJson)
         {
-            if (obj is JObject)
+            if (obj is JObject || obj is JArray)
             {
                 isJson = true;
                 return Helper.UTF8NoBom.GetBytes(Codec.Json.To(obj));


### PR DESCRIPTION
Sending an event with data/metadata as JSON array through the HTTP API does not work, it results in an empty string:

`curl -i -d @event.txt -H "Content-Type:application/vnd.eventstore.events+json" "http://127.0.0.1:2113/streams/stream"`

event.txt:

```
[
  {
    "eventId": "fbf4a1a1-b4a3-4dfe-a01f-ec52c34e1717",
    "eventType": "event",
    "data": [{"a":1},{"b":2}],
    "metadata": [{"c":3},{"d":4}]
  }
]
```

However, JSON arrays work fine with .NET API:

```
_conn.AppendToStreamAsync(
    "stream",ExpectedVersion.Any,
    new EventData[]{
        new EventData(
            Guid.NewGuid(),
            "type",
            true,
            Encoding.ASCII.GetBytes("[{},{}]"),
            Encoding.ASCII.GetBytes("[{},{}]"))
    }).Wait();
```
