### PR TITLE
Add option to reduce pressure on the system file cache

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -232,6 +232,9 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.SkipIndexScanOnReadsDescr, Opts.AppGroup)]
         public bool SkipIndexScanOnReads { get; set; }
 
+        [ArgDescription(Opts.ReduceFileCachePressureDescr, Opts.DbGroup)]
+        public bool ReduceFileCachePressure { get; set; }
+
         public ClusterNodeOptions()
         {
             Config = "";
@@ -345,6 +348,7 @@ namespace EventStore.ClusterNode
             AlwaysKeepScavenged = Opts.AlwaysKeepScavengedDefault;
 
             SkipIndexScanOnReads = Opts.SkipIndexScanOnReadsDefault;
+            ReduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
 
             ConnectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
             ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -281,6 +281,8 @@ namespace EventStore.ClusterNode
                 builder.EnableWriteThrough();
             if (options.SkipIndexScanOnReads)
                 builder.SkipIndexScanOnReads();
+            if (options.ReduceFileCachePressure)
+                builder.ReduceFileCachePressure();
 
             if (options.IntSecureTcpPort > 0 || options.ExtSecureTcpPort > 0)
             {

--- a/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
@@ -94,7 +94,7 @@ namespace EventStore.Core.Tests.TransactionLog.Optimization
 
         private TFChunk CreateChunk(int chunkNumber, bool scavenged, out List<PosMap> posmap){
             var map = new List<PosMap>();
-            var chunk = TFChunk.CreateNew(GetFilePathFor("chunk-"+chunkNumber+"-"+Guid.NewGuid()), 1024*1024, chunkNumber, chunkNumber, scavenged, false, false, false, 5);
+            var chunk = TFChunk.CreateNew(GetFilePathFor("chunk-"+chunkNumber+"-"+Guid.NewGuid()), 1024*1024, chunkNumber, chunkNumber, scavenged, false, false, false, 5, false);
             long offset = chunkNumber * 1024 * 1024;
             long logPos = 0 + offset;
             for (int i = 0, n = ChunkFooter.Size/PosMap.FullSize + 1; i < n; ++i)

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging
         public void is_fully_resident_in_memory_when_cached()
         {
             var map = new List<PosMap>();
-            var chunk = TFChunk.CreateNew(Filename, 1024*1024, 0, 0, true, false, false, false, 5);
+            var chunk = TFChunk.CreateNew(Filename, 1024*1024, 0, 0, true, false, false, false, 5, false);
             long logPos = 0;
             for (int i = 0, n = ChunkFooter.Size/PosMap.FullSize + 1; i < n; ++i)
             {

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.TransactionLog
         {
             return TFChunk.CreateNew(fileName, chunkSize, 0, 0, 
                                      isScavenged: isScavenged, inMem: false, unbuffered: false, 
-                                     writethrough: false, initialReaderCount: 5);
+                                     writethrough: false, initialReaderCount: 5, reduceFileCachePressure: false);
         }
     }
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Tests.TransactionLog
             base.TestFixtureSetUp();
             _chunk = TFChunkHelper.CreateNewChunk(Filename);
             _chunk.Complete();
-            _testChunk = TFChunk.FromCompletedFile(Filename, true, false, 5);
+            _testChunk = TFChunk.FromCompletedFile(Filename, true, false, 5, reduceFileCachePressure:false);
         }
 
         [TearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -10,7 +10,7 @@ namespace EventStore.Core.Tests.TransactionLog
         [Test]
         public void it_should_throw_a_file_not_found_exception()
         {
-            Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5));
+            Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5, reduceFileCachePressure: false));
         }
     }
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog
             _result = _chunk.TryAppend(_record);
             _chunk.Flush();
             _chunk.Complete();
-            _cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5);
+            _cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5, reduceFileCachePressure: false);
             _cachedChunk.CacheInMemory();
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog
             _result = _chunk.TryAppend(_record);
             _chunk.Flush();
             _chunk.Complete();
-            _uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5);
+            _uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false, initialReaderCount: 5, reduceFileCachePressure: false);
             _uncachedChunk.CacheInMemory();
             _uncachedChunk.UnCacheFromMemory();
         }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -76,6 +76,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
         public readonly bool AlwaysKeepScavenged;
         public readonly bool SkipIndexScanOnReads;
+        public readonly bool ReduceFileCachePressure;
 
         public readonly bool GossipOnSingleNode;
 
@@ -140,7 +141,8 @@ namespace EventStore.Core.Cluster.Settings
                                     int readerThreadsCount = 4,
                                     bool alwaysKeepScavenged = false,
                                     bool gossipOnSingleNode = false,
-                                    bool skipIndexScanOnReads = false)
+                                    bool skipIndexScanOnReads = false,
+                                    bool reduceFileCachePressure = false)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -233,6 +235,7 @@ namespace EventStore.Core.Cluster.Settings
             ReaderThreadsCount = readerThreadsCount;
             AlwaysKeepScavenged = alwaysKeepScavenged;
             SkipIndexScanOnReads = skipIndexScanOnReads;
+            ReduceFileCachePressure = reduceFileCachePressure;
         }
 
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -52,10 +52,10 @@ namespace EventStore.Core.TransactionLog.Chunks
                     // but the actual last chunk is (lastChunkNum-1) one and it could be not completed yet -- perfectly valid situation.
                     var footer = ReadChunkFooter(versions[0]);
                     if (footer.IsCompleted)
-                        chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache: Config.OptimizeReadSideCache);
+                        chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache: Config.OptimizeReadSideCache, reduceFileCachePressure: Config.ReduceFileCachePressure);
                     else
                     {
-                        chunk = TFChunk.TFChunk.FromOngoingFile(versions[0], Config.ChunkSize, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough, initialReaderCount:Config.InitialReaderCount);
+                        chunk = TFChunk.TFChunk.FromOngoingFile(versions[0], Config.ChunkSize, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough, initialReaderCount:Config.InitialReaderCount, reduceFileCachePressure: Config.ReduceFileCachePressure);
                         // chunk is full with data, we should complete it right here
                         if (!readOnly)
                             chunk.Complete();
@@ -63,7 +63,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 }
                 else
                 {
-                    chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache: Config.OptimizeReadSideCache);
+                    chunk = TFChunk.TFChunk.FromCompletedFile(versions[0], verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache: Config.OptimizeReadSideCache, reduceFileCachePressure: Config.ReduceFileCachePressure);
                 }
                 Manager.AddChunk(chunk);
                 chunkNum = chunk.ChunkHeader.ChunkEndNumber + 1;
@@ -84,7 +84,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 var chunkLocalPos = chunkHeader.GetLocalLogPosition(checkpoint);
                 if (chunkHeader.IsScavenged)
                 {
-                    var lastChunk = TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache: Config.OptimizeReadSideCache);
+                    var lastChunk = TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false, unbufferedRead:Config.Unbuffered, initialReaderCount:Config.InitialReaderCount, optimizeReadSideCache:Config.OptimizeReadSideCache, reduceFileCachePressure:Config.ReduceFileCachePressure);
                     if (lastChunk.ChunkFooter.LogicalDataSize != chunkLocalPos)
                     {
                         lastChunk.Dispose();
@@ -106,7 +106,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 }
                 else
                 {
-                    var lastChunk = TFChunk.TFChunk.FromOngoingFile(chunkFileName, (int)chunkLocalPos, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough, initialReaderCount:Config.InitialReaderCount);
+                    var lastChunk = TFChunk.TFChunk.FromOngoingFile(chunkFileName, (int)chunkLocalPos, checkSize: false, unbuffered:Config.Unbuffered, writethrough:Config.WriteThrough, initialReaderCount:Config.InitialReaderCount, reduceFileCachePressure:Config.ReduceFileCachePressure);
                     Manager.AddChunk(lastChunk);
                 }
             }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -20,6 +20,7 @@ namespace EventStore.Core.TransactionLog.Chunks
         public readonly bool WriteThrough;
         public readonly int InitialReaderCount;
         public readonly bool OptimizeReadSideCache;
+        public readonly bool ReduceFileCachePressure;
 
         public TFChunkDbConfig(string path, 
                                IFileNamingStrategy fileNamingStrategy, 
@@ -34,7 +35,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                bool inMemDb = false,
                                bool unbuffered = false,
                                bool writethrough = false,
-                               bool optimizeReadSideCache = false)
+                               bool optimizeReadSideCache = false,
+                               bool reduceFileCachePressure = false)
         {
             Ensure.NotNullOrEmpty(path, "path");
             Ensure.NotNull(fileNamingStrategy, "fileNamingStrategy");
@@ -61,6 +63,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             WriteThrough = writethrough;
             InitialReaderCount = initialReaderCount;
             OptimizeReadSideCache = optimizeReadSideCache;
+            ReduceFileCachePressure = reduceFileCachePressure;
         }
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -106,7 +106,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                                     _config.InMemDb,
                                                     _config.Unbuffered,
                                                     _config.WriteThrough,
-                                                    _config.InitialReaderCount);
+                                                    _config.InitialReaderCount,
+                                                    _config.ReduceFileCachePressure);
         }
 
         public TFChunk.TFChunk AddNewChunk()
@@ -123,7 +124,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                                       inMem: _config.InMemDb,
                                                       unbuffered: _config.Unbuffered,
                                                       writethrough: _config.WriteThrough,
-                                                      initialReaderCount: _config.InitialReaderCount);
+                                                      initialReaderCount: _config.InitialReaderCount,
+                                                      reduceFileCachePressure: _config.ReduceFileCachePressure);
                 AddChunk(chunk);
                 return chunk;
             }
@@ -147,7 +149,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                                              _config.InMemDb,
                                                              unbuffered: _config.Unbuffered,
                                                              writethrough: _config.WriteThrough,
-                                                             initialReaderCount: _config.InitialReaderCount);
+                                                             initialReaderCount: _config.InitialReaderCount,
+                                                             reduceFileCachePressure: _config.ReduceFileCachePressure);
                 AddChunk(chunk);
                 return chunk;
             }
@@ -198,7 +201,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 var newFileName = _config.FileNamingStrategy.DetermineBestVersionFilenameFor(chunkHeader.ChunkStartNumber);
                 Log.Info("File {0} will be moved to file {1}", Path.GetFileName(oldFileName), Path.GetFileName(newFileName));
                 File.Move(oldFileName, newFileName);
-                newChunk = TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered, _config.InitialReaderCount, _config.OptimizeReadSideCache);
+                newChunk = TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered, _config.InitialReaderCount, _config.OptimizeReadSideCache, _config.ReduceFileCachePressure);
             }
 
             lock (_chunksLocker)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -160,7 +160,8 @@ namespace EventStore.Core.TransactionLog.Chunks
                                                      inMem: _db.Config.InMemDb,
                                                      unbuffered: _db.Config.Unbuffered,
                                                      writethrough: _db.Config.WriteThrough,
-                                                     initialReaderCount: _db.Config.InitialReaderCount);
+                                                     initialReaderCount: _db.Config.InitialReaderCount,
+                                                     reduceFileCachePressure: _db.Config.ReduceFileCachePressure);
             }
             catch (IOException exc)
             {

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -166,6 +166,9 @@ namespace EventStore.Core.Util
         public const string SkipIndexScanOnReadsDescr = "Skip Index Scan on Reads. This skips the index scan which was used to stop reading duplicates.";
         public static readonly bool SkipIndexScanOnReadsDefault = false;
 
+        public const string ReduceFileCachePressureDescr = "Change the way the DB files are opened to reduce their stickiness in the system file cache.";
+        public static readonly bool ReduceFileCachePressureDefault = false;
+
         //Loading certificates from files
         public const string CertificateFileDescr = "The path to certificate file.";
         public static readonly string CertificateFileDefault = string.Empty;


### PR DESCRIPTION
Second attempt at getting this change in. See issue #1603.

- A command line option to enable this patch. Off by default.
- The only interesting change is TFChunk.cs#377.
- Removes the RandomAccess hint when opening chunk files.
- This makes windows mark the files as standby pages instead of active pages so they are discarded in preference to process memory.

We've been running with this for 9 months. No obvious performance issues and solved all the ones we had related to low memory.
