### PR TITLE
Clean up persistent subscription logging

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointWriter.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointWriter.cs
@@ -50,7 +50,6 @@ namespace EventStore.Core.Services.PersistentSubscription
 
         private void PublishCheckpoint(long state)
         {
-            Log.Debug("Publishing checkpoint for {0}: {1}", _subscriptionStateStream, state);
             _outstandingWrite = true;
             var evnt = new Event(Guid.NewGuid(), "SubscriptionCheckpoint", true, state.ToJson(), null);            
             _ioDispatcher.WriteEvent(_subscriptionStateStream, _version, evnt, SystemAccount.Principal, WriteStateCompleted);
@@ -90,7 +89,6 @@ namespace EventStore.Core.Services.PersistentSubscription
             _outstandingWrite = false;
             if (msg.Result == OperationResult.Success)
             {
-                Log.Debug("Checkpoint write successful for {0}", _subscriptionStateStream);
                 _version = msg.LastEventNumber;
             }
             else


### PR DESCRIPTION
- Make everything consistent with punctuation and naming.
- Use the full subscription id everywhere.
- When retrying an event, log the stream id and event number.
- Reduce the logging of the persistent subscription checkpoints.

The main thing here is the last point. The logs currently have a lot of fairly useless entries for the persistent subscription checkpoints. These are of course in the ES database anyway so no loss removing them.