### PR TITLE
Minor corrections to text and brand name

### DIFF
--- a/scripts/nuget-clientapi/EventStore.Client.Embedded.nuspec
+++ b/scripts/nuget-clientapi/EventStore.Client.Embedded.nuspec
@@ -9,8 +9,8 @@
     <projectUrl>https://eventstore.org</projectUrl>
     <iconUrl>https://eventstore.org/images/ouro.svg</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The embedded client API for the Event Store. Get the open source or commercial versions of the Event Store server from https://eventstore.org/</description>
-    <releaseNotes>Embedded Client API for version 4 of the Event Store</releaseNotes>
+    <description>The embedded client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</description>
+    <releaseNotes>Embedded Client API for version 4 of Event Store</releaseNotes>
     <copyright>Copyright 2012-2018 Event Store LLP</copyright>
     <tags>eventstore client embedded</tags>
     <dependencies>

--- a/scripts/nuget-clientapi/EventStore.Client.nuspec
+++ b/scripts/nuget-clientapi/EventStore.Client.nuspec
@@ -9,8 +9,8 @@
     <projectUrl>https://eventstore.org</projectUrl>
     <iconUrl>https://eventstore.org/images/ouro.svg</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The client API for the Event Store. Get the open source or commercial versions of the Event Store server from https://eventstore.org/</description>
-    <releaseNotes>Client API for version 4 of the Event Store</releaseNotes>
+    <description>The client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</description>
+    <releaseNotes>Client API for version 4 of Event Store</releaseNotes>
     <copyright>Copyright 2012-2018 Event Store LLP</copyright>
     <tags>eventstore client</tags>
     <dependencies>


### PR DESCRIPTION
Just removing 'the' from Event Store to bring it inline with docs and branding elsewhere.