### PR TITLE
Changing user to admin requires restart fix

### DIFF
--- a/src/EventStore.Core/Services/UserManagement/UserManagementService.cs
+++ b/src/EventStore.Core/Services/UserManagement/UserManagementService.cs
@@ -90,7 +90,7 @@ namespace EventStore.Core.Services.UserManagement
                 return;
             } 
             ReadUpdateWriteReply(
-                message, data => data.SetFullName(message.FullName).SetGroups(message.Groups), resetPasswordCache: false);
+                message, data => data.SetFullName(message.FullName).SetGroups(message.Groups), resetPasswordCache: true);
         }
 
         public void Handle(UserManagementMessage.Enable message)


### PR DESCRIPTION
 Changing user to admin requires EventStore node to be restarted earlier.

**Steps to reproduce :** 

1. Run a local event store node using on Mac
mono ./bin/clusternode/EventStore.ClusterNode.exe --run-projections=all --db ../db --log ../logs

2. Create a non-admin user

3. Check that the following request fails:
curl -i -XPOST http://localhost:2113/projection/%24by_category/command/enable -d '' USER:PWD

4. Make the user an admin

5. Run the same curl request again:
curl -i -XPOST http://localhost:2113/projection/%24by_category/command/enable -d '' USER:PWD
And it should fail.

6. Restart the node. It should work now. 

This PR fixes this issue.