### PR TITLE
Fix bug in MakeUrl() where url is wrongly formed when query parameters are present

### DIFF
--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/creating.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/creating.cs
@@ -44,6 +44,44 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription
         }
     }
 
+   [TestFixture, Category("LongRunning")]
+    class when_creating_a_subscription_with_query_params : with_admin_user
+    {
+        private HttpWebResponse _response;
+
+        protected override void Given()
+        {
+        }
+
+        protected override void When()
+        {
+            _response = MakeJsonPut(
+                "/subscriptions/stream/groupname334?testing=test",
+                new
+                {
+                    ResolveLinkTos = true
+                }, _admin);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _response.Close();
+        }
+
+        [Test]
+        public void returns_created()
+        {
+            Assert.AreEqual(HttpStatusCode.Created, _response.StatusCode);
+        }
+
+        [Test]
+        public void returns_location_header()
+        {
+            Assert.AreEqual("http://" + _node.ExtHttpEndPoint + "/subscriptions/stream/groupname334", _response.Headers["location"]);
+        }
+    }
+
     [TestFixture, Category("LongRunning")]
     class when_creating_a_subscription_without_permissions : with_admin_user
     {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -61,7 +61,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
             return new RequestParams(done: true);
         }
 
-        protected void Register(IHttpService service, string uriTemplate, string httpMethod, 
+        protected void Register(IHttpService service, string uriTemplate, string httpMethod,
                                 Action<HttpEntityManager, UriTemplateMatch> handler, ICodec[] requestCodecs, ICodec[] responseCodecs)
         {
             service.RegisterAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs), handler);
@@ -82,9 +82,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
         protected static string MakeUrl(HttpEntityManager http, string path)
         {
-            var builder = new UriBuilder(http.ResponseUrl);
             if(path.Length > 0 && path[0] == '/') path = path.Substring(1);
-            builder.Path = builder.Path + path;
+            var hostUri = http.ResponseUrl;
+            var builder = new UriBuilder(hostUri.Scheme, hostUri.Host, hostUri.Port, hostUri.LocalPath + path);
             return builder.Uri.AbsoluteUri;
         }
     }


### PR DESCRIPTION
The bug manifests itself when trying to create a projection in the "Query" tab.