### PR TITLE
Non Promotable Clone

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -305,6 +305,9 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.MaxAutoMergeIndexLevelDescr, Opts.DbGroup)]
 		public int MaxAutoMergeIndexLevel { get; set; }
 
+		[ArgDescription(Opts.IsPromotableDescr, Opts.ClusterGroup)]
+		public bool IsPromotable { get; set; }
+
 		public ClusterNodeOptions() {
 			Config = "";
 			Help = Opts.ShowHelpDefault;
@@ -426,6 +429,8 @@ namespace EventStore.ClusterNode {
 			ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
 
 			MaxAutoMergeIndexLevel = Opts.MaxAutoMergeIndexLevelDefault;
+
+			IsPromotable = Opts.IsPromotableDefault;
 		}
 	}
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -166,7 +166,7 @@ namespace EventStore.ClusterNode {
 
 			VNodeBuilder builder;
 			if (options.ClusterSize > 1) {
-				builder = ClusterVNodeBuilder.AsClusterMember(options.ClusterSize);
+				builder = ClusterVNodeBuilder.AsClusterMember(options.ClusterSize).AsPromotable(options.IsPromotable);
 			} else {
 				builder = ClusterVNodeBuilder.AsSingleNode();
 			}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsAndGossipTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsAndGossipTestCase.cs
@@ -72,7 +72,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			var members = _createInitialGossip(instance, allInstances.ToArray());
 			_updateGossipProcessor.SetInitialData(allInstances, members);
 
-			return new GossipMessage.GossipUpdated(new ClusterInfo(members));
+			return new GossipMessage.GossipUpdated(new ClusterInfo(members),
+				new ClusterInfo(_createInitialGossip(instance, allInstances.ToArray())));
 		}
 
 		protected override SendOverHttpProcessor GetSendOverHttpProcessor() {

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
@@ -33,6 +33,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 
 		private readonly List<ElectionsInstance> _instances = new List<ElectionsInstance>();
 
+		private readonly bool _isPromotable;
+
 		public RandomizedElectionsTestCase(int maxIterCnt,
 			int instancesCnt,
 			double httpLossProbability,
@@ -40,7 +42,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			int httpMaxDelay,
 			int timerMinDelay,
 			int timerMaxDelay,
-			int? rndSeed = null) {
+			int? rndSeed = null,
+			bool isPromotable = true) {
 			RndSeed = rndSeed ?? Math.Abs(Environment.TickCount);
 			Rnd = new Random(RndSeed);
 
@@ -51,6 +54,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			HttpMaxDelay = httpMaxDelay;
 			_timerMinDelay = timerMinDelay;
 			_timerMaxDelay = timerMaxDelay;
+			_isPromotable = isPromotable;
 
 			Runner = new RandomTestRunner(_maxIterCnt);
 			Logger = new ElectionsLogger();
@@ -64,7 +68,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 				var outputBus = new InMemoryBus(string.Format("ELECTIONS-OUTPUT-BUS-{0}", i));
 				var endPoint = new IPEndPoint(BaseEndPoint.Address, BaseEndPoint.Port + i);
 				var nodeInfo = new VNodeInfo(Guid.NewGuid(), 0, endPoint, endPoint, endPoint, endPoint, endPoint,
-					endPoint);
+					endPoint, _isPromotable);
 				_instances.Add(new ElectionsInstance(nodeInfo.InstanceId, endPoint, inputBus, outputBus));
 
 				sendOverHttpHandler.RegisterEndPoint(endPoint, inputBus);
@@ -110,7 +114,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			var members = allInstances.Select(
 				x => MemberInfo.ForVNode(x.InstanceId, DateTime.UtcNow, VNodeState.Unknown, true,
 					x.EndPoint, null, x.EndPoint, null, x.EndPoint, x.EndPoint, -1, 0, 0, -1, -1, Guid.Empty, 0));
-			var gossip = new GossipMessage.GossipUpdated(new ClusterInfo(members.ToArray()));
+			var gossip = new GossipMessage.GossipUpdated(new ClusterInfo(members.ToArray()), new ClusterInfo());
 			return gossip;
 		}
 

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/UpdateGossipProcessor.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/UpdateGossipProcessor.cs
@@ -74,7 +74,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 					_sendOverHttpProcessor.RegisterEndpointToSkip(memberInfo.ExternalTcpEndPoint, !memberInfo.IsAlive);
 				}
 
-				var updateGossipMessage = new GossipMessage.GossipUpdated(new ClusterInfo(updatedGossip));
+				var updateGossipMessage = new GossipMessage.GossipUpdated(new ClusterInfo(updatedGossip), 
+					new ClusterInfo(_initialGossip));
 
 				_enqueue(item, updateGossipMessage);
 				_previousGossip[item.EndPoint] = updatedGossip;

--- a/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using EventStore.Core.Cluster;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Helpers;
@@ -20,7 +21,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		private void ProcessElections() {
-			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo);
+			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo, new ClusterInfo());
 			_electionsUnit.Publish(gossipUpdate);
 
 			_electionsUnit.Publish(new ElectionMessage.StartElections());
@@ -50,7 +51,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		private void ProcessElections() {
-			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo);
+			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo, new ClusterInfo());
 			_electionsUnit.Publish(gossipUpdate);
 
 			_electionsUnit.Publish(new ElectionMessage.StartElections());
@@ -91,7 +92,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		private void ProcessElections() {
-			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo);
+			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo, new ClusterInfo());
 			_electionsUnit.Publish(gossipUpdate);
 
 			_electionsUnit.Publish(new ElectionMessage.StartElections());
@@ -119,6 +120,60 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		public void elect_node_with_biggest_port_ip_for_equal_writerchecksums() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
+		}
+	}
+
+	[TestFixture]
+	public sealed class elections_service_should_not_elect_nonpromotableclone {
+		private ElectionsServiceUnit _electionsUnit;
+		private const int SelfIndex = 0;
+		private const int View = 2;
+
+		[SetUp]
+		public void SetUp() {
+			var clusterSettingsFactory = new ClusterSettingsFactory();
+			var clusterSettings = clusterSettingsFactory.GetClusterSettingsWithSelfAsNonPromotableClone(SelfIndex, 3);
+
+			_electionsUnit = new ElectionsServiceUnit(clusterSettings);
+			_electionsUnit.UpdateClusterMemberInfo(0, isAlive: true);
+			_electionsUnit.UpdateClusterMemberInfo(1, isAlive: true);
+			_electionsUnit.UpdateClusterMemberInfo(2, isAlive: false);
+
+			StartElections();
+			Prepare(SelfIndex, View);
+		}
+
+		private void StartElections() {
+			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo, new ClusterInfo());
+			_electionsUnit.Publish(gossipUpdate);
+
+			_electionsUnit.Publish(new ElectionMessage.StartElections());
+
+			_electionsUnit.RepublishFromPublisher();
+
+			_electionsUnit.RepublishFromPublisher();
+			Assert.That(_electionsUnit.Publisher.Messages.All(x => x is HttpMessage.SendOverHttp || x is TimerMessage.Schedule),
+				Is.True,
+				"Only OverHttp or Schedule messages are expected.");
+
+			_electionsUnit.RepublishFromPublisher();
+
+			_electionsUnit.RepublishFromPublisher();
+			Assert.That(_electionsUnit.Publisher.Messages.All(x => x is HttpMessage.SendOverHttp || x is TimerMessage.Schedule),
+				Is.True,
+				"Only OverHttp or Schedule messages are expected.");
+
+			_electionsUnit.RepublishFromPublisher();
+		}
+
+		private void Prepare(int selfIndex, int view) {
+			_electionsUnit.Publish(new ElectionMessage.Prepare(_electionsUnit.ClusterInfo.Members[selfIndex].InstanceId,
+				_electionsUnit.ClusterInfo.Members[selfIndex].ExternalTcpEndPoint, view));
+		}
+
+		[Test]
+		public void prepare_node_for_election_fail_if_nonpromotableclone() {
+			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.PrepareKo>());
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
@@ -94,7 +94,7 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication {
 			var masterIPEndPoint = new IPEndPoint(IPAddress.Loopback, 2113);
 			_service.Handle(new SystemMessage.BecomeSlave(Guid.NewGuid(), new VNodeInfo(Guid.NewGuid(), 1,
 				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint,
-				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint)));
+				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint, true)));
 		}
 	}
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -83,6 +83,8 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool FaultOutOfOrderProjections;
 		public readonly bool StructuredLog;
 
+		public readonly bool IsPromotable;
+
 		public ClusterVNodeSettings(Guid instanceId, int debugIndex,
 			IPEndPoint internalTcpEndPoint,
 			IPEndPoint internalSecureTcpEndPoint,
@@ -149,7 +151,8 @@ namespace EventStore.Core.Cluster.Settings {
 			int initializationThreads = 1,
 			bool faultOutOfOrderProjections = false,
 			bool structuredLog = false,
-			int maxAutoMergeIndexLevel = 1000) {
+			int maxAutoMergeIndexLevel = 1000,
+			bool isPromotable = true) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
@@ -178,7 +181,8 @@ namespace EventStore.Core.Cluster.Settings {
 			NodeInfo = new VNodeInfo(instanceId, debugIndex,
 				internalTcpEndPoint, internalSecureTcpEndPoint,
 				externalTcpEndPoint, externalSecureTcpEndPoint,
-				internalHttpEndPoint, externalHttpEndPoint);
+				internalHttpEndPoint, externalHttpEndPoint,
+				isPromotable);
 			GossipAdvertiseInfo = gossipAdvertiseInfo;
 			IntHttpPrefixes = intHttpPrefixes;
 			ExtHttpPrefixes = extHttpPrefixes;
@@ -249,6 +253,7 @@ namespace EventStore.Core.Cluster.Settings {
 			MaxAutoMergeIndexLevel = maxAutoMergeIndexLevel;
 			FaultOutOfOrderProjections = faultOutOfOrderProjections;
 			StructuredLog = structuredLog;
+			IsPromotable = isPromotable;
 		}
 
 

--- a/src/EventStore.Core/Cluster/VNodeInfo.cs
+++ b/src/EventStore.Core/Cluster/VNodeInfo.cs
@@ -2,11 +2,11 @@ using EventStore.Core.Data;
 
 namespace EventStore.Core.Cluster {
 	public static class VNodeInfoHelper {
-		public static VNodeInfo FromMemberInfo(MemberInfo member) {
+		public static VNodeInfo FromMemberInfo(MemberInfo member, bool isPromotable) {
 			return new VNodeInfo(member.InstanceId, 0,
 				member.InternalTcpEndPoint, member.InternalSecureTcpEndPoint,
 				member.ExternalTcpEndPoint, member.ExternalSecureTcpEndPoint,
-				member.InternalHttpEndPoint, member.ExternalHttpEndPoint);
+				member.InternalHttpEndPoint, member.ExternalHttpEndPoint, isPromotable);
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -573,7 +573,8 @@ namespace EventStore.Core {
 				vNodeSettings.GossipAdvertiseInfo.ExternalTcp,
 				vNodeSettings.GossipAdvertiseInfo.ExternalSecureTcp,
 				vNodeSettings.GossipAdvertiseInfo.InternalHttp,
-				vNodeSettings.GossipAdvertiseInfo.ExternalHttp);
+				vNodeSettings.GossipAdvertiseInfo.ExternalHttp,
+				_nodeInfo.IsPromotable);
 			if (!isSingleNode) {
 				// MASTER REPLICATION
 				var masterReplicationService = new MasterReplicationService(_mainQueue, gossipInfo.InstanceId, db,

--- a/src/EventStore.Core/Data/VNodeInfo.cs
+++ b/src/EventStore.Core/Data/VNodeInfo.cs
@@ -12,11 +12,12 @@ namespace EventStore.Core.Data {
 		public readonly IPEndPoint ExternalSecureTcp;
 		public readonly IPEndPoint InternalHttp;
 		public readonly IPEndPoint ExternalHttp;
+		public readonly bool IsPromotable;
 
 		public VNodeInfo(Guid instanceId, int debugIndex,
 			IPEndPoint internalTcp, IPEndPoint internalSecureTcp,
 			IPEndPoint externalTcp, IPEndPoint externalSecureTcp,
-			IPEndPoint internalHttp, IPEndPoint externalHttp) {
+			IPEndPoint internalHttp, IPEndPoint externalHttp, bool isPromotable) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcp, "internalTcp");
 			Ensure.NotNull(externalTcp, "externalTcp");
@@ -31,6 +32,7 @@ namespace EventStore.Core.Data {
 			ExternalSecureTcp = externalSecureTcp;
 			InternalHttp = internalHttp;
 			ExternalHttp = externalHttp;
+			IsPromotable = isPromotable;
 		}
 
 		public bool Is(IPEndPoint endPoint) {

--- a/src/EventStore.Core/Data/VNodeState.cs
+++ b/src/EventStore.Core/Data/VNodeState.cs
@@ -10,14 +10,16 @@ namespace EventStore.Core.Data {
 		Master,
 		Manager,
 		ShuttingDown,
-		Shutdown
+		Shutdown,
+		NonPromotableClone
 	}
 
 	public static class VNodeStateExtensions {
 		public static bool IsReplica(this VNodeState state) {
 			return state == VNodeState.CatchingUp
 			       || state == VNodeState.Clone
-			       || state == VNodeState.Slave;
+			       || state == VNodeState.Slave
+			       || state == VNodeState.NonPromotableClone;
 		}
 	}
 }

--- a/src/EventStore.Core/Messages/ElectionMessage.cs
+++ b/src/EventStore.Core/Messages/ElectionMessage.cs
@@ -205,6 +205,51 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class PrepareKo : Message {
+			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+			public override int MsgTypeId { get { return TypeId; } }
+
+			public readonly int View;
+			public readonly Guid ServerId;
+			public readonly IPEndPoint ServerInternalHttp;
+			public readonly int EpochNumber;
+			public readonly long EpochPosition;
+			public readonly Guid EpochId;
+			public readonly long LastCommitPosition;
+			public readonly long WriterCheckpoint;
+			public readonly long ChaserCheckpoint;
+			public readonly int NodePriority;
+
+			public PrepareKo(int view,
+							 Guid serverId,
+							 IPEndPoint serverInternalHttp,
+							 int epochNumber,
+							 long epochPosition,
+							 Guid epochId,
+							 long lastCommitPosition,
+							 long writerCheckpoint,
+							 long chaserCheckpoint,
+							 int nodePriority) {
+				View = view;
+				ServerId = serverId;
+				ServerInternalHttp = serverInternalHttp;
+				EpochNumber = epochNumber;
+				EpochPosition = epochPosition;
+				EpochId = epochId;
+				LastCommitPosition = lastCommitPosition;
+				WriterCheckpoint = writerCheckpoint;
+				ChaserCheckpoint = chaserCheckpoint;
+				NodePriority = nodePriority;
+			}
+
+			public override string ToString() {
+				return string.Format("---- PrepareKo (NPC): view {0}, serverId {1}, serverInternalHttp {2}, epochNumber {3}, " +
+									 "epochPosition {4}, epochId {5}, lastCommitPosition {6}, writerCheckpoint {7}, chaserCheckpoint {8}, nodePriority: {9}",
+									 View, ServerId, ServerInternalHttp, EpochNumber,
+									 EpochPosition, EpochId, LastCommitPosition, WriterCheckpoint, ChaserCheckpoint, NodePriority);
+			}
+		}
+
 		public class Proposal : Message {
 			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Messages/GossipMessage.cs
+++ b/src/EventStore.Core/Messages/GossipMessage.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using EventStore.Core.Cluster;
+using EventStore.Core.Data;
 using EventStore.Core.Messaging;
 
 namespace EventStore.Core.Messages {
@@ -55,7 +57,7 @@ namespace EventStore.Core.Messages {
 
 			public GossipReceived(IEnvelope envelope, ClusterInfo clusterInfo, IPEndPoint server) {
 				Envelope = envelope;
-				ClusterInfo = clusterInfo;
+				ClusterInfo = AdaptNames(clusterInfo);
 				Server = server;
 			}
 		}
@@ -71,7 +73,7 @@ namespace EventStore.Core.Messages {
 			public readonly IPEndPoint ServerEndPoint;
 
 			public SendGossip(ClusterInfo clusterInfo, IPEndPoint serverEndPoint) {
-				ClusterInfo = clusterInfo;
+				ClusterInfo = AdaptNames(clusterInfo);
 				ServerEndPoint = serverEndPoint;
 			}
 		}
@@ -84,10 +86,26 @@ namespace EventStore.Core.Messages {
 			}
 
 			public readonly ClusterInfo ClusterInfo;
+			public readonly ClusterInfo OldClusterInfo;
 
-			public GossipUpdated(ClusterInfo clusterInfo) {
-				ClusterInfo = clusterInfo;
+			public GossipUpdated(ClusterInfo clusterInfo, ClusterInfo oldClusterInfo) {
+				ClusterInfo = AdaptNames(clusterInfo);
+				OldClusterInfo = oldClusterInfo;
 			}
+		}
+
+		private static ClusterInfo AdaptNames(ClusterInfo cluster) {
+			var newOtherMembers = new List<MemberInfo>();
+			foreach (var memberInfo in cluster.Members) {
+				// TODO add a version in memberInfo to avoid adapt names for compatible nodes
+				if (memberInfo.State == VNodeState.NonPromotableClone) {
+					newOtherMembers.Add(memberInfo.Updated(VNodeState.Clone, memberInfo.IsAlive, memberInfo.LastCommitPosition,
+						memberInfo.WriterCheckpoint, memberInfo.ChaserCheckpoint));
+				} else {
+					newOtherMembers.Add(memberInfo);
+				}
+			}
+			return new ClusterInfo(newOtherMembers);
 		}
 
 		public class GossipSendFailed : Message {

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -209,6 +209,17 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class BecomeNonPromotableClone : ReplicaStateMessage {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public BecomeNonPromotableClone(Guid correlationId, VNodeInfo master) : base(correlationId, VNodeState.NonPromotableClone, master) {
+			}
+		}
+
 		public class BecomeSlave : ReplicaStateMessage {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -44,6 +44,7 @@ namespace EventStore.Core.Services {
 				case VNodeState.PreReplica:
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
+				case VNodeState.NonPromotableClone:
 				case VNodeState.Slave:
 					_masterInfo = ((SystemMessage.ReplicaStateMessage)message).Master;
 					break;

--- a/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
+++ b/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
@@ -173,6 +173,7 @@ namespace EventStore.Core.Services.Monitoring {
 			switch (message.State) {
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
+				case VNodeState.NonPromotableClone:
 				case VNodeState.Slave:
 				case VNodeState.Master: {
 					SetStatsStreamMetadata();

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -102,6 +102,7 @@ namespace EventStore.Core.Services.Replication {
 				}
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
+				case VNodeState.NonPromotableClone:
 				case VNodeState.Slave: {
 					// nothing changed, essentially
 					break;
@@ -188,7 +189,7 @@ namespace EventStore.Core.Services.Replication {
 			SendTcpMessage(_connection,
 				new ReplicationMessage.SubscribeReplica(
 					logPosition, chunk.ChunkHeader.ChunkId, epochs, _nodeInfo.InternalTcp,
-					message.MasterId, message.SubscriptionId, isPromotable: true));
+					message.MasterId, message.SubscriptionId, isPromotable: _nodeInfo.IsPromotable));
 		}
 
 		public void Handle(ReplicationMessage.AckLogPosition message) {
@@ -221,6 +222,7 @@ namespace EventStore.Core.Services.Replication {
 
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
+				case VNodeState.NonPromotableClone:
 				case VNodeState.Slave: {
 					Debug.Assert(_connection != null, "Connection manager is null in slave/clone/catching up state");
 					SendTcpMessage(_connection, message.Message);

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -360,6 +360,9 @@ namespace EventStore.Core.Util {
 		public const string GossipSeedDescr = "Endpoints for other cluster nodes from which to seed gossip";
 		public static readonly IPEndPoint[] GossipSeedDefault = new IPEndPoint[0];
 
+		public const string IsPromotableDescr = "Whether or not this node is allowed to join into elections if false this node is just an async replica";
+		public static readonly bool IsPromotableDefault = true;
+
 		/*
 		 *  MANAGER OPTIONS
 		 */

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -134,6 +134,8 @@ namespace EventStore.Core {
 
 		private bool _gossipOnSingleNode;
 
+		protected bool _isPromotable;
+
 		// ReSharper restore FieldCanBeMadeReadOnly.Local
 
 		protected VNodeBuilder() {
@@ -225,6 +227,12 @@ namespace EventStore.Core {
 			_faultOutOfOrderProjections = Opts.FaultOutOfOrderProjectionsDefault;
 			_reduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
 			_initializationThreads = Opts.InitializationThreadsDefault;
+			_isPromotable = Opts.IsPromotableDefault;
+		}
+
+		public VNodeBuilder AsPromotable(bool value) {
+			_isPromotable = value;
+			return this;
 		}
 
 		protected VNodeBuilder WithSingleNodeSettings() {
@@ -1380,7 +1388,8 @@ namespace EventStore.Core {
 				_initializationThreads,
 				_faultOutOfOrderProjections,
 				_structuredLog,
-				_maxAutoMergeIndexLevel);
+				_maxAutoMergeIndexLevel,
+				_isPromotable);
 
 			var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
@@ -55,7 +55,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system {
 						new IPEndPoint(IPAddress.Loopback, 1113),
 						new IPEndPoint(IPAddress.Loopback, 1114),
 						new IPEndPoint(IPAddress.Loopback, 1115),
-						new IPEndPoint(IPAddress.Loopback, 1116)
+						new IPEndPoint(IPAddress.Loopback, 1116),
+						true
 					)));
 				yield return (new SystemMessage.SystemCoreReady());
 				yield return Yield;


### PR DESCRIPTION
There is a new IsPromotable config setting (default true)
When it is set to false, the node does not partecipate in the election process as a candidate and it does not allow the cluster to stay up if there are not enough (other) nodes to form a quorum
Added a new test for the ElectionService changes (more tests can be added... as usual)

To test this PR, run a cluster of 3 nodes. This cluster could be the current stable version.
Once that the cluster is up and running, run a node using this PR code and IsPromotable set to false.
Remember to keep the clustersize 3 and use the same gossip port of the other nodes in order to join the existing cluster.
You can verify that the node is recognize as NonPromotableClone and it does not partecipate as a candidate in the Election Process when you shut down the other nodes for testing.

Closes #263
Closes EventStore/EventStore.CommercialHA#36