### PR TITLE
Fix inappropriate UserInitiated drop reason.

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
@@ -257,7 +257,9 @@ namespace EventStore.ClientAPI.ClientOperations
         private void ExecuteActionAsync(Func<Task> action)
         {
             _actionQueue.Enqueue(action);
-            if (_actionQueue.Count > _maxQueueSize) DropSubscription(SubscriptionDropReason.UserInitiated, new Exception("client buffer too big"));
+            if (_actionQueue.Count > _maxQueueSize)
+                DropSubscription(SubscriptionDropReason.ProcessingQueueOverflow,
+                    new Exception(string.Format("Action queue exceeded the maximum size ({0} items)", _maxQueueSize)));
             if (Interlocked.CompareExchange(ref _actionExecuting, 1, 0) == 0)
                 ThreadPool.QueueUserWorkItem(ExecuteActions);
         }


### PR DESCRIPTION
Fixes an issue where the subscription drop was reported as `UserInitiated` when the internal action queue exceeds its max length.
Also improves the message on the exception which is generated.

This implements the minimal fix suggested by @riccardone on [#1728](https://github.com/EventStore/EventStore/pull/1728#discussion_r221461887)
