### PR TITLE
Dispose chunk before attempting deletion

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -369,6 +369,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 Log.Info("{0}", oldChunksList);
                 Log.Info("Stopping scavenging and removing temp chunk '{0}'...", tmpChunkPath);
                 Log.Info("Exception message: {0}.", exc.Message);
+                newChunk.Dispose();
                 DeleteTempChunk(tmpChunkPath, MaxRetryCount);
                 _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, exc.Message);
 
@@ -386,6 +387,7 @@ namespace EventStore.Core.TransactionLog.Chunks
             {
                 Log.Info("Got exception while scavenging chunk: #{0}-{1}. This chunk will be skipped\n"
                          + "Exception: {2}.", chunkStartNumber, chunkEndNumber, ex.ToString());
+                newChunk.Dispose();
                 DeleteTempChunk(tmpChunkPath, MaxRetryCount);
                 _scavengerLog.ChunksNotScavenged(chunkStartNumber, chunkEndNumber, sw.Elapsed, ex.Message);
 
@@ -405,6 +407,7 @@ namespace EventStore.Core.TransactionLog.Chunks
                 if (retries > 0) {
                     Log.Error("Failed to delete the temp chunk. Retrying {0}/{1}. Reason: {2}",
                         MaxRetryCount - retries, MaxRetryCount, ex);
+                    Thread.Sleep(5000);
                     DeleteTempChunk(tmpChunkPath, retries - 1);
                 }
                 else


### PR DESCRIPTION
Temporary chunks were not being disposed when exceptions are thrown during a scavenge (after the new chunk has been created). This would prevent the temporary chunk from being deleted on Windows even after 5 trials, throwing another exception which would prevent halt the scavenge operation and prevent subsequent chunks from being scavenged.

This PR adds:
- Disposal of temporary chunk before attempting deletion
- Sleeping for 5 secs between each deletion trial