### PR TITLE
Make UseDebugLogger write to Debugger from NuGet version of client lib OOTB

### DIFF
--- a/src/EventStore.ClientAPI/Common/Log/DebugLogger.cs
+++ b/src/EventStore.ClientAPI/Common/Log/DebugLogger.cs
@@ -6,32 +6,32 @@ namespace EventStore.ClientAPI.Common.Log
     {
         public void Error(string format, params object[] args)
         {
-            System.Diagnostics.Debug.WriteLine(Log("ERROR", format, args));
+            System.Diagnostics.Trace.WriteLine(Log("ERROR", format, args));
         }
 
         public void Error(Exception ex, string format, params object[] args)
         {
-            System.Diagnostics.Debug.WriteLine(Log("ERROR", ex, format, args));
+            System.Diagnostics.Trace.WriteLine(Log("ERROR", ex, format, args));
         }
 
         public void Debug(string format, params object[] args)
         {
-            System.Diagnostics.Debug.WriteLine(Log("DEBUG", format, args));
+            System.Diagnostics.Trace.WriteLine(Log("DEBUG", format, args));
         }
 
         public void Debug(Exception ex, string format, params object[] args)
         {
-            System.Diagnostics.Debug.WriteLine(Log("DEBUG", ex, format, args));
+            System.Diagnostics.Trace.WriteLine(Log("DEBUG", ex, format, args));
         }
 
         public void Info(string format, params object[] args)
         {
-            System.Diagnostics.Debug.WriteLine(Log("INFO", format, args));
+            System.Diagnostics.Trace.WriteLine(Log("INFO", format, args));
         }
 
         public void Info(Exception ex, string format, params object[] args)
         {
-            System.Diagnostics.Debug.WriteLine(Log("INFO", ex, format, args));
+            System.Diagnostics.Trace.WriteLine(Log("INFO", ex, format, args));
         }
 
 


### PR DESCRIPTION
This fixes #1575 by changing the internal logger triggered by the invocation of the `.UseDebugLogger()` config DSL element to write via `Trace.WriteLine` instead of using `Debug.WriteLine`, in order to make the API do what I as a user of the NuGet package assumed when the intellisense xmldoc tells us:

    /// Configures the connection to output log messages to the listeners
    /// configured on <see cref="System.Diagnostics.Debug" />.

(The reason that it does not emit anything as it stands is because `Debug.WriteLine` is tagged `Conditional("DEBUG")`  in the BCL impl; thus any retail build of the NuGet package does not emit any messages to `OutputDebugString` (verified via SysInternals DbgView). Trace.WriteLine is, per the docs, the unconditional equivalent of `Debug.WriteLine`)