### PR TITLE
Fix soft delete's "truncate before" checkpoint.

### DIFF
--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -399,7 +399,7 @@ namespace EventStore.Core.Services.Storage
                     var expectedVersion = _indexWriter.GetStreamLastEventNumber(metastreamId);
                     var logPosition = Writer.Checkpoint.ReadNonFlushed();
                     const PrepareFlags flags = PrepareFlags.SingleWrite | PrepareFlags.IsCommitted | PrepareFlags.IsJson;
-                    var data = new StreamMetadata(truncateBefore: EventNumber.DeletedStream).ToJsonBytes();
+                    var data = new StreamMetadata(truncateBefore: expectedVersion + 1).ToJsonBytes();
                     var res = WritePrepareWithRetry(
                         LogRecord.Prepare(logPosition, message.CorrelationId, eventId, logPosition, 0,
                             metastreamId, expectedVersion, flags, SystemEventTypes.StreamMetadata,

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -397,9 +397,10 @@ namespace EventStore.Core.Services.Storage
                     // SOFT DELETE
                     var metastreamId = SystemStreams.MetastreamOf(message.EventStreamId);
                     var expectedVersion = _indexWriter.GetStreamLastEventNumber(metastreamId);
+                    var truncateBefore = expectedVersion + 1;
                     var logPosition = Writer.Checkpoint.ReadNonFlushed();
                     const PrepareFlags flags = PrepareFlags.SingleWrite | PrepareFlags.IsCommitted | PrepareFlags.IsJson;
-                    var data = new StreamMetadata(truncateBefore: expectedVersion + 1).ToJsonBytes();
+                    var data = new StreamMetadata(truncateBefore: truncateBefore).ToJsonBytes();
                     var res = WritePrepareWithRetry(
                         LogRecord.Prepare(logPosition, message.CorrelationId, eventId, logPosition, 0,
                             metastreamId, expectedVersion, flags, SystemEventTypes.StreamMetadata,


### PR DESCRIPTION
**It seems that the truncate before (`$tb`) event is incorrectly written into the stream every time a soft delete occurs.** The documentation explicitly states the following:

> When you delete a stream, its TruncateBefore or $tb is set to the streams current last event number.

Source: https://eventstore.org/docs/server/deleting-streams-and-events/index.html?q=delete%20stream
As you can verify in my PR, this is not the case.

I've already described the issue here:
https://stackoverflow.com/questions/52605285/event-store-cannot-write-to-soft-deleted-streams
and here:
https://groups.google.com/forum/#!topic/event-store/DRtYcK74oRE

To summarize:

- The current implementation writes long.MaxValue as the `$tb` checkpoint value instead of the last event number.
- This prevents appending new events to the stream. The client API calls succeed but the events are not stored.

Please carefully review this PR because it seems strange that no one reported this issue before. I've manually emitted `$tb` events to my local event store using the client API and was able to get the behavior described in the docs. For this to work I needed to set the checkpoint value to the number of events in the stream. I am not 100% confident that `expectedVersion + 1` (my change) is equivalent to the number of events in the stream. Would be great if someone can confirm or suggest a better fix.