### PR TITLE
Giving the correct reason when the subscription drops due to overflow

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
@@ -257,7 +257,10 @@ namespace EventStore.ClientAPI.ClientOperations
         private void ExecuteActionAsync(Func<Task> action)
         {
             _actionQueue.Enqueue(action);
-            if (_actionQueue.Count > _maxQueueSize) DropSubscription(SubscriptionDropReason.UserInitiated, new Exception("client buffer too big"));
+            
+            if (_actionQueue.Count > _maxQueueSize) 
+                DropSubscription(SubscriptionDropReason.ProcessingQueueOverflow, new Exception("client buffer too big"));
+            
             if (Interlocked.CompareExchange(ref _actionExecuting, 1, 0) == 0)
                 ThreadPool.QueueUserWorkItem(ExecuteActions);
         }


### PR DESCRIPTION
Fixes #1726 