### PR TITLE
Moved test results to TESTS tab in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,9 @@ test_script:
        /framework:net-4.5 /timeout=60000 
        /out:TestResults.txt 
        --result=TestResults.xml;format=AppVeyor
+artifacts:
+  - path: '**\TestResults.*'
+    name: TestResults
 notifications:
 - provider: Slack
   incoming_webhook:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,18 +3,13 @@ image: Visual Studio 2017
 build_script:
 - ps: .\build.cmd -Configuration debug -Platform x64
 test_script:
-- ps: >-
-    .\tools\nunit-3.4.1\bin\nunit3-console.exe bin\tests\EventStore.BufferManagement.Tests.dll bin\tests\EventStore.Core.Tests.dll bin\tests\EventStore.Projections.Core.Tests.dll /framework:net-4.5 /timeout=60000
-
-
-    $result = Select-String -Path TestResult.xml -Pattern "result=`"Failed`""
-
-
-    if ([string]::IsNullOrEmpty($result) -eq "True"){
-       $host.SetShouldExit(0)
-    }else{
-       $host.SetShouldExit(1)
-    }
+- cmd: nunit3-console 
+       bin\tests\EventStore.BufferManagement.Tests.dll 
+       bin\tests\EventStore.Core.Tests.dll 
+       bin\tests\EventStore.Projections.Core.Tests.dll 
+       /framework:net-4.5 /timeout=60000 
+       /out:TestResults.txt 
+       --result=TestResults.xml;format=AppVeyor
 notifications:
 - provider: Slack
   incoming_webhook:


### PR DESCRIPTION
#### Improvement of CI test results visibility
- Test results show in real-time on `TESTS`
- `CONSOLE` log reduces (60k+ rows to 0.9k, all to see)
- The existing detailed test logs are stored in `ARTIFACTS`

#### Notes
- This PR is related to #1709

***
![eventstore-tests-realtime-3](https://user-images.githubusercontent.com/22805312/45582547-0bd3f400-b8ed-11e8-9784-5845e4105e61.gif)