### PR TITLE
Off by one bug in TFChunkDB causing pre-last chunk file not to be verified

### DIFF
--- a/src/EventStore.Core/Exceptions/CorruptDatabaseException.cs
+++ b/src/EventStore.Core/Exceptions/CorruptDatabaseException.cs
@@ -5,5 +5,6 @@ namespace EventStore.Core.Exceptions
     public class CorruptDatabaseException : Exception
     {
         public CorruptDatabaseException(Exception inner) : base("Corrupt database detected.", inner) { }
+        public CorruptDatabaseException(string message, Exception inner) : base(message, inner) { }
     }
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -122,7 +122,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             if (verifyHash && lastChunkNum > 0)
             {
                 var preLastChunk = Manager.GetChunk(lastChunkNum - 1);
-                var lastBgChunkNum = preLastChunk.ChunkHeader.ChunkStartNumber - 1;
+                var lastBgChunkNum = preLastChunk.ChunkHeader.ChunkStartNumber;
                 ThreadPool.QueueUserWorkItem(_ =>
                 {
                     for (int chunkNum = lastBgChunkNum; chunkNum >= 0; )
@@ -143,8 +143,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                         {
                             var msg = string.Format("Verification of chunk {0} failed, terminating server...", chunk);
                             Log.FatalException(exc, msg);
-                            Application.Exit(ExitCode.Error, msg);
-                            return;
+                            throw new CorruptDatabaseException(msg, exc);
                         }
                         chunkNum = chunk.ChunkHeader.ChunkStartNumber - 1;
                     }


### PR DESCRIPTION
Can be reproduced with following steps:
- Create a database with 3 chunk files (chunk-000000.000000 - chunk-000002.000000)
- Stop EventStore
- Change 1 byte of event data in chunk-000001.000000
- Start EventStore
- chunk-000001.000000 is not verified during startup and database starts without errors
