### PR TITLE
Bycorrid

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/handlers/categorize_events_by_correlation_id.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/handlers/categorize_events_by_correlation_id.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Standard;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Projections.Core.Services.Processing.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.handlers
+{
+    public static class categorize_events_by_correlation_id
+    {
+        [TestFixture]
+        public class when_handling_simple_event
+        {
+            private ByCorrelationId _handler;
+            private string _state;
+            private EmittedEventEnvelope[] _emittedEvents;
+            private bool _result;
+
+            [SetUp]
+            public void when()
+            {
+                _handler = new ByCorrelationId("", Console.WriteLine);
+                _handler.Initialize();
+                string sharedState;
+                _result = _handler.ProcessEvent(
+                    "", CheckpointTag.FromPosition(0, 200, 150), null,
+                    new ResolvedEvent(
+                        "cat1-stream1", 10, "cat1-stream1", 10, false, new TFPos(200, 150), Guid.NewGuid(),
+                        "event_type", true, "{}", "{\"$correlationId\":\"testing1\"}"), out _state, out sharedState, out _emittedEvents);
+            }
+
+            [Test]
+            public void result_is_true()
+            {
+                Assert.IsTrue(_result);
+            }
+
+            [Test]
+            public void state_stays_null()
+            {
+                Assert.IsNull(_state);
+            }
+
+            [Test]
+            public void emits_correct_link()
+            {
+                Assert.NotNull(_emittedEvents);
+                Assert.AreEqual(1, _emittedEvents.Length);
+                var @event = _emittedEvents[0].Event;
+                Assert.AreEqual("$>", @event.EventType);
+                Assert.AreEqual("$bc-testing1", @event.StreamId);
+                Assert.AreEqual("10@cat1-stream1", @event.Data);
+            }
+
+        }
+
+        [TestFixture]
+        public class when_handling_link_to_event
+        {
+            private ByCorrelationId _handler;
+            private string _state;
+            private EmittedEventEnvelope[] _emittedEvents;
+            private bool _result;
+
+            [SetUp]
+            public void when()
+            {
+                _handler = new ByCorrelationId("", Console.WriteLine);
+                _handler.Initialize();
+                string sharedState;
+                _result = _handler.ProcessEvent(
+                    "", CheckpointTag.FromPosition(0, 200, 150), null,
+                    new ResolvedEvent(
+                        "cat2-stream2", 20, "cat2-stream2", 20, true, new TFPos(200, 150), Guid.NewGuid(),
+                        "$>", true, "10@cat1-stream1", "{\"$correlationId\":\"testing2\"}"), out _state, out sharedState, out _emittedEvents);
+            }
+
+            [Test]
+            public void result_is_true()
+            {
+                Assert.IsTrue(_result);
+            }
+
+            [Test]
+            public void state_stays_null()
+            {
+                Assert.IsNull(_state);
+            }
+
+            [Test]
+            public void emits_correct_link()
+            {
+                Assert.NotNull(_emittedEvents);
+                Assert.AreEqual(1, _emittedEvents.Length);
+                var @event = _emittedEvents[0].Event;
+                Assert.AreEqual("$>", @event.EventType);
+                Assert.AreEqual("$bc-testing2", @event.StreamId);
+                Assert.AreEqual("10@cat1-stream1", @event.Data);
+            }
+        }
+
+        [TestFixture]
+        public class when_handling_non_json_event
+        {
+            private ByCorrelationId _handler;
+            private string _state;
+            private EmittedEventEnvelope[] _emittedEvents;
+            private bool _result;
+
+            [SetUp]
+            public void when()
+            {
+                _handler = new ByCorrelationId("", Console.WriteLine);
+                _handler.Initialize();
+                string sharedState;
+                _result = _handler.ProcessEvent(
+                    "", CheckpointTag.FromPosition(0, 200, 150), null,
+                    new ResolvedEvent(
+                        "cat1-stream1", 10, "cat1-stream1", 10, false, new TFPos(200, 150), Guid.NewGuid(),
+                        "event_type", false, "non_json_data", "non_json_metadata"), out _state, out sharedState, out _emittedEvents);
+            }
+
+            [Test]
+            public void result_is_false()
+            {
+                Assert.IsFalse(_result);
+            }
+
+            [Test]
+            public void state_stays_null()
+            {
+                Assert.IsNull(_state);
+            }
+
+            [Test]
+            public void does_not_emit_link()
+            {
+                Assert.IsNull(_emittedEvents);
+            }
+        }
+
+        [TestFixture]
+        public class when_handling_json_event_with_no_correlation_id
+        {
+            private ByCorrelationId _handler;
+            private string _state;
+            private EmittedEventEnvelope[] _emittedEvents;
+            private bool _result;
+
+            [SetUp]
+            public void when()
+            {
+                _handler = new ByCorrelationId("", Console.WriteLine);
+                _handler.Initialize();
+                string sharedState;
+                _result = _handler.ProcessEvent(
+                    "", CheckpointTag.FromPosition(0, 200, 150), null,
+                    new ResolvedEvent(
+                        "cat1-stream1", 10, "cat1-stream1", 10, false, new TFPos(200, 150), Guid.NewGuid(),
+                        "event_type", true, "{}", "{}"), out _state, out sharedState, out _emittedEvents);
+            }
+
+            [Test]
+            public void result_is_false()
+            {
+                Assert.IsFalse(_result);
+            }
+
+            [Test]
+            public void state_stays_null()
+            {
+                Assert.IsNull(_state);
+            }
+
+            [Test]
+            public void does_not_emit_link()
+            {
+                Assert.IsNull(_emittedEvents);
+            }
+        }
+
+        [TestFixture]
+        public class when_handling_json_event_with_non_json_metadata
+        {
+            private ByCorrelationId _handler;
+            private string _state;
+            private EmittedEventEnvelope[] _emittedEvents;
+            private bool _result;
+
+            [SetUp]
+            public void when()
+            {
+                _handler = new ByCorrelationId("", Console.WriteLine);
+                _handler.Initialize();
+                string sharedState;
+                _result = _handler.ProcessEvent(
+                    "", CheckpointTag.FromPosition(0, 200, 150), null,
+                    new ResolvedEvent(
+                        "cat1-stream1", 10, "cat1-stream1", 10, false, new TFPos(200, 150), Guid.NewGuid(),
+                        "event_type", true, "{}", "non_json_metadata"), out _state, out sharedState, out _emittedEvents);
+            }
+
+            [Test]
+            public void result_is_false()
+            {
+                Assert.IsFalse(_result);
+            }
+
+            [Test]
+            public void state_stays_null()
+            {
+                Assert.IsNull(_state);
+            }
+
+            [Test]
+            public void does_not_emit_link()
+            {
+                Assert.IsNull(_emittedEvents);
+            }
+        }        
+    }
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system
             {
                 var statistics = HandledMessages.OfType<ProjectionManagementMessage.Statistics>().LastOrDefault();
                 Assert.NotNull(statistics);
-                Assert.AreEqual(4, statistics.Projections.Length);
+                Assert.AreEqual(5, statistics.Projections.Length);
             }
 
             [Test]

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -102,7 +102,8 @@ namespace EventStore.Projections.Core
             "$by_category",
             "$stream_by_category",
             "$streams",
-            "$by_event_type"
+            "$by_event_type",
+            "$by_correlation_id"
         };
 
         public void Handle(CoreProjectionStatusMessage.Stopped message)

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -807,6 +807,10 @@ namespace EventStore.Projections.Core.Services.Management
                 String.Join(", ", registeredProjections
                     .Where(x => x.Key != ProjectionEventTypes.ProjectionsInitialized)
                     .Select(x => x.Key)));
+
+            //create any missing system projections
+            CreateSystemProjections(registeredProjections.Select(x => x.Key).ToList());
+
             foreach (var projectionRegistration in registeredProjections.Where(x => x.Key != ProjectionEventTypes.ProjectionsInitialized))
             {
                 int queueIndex = GetNextWorkerIndex();
@@ -862,24 +866,37 @@ namespace EventStore.Projections.Core.Services.Management
 
         private void CreateSystemProjections()
         {
+            CreateSystemProjections(new List<String>());
+        }
+
+        private void CreateSystemProjections(List<String> existingSystemProjections){
             if (_initializeSystemProjections)
             {
+                if(!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections.StreamsStandardProjection))
                 CreateSystemProjection(
                     ProjectionNamesBuilder.StandardProjections.StreamsStandardProjection,
                     typeof(IndexStreams),
                     "");
+
+                if(!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection))
                 CreateSystemProjection(
                     ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection,
                     typeof(CategorizeStreamByPath),
                     "first\r\n-");
+
+                if(!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection))
                 CreateSystemProjection(
                     ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection,
                     typeof(CategorizeEventsByStreamPath),
                     "first\r\n-");
+
+                if(!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection))
                 CreateSystemProjection(
                     ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection,
                     typeof(IndexEventsByEventType),
                     "");
+
+                if(!existingSystemProjections.Contains(ProjectionNamesBuilder.StandardProjections.EventByCorrIdStandardProjection))
                 CreateSystemProjection(
                     ProjectionNamesBuilder.StandardProjections.EventByCorrIdStandardProjection,
                     typeof(ByCorrelationId),

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -286,7 +286,8 @@ namespace EventStore.Projections.Core.Services.Management
             return name == ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection ||
                    name == ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection ||
                    name == ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection ||
-                   name == ProjectionNamesBuilder.StandardProjections.StreamsStandardProjection;
+                   name == ProjectionNamesBuilder.StandardProjections.StreamsStandardProjection ||
+                   name == ProjectionNamesBuilder.StandardProjections.EventByCorrIdStandardProjection;
         }
 
         public void Handle(ProjectionManagementMessage.Command.GetQuery message)
@@ -878,6 +879,10 @@ namespace EventStore.Projections.Core.Services.Management
                 CreateSystemProjection(
                     ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection,
                     typeof(IndexEventsByEventType),
+                    "");
+                CreateSystemProjection(
+                    ProjectionNamesBuilder.StandardProjections.EventByCorrIdStandardProjection,
+                    typeof(ByCorrelationId),
                     "");
             }
         }

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -900,7 +900,7 @@ namespace EventStore.Projections.Core.Services.Management
                 CreateSystemProjection(
                     ProjectionNamesBuilder.StandardProjections.EventByCorrIdStandardProjection,
                     typeof(ByCorrelationId),
-                    "");
+                    "{\"correlationIdProperty\":\"$correlationId\"}");
             }
         }
 

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionNamesBuilder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionNamesBuilder.cs
@@ -12,6 +12,8 @@ namespace EventStore.Projections.Core.Services.Processing
             public const string StreamByCategoryStandardProjection = "$stream_by_category";
             public const string EventByCategoryStandardProjection = "$by_category";
             public const string EventByTypeStandardProjection = "$by_event_type";
+            public const string EventByCorrIdStandardProjection = "$by_correlation_id";
+
         }
 
         public static ProjectionNamesBuilder CreateForTest(string name)

--- a/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
+++ b/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
@@ -116,9 +116,17 @@ namespace EventStore.Projections.Core.Standard
             else
                 linkTarget = data.EventSequenceNumber + "@" + data.EventStreamId;
 
-            var linkMetadata = new ExtraMetaData(
-                new Dictionary<string,string> {{"$originalEventTimestamp", "\""+data.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ")+"\""}}
-            );
+            var metadataDict = new Dictionary<string,string>();
+            metadataDict.Add("$eventTimestamp", "\""+data.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ")+"\"");
+            if(data.EventType == SystemEventTypes.LinkTo){
+                JObject linkObj = new JObject();
+                linkObj.Add("eventId", data.EventId);
+                linkObj.Add("metadata", metadata);
+                metadataDict.Add("$link", linkObj.ToJson());
+            }
+
+            var linkMetadata = new ExtraMetaData(metadataDict);
+
             emittedEvents = new[]
             {
                 new EmittedEventEnvelope(

--- a/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
+++ b/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
@@ -116,13 +116,18 @@ namespace EventStore.Projections.Core.Standard
             else
                 linkTarget = data.EventSequenceNumber + "@" + data.EventStreamId;
 
+            var linkMetadata = new ExtraMetaData(
+                new Dictionary<string,string> {{"$originalEventTimestamp", "\""+data.Timestamp.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ")+"\""}}
+            );
             emittedEvents = new[]
             {
                 new EmittedEventEnvelope(
                     new EmittedDataEvent(
                         _corrIdStreamPrefix + correlationId, Guid.NewGuid(), "$>", false,
                         linkTarget,
-                        null, eventPosition, expectedTag: null))
+                        linkMetadata,
+                        eventPosition,
+                        expectedTag: null))
             };
 
 

--- a/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
+++ b/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using EventStore.Common.Utils;
+
+namespace EventStore.Projections.Core.Standard
+{
+    public class ByCorrelationId : IProjectionStateHandler, IProjectionCheckpointHandler
+    {
+        private readonly string _corrIdStreamPrefix;
+        private readonly string _corrIdCheckpointStream;
+
+        public ByCorrelationId(string source, Action<string, object[]> logger)
+        {
+            if (!string.IsNullOrWhiteSpace(source))
+                throw new InvalidOperationException("Empty source expected");
+            if (logger != null)
+            {
+//                logger("Index events by event type projection handler has been initialized");
+            }
+            // we will need to declare event types we are interested in
+            _corrIdStreamPrefix = "$bc-";
+            _corrIdCheckpointStream = "$bc";
+        }
+
+        public void ConfigureSourceProcessingStrategy(SourceDefinitionBuilder builder)
+        {
+            builder.FromAll();
+            builder.AllEvents();
+        }
+
+        public void Load(string state)
+        {
+        }
+
+        public void LoadShared(string state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Initialize()
+        {
+        }
+
+        public void InitializeShared()
+        {
+        }
+
+        public string GetStatePartition(CheckpointTag eventPosition, string category, ResolvedEvent data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string TransformCatalogEvent(CheckpointTag eventPosition, ResolvedEvent data)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool ProcessEvent(
+            string partition, CheckpointTag eventPosition, string category1, ResolvedEvent data,
+            out string newState, out string newSharedState, out EmittedEventEnvelope[] emittedEvents)
+        {
+            newSharedState = null;
+            emittedEvents = null;
+            newState = null;
+            if (data.EventStreamId != data.PositionStreamId)
+                return false;
+            if (!data.IsJson) 
+                return false;
+            var metadata = JObject.Parse(data.Metadata);
+            var indexedEventType = data.EventType;
+            
+            string correlationId = metadata["$correlationId"].Value<string>();
+            
+            if (correlationId == null) 
+                return false;
+            string positionStreamId = data.PositionStreamId;
+            emittedEvents = new[]
+            {
+                new EmittedEventEnvelope(
+                    new EmittedDataEvent(
+                        _corrIdStreamPrefix + correlationId, Guid.NewGuid(), "$>", false,
+                        data.EventSequenceNumber + "@" + positionStreamId,
+                        null, eventPosition, expectedTag: null))
+            };
+
+
+            return true;
+        }
+
+        public bool ProcessPartitionCreated(string partition, CheckpointTag createPosition, ResolvedEvent data, out EmittedEventEnvelope[] emittedEvents)
+        {
+            emittedEvents = null;
+            return false;
+        }
+
+        public bool ProcessPartitionDeleted(string partition, CheckpointTag deletePosition, out string newState)
+        {
+            throw new NotImplementedException();
+        }
+
+        public string TransformStateToResult()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public void ProcessNewCheckpoint(CheckpointTag checkpointPosition, out EmittedEventEnvelope[] emittedEvents)
+        {
+            emittedEvents = new[]
+            {
+                new EmittedEventEnvelope(
+                    new EmittedDataEvent(
+                        _corrIdCheckpointStream, Guid.NewGuid(), ProjectionEventTypes.PartitionCheckpoint,
+                        true, checkpointPosition.ToJsonString(), null, checkpointPosition, expectedTag: null))
+            };
+        }
+
+        public IQuerySources GetSourceDefinition()
+        {
+            return SourceDefinitionBuilder.From(ConfigureSourceProcessingStrategy);
+        }
+
+    }
+}


### PR DESCRIPTION
This PR adds a new internal projection $by_correlation_id. This makes a stream per correlation id which can be useful in many scenarios. In the future this is the internal work required for building up the correlationid graph which will also use causationid to show the full graph.