### PR TITLE
new EventStore.Plugins library to run plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 TestResult.xml
 *.nupkg
 /packages
+*packages
 /Logs
 /Data
 /Data-logs

--- a/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
+++ b/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
@@ -58,6 +58,9 @@
       <Name>EventStore.Common</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -69,6 +69,10 @@
       <Project>{D42A5833-4F20-4FCC-B364-6207AE016732}</Project>
       <Name>EventStore.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\EventStore.Plugins\EventStore.Plugins.csproj">
+      <Project>{f853ad1d-d328-4169-9a85-94d500844aff}</Project>
+      <Name>EventStore.Plugins</Name>
+    </ProjectReference>
     <ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj">
       <Project>{03E02082-E179-4730-81FF-CE914749D6E3}</Project>
       <Name>EventStore.Projections.Core</Name>

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -19,6 +19,7 @@ using EventStore.Core.Util;
 using System.Net.NetworkInformation;
 using EventStore.Core.Data;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Plugins;
 
 namespace EventStore.ClusterNode
 {
@@ -310,8 +311,31 @@ namespace EventStore.ClusterNode
             var authenticationProviderFactory = GetAuthenticationProviderFactory(options.AuthenticationType, authenticationConfig, plugInContainer);
             var consumerStrategyFactories = GetPlugInConsumerStrategyFactories(plugInContainer);
             builder.WithAuthenticationProvider(authenticationProviderFactory);
+            var pluginFactory = GetServiceFactory(plugInContainer);
+            builder.WithPlugins(pluginFactory);
 
             return builder.Build(options, consumerStrategyFactories);
+        }
+
+        private static IEventStoreServiceFactory GetServiceFactory(CompositionContainer plugInContainer)
+        {
+            var allPlugins = plugInContainer.GetExports<IEventStorePlugin>();
+
+            foreach (var potentialPlugin in allPlugins)
+            {
+                try
+                {
+                    var plugin = potentialPlugin.Value;
+                    Log.Info("Loaded EventStore strategy plugin: {0} version {1}.", plugin.Name, plugin.Version);
+                    return plugin.GetStrategyFactory();
+                }
+                catch (CompositionException ex)
+                {
+                    Log.ErrorException(ex, "Error loading EventStore strategy plugin.");
+                }
+            }
+
+            return null;
         }
 
         private static IPersistentSubscriptionConsumerStrategyFactory[] GetPlugInConsumerStrategyFactories(CompositionContainer plugInContainer)
@@ -375,12 +399,18 @@ namespace EventStore.ClusterNode
         {
             var catalog = new AggregateCatalog();
 
-            catalog.Catalogs.Add(new AssemblyCatalog(typeof (Program).Assembly));
+            catalog.Catalogs.Add(new AssemblyCatalog(typeof(Program).Assembly));
 
             if (Directory.Exists(Locations.PluginsDirectory))
             {
                 Log.Info("Plugins path: {0}", Locations.PluginsDirectory);
                 catalog.Catalogs.Add(new DirectoryCatalog(Locations.PluginsDirectory));
+                // iterate over all directories in .\Plugins dir and add all *Plugin dirs to catalogs
+                foreach (var path in Directory.EnumerateDirectories(Locations.PluginsDirectory, "*Plugin", SearchOption.TopDirectoryOnly))
+                {
+                    Log.Info("Plugin found: {0}", path);
+                    catalog.Catalogs.Add(new DirectoryCatalog(path));
+                }
             }
             else
             {

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -682,6 +682,10 @@
       <Project>{D42A5833-4F20-4FCC-B364-6207AE016732}</Project>
       <Name>EventStore.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\EventStore.Plugins\EventStore.Plugins.csproj">
+      <Project>{f853ad1d-d328-4169-9a85-94d500844aff}</Project>
+      <Name>EventStore.Plugins</Name>
+    </ProjectReference>
     <ProjectReference Include="..\EventStore.Transport.Http\EventStore.Transport.Http.csproj">
       <Project>{30AF4820-DC60-4674-9E19-C4518445545A}</Project>
       <Name>EventStore.Transport.Http</Name>
@@ -715,6 +719,9 @@
     <None Include="Resources\es-tile.png">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -79,6 +79,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly bool SkipIndexScanOnReads;
         public readonly bool ReduceFileCachePressure;
         public readonly IEventStoreServiceFactory PluginsServiceFactory;
+        public readonly IEventStoreControllerFactory PluginsControllerFactory;
 
         public readonly bool GossipOnSingleNode;
 
@@ -145,7 +146,8 @@ namespace EventStore.Core.Cluster.Settings
                                     bool gossipOnSingleNode = false,
                                     bool skipIndexScanOnReads = false,
                                     bool reduceFileCachePressure = false,
-                                    IEventStoreServiceFactory pluginsServiceFactory = null)
+                                    IEventStoreServiceFactory pluginsServiceFactory = null,
+                                    IEventStoreControllerFactory pluginsControllerFactory = null)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -240,6 +242,7 @@ namespace EventStore.Core.Cluster.Settings
             SkipIndexScanOnReads = skipIndexScanOnReads;
             ReduceFileCachePressure = reduceFileCachePressure;
             PluginsServiceFactory = pluginsServiceFactory;
+            PluginsControllerFactory = pluginsControllerFactory;
         }
 
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -8,6 +8,7 @@ using EventStore.Core.Authentication;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Plugins;
 
 namespace EventStore.Core.Cluster.Settings
 {
@@ -77,6 +78,7 @@ namespace EventStore.Core.Cluster.Settings
         public readonly bool AlwaysKeepScavenged;
         public readonly bool SkipIndexScanOnReads;
         public readonly bool ReduceFileCachePressure;
+        public readonly IEventStoreServiceFactory PluginsServiceFactory;
 
         public readonly bool GossipOnSingleNode;
 
@@ -142,7 +144,8 @@ namespace EventStore.Core.Cluster.Settings
                                     bool alwaysKeepScavenged = false,
                                     bool gossipOnSingleNode = false,
                                     bool skipIndexScanOnReads = false,
-                                    bool reduceFileCachePressure = false)
+                                    bool reduceFileCachePressure = false,
+                                    IEventStoreServiceFactory pluginsServiceFactory = null)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -236,6 +239,7 @@ namespace EventStore.Core.Cluster.Settings
             AlwaysKeepScavenged = alwaysKeepScavenged;
             SkipIndexScanOnReads = skipIndexScanOnReads;
             ReduceFileCachePressure = reduceFileCachePressure;
+            PluginsServiceFactory = pluginsServiceFactory;
         }
 
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -322,8 +322,9 @@ namespace EventStore.Core
 
             // Plugins 
             var pluginsHostService = new PluginsHostService(vNodeSettings.PluginsServiceFactory);
-            _mainBus.Subscribe(pluginsHostService);
-            var geoReplicaController = new GeoReplicaController(_mainQueue, pluginsHostService);
+            _mainBus.Subscribe<SystemMessage.StateChangeMessage>(pluginsHostService);
+            _mainBus.Subscribe<PluginMessage.GetStats>(pluginsHostService);
+            var geoReplicaController = new GeoReplicaController(_mainQueue, _workersHandler, pluginsHostService);
 
             // HTTP SENDERS
             gossipController.SubscribeSenders(httpPipe);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -324,7 +324,7 @@ namespace EventStore.Core
             var pluginsHostService = new PluginsHostService(vNodeSettings.PluginsServiceFactory);
             _mainBus.Subscribe<SystemMessage.StateChangeMessage>(pluginsHostService);
             _mainBus.Subscribe<PluginMessage.GetStats>(pluginsHostService);
-            var geoReplicaController = new GeoReplicaController(_mainQueue, _workersHandler, pluginsHostService);
+            var pluginController = new PluginsController(vNodeSettings.PluginsControllerFactory, _mainQueue, _workersHandler, pluginsHostService);
 
             // HTTP SENDERS
             gossipController.SubscribeSenders(httpPipe);
@@ -345,7 +345,7 @@ namespace EventStore.Core
             if(vNodeSettings.GossipOnPublic)
                 _externalHttpService.SetupController(gossipController);
             _externalHttpService.SetupController(histogramController);
-            _externalHttpService.SetupController(geoReplicaController);
+            _externalHttpService.SetupController(pluginController);
 
             _mainBus.Subscribe<SystemMessage.SystemInit>(_externalHttpService);
             _mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_externalHttpService);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -36,6 +36,7 @@ using System.Threading;
 using EventStore.Core.Services.Histograms;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using System.Threading.Tasks;
+using EventStore.Core.Services.Plugins;
 
 namespace EventStore.Core
 {
@@ -452,6 +453,10 @@ namespace EventStore.Core
             _mainBus.Subscribe(perSubscrQueue.WidenFrom<MonitoringMessage.GetStreamPersistentSubscriptionStats, Message>());
             _mainBus.Subscribe(perSubscrQueue.WidenFrom<MonitoringMessage.GetPersistentSubscriptionStats, Message>());
             _mainBus.Subscribe(perSubscrQueue.WidenFrom<SubscriptionMessage.PersistentSubscriptionTimerTick, Message>());
+
+            // Plugins 
+            var pluginsHostService = new PluginsHostService(vNodeSettings.PluginsServiceFactory);
+            _mainBus.Subscribe(pluginsHostService);
 
             //TODO CC can have multiple threads working on subscription if partition
             var consumerStrategyRegistry = new PersistentSubscriptionConsumerStrategyRegistry(_mainQueue, _mainBus, vNodeSettings.AdditionalConsumerStrategies);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -321,7 +321,7 @@ namespace EventStore.Core
             var electController = new ElectController(_mainQueue);
 
             // Plugins 
-            var pluginsHostService = new PluginsHostService(vNodeSettings.PluginsServiceFactory);
+            var pluginsHostService = new PluginsHostService(vNodeSettings.PluginsServiceFactory, db.Config.WriterCheckpoint);
             _mainBus.Subscribe<SystemMessage.StateChangeMessage>(pluginsHostService);
             _mainBus.Subscribe<PluginMessage.GetStats>(pluginsHostService);
             var pluginController = new PluginsController(vNodeSettings.PluginsControllerFactory, _mainQueue, _workersHandler, pluginsHostService);

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -282,7 +282,7 @@
     <Compile Include="Services\Transport\Http\Authentication\Rfc2898PasswordHashAlgorithm.cs" />
     <Compile Include="Data\UserData.cs" />
     <Compile Include="Services\Transport\Http\Authentication\TrustedHttpAuthenticationProvider.cs" />
-    <Compile Include="Services\Transport\Http\Controllers\GeoReplicaController.cs" />
+    <Compile Include="Services\Transport\Http\Controllers\PluginsController.cs" />
     <Compile Include="Services\Transport\Http\Controllers\ClusterWebUIController.cs" />
     <Compile Include="Services\Transport\Http\Controllers\ElectController.cs" />
     <Compile Include="Services\Transport\Http\Controllers\GossipController.cs" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>..\..\bin\intermediate\</OutputPath>
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -232,6 +232,7 @@
     <Compile Include="Services\PersistentSubscription\RetryableMessage.cs" />
     <Compile Include="Services\PersistentSubscription\SequencedEvent.cs" />
     <Compile Include="Services\PersistentSubscription\StreamBuffer.cs" />
+    <Compile Include="Services\Plugins\IPluginPublisher.cs" />
     <Compile Include="Services\Plugins\PluginsHostService.cs" />
     <Compile Include="Services\Replication\MasterReplicationService.cs" />
     <Compile Include="Services\Replication\ReplicaService.cs" />
@@ -280,6 +281,7 @@
     <Compile Include="Services\Transport\Http\Authentication\Rfc2898PasswordHashAlgorithm.cs" />
     <Compile Include="Data\UserData.cs" />
     <Compile Include="Services\Transport\Http\Authentication\TrustedHttpAuthenticationProvider.cs" />
+    <Compile Include="Services\Transport\Http\Controllers\GeoReplicaController.cs" />
     <Compile Include="Services\Transport\Http\Controllers\ClusterWebUIController.cs" />
     <Compile Include="Services\Transport\Http\Controllers\ElectController.cs" />
     <Compile Include="Services\Transport\Http\Controllers\GossipController.cs" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Services\PersistentSubscription\RetryableMessage.cs" />
     <Compile Include="Services\PersistentSubscription\SequencedEvent.cs" />
     <Compile Include="Services\PersistentSubscription\StreamBuffer.cs" />
+    <Compile Include="Services\Plugins\PluginsHostService.cs" />
     <Compile Include="Services\Replication\MasterReplicationService.cs" />
     <Compile Include="Services\Replication\ReplicaService.cs" />
     <Compile Include="Services\RequestForwardingService.cs" />
@@ -441,6 +442,10 @@
     <ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj">
       <Project>{B4C9BE3D-43B1-4049-A23A-5DC53DB3F0B0}</Project>
       <Name>EventStore.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\EventStore.Plugins\EventStore.Plugins.csproj">
+      <Project>{f853ad1d-d328-4169-9a85-94d500844aff}</Project>
+      <Name>EventStore.Plugins</Name>
     </ProjectReference>
     <ProjectReference Include="..\EventStore.Transport.Http\EventStore.Transport.Http.csproj">
       <Project>{30AF4820-DC60-4674-9E19-C4518445545A}</Project>

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -173,6 +173,7 @@
     <Compile Include="Messages\ElectionMessageDtos.cs" />
     <Compile Include="Messages\GossipMessage.cs" />
     <Compile Include="Messages\MemberInfoDto.cs" />
+    <Compile Include="Messages\PluginMessage.cs" />
     <Compile Include="Messages\ReplicationMessage.cs" />
     <Compile Include="Messages\ReplicationMessageDto.cs" />
     <Compile Include="Messages\SubscriptionMessage.cs" />

--- a/src/EventStore.Core/Messages/PluginMessage.cs
+++ b/src/EventStore.Core/Messages/PluginMessage.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using EventStore.Common.Utils;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Messages
+{
+    public static class PluginMessage
+    {
+        public class GetStats : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly IEnvelope Envelope;
+
+            public GetStats(IEnvelope envelope)
+            {
+                Ensure.NotNull(envelope, "envelope");
+                Envelope = envelope;
+            }
+        }
+
+        public class GetStatsCompleted : Message
+        {
+            private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly OperationStatus Result;
+            public readonly string Stats;
+            public string ErrorString;
+
+            public GetStatsCompleted(OperationStatus result, string stats, string errorString = "")
+            {
+                Result = result;
+                Stats = stats;
+                ErrorString = errorString;
+            }
+
+            public enum OperationStatus
+            {
+                Success = 0,
+                NotFound = 1,
+                Fail = 2,
+                NotReady = 3
+            }
+        }
+    }
+}

--- a/src/EventStore.Core/Services/Plugins/IPluginPublisher.cs
+++ b/src/EventStore.Core/Services/Plugins/IPluginPublisher.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace EventStore.Core.Services.Plugins
+{
+    public interface IPluginPublisher
+    {
+        bool TryPublish(IDictionary<string, dynamic> message);
+    }
+}

--- a/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
+++ b/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Services.Plugins
     {
         private static readonly ILogger Log = LogManager.GetLoggerFor<PluginsHostService>();
         private readonly IEventStoreServiceFactory _serviceFactory;
-        private IList<IEventStoreService> _eventStoreServices;
+        private IList<IEventStoreService> _eventStoreServices = new List<IEventStoreService>();
 
         public PluginsHostService(IEventStoreServiceFactory factory)
         {

--- a/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
+++ b/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Common.Log;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Plugins;
+
+namespace EventStore.Core.Services.Plugins
+{
+    public class PluginsHostService : IHandle<SystemMessage.StateChangeMessage>
+    {
+        private static readonly ILogger Log = LogManager.GetLoggerFor<PluginsHostService>();
+        private readonly IEventStoreServiceFactory _serviceFactory;
+        private IList<IEventStoreService> _eventStoreServices;
+
+        public PluginsHostService(IEventStoreServiceFactory factory)
+        {
+            _serviceFactory = factory;
+        }
+
+        public void Handle(SystemMessage.StateChangeMessage message)
+        {
+            if (message.State != VNodeState.Master && message.State != VNodeState.Clone &&
+                message.State != VNodeState.Slave) return;
+            try
+            {
+                var t = new Thread(Start) { IsBackground = true };
+                t.Start();
+            }
+            catch (Exception e)
+            {
+                Log.ErrorException(e, "Error on PluginsHostService");
+            }
+        }
+
+        private void Start()
+        {
+            if (_serviceFactory == null)
+                return;
+            _eventStoreServices = _serviceFactory.Create();
+            foreach (var service in _eventStoreServices)
+            {
+                service.Start();
+            }
+        }
+    }
+}

--- a/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
+++ b/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
@@ -11,8 +11,8 @@ using Newtonsoft.Json;
 
 namespace EventStore.Core.Services.Plugins
 {
-    public class PluginsHostService : 
-        IHandle<SystemMessage.StateChangeMessage>, 
+    public class PluginsHostService :
+        IHandle<SystemMessage.StateChangeMessage>,
         IHandle<PluginMessage.GetStats>,
         IPluginPublisher
     {
@@ -47,7 +47,10 @@ namespace EventStore.Core.Services.Plugins
             _eventStoreServices = _serviceFactory.Create();
             foreach (var service in _eventStoreServices)
                 if (service.AutoStart)
+                {
                     service.Start();
+                    Log.Info($"Plugin '{service.Name}' started");
+                }
         }
 
         public bool TryPublish(IDictionary<string, dynamic> request)

--- a/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
+++ b/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.Plugins
         {
             var result = false;
             foreach (var service in _eventStoreServices)
-                if (service.Try(request))
+                if (service.TryHandle(request))
                     result = true;
             return result;
         }

--- a/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
+++ b/src/EventStore.Core/Services/Plugins/PluginsHostService.cs
@@ -19,6 +19,7 @@ namespace EventStore.Core.Services.Plugins
         private static readonly ILogger Log = LogManager.GetLoggerFor<PluginsHostService>();
         private readonly IEventStoreServiceFactory _serviceFactory;
         private IList<IEventStoreService> _eventStoreServices = new List<IEventStoreService>();
+        private bool _started;
 
         public PluginsHostService(IEventStoreServiceFactory factory)
         {
@@ -29,10 +30,13 @@ namespace EventStore.Core.Services.Plugins
         {
             if (message.State != VNodeState.Master && message.State != VNodeState.Clone &&
                 message.State != VNodeState.Slave) return;
+            if (_started)
+                return;
             try
             {
                 var t = new Thread(Start) { IsBackground = true };
                 t.Start();
+                _started = true;
             }
             catch (Exception e)
             {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/GeoReplicaController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/GeoReplicaController.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Common.Log;
+using EventStore.Core.Bus;
+using EventStore.Core.Services.Plugins;
+using EventStore.Transport.Http;
+using EventStore.Transport.Http.Codecs;
+using EventStore.Transport.Http.EntityManagement;
+
+namespace EventStore.Core.Services.Transport.Http.Controllers
+{
+    public class GeoReplicaController : CommunicationController
+    {
+        private readonly IPluginPublisher _pluginPublisher;
+        private static readonly ILogger Log = LogManager.GetLoggerFor<GeoReplicaController>();
+
+        private static readonly ICodec[] SupportedCodecs = new ICodec[] { Codec.Text, Codec.Json, Codec.Xml, Codec.ApplicationXml };
+
+        public GeoReplicaController(IPublisher publisher, IPluginPublisher pluginPublisher) : base(publisher)
+        {
+            _pluginPublisher = pluginPublisher;
+        }
+
+        protected override void SubscribeCore(IHttpService service)
+        {
+            service.RegisterAction(new ControllerAction("/georeplica/dispatcher/{name}/start", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs), OnPostGeoReplicaStart);
+            service.RegisterAction(new ControllerAction("/georeplica/dispatcher/{name}/stop", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs), OnPostGeoReplicaStop);
+        }
+
+        private void OnPostGeoReplicaStart(HttpEntityManager entity, UriTemplateMatch match)
+        {
+            if (entity.User != null && (entity.User.IsInRole(SystemRoles.Admins) || entity.User.IsInRole(SystemRoles.Operations)))
+            {
+                var name = match.BoundVariables["name"];
+                Log.Info("Request start GeoReplica because Start command has been received.");
+                ProcessRequest(entity, new Dictionary<string, dynamic>
+                {
+                    {"Name", name},
+                    {"ServiceType", "Dispatcher"},
+                    {"Action", "Start"}
+                });
+            }
+            else
+            {
+                entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
+            }
+        }
+
+        private void OnPostGeoReplicaStop(HttpEntityManager entity, UriTemplateMatch match)
+        {
+            if (entity.User != null && (entity.User.IsInRole(SystemRoles.Admins) || entity.User.IsInRole(SystemRoles.Operations)))
+            {
+                var name = match.BoundVariables["name"];
+                Log.Info("Request stop GeoReplica because Stop request has been received.");
+                ProcessRequest(entity,
+                    new Dictionary<string, dynamic>
+                    {
+                        {"Name", name},
+                        {"ServiceType", "Dispatcher"},
+                        {"Action", "Stop"}
+                    });
+            }
+            else
+            {
+                entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
+            }
+        }
+
+        private void ProcessRequest(HttpEntityManager entity, IDictionary<string, dynamic> request)
+        {
+            if (_pluginPublisher.TryPublish(request))
+            {
+                entity.ReplyStatus(HttpStatusCode.OK, "OK", LogReplyError);
+            }
+            else
+            {
+                entity.ReplyStatus(HttpStatusCode.BadRequest, "KO", LogReplyError);
+            }
+        }
+
+        private void LogReplyError(Exception exc)
+        {
+            Log.Debug("Error while closing HTTP connection (georeplica controller): {0}.", exc.Message);
+        }
+    }
+}

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PluginsController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PluginsController.cs
@@ -30,6 +30,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
         protected override void SubscribeCore(IHttpService service)
         {
+            if (_eventStoreControllerFactory == null)
+                return;
             _controllers = _eventStoreControllerFactory.Create();
             foreach (var ctrl in _controllers)
             {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PluginsController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PluginsController.cs
@@ -30,6 +30,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
 
         protected override void SubscribeCore(IHttpService service)
         {
+            service.RegisterAction(new ControllerAction("plugins", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs), OnPostConfig);
             if (_eventStoreControllerFactory == null)
                 return;
             _controllers = _eventStoreControllerFactory.Create();
@@ -47,6 +48,28 @@ namespace EventStore.Core.Services.Transport.Http.Controllers
                 _networkSendQueue, entity, Format.GetPluginStatsCompleted,
                 (e, m) => Configure.Ok(e.ResponseCodec.ContentType, Helper.UTF8NoBom, null, null, false));
             Publish(new PluginMessage.GetStats(sendToHttpEnvelope));
+        }
+
+        private void OnPostConfig(HttpEntityManager entity, UriTemplateMatch match)
+        {
+            if (entity.User != null && (entity.User.IsInRole(SystemRoles.Admins) || entity.User.IsInRole(SystemRoles.Operations)))
+            {
+                // TODO
+
+                //var serviceType = match.BoundVariables["servicetype"];
+                //var name = match.BoundVariables["name"];
+                //Log.Info("Request start a plugin service because Start command has been received.");
+                //ProcessRequest(entity, new Dictionary<string, dynamic>
+                //{
+                //    {"Name", name},
+                //    {"ServiceType", serviceType},
+                //    {"Action", "Start"}
+                //});
+            }
+            else
+            {
+                entity.ReplyStatus(HttpStatusCode.Unauthorized, "Unauthorized", LogReplyError);
+            }
         }
 
         private void OnPostPluginStart(HttpEntityManager entity, UriTemplateMatch match)

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -89,6 +89,14 @@ namespace EventStore.Core.Services.Transport.Http
             return entity.ResponseCodec.To(completed.Stats);
         }
 
+        public static string GetPluginStatsCompleted(HttpResponseFormatterArgs entity, Message message)
+        {
+            if (!(message is PluginMessage.GetStatsCompleted completed) || !string.IsNullOrEmpty(completed.ErrorString))
+                return string.Empty;
+
+            return entity.ResponseCodec.To(completed.Stats);
+        }
+
         public static string GetReplicationStatsCompleted(HttpResponseFormatterArgs entity, Message message)
         {
             if (message.GetType() != typeof(ReplicationMessage.GetReplicationStatsCompleted))

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -91,7 +91,8 @@ namespace EventStore.Core.Services.Transport.Http
 
         public static string GetPluginStatsCompleted(HttpResponseFormatterArgs entity, Message message)
         {
-            if (!(message is PluginMessage.GetStatsCompleted completed) || !string.IsNullOrEmpty(completed.ErrorString))
+            var completed = message as PluginMessage.GetStatsCompleted;
+            if (completed == null || !string.IsNullOrEmpty(completed.ErrorString))
                 return string.Empty;
 
             return entity.ResponseCodec.To(completed.Stats);

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -18,6 +18,7 @@ using EventStore.Core.Services.Transport.Http.Controllers;
 using EventStore.Core.Data;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using EventStore.Core.Index;
+using EventStore.Plugins;
 
 namespace EventStore.Core
 {
@@ -130,6 +131,7 @@ namespace EventStore.Core
         protected bool _alwaysKeepScavenged;
         protected bool _skipIndexScanOnReads;
         private bool _reduceFileCachePressure;
+        protected IEventStoreServiceFactory _pluginsServiceFactory;
 
         private bool _gossipOnSingleNode;
         // ReSharper restore FieldCanBeMadeReadOnly.Local
@@ -220,6 +222,12 @@ namespace EventStore.Core
             _chunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
             _projectionsQueryExpiry = TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault);
             _reduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
+        }
+
+        public VNodeBuilder WithPlugins(IEventStoreServiceFactory pluginsServiceFactory)
+        {
+            _pluginsServiceFactory = pluginsServiceFactory;
+            return this;
         }
 
         protected VNodeBuilder WithSingleNodeSettings()
@@ -1421,7 +1429,9 @@ namespace EventStore.Core
                     _readerThreadsCount,
                     _alwaysKeepScavenged,
                     _gossipOnSingleNode,
-                    _skipIndexScanOnReads);
+                    _skipIndexScanOnReads,
+                    _reduceFileCachePressure,
+                    _pluginsServiceFactory);
             var infoController = new InfoController(options, _projectionType);
 
             _log.Info("{0,-25} {1}", "INSTANCE ID:", _vNodeSettings.NodeInfo.InstanceId);

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -132,6 +132,7 @@ namespace EventStore.Core
         protected bool _skipIndexScanOnReads;
         private bool _reduceFileCachePressure;
         protected IEventStoreServiceFactory _pluginsServiceFactory;
+        protected IEventStoreControllerFactory _pluginsControllerFactory;
 
         private bool _gossipOnSingleNode;
         // ReSharper restore FieldCanBeMadeReadOnly.Local
@@ -227,6 +228,12 @@ namespace EventStore.Core
         public VNodeBuilder WithPlugins(IEventStoreServiceFactory pluginsServiceFactory)
         {
             _pluginsServiceFactory = pluginsServiceFactory;
+            return this;
+        }
+
+        public VNodeBuilder WithControllers(IEventStoreControllerFactory pluginsControllerFactory)
+        {
+            _pluginsControllerFactory = pluginsControllerFactory;
             return this;
         }
 
@@ -1431,7 +1438,8 @@ namespace EventStore.Core
                     _gossipOnSingleNode,
                     _skipIndexScanOnReads,
                     _reduceFileCachePressure,
-                    _pluginsServiceFactory);
+                    _pluginsServiceFactory,
+                    _pluginsControllerFactory);
             var infoController = new InfoController(options, _projectionType);
 
             _log.Info("{0,-25} {1}", "INSTANCE ID:", _vNodeSettings.NodeInfo.InstanceId);

--- a/src/EventStore.Plugins/EventStore.Plugins.csproj
+++ b/src/EventStore.Plugins/EventStore.Plugins.csproj
@@ -40,8 +40,11 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="IEventStoreController.cs" />
+    <Compile Include="IEventStoreControllerPlugin.cs" />
     <Compile Include="IEventStorePlugin.cs" />
     <Compile Include="IEventStoreService.cs" />
+    <Compile Include="IEventStoreControllerFactory.cs" />
     <Compile Include="IEventStoreServiceFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/EventStore.Plugins/EventStore.Plugins.csproj
+++ b/src/EventStore.Plugins/EventStore.Plugins.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F853AD1D-D328-4169-9A85-94D500844AFF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>EventStore.Plugins</RootNamespace>
+    <AssemblyName>EventStore.Plugins</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="IEventStorePlugin.cs" />
+    <Compile Include="IEventStoreService.cs" />
+    <Compile Include="IEventStoreServiceFactory.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/src/EventStore.Plugins/EventStore.Plugins.nuspec
+++ b/src/EventStore.Plugins/EventStore.Plugins.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>EventStore.Plugins</id>
+    <version>1.0.0</version>
+    <title>EventStore.Plugins</title>
+    <authors>EventStore LLP - Riccardo Di Nuzzo</authors>
+    <owners>EventStore LLP</owners>
+    <licenseUrl>https://github.com/EventStore/EventStore/blob/master/LICENSE.md</licenseUrl>
+    <projectUrl>https://github.com/EventStore/EventStore</projectUrl>    
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>This library is used to build Plugins for Event Store (eventstore.org)</description>
+    <releaseNotes>First release</releaseNotes>
+    <copyright>Copyright 2018</copyright>
+    <tags>EventStore, Plugin</tags>
+  </metadata>
+</package>

--- a/src/EventStore.Plugins/EventStore.Plugins.nuspec
+++ b/src/EventStore.Plugins/EventStore.Plugins.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>EventStore.Plugins</id>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <title>EventStore.Plugins</title>
     <authors>EventStore LLP - Riccardo Di Nuzzo</authors>
     <owners>EventStore LLP</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/EventStore/EventStore</projectUrl>    
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This library is used to build Plugins for Event Store (eventstore.org)</description>
-    <releaseNotes>Exposed a method to pull the plugin stats</releaseNotes>
+    <releaseNotes>Changed method name (previous it was Try now it is TryHandle)</releaseNotes>
     <copyright>Copyright 2018</copyright>
     <tags>EventStore, Plugin</tags>
   </metadata>

--- a/src/EventStore.Plugins/EventStore.Plugins.nuspec
+++ b/src/EventStore.Plugins/EventStore.Plugins.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>EventStore.Plugins</id>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <title>EventStore.Plugins</title>
     <authors>EventStore LLP - Riccardo Di Nuzzo</authors>
     <owners>EventStore LLP</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/EventStore/EventStore</projectUrl>    
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This library is used to build Plugins for Event Store (eventstore.org)</description>
-    <releaseNotes>First release</releaseNotes>
+    <releaseNotes>Exposed a method to push an Http message into the plugin</releaseNotes>
     <copyright>Copyright 2018</copyright>
     <tags>EventStore, Plugin</tags>
   </metadata>

--- a/src/EventStore.Plugins/EventStore.Plugins.nuspec
+++ b/src/EventStore.Plugins/EventStore.Plugins.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>EventStore.Plugins</id>
-    <version>1.3.0</version>
+    <version>1.5.0</version>
     <title>EventStore.Plugins</title>
     <authors>EventStore LLP - Riccardo Di Nuzzo</authors>
     <owners>EventStore LLP</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/EventStore/EventStore</projectUrl>    
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This library is used to build Plugins for Event Store (eventstore.org)</description>
-    <releaseNotes>Changed method name (previous it was Try now it is TryHandle)</releaseNotes>
+    <releaseNotes>Implemented Http Controller plugins</releaseNotes>
     <copyright>Copyright 2018</copyright>
     <tags>EventStore, Plugin</tags>
   </metadata>

--- a/src/EventStore.Plugins/EventStore.Plugins.nuspec
+++ b/src/EventStore.Plugins/EventStore.Plugins.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>EventStore.Plugins</id>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <title>EventStore.Plugins</title>
     <authors>EventStore LLP - Riccardo Di Nuzzo</authors>
     <owners>EventStore LLP</owners>
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/EventStore/EventStore</projectUrl>    
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>This library is used to build Plugins for Event Store (eventstore.org)</description>
-    <releaseNotes>Exposed a method to push an Http message into the plugin</releaseNotes>
+    <releaseNotes>Exposed a method to pull the plugin stats</releaseNotes>
     <copyright>Copyright 2018</copyright>
     <tags>EventStore, Plugin</tags>
   </metadata>

--- a/src/EventStore.Plugins/IEventStoreController.cs
+++ b/src/EventStore.Plugins/IEventStoreController.cs
@@ -1,0 +1,9 @@
+﻿namespace EventStore.Plugins
+{
+    public interface IEventStoreController
+    {
+        string StartUriTemplate { get; }
+        string StopUriTemplate { get; }
+        string StatsUriTemplate { get; }
+    }
+}

--- a/src/EventStore.Plugins/IEventStoreControllerFactory.cs
+++ b/src/EventStore.Plugins/IEventStoreControllerFactory.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace EventStore.Plugins
+{
+    public interface IEventStoreControllerFactory
+    {
+        IList<IEventStoreController> Create();
+    }
+}

--- a/src/EventStore.Plugins/IEventStoreControllerPlugin.cs
+++ b/src/EventStore.Plugins/IEventStoreControllerPlugin.cs
@@ -1,0 +1,9 @@
+﻿namespace EventStore.Plugins
+{
+    public interface IEventStoreControllerPlugin
+    {
+        string Name { get; }
+        string Version { get; }
+        IEventStoreControllerFactory GetStrategyFactory();
+    }
+}

--- a/src/EventStore.Plugins/IEventStorePlugin.cs
+++ b/src/EventStore.Plugins/IEventStorePlugin.cs
@@ -1,0 +1,9 @@
+﻿namespace EventStore.Plugins
+{
+    public interface IEventStorePlugin
+    {
+        string Name { get; }
+        string Version { get; }
+        IEventStoreServiceFactory GetStrategyFactory();
+    }
+}

--- a/src/EventStore.Plugins/IEventStoreService.cs
+++ b/src/EventStore.Plugins/IEventStoreService.cs
@@ -1,0 +1,7 @@
+﻿namespace EventStore.Plugins
+{
+    public interface IEventStoreService
+    {
+        void Start();
+    }
+}

--- a/src/EventStore.Plugins/IEventStoreService.cs
+++ b/src/EventStore.Plugins/IEventStoreService.cs
@@ -9,5 +9,6 @@ namespace EventStore.Plugins
         void Stop();
         bool AutoStart { get; }
         bool Try(IDictionary<string, dynamic> request);
+        IDictionary<string, dynamic> GetStats();
     }
 }

--- a/src/EventStore.Plugins/IEventStoreService.cs
+++ b/src/EventStore.Plugins/IEventStoreService.cs
@@ -8,7 +8,7 @@ namespace EventStore.Plugins
         void Start();
         void Stop();
         bool AutoStart { get; }
-        bool Try(IDictionary<string, dynamic> request);
+        bool TryHandle(IDictionary<string, dynamic> request);
         IDictionary<string, dynamic> GetStats();
     }
 }

--- a/src/EventStore.Plugins/IEventStoreService.cs
+++ b/src/EventStore.Plugins/IEventStoreService.cs
@@ -1,7 +1,13 @@
-﻿namespace EventStore.Plugins
+﻿using System.Collections.Generic;
+
+namespace EventStore.Plugins
 {
     public interface IEventStoreService
     {
+        string Name { get; }
         void Start();
+        void Stop();
+        bool AutoStart { get; }
+        bool Try(IDictionary<string, dynamic> request);
     }
 }

--- a/src/EventStore.Plugins/IEventStoreServiceFactory.cs
+++ b/src/EventStore.Plugins/IEventStoreServiceFactory.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace EventStore.Plugins
+{
+    public interface IEventStoreServiceFactory
+    {
+        IList<IEventStoreService> Create();
+    }
+}

--- a/src/EventStore.Plugins/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Plugins/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("EventStore.Plugins")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("EventStore.Plugins")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f853ad1d-d328-4169-9a85-94d500844aff")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/EventStore.Plugins/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Plugins/Properties/AssemblyInfo.cs
@@ -1,35 +1,18 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("EventStore.Plugins")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Event Store LLP")]
 [assembly: AssemblyProduct("EventStore.Plugins")]
-[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
+//NOTE: Do not change these, they will be modified during the build by TeamCity.
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]
+
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("f853ad1d-d328-4169-9a85-94d500844aff")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: Guid("ccc0be24-ec2c-4a7e-98ae-892648fb1e4c")]

--- a/src/EventStore.Plugins/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Plugins/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Plugins")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Event Store LLP")]
 [assembly: AssemblyProduct("EventStore.Plugins")]
 [assembly: AssemblyCopyright("Copyright ©  2018")]
 [assembly: AssemblyTrademark("")]
@@ -31,6 +31,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -621,6 +621,9 @@
     <Folder Include="Services\checkpoint_strategy\" />
     <Folder Include="Services\projections_manager\parallel_query\" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <IsMac>false</IsMac>

--- a/src/EventStore.sln
+++ b/src/EventStore.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventStore.ClusterNode", "E
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventStore.ClientAPI.Embedded", "EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj", "{0ED5BED0-EBF0-4C9D-B2A3-0EA54A767C3F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventStore.Plugins", "EventStore.Plugins\EventStore.Plugins.csproj", "{F853AD1D-D328-4169-9A85-94D500844AFF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -93,9 +95,16 @@ Global
 		{0ED5BED0-EBF0-4C9D-B2A3-0EA54A767C3F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0ED5BED0-EBF0-4C9D-B2A3-0EA54A767C3F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0ED5BED0-EBF0-4C9D-B2A3-0EA54A767C3F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F853AD1D-D328-4169-9A85-94D500844AFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F853AD1D-D328-4169-9A85-94D500844AFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F853AD1D-D328-4169-9A85-94D500844AFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F853AD1D-D328-4169-9A85-94D500844AFF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {82FD2617-028D-489D-9445-7A177787FEB1}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = EventStore.MultiNode\EventStore.MultiNode.csproj


### PR DESCRIPTION
The new EventStore.Plugins library contains few contracts that can be implemented by an external Plugin to run special features like the new GeoReplicaPlugin
When used to develop a new plugins the new 'EventStore.Plugins' can be referenced as a nuget package
example using Package Manager: install-package EventStore.Plugins

Other minor changes:
- Fixed .gitignore
- There are some changes to test projects that are made by latest version of Visual Studio. It adds an identifier to any Test project