### PR TITLE
Add queue timeout facility

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -61,6 +61,10 @@ namespace EventStore.ClientAPI
         /// </summary>
         public readonly TimeSpan ReconnectionDelay;
         /// <summary>
+        /// The amount of time a request for an operation is permitted to be queued awaiting transmission to the server.
+        /// </summary>
+        public readonly TimeSpan QueueTimeout;
+        /// <summary>
         /// The amount of time before an operation is considered to have timed out.
         /// </summary>
         public readonly TimeSpan OperationTimeout;
@@ -139,6 +143,7 @@ namespace EventStore.ClientAPI
                                     int maxReconnections,
                                     bool requireMaster,
                                     TimeSpan reconnectionDelay,
+                                    TimeSpan queueTimeout,
                                     TimeSpan operationTimeout,
                                     TimeSpan operationTimeoutCheckPeriod,
                                     UserCredentials defaultUserCredentials,
@@ -173,6 +178,7 @@ namespace EventStore.ClientAPI
             MaxReconnections = maxReconnections;
             RequireMaster = requireMaster;
             ReconnectionDelay = reconnectionDelay;
+            QueueTimeout = queueTimeout;
             OperationTimeout = operationTimeout;
             OperationTimeoutCheckPeriod = operationTimeoutCheckPeriod;
             ClientConnectionTimeout = clientConnectionTimeout;

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -23,6 +23,7 @@ namespace EventStore.ClientAPI
         private bool _requireMaster = Consts.DefaultRequireMaster;
 
         private TimeSpan _reconnectionDelay = Consts.DefaultReconnectionDelay;
+        private TimeSpan _queueTimeout = Consts.DefaultQueueTimeout;
         private TimeSpan _operationTimeout = Consts.DefaultOperationTimeout;
         private TimeSpan _operationTimeoutCheckPeriod = Consts.DefaultOperationTimeoutCheckPeriod;
 
@@ -211,6 +212,17 @@ namespace EventStore.ClientAPI
         public ConnectionSettingsBuilder SetReconnectionDelayTo(TimeSpan reconnectionDelay)
         {
             _reconnectionDelay = reconnectionDelay;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets the maximum permitted time a request may be queued awaiting transmission; if exceeded an <see cref="Exceptions.OperationExpiredException"/> is thrown.
+        /// </summary>
+        /// <param name="queueTimeout"></param>
+        /// <returns></returns>
+        public ConnectionSettingsBuilder SetQueueTimeoutTo(TimeSpan queueTimeout)
+        {
+            _queueTimeout = queueTimeout;
             return this;
         }
 
@@ -449,6 +461,7 @@ namespace EventStore.ClientAPI
                                           _maxReconnections,
                                           _requireMaster,
                                           _reconnectionDelay,
+                                          _queueTimeout,
                                           _operationTimeout,
                                           _operationTimeoutCheckPeriod,
                                           _defaultUserCredentials,

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -72,6 +72,7 @@
     <Compile Include="ConnectionString.cs" />
     <Compile Include="EventStorePersistentSubscription.cs" />
     <Compile Include="EventStorePersistentSubscriptionBase.cs" />
+    <Compile Include="Exceptions\OperationExpiredException.cs" />
     <Compile Include="Exceptions\UserCommandConflictException.cs" />
     <Compile Include="Exceptions\UserCommandFailedException.cs" />
     <Compile Include="IConnectToPersistentSubscriptions.cs" />

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -92,7 +92,7 @@ namespace EventStore.ClientAPI
                         connectionSettings.MaxQueueSize, connectionSettings.MaxConcurrentItems,
                         connectionSettings.MaxRetries, connectionSettings.MaxReconnections,
                         connectionSettings.RequireMaster, connectionSettings.ReconnectionDelay,
-                        connectionSettings.OperationTimeout,
+                        connectionSettings.QueueTimeout, connectionSettings.OperationTimeout,
                         connectionSettings.OperationTimeoutCheckPeriod, credential, connectionSettings.UseSslConnection,
                         connectionSettings.TargetHost,
                         connectionSettings.ValidateServer, connectionSettings.FailOnNoServerResponse,

--- a/src/EventStore.ClientAPI/Exceptions/OperationExpiredException.cs
+++ b/src/EventStore.ClientAPI/Exceptions/OperationExpiredException.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace EventStore.ClientAPI.Exceptions
+{
+    /// <summary>
+    /// Exception thrown if an operation expires before it can be scheduled.
+    /// </summary>
+    public class OperationExpiredException : EventStoreConnectionException
+    {
+        /// <summary>
+        /// Constructs a new <see cref="OperationExpiredException"/>.
+        /// </summary>
+        public OperationExpiredException()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="OperationExpiredException"/>.
+        /// </summary>
+        public OperationExpiredException(string message) : base(message)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="OperationExpiredException"/>.
+        /// </summary>
+        public OperationExpiredException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="OperationExpiredException"/>.
+        /// </summary>
+        protected OperationExpiredException(SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/EventStore.ClientAPI/Internal/Consts.cs
+++ b/src/EventStore.ClientAPI/Internal/Consts.cs
@@ -12,6 +12,7 @@ namespace EventStore.ClientAPI
         public const bool DefaultRequireMaster = true;
 
         public static readonly TimeSpan DefaultReconnectionDelay = TimeSpan.FromMilliseconds(100);
+        public static readonly TimeSpan DefaultQueueTimeout = TimeSpan.Zero; // Unlimited
         public static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(7);
         public static readonly TimeSpan DefaultOperationTimeoutCheckPeriod = TimeSpan.FromSeconds(1);
 

--- a/src/EventStore.ClientAPI/Internal/OperationsManager.cs
+++ b/src/EventStore.ClientAPI/Internal/OperationsManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -54,7 +55,7 @@ namespace EventStore.ClientAPI.Internal
         private readonly string _connectionName;
         private readonly ConnectionSettings _settings;
         private readonly Dictionary<Guid, OperationItem> _activeOperations = new Dictionary<Guid, OperationItem>();
-        private readonly Queue<OperationItem> _waitingOperations = new Queue<OperationItem>();
+        private readonly ConcurrentQueue<OperationItem> _waitingOperations = new ConcurrentQueue<OperationItem>();
         private readonly List<OperationItem> _retryPendingOperations = new List<OperationItem>();
         private readonly object _lock = new object();
         private int _totalOperationCount;
@@ -82,7 +83,8 @@ namespace EventStore.ClientAPI.Internal
                 operation.Operation.Fail(connectionClosedException);
             }
             _activeOperations.Clear();
-            _waitingOperations.Clear();
+            OperationItem dummy;
+            while(_waitingOperations.TryDequeue(out dummy));
             _retryPendingOperations.Clear();
             _totalOperationCount = 0;
         }
@@ -175,12 +177,41 @@ namespace EventStore.ClientAPI.Internal
             Ensure.NotNull(connection, "connection");
             lock(_lock)
             {
-                while (_waitingOperations.Count > 0 && _activeOperations.Count < _settings.MaxConcurrentItems)
+                // We don't want to transmit or retain expired requests, so we trim any from before the cutoff implied by the current time
+                var cutoff = _settings.QueueTimeout == TimeSpan.Zero ? (DateTime?)null : DateTime.UtcNow - _settings.QueueTimeout;
+
+                OperationItem operation;
+                while (_activeOperations.Count < _settings.MaxConcurrentItems)
                 {
-                    ExecuteOperation(_waitingOperations.Dequeue(), connection);
+                    if (!_waitingOperations.TryDequeue(out operation))
+                        break;
+                    if (cutoff == null || !TryExpireItem(cutoff.Value, operation))
+                        ExecuteOperation(operation, connection);
+                }
+
+                if (cutoff != null)
+                {
+                    // In case the active operations queue is at capacity, we trim expired items from the front of the queue
+                    while (_waitingOperations.TryPeek(out operation) && TryExpireItem(cutoff.Value, operation))
+                    {
+                        _waitingOperations.TryDequeue(out operation);
+                    }
                 }
                 _totalOperationCount = _activeOperations.Count + _waitingOperations.Count;
             }
+        }
+
+        bool TryExpireItem(DateTime cutoffDate, OperationItem operation)
+        {
+            if (operation.CreatedTime > cutoffDate)
+                return false;
+
+            var err = string.Format("EventStoreConnection '{0}': request expired.\n"
+                                                    + "UTC now: {1:HH:mm:ss.fff}, operation: {2}.",
+                                                    _connectionName, DateTime.UtcNow, operation);
+            _settings.Log.Debug(err);
+            operation.Operation.Fail(new OperationExpiredException(err));
+            return true;
         }
 
         public void ExecuteOperation(OperationItem operation, TcpPackageConnection connection) {


### PR DESCRIPTION
This PR results from load and resilience testing I've been carrying out on a production HA cluster and cross checking with local load tests.

The local load tests involve running 2000 tps of read, append (with expected version based on read), read write to very success for an independent stream per transaction. (box can take 2500 most of the time; this is an intentionally relatively low load). The 2000 tps is a target; the runner will attempt up to 4000 requests in parallel to catch up if the 2000 tps are not achieved; in other words, I configure it such that we don't saturate the request queue, but we do saturate the operations queue. (I'm not in a position to furnish the load test harness right now; securing clearance re open sourcing of my wrappers, tests and load harness is in progress)

Each transaction runs on an independent `Task` within an x64 .NET 4.6.1 console app with a `SetMinThreads(7768, 768)` startup tweak (I have tested without any `SetMinThreads`, and with `(100, 100)`; both settings work, but are not in alignment with my broader requirements).

During testing, I intermittently
- [x] close sockets (to trigger instant reconnect)
- [x] Ctrl-C the local server (reconnect, inc a cold/warming up server)
- [x] do heavy compiles (to trigger overloads leading to threadpool saturation), let screensaver kick in

A common issue observed in this test scenario is that the ES connection does not afford one a way in which to exert backpressure on the system as a whole. The provided `SetQueueTimeoutTo` API on the config DSL is what I utilise to effect this. I've load tested this in some depth and it exhibits the desired characteristics in that it:
- [x] never hangs
- [x] deals with the outages
- [x] will throw if overloaded, giving a predictable load-shedding/timeout behavior
- [x] can recover from the point of being saturated.

The OOTB behavior without invoking the API is intended to be identical (the `TimeSpan.Zero` default value means the condition is never checked and the exception can never be thrown); I've verified that the normal latencies under significant load without overload situations are the pretty much identical (despite that I've replaces a `Queue` with a `ConcurrentQueue` given the fact that the queue is `Enqueue`d to from multiple threads).