### PR TITLE
Added max count to PersistentSubscriptionConfig

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -693,7 +693,12 @@ namespace EventStore.Core.Services.PersistentSubscription
             Log.Debug("Saving persistent subscription configuration");
             var data = _config.GetSerializedForm();
             var ev = new Event(Guid.NewGuid(), "PersistentConfig1", true, data, new byte[0]);
-            _ioDispatcher.WriteEvent(SystemStreams.PersistentSubscriptionConfig, ExpectedVersion.Any, ev, SystemAccount.Principal, x => HandleSaveConfigurationCompleted(continueWith, x));
+            var metadata = new StreamMetadata(maxCount: 2);
+            Lazy<StreamMetadata> streamMetadata = new Lazy<StreamMetadata>(()=>metadata);
+            Event[] events = new Event[]{ev};
+            _ioDispatcher.ConfigureStreamAndWriteEvents(SystemStreams.PersistentSubscriptionConfig,
+            ExpectedVersion.Any,streamMetadata,events,SystemAccount.Principal,
+            x => HandleSaveConfigurationCompleted(continueWith, x));
         }
 
         private void HandleSaveConfigurationCompleted(Action continueWith, ClientMessage.WriteEventsCompleted obj)


### PR DESCRIPTION
 The $PersistentSubscriptionConfig stream can become huge. This is to limit the max count of the stream. 