### PR TITLE
Handle IPv6 addresses from Dns.GetHostAddresses

### DIFF
--- a/src/EventStore.ClientAPI/Transport.Http/EndpointExtensions.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/EndpointExtensions.cs
@@ -11,7 +11,7 @@ namespace EventStore.ClientAPI.Transport.Http
             if(endPoint is IPEndPoint)
             {
                 var ipEndPoint = endPoint as IPEndPoint;
-                return CreateHttpUrl(schema, ipEndPoint.Address.ToString(), ipEndPoint.Port, rawUrl != null ? rawUrl.TrimStart('/') : string.Empty);
+                return CreateHttpUrl(schema, ipEndPoint.ToString(), rawUrl != null ? rawUrl.TrimStart('/') : string.Empty);
             }
             if (endPoint is DnsEndPoint)
             {
@@ -26,7 +26,7 @@ namespace EventStore.ClientAPI.Transport.Http
             if (endPoint is IPEndPoint)
             {
                 var ipEndPoint = endPoint as IPEndPoint;
-                return CreateHttpUrl(schema, ipEndPoint.Address.ToString(), ipEndPoint.Port, string.Format(formatString.TrimStart('/'), args));
+                return CreateHttpUrl(schema, ipEndPoint.ToString(), string.Format(formatString.TrimStart('/'), args));
             }
             if (endPoint is DnsEndPoint)
             {
@@ -39,6 +39,11 @@ namespace EventStore.ClientAPI.Transport.Http
         private static string CreateHttpUrl(string schema, string host, int port, string path)
         {
             return $"{schema}://{host}:{port}/{path}";
+        }
+
+        private static string CreateHttpUrl(string schema, string address, string path)
+        {
+            return $"{schema}://{address}/{path}";
         }
     }
 }


### PR DESCRIPTION
As mentioned in #1598, passing `"localhost"` to `SetClusterDns` causes the client to internally throw exceptions (and triggers a delay in resolution due to the fact that each failed connection attempt is succeededby a `Sleep(500)`), which can be observed by wiring up the logging.

This PR resolves the root problem (needing to route around this part of the config DSL using `SetGossipSeedEndPoints` by independenly generating the list and then filtering for only IPv4 addresses) by letting `IPAddress.ToString()` render IPV6 addresses in the IETF-defined canonical rendition format: `[addr]:port`, which renders the IPv6 `::1` as `[::1]`, replacing the existing logic which would instead render as `scheme://::1:port/path`, which triggers the exceptions cited in #1598 internally).

I've tested this fix on a 3-node HA cluster defined via a DNS entry (works, before and after as there are only IPv4 addresses) and on my `localhost` (which has two entries:- IPv4 and IPv6).

Ideally someone who has thought about it more should eval before this gets blindly merged - perhaps this signifies something that might be more appropriately remediated at a different level.