### PR TITLE
Queue related bugfixes

### DIFF
--- a/src/EventStore.Core.Tests/Bus/when_consumer_throws.cs
+++ b/src/EventStore.Core.Tests/Bus/when_consumer_throws.cs
@@ -31,6 +31,9 @@ namespace EventStore.Core.Tests.Bus
         [Test]
         public void all_messages_in_the_queue_should_be_delivered()
         {
+#if DEBUG
+            Assert.Ignore("This test is not supported with DEBUG conditional since all exceptions are thrown in DEBUG builds.");
+#else
             Consumer.SetWaitingCount(3);
 
             Queue.Publish(new TestMessage());
@@ -46,6 +49,7 @@ namespace EventStore.Core.Tests.Bus
             Assert.IsTrue(Consumer.HandledMessages.ContainsSingle<TestMessage>());
             Assert.IsTrue(Consumer.HandledMessages.ContainsSingle<ExecutableTestMessage>());
             Assert.IsTrue(Consumer.HandledMessages.ContainsSingle<TestMessage2>());
+#endif
         }
     }
 

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -21,6 +21,7 @@ using EventStore.Core.Cluster.Settings;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.Services.Transport.Http.Controllers;
 using EventStore.Core.Tests.Common.VNodeBuilderTests;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.Helpers
 {
@@ -48,8 +49,8 @@ namespace EventStore.Core.Tests.Helpers
         public readonly TFChunkDb Db;
         public readonly string DbPath;
 
-        public MiniNode(string pathname, 
-                        int? tcpPort = null, int? tcpSecPort = null, int? httpPort = null, 
+        public MiniNode(string pathname,
+                        int? tcpPort = null, int? tcpSecPort = null, int? httpPort = null,
                         ISubsystem[] subsystems = null,
                         int? chunkSize = null, int? cachedChunkSize = null, bool enableTrustedAuth = false, bool skipInitializeStandardUsersCheck = true,
                         int memTableSize = 1000,
@@ -78,7 +79,7 @@ namespace EventStore.Core.Tests.Helpers
             {
                 DbPath = Path.Combine(pathname, string.Format("mini-node-db-{0}-{1}-{2}", extTcpPort, extSecTcpPort, extHttpPort));
             }
-            else 
+            else
             {
                 DbPath = dbPath;
             }
@@ -92,7 +93,7 @@ namespace EventStore.Core.Tests.Helpers
             var builder = TestVNodeBuilder.AsSingleNode();
             if(inMemDb)
                 builder.RunInMemory();
-            else 
+            else
                 builder.RunOnDisk(DbPath);
 
             builder.WithInternalTcpOn(IntTcpEndPoint)
@@ -130,7 +131,7 @@ namespace EventStore.Core.Tests.Helpers
 
             if(subsystems != null)
             {
-                foreach(var subsystem in subsystems) 
+                foreach(var subsystem in subsystems)
                 {
                     builder.AddCustomSubsystem(subsystem);
                 }
@@ -152,21 +153,73 @@ namespace EventStore.Core.Tests.Helpers
                      "TCP ENDPOINT:", TcpEndPoint,
                      "TCP SECURE ENDPOINT:", TcpSecEndPoint,
                      "HTTP ENDPOINT:", ExtHttpEndPoint);
-            
+
             Node = builder.Build();
             Db = ((TestVNodeBuilder)builder).GetDb();
 
             Node.ExternalHttpService.SetupController(new TestController(Node.MainQueue));
         }
 
-        public void Start()
+        public void Start(){
+            var monitorTcs = new TaskCompletionSource<object>();
+            MonitorFailures(monitorTcs);
+            StartMiniNode(monitorTcs.Task).Wait();
+            ContinueMonitoringFailures(monitorTcs);
+        }
+
+        private Task StartMiniNode(Task monitorFailuresTask)
         {
             StartingTime.Start();
 
-            if (!Node.StartAndWaitUntilReady().Wait(60000))
-                throw new TimeoutException("MiniNode has not started in 60 seconds.");
+            var startNodeTask = Node.StartAndWaitUntilReady(); //starts the node
+            var startupTimeoutTask = Task.Delay(TimeSpan.FromSeconds(60)); //startup timeout of 60s
 
-            StartingTime.Stop();
+            return Task.WhenAny(
+                monitorFailuresTask,
+                startNodeTask,
+                startupTimeoutTask
+            ).ContinueWith((t)=>{
+                StartingTime.Stop();
+                if(monitorFailuresTask.IsCompleted){
+                    if(monitorFailuresTask.Exception != null)
+                        throw monitorFailuresTask.Exception;
+                    else{
+                        throw new ApplicationException("Monitor Failures task completed but no exceptions were thrown.");
+                    }
+                } else if(startupTimeoutTask.IsCompleted){
+                    throw new TimeoutException("MiniNode has not started in 60 seconds.");
+                } else if(startNodeTask.IsCompleted){
+                    if(t.Status != TaskStatus.RanToCompletion)
+                        throw new ApplicationException("MiniNode has not properly started.");
+                    Log.Info("MiniNode successfully started!");
+                }
+            });
+        }
+
+        public void MonitorFailures(TaskCompletionSource<object> tcs){
+            if(tcs.Task.IsCompleted)
+                return;
+            Task.WhenAny(Node.Tasks)
+            .ContinueWith((t)=>{
+                if(tcs.Task.IsCompleted)
+                    return;
+
+                if(t.Result.Exception != null)
+                    tcs.TrySetException(t.Result.Exception);
+                else
+                    MonitorFailures(tcs);
+            });
+        }
+
+        public void ContinueMonitoringFailures(TaskCompletionSource<object> tcs){
+            if(tcs.Task.IsCompleted)
+                return;
+            tcs.Task.ContinueWith((t) => {
+                if(t.Exception != null)
+                    throw t.Exception;
+                else
+                    throw new ApplicationException("Node Monitor task completed but no exceptions were thrown.");
+            });
         }
 
         public void Shutdown(bool keepDb = false, bool keepPorts = false)
@@ -175,7 +228,7 @@ namespace EventStore.Core.Tests.Helpers
 
             if (!Node.Stop(TimeSpan.FromSeconds(20), true, true))
                 throw new TimeoutException("MiniNode has not shut down in 20 seconds.");
-            
+
             if (!keepPorts)
             {
                 PortsHelper.ReturnPort(TcpEndPoint.Port);
@@ -185,7 +238,7 @@ namespace EventStore.Core.Tests.Helpers
                 PortsHelper.ReturnPort(IntTcpEndPoint.Port);
                 PortsHelper.ReturnPort(IntSecTcpEndPoint.Port);
             }
-            
+
             if (!keepDb)
                 TryDeleteDirectory(DbPath);
 

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -136,6 +136,9 @@ namespace EventStore.Core.Tests.Integration
             _nodes[1].Shutdown();
             _nodes[2].Shutdown();
             base.TestFixtureTearDown();
+#if DEBUG
+            QueueStatsCollector.InitializeIdleDetection(false);
+#endif
         }
 
         protected static void WaitIdle()

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -135,10 +135,11 @@ namespace EventStore.Core.Tests.Integration
             _nodes[0].Shutdown();
             _nodes[1].Shutdown();
             _nodes[2].Shutdown();
-            base.TestFixtureTearDown();
 #if DEBUG
+            QueueStatsCollector.WaitIdle(waitForCheckpoints: false, waitForNonEmptyTf: false);
             QueueStatsCollector.InitializeIdleDetection(false);
 #endif
+            base.TestFixtureTearDown();
         }
 
         protected static void WaitIdle()

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -54,6 +54,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http
                 var pipelineBus = InMemoryBus.CreateTest();
                 var queue = new QueuedHandlerThreadPool(pipelineBus, "Test", true, TimeSpan.FromMilliseconds(50));
                 _multiQueuedHandler = new MultiQueuedHandler(new IQueuedHandler[]{queue}, null);
+                _multiQueuedHandler.Start();
                 var httpAuthenticationProviders = new HttpAuthenticationProvider[] {new AnonymousHttpAuthenticationProvider()};
 
                 _service = new HttpService(ServiceAccessibility.Private, _bus, new NaiveUriRouter(),

--- a/src/EventStore.Core.Tests/TestsInitFixture.cs
+++ b/src/EventStore.Core.Tests/TestsInitFixture.cs
@@ -16,12 +16,19 @@ namespace EventStore.Core.Tests
         public void SetUp()
         {
             Console.WriteLine("Initializing tests (setting console loggers)...");
+            SetUpDebugListeners();
             LogManager.SetLogFactory(x => new ConsoleLogger());
             Application.AddDefines(new[] { Application.AdditionalCommitChecks });
             LogEnvironmentInfo();
 
             if (!Debugger.IsAttached)
                 PortsHelper.InitPorts(IPAddress.Loopback);
+        }
+
+        private void SetUpDebugListeners()
+        {
+            Debug.Listeners.Clear(); //prevent message box popup when assertions fail
+            Debug.Listeners.Add(new ThrowExceptionTraceListener()); //all failed assertions should throw an exception to halt the tests
         }
 
         private void LogEnvironmentInfo()
@@ -53,6 +60,29 @@ namespace EventStore.Core.Tests
 
             Console.WriteLine(msg);
             LogManager.Finish();
+        }
+    }
+
+    internal class ThrowExceptionTraceListener : TraceListener
+    {
+        public ThrowExceptionTraceListener()
+        {
+        }
+
+        public override void Fail(string message){
+            throw new AssertionException(message);
+        }
+        public override void Fail(string message, string detailMessage){
+            var msg = message + detailMessage!=null?" "+detailMessage:"";
+            throw new AssertionException(msg);
+        }
+
+        public override void Write(string message)
+        {
+        }
+
+        public override void WriteLine(string message)
+        {
         }
     }
 }

--- a/src/EventStore.Core.Tests/TestsInitFixture.cs
+++ b/src/EventStore.Core.Tests/TestsInitFixture.cs
@@ -70,11 +70,11 @@ namespace EventStore.Core.Tests
         }
 
         public override void Fail(string message){
-            throw new AssertionException(message);
+            Assert.Fail(message);
         }
         public override void Fail(string message, string detailMessage){
             var msg = message + detailMessage!=null?" "+detailMessage:"";
-            throw new AssertionException(msg);
+            Assert.Fail(msg);
         }
 
         public override void Write(string message)

--- a/src/EventStore.Core/Bus/IQueuedHandler.cs
+++ b/src/EventStore.Core/Bus/IQueuedHandler.cs
@@ -1,4 +1,5 @@
-﻿using EventStore.Core.Messaging;
+﻿using System.Threading.Tasks;
+using EventStore.Core.Messaging;
 using EventStore.Core.Services.Monitoring.Stats;
 
 namespace EventStore.Core.Bus
@@ -6,7 +7,7 @@ namespace EventStore.Core.Bus
     public interface IQueuedHandler: IHandle<Message>, IPublisher
     {
         string Name { get; }
-        void Start();
+        Task Start();
         void Stop();
         void RequestStop();
         //void Publish(Message message);

--- a/src/EventStore.Core/Bus/MultiQueuedHandler.cs
+++ b/src/EventStore.Core/Bus/MultiQueuedHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Common.Utils;
@@ -49,12 +50,14 @@ namespace EventStore.Core.Bus
             return Interlocked.Increment(ref _nextQueueNum);
         }
 
-        public void Start()
+        public IEnumerable<Task> Start()
         {
+            var tasks = new List<Task>();
             for (int i = 0; i < Queues.Length; ++i)
             {
-                Queues[i].Start();
+                tasks.Add(Queues[i].Start());
             }
+            return tasks;
         }
 
         public void Stop()

--- a/src/EventStore.Core/Bus/QueueStatsCollector.cs
+++ b/src/EventStore.Core/Bus/QueueStatsCollector.cs
@@ -17,13 +17,6 @@ namespace EventStore.Core.Bus
         public readonly string GroupName;
 
         public Type InProgressMessage { get { return _inProgressMsgType; } }
-
-#if DEBUG
-        public static int NonIdle
-        {
-            get { return _nonIdle; }
-        }
-#endif
         private readonly object _statisticsLock = new object(); // this lock is mostly acquired from a single thread (+ rarely to get statistics), so performance penalty is not too high
 
         private readonly Stopwatch _busyWatch = new Stopwatch();
@@ -126,9 +119,9 @@ namespace EventStore.Core.Bus
             {
                 lock (_notifyLock)
                 {
-                    _nonIdle = NonIdle - 1;
+                    _nonIdle--;
                     Debug.Assert(_nonIdle >= 0,string.Format("QueueStatsCollector [{0}] _nonIdle = {1} < 0",Name,_nonIdle));
-                    if (NonIdle == 0)
+                    if (_nonIdle == 0)
                     {
                         Monitor.Pulse(_notifyLock);
                     }
@@ -162,7 +155,7 @@ namespace EventStore.Core.Bus
             {
                 lock (_notifyLock)
                 {
-                    _nonIdle = NonIdle + 1;
+                    _nonIdle++;
                 }
             }
 #endif

--- a/src/EventStore.Core/Bus/QueueStatsCollector.cs
+++ b/src/EventStore.Core/Bus/QueueStatsCollector.cs
@@ -77,14 +77,10 @@ namespace EventStore.Core.Bus
             EnterIdle();
         }
 
-        public void Stop(bool allowMultipleCalls=false)
+        public void Stop()
         {
 #if DEBUG
-        if(!allowMultipleCalls)
             Debug.Assert(_started, string.Format("QueueStatsCollector [{0}] was not started when Stop() entered",Name));
-
-        if(!_started)
-            return;
 #endif
             EnterIdle();
             _totalTimeWatch.Stop();

--- a/src/EventStore.Core/Bus/QueueStatsCollector.cs
+++ b/src/EventStore.Core/Bus/QueueStatsCollector.cs
@@ -77,10 +77,14 @@ namespace EventStore.Core.Bus
             EnterIdle();
         }
 
-        public void Stop()
+        public void Stop(bool allowMultipleCalls=false)
         {
 #if DEBUG
+        if(!allowMultipleCalls)
             Debug.Assert(_started, string.Format("QueueStatsCollector [{0}] was not started when Stop() entered",Name));
+
+        if(!_started)
+            return;
 #endif
             EnterIdle();
             _totalTimeWatch.Stop();

--- a/src/EventStore.Core/Bus/QueueStatsCollector.cs
+++ b/src/EventStore.Core/Bus/QueueStatsCollector.cs
@@ -241,7 +241,7 @@ namespace EventStore.Core.Bus
 #endif
 
         [Conditional("DEBUG")]
-        public static void WaitIdle(bool waitForNonEmptyTf = false, int multiplier = 1)
+        public static void WaitIdle(bool waitForCheckpoints = true,bool waitForNonEmptyTf = false, int multiplier = 1)
         {
 #if DEBUG
             var counter = 0;
@@ -250,8 +250,8 @@ namespace EventStore.Core.Bus
                 var successes = 0;
                 while (successes < 2)
                 {
-                    while (_nonIdle > 0 || _lengths > 0 || AreCheckpointsDifferent(0) || AreCheckpointsDifferent(1)
-                           || AreCheckpointsDifferent(2) || AnyCheckpointsDifferent()
+                    while (_nonIdle > 0 || _lengths > 0 || (waitForCheckpoints && (AreCheckpointsDifferent(0) || AreCheckpointsDifferent(1)
+                           || AreCheckpointsDifferent(2) || AnyCheckpointsDifferent()))
                            || (waitForNonEmptyTf && _writerCheckpoint[0].Read() == 0))
                     {
                         if (!Monitor.Wait(_notifyLock, 100))

--- a/src/EventStore.Core/Bus/QueuedHandlerAutoReset.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerAutoReset.cs
@@ -148,17 +148,19 @@ namespace EventStore.Core.Bus
 #endif
                 }
             }
-            _queueStats.Stop();
-
-            _stopped.Set();
-            _queueMonitor.Unregister(this);
-            Thread.EndThreadAffinity();
         }
         catch(Exception ex){
 #if DEBUG
             _tcs.TrySetException(ex);
 #endif
             throw;
+        }
+        finally{
+            _queueStats.Stop();
+
+            _stopped.Set();
+            _queueMonitor.Unregister(this);
+            Thread.EndThreadAffinity();
         }
 
         }

--- a/src/EventStore.Core/Bus/QueuedHandlerAutoReset.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerAutoReset.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Monitoring.Stats;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Bus
 {
@@ -38,6 +39,7 @@ namespace EventStore.Core.Bus
         // monitoring
         private readonly QueueMonitor _queueMonitor;
         private readonly QueueStatsCollector _queueStats;
+        private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
 
         public QueuedHandlerAutoReset(IHandle<Message> consumer,
                                       string name,
@@ -59,7 +61,7 @@ namespace EventStore.Core.Bus
             _queueStats = new QueueStatsCollector(name, groupName);
         }
 
-        public void Start()
+        public Task Start()
         {
             if (_thread != null)
                 throw new InvalidOperationException("Already a thread running.");
@@ -70,6 +72,7 @@ namespace EventStore.Core.Bus
 
             _thread = new Thread(ReadFromQueue) {IsBackground = true, Name = Name};
             _thread.Start();
+            return _tcs.Task;
         }
 
         public void Stop()
@@ -86,6 +89,7 @@ namespace EventStore.Core.Bus
 
         private void ReadFromQueue(object o)
         {
+        try{
             _queueStats.Start();
             Thread.BeginThreadAffinity(); // ensure we are not switching between OS threads. Required at least for v8.
 
@@ -139,6 +143,9 @@ namespace EventStore.Core.Bus
                 catch (Exception ex)
                 {
                     Log.ErrorException(ex, "Error while processing message {0} in queued handler '{1}'.", msg, Name);
+#if DEBUG
+                    throw;
+#endif
                 }
             }
             _queueStats.Stop();
@@ -146,6 +153,14 @@ namespace EventStore.Core.Bus
             _stopped.Set();
             _queueMonitor.Unregister(this);
             Thread.EndThreadAffinity();
+        }
+        catch(Exception ex){
+#if DEBUG
+            _tcs.TrySetException(ex);
+#endif
+            throw;
+        }
+
         }
 
         public void Publish(Message message)

--- a/src/EventStore.Core/Bus/QueuedHandlerAutoReset.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerAutoReset.cs
@@ -150,9 +150,7 @@ namespace EventStore.Core.Bus
             }
         }
         catch(Exception ex){
-#if DEBUG
             _tcs.TrySetException(ex);
-#endif
             throw;
         }
         finally{

--- a/src/EventStore.Core/Bus/QueuedHandlerAutoResetWithMPSC.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerAutoResetWithMPSC.cs
@@ -180,9 +180,7 @@ namespace EventStore.Core.Bus
             }
         }
         catch(Exception ex){
-#if DEBUG
             _tcs.TrySetException(ex);
-#endif
             throw;
         }
         finally{

--- a/src/EventStore.Core/Bus/QueuedHandlerAutoResetWithMPSC.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerAutoResetWithMPSC.cs
@@ -178,17 +178,19 @@ namespace EventStore.Core.Bus
 #endif
                 }
             }
-            _queueStats.Stop();
-
-            _stopped.Set();
-            _queueMonitor.Unregister(this);
-            Thread.EndThreadAffinity();
         }
         catch(Exception ex){
 #if DEBUG
             _tcs.TrySetException(ex);
 #endif
             throw;
+        }
+        finally{
+            _queueStats.Stop();
+
+            _stopped.Set();
+            _queueMonitor.Unregister(this);
+            Thread.EndThreadAffinity();
         }
 
         }

--- a/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Monitoring.Stats;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Bus
 {
@@ -37,6 +38,8 @@ namespace EventStore.Core.Bus
 
         private readonly QueueMonitor _queueMonitor;
         private readonly QueueStatsCollector _queueStats;
+        private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
+
         
         public QueuedHandlerMRES(IHandle<Message> consumer,
                                  string name,
@@ -58,7 +61,7 @@ namespace EventStore.Core.Bus
             _queueStats = new QueueStatsCollector(name, groupName);
         }
 
-        public void Start()
+        public Task Start()
         {
             if (_thread != null)
                 throw new InvalidOperationException("Already a thread running.");
@@ -69,6 +72,7 @@ namespace EventStore.Core.Bus
 
             _thread = new Thread(ReadFromQueue) { IsBackground = true, Name = Name };
             _thread.Start();
+            return _tcs.Task;
         }
 
         public void Stop()
@@ -85,6 +89,7 @@ namespace EventStore.Core.Bus
 
         private void ReadFromQueue(object o)
         {
+        try{
             _queueStats.Start();
             Thread.BeginThreadAffinity(); // ensure we are not switching between OS threads. Required at least for v8.
             
@@ -140,6 +145,9 @@ namespace EventStore.Core.Bus
                 catch (Exception ex)
                 {
                     Log.ErrorException(ex, "Error while processing message {0} in queued handler '{1}'.", msg, Name);
+#if DEBUG
+                    throw;
+#endif
                 }
             }
             _queueStats.Stop();
@@ -147,6 +155,15 @@ namespace EventStore.Core.Bus
             _stopped.Set();
             _queueMonitor.Unregister(this);
             Thread.EndThreadAffinity();
+
+        }
+        catch (Exception ex) {
+#if DEBUG
+            _tcs.TrySetException(ex);
+#endif
+            throw;
+        }
+
         }
 
         public void Publish(Message message)

--- a/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
@@ -150,18 +150,19 @@ namespace EventStore.Core.Bus
 #endif
                 }
             }
-            _queueStats.Stop();
-
-            _stopped.Set();
-            _queueMonitor.Unregister(this);
-            Thread.EndThreadAffinity();
-
         }
         catch (Exception ex) {
 #if DEBUG
             _tcs.TrySetException(ex);
 #endif
             throw;
+        }
+        finally{
+            _queueStats.Stop();
+
+            _stopped.Set();
+            _queueMonitor.Unregister(this);
+            Thread.EndThreadAffinity();
         }
 
         }

--- a/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
@@ -152,9 +152,7 @@ namespace EventStore.Core.Bus
             }
         }
         catch (Exception ex) {
-#if DEBUG
             _tcs.TrySetException(ex);
-#endif
             throw;
         }
         finally{

--- a/src/EventStore.Core/Bus/QueuedHandlerMRESWithMPSC.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRESWithMPSC.cs
@@ -177,17 +177,19 @@ namespace EventStore.Core.Bus
 #endif
                 }
             }
-            _queueStats.Stop();
-
-            _stopped.Set();
-            _queueMonitor.Unregister(this);
-            Thread.EndThreadAffinity();
         }
         catch(Exception ex){
 #if DEBUG
             _tcs.TrySetException(ex);
 #endif
             throw;
+        }
+        finally{
+            _queueStats.Stop();
+
+            _stopped.Set();
+            _queueMonitor.Unregister(this);
+            Thread.EndThreadAffinity();
         }
 
         }

--- a/src/EventStore.Core/Bus/QueuedHandlerMRESWithMPSC.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRESWithMPSC.cs
@@ -179,9 +179,7 @@ namespace EventStore.Core.Bus
             }
         }
         catch(Exception ex){
-#if DEBUG
             _tcs.TrySetException(ex);
-#endif
             throw;
         }
         finally{

--- a/src/EventStore.Core/Bus/QueuedHandlerMRESWithMPSC.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRESWithMPSC.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
@@ -41,6 +42,7 @@ namespace EventStore.Core.Bus
 
         private readonly QueueMonitor _queueMonitor;
         private readonly QueueStatsCollector _queueStats;
+        private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
 
         public QueuedHandlerMresWithMpsc(IHandle<Message> consumer,
             string name,
@@ -62,7 +64,7 @@ namespace EventStore.Core.Bus
             _queueStats = new QueueStatsCollector(name, groupName);
         }
 
-        public void Start()
+        public Task Start()
         {
             if (_thread != null)
                 throw new InvalidOperationException("Already a thread running.");
@@ -73,6 +75,7 @@ namespace EventStore.Core.Bus
 
             _thread = new Thread(ReadFromQueue) {IsBackground = true, Name = Name};
             _thread.Start();
+            return _tcs.Task;
         }
 
         public void Stop()
@@ -89,6 +92,7 @@ namespace EventStore.Core.Bus
 
         private void ReadFromQueue(object o)
         {
+        try{
             _queueStats.Start();
             Thread.BeginThreadAffinity(); // ensure we are not switching between OS threads. Required at least for v8.
 
@@ -155,6 +159,9 @@ namespace EventStore.Core.Bus
                             catch (Exception ex)
                             {
                                 Log.ErrorException(ex, "Error while processing message {0} in queued handler '{1}'.", msg, Name);
+#if DEBUG
+                                throw;
+#endif
                             }
 
                             estimatedQueueCount -= 1;
@@ -165,6 +172,9 @@ namespace EventStore.Core.Bus
                 catch (Exception ex)
                 {
                     Log.ErrorException(ex, "Error while processing message {0} in queued handler '{1}'.", msg, Name);
+#if DEBUG
+                    throw;
+#endif
                 }
             }
             _queueStats.Stop();
@@ -172,6 +182,14 @@ namespace EventStore.Core.Bus
             _stopped.Set();
             _queueMonitor.Unregister(this);
             Thread.EndThreadAffinity();
+        }
+        catch(Exception ex){
+#if DEBUG
+            _tcs.TrySetException(ex);
+#endif
+            throw;
+        }
+
         }
 
         public void Publish(Message message)

--- a/src/EventStore.Core/Bus/QueuedHandlerPulse.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerPulse.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Monitoring.Stats;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Bus
 {
@@ -39,6 +40,8 @@ namespace EventStore.Core.Bus
         private readonly QueueStatsCollector _queueStats;
 
         private readonly object _locker = new object();
+        private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
+
 
         public QueuedHandlerPulse(IHandle<Message> consumer,
                                   string name,
@@ -59,7 +62,7 @@ namespace EventStore.Core.Bus
             _queueStats = new QueueStatsCollector(name, groupName);
         }
 
-        public void Start()
+        public Task Start()
         {
             if (_thread != null)
                 throw new InvalidOperationException("Already a thread running.");
@@ -70,6 +73,7 @@ namespace EventStore.Core.Bus
 
             _thread = new Thread(ReadFromQueue) { IsBackground = true, Name = Name };
             _thread.Start();
+            return _tcs.Task;
         }
 
         public void Stop()
@@ -86,6 +90,7 @@ namespace EventStore.Core.Bus
 
         private void ReadFromQueue(object o)
         {
+        try{
             _queueStats.Start();
             Thread.BeginThreadAffinity(); // ensure we are not switching between OS threads. Required at least for v8.
             
@@ -141,6 +146,9 @@ namespace EventStore.Core.Bus
                 catch (Exception ex)
                 {
                     Log.ErrorException(ex, "Error while processing message {0} in queued handler '{1}'.", msg, Name);
+#if DEBUG
+                    throw;
+#endif
                 }
             }
             _queueStats.Stop();
@@ -148,6 +156,14 @@ namespace EventStore.Core.Bus
             _stopped.Set();
             _queueMonitor.Unregister(this);
             Thread.EndThreadAffinity();
+        }
+        catch(Exception ex){
+#if DEBUG
+            _tcs.TrySetException(ex);
+#endif
+            throw;
+        }
+
         }
 
         public void Publish(Message message)

--- a/src/EventStore.Core/Bus/QueuedHandlerPulse.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerPulse.cs
@@ -153,9 +153,7 @@ namespace EventStore.Core.Bus
             }
         }
         catch(Exception ex){
-#if DEBUG
             _tcs.TrySetException(ex);
-#endif
             throw;
         }
         finally{

--- a/src/EventStore.Core/Bus/QueuedHandlerPulse.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerPulse.cs
@@ -151,17 +151,19 @@ namespace EventStore.Core.Bus
 #endif
                 }
             }
-            _queueStats.Stop();
-
-            _stopped.Set();
-            _queueMonitor.Unregister(this);
-            Thread.EndThreadAffinity();
         }
         catch(Exception ex){
 #if DEBUG
             _tcs.TrySetException(ex);
 #endif
             throw;
+        }
+        finally{
+            _queueStats.Stop();
+
+            _stopped.Set();
+            _queueMonitor.Unregister(this);
+            Thread.EndThreadAffinity();
         }
 
         }

--- a/src/EventStore.Core/Bus/QueuedHandlerSleep.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerSleep.cs
@@ -154,17 +154,19 @@ namespace EventStore.Core.Bus
 #endif
                 }
             }
-            _queueStats.Stop();
-
-            _stopped.Set();
-            _queueMonitor.Unregister(this);
-            Thread.EndThreadAffinity();
         }
         catch(Exception ex){
 #if DEBUG
             _tcs.TrySetException(ex);
 #endif
             throw;
+        }
+        finally{
+            _queueStats.Stop();
+
+            _stopped.Set();
+            _queueMonitor.Unregister(this);
+            Thread.EndThreadAffinity();
         }
 
         }

--- a/src/EventStore.Core/Bus/QueuedHandlerSleep.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerSleep.cs
@@ -156,9 +156,7 @@ namespace EventStore.Core.Bus
             }
         }
         catch(Exception ex){
-#if DEBUG
             _tcs.TrySetException(ex);
-#endif
             throw;
         }
         finally{

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -141,9 +141,7 @@ namespace EventStore.Core.Bus
             }
         }
         catch(Exception ex){
-#if DEBUG
             _tcs.TrySetException(ex);
-#endif
             throw;
         }
         finally{

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -135,10 +135,6 @@ namespace EventStore.Core.Bus
                     }
                 }
 
-                _queueStats.EnterIdle();
-                _queueStats.Stop();
-                _stopped.Set();
-
                 Interlocked.CompareExchange(ref _isRunning, 0, 1);
                 // try to reacquire lock if needed
                 proceed = !_stop && _queue.Count > 0 && Interlocked.CompareExchange(ref _isRunning, 1, 0) == 0; 
@@ -149,6 +145,11 @@ namespace EventStore.Core.Bus
             _tcs.TrySetException(ex);
 #endif
             throw;
+        }
+        finally{
+            _queueStats.EnterIdle();
+            _queueStats.Stop();
+            _stopped.Set();
         }
 
         }

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -135,6 +135,9 @@ namespace EventStore.Core.Bus
                     }
                 }
 
+                _queueStats.EnterIdle();
+                _stopped.Set();
+
                 Interlocked.CompareExchange(ref _isRunning, 0, 1);
                 // try to reacquire lock if needed
                 proceed = !_stop && _queue.Count > 0 && Interlocked.CompareExchange(ref _isRunning, 1, 0) == 0; 

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -136,6 +136,7 @@ namespace EventStore.Core.Bus
                 }
 
                 _queueStats.EnterIdle();
+                _queueStats.Stop();
                 _stopped.Set();
 
                 Interlocked.CompareExchange(ref _isRunning, 0, 1);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -530,6 +530,7 @@ namespace EventStore.Core
             // MASTER REPLICATION
                 var masterReplicationService = new MasterReplicationService(_mainQueue, gossipInfo.InstanceId, db, _workersHandler,
                                                                         epochManager, vNodeSettings.ClusterNodeCount);
+                AddTask(masterReplicationService.Task);
                 _mainBus.Subscribe<SystemMessage.SystemStart>(masterReplicationService);
                 _mainBus.Subscribe<SystemMessage.StateChangeMessage>(masterReplicationService);
                 _mainBus.Subscribe<ReplicationMessage.ReplicaSubscriptionRequest>(masterReplicationService);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -513,7 +513,9 @@ namespace EventStore.Core
 
             // TIMER
             _timeProvider = new RealTimeProvider();
-            _timerService = new TimerService(new ThreadBasedScheduler(_timeProvider));
+            var threadBasedScheduler = new ThreadBasedScheduler(_timeProvider);
+            AddTask(threadBasedScheduler.Task);
+            _timerService = new TimerService(threadBasedScheduler);
             _mainBus.Subscribe<SystemMessage.BecomeShutdown>(_timerService);
             _mainBus.Subscribe<TimerMessage.Schedule>(_timerService);
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -555,6 +555,7 @@ namespace EventStore.Core
             _mainQueue.Start();
             monitoringQueue.Start();
             subscrQueue.Start();
+            perSubscrQueue.Start();
 
             if (subsystems != null)
             {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -36,6 +36,8 @@ using System.Threading;
 using EventStore.Core.Services.Histograms;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using System.Threading.Tasks;
+using System.Collections;
+using System.Diagnostics;
 
 namespace EventStore.Core
 {
@@ -72,6 +74,12 @@ namespace EventStore.Core
         private readonly InMemoryBus[] _workerBuses;
         private readonly MultiQueuedHandler _workersHandler;
         public event EventHandler<VNodeStatusChangeArgs> NodeStatusChanged;
+        private readonly List<Task> _tasks = new List<Task>();
+        public IEnumerable<Task> Tasks { get { return _tasks; } }
+#if DEBUG
+        public TaskCompletionSource<bool> _taskAddedTrigger = new TaskCompletionSource<bool>();
+        public object _taskAddLock = new object();
+#endif
 
         protected virtual void OnNodeStatusChanged(VNodeStatusChangeArgs e)
         {
@@ -89,6 +97,10 @@ namespace EventStore.Core
             Ensure.NotNull(db, "db");
             Ensure.NotNull(vNodeSettings, "vNodeSettings");
             Ensure.NotNull(gossipSeedSource, "gossipSeedSource");
+
+#if DEBUG
+            AddTask(_taskAddedTrigger.Task);
+#endif
 
             var isSingleNode = vNodeSettings.ClusterNodeCount == 1;
             _nodeInfo = vNodeSettings.NodeInfo;
@@ -200,6 +212,8 @@ namespace EventStore.Core
             var storageWriter = new ClusterStorageWriterService(_mainQueue, _mainBus, vNodeSettings.MinFlushDelay,
                                                                 db, writer, readIndex.IndexWriter, epochManager,
                                                                 () => readIndex.LastCommitPosition); // subscribes internally
+            AddTasks(storageWriter.Tasks);
+
             monitoringRequestBus.Subscribe<MonitoringMessage.InternalStatsRequest>(storageWriter);
 
             var storageReader = new StorageReaderService(_mainQueue, _mainBus, readIndex, vNodeSettings.ReaderThreadsCount, db.Config.WriterCheckpoint);
@@ -209,12 +223,16 @@ namespace EventStore.Core
             monitoringRequestBus.Subscribe<MonitoringMessage.InternalStatsRequest>(storageReader);
 
             var indexCommitterService = new IndexCommitterService(readIndex.IndexCommitter, _mainQueue, db.Config.ReplicationCheckpoint, db.Config.WriterCheckpoint, vNodeSettings.CommitAckCount);
+            AddTask(indexCommitterService.Task);
+
             _mainBus.Subscribe<SystemMessage.StateChangeMessage>(indexCommitterService);
             _mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(indexCommitterService);
             _mainBus.Subscribe<StorageMessage.CommitAck>(indexCommitterService);
 
             var chaser = new TFChunkChaser(db, db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint, db.Config.OptimizeReadSideCache);
             var storageChaser = new StorageChaser(_mainQueue, db.Config.WriterCheckpoint, chaser, indexCommitterService, epochManager);
+            AddTask(storageChaser.Task);
+
 #if DEBUG
             QueueStatsCollector.InitializeCheckpoints(
                 _nodeInfo.DebugIndex, db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint);
@@ -551,11 +569,11 @@ namespace EventStore.Core
                 _mainBus.Subscribe<SystemMessage.VNodeConnectionEstablished>(gossip);
                 _mainBus.Subscribe<SystemMessage.VNodeConnectionLost>(gossip);
             }
-            _workersHandler.Start();
-            _mainQueue.Start();
-            monitoringQueue.Start();
-            subscrQueue.Start();
-            perSubscrQueue.Start();
+            AddTasks(_workersHandler.Start());
+            AddTask(_mainQueue.Start());
+            AddTask(monitoringQueue.Start());
+            AddTask(subscrQueue.Start());
+            AddTask(perSubscrQueue.Start());
 
             if (subsystems != null)
             {
@@ -608,6 +626,37 @@ namespace EventStore.Core
         public void Handle(SystemMessage.BecomeShutdown message)
         {
             _shutdownEvent.Set();
+        }
+
+        [Conditional("DEBUG")]
+        public void AddTasks(IEnumerable<Task> tasks){
+#if DEBUG
+            foreach(var task in tasks){
+                AddTask(task);
+            }
+#endif
+        }
+
+        [Conditional("DEBUG")]
+        public void AddTask(Task task){
+#if DEBUG
+            lock(_taskAddLock){
+                _tasks.Add(task);
+
+                //keep reference to old trigger task
+                var oldTrigger = _taskAddedTrigger;
+
+                //create and add new trigger task to list
+                _taskAddedTrigger = new TaskCompletionSource<bool>();
+                _tasks.Add(_taskAddedTrigger.Task);
+
+                //remove old trigger task from list
+                _tasks.Remove(oldTrigger.Task);
+
+                //trigger old trigger task
+                oldTrigger.SetResult(true);
+            }
+#endif
         }
 
         public Task<ClusterVNode> StartAndWaitUntilReady()

--- a/src/EventStore.Core/ISubsystem.cs
+++ b/src/EventStore.Core/ISubsystem.cs
@@ -1,10 +1,13 @@
-﻿namespace EventStore.Core
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace EventStore.Core
 {
     public interface ISubsystem
     {
         void Register(StandardComponents standardComponents);
 
-        void Start();
+        IEnumerable<Task> Start();
         void Stop();
     }
 }

--- a/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
@@ -64,6 +65,8 @@ namespace EventStore.Core.Services.Replication
         private TimeSpan _noQuorumTimestamp = TimeSpan.Zero;
         private bool _noQuorumNotified;
         private ManualResetEventSlim _flushSignal = new ManualResetEventSlim();
+        private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
+        public Task Task { get {return _tcs.Task;} }
         
         public MasterReplicationService(IPublisher publisher, 
                                         Guid instanceId, 
@@ -326,6 +329,7 @@ namespace EventStore.Core.Services.Replication
 
         private void MainLoop()
         {
+            try{
             _queueStats.Start();
             QueueMonitor.Default.Register(this);
 
@@ -360,6 +364,9 @@ namespace EventStore.Core.Services.Replication
                 catch (Exception exc)
                 {
                     Log.InfoException(exc, "Error during master replication iteration.");
+#if DEBUG
+                    throw;
+#endif
                 }
             }
 
@@ -371,9 +378,17 @@ namespace EventStore.Core.Services.Replication
             _db.Config.WriterCheckpoint.Flushed -= OnWriterFlushed;
 
             _publisher.Publish(new SystemMessage.ServiceShutdown(Name));
-            
-            _queueStats.Stop();
-            QueueMonitor.Default.Unregister(this);
+            }
+            catch(Exception ex){
+#if DEBUG
+                _tcs.TrySetException(ex);
+#endif
+                throw;
+            }
+            finally{
+                _queueStats.Stop();
+                QueueMonitor.Default.Unregister(this);
+            }
         }
 
         private void OnWriterFlushed(long obj)

--- a/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
@@ -380,9 +380,7 @@ namespace EventStore.Core.Services.Replication
             _publisher.Publish(new SystemMessage.ServiceShutdown(Name));
             }
             catch(Exception ex){
-#if DEBUG
                 _tcs.TrySetException(ex);
-#endif
                 throw;
             }
             finally{

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -133,11 +133,11 @@ namespace EventStore.Core.Services.Storage
                 }
                _queueStats.ProcessingEnded(0);
             }
+            finally{
+                _queueStats.Stop();
+                QueueMonitor.Default.Unregister(this);
+            }
             _publisher.Publish(new SystemMessage.ServiceShutdown(Name));
-
-            _queueStats.EnterIdle();
-            _queueStats.Stop();
-            QueueMonitor.Default.Unregister(this);
         }
 
         private void ProcessCommitReplicated(StorageMessage.CommitAck message)

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -123,9 +123,7 @@ namespace EventStore.Core.Services.Storage
                 _queueStats.EnterIdle();
                 _queueStats.ProcessingStarted<FaultedIndexCommitterServiceState>(0);
                 Log.FatalException(exc, "Error in IndexCommitterService. Terminating...");
-#if DEBUG
                 _tcs.TrySetException(exc);
-#endif
                 Application.Exit(ExitCode.Error, "Error in IndexCommitterService. Terminating...\nError: " + exc.Message);
                 while (!_stop)
                 {

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -233,10 +233,10 @@ namespace EventStore.Core.Services.Storage
         {
             if(_state != VNodeState.Master || _commitCount == 1)
             {
-                _replicatedQueue.Enqueue(message);
 #if DEBUG
                 _queueStats.Enqueued();
 #endif
+                _replicatedQueue.Enqueue(message);
                 _addMsgSignal.Set();
                 return;
             }
@@ -263,10 +263,10 @@ namespace EventStore.Core.Services.Storage
 
         private void CommitReplicated(StorageMessage.CommitAck message)
         {
-            _replicatedQueue.Enqueue(message);
 #if DEBUG
             _queueStats.Enqueued();
 #endif
+            _replicatedQueue.Enqueue(message);
             _addMsgSignal.Set();
         }
 

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -134,16 +134,14 @@ namespace EventStore.Core.Services.Storage
                 }
                 _queueStats.ProcessingEnded(0);
             }
+            finally{
+                _queueStats.Stop();
+                QueueMonitor.Default.Unregister(this);
+            }
 
             _writerCheckpoint.Flushed -= OnWriterFlushed;
-
             _chaser.Close();
-
             _masterBus.Publish(new SystemMessage.ServiceShutdown(Name));
-
-            _queueStats.EnterIdle();
-            _queueStats.Stop();
-            QueueMonitor.Default.Unregister(this);
         }
 
         private void OnWriterFlushed(long obj)

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -124,9 +124,7 @@ namespace EventStore.Core.Services.Storage
                 Log.FatalException(exc, "Error in StorageChaser. Terminating...");
                 _queueStats.EnterIdle();
                 _queueStats.ProcessingStarted<FaultedChaserState>(0);
-#if DEBUG
                 _tcs.TrySetException(exc);
-#endif
                 Application.Exit(ExitCode.Error, "Error in StorageChaser. Terminating...\nError: " + exc.Message);
                 while (!_stop)
                 {

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -14,6 +14,7 @@ using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services.Histograms;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Services.Storage
 {
@@ -54,6 +55,8 @@ namespace EventStore.Core.Services.Storage
         private bool _commitsAfterEof;
         private const string _chaserWaitHistogram = "chaser-wait";
         private const string _chaserFlushHistogram = "chaser-flush";
+        private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
+        public Task Task { get {return _tcs.Task;} }
 
         public StorageChaser(IPublisher masterBus,
                              ICheckpoint writerCheckpoint,
@@ -92,11 +95,11 @@ namespace EventStore.Core.Services.Storage
 
         private void ChaseTransactionLog()
         {
-            _queueStats.Start();
-            QueueMonitor.Default.Register(this);
-
             try
             {
+                _queueStats.Start();
+                QueueMonitor.Default.Register(this);
+
                 _writerCheckpoint.Flushed += OnWriterFlushed;
 
                 _chaser.Open();
@@ -121,6 +124,9 @@ namespace EventStore.Core.Services.Storage
                 Log.FatalException(exc, "Error in StorageChaser. Terminating...");
                 _queueStats.EnterIdle();
                 _queueStats.ProcessingStarted<FaultedChaserState>(0);
+#if DEBUG
+                _tcs.TrySetException(exc);
+#endif
                 Application.Exit(ExitCode.Error, "Error in StorageChaser. Terminating...\nError: " + exc.Message);
                 while (!_stop)
                 {

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
@@ -70,6 +71,8 @@ namespace EventStore.Core.Services.Storage
         private long _maxFlushSize;
         private long _maxFlushDelay;
         private const string _writerFlushHistogram = "writer-flush";
+        private readonly List<Task> _tasks = new List<Task>();
+        public IEnumerable<Task> Tasks {get {return _tasks;}}
 
         public StorageWriterService(IPublisher bus,
             ISubscriber subscribeToBus,
@@ -104,7 +107,7 @@ namespace EventStore.Core.Services.Storage
                 "StorageWriterQueue",
                 true,
                 TimeSpan.FromMilliseconds(500));
-            StorageWriterQueue.Start();
+            _tasks.Add(StorageWriterQueue.Start());
 
             SubscribeToMessage<SystemMessage.SystemInit>();
             SubscribeToMessage<SystemMessage.StateChangeMessage>();

--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -86,9 +86,7 @@ namespace EventStore.Core.Services.TimerService
             }
             }
             catch(Exception ex){
-#if DEBUG
                 _tcs.TrySetException(ex);
-#endif
                 throw;
             }
             finally{

--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -5,6 +5,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.DataStructures;
 using EventStore.Core.Services.Monitoring.Stats;
 using System.Collections.Concurrent;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Services.TimerService
 {
@@ -21,6 +22,8 @@ namespace EventStore.Core.Services.TimerService
         private volatile bool _stop;
 
         private readonly QueueStatsCollector _queueStats = new QueueStatsCollector("Timer");
+        private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
+        public Task Task { get {return _tcs.Task;} }
 
         public ThreadBasedScheduler(ITimeProvider timeProvider)
         {
@@ -45,6 +48,7 @@ namespace EventStore.Core.Services.TimerService
 
         private void DoTiming()
         {
+            try{
             _queueStats.Start();
             QueueMonitor.Default.Register(this);
 
@@ -80,9 +84,17 @@ namespace EventStore.Core.Services.TimerService
                     Thread.Sleep(10);
                 }
             }
-
-            _queueStats.Stop();
-            QueueMonitor.Default.Unregister(this);
+            }
+            catch(Exception ex){
+#if DEBUG
+                _tcs.TrySetException(ex);
+#endif
+                throw;
+            }
+            finally{
+                _queueStats.Stop();
+                QueueMonitor.Default.Unregister(this);
+            }
         }
 
         public void Dispose()

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -456,8 +456,9 @@ namespace EventStore.Core.Services.VNode
         private void Handle(UserManagementMessage.UserManagementServiceInitialized message)
         {
             if (_subSystems != null){
-                foreach (var subsystem in _subSystems)
-                    subsystem.Start();
+                foreach (var subsystem in _subSystems){
+                    _node.AddTasks(subsystem.Start());
+                }
             }
             _outputBus.Publish(message);
             _fsm.Handle(new SystemMessage.SystemCoreReady());

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -167,10 +167,11 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
             _nodes[0].Shutdown();
             _nodes[1].Shutdown();
             _nodes[2].Shutdown();
-            base.TestFixtureTearDown();
 #if DEBUG
+            QueueStatsCollector.WaitIdle(waitForCheckpoints: false, waitForNonEmptyTf: false);
             QueueStatsCollector.InitializeIdleDetection(false);
 #endif
+            base.TestFixtureTearDown();
         }
 
         protected virtual void When()

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -148,11 +148,11 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
 
             if (_node != null)
                 _node.Shutdown();
-
-            base.TestFixtureTearDown();
 #if DEBUG
+            QueueStatsCollector.WaitIdle(waitForCheckpoints: false, waitForNonEmptyTf: false);
             QueueStatsCollector.InitializeIdleDetection(false);
 #endif
+            base.TestFixtureTearDown();
         }
 
         protected virtual void When()

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using EventStore.Common.Options;
 using EventStore.Core;
 using EventStore.Core.Bus;
@@ -70,16 +71,18 @@ namespace EventStore.Projections.Core
         }
 
 
-        public void Start()
+        public IEnumerable<Task> Start()
         {
+            var tasks = new List<Task>();
             if(_subsystemStarted == false)
             {
                 if (_masterInputQueue != null)
-                    _masterInputQueue.Start();
+                    tasks.Add(_masterInputQueue.Start());
                 foreach (var queue in _coreQueues)
-                    queue.Value.Start();
+                    tasks.Add(queue.Value.Start());
             }
             _subsystemStarted = true;
+            return tasks;
         }
 
         public void Stop()


### PR DESCRIPTION
This PR fixes a few bugs related to queues identified through debug builds:
afc5f5b - Add missing Start() call for perSubscrQueue
623a41c , 8de056f - Do not count items on stopped queues in _length to prevent WaitIdle() from waiting indefinitely in debug builds
690853e -  Add missing Start() call in PortableServer

PR #1640 also fixes 2 bugs related to queue stats which may cause debug builds to hang

The PR also adds a few debug assertions to strengthen the code base:
c90f53e - This has been added to identify debug assertion failures when running tests by adding a TraceListener which throws exceptions on assertion failures. The default behaviour on Windows is to open up a message box which hangs nunit - clearing the Debug Trace Listeners should prevent this from happening.
b7ab2b5 - Add debug assertions to QueueStatsCollector to identify related issues early during development