### PR TITLE
Scavenge log cleanup

### DIFF
--- a/src/EventStore.ClientAPI/Messages/ClientMessage.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessage.cs
@@ -1215,43 +1215,35 @@ namespace EventStore.ClientAPI.Messages
     }
   }
   
-  [Serializable, ProtoContract(Name=@"ScavengeDatabaseCompleted")]
-  public partial class ScavengeDatabaseCompleted
+  [Serializable, ProtoContract(Name=@"ScavengeDatabaseResponse")]
+  public partial class ScavengeDatabaseResponse
   {
     [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
-    public readonly ScavengeDatabaseCompleted.ScavengeResult Result;
+    public readonly ScavengeDatabaseResponse.ScavengeResult Result;
   
-    [ProtoMember(2, IsRequired = false, Name=@"error", DataFormat = DataFormat.Default)]
-    public readonly string Error;
-  
-    [ProtoMember(3, IsRequired = true, Name=@"total_time_ms", DataFormat = DataFormat.TwosComplement)]
-    public readonly int TotalTimeMs;
-  
-    [ProtoMember(4, IsRequired = true, Name=@"total_space_saved", DataFormat = DataFormat.TwosComplement)]
-    public readonly long TotalSpaceSaved;
+    [ProtoMember(2, IsRequired = false, Name=@"scavengeId", DataFormat = DataFormat.Default)]
+    public readonly string ScavengeId;
   
     [ProtoContract(Name=@"ScavengeResult")]
     public enum ScavengeResult
     {
             
-      [ProtoEnum(Name=@"Success", Value=0)]
-      Success = 0,
+      [ProtoEnum(Name=@"Started", Value=0)]
+      Started = 0,
             
       [ProtoEnum(Name=@"InProgress", Value=1)]
       InProgress = 1,
             
-      [ProtoEnum(Name=@"Failed", Value=2)]
-      Failed = 2
+      [ProtoEnum(Name=@"Unauthorized", Value=2)]
+      Unauthorized = 2
     }
   
-    private ScavengeDatabaseCompleted() {}
+    private ScavengeDatabaseResponse() {}
   
-    public ScavengeDatabaseCompleted(ScavengeDatabaseCompleted.ScavengeResult result, string error, int totalTimeMs, long totalSpaceSaved)
+    public ScavengeDatabaseResponse(ScavengeDatabaseResponse.ScavengeResult result, string scavengeId)
     {
         Result = result;
-        Error = error;
-        TotalTimeMs = totalTimeMs;
-        TotalSpaceSaved = totalSpaceSaved;
+        ScavengeId = scavengeId;
     }
   }
   

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -1,4 +1,5 @@
-﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -513,6 +514,7 @@
     <Compile Include="Services\TimeService\time_service_should.cs" />
     <Compile Include="SpecificationWithFile.cs" />
     <Compile Include="TestsInitFixture.cs" />
+    <Compile Include="TransactionLog\Scavenging\Helpers\FakeTFScavengerLog.cs" />
     <Compile Include="TransactionLog\Scavenging\when_having_stream_with_start_from_specified.cs" />
     <Compile Include="TransactionLog\Scavenging\scavenged_chunk.cs" />
     <Compile Include="TransactionLog\Truncation\when_truncating_into_the_middle_of_completed_chunk.cs" />

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -13,11 +13,11 @@ using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
 using EventStore.Core.Util;
 using EventStore.Core.Index.Hashes;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
 
 namespace EventStore.Core.Tests.Services.Storage
 {
@@ -35,8 +35,6 @@ namespace EventStore.Core.Tests.Services.Storage
         protected ICheckpoint WriterCheckpoint;
         protected ICheckpoint ChaserCheckpoint;
         protected ICheckpoint ReplicationCheckpoint;
-        protected IODispatcher IODispatcher;
-        protected InMemoryBus Bus;
 
         private TFChunkScavenger _scavenger;
         private bool _scavenge;
@@ -59,9 +57,6 @@ namespace EventStore.Core.Tests.Services.Storage
             WriterCheckpoint = new InMemoryCheckpoint(0);
             ChaserCheckpoint = new InMemoryCheckpoint(0);
             ReplicationCheckpoint = new InMemoryCheckpoint(-1);
-
-            Bus = new InMemoryBus("bus");
-            IODispatcher = new IODispatcher(Bus, new PublishEnvelope(Bus));
 
             Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, WriterCheckpoint, ChaserCheckpoint, replicationCheckpoint: ReplicationCheckpoint));
 
@@ -103,7 +98,7 @@ namespace EventStore.Core.Tests.Services.Storage
             {
                 if (_completeLastChunkOnScavenge)
                     Db.Manager.GetChunk(Db.Manager.ChunksCount - 1).Complete();
-                _scavenger = new TFChunkScavenger(Db, IODispatcher, TableIndex, ReadIndex, Guid.NewGuid(), "fakeNodeIp");
+                _scavenger = new TFChunkScavenger(Db, new FakeTFScavengerLog(), TableIndex, ReadIndex);
                 _scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: _mergeChunks);
             }
         }

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
 			using(var conn = TestConnection.Create(_node.TcpEndPoint, TcpType.Normal, DefaultData.AdminCredentials))
 			{
 				conn.ConnectAsync().Wait();
-				var countdown = new CountdownEvent(3);
+				var countdown = new CountdownEvent(2);
 				_result = new List<ResolvedEvent>();
 
 				conn.SubscribeToStreamFrom(SystemStreams.ScavengesStream, null, CatchUpSubscriptionSettings.Default,
@@ -69,13 +69,6 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
 					Assert.Fail("Timeout expired while waiting for events.");
 				}
 			}
-		}
-
-		[Test]
-		public void should_create_scavenge_index_initialized_event()
-		{
-			var scavengeIndexInitialized = _result.FirstOrDefault(x=>x.Event.EventType == SystemEventTypes.ScavengeIndexInitialized);
-			Assert.IsNotNull(scavengeIndexInitialized);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.Chunks;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
+{
+    public class FakeTFScavengerLog : ITFChunkScavengerLog
+    {
+        public void ScavengeStarted()
+        {
+            
+        }
+
+        public void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved)
+        {
+        }
+
+        public void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved,
+            string errorMessage)
+        {
+        }
+
+        public void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        {
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
 {
     public class FakeTFScavengerLog : ITFChunkScavengerLog
     {
+        public string ScavengeId { get; } = "FakeScavenge";
+
         public void ScavengeStarted()
         {
             
@@ -20,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
         {
         }
 
-        public void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        public void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
         {
         }
     }

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -1,20 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using EventStore.Core.Bus;
 using EventStore.Core.DataStructures;
-using EventStore.Core.Helpers;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
-using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Settings;
 using EventStore.Core.Tests.Fakes;
-using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
-using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
 using EventStore.Core.Util;
@@ -70,10 +64,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
             ReadIndex.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 
             //var scavengeReadIndex = new ScavengeReadIndex(_dbResult.Streams, _metastreamMaxCount);
-            var bus = new InMemoryBus("Bus");
-            var ioDispatcher = new IODispatcher(bus, new PublishEnvelope(bus));
-            var scavenger = new TFChunkScavenger(_dbResult.Db, ioDispatcher, tableIndex, ReadIndex, Guid.NewGuid(), "fakeNodeIp",
-                                            unsafeIgnoreHardDeletes: UnsafeIgnoreHardDelete());
+            var scavenger = new TFChunkScavenger(_dbResult.Db, new FakeTFScavengerLog(), tableIndex, ReadIndex, unsafeIgnoreHardDeletes: UnsafeIgnoreHardDelete());
             scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Services.Storage;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -68,10 +69,7 @@ namespace EventStore.Core.Tests.TransactionLog
             _db.Config.ChaserCheckpoint.Write(chunk.ChunkHeader.ChunkEndPosition);
             _db.Config.ChaserCheckpoint.Flush();
 
-            var bus = new InMemoryBus("Bus");
-            var ioDispatcher = new IODispatcher(bus, new PublishEnvelope(bus));
-            var scavenger = new TFChunkScavenger(_db, ioDispatcher, new FakeTableIndex(),
-                                                 new FakeReadIndex(x => x == "es-to-scavenge"), Guid.NewGuid(), "fakeNodeIp");
+            var scavenger = new TFChunkScavenger(_db, new FakeTFScavengerLog(), new FakeTableIndex(), new FakeReadIndex(x => x == "es-to-scavenge"));
             scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);
 
             _scavengedChunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -310,7 +310,7 @@ namespace EventStore.Core
 
             _mainBus.Subscribe<SystemMessage.StateChangeMessage>(infoController);
 
-            var adminController = new AdminController(_mainQueue);
+            var adminController = new AdminController(_mainQueue, _workersHandler);
             var pingController = new PingController();
             var histogramController = new HistogramController();
             var statController = new StatController(monitoringQueue, _workersHandler);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -477,14 +477,13 @@ namespace EventStore.Core
             perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionTimerTick>(persistentSubscription);
 
             // STORAGE SCAVENGER
+            var scavengerLogManager = new TFChunkScavengerLogManager(_nodeInfo.ExternalHttp.ToString(), TimeSpan.FromDays(vNodeSettings.ScavengeHistoryMaxAge), ioDispatcher);
             var storageScavenger = new StorageScavenger(db,
-                                                        ioDispatcher,
                                                         tableIndex,
                                                         readIndex,
+                                                        scavengerLogManager,
                                                         vNodeSettings.AlwaysKeepScavenged,
-                                                        _nodeInfo.ExternalHttp.ToString(),
                                                         !vNodeSettings.DisableScavengeMerging,
-                                                        vNodeSettings.ScavengeHistoryMaxAge,
                                                         unsafeIgnoreHardDeletes: vNodeSettings.UnsafeIgnoreHardDeletes);
 
 			// ReSharper disable RedundantTypeArgumentsOfMethod

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -1,4 +1,5 @@
-﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -310,7 +311,11 @@
     <Compile Include="Settings\VNodeSettings.cs" />
     <Compile Include="StandardComponents.cs" />
     <Compile Include="TransactionLog\Checkpoint\Checkpoint.cs" />
+    <Compile Include="TransactionLog\Chunks\ITFChunkScavengerLog.cs" />
+    <Compile Include="TransactionLog\Chunks\ITFChunkScavengerLogManager.cs" />
     <Compile Include="TransactionLog\Chunks\TFChunkDbTruncator.cs" />
+    <Compile Include="TransactionLog\Chunks\TFChunkScavengerLog.cs" />
+    <Compile Include="TransactionLog\Chunks\TFChunkScavengerLogManager.cs" />
     <Compile Include="TransactionLog\Chunks\TFChunk\BulkReadResult.cs" />
     <Compile Include="TransactionLog\Chunks\TFChunk\PosMap.cs" />
     <Compile Include="TransactionLog\Chunks\TFChunk\TFChunkReadSide.cs" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Messages\MemberInfoDto.cs" />
     <Compile Include="Messages\ReplicationMessage.cs" />
     <Compile Include="Messages\ReplicationMessageDto.cs" />
+    <Compile Include="Messages\ScavengeResultDto.cs" />
     <Compile Include="Messages\SubscriptionMessage.cs" />
     <Compile Include="Messages\HttpClientMessageDto.cs" />
     <Compile Include="Messages\InternalAuthenticationProviderMessages.cs" />

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1378,41 +1378,36 @@ namespace EventStore.Core.Messages
                 User = user;
             }
 
-            public enum ScavengeResult
-            {
-                Success,
-                InProgress,
-                Failed
-            }
+            
         }
-
-        public class ScavengeDatabaseCompleted: Message
+        
+        public class ScavengeDatabaseResponse : Message
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
             public override int MsgTypeId { get { return TypeId; } }
 
             public readonly Guid CorrelationId;
-            public readonly ScavengeDatabase.ScavengeResult Result;
-            public readonly string Error;
-            public readonly TimeSpan TotalTime;
-            public readonly long TotalSpaceSaved;
+            public readonly ScavengeResponse Result;
+            public readonly string ScavengeId;
 
-            public ScavengeDatabaseCompleted(Guid correlationId,
-                                             ScavengeDatabase.ScavengeResult result,
-                                             string error,
-                                             TimeSpan totalTime,
-                                             long totalSpaceSaved)
+            public ScavengeDatabaseResponse(Guid correlationId,
+                ScavengeResponse result, string scavengeId)
             {
                 CorrelationId = correlationId;
                 Result = result;
-                Error = error;
-                TotalTime = totalTime;
-                TotalSpaceSaved = totalSpaceSaved;
+                ScavengeId = scavengeId;
             }
 
             public override string ToString()
             {
-                return String.Format("Result: {0}, Error: {1}, TotalTime: {2}, TotalSpaceSaved: {3}", Result, Error, TotalTime, TotalSpaceSaved);
+                return String.Format("Result: {0}, ScavengeId: {1}", Result, ScavengeId);
+            }
+
+            public enum ScavengeResponse
+            {
+                Started,
+                Unauthorized,
+                InProgress,
             }
         }
 

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1387,11 +1387,11 @@ namespace EventStore.Core.Messages
             public override int MsgTypeId { get { return TypeId; } }
 
             public readonly Guid CorrelationId;
-            public readonly ScavengeResponse Result;
+            public readonly ScavengeResult Result;
             public readonly string ScavengeId;
 
             public ScavengeDatabaseResponse(Guid correlationId,
-                ScavengeResponse result, string scavengeId)
+                ScavengeResult result, string scavengeId)
             {
                 CorrelationId = correlationId;
                 Result = result;
@@ -1403,7 +1403,7 @@ namespace EventStore.Core.Messages
                 return String.Format("Result: {0}, ScavengeId: {1}", Result, ScavengeId);
             }
 
-            public enum ScavengeResponse
+            public enum ScavengeResult
             {
                 Started,
                 Unauthorized,

--- a/src/EventStore.Core/Messages/ScavengeResultDto.cs
+++ b/src/EventStore.Core/Messages/ScavengeResultDto.cs
@@ -1,0 +1,16 @@
+﻿namespace EventStore.Core.Messages
+{
+    public class ScavengeResultDto
+    {
+        public string ScavengeId { get; set; }
+
+        public ScavengeResultDto()
+        {
+        }
+
+        public ScavengeResultDto(string scavengeId)
+        {
+            ScavengeId = scavengeId;
+        }
+    }
+}

--- a/src/EventStore.Core/Messages/TcpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDto.cs
@@ -1215,43 +1215,35 @@ namespace EventStore.Core.Messages
     }
   }
   
-  [Serializable, ProtoContract(Name=@"ScavengeDatabaseCompleted")]
-  public partial class ScavengeDatabaseCompleted
+  [Serializable, ProtoContract(Name=@"ScavengeDatabaseResponse")]
+  public partial class ScavengeDatabaseResponse
   {
     [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
-    public readonly ScavengeDatabaseCompleted.ScavengeResult Result;
+    public readonly ScavengeDatabaseResponse.ScavengeResult Result;
   
-    [ProtoMember(2, IsRequired = false, Name=@"error", DataFormat = DataFormat.Default)]
-    public readonly string Error;
-  
-    [ProtoMember(3, IsRequired = true, Name=@"total_time_ms", DataFormat = DataFormat.TwosComplement)]
-    public readonly int TotalTimeMs;
-  
-    [ProtoMember(4, IsRequired = true, Name=@"total_space_saved", DataFormat = DataFormat.TwosComplement)]
-    public readonly long TotalSpaceSaved;
+    [ProtoMember(2, IsRequired = false, Name=@"scavengeId", DataFormat = DataFormat.Default)]
+    public readonly string ScavengeId;
   
     [ProtoContract(Name=@"ScavengeResult")]
     public enum ScavengeResult
     {
             
-      [ProtoEnum(Name=@"Success", Value=0)]
-      Success = 0,
+      [ProtoEnum(Name=@"Started", Value=0)]
+      Started = 0,
             
       [ProtoEnum(Name=@"InProgress", Value=1)]
       InProgress = 1,
             
-      [ProtoEnum(Name=@"Failed", Value=2)]
-      Failed = 2
+      [ProtoEnum(Name=@"Unauthorized", Value=2)]
+      Unauthorized = 2
     }
   
-    private ScavengeDatabaseCompleted() {}
+    private ScavengeDatabaseResponse() {}
   
-    public ScavengeDatabaseCompleted(ScavengeDatabaseCompleted.ScavengeResult result, string error, int totalTimeMs, long totalSpaceSaved)
+    public ScavengeDatabaseResponse(ScavengeDatabaseResponse.ScavengeResult result, string scavengeId)
     {
         Result = result;
-        Error = error;
-        TotalTimeMs = totalTimeMs;
-        TotalSpaceSaved = totalSpaceSaved;
+        ScavengeId = scavengeId;
     }
   }
   

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -53,7 +53,7 @@ namespace EventStore.Core.Services.Storage
             if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
             {
                 message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
-                    ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized, null));
+                    ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized, null));
             }
             else if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
             {
@@ -62,7 +62,7 @@ namespace EventStore.Core.Services.Storage
             else
             {
                 message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
-                    ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress, null));
+                    ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress, null));
             }
         }
 
@@ -80,7 +80,7 @@ namespace EventStore.Core.Services.Storage
                 tfChunkScavengerLog.ScavengeStarted();
 
                 message.Envelope.ReplyWith(
-                    new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started, tfChunkScavengerLog.ScavengeId)
+                    new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started, tfChunkScavengerLog.ScavengeId)
                 );
                 
                 var scavenger = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -11,6 +11,9 @@ using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Services.Storage
 {
+
+    
+
     public class StorageScavenger : IHandle<ClientMessage.ScavengeDatabase>, IHandle<UserManagementMessage.UserManagementServiceInitialized>
     {
         private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
@@ -49,11 +52,8 @@ namespace EventStore.Core.Services.Storage
         {
             if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
             {
-                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId,
-                    ClientMessage.ScavengeDatabase.ScavengeResult.Failed,
-                    "Access denied.",
-                    TimeSpan.FromMilliseconds(0),
-                    0));
+                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
+                    ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized, null));
             }
             else if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
             {
@@ -61,11 +61,8 @@ namespace EventStore.Core.Services.Storage
             }
             else
             {
-                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId,
-                                                            ClientMessage.ScavengeDatabase.ScavengeResult.InProgress,
-                                                            "Scavenge already in progress.",
-                                                            TimeSpan.FromMilliseconds(0),
-                                                            0));
+                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
+                    ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress, null));
             }
         }
 
@@ -75,34 +72,32 @@ namespace EventStore.Core.Services.Storage
 
             var tfChunkScavengerLog = _logManager.CreateLog();
 
-            ClientMessage.ScavengeDatabase.ScavengeResult result;
+            ScavengeResult result = ScavengeResult.Success;
             string error = null;
             long spaceSaved = 0;
             try
             {
                 tfChunkScavengerLog.ScavengeStarted();
 
+                message.Envelope.ReplyWith(
+                    new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started, tfChunkScavengerLog.ScavengeId)
+                );
+                
                 var scavenger = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);
 
                 spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
-
-                result = ClientMessage.ScavengeDatabase.ScavengeResult.Success;
-
+                
             }
             catch (Exception exc)
             {
+                result = ScavengeResult.Failed;
                 Log.ErrorException(exc, "SCAVENGING: error while scavenging DB.");
-                result = ClientMessage.ScavengeDatabase.ScavengeResult.Failed;
                 error = string.Format("Error while scavenging DB: {0}.", exc.Message);
             }
 
             Interlocked.Exchange(ref _isScavengingRunning, 0);
 
             tfChunkScavengerLog.ScavengeCompleted(result, error, spaceSaved, sw.Elapsed);
-            
-            message.Envelope.ReplyWith(
-                new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId, result, error, sw.Elapsed, spaceSaved)
-            );
         }
 
     }

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -1,67 +1,61 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
-using EventStore.Core.Data;
-using EventStore.Core.Helpers;
 using EventStore.Core.Index;
-using EventStore.Core.Index.Hashes;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
-using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Services.Storage
 {
-    public class StorageScavenger : IHandle<ClientMessage.ScavengeDatabase>,
-                                    IHandle<UserManagementMessage.UserManagementServiceInitialized>
+    public class StorageScavenger : IHandle<ClientMessage.ScavengeDatabase>, IHandle<UserManagementMessage.UserManagementServiceInitialized>
     {
         private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
 
         private readonly TFChunkDb _db;
-        private readonly IODispatcher _ioDispatcher;
         private readonly ITableIndex _tableIndex;
         private readonly IReadIndex _readIndex;
         private readonly bool _alwaysKeepScavenged;
         private readonly bool _mergeChunks;
-        private readonly string _nodeEndpoint;
-        private readonly int _scavengeHistoryMaxAge;
         private readonly bool _unsafeIgnoreHardDeletes;
+        private readonly ITFChunkScavengerLogManager _logManager;
         private int _isScavengingRunning;
-        private const int MaxRetryCount = 5;
 
-        public StorageScavenger(TFChunkDb db, IODispatcher ioDispatcher, ITableIndex tableIndex,
-                                IReadIndex readIndex, bool alwaysKeepScavenged, string nodeEndpoint, bool mergeChunks,
-                                int scavengeHistoryMaxAge, bool unsafeIgnoreHardDeletes)
+        public StorageScavenger(TFChunkDb db, ITableIndex tableIndex, IReadIndex readIndex, ITFChunkScavengerLogManager logManager, bool alwaysKeepScavenged, bool mergeChunks, bool unsafeIgnoreHardDeletes)
         {
             Ensure.NotNull(db, "db");
-            Ensure.NotNull(ioDispatcher, "ioDispatcher");
+            Ensure.NotNull(logManager, "logManager");
             Ensure.NotNull(tableIndex, "tableIndex");
             Ensure.NotNull(readIndex, "readIndex");
-            Ensure.NotNull(nodeEndpoint, "nodeEndpoint");
 
             _db = db;
-            _ioDispatcher = ioDispatcher;
             _tableIndex = tableIndex;
             _readIndex = readIndex;
             _alwaysKeepScavenged = alwaysKeepScavenged;
-            _mergeChunks = mergeChunks;
-            _nodeEndpoint = nodeEndpoint;
-            _scavengeHistoryMaxAge = scavengeHistoryMaxAge;
+            _mergeChunks = mergeChunks;            
             _unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
+            _logManager = logManager;
         }
 
         public void Handle(UserManagementMessage.UserManagementServiceInitialized message)
         {
-            WriteScavengeIndexInitializedEvent();
+            _logManager.Initialise();
         }
 
         public void Handle(ClientMessage.ScavengeDatabase message)
         {
-            if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
+            if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
+            {
+                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId,
+                    ClientMessage.ScavengeDatabase.ScavengeResult.Failed,
+                    "Access denied.",
+                    TimeSpan.FromMilliseconds(0),
+                    0));
+            }
+            else if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
             {
                 ThreadPool.QueueUserWorkItem(_ => Scavenge(message));
             }
@@ -78,27 +72,22 @@ namespace EventStore.Core.Services.Storage
         private void Scavenge(ClientMessage.ScavengeDatabase message)
         {
             var sw = Stopwatch.StartNew();
-            Guid scavengeId = Guid.NewGuid();
-            var streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, scavengeId);
+
+            var tfChunkScavengerLog = _logManager.CreateLog();
+
             ClientMessage.ScavengeDatabase.ScavengeResult result;
             string error = null;
             long spaceSaved = 0;
             try
             {
-                if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
-                {
-                    result = ClientMessage.ScavengeDatabase.ScavengeResult.Failed;
-                    error = "Access denied.";
-                }
-                else
-                {
-                    WriteScavengeStartedEvent(streamName, scavengeId);
+                tfChunkScavengerLog.ScavengeStarted();
 
-                    var scavenger = new TFChunkScavenger(_db, _ioDispatcher, _tableIndex, _readIndex, scavengeId,
-                                                                                 _nodeEndpoint, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);
-                    spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
-                    result = ClientMessage.ScavengeDatabase.ScavengeResult.Success;
-                }
+                var scavenger = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);
+
+                spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
+
+                result = ClientMessage.ScavengeDatabase.ScavengeResult.Success;
+
             }
             catch (Exception exc)
             {
@@ -109,100 +98,12 @@ namespace EventStore.Core.Services.Storage
 
             Interlocked.Exchange(ref _isScavengingRunning, 0);
 
-            WriteScavengeCompletedEvent(streamName, scavengeId, result, error, spaceSaved, sw.Elapsed);
+            tfChunkScavengerLog.ScavengeCompleted(result, error, spaceSaved, sw.Elapsed);
+            
             message.Envelope.ReplyWith(
                 new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId, result, error, sw.Elapsed, spaceSaved)
             );
         }
 
-        private void WriteScavengeIndexInitializedEvent()
-        {
-            var metadataEventId = Guid.NewGuid();
-            var metaStreamId = SystemStreams.MetastreamOf(SystemStreams.ScavengesStream);
-            var metadata = new StreamMetadata(maxAge: TimeSpan.FromDays(_scavengeHistoryMaxAge));
-            var metaStreamEvent = new Event(metadataEventId, SystemEventTypes.StreamMetadata, isJson: true,
-                                            data: metadata.ToJsonBytes(), metadata: null);
-            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => { 
-                if(m.Result != OperationResult.Success){
-                    Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge, SystemStreams.ScavengesStream, m.Result);
-                }
-            });
-
-            var indexInitializedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeIndexInitialized,
-                    true, new Dictionary<string, object>{}.ToJsonBytes(), null);
-            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.NoStream, indexInitializedEvent, SystemAccount.Principal, m => {
-                if(m.Result != OperationResult.Success && m.Result != OperationResult.WrongExpectedVersion){
-                    Log.Error("Failed to write the {0} event to the {1} stream. Reason: {2}", SystemEventTypes.ScavengeIndexInitialized, SystemStreams.ScavengesStream, m.Result);
-                }
-             });
-        }
-
-        private void WriteScavengeStartedEvent(string streamName, Guid scavengeId)
-        {
-            var metadataEventId = Guid.NewGuid();
-            var metaStreamId = SystemStreams.MetastreamOf(streamName);
-            var metadata = new StreamMetadata(maxAge: TimeSpan.FromDays(_scavengeHistoryMaxAge));
-            var metaStreamEvent = new Event(metadataEventId, SystemEventTypes.StreamMetadata, isJson: true,
-                                            data: metadata.ToJsonBytes(), metadata: null);
-            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => { 
-                if(m.Result != OperationResult.Success){
-                    Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge, streamName, m.Result);
-                }
-            });
-
-            var scavengeStartedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeStarted, true, new Dictionary<string, object>{
-                    {"scavengeId", scavengeId},
-                    {"nodeEndpoint", _nodeEndpoint},
-                }.ToJsonBytes(), null);
-            WriteScavengeDetailEvent(streamName, scavengeStartedEvent, MaxRetryCount);
-        }
-
-        private void WriteScavengeCompletedEvent(string streamName, Guid scavengeId, ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan timeTaken)
-        {
-            var scavengeCompletedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeCompleted, true, new Dictionary<string, object>{
-                    {"scavengeId", scavengeId},
-                    {"nodeEndpoint", _nodeEndpoint},
-                    {"result", result},
-                    {"error", error},
-                    {"timeTaken", timeTaken},
-                    {"spaceSaved", spaceSaved}
-                }.ToJsonBytes(), null);
-            WriteScavengeDetailEvent(streamName, scavengeCompletedEvent, MaxRetryCount);
-        }
-
-        private void WriteScavengeDetailEvent(string streamId, Event eventToWrite, int retryCount){
-            _ioDispatcher.WriteEvent(streamId, ExpectedVersion.Any, eventToWrite, SystemAccount.Principal, x => WriteScavengeDetailEventCompleted(x, eventToWrite, streamId, retryCount));
-        }
-
-        private void WriteScavengeIndexEvent(Event linkToEvent, int retryCount){
-            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.Any, linkToEvent, SystemAccount.Principal, m => WriteScavengeIndexEventCompleted(m, linkToEvent, retryCount));
-        }
-
-        private void WriteScavengeIndexEventCompleted(ClientMessage.WriteEventsCompleted msg, Event linkToEvent, int retryCount){
-            if(msg.Result != OperationResult.Success){
-                if(retryCount > 0){
-                    Log.Error("Failed to write an event to the {0} stream. Retrying {1}/{2}. Reason: {3}", SystemStreams.ScavengesStream, (MaxRetryCount - retryCount) + 1, MaxRetryCount, msg.Result);
-                    WriteScavengeIndexEvent(linkToEvent, --retryCount);
-                }else{
-                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", SystemStreams.ScavengesStream, MaxRetryCount, msg.Result);
-                }
-            }
-        }
-
-        private void WriteScavengeDetailEventCompleted(ClientMessage.WriteEventsCompleted msg, Event eventToWrite, string streamId, int retryCount)
-        {
-            if(msg.Result != OperationResult.Success){
-                if(retryCount > 0){
-                    Log.Error("Failed to write an event to the {0} stream. Retrying {1}/{2}. Reason: {3}", streamId, (MaxRetryCount - retryCount) + 1, MaxRetryCount, msg.Result);
-                    WriteScavengeDetailEvent(streamId, eventToWrite, --retryCount);
-                }else{
-                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", streamId, MaxRetryCount, msg.Result);
-                }
-            }else{
-                string eventLinkTo = string.Format("{0}@{1}", msg.FirstEventNumber, streamId);
-                var linkToIndexEvent = new Event(Guid.NewGuid(), SystemEventTypes.LinkTo, false, eventLinkTo, null);
-                WriteScavengeIndexEvent(linkToIndexEvent, MaxRetryCount);
-            }
-        }
     }
 }

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -83,7 +83,6 @@ namespace EventStore.Core.Services
         public const string ScavengeStarted = "$scavengeStarted";
         public const string ScavengeCompleted = "$scavengeCompleted";
         public const string ScavengeChunksCompleted = "$scavengeChunksCompleted";
-        public const string ScavengeIndexInitialized = "$scavengeIndexInitialized";
 
         public static string StreamReferenceEventToStreamId(string eventType, byte[] data)
         {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -55,11 +55,11 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                     var completed = message as ClientMessage.ScavengeDatabaseResponse;
                     switch (completed?.Result)
                     {
-                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started:
+                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started:
                             return Configure.Ok(e.ResponseCodec.ContentType);
-                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress:
+                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress:
                             return Configure.BadRequest();
-                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized:
+                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized:
                             return Configure.Unauthorized();
                         default:
                             return Configure.InternalServerError();

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             var envelope = new SendToHttpEnvelope(_networkSendQueue, entity, (e, message) =>
                 {
                     var completed = message as ClientMessage.ScavengeDatabaseResponse;
-                    return e.ResponseCodec.To(completed?.ScavengeId);
+                    return e.ResponseCodec.To(new ScavengeResultDto(completed?.ScavengeId));
                 },
                 (e, message) =>
                 {

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -606,23 +606,24 @@ namespace EventStore.Core.Services.Transport.Tcp
 
         private TcpPackage WrapScavengeDatabaseResponse(ClientMessage.ScavengeDatabaseResponse msg)
         {
-            TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult result;
+            TcpClientMessageDto.ScavengeDatabaseResponse.ScavengeResult result;
             switch (msg.Result)
             {
-                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started:
-                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.Success;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started:
+                    result = TcpClientMessageDto.ScavengeDatabaseResponse.ScavengeResult.Started;
                     break;
-                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized:
-                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.Failed;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized:
+                    result = TcpClientMessageDto.ScavengeDatabaseResponse.ScavengeResult.Unauthorized;
                     break;
-                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress:
-                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.InProgress;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress:
+                    result = TcpClientMessageDto.ScavengeDatabaseResponse.ScavengeResult.InProgress;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            var dto = new TcpClientMessageDto.ScavengeDatabaseCompleted(result, null, 0, 0);
-            return new TcpPackage(TcpCommand.ScavengeDatabaseCompleted, msg.CorrelationId, dto.Serialize());
+
+            var dto = new TcpClientMessageDto.ScavengeDatabaseResponse(result, msg.ScavengeId);
+            return new TcpPackage(TcpCommand.ScavengeDatabaseResponse, msg.CorrelationId, dto.Serialize());
         }
 
         private ClientMessage.NotHandled UnwrapNotHandled(TcpPackage package, IEnvelope envelope)

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -82,7 +82,7 @@ namespace EventStore.Core.Services.Transport.Tcp
             AddWrapper<ClientMessage.PersistentSubscriptionStreamEventAppeared>(WrapPersistentSubscriptionStreamEventAppeared, ClientVersion.V2);
 
             AddUnwrapper(TcpCommand.ScavengeDatabase, UnwrapScavengeDatabase, ClientVersion.V2);
-            AddWrapper<ClientMessage.ScavengeDatabaseCompleted>(WrapScavengeDatabaseResponse, ClientVersion.V2);
+            AddWrapper<ClientMessage.ScavengeDatabaseResponse>(WrapScavengeDatabaseResponse, ClientVersion.V2);
 
             AddWrapper<ClientMessage.NotHandled>(WrapNotHandled, ClientVersion.V2);
             AddUnwrapper(TcpCommand.NotHandled, UnwrapNotHandled, ClientVersion.V2);
@@ -604,11 +604,24 @@ namespace EventStore.Core.Services.Transport.Tcp
             return new ClientMessage.ScavengeDatabase(envelope, package.CorrelationId, user);
         }
 
-        private TcpPackage WrapScavengeDatabaseResponse(ClientMessage.ScavengeDatabaseCompleted msg)
+        private TcpPackage WrapScavengeDatabaseResponse(ClientMessage.ScavengeDatabaseResponse msg)
         {
-            var dto = new TcpClientMessageDto.ScavengeDatabaseCompleted(
-                (TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult)msg.Result, msg.Error,
-                (int)msg.TotalTime.TotalMilliseconds, msg.TotalSpaceSaved);
+            TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult result;
+            switch (msg.Result)
+            {
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started:
+                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.Success;
+                    break;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized:
+                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.Failed;
+                    break;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress:
+                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.InProgress;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            var dto = new TcpClientMessageDto.ScavengeDatabaseCompleted(result, null, 0, 0);
             return new TcpPackage(TcpCommand.ScavengeDatabaseCompleted, msg.CorrelationId, dto.Serialize());
         }
 

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpCommand.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpCommand.cs
@@ -68,7 +68,7 @@ namespace EventStore.Core.Services.Transport.Tcp
         UpdatePersistentSubscriptionCompleted = 0xCF,
 
         ScavengeDatabase = 0xD0,
-        ScavengeDatabaseCompleted = 0xD1,
+        ScavengeDatabaseResponse = 0xD1,
 
         BadRequest = 0xF0,
         NotHandled = 0xF1,

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
@@ -5,12 +5,20 @@ namespace EventStore.Core.TransactionLog.Chunks
 {
     public interface ITFChunkScavengerLog
     {
+        string ScavengeId { get; }
+        
         void ScavengeStarted();
 
         void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved);
-        
+
         void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved, string errorMessage);
-        
-        void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed);
+
+        void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed);
+    }
+    
+    public enum ScavengeResult
+    {
+        Success,
+        Failed
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using EventStore.Core.Messages;
+
+namespace EventStore.Core.TransactionLog.Chunks
+{
+    public interface ITFChunkScavengerLog
+    {
+        void ScavengeStarted();
+
+        void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved);
+        
+        void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved, string errorMessage);
+        
+        void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed);
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLogManager.cs
@@ -1,0 +1,9 @@
+﻿namespace EventStore.Core.TransactionLog.Chunks
+{
+    public interface ITFChunkScavengerLogManager
+    {
+        void Initialise();
+
+        ITFChunkScavengerLog CreateLog();
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -7,14 +7,11 @@ using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Exceptions;
-using EventStore.Core.Helpers;
 using EventStore.Core.Index;
 using EventStore.Core.Services;
 using EventStore.Core.Services.Storage.ReaderIndex;
-using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
-using EventStore.Core.Messages;
 
 namespace EventStore.Core.TransactionLog.Chunks
 {
@@ -23,29 +20,23 @@ namespace EventStore.Core.TransactionLog.Chunks
         private static readonly ILogger Log = LogManager.GetLoggerFor<TFChunkScavenger>();
 
         private readonly TFChunkDb _db;
-        private readonly IODispatcher _ioDispatcher;
+        private readonly ITFChunkScavengerLog _scavengerLog;
         private readonly ITableIndex _tableIndex;
-        private readonly Guid _scavengeId;
-        private readonly string _nodeEndpoint;
         private readonly IReadIndex _readIndex;
         private readonly long _maxChunkDataSize;
         private readonly bool _unsafeIgnoreHardDeletes;
         private const int MaxRetryCount = 5;
 
-        public TFChunkScavenger(TFChunkDb db, IODispatcher ioDispatcher, ITableIndex tableIndex, IReadIndex readIndex,
-                                Guid scavengeId, string nodeEndpoint, long? maxChunkDataSize = null, bool unsafeIgnoreHardDeletes=false)
+        public TFChunkScavenger(TFChunkDb db, ITFChunkScavengerLog scavengerLog, ITableIndex tableIndex, IReadIndex readIndex, long? maxChunkDataSize = null, bool unsafeIgnoreHardDeletes=false)
         {
             Ensure.NotNull(db, "db");
-            Ensure.NotNull(ioDispatcher, "ioDispatcher");
+            Ensure.NotNull(scavengerLog, "scavengerLog");
             Ensure.NotNull(tableIndex, "tableIndex");
-            Ensure.NotNull(nodeEndpoint, "nodeEndpoint");
             Ensure.NotNull(readIndex, "readIndex");
 
             _db = db;
-            _ioDispatcher = ioDispatcher;
+            _scavengerLog = scavengerLog;
             _tableIndex = tableIndex;
-            _scavengeId = scavengeId;
-            _nodeEndpoint = nodeEndpoint;
             _readIndex = readIndex;
             _maxChunkDataSize = maxChunkDataSize ?? db.Config.ChunkSize;
             _unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
@@ -231,7 +222,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                     Log.Trace("Scavenged chunk removed.");
 
                     newChunk.MarkForDeletion();
-                    PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, spaceSaved);
+                    _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, "Decided to keep old chunk.");
+
                     return false;
                 }
 
@@ -272,7 +264,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                         chunkEndNumber, Path.GetFileName(chunk.FileName));
                     Log.Trace("Old chunks total size: {0}, scavenged chunk size: {1}.", oldSize, newSize);
                     spaceSaved = oldSize - newSize;
-                    PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, true, spaceSaved);
+                    _scavengerLog.ChunksScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved);
+
                     return true;
                 }
                 else
@@ -282,7 +275,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                     Log.Trace("completed in {1}.", sw.Elapsed);
                     Log.Trace("But switching was prevented for new chunk: #{0}-{1} ({2}).", chunkStartNumber, chunkEndNumber, Path.GetFileName(tmpChunkPath));
                     Log.Trace("Old chunks total size: {0}, scavenged chunk size: {1}.", oldSize, newSize);
-                    PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, spaceSaved);
+                    _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, "Chunk switch prevented.");
+
                     return false;
                 }
             }
@@ -294,7 +288,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                 Log.Info("Stopping scavenging and removing temp chunk '{0}'...", tmpChunkPath);
                 Log.Info("Exception message: {0}.", exc.Message);
                 DeleteTempChunk(tmpChunkPath, MaxRetryCount);
-                PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, spaceSaved, exc.Message);
+                _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, exc.Message);
+
                 return false;
             }
             catch (Exception ex)
@@ -302,7 +297,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                 Log.Info("Got exception while scavenging chunk: #{0}-{1}. This chunk will be skipped\n"
                          + "Exception: {2}.", chunkStartNumber, chunkEndNumber, ex.ToString());
                 DeleteTempChunk(tmpChunkPath, MaxRetryCount);
-                PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, 0, ex.Message);
+                _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, ex.Message);
+
                 return false;
             }
         }
@@ -325,38 +321,6 @@ namespace EventStore.Core.TransactionLog.Chunks
                 {
                     Log.Error("Failed to delete the temp chunk. Retry limit of {0} reached. Reason: {1}", MaxRetryCount, ex);
                     throw;
-                }
-            }
-        }
-
-        private void PublishChunksCompletedEvent(int chunkStartNumber, int chunkEndNumber,
-                                                 TimeSpan elapsed, bool wasScavenged, long spaceSaved, string errorMessage = "")
-        {
-            var evnt = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeChunksCompleted, true, new Dictionary<string, object>{
-                    {"scavengeId", _scavengeId},
-                    {"chunkStartNumber", chunkStartNumber},
-                    {"chunkEndNumber", chunkEndNumber},
-                    {"timeTaken", elapsed},
-                    {"wasScavenged", wasScavenged},
-                    {"spaceSaved", spaceSaved},
-                    {"nodeEndpoint", _nodeEndpoint},
-                    {"errorMessage", errorMessage}
-                }.ToJsonBytes(), null);
-
-            var streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, _scavengeId);
-            WriteScavengeChunkCompletedEvent(streamName, evnt, MaxRetryCount);
-        }
-
-        private void WriteScavengeChunkCompletedEvent(string streamId, Event eventToWrite, int retryCount){
-            _ioDispatcher.WriteEvent(streamId, ExpectedVersion.Any, eventToWrite, SystemAccount.Principal, m => WriteScavengeChunkCompletedEventCompleted(m, streamId, eventToWrite, retryCount));
-        }
-
-        private void WriteScavengeChunkCompletedEventCompleted(ClientMessage.WriteEventsCompleted msg, string streamId, Event eventToWrite, int retryCount){
-            if(msg.Result != OperationResult.Success){
-                if(retryCount > 0){
-                    WriteScavengeChunkCompletedEvent(streamId, eventToWrite, --retryCount);
-                }else{
-                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", streamId, MaxRetryCount, msg.Result);
                 }
             }
         }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
@@ -15,13 +15,13 @@ namespace EventStore.Core.TransactionLog.Chunks
     {
         private readonly string _streamName;
         private readonly IODispatcher _ioDispatcher;
-        private readonly Guid _scavengeId;
+        private readonly string _scavengeId;
         private readonly string _nodeId;
         private readonly int _retryAttempts;
         private readonly TimeSpan _scavengeHistoryMaxAge;
         private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
 
-        public TFChunkScavengerLog(IODispatcher ioDispatcher, Guid scavengeId, string nodeId, int retryAttempts, TimeSpan scavengeHistoryMaxAge)
+        public TFChunkScavengerLog(IODispatcher ioDispatcher, string scavengeId, string nodeId, int retryAttempts, TimeSpan scavengeHistoryMaxAge)
         {
             _ioDispatcher = ioDispatcher;
             _scavengeId = scavengeId;
@@ -31,6 +31,8 @@ namespace EventStore.Core.TransactionLog.Chunks
 
             _streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, scavengeId);
         }
+
+        public string ScavengeId => _scavengeId;
 
         public void ScavengeStarted()
         {
@@ -53,7 +55,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             WriteScavengeDetailEvent(_streamName, scavengeStartedEvent, _retryAttempts);
         }
 
-        public void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        public void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
         {
             var scavengeCompletedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeCompleted, true, new Dictionary<string, object>{
                 {"scavengeId", _scavengeId},

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Common.Log;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Storage;
+using EventStore.Core.Services.UserManagement;
+
+namespace EventStore.Core.TransactionLog.Chunks
+{
+    class TFChunkScavengerLog : ITFChunkScavengerLog
+    {
+        private readonly string _streamName;
+        private readonly IODispatcher _ioDispatcher;
+        private readonly Guid _scavengeId;
+        private readonly string _nodeId;
+        private readonly int _retryAttempts;
+        private readonly TimeSpan _scavengeHistoryMaxAge;
+        private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
+
+        public TFChunkScavengerLog(IODispatcher ioDispatcher, Guid scavengeId, string nodeId, int retryAttempts, TimeSpan scavengeHistoryMaxAge)
+        {
+            _ioDispatcher = ioDispatcher;
+            _scavengeId = scavengeId;
+            _nodeId = nodeId;
+            _retryAttempts = retryAttempts;
+            _scavengeHistoryMaxAge = scavengeHistoryMaxAge;
+
+            _streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, scavengeId);
+        }
+
+        public void ScavengeStarted()
+        {
+            var metadataEventId = Guid.NewGuid();
+            var metaStreamId = SystemStreams.MetastreamOf(_streamName);
+            var metadata = new StreamMetadata(maxAge: _scavengeHistoryMaxAge);
+            var metaStreamEvent = new Event(metadataEventId, SystemEventTypes.StreamMetadata, isJson: true,
+                data: metadata.ToJsonBytes(), metadata: null);
+            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => {
+                if (m.Result != OperationResult.Success)
+                {
+                    Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge.TotalDays, _streamName, m.Result);
+                }
+            });
+
+            var scavengeStartedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeStarted, true, new Dictionary<string, object>{
+                {"scavengeId", _scavengeId},
+                {"nodeEndpoint", _nodeId},
+            }.ToJsonBytes(), null);
+            WriteScavengeDetailEvent(_streamName, scavengeStartedEvent, _retryAttempts);
+        }
+
+        public void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        {
+            var scavengeCompletedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeCompleted, true, new Dictionary<string, object>{
+                {"scavengeId", _scavengeId},
+                {"nodeEndpoint", _nodeId},
+                {"result", result},
+                {"error", error},
+                {"timeTaken", elapsed},
+                {"spaceSaved", spaceSaved}
+            }.ToJsonBytes(), null);
+            WriteScavengeDetailEvent(_streamName, scavengeCompletedEvent, _retryAttempts);
+        }
+
+        public void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved)
+        {
+            var evnt = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeChunksCompleted, true, new Dictionary<string, object>{
+                {"scavengeId", _scavengeId},
+                {"chunkStartNumber", chunkStartNumber},
+                {"chunkEndNumber", chunkEndNumber},
+                {"timeTaken", elapsed},
+                {"wasScavenged", true},
+                {"spaceSaved", spaceSaved},
+                {"nodeEndpoint", _nodeId},
+                {"errorMessage", ""}
+            }.ToJsonBytes(), null);
+
+            WriteScavengeChunkCompletedEvent(_streamName, evnt, _retryAttempts);
+        }
+
+        public void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved, string errorMessage)
+        {
+            var evnt = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeChunksCompleted, true, new Dictionary<string, object>{
+                {"scavengeId", _scavengeId},
+                {"chunkStartNumber", chunkStartNumber},
+                {"chunkEndNumber", chunkEndNumber},
+                {"timeTaken", elapsed},
+                {"wasScavenged", false},
+                {"spaceSaved", spaceSaved},
+                {"nodeEndpoint", _nodeId},
+                {"errorMessage", errorMessage}
+            }.ToJsonBytes(), null);
+
+            WriteScavengeChunkCompletedEvent(_streamName, evnt, _retryAttempts);
+        }
+
+        private void WriteScavengeChunkCompletedEvent(string streamId, Event eventToWrite, int retryCount)
+        {
+            _ioDispatcher.WriteEvent(streamId, ExpectedVersion.Any, eventToWrite, SystemAccount.Principal, m => WriteScavengeChunkCompletedEventCompleted(m, streamId, eventToWrite, retryCount));
+        }
+
+        private void WriteScavengeChunkCompletedEventCompleted(ClientMessage.WriteEventsCompleted msg, string streamId, Event eventToWrite, int retryCount)
+        {
+            if (msg.Result != OperationResult.Success)
+            {
+                if (retryCount > 0)
+                {
+                    WriteScavengeChunkCompletedEvent(streamId, eventToWrite, --retryCount);
+                }
+                else
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", streamId, _retryAttempts, msg.Result);
+                }
+            }
+        }
+
+        private void WriteScavengeDetailEvent(string streamId, Event eventToWrite, int retryCount)
+        {
+            _ioDispatcher.WriteEvent(streamId, ExpectedVersion.Any, eventToWrite, SystemAccount.Principal, x => WriteScavengeDetailEventCompleted(x, eventToWrite, streamId, retryCount));
+        }
+
+        private void WriteScavengeIndexEvent(Event linkToEvent, int retryCount)
+        {
+            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.Any, linkToEvent, SystemAccount.Principal, m => WriteScavengeIndexEventCompleted(m, linkToEvent, retryCount));
+        }
+
+        private void WriteScavengeIndexEventCompleted(ClientMessage.WriteEventsCompleted msg, Event linkToEvent, int retryCount)
+        {
+            if (msg.Result != OperationResult.Success)
+            {
+                if (retryCount > 0)
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retrying {1}/{2}. Reason: {3}", SystemStreams.ScavengesStream, (_retryAttempts - retryCount) + 1, _retryAttempts, msg.Result);
+                    WriteScavengeIndexEvent(linkToEvent, --retryCount);
+                }
+                else
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", SystemStreams.ScavengesStream, _retryAttempts, msg.Result);
+                }
+            }
+        }
+
+        private void WriteScavengeDetailEventCompleted(ClientMessage.WriteEventsCompleted msg, Event eventToWrite, string streamId, int retryCount)
+        {
+            if (msg.Result != OperationResult.Success)
+            {
+                if (retryCount > 0)
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retrying {1}/{2}. Reason: {3}", streamId, (_retryAttempts - retryCount) + 1, _retryAttempts, msg.Result);
+                    WriteScavengeDetailEvent(streamId, eventToWrite, --retryCount);
+                }
+                else
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", streamId, _retryAttempts, msg.Result);
+                }
+            }
+            else
+            {
+                string eventLinkTo = string.Format("{0}@{1}", msg.FirstEventNumber, streamId);
+                var linkToIndexEvent = new Event(Guid.NewGuid(), SystemEventTypes.LinkTo, false, eventLinkTo, null);
+                WriteScavengeIndexEvent(linkToIndexEvent, _retryAttempts);
+            }
+        }
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Common.Log;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Storage;
+using EventStore.Core.Services.UserManagement;
+
+namespace EventStore.Core.TransactionLog.Chunks
+{
+    public class TFChunkScavengerLogManager : ITFChunkScavengerLogManager
+    {
+        private readonly string _nodeEndpoint;
+        private readonly TimeSpan _scavengeHistoryMaxAge;
+        private readonly IODispatcher _ioDispatcher;
+        private const int MaxRetryCount = 5;
+        private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
+
+        public TFChunkScavengerLogManager(string nodeEndpoint, TimeSpan scavengeHistoryMaxAge, IODispatcher ioDispatcher)
+        {
+            _nodeEndpoint = nodeEndpoint;
+            _scavengeHistoryMaxAge = scavengeHistoryMaxAge;
+            _ioDispatcher = ioDispatcher;
+        }
+
+        public void Initialise()
+        {
+            var metaStreamId = SystemStreams.MetastreamOf(SystemStreams.ScavengesStream);
+            var metadata = new StreamMetadata(maxAge: _scavengeHistoryMaxAge);
+            var metaStreamEvent = new Event(Guid.NewGuid(), SystemEventTypes.StreamMetadata, isJson: true,
+                data: metadata.ToJsonBytes(), metadata: null);
+            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => {
+                if (m.Result != OperationResult.Success)
+                {
+                    Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge.TotalDays, SystemStreams.ScavengesStream, m.Result);
+                }
+            });
+
+            var indexInitializedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeIndexInitialized,
+                true, new Dictionary<string, object> { }.ToJsonBytes(), null);
+            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.NoStream, indexInitializedEvent, SystemAccount.Principal, m => {
+                if (m.Result != OperationResult.Success && m.Result != OperationResult.WrongExpectedVersion)
+                {
+                    Log.Error("Failed to write the {0} event to the {1} stream. Reason: {2}", SystemEventTypes.ScavengeIndexInitialized, SystemStreams.ScavengesStream, m.Result);
+                }
+            });
+        }
+
+        public ITFChunkScavengerLog CreateLog()
+        {
+            return new TFChunkScavengerLog(_ioDispatcher, Guid.NewGuid(), _nodeEndpoint, MaxRetryCount, _scavengeHistoryMaxAge);
+        }
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using EventStore.Common.Log;
-using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
@@ -36,15 +34,6 @@ namespace EventStore.Core.TransactionLog.Chunks
                 if (m.Result != OperationResult.Success)
                 {
                     Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge.TotalDays, SystemStreams.ScavengesStream, m.Result);
-                }
-            });
-
-            var indexInitializedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeIndexInitialized,
-                true, new Dictionary<string, object> { }.ToJsonBytes(), null);
-            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.NoStream, indexInitializedEvent, SystemAccount.Principal, m => {
-                if (m.Result != OperationResult.Success && m.Result != OperationResult.WrongExpectedVersion)
-                {
-                    Log.Error("Failed to write the {0} event to the {1} stream. Reason: {2}", SystemEventTypes.ScavengeIndexInitialized, SystemStreams.ScavengesStream, m.Result);
                 }
             });
         }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.TransactionLog.Chunks
 
         public ITFChunkScavengerLog CreateLog()
         {
-            return new TFChunkScavengerLog(_ioDispatcher, Guid.NewGuid(), _nodeEndpoint, MaxRetryCount, _scavengeHistoryMaxAge);
+            return new TFChunkScavengerLog(_ioDispatcher, Guid.NewGuid().ToString(), _nodeEndpoint, MaxRetryCount, _scavengeHistoryMaxAge);
         }
     }
 }

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -364,18 +364,17 @@ message NotHandled {
 message ScavengeDatabase {
 }
 
-message ScavengeDatabaseCompleted {
+message ScavengeDatabaseResponse {
 	
 	enum ScavengeResult {
-		Success = 0;
+		Started = 0;
 		InProgress = 1;
-		Failed = 2;
+		Unauthorized = 2;
 	}
 	
 	required ScavengeResult result = 1;
-	optional string error = 2;
-	required int32 total_time_ms = 3;
-	required int64 total_space_saved = 4;
+	optional string scavengeId = 2;
+	
 }
 
 message IdentifyClient {


### PR DESCRIPTION
## Intro
This is the first in a series of PRs I will submit around scavenging. I'm breaking it down to avoid a massive PR and also get approval for each part.

1. Clean up of scavenge log. (This PR)
2. Add ability to stop a scavenge.
3. Automatically mark interrupted scavenges as stopped.
4. Add ability to start a scavenge from a chunk number/log position.
5. Remove the scavenge from the merge pass. This takes a long time and is mostly doing nothing.

## Motivation
- We have a large db that takes about 3 weeks to scavenge.
- A lot of the time we'll have to restart a node resulting in the scavenge stopping.
- Starting a new scavenge starts from the beginning meaning we don't ever reach the most recent chunks.
- If we have a period of high load and need to stop the scavenge then we currently have to restart the node.
- Most of the benefit of scavenging comes from the recent chunks. Our oldest chunks never reduce in size.

## Details
- This PR moves all scavenge log writing to a single class out and out of the actual scavenge code.
- The $scavengeinitialized event has been removed. As there is a max age on the stream it's a little pointless.
- The ScavengeDatabaseCompleted has been replaced with ScavengeDatabaseResponse. This is sent immediately instead of after the scavenge has completed. Nobody will be listening for 3 weeks!
- The response to the ScavengeDatabase message is now being returned on the HTTP interface instead of being ignored.
- The TCP interface has changed to match the last 2 points. This doesn't appear to be implemented in the .net client. The JVM client looks semi implemented but I'm not sure. I can revert this part for compatibility sake, but...

## Questions
- Why does the TCP scavenge interface exist? It seems surplus, unused and not fitting the pattern used for other admin functions. Can I delete it?
- Any feedback on my plans?
