### PR TITLE
Stop scavenge

### DIFF
--- a/src/EventStore.ClientAPI/Messages/ClientMessage.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessage.cs
@@ -1215,43 +1215,35 @@ namespace EventStore.ClientAPI.Messages
     }
   }
   
-  [Serializable, ProtoContract(Name=@"ScavengeDatabaseCompleted")]
-  public partial class ScavengeDatabaseCompleted
+  [Serializable, ProtoContract(Name=@"ScavengeDatabaseResponse")]
+  public partial class ScavengeDatabaseResponse
   {
     [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
-    public readonly ScavengeDatabaseCompleted.ScavengeResult Result;
+    public readonly ScavengeDatabaseResponse.ScavengeResult Result;
   
-    [ProtoMember(2, IsRequired = false, Name=@"error", DataFormat = DataFormat.Default)]
-    public readonly string Error;
-  
-    [ProtoMember(3, IsRequired = true, Name=@"total_time_ms", DataFormat = DataFormat.TwosComplement)]
-    public readonly int TotalTimeMs;
-  
-    [ProtoMember(4, IsRequired = true, Name=@"total_space_saved", DataFormat = DataFormat.TwosComplement)]
-    public readonly long TotalSpaceSaved;
+    [ProtoMember(2, IsRequired = false, Name=@"scavengeId", DataFormat = DataFormat.Default)]
+    public readonly string ScavengeId;
   
     [ProtoContract(Name=@"ScavengeResult")]
     public enum ScavengeResult
     {
             
-      [ProtoEnum(Name=@"Success", Value=0)]
-      Success = 0,
+      [ProtoEnum(Name=@"Started", Value=0)]
+      Started = 0,
             
       [ProtoEnum(Name=@"InProgress", Value=1)]
       InProgress = 1,
             
-      [ProtoEnum(Name=@"Failed", Value=2)]
-      Failed = 2
+      [ProtoEnum(Name=@"Unauthorized", Value=2)]
+      Unauthorized = 2
     }
   
-    private ScavengeDatabaseCompleted() {}
+    private ScavengeDatabaseResponse() {}
   
-    public ScavengeDatabaseCompleted(ScavengeDatabaseCompleted.ScavengeResult result, string error, int totalTimeMs, long totalSpaceSaved)
+    public ScavengeDatabaseResponse(ScavengeDatabaseResponse.ScavengeResult result, string scavengeId)
     {
         Result = result;
-        Error = error;
-        TotalTimeMs = totalTimeMs;
-        TotalSpaceSaved = totalSpaceSaved;
+        ScavengeId = scavengeId;
     }
   }
   

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -515,8 +515,16 @@
     <Compile Include="SpecificationWithFile.cs" />
     <Compile Include="TestsInitFixture.cs" />
     <Compile Include="TransactionLog\Scavenging\Helpers\FakeTFScavengerLog.cs" />
+    <Compile Include="TransactionLog\Scavenging\Helpers\ScavengeLifeCycleScenario.cs" />
     <Compile Include="TransactionLog\Scavenging\when_having_stream_with_start_from_specified.cs" />
     <Compile Include="TransactionLog\Scavenging\scavenged_chunk.cs" />
+    <Compile Include="TransactionLog\Scavenging\when_scavenge_cancelled_after_chunck_scavenged.cs" />
+    <Compile Include="TransactionLog\Scavenging\when_scavenge_cancelled_after_completed.cs" />
+    <Compile Include="TransactionLog\Scavenging\when_scavenge_cancelled_after_started.cs" />
+    <Compile Include="TransactionLog\Scavenging\when_scavenge_cancelled_before_started.cs" />
+    <Compile Include="TransactionLog\Scavenging\when_scavenge_succeeds_without_error.cs" />
+    <Compile Include="TransactionLog\Scavenging\when_scavenge_throws_exception_on_completed.cs" />
+    <Compile Include="TransactionLog\Scavenging\when_scavenge_throws_exception_processing_chunk.cs" />
     <Compile Include="TransactionLog\Truncation\when_truncating_into_the_middle_of_completed_chunk.cs" />
     <Compile Include="TransactionLog\Truncation\when_truncating_into_the_middle_of_ongoing_chunk.cs" />
     <Compile Include="TransactionLog\Truncation\when_truncating_to_the_very_beginning_of_db.cs" />

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -1,4 +1,5 @@
-﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -513,6 +514,7 @@
     <Compile Include="Services\TimeService\time_service_should.cs" />
     <Compile Include="SpecificationWithFile.cs" />
     <Compile Include="TestsInitFixture.cs" />
+    <Compile Include="TransactionLog\Scavenging\Helpers\FakeTFScavengerLog.cs" />
     <Compile Include="TransactionLog\Scavenging\when_having_stream_with_start_from_specified.cs" />
     <Compile Include="TransactionLog\Scavenging\scavenged_chunk.cs" />
     <Compile Include="TransactionLog\Truncation\when_truncating_into_the_middle_of_completed_chunk.cs" />

--- a/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
+++ b/src/EventStore.Core.Tests/Integration/when_a_single_node_is_restarted_multiple_times.cs
@@ -4,6 +4,7 @@ using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 
 namespace EventStore.Core.Tests.Integration
 {
@@ -12,6 +13,8 @@ namespace EventStore.Core.Tests.Integration
     {
         private List<Guid> _epochIds = new List<Guid>();
         private const int _numberOfNodeStarts = 5;
+        private readonly AutoResetEvent _waitForStart = new AutoResetEvent(false);
+
         protected override void BeforeNodeStarts()
         {
             _node.Node.MainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(Handle));
@@ -22,16 +25,19 @@ namespace EventStore.Core.Tests.Integration
         {
             for (int i = 0; i < _numberOfNodeStarts - 1; i++)
             {
+                _waitForStart.WaitOne(5000);
                 ShutdownNode();
                 StartNode();
             }
 
+            _waitForStart.WaitOne(5000);
             base.Given();
         }
 
         private void Handle(SystemMessage.EpochWritten msg)
         {
             _epochIds.Add(msg.Epoch.EpochId);
+            _waitForStart.Set();
         }
 
         [Test]

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -99,7 +99,7 @@ namespace EventStore.Core.Tests.Services.Storage
                 if (_completeLastChunkOnScavenge)
                     Db.Manager.GetChunk(Db.Manager.ChunksCount - 1).Complete();
                 _scavenger = new TFChunkScavenger(Db, new FakeTFScavengerLog(), TableIndex, ReadIndex);
-                _scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: _mergeChunks);
+                _scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: _mergeChunks).Wait();
             }
         }
 

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -13,11 +13,11 @@ using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
 using EventStore.Core.Util;
 using EventStore.Core.Index.Hashes;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
 
 namespace EventStore.Core.Tests.Services.Storage
 {
@@ -35,8 +35,6 @@ namespace EventStore.Core.Tests.Services.Storage
         protected ICheckpoint WriterCheckpoint;
         protected ICheckpoint ChaserCheckpoint;
         protected ICheckpoint ReplicationCheckpoint;
-        protected IODispatcher IODispatcher;
-        protected InMemoryBus Bus;
 
         private TFChunkScavenger _scavenger;
         private bool _scavenge;
@@ -59,9 +57,6 @@ namespace EventStore.Core.Tests.Services.Storage
             WriterCheckpoint = new InMemoryCheckpoint(0);
             ChaserCheckpoint = new InMemoryCheckpoint(0);
             ReplicationCheckpoint = new InMemoryCheckpoint(-1);
-
-            Bus = new InMemoryBus("bus");
-            IODispatcher = new IODispatcher(Bus, new PublishEnvelope(Bus));
 
             Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, WriterCheckpoint, ChaserCheckpoint, replicationCheckpoint: ReplicationCheckpoint));
 
@@ -103,7 +98,7 @@ namespace EventStore.Core.Tests.Services.Storage
             {
                 if (_completeLastChunkOnScavenge)
                     Db.Manager.GetChunk(Db.Manager.ChunksCount - 1).Complete();
-                _scavenger = new TFChunkScavenger(Db, IODispatcher, TableIndex, ReadIndex, Guid.NewGuid(), "fakeNodeIp");
+                _scavenger = new TFChunkScavenger(Db, new FakeTFScavengerLog(), TableIndex, ReadIndex);
                 _scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: _mergeChunks);
             }
         }

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_running_a_scavenge_from_storage_scavenger.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
 			using(var conn = TestConnection.Create(_node.TcpEndPoint, TcpType.Normal, DefaultData.AdminCredentials))
 			{
 				conn.ConnectAsync().Wait();
-				var countdown = new CountdownEvent(3);
+				var countdown = new CountdownEvent(2);
 				_result = new List<ResolvedEvent>();
 
 				conn.SubscribeToStreamFrom(SystemStreams.ScavengesStream, null, CatchUpSubscriptionSettings.Default,
@@ -69,13 +69,6 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge
 					Assert.Fail("Timeout expired while waiting for events.");
 				}
 			}
-		}
-
-		[Test]
-		public void should_create_scavenge_index_initialized_event()
-		{
-			var scavengeIndexInitialized = _result.FirstOrDefault(x=>x.Event.EventType == SystemEventTypes.ScavengeIndexInitialized);
-			Assert.IsNotNull(scavengeIndexInitialized);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
             ChunkScavenged?.Invoke(this, scavengedLog);
         }
 
-        public void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved,
+        public void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed,
             string errorMessage)
         {
             var scavengedLog = new ScavengedLog(chunkStartNumber, chunkEndNumber, false, "");
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
 
         }
 
-        public void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        public void ScavengeCompleted(ScavengeResult result, string error, TimeSpan elapsed)
         {
             Completed = true;
             Result = result;

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using EventStore.Core.Messages;
+using EventStore.Core.TransactionLog.Chunks;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
+{
+    public class FakeTFScavengerLog : ITFChunkScavengerLog
+    {
+        public void ScavengeStarted()
+        {
+            
+        }
+
+        public void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved)
+        {
+        }
+
+        public void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved,
+            string errorMessage)
+        {
+        }
+
+        public void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        {
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
@@ -7,22 +8,63 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
     {
         public string ScavengeId { get; } = "FakeScavenge";
 
+        public bool Started { get; private set; }
+
+        public bool Completed { get; private set; }
+
+        public ScavengeResult Result { get; private set; }
+
+        public event EventHandler<EventArgs> StartedCallback;
+        public event EventHandler<ScavengedLog> ChunkScavenged;
+        public event EventHandler<EventArgs> CompletedCallback;
+
+        public IList<ScavengedLog> Scavenged { get; } = new List<ScavengedLog>(); 
+
         public void ScavengeStarted()
         {
-            
+            Started = true;
+            StartedCallback?.Invoke(this, EventArgs.Empty);
         }
 
         public void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved)
         {
+            var scavengedLog = new ScavengedLog(chunkStartNumber, chunkEndNumber, true, "");
+            Scavenged.Add(scavengedLog);
+            ChunkScavenged?.Invoke(this, scavengedLog);
         }
 
         public void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved,
             string errorMessage)
         {
+            var scavengedLog = new ScavengedLog(chunkStartNumber, chunkEndNumber, false, "");
+            Scavenged.Add(scavengedLog);
+            ChunkScavenged?.Invoke(this, scavengedLog);
+
         }
 
         public void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
         {
+            Completed = true;
+            Result = result;
+            CompletedCallback?.Invoke(this, EventArgs.Empty);
+        }
+
+        public class ScavengedLog
+        {
+            public int ChunkStart { get; }
+            public int ChunkEnd { get; }
+            public bool Scavenged { get; }
+            public string Error { get; }
+
+            public ScavengedLog(int chunkStart, int chunkEnd, bool scavenged, string error)
+            {
+                ChunkStart = chunkStart;
+                ChunkEnd = chunkEnd;
+                Scavenged = scavenged;
+                Error = error;
+            }
         }
     }
+
+    
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
 {
     public class FakeTFScavengerLog : ITFChunkScavengerLog
     {
+        public string ScavengeId { get; } = "FakeScavenge";
+
         public void ScavengeStarted()
         {
             
@@ -20,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
         {
         }
 
-        public void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        public void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
         {
         }
     }

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
@@ -1,0 +1,49 @@
+﻿using EventStore.Core.Tests.Services.Storage;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
+{
+    [TestFixture]
+    abstract class ScavengeLifeCycleScenario : SpecificationWithDirectoryPerTestFixture
+    {
+        protected TFChunkDb Db { get { return _dbResult.Db; } }
+
+        private DbResult _dbResult;
+        protected TFChunkScavenger TfChunkScavenger;
+        protected FakeTFScavengerLog Log;
+
+        public override void TestFixtureSetUp()
+        {
+            base.TestFixtureSetUp();
+
+            var dbConfig = TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 1024 * 1024);
+            var dbCreationHelper = new TFChunkDbCreationHelper(dbConfig);
+            
+            _dbResult = dbCreationHelper
+                .Chunk().CompleteLastChunk()
+                .Chunk().CompleteLastChunk()
+                .Chunk()
+                .CreateDb();
+
+            _dbResult.Db.Config.WriterCheckpoint.Flush();
+            _dbResult.Db.Config.ChaserCheckpoint.Write(_dbResult.Db.Config.WriterCheckpoint.Read());
+            _dbResult.Db.Config.ChaserCheckpoint.Flush();
+
+            Log = new FakeTFScavengerLog();
+            TfChunkScavenger = new TFChunkScavenger(_dbResult.Db, Log, new FakeTableIndex(), new FakeReadIndex(_ => false));
+
+            When();
+        }
+
+        public override void TestFixtureTearDown()
+        {
+            _dbResult.Db.Close();
+
+            base.TestFixtureTearDown();
+        }
+
+        protected abstract void When();
+
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -1,20 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using EventStore.Core.Bus;
 using EventStore.Core.DataStructures;
-using EventStore.Core.Helpers;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
-using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Settings;
 using EventStore.Core.Tests.Fakes;
-using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
-using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
 using EventStore.Core.Util;
@@ -70,10 +64,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
             ReadIndex.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 
             //var scavengeReadIndex = new ScavengeReadIndex(_dbResult.Streams, _metastreamMaxCount);
-            var bus = new InMemoryBus("Bus");
-            var ioDispatcher = new IODispatcher(bus, new PublishEnvelope(bus));
-            var scavenger = new TFChunkScavenger(_dbResult.Db, ioDispatcher, tableIndex, ReadIndex, Guid.NewGuid(), "fakeNodeIp",
-                                            unsafeIgnoreHardDeletes: UnsafeIgnoreHardDelete());
+            var scavenger = new TFChunkScavenger(_dbResult.Db, new FakeTFScavengerLog(), tableIndex, ReadIndex, unsafeIgnoreHardDeletes: UnsafeIgnoreHardDelete());
             scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -63,9 +63,8 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
             ReadIndex = new ReadIndex(new NoopPublisher(), readerPool, tableIndex, 100, true, _metastreamMaxCount, Opts.HashCollisionReadLimitDefault, Opts.SkipIndexScanOnReadsDefault, _dbResult.Db.Config.ReplicationCheckpoint);
             ReadIndex.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 
-            //var scavengeReadIndex = new ScavengeReadIndex(_dbResult.Streams, _metastreamMaxCount);
             var scavenger = new TFChunkScavenger(_dbResult.Db, new FakeTFScavengerLog(), tableIndex, ReadIndex, unsafeIgnoreHardDeletes: UnsafeIgnoreHardDelete());
-            scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);
+            scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false).Wait();
         }
 
         public override void TestFixtureTearDown()

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_chunck_scavenged.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_chunck_scavenged.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging
+{
+    [TestFixture]
+    class when_scavenge_cancelled_after_chunck_scavenged : ScavengeLifeCycleScenario
+    {
+        protected override void When()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Log.ChunkScavenged += (sender, args) => cancellationTokenSource.Cancel();
+            TfChunkScavenger.Scavenge(true, true, cancellationTokenSource.Token).Wait();
+        }
+
+        [Test]
+        public void completed_logged_with_stopped_result()
+        {
+            Assert.That(Log.Completed);
+            Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Stopped));
+        }
+
+        [Test]
+        public void scavenge_record_for_first_and_cancelled_chunk()
+        {
+            Assert.That(Log.Scavenged, Has.Count.EqualTo(1));
+            Assert.That(Log.Scavenged[0].Scavenged, Is.True);
+        }
+
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_completed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_completed.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging
+{
+    [TestFixture]
+    class when_scavenge_cancelled_after_completed : ScavengeLifeCycleScenario
+    {
+        protected override void When()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Log.CompletedCallback += (sender, args) => cancellationTokenSource.Cancel();
+            TfChunkScavenger.Scavenge(true, true, cancellationTokenSource.Token).Wait();
+        }
+
+        [Test]
+        public void completed_logged_with_success_result()
+        {
+            Assert.That(Log.Completed);
+            Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Success));
+        }
+
+        [Test]
+        public void scavenge_record_for_all_completed_chunks_plus_merge()
+        {
+            Assert.That(Log.Scavenged, Has.Count.EqualTo(3));
+            Assert.That(Log.Scavenged[0].Scavenged, Is.True);
+            Assert.That(Log.Scavenged[1].Scavenged, Is.True);
+            Assert.That(Log.Scavenged[2].Scavenged, Is.True);
+        }
+
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_started.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_started.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging
+{
+    [TestFixture]
+    class when_scavenge_cancelled_after_started : ScavengeLifeCycleScenario
+    {
+        protected override void When()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Log.StartedCallback += (sender, args) => cancellationTokenSource.Cancel();
+            TfChunkScavenger.Scavenge(false, true, cancellationTokenSource.Token).Wait();
+        }
+
+        [Test]
+        public void completed_logged_with_stopped_result()
+        {
+
+            Assert.That(Log.Completed);
+            Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Stopped));
+        }
+
+        [Test]
+        public void no_chunks_scavenged()
+        {
+            Assert.That(Log.Scavenged, Is.Empty);
+        }
+
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_before_started.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_before_started.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging
+{
+    [TestFixture]
+    class when_scavenge_cancelled_before_started : ScavengeLifeCycleScenario
+    {
+        protected override void When()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+            TfChunkScavenger.Scavenge(false, true, cancellationTokenSource.Token).Wait();
+        }
+
+        [Test]
+        public void completed_logged_with_stopped_result()
+        {
+            Assert.That(Log.Completed);
+            Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Stopped));
+        }
+
+        [Test]
+        public void no_chunks_scavenged()
+        {
+            Assert.That(Log.Scavenged, Is.Empty);
+        }
+
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_succeeds_without_error.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_succeeds_without_error.cs
@@ -1,0 +1,45 @@
+﻿using System.Threading;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging
+{
+    [TestFixture]
+    class when_scavenge_succeeds_without_error : ScavengeLifeCycleScenario
+    {
+        protected override void When()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+            TfChunkScavenger.Scavenge(true, true, cancellationTokenSource.Token).Wait();
+        }
+
+        [Test]
+        public void log_started()
+        {
+            Assert.That(Log.Started);
+        }
+
+        [Test]
+        public void log_completed_with_success()
+        {
+            Assert.That(Log.Completed);
+            Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Success));
+        }
+
+        [Test]
+        public void scavenge_record_for_all_completed_chunks_plus_merge()
+        {
+            Assert.That(Log.Scavenged, Has.Count.EqualTo(3));
+            Assert.That(Log.Scavenged[0].Scavenged, Is.True);
+            Assert.That(Log.Scavenged[0].ChunkStart, Is.EqualTo(0));
+            Assert.That(Log.Scavenged[0].ChunkEnd, Is.EqualTo(0));            
+            Assert.That(Log.Scavenged[1].Scavenged, Is.True);
+            Assert.That(Log.Scavenged[1].ChunkStart, Is.EqualTo(1));
+            Assert.That(Log.Scavenged[1].ChunkEnd, Is.EqualTo(1));
+            Assert.That(Log.Scavenged[2].Scavenged, Is.True);
+            Assert.That(Log.Scavenged[2].ChunkStart, Is.EqualTo(0));
+            Assert.That(Log.Scavenged[2].ChunkEnd, Is.EqualTo(1));
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_on_completed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_on_completed.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging
+{
+    [TestFixture]
+    class when_scavenge_throws_exception_on_completed : ScavengeLifeCycleScenario
+    {
+        protected override void When()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Log.CompletedCallback += (sender, args) =>
+            {
+                throw new Exception("Expected exception.");
+            };
+            TfChunkScavenger.Scavenge(true, true, cancellationTokenSource.Token).Wait();
+        }
+
+        [Test]
+        public void no_exception_is_thrown()
+        {
+            Assert.That(Log.Completed);
+            Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Success));
+        }
+        
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_processing_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_processing_chunk.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Scavenging
+{
+    [TestFixture]
+    class when_scavenge_throws_exception_processing_chunk : ScavengeLifeCycleScenario
+    {
+        protected override void When()
+        {
+            var cancellationTokenSource = new CancellationTokenSource();
+
+            Log.ChunkScavenged += (sender, args) =>
+            {
+                if (args.Scavenged)
+                    throw new Exception("Expected exception.");
+            };
+
+            TfChunkScavenger.Scavenge(true, true, cancellationTokenSource.Token).Wait();
+        }
+
+        [Test]
+        public void no_exception_is_thrown_to_caller()
+        {
+            Assert.That(Log.Completed);
+            Assert.That(Log.Result, Is.EqualTo(ScavengeResult.Failed));
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Services.Storage;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -68,10 +69,7 @@ namespace EventStore.Core.Tests.TransactionLog
             _db.Config.ChaserCheckpoint.Write(chunk.ChunkHeader.ChunkEndPosition);
             _db.Config.ChaserCheckpoint.Flush();
 
-            var bus = new InMemoryBus("Bus");
-            var ioDispatcher = new IODispatcher(bus, new PublishEnvelope(bus));
-            var scavenger = new TFChunkScavenger(_db, ioDispatcher, new FakeTableIndex(),
-                                                 new FakeReadIndex(x => x == "es-to-scavenge"), Guid.NewGuid(), "fakeNodeIp");
+            var scavenger = new TFChunkScavenger(_db, new FakeTFScavengerLog(), new FakeTableIndex(), new FakeReadIndex(x => x == "es-to-scavenge"));
             scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);
 
             _scavengedChunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -70,7 +70,7 @@ namespace EventStore.Core.Tests.TransactionLog
             _db.Config.ChaserCheckpoint.Flush();
 
             var scavenger = new TFChunkScavenger(_db, new FakeTFScavengerLog(), new FakeTableIndex(), new FakeReadIndex(x => x == "es-to-scavenge"));
-            scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);
+            scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false).Wait();
 
             _scavengedChunk = _db.Manager.GetChunk(0);
         }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -310,7 +310,7 @@ namespace EventStore.Core
 
             _mainBus.Subscribe<SystemMessage.StateChangeMessage>(infoController);
 
-            var adminController = new AdminController(_mainQueue);
+            var adminController = new AdminController(_mainQueue, _workersHandler);
             var pingController = new PingController();
             var histogramController = new HistogramController();
             var statController = new StatController(monitoringQueue, _workersHandler);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -488,6 +488,7 @@ namespace EventStore.Core
 
 			// ReSharper disable RedundantTypeArgumentsOfMethod
             _mainBus.Subscribe<ClientMessage.ScavengeDatabase>(storageScavenger);
+            _mainBus.Subscribe<ClientMessage.StopDatabaseScavenge>(storageScavenger);
             _mainBus.Subscribe<UserManagementMessage.UserManagementServiceInitialized>(storageScavenger);
             // ReSharper restore RedundantTypeArgumentsOfMethod
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -477,14 +477,13 @@ namespace EventStore.Core
             perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionTimerTick>(persistentSubscription);
 
             // STORAGE SCAVENGER
+            var scavengerLogManager = new TFChunkScavengerLogManager(_nodeInfo.ExternalHttp.ToString(), TimeSpan.FromDays(vNodeSettings.ScavengeHistoryMaxAge), ioDispatcher);
             var storageScavenger = new StorageScavenger(db,
-                                                        ioDispatcher,
                                                         tableIndex,
                                                         readIndex,
+                                                        scavengerLogManager,
                                                         vNodeSettings.AlwaysKeepScavenged,
-                                                        _nodeInfo.ExternalHttp.ToString(),
                                                         !vNodeSettings.DisableScavengeMerging,
-                                                        vNodeSettings.ScavengeHistoryMaxAge,
                                                         unsafeIgnoreHardDeletes: vNodeSettings.UnsafeIgnoreHardDeletes);
 
 			// ReSharper disable RedundantTypeArgumentsOfMethod

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -1,4 +1,5 @@
-﻿<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -310,7 +311,11 @@
     <Compile Include="Settings\VNodeSettings.cs" />
     <Compile Include="StandardComponents.cs" />
     <Compile Include="TransactionLog\Checkpoint\Checkpoint.cs" />
+    <Compile Include="TransactionLog\Chunks\ITFChunkScavengerLog.cs" />
+    <Compile Include="TransactionLog\Chunks\ITFChunkScavengerLogManager.cs" />
     <Compile Include="TransactionLog\Chunks\TFChunkDbTruncator.cs" />
+    <Compile Include="TransactionLog\Chunks\TFChunkScavengerLog.cs" />
+    <Compile Include="TransactionLog\Chunks\TFChunkScavengerLogManager.cs" />
     <Compile Include="TransactionLog\Chunks\TFChunk\BulkReadResult.cs" />
     <Compile Include="TransactionLog\Chunks\TFChunk\PosMap.cs" />
     <Compile Include="TransactionLog\Chunks\TFChunk\TFChunkReadSide.cs" />

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1378,41 +1378,36 @@ namespace EventStore.Core.Messages
                 User = user;
             }
 
-            public enum ScavengeResult
-            {
-                Success,
-                InProgress,
-                Failed
-            }
+            
         }
-
-        public class ScavengeDatabaseCompleted: Message
+        
+        public class ScavengeDatabaseResponse : Message
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
             public override int MsgTypeId { get { return TypeId; } }
 
             public readonly Guid CorrelationId;
-            public readonly ScavengeDatabase.ScavengeResult Result;
-            public readonly string Error;
-            public readonly TimeSpan TotalTime;
-            public readonly long TotalSpaceSaved;
+            public readonly ScavengeResponse Result;
+            public readonly string ScavengeId;
 
-            public ScavengeDatabaseCompleted(Guid correlationId,
-                                             ScavengeDatabase.ScavengeResult result,
-                                             string error,
-                                             TimeSpan totalTime,
-                                             long totalSpaceSaved)
+            public ScavengeDatabaseResponse(Guid correlationId,
+                ScavengeResponse result, string scavengeId)
             {
                 CorrelationId = correlationId;
                 Result = result;
-                Error = error;
-                TotalTime = totalTime;
-                TotalSpaceSaved = totalSpaceSaved;
+                ScavengeId = scavengeId;
             }
 
             public override string ToString()
             {
-                return String.Format("Result: {0}, Error: {1}, TotalTime: {2}, TotalSpaceSaved: {3}", Result, Error, TotalTime, TotalSpaceSaved);
+                return String.Format("Result: {0}, ScavengeId: {1}", Result, ScavengeId);
+            }
+
+            public enum ScavengeResponse
+            {
+                Started,
+                Unauthorized,
+                InProgress,
             }
         }
 

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1387,11 +1387,11 @@ namespace EventStore.Core.Messages
             public override int MsgTypeId { get { return TypeId; } }
 
             public readonly Guid CorrelationId;
-            public readonly ScavengeResponse Result;
+            public readonly ScavengeResult Result;
             public readonly string ScavengeId;
 
             public ScavengeDatabaseResponse(Guid correlationId,
-                ScavengeResponse result, string scavengeId)
+                ScavengeResult result, string scavengeId)
             {
                 CorrelationId = correlationId;
                 Result = result;
@@ -1403,7 +1403,7 @@ namespace EventStore.Core.Messages
                 return String.Format("Result: {0}, ScavengeId: {1}", Result, ScavengeId);
             }
 
-            public enum ScavengeResponse
+            public enum ScavengeResult
             {
                 Started,
                 Unauthorized,

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1377,8 +1377,26 @@ namespace EventStore.Core.Messages
                 CorrelationId = correlationId;
                 User = user;
             }
+        }
+        
+        public class StopDatabaseScavenge : Message
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
 
-            
+            public readonly IEnvelope Envelope;
+            public readonly Guid CorrelationId;
+            public readonly IPrincipal User;
+            public readonly string ScavengeId;
+
+            public StopDatabaseScavenge(IEnvelope envelope, Guid correlationId, IPrincipal user, string scavengeId)
+            {
+                Ensure.NotNull(envelope, "envelope");
+                Envelope = envelope;
+                CorrelationId = correlationId;
+                User = user;
+                ScavengeId = scavengeId;
+            }
         }
         
         public class ScavengeDatabaseResponse : Message
@@ -1407,7 +1425,9 @@ namespace EventStore.Core.Messages
             {
                 Started,
                 Unauthorized,
-                InProgress,
+                InProgress,                
+                Stopped,
+                InvalidScavengeId
             }
         }
 

--- a/src/EventStore.Core/Messages/TcpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDto.cs
@@ -1215,43 +1215,35 @@ namespace EventStore.Core.Messages
     }
   }
   
-  [Serializable, ProtoContract(Name=@"ScavengeDatabaseCompleted")]
-  public partial class ScavengeDatabaseCompleted
+  [Serializable, ProtoContract(Name=@"ScavengeDatabaseResponse")]
+  public partial class ScavengeDatabaseResponse
   {
     [ProtoMember(1, IsRequired = true, Name=@"result", DataFormat = DataFormat.TwosComplement)]
-    public readonly ScavengeDatabaseCompleted.ScavengeResult Result;
+    public readonly ScavengeDatabaseResponse.ScavengeResult Result;
   
-    [ProtoMember(2, IsRequired = false, Name=@"error", DataFormat = DataFormat.Default)]
-    public readonly string Error;
-  
-    [ProtoMember(3, IsRequired = true, Name=@"total_time_ms", DataFormat = DataFormat.TwosComplement)]
-    public readonly int TotalTimeMs;
-  
-    [ProtoMember(4, IsRequired = true, Name=@"total_space_saved", DataFormat = DataFormat.TwosComplement)]
-    public readonly long TotalSpaceSaved;
+    [ProtoMember(2, IsRequired = false, Name=@"scavengeId", DataFormat = DataFormat.Default)]
+    public readonly string ScavengeId;
   
     [ProtoContract(Name=@"ScavengeResult")]
     public enum ScavengeResult
     {
             
-      [ProtoEnum(Name=@"Success", Value=0)]
-      Success = 0,
+      [ProtoEnum(Name=@"Started", Value=0)]
+      Started = 0,
             
       [ProtoEnum(Name=@"InProgress", Value=1)]
       InProgress = 1,
             
-      [ProtoEnum(Name=@"Failed", Value=2)]
-      Failed = 2
+      [ProtoEnum(Name=@"Unauthorized", Value=2)]
+      Unauthorized = 2
     }
   
-    private ScavengeDatabaseCompleted() {}
+    private ScavengeDatabaseResponse() {}
   
-    public ScavengeDatabaseCompleted(ScavengeDatabaseCompleted.ScavengeResult result, string error, int totalTimeMs, long totalSpaceSaved)
+    public ScavengeDatabaseResponse(ScavengeDatabaseResponse.ScavengeResult result, string scavengeId)
     {
         Result = result;
-        Error = error;
-        TotalTimeMs = totalTimeMs;
-        TotalSpaceSaved = totalSpaceSaved;
+        ScavengeId = scavengeId;
     }
   }
   

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -53,7 +53,7 @@ namespace EventStore.Core.Services.Storage
             if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
             {
                 message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
-                    ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized, null));
+                    ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized, null));
             }
             else if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
             {
@@ -62,7 +62,7 @@ namespace EventStore.Core.Services.Storage
             else
             {
                 message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
-                    ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress, null));
+                    ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress, null));
             }
         }
 
@@ -80,7 +80,7 @@ namespace EventStore.Core.Services.Storage
                 tfChunkScavengerLog.ScavengeStarted();
 
                 message.Envelope.ReplyWith(
-                    new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started, tfChunkScavengerLog.ScavengeId)
+                    new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started, tfChunkScavengerLog.ScavengeId)
                 );
                 
                 var scavenger = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -11,6 +11,9 @@ using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Services.Storage
 {
+
+    
+
     public class StorageScavenger : IHandle<ClientMessage.ScavengeDatabase>, IHandle<UserManagementMessage.UserManagementServiceInitialized>
     {
         private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
@@ -49,11 +52,8 @@ namespace EventStore.Core.Services.Storage
         {
             if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
             {
-                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId,
-                    ClientMessage.ScavengeDatabase.ScavengeResult.Failed,
-                    "Access denied.",
-                    TimeSpan.FromMilliseconds(0),
-                    0));
+                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
+                    ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized, null));
             }
             else if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
             {
@@ -61,11 +61,8 @@ namespace EventStore.Core.Services.Storage
             }
             else
             {
-                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId,
-                                                            ClientMessage.ScavengeDatabase.ScavengeResult.InProgress,
-                                                            "Scavenge already in progress.",
-                                                            TimeSpan.FromMilliseconds(0),
-                                                            0));
+                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
+                    ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress, null));
             }
         }
 
@@ -75,34 +72,32 @@ namespace EventStore.Core.Services.Storage
 
             var tfChunkScavengerLog = _logManager.CreateLog();
 
-            ClientMessage.ScavengeDatabase.ScavengeResult result;
+            ScavengeResult result = ScavengeResult.Success;
             string error = null;
             long spaceSaved = 0;
             try
             {
                 tfChunkScavengerLog.ScavengeStarted();
 
+                message.Envelope.ReplyWith(
+                    new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started, tfChunkScavengerLog.ScavengeId)
+                );
+                
                 var scavenger = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);
 
                 spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
-
-                result = ClientMessage.ScavengeDatabase.ScavengeResult.Success;
-
+                
             }
             catch (Exception exc)
             {
+                result = ScavengeResult.Failed;
                 Log.ErrorException(exc, "SCAVENGING: error while scavenging DB.");
-                result = ClientMessage.ScavengeDatabase.ScavengeResult.Failed;
                 error = string.Format("Error while scavenging DB: {0}.", exc.Message);
             }
 
             Interlocked.Exchange(ref _isScavengingRunning, 0);
 
             tfChunkScavengerLog.ScavengeCompleted(result, error, spaceSaved, sw.Elapsed);
-            
-            message.Envelope.ReplyWith(
-                new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId, result, error, sw.Elapsed, spaceSaved)
-            );
         }
 
     }

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -1,23 +1,20 @@
 using System;
-using System.Diagnostics;
+using System.Security.Principal;
 using System.Threading;
-using EventStore.Common.Log;
+using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Index;
 using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Services.Storage
 {
 
-    
-
-    public class StorageScavenger : IHandle<ClientMessage.ScavengeDatabase>, IHandle<UserManagementMessage.UserManagementServiceInitialized>
+    public class StorageScavenger : IHandle<ClientMessage.ScavengeDatabase>, IHandle<ClientMessage.StopDatabaseScavenge>, IHandle<UserManagementMessage.UserManagementServiceInitialized>
     {
-        private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
-
         private readonly TFChunkDb _db;
         private readonly ITableIndex _tableIndex;
         private readonly IReadIndex _readIndex;
@@ -25,7 +22,10 @@ namespace EventStore.Core.Services.Storage
         private readonly bool _mergeChunks;
         private readonly bool _unsafeIgnoreHardDeletes;
         private readonly ITFChunkScavengerLogManager _logManager;
-        private int _isScavengingRunning;
+        private readonly object _lock = new object();
+
+        private TFChunkScavenger _currentScavenge;
+        private CancellationTokenSource _cancellationTokenSource;
 
         public StorageScavenger(TFChunkDb db, ITableIndex tableIndex, IReadIndex readIndex, ITFChunkScavengerLogManager logManager, bool alwaysKeepScavenged, bool mergeChunks, bool unsafeIgnoreHardDeletes)
         {
@@ -50,55 +50,74 @@ namespace EventStore.Core.Services.Storage
 
         public void Handle(ClientMessage.ScavengeDatabase message)
         {
-            if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
+            if (IsAllowed(message.User, message.CorrelationId, message.Envelope))
             {
-                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
-                    ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized, null));
-            }
-            else if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
-            {
-                ThreadPool.QueueUserWorkItem(_ => Scavenge(message));
-            }
-            else
-            {
-                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
-                    ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress, null));
+                lock (_lock)
+                {
+                    if (_currentScavenge != null)
+                    {
+                        message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
+                            ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress, _currentScavenge.ScavengeId));
+                    }
+                    else
+                    {
+                        var tfChunkScavengerLog = _logManager.CreateLog();
+
+                        _cancellationTokenSource = new CancellationTokenSource();                        
+                        var newScavenge = _currentScavenge = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);
+                        var newScavengeTask = _currentScavenge.Scavenge(_alwaysKeepScavenged, _mergeChunks, _cancellationTokenSource.Token);
+
+                        HandleCleanupWhenFinished(newScavengeTask, newScavenge);
+
+                        message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started, tfChunkScavengerLog.ScavengeId));
+                    }
+                }
             }
         }
 
-        private void Scavenge(ClientMessage.ScavengeDatabase message)
+        public void Handle(ClientMessage.StopDatabaseScavenge message)
         {
-            var sw = Stopwatch.StartNew();
+            if (IsAllowed(message.User, message.CorrelationId, message.Envelope))
+            {                
+                lock (_lock)
+                {
+                    if (_currentScavenge != null && _currentScavenge.ScavengeId == message.ScavengeId)
+                    {
+                        _cancellationTokenSource.Cancel();
 
-            var tfChunkScavengerLog = _logManager.CreateLog();
-
-            ScavengeResult result = ScavengeResult.Success;
-            string error = null;
-            long spaceSaved = 0;
-            try
-            {
-                tfChunkScavengerLog.ScavengeStarted();
-
-                message.Envelope.ReplyWith(
-                    new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started, tfChunkScavengerLog.ScavengeId)
-                );
-                
-                var scavenger = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);
-
-                spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
-                
+                        message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Stopped, _currentScavenge.ScavengeId));
+                    }
+                    else
+                    {
+                        message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InvalidScavengeId, _currentScavenge?.ScavengeId));
+                    }
+                }
             }
-            catch (Exception exc)
-            {
-                result = ScavengeResult.Failed;
-                Log.ErrorException(exc, "SCAVENGING: error while scavenging DB.");
-                error = string.Format("Error while scavenging DB: {0}.", exc.Message);
-            }
-
-            Interlocked.Exchange(ref _isScavengingRunning, 0);
-
-            tfChunkScavengerLog.ScavengeCompleted(result, error, spaceSaved, sw.Elapsed);
         }
 
+        private async void HandleCleanupWhenFinished(Task newScavengeTask, TFChunkScavenger newScavenge)
+        {
+            // Clean up the reference to the TfChunkScavenger once it's finished.
+            await newScavengeTask;
+
+            lock (_lock)
+            {
+                if (newScavenge == _currentScavenge)
+                {
+                    _currentScavenge = null;
+                }
+            }
+        }
+
+        private bool IsAllowed(IPrincipal user, Guid correlationId, IEnvelope envelope)
+        {
+            if (user == null || (!user.IsInRole(SystemRoles.Admins) && !user.IsInRole(SystemRoles.Operations)))
+            {
+                envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(correlationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized, null));
+                return false;
+            }
+
+            return true;
+        }
     }
 }

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -1,67 +1,61 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
-using EventStore.Core.Data;
-using EventStore.Core.Helpers;
 using EventStore.Core.Index;
-using EventStore.Core.Index.Hashes;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
-using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Services.Storage
 {
-    public class StorageScavenger : IHandle<ClientMessage.ScavengeDatabase>,
-                                    IHandle<UserManagementMessage.UserManagementServiceInitialized>
+    public class StorageScavenger : IHandle<ClientMessage.ScavengeDatabase>, IHandle<UserManagementMessage.UserManagementServiceInitialized>
     {
         private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
 
         private readonly TFChunkDb _db;
-        private readonly IODispatcher _ioDispatcher;
         private readonly ITableIndex _tableIndex;
         private readonly IReadIndex _readIndex;
         private readonly bool _alwaysKeepScavenged;
         private readonly bool _mergeChunks;
-        private readonly string _nodeEndpoint;
-        private readonly int _scavengeHistoryMaxAge;
         private readonly bool _unsafeIgnoreHardDeletes;
+        private readonly ITFChunkScavengerLogManager _logManager;
         private int _isScavengingRunning;
-        private const int MaxRetryCount = 5;
 
-        public StorageScavenger(TFChunkDb db, IODispatcher ioDispatcher, ITableIndex tableIndex,
-                                IReadIndex readIndex, bool alwaysKeepScavenged, string nodeEndpoint, bool mergeChunks,
-                                int scavengeHistoryMaxAge, bool unsafeIgnoreHardDeletes)
+        public StorageScavenger(TFChunkDb db, ITableIndex tableIndex, IReadIndex readIndex, ITFChunkScavengerLogManager logManager, bool alwaysKeepScavenged, bool mergeChunks, bool unsafeIgnoreHardDeletes)
         {
             Ensure.NotNull(db, "db");
-            Ensure.NotNull(ioDispatcher, "ioDispatcher");
+            Ensure.NotNull(logManager, "logManager");
             Ensure.NotNull(tableIndex, "tableIndex");
             Ensure.NotNull(readIndex, "readIndex");
-            Ensure.NotNull(nodeEndpoint, "nodeEndpoint");
 
             _db = db;
-            _ioDispatcher = ioDispatcher;
             _tableIndex = tableIndex;
             _readIndex = readIndex;
             _alwaysKeepScavenged = alwaysKeepScavenged;
-            _mergeChunks = mergeChunks;
-            _nodeEndpoint = nodeEndpoint;
-            _scavengeHistoryMaxAge = scavengeHistoryMaxAge;
+            _mergeChunks = mergeChunks;            
             _unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
+            _logManager = logManager;
         }
 
         public void Handle(UserManagementMessage.UserManagementServiceInitialized message)
         {
-            WriteScavengeIndexInitializedEvent();
+            _logManager.Initialise();
         }
 
         public void Handle(ClientMessage.ScavengeDatabase message)
         {
-            if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
+            if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
+            {
+                message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId,
+                    ClientMessage.ScavengeDatabase.ScavengeResult.Failed,
+                    "Access denied.",
+                    TimeSpan.FromMilliseconds(0),
+                    0));
+            }
+            else if (Interlocked.CompareExchange(ref _isScavengingRunning, 1, 0) == 0)
             {
                 ThreadPool.QueueUserWorkItem(_ => Scavenge(message));
             }
@@ -78,27 +72,22 @@ namespace EventStore.Core.Services.Storage
         private void Scavenge(ClientMessage.ScavengeDatabase message)
         {
             var sw = Stopwatch.StartNew();
-            Guid scavengeId = Guid.NewGuid();
-            var streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, scavengeId);
+
+            var tfChunkScavengerLog = _logManager.CreateLog();
+
             ClientMessage.ScavengeDatabase.ScavengeResult result;
             string error = null;
             long spaceSaved = 0;
             try
             {
-                if (message.User == null || (!message.User.IsInRole(SystemRoles.Admins) && !message.User.IsInRole(SystemRoles.Operations)))
-                {
-                    result = ClientMessage.ScavengeDatabase.ScavengeResult.Failed;
-                    error = "Access denied.";
-                }
-                else
-                {
-                    WriteScavengeStartedEvent(streamName, scavengeId);
+                tfChunkScavengerLog.ScavengeStarted();
 
-                    var scavenger = new TFChunkScavenger(_db, _ioDispatcher, _tableIndex, _readIndex, scavengeId,
-                                                                                 _nodeEndpoint, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);
-                    spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
-                    result = ClientMessage.ScavengeDatabase.ScavengeResult.Success;
-                }
+                var scavenger = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex, unsafeIgnoreHardDeletes: _unsafeIgnoreHardDeletes);
+
+                spaceSaved = scavenger.Scavenge(_alwaysKeepScavenged, _mergeChunks);
+
+                result = ClientMessage.ScavengeDatabase.ScavengeResult.Success;
+
             }
             catch (Exception exc)
             {
@@ -109,100 +98,12 @@ namespace EventStore.Core.Services.Storage
 
             Interlocked.Exchange(ref _isScavengingRunning, 0);
 
-            WriteScavengeCompletedEvent(streamName, scavengeId, result, error, spaceSaved, sw.Elapsed);
+            tfChunkScavengerLog.ScavengeCompleted(result, error, spaceSaved, sw.Elapsed);
+            
             message.Envelope.ReplyWith(
                 new ClientMessage.ScavengeDatabaseCompleted(message.CorrelationId, result, error, sw.Elapsed, spaceSaved)
             );
         }
 
-        private void WriteScavengeIndexInitializedEvent()
-        {
-            var metadataEventId = Guid.NewGuid();
-            var metaStreamId = SystemStreams.MetastreamOf(SystemStreams.ScavengesStream);
-            var metadata = new StreamMetadata(maxAge: TimeSpan.FromDays(_scavengeHistoryMaxAge));
-            var metaStreamEvent = new Event(metadataEventId, SystemEventTypes.StreamMetadata, isJson: true,
-                                            data: metadata.ToJsonBytes(), metadata: null);
-            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => { 
-                if(m.Result != OperationResult.Success){
-                    Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge, SystemStreams.ScavengesStream, m.Result);
-                }
-            });
-
-            var indexInitializedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeIndexInitialized,
-                    true, new Dictionary<string, object>{}.ToJsonBytes(), null);
-            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.NoStream, indexInitializedEvent, SystemAccount.Principal, m => {
-                if(m.Result != OperationResult.Success && m.Result != OperationResult.WrongExpectedVersion){
-                    Log.Error("Failed to write the {0} event to the {1} stream. Reason: {2}", SystemEventTypes.ScavengeIndexInitialized, SystemStreams.ScavengesStream, m.Result);
-                }
-             });
-        }
-
-        private void WriteScavengeStartedEvent(string streamName, Guid scavengeId)
-        {
-            var metadataEventId = Guid.NewGuid();
-            var metaStreamId = SystemStreams.MetastreamOf(streamName);
-            var metadata = new StreamMetadata(maxAge: TimeSpan.FromDays(_scavengeHistoryMaxAge));
-            var metaStreamEvent = new Event(metadataEventId, SystemEventTypes.StreamMetadata, isJson: true,
-                                            data: metadata.ToJsonBytes(), metadata: null);
-            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => { 
-                if(m.Result != OperationResult.Success){
-                    Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge, streamName, m.Result);
-                }
-            });
-
-            var scavengeStartedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeStarted, true, new Dictionary<string, object>{
-                    {"scavengeId", scavengeId},
-                    {"nodeEndpoint", _nodeEndpoint},
-                }.ToJsonBytes(), null);
-            WriteScavengeDetailEvent(streamName, scavengeStartedEvent, MaxRetryCount);
-        }
-
-        private void WriteScavengeCompletedEvent(string streamName, Guid scavengeId, ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan timeTaken)
-        {
-            var scavengeCompletedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeCompleted, true, new Dictionary<string, object>{
-                    {"scavengeId", scavengeId},
-                    {"nodeEndpoint", _nodeEndpoint},
-                    {"result", result},
-                    {"error", error},
-                    {"timeTaken", timeTaken},
-                    {"spaceSaved", spaceSaved}
-                }.ToJsonBytes(), null);
-            WriteScavengeDetailEvent(streamName, scavengeCompletedEvent, MaxRetryCount);
-        }
-
-        private void WriteScavengeDetailEvent(string streamId, Event eventToWrite, int retryCount){
-            _ioDispatcher.WriteEvent(streamId, ExpectedVersion.Any, eventToWrite, SystemAccount.Principal, x => WriteScavengeDetailEventCompleted(x, eventToWrite, streamId, retryCount));
-        }
-
-        private void WriteScavengeIndexEvent(Event linkToEvent, int retryCount){
-            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.Any, linkToEvent, SystemAccount.Principal, m => WriteScavengeIndexEventCompleted(m, linkToEvent, retryCount));
-        }
-
-        private void WriteScavengeIndexEventCompleted(ClientMessage.WriteEventsCompleted msg, Event linkToEvent, int retryCount){
-            if(msg.Result != OperationResult.Success){
-                if(retryCount > 0){
-                    Log.Error("Failed to write an event to the {0} stream. Retrying {1}/{2}. Reason: {3}", SystemStreams.ScavengesStream, (MaxRetryCount - retryCount) + 1, MaxRetryCount, msg.Result);
-                    WriteScavengeIndexEvent(linkToEvent, --retryCount);
-                }else{
-                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", SystemStreams.ScavengesStream, MaxRetryCount, msg.Result);
-                }
-            }
-        }
-
-        private void WriteScavengeDetailEventCompleted(ClientMessage.WriteEventsCompleted msg, Event eventToWrite, string streamId, int retryCount)
-        {
-            if(msg.Result != OperationResult.Success){
-                if(retryCount > 0){
-                    Log.Error("Failed to write an event to the {0} stream. Retrying {1}/{2}. Reason: {3}", streamId, (MaxRetryCount - retryCount) + 1, MaxRetryCount, msg.Result);
-                    WriteScavengeDetailEvent(streamId, eventToWrite, --retryCount);
-                }else{
-                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", streamId, MaxRetryCount, msg.Result);
-                }
-            }else{
-                string eventLinkTo = string.Format("{0}@{1}", msg.FirstEventNumber, streamId);
-                var linkToIndexEvent = new Event(Guid.NewGuid(), SystemEventTypes.LinkTo, false, eventLinkTo, null);
-                WriteScavengeIndexEvent(linkToIndexEvent, MaxRetryCount);
-            }
-        }
     }
 }

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -83,7 +83,6 @@ namespace EventStore.Core.Services
         public const string ScavengeStarted = "$scavengeStarted";
         public const string ScavengeCompleted = "$scavengeCompleted";
         public const string ScavengeChunksCompleted = "$scavengeChunksCompleted";
-        public const string ScavengeIndexInitialized = "$scavengeIndexInitialized";
 
         public static string StreamReferenceEventToStreamId(string eventType, byte[] data)
         {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -55,11 +55,11 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                     var completed = message as ClientMessage.ScavengeDatabaseResponse;
                     switch (completed?.Result)
                     {
-                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started:
+                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started:
                             return Configure.Ok(e.ResponseCodec.ContentType);
-                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress:
+                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress:
                             return Configure.BadRequest();
-                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized:
+                        case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized:
                             return Configure.Unauthorized();
                         default:
                             return Configure.InternalServerError();

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -606,23 +606,24 @@ namespace EventStore.Core.Services.Transport.Tcp
 
         private TcpPackage WrapScavengeDatabaseResponse(ClientMessage.ScavengeDatabaseResponse msg)
         {
-            TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult result;
+            TcpClientMessageDto.ScavengeDatabaseResponse.ScavengeResult result;
             switch (msg.Result)
             {
-                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started:
-                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.Success;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started:
+                    result = TcpClientMessageDto.ScavengeDatabaseResponse.ScavengeResult.Started;
                     break;
-                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized:
-                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.Failed;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized:
+                    result = TcpClientMessageDto.ScavengeDatabaseResponse.ScavengeResult.Unauthorized;
                     break;
-                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress:
-                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.InProgress;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress:
+                    result = TcpClientMessageDto.ScavengeDatabaseResponse.ScavengeResult.InProgress;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-            var dto = new TcpClientMessageDto.ScavengeDatabaseCompleted(result, null, 0, 0);
-            return new TcpPackage(TcpCommand.ScavengeDatabaseCompleted, msg.CorrelationId, dto.Serialize());
+
+            var dto = new TcpClientMessageDto.ScavengeDatabaseResponse(result, msg.ScavengeId);
+            return new TcpPackage(TcpCommand.ScavengeDatabaseResponse, msg.CorrelationId, dto.Serialize());
         }
 
         private ClientMessage.NotHandled UnwrapNotHandled(TcpPackage package, IEnvelope envelope)

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -82,7 +82,7 @@ namespace EventStore.Core.Services.Transport.Tcp
             AddWrapper<ClientMessage.PersistentSubscriptionStreamEventAppeared>(WrapPersistentSubscriptionStreamEventAppeared, ClientVersion.V2);
 
             AddUnwrapper(TcpCommand.ScavengeDatabase, UnwrapScavengeDatabase, ClientVersion.V2);
-            AddWrapper<ClientMessage.ScavengeDatabaseCompleted>(WrapScavengeDatabaseResponse, ClientVersion.V2);
+            AddWrapper<ClientMessage.ScavengeDatabaseResponse>(WrapScavengeDatabaseResponse, ClientVersion.V2);
 
             AddWrapper<ClientMessage.NotHandled>(WrapNotHandled, ClientVersion.V2);
             AddUnwrapper(TcpCommand.NotHandled, UnwrapNotHandled, ClientVersion.V2);
@@ -604,11 +604,24 @@ namespace EventStore.Core.Services.Transport.Tcp
             return new ClientMessage.ScavengeDatabase(envelope, package.CorrelationId, user);
         }
 
-        private TcpPackage WrapScavengeDatabaseResponse(ClientMessage.ScavengeDatabaseCompleted msg)
+        private TcpPackage WrapScavengeDatabaseResponse(ClientMessage.ScavengeDatabaseResponse msg)
         {
-            var dto = new TcpClientMessageDto.ScavengeDatabaseCompleted(
-                (TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult)msg.Result, msg.Error,
-                (int)msg.TotalTime.TotalMilliseconds, msg.TotalSpaceSaved);
+            TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult result;
+            switch (msg.Result)
+            {
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Started:
+                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.Success;
+                    break;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.Unauthorized:
+                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.Failed;
+                    break;
+                case ClientMessage.ScavengeDatabaseResponse.ScavengeResponse.InProgress:
+                    result = TcpClientMessageDto.ScavengeDatabaseCompleted.ScavengeResult.InProgress;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+            var dto = new TcpClientMessageDto.ScavengeDatabaseCompleted(result, null, 0, 0);
             return new TcpPackage(TcpCommand.ScavengeDatabaseCompleted, msg.CorrelationId, dto.Serialize());
         }
 

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpCommand.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpCommand.cs
@@ -68,7 +68,7 @@ namespace EventStore.Core.Services.Transport.Tcp
         UpdatePersistentSubscriptionCompleted = 0xCF,
 
         ScavengeDatabase = 0xD0,
-        ScavengeDatabaseCompleted = 0xD1,
+        ScavengeDatabaseResponse = 0xD1,
 
         BadRequest = 0xF0,
         NotHandled = 0xF1,

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -106,6 +106,7 @@ namespace EventStore.Core.Services.VNode
                     .When<SystemMessage.SystemStart>().Do(Handle)
                     .When<SystemMessage.ServiceInitialized>().Do(Handle)
                     .When<ClientMessage.ScavengeDatabase>().Ignore()
+                    .When<ClientMessage.StopDatabaseScavenge>().Ignore()
                     .WhenOther().ForwardTo(_outputBus)
 
                 .InState(VNodeState.Unknown)

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
@@ -5,12 +5,20 @@ namespace EventStore.Core.TransactionLog.Chunks
 {
     public interface ITFChunkScavengerLog
     {
+        string ScavengeId { get; }
+        
         void ScavengeStarted();
 
         void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved);
-        
+
         void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved, string errorMessage);
-        
-        void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed);
+
+        void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed);
+    }
+    
+    public enum ScavengeResult
+    {
+        Success,
+        Failed
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using EventStore.Core.Messages;
+
+namespace EventStore.Core.TransactionLog.Chunks
+{
+    public interface ITFChunkScavengerLog
+    {
+        void ScavengeStarted();
+
+        void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved);
+        
+        void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved, string errorMessage);
+        
+        void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed);
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using EventStore.Core.Messages;
 
 namespace EventStore.Core.TransactionLog.Chunks
 {
@@ -11,9 +10,9 @@ namespace EventStore.Core.TransactionLog.Chunks
 
         void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved);
 
-        void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved, string errorMessage);
+        void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, string errorMessage);
 
-        void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed);
+        void ScavengeCompleted(ScavengeResult result, string error, TimeSpan elapsed);
     }
     
     public enum ScavengeResult

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
@@ -19,6 +19,7 @@ namespace EventStore.Core.TransactionLog.Chunks
     public enum ScavengeResult
     {
         Success,
-        Failed
+        Failed,
+        Stopped
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLogManager.cs
@@ -1,0 +1,9 @@
+﻿namespace EventStore.Core.TransactionLog.Chunks
+{
+    public interface ITFChunkScavengerLogManager
+    {
+        void Initialise();
+
+        ITFChunkScavengerLog CreateLog();
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
@@ -41,18 +43,65 @@ namespace EventStore.Core.TransactionLog.Chunks
             _maxChunkDataSize = maxChunkDataSize ?? db.Config.ChunkSize;
             _unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
         }
+        
+        public string ScavengeId => _scavengerLog.ScavengeId;
 
-        public long Scavenge(bool alwaysKeepScavenged, bool mergeChunks)
+        public Task Scavenge(bool alwaysKeepScavenged, bool mergeChunks, CancellationToken ct = default(CancellationToken))
+        {
+            // Note we aren't passing the CancellationToken to the task on purpose so awaiters
+            // don't have to handle Exceptions and can wait for the actual completion of the task.
+            return Task.Factory.StartNew(() =>
+            {
+                var sw = Stopwatch.StartNew();
+                long spaceSaved = 0;
+
+                ScavengeResult result = ScavengeResult.Success;
+                string error = null;
+                try
+                {
+                    _scavengerLog.ScavengeStarted();
+                    
+                    ScavengeInternal(alwaysKeepScavenged, mergeChunks, ref spaceSaved, ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    Log.Info("SCAVENGING: Scavenge cancelled.");
+                    result = ScavengeResult.Stopped;
+                }
+                catch (Exception exc)
+                {
+                    result = ScavengeResult.Failed;
+                    Log.ErrorException(exc, "SCAVENGING: error while scavenging DB.");
+                    error = string.Format("Error while scavenging DB: {0}.", exc.Message);
+                }
+                finally
+                {
+                    try
+                    {
+                        _scavengerLog.ScavengeCompleted(result, error, spaceSaved, sw.Elapsed);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.ErrorException(ex, "Error whilst recording scavenge completed. Scavenge result: {0}, Space saved: {1}, Elapsed: {2}, Original error: {3}", result, spaceSaved, sw.Elapsed, error);
+                    }
+                }
+
+            }, TaskCreationOptions.LongRunning);
+        }
+
+        private void ScavengeInternal(bool alwaysKeepScavenged, bool mergeChunks, ref long spaceSaved,
+            CancellationToken ct)
         {
             var totalSw = Stopwatch.StartNew();
             var sw = Stopwatch.StartNew();
-            long spaceSaved = 0;
-
+            
             Log.Trace("SCAVENGING: started scavenging of DB. Chunks count at start: {0}. Options: alwaysKeepScavenged = {1}, mergeChunks = {2}",
                       _db.Manager.ChunksCount, alwaysKeepScavenged, mergeChunks);
 
             for (long scavengePos = 0; scavengePos < _db.Config.ChaserCheckpoint.Read(); )
             {
+                ct.ThrowIfCancellationRequested();
+
                 var chunk = _db.Manager.GetChunkFor(scavengePos);
                 if (!chunk.IsReadOnly)
                 {
@@ -61,10 +110,11 @@ namespace EventStore.Core.TransactionLog.Chunks
                 }
 
                 long saved;
-                ScavengeChunks(alwaysKeepScavenged, new[] {chunk}, out saved);
+                ScavengeChunks(alwaysKeepScavenged, new[] {chunk}, out saved, ct);
                 spaceSaved += saved;
 
                 scavengePos = chunk.ChunkHeader.ChunkEndPosition;
+
             }
             Log.Trace("SCAVENGING: initial pass completed in {0}.", sw.Elapsed);
 
@@ -82,6 +132,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                     long totalDataSize = 0;
                     for (long scavengePos = 0; scavengePos < _db.Config.ChaserCheckpoint.Read();)
                     {
+                        ct.ThrowIfCancellationRequested();
+
                         var chunk = _db.Manager.GetChunkFor(scavengePos);
                         if (!chunk.IsReadOnly)
                         {
@@ -93,7 +145,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                             if (chunks.Count == 0)
                                 throw new Exception("SCAVENGING: no chunks to merge, unexpectedly...");
                             long saved;
-                            if (chunks.Count > 1 && ScavengeChunks(alwaysKeepScavenged, chunks, out saved))
+                            if (chunks.Count > 1 && ScavengeChunks(alwaysKeepScavenged, chunks, out saved, ct))
                             {
                                 spaceSaved += saved;
                                 mergedSomething = true;
@@ -105,10 +157,11 @@ namespace EventStore.Core.TransactionLog.Chunks
                         totalDataSize += chunk.PhysicalDataSize;
                         scavengePos = chunk.ChunkHeader.ChunkEndPosition;
                     }
+
                     if (chunks.Count > 1)
                     {
                         long saved;
-                        if (ScavengeChunks(alwaysKeepScavenged, chunks, out saved))
+                        if (ScavengeChunks(alwaysKeepScavenged, chunks, out saved, ct))
                         {
                             spaceSaved += saved;
                             mergedSomething = true;
@@ -118,11 +171,10 @@ namespace EventStore.Core.TransactionLog.Chunks
                               passNum, sw.Elapsed, mergedSomething ? "Some chunks" : "Nothing");
                 } while (mergedSomething);
             }
-            Log.Trace("SCAVENGING: total time taken: {0}, total space saved: {1}.", totalSw.Elapsed, spaceSaved);
-            return spaceSaved;
+            Log.Trace("SCAVENGING: total time taken: {0}, total space saved: {1}.", totalSw.Elapsed, spaceSaved);            
         }
 
-        private bool ScavengeChunks(bool alwaysKeepScavenged, IList<TFChunk.TFChunk> oldChunks, out long spaceSaved)
+        private bool ScavengeChunks(bool alwaysKeepScavenged, IList<TFChunk.TFChunk> oldChunks, out long spaceSaved, CancellationToken ct)
         {
             spaceSaved = 0;
 
@@ -167,13 +219,26 @@ namespace EventStore.Core.TransactionLog.Chunks
                 foreach (var oldChunk in oldChunks)
                 {
                     TraverseChunk(oldChunk,
-                                  (prepare, _) => { /* NOOP */ },
-                                  (commit, _) =>
-                                  {
-                                      if (commit.TransactionPosition >= chunkStartPos)
-                                          commits.Add(commit.TransactionPosition, new CommitInfo(commit));
-                                  },
-                                  (system, _) => { /* NOOP */ });
+                        (prepare, _) =>
+                        {
+                            ct.ThrowIfCancellationRequested();
+
+                            /* NOOP */
+                        },
+                        (commit, _) =>
+                        {
+
+                            ct.ThrowIfCancellationRequested();
+
+                            if (commit.TransactionPosition >= chunkStartPos)
+                                commits.Add(commit.TransactionPosition, new CommitInfo(commit));
+                        },
+                        (system, _) =>
+                        {
+                            ct.ThrowIfCancellationRequested();
+
+                            /* NOOP */
+                        });
                 }
 
                 long newSize = 0;
@@ -181,36 +246,44 @@ namespace EventStore.Core.TransactionLog.Chunks
 
                 foreach (var oldChunk in oldChunks)
                 {
+                    ct.ThrowIfCancellationRequested();
+
                     TraverseChunk(oldChunk,
-                                  (prepare, len) =>
-                                  {
-                                      if (ShouldKeepPrepare(prepare, commits, chunkStartPos, chunkEndPos))
-                                      {
-                                          newSize += len + 2 * sizeof(int);
-                                          positionMapCount++;
-                                      }
-                                  },
-                                  (commit, len) =>
-                                  {
-                                      if (ShouldKeepCommit(commit, commits))
-                                      {
-                                          newSize += len + 2 * sizeof(int);
-                                          positionMapCount++;
-                                      }
-                                  },
-                                  (system, len) =>
-                                  {
-                                      newSize += len + 2 * sizeof(int);
-                                      positionMapCount++;
-                                  });
+                        (prepare, len) =>
+                        {
+                            ct.ThrowIfCancellationRequested();
+
+                            if (ShouldKeepPrepare(prepare, commits, chunkStartPos, chunkEndPos))
+                            {
+                                newSize += len + 2 * sizeof(int);
+                                positionMapCount++;
+                            }
+                        },
+                        (commit, len) =>
+                        {
+                            ct.ThrowIfCancellationRequested();
+
+                            if (ShouldKeepCommit(commit, commits))
+                            {
+                                newSize += len + 2 * sizeof(int);
+                                positionMapCount++;
+                            }
+                        },
+                        (system, len) =>
+                        {
+                            ct.ThrowIfCancellationRequested();
+
+                            newSize += len + 2 * sizeof(int);
+                            positionMapCount++;
+                        });
                 }
 
                 newSize += positionMapCount * PosMap.FullSize + ChunkHeader.Size + ChunkFooter.Size;
-                if(newChunk.ChunkHeader.Version >= (byte) TFChunk.TFChunk.ChunkVersions.Aligned)
-                    newSize = TFChunk.TFChunk.GetAlignedSize((int)newSize);
+                if (newChunk.ChunkHeader.Version >= (byte) TFChunk.TFChunk.ChunkVersions.Aligned)
+                    newSize = TFChunk.TFChunk.GetAlignedSize((int) newSize);
 
                 var oldVersion = oldChunks.Any(x => x.ChunkHeader.Version != 3);
-                var oldSize = oldChunks.Sum(x => (long)x.FileSize);
+                var oldSize = oldChunks.Sum(x => (long) x.FileSize);
 
                 if (oldSize <= newSize && !alwaysKeepScavenged && !_unsafeIgnoreHardDeletes && !oldVersion)
                 {
@@ -222,7 +295,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                     Log.Trace("Scavenged chunk removed.");
 
                     newChunk.MarkForDeletion();
-                    _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, "Decided to keep old chunk.");
+                    _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved,
+                        "Decided to keep old chunk.");
 
                     return false;
                 }
@@ -231,26 +305,38 @@ namespace EventStore.Core.TransactionLog.Chunks
                 foreach (var oldChunk in oldChunks)
                 {
                     TraverseChunk(oldChunk,
-                                  (prepare, _) =>
-                                  {
-                                      if (ShouldKeepPrepare(prepare, commits, chunkStartPos, chunkEndPos))
-                                          positionMapping.Add(WriteRecord(newChunk, prepare));
-                                  },
-                                  (commit, _) =>
-                                  {
-                                      if (ShouldKeepCommit(commit, commits))
-                                          positionMapping.Add(WriteRecord(newChunk, commit));
-                                  },
-                                  // we always keep system log records for now
-                                  (system, _) => positionMapping.Add(WriteRecord(newChunk, system)));
+                        (prepare, _) =>
+                        {
+                            ct.ThrowIfCancellationRequested();
+
+                            if (ShouldKeepPrepare(prepare, commits, chunkStartPos, chunkEndPos))
+                                positionMapping.Add(WriteRecord(newChunk, prepare));
+                        },
+                        (commit, _) =>
+                        {
+                            ct.ThrowIfCancellationRequested();
+
+                            if (ShouldKeepCommit(commit, commits))
+                                positionMapping.Add(WriteRecord(newChunk, commit));
+                        },
+                        // we always keep system log records for now
+                        (system, _) =>
+                        {
+                            ct.ThrowIfCancellationRequested();
+
+                            positionMapping.Add(WriteRecord(newChunk, system));
+                        });
                 }
+
                 newChunk.CompleteScavenge(positionMapping);
 
-                if(_unsafeIgnoreHardDeletes) {
+                if (_unsafeIgnoreHardDeletes)
+                {
                     Log.Trace("Forcing scavenge chunk to be kept even if bigger.");
                 }
 
-                if(oldVersion) {
+                if (oldVersion)
+                {
                     Log.Trace("Forcing scavenged chunk to be kept as old chunk is a previous version.");
                 }
 
@@ -273,16 +359,19 @@ namespace EventStore.Core.TransactionLog.Chunks
                     Log.Trace("Scavenging of chunks:");
                     Log.Trace("{0}", oldChunksList);
                     Log.Trace("completed in {1}.", sw.Elapsed);
-                    Log.Trace("But switching was prevented for new chunk: #{0}-{1} ({2}).", chunkStartNumber, chunkEndNumber, Path.GetFileName(tmpChunkPath));
+                    Log.Trace("But switching was prevented for new chunk: #{0}-{1} ({2}).", chunkStartNumber,
+                        chunkEndNumber, Path.GetFileName(tmpChunkPath));
                     Log.Trace("Old chunks total size: {0}, scavenged chunk size: {1}.", oldSize, newSize);
-                    _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, "Chunk switch prevented.");
+                    _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved,
+                        "Chunk switch prevented.");
 
                     return false;
                 }
             }
             catch (FileBeingDeletedException exc)
             {
-                Log.Info("Got FileBeingDeletedException exception during scavenging, that probably means some chunks were re-replicated.");
+                Log.Info(
+                    "Got FileBeingDeletedException exception during scavenging, that probably means some chunks were re-replicated.");
                 Log.Info("Scavenging of following chunks will be skipped:");
                 Log.Info("{0}", oldChunksList);
                 Log.Info("Stopping scavenging and removing temp chunk '{0}'...", tmpChunkPath);
@@ -290,6 +379,14 @@ namespace EventStore.Core.TransactionLog.Chunks
                 DeleteTempChunk(tmpChunkPath, MaxRetryCount);
                 _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, exc.Message);
 
+                return false;
+            }
+            catch (OperationCanceledException)
+            {
+                Log.Info("Scavenging cancelled at:");
+                Log.Info("{0}", oldChunksList);
+                newChunk.MarkForDeletion();                
+                _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, "Scavenge cancelled");
                 return false;
             }
             catch (Exception ex)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -7,14 +7,11 @@ using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Exceptions;
-using EventStore.Core.Helpers;
 using EventStore.Core.Index;
 using EventStore.Core.Services;
 using EventStore.Core.Services.Storage.ReaderIndex;
-using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
-using EventStore.Core.Messages;
 
 namespace EventStore.Core.TransactionLog.Chunks
 {
@@ -23,29 +20,23 @@ namespace EventStore.Core.TransactionLog.Chunks
         private static readonly ILogger Log = LogManager.GetLoggerFor<TFChunkScavenger>();
 
         private readonly TFChunkDb _db;
-        private readonly IODispatcher _ioDispatcher;
+        private readonly ITFChunkScavengerLog _scavengerLog;
         private readonly ITableIndex _tableIndex;
-        private readonly Guid _scavengeId;
-        private readonly string _nodeEndpoint;
         private readonly IReadIndex _readIndex;
         private readonly long _maxChunkDataSize;
         private readonly bool _unsafeIgnoreHardDeletes;
         private const int MaxRetryCount = 5;
 
-        public TFChunkScavenger(TFChunkDb db, IODispatcher ioDispatcher, ITableIndex tableIndex, IReadIndex readIndex,
-                                Guid scavengeId, string nodeEndpoint, long? maxChunkDataSize = null, bool unsafeIgnoreHardDeletes=false)
+        public TFChunkScavenger(TFChunkDb db, ITFChunkScavengerLog scavengerLog, ITableIndex tableIndex, IReadIndex readIndex, long? maxChunkDataSize = null, bool unsafeIgnoreHardDeletes=false)
         {
             Ensure.NotNull(db, "db");
-            Ensure.NotNull(ioDispatcher, "ioDispatcher");
+            Ensure.NotNull(scavengerLog, "scavengerLog");
             Ensure.NotNull(tableIndex, "tableIndex");
-            Ensure.NotNull(nodeEndpoint, "nodeEndpoint");
             Ensure.NotNull(readIndex, "readIndex");
 
             _db = db;
-            _ioDispatcher = ioDispatcher;
+            _scavengerLog = scavengerLog;
             _tableIndex = tableIndex;
-            _scavengeId = scavengeId;
-            _nodeEndpoint = nodeEndpoint;
             _readIndex = readIndex;
             _maxChunkDataSize = maxChunkDataSize ?? db.Config.ChunkSize;
             _unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
@@ -231,7 +222,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                     Log.Trace("Scavenged chunk removed.");
 
                     newChunk.MarkForDeletion();
-                    PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, spaceSaved);
+                    _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, "Decided to keep old chunk.");
+
                     return false;
                 }
 
@@ -272,7 +264,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                         chunkEndNumber, Path.GetFileName(chunk.FileName));
                     Log.Trace("Old chunks total size: {0}, scavenged chunk size: {1}.", oldSize, newSize);
                     spaceSaved = oldSize - newSize;
-                    PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, true, spaceSaved);
+                    _scavengerLog.ChunksScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved);
+
                     return true;
                 }
                 else
@@ -282,7 +275,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                     Log.Trace("completed in {1}.", sw.Elapsed);
                     Log.Trace("But switching was prevented for new chunk: #{0}-{1} ({2}).", chunkStartNumber, chunkEndNumber, Path.GetFileName(tmpChunkPath));
                     Log.Trace("Old chunks total size: {0}, scavenged chunk size: {1}.", oldSize, newSize);
-                    PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, spaceSaved);
+                    _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, "Chunk switch prevented.");
+
                     return false;
                 }
             }
@@ -294,7 +288,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                 Log.Info("Stopping scavenging and removing temp chunk '{0}'...", tmpChunkPath);
                 Log.Info("Exception message: {0}.", exc.Message);
                 DeleteTempChunk(tmpChunkPath, MaxRetryCount);
-                PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, spaceSaved, exc.Message);
+                _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, exc.Message);
+
                 return false;
             }
             catch (Exception ex)
@@ -302,7 +297,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                 Log.Info("Got exception while scavenging chunk: #{0}-{1}. This chunk will be skipped\n"
                          + "Exception: {2}.", chunkStartNumber, chunkEndNumber, ex.ToString());
                 DeleteTempChunk(tmpChunkPath, MaxRetryCount);
-                PublishChunksCompletedEvent(chunkStartNumber, chunkEndNumber, sw.Elapsed, false, 0, ex.Message);
+                _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, spaceSaved, ex.Message);
+
                 return false;
             }
         }
@@ -325,38 +321,6 @@ namespace EventStore.Core.TransactionLog.Chunks
                 {
                     Log.Error("Failed to delete the temp chunk. Retry limit of {0} reached. Reason: {1}", MaxRetryCount, ex);
                     throw;
-                }
-            }
-        }
-
-        private void PublishChunksCompletedEvent(int chunkStartNumber, int chunkEndNumber,
-                                                 TimeSpan elapsed, bool wasScavenged, long spaceSaved, string errorMessage = "")
-        {
-            var evnt = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeChunksCompleted, true, new Dictionary<string, object>{
-                    {"scavengeId", _scavengeId},
-                    {"chunkStartNumber", chunkStartNumber},
-                    {"chunkEndNumber", chunkEndNumber},
-                    {"timeTaken", elapsed},
-                    {"wasScavenged", wasScavenged},
-                    {"spaceSaved", spaceSaved},
-                    {"nodeEndpoint", _nodeEndpoint},
-                    {"errorMessage", errorMessage}
-                }.ToJsonBytes(), null);
-
-            var streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, _scavengeId);
-            WriteScavengeChunkCompletedEvent(streamName, evnt, MaxRetryCount);
-        }
-
-        private void WriteScavengeChunkCompletedEvent(string streamId, Event eventToWrite, int retryCount){
-            _ioDispatcher.WriteEvent(streamId, ExpectedVersion.Any, eventToWrite, SystemAccount.Principal, m => WriteScavengeChunkCompletedEventCompleted(m, streamId, eventToWrite, retryCount));
-        }
-
-        private void WriteScavengeChunkCompletedEventCompleted(ClientMessage.WriteEventsCompleted msg, string streamId, Event eventToWrite, int retryCount){
-            if(msg.Result != OperationResult.Success){
-                if(retryCount > 0){
-                    WriteScavengeChunkCompletedEvent(streamId, eventToWrite, --retryCount);
-                }else{
-                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", streamId, MaxRetryCount, msg.Result);
                 }
             }
         }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
@@ -15,13 +15,13 @@ namespace EventStore.Core.TransactionLog.Chunks
     {
         private readonly string _streamName;
         private readonly IODispatcher _ioDispatcher;
-        private readonly Guid _scavengeId;
+        private readonly string _scavengeId;
         private readonly string _nodeId;
         private readonly int _retryAttempts;
         private readonly TimeSpan _scavengeHistoryMaxAge;
         private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
 
-        public TFChunkScavengerLog(IODispatcher ioDispatcher, Guid scavengeId, string nodeId, int retryAttempts, TimeSpan scavengeHistoryMaxAge)
+        public TFChunkScavengerLog(IODispatcher ioDispatcher, string scavengeId, string nodeId, int retryAttempts, TimeSpan scavengeHistoryMaxAge)
         {
             _ioDispatcher = ioDispatcher;
             _scavengeId = scavengeId;
@@ -31,6 +31,8 @@ namespace EventStore.Core.TransactionLog.Chunks
 
             _streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, scavengeId);
         }
+
+        public string ScavengeId => _scavengeId;
 
         public void ScavengeStarted()
         {
@@ -53,7 +55,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             WriteScavengeDetailEvent(_streamName, scavengeStartedEvent, _retryAttempts);
         }
 
-        public void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        public void ScavengeCompleted(ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
         {
             var scavengeCompletedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeCompleted, true, new Dictionary<string, object>{
                 {"scavengeId", _scavengeId},

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Common.Log;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Storage;
+using EventStore.Core.Services.UserManagement;
+
+namespace EventStore.Core.TransactionLog.Chunks
+{
+    class TFChunkScavengerLog : ITFChunkScavengerLog
+    {
+        private readonly string _streamName;
+        private readonly IODispatcher _ioDispatcher;
+        private readonly Guid _scavengeId;
+        private readonly string _nodeId;
+        private readonly int _retryAttempts;
+        private readonly TimeSpan _scavengeHistoryMaxAge;
+        private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
+
+        public TFChunkScavengerLog(IODispatcher ioDispatcher, Guid scavengeId, string nodeId, int retryAttempts, TimeSpan scavengeHistoryMaxAge)
+        {
+            _ioDispatcher = ioDispatcher;
+            _scavengeId = scavengeId;
+            _nodeId = nodeId;
+            _retryAttempts = retryAttempts;
+            _scavengeHistoryMaxAge = scavengeHistoryMaxAge;
+
+            _streamName = string.Format("{0}-{1}", SystemStreams.ScavengesStream, scavengeId);
+        }
+
+        public void ScavengeStarted()
+        {
+            var metadataEventId = Guid.NewGuid();
+            var metaStreamId = SystemStreams.MetastreamOf(_streamName);
+            var metadata = new StreamMetadata(maxAge: _scavengeHistoryMaxAge);
+            var metaStreamEvent = new Event(metadataEventId, SystemEventTypes.StreamMetadata, isJson: true,
+                data: metadata.ToJsonBytes(), metadata: null);
+            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => {
+                if (m.Result != OperationResult.Success)
+                {
+                    Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge.TotalDays, _streamName, m.Result);
+                }
+            });
+
+            var scavengeStartedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeStarted, true, new Dictionary<string, object>{
+                {"scavengeId", _scavengeId},
+                {"nodeEndpoint", _nodeId},
+            }.ToJsonBytes(), null);
+            WriteScavengeDetailEvent(_streamName, scavengeStartedEvent, _retryAttempts);
+        }
+
+        public void ScavengeCompleted(ClientMessage.ScavengeDatabase.ScavengeResult result, string error, long spaceSaved, TimeSpan elapsed)
+        {
+            var scavengeCompletedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeCompleted, true, new Dictionary<string, object>{
+                {"scavengeId", _scavengeId},
+                {"nodeEndpoint", _nodeId},
+                {"result", result},
+                {"error", error},
+                {"timeTaken", elapsed},
+                {"spaceSaved", spaceSaved}
+            }.ToJsonBytes(), null);
+            WriteScavengeDetailEvent(_streamName, scavengeCompletedEvent, _retryAttempts);
+        }
+
+        public void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved)
+        {
+            var evnt = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeChunksCompleted, true, new Dictionary<string, object>{
+                {"scavengeId", _scavengeId},
+                {"chunkStartNumber", chunkStartNumber},
+                {"chunkEndNumber", chunkEndNumber},
+                {"timeTaken", elapsed},
+                {"wasScavenged", true},
+                {"spaceSaved", spaceSaved},
+                {"nodeEndpoint", _nodeId},
+                {"errorMessage", ""}
+            }.ToJsonBytes(), null);
+
+            WriteScavengeChunkCompletedEvent(_streamName, evnt, _retryAttempts);
+        }
+
+        public void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved, string errorMessage)
+        {
+            var evnt = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeChunksCompleted, true, new Dictionary<string, object>{
+                {"scavengeId", _scavengeId},
+                {"chunkStartNumber", chunkStartNumber},
+                {"chunkEndNumber", chunkEndNumber},
+                {"timeTaken", elapsed},
+                {"wasScavenged", false},
+                {"spaceSaved", spaceSaved},
+                {"nodeEndpoint", _nodeId},
+                {"errorMessage", errorMessage}
+            }.ToJsonBytes(), null);
+
+            WriteScavengeChunkCompletedEvent(_streamName, evnt, _retryAttempts);
+        }
+
+        private void WriteScavengeChunkCompletedEvent(string streamId, Event eventToWrite, int retryCount)
+        {
+            _ioDispatcher.WriteEvent(streamId, ExpectedVersion.Any, eventToWrite, SystemAccount.Principal, m => WriteScavengeChunkCompletedEventCompleted(m, streamId, eventToWrite, retryCount));
+        }
+
+        private void WriteScavengeChunkCompletedEventCompleted(ClientMessage.WriteEventsCompleted msg, string streamId, Event eventToWrite, int retryCount)
+        {
+            if (msg.Result != OperationResult.Success)
+            {
+                if (retryCount > 0)
+                {
+                    WriteScavengeChunkCompletedEvent(streamId, eventToWrite, --retryCount);
+                }
+                else
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", streamId, _retryAttempts, msg.Result);
+                }
+            }
+        }
+
+        private void WriteScavengeDetailEvent(string streamId, Event eventToWrite, int retryCount)
+        {
+            _ioDispatcher.WriteEvent(streamId, ExpectedVersion.Any, eventToWrite, SystemAccount.Principal, x => WriteScavengeDetailEventCompleted(x, eventToWrite, streamId, retryCount));
+        }
+
+        private void WriteScavengeIndexEvent(Event linkToEvent, int retryCount)
+        {
+            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.Any, linkToEvent, SystemAccount.Principal, m => WriteScavengeIndexEventCompleted(m, linkToEvent, retryCount));
+        }
+
+        private void WriteScavengeIndexEventCompleted(ClientMessage.WriteEventsCompleted msg, Event linkToEvent, int retryCount)
+        {
+            if (msg.Result != OperationResult.Success)
+            {
+                if (retryCount > 0)
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retrying {1}/{2}. Reason: {3}", SystemStreams.ScavengesStream, (_retryAttempts - retryCount) + 1, _retryAttempts, msg.Result);
+                    WriteScavengeIndexEvent(linkToEvent, --retryCount);
+                }
+                else
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", SystemStreams.ScavengesStream, _retryAttempts, msg.Result);
+                }
+            }
+        }
+
+        private void WriteScavengeDetailEventCompleted(ClientMessage.WriteEventsCompleted msg, Event eventToWrite, string streamId, int retryCount)
+        {
+            if (msg.Result != OperationResult.Success)
+            {
+                if (retryCount > 0)
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retrying {1}/{2}. Reason: {3}", streamId, (_retryAttempts - retryCount) + 1, _retryAttempts, msg.Result);
+                    WriteScavengeDetailEvent(streamId, eventToWrite, --retryCount);
+                }
+                else
+                {
+                    Log.Error("Failed to write an event to the {0} stream. Retry limit of {1} reached. Reason: {2}", streamId, _retryAttempts, msg.Result);
+                }
+            }
+            else
+            {
+                string eventLinkTo = string.Format("{0}@{1}", msg.FirstEventNumber, streamId);
+                var linkToIndexEvent = new Event(Guid.NewGuid(), SystemEventTypes.LinkTo, false, eventLinkTo, null);
+                WriteScavengeIndexEvent(linkToIndexEvent, _retryAttempts);
+            }
+        }
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Common.Log;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Storage;
+using EventStore.Core.Services.UserManagement;
+
+namespace EventStore.Core.TransactionLog.Chunks
+{
+    public class TFChunkScavengerLogManager : ITFChunkScavengerLogManager
+    {
+        private readonly string _nodeEndpoint;
+        private readonly TimeSpan _scavengeHistoryMaxAge;
+        private readonly IODispatcher _ioDispatcher;
+        private const int MaxRetryCount = 5;
+        private static readonly ILogger Log = LogManager.GetLoggerFor<StorageScavenger>();
+
+        public TFChunkScavengerLogManager(string nodeEndpoint, TimeSpan scavengeHistoryMaxAge, IODispatcher ioDispatcher)
+        {
+            _nodeEndpoint = nodeEndpoint;
+            _scavengeHistoryMaxAge = scavengeHistoryMaxAge;
+            _ioDispatcher = ioDispatcher;
+        }
+
+        public void Initialise()
+        {
+            var metaStreamId = SystemStreams.MetastreamOf(SystemStreams.ScavengesStream);
+            var metadata = new StreamMetadata(maxAge: _scavengeHistoryMaxAge);
+            var metaStreamEvent = new Event(Guid.NewGuid(), SystemEventTypes.StreamMetadata, isJson: true,
+                data: metadata.ToJsonBytes(), metadata: null);
+            _ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => {
+                if (m.Result != OperationResult.Success)
+                {
+                    Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge.TotalDays, SystemStreams.ScavengesStream, m.Result);
+                }
+            });
+
+            var indexInitializedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeIndexInitialized,
+                true, new Dictionary<string, object> { }.ToJsonBytes(), null);
+            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.NoStream, indexInitializedEvent, SystemAccount.Principal, m => {
+                if (m.Result != OperationResult.Success && m.Result != OperationResult.WrongExpectedVersion)
+                {
+                    Log.Error("Failed to write the {0} event to the {1} stream. Reason: {2}", SystemEventTypes.ScavengeIndexInitialized, SystemStreams.ScavengesStream, m.Result);
+                }
+            });
+        }
+
+        public ITFChunkScavengerLog CreateLog()
+        {
+            return new TFChunkScavengerLog(_ioDispatcher, Guid.NewGuid(), _nodeEndpoint, MaxRetryCount, _scavengeHistoryMaxAge);
+        }
+    }
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using EventStore.Common.Log;
-using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
@@ -36,15 +34,6 @@ namespace EventStore.Core.TransactionLog.Chunks
                 if (m.Result != OperationResult.Success)
                 {
                     Log.Error("Failed to write the $maxAge of {0} days metadata for the {1} stream. Reason: {2}", _scavengeHistoryMaxAge.TotalDays, SystemStreams.ScavengesStream, m.Result);
-                }
-            });
-
-            var indexInitializedEvent = new Event(Guid.NewGuid(), SystemEventTypes.ScavengeIndexInitialized,
-                true, new Dictionary<string, object> { }.ToJsonBytes(), null);
-            _ioDispatcher.WriteEvent(SystemStreams.ScavengesStream, ExpectedVersion.NoStream, indexInitializedEvent, SystemAccount.Principal, m => {
-                if (m.Result != OperationResult.Success && m.Result != OperationResult.WrongExpectedVersion)
-                {
-                    Log.Error("Failed to write the {0} event to the {1} stream. Reason: {2}", SystemEventTypes.ScavengeIndexInitialized, SystemStreams.ScavengesStream, m.Result);
                 }
             });
         }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.TransactionLog.Chunks
 
         public ITFChunkScavengerLog CreateLog()
         {
-            return new TFChunkScavengerLog(_ioDispatcher, Guid.NewGuid(), _nodeEndpoint, MaxRetryCount, _scavengeHistoryMaxAge);
+            return new TFChunkScavengerLog(_ioDispatcher, Guid.NewGuid().ToString(), _nodeEndpoint, MaxRetryCount, _scavengeHistoryMaxAge);
         }
     }
 }

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -364,18 +364,17 @@ message NotHandled {
 message ScavengeDatabase {
 }
 
-message ScavengeDatabaseCompleted {
+message ScavengeDatabaseResponse {
 	
 	enum ScavengeResult {
-		Success = 0;
+		Started = 0;
 		InProgress = 1;
-		Failed = 2;
+		Unauthorized = 2;
 	}
 	
 	required ScavengeResult result = 1;
-	optional string error = 2;
-	required int32 total_time_ms = 3;
-	required int64 total_space_saved = 4;
+	optional string scavengeId = 2;
+	
 }
 
 message IdentifyClient {


### PR DESCRIPTION
This PR includes #1629 and will look a lot smaller once that is merged.

This allows operations to stop a running scavenge by calling DELETE /admin/scavenge/{scavengeId}. The scavenge log will show a completed/stopped event.

I moved the threading code to inside the TFChunkScavenger and changed it to a Task.