### PR TITLE
Multitarget client with net46 and netstandard2.0

### DIFF
--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -22,6 +22,5 @@
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
       <PackageReference Include="System.Net.Requests" Version="4.3.0" />
       <PackageReference Include="System.Net.Security" Version="4.3.2" />
-      <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
@@ -12,10 +12,16 @@
     <DocumentationFile>$(OutputPath)\EventStore.ClientAPI.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-  <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
       <PackageReference Include="protobuf-net" Version="2.4.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+      <PackageReference Include="System.Net.Http" Version="4.3.4" />
+      <PackageReference Include="System.Net.Requests" Version="4.3.0" />
+      <PackageReference Include="System.Net.Security" Version="4.3.2" />
+      <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreNodeConnection.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using EventStore.ClientAPI.ClientOperations;
 using EventStore.ClientAPI.Common;
@@ -13,7 +12,7 @@ namespace EventStore.ClientAPI.Internal
     /// Maintains a full duplex connection to the EventStore
     /// </summary>
     /// <remarks>
-    /// An <see cref="EventStoreConnection"/> operates quite differently than say a <see cref="SqlConnection"/>. Normally
+    /// An <see cref="EventStoreConnection"/> operates quite differently than say a SqlConnection. Normally
     /// when using an <see cref="EventStoreConnection"/> you want to keep the connection open for a much longer of time than
     /// when you use a SqlConnection. If you prefer the usage pattern of using(new Connection()) .. then you would likely
     /// want to create a FlyWeight on top of the <see cref="EventStoreConnection"/>.


### PR DESCRIPTION
Thanks to @jageall for helping out with this. Suggestions are welcome.

The following is based on the compatibility matrix available here: https://docs.microsoft.com/en-us/dotnet/standard/net-standard#net-implementation-support

.NET core 2.0 projects (on Windows/Linux/Mac) and existing .NET Framework 4.6.1+ projects (on Windows) should be able to reference the `netstandard2.0` ClientAPI library according to the compatibility matrix.

.NET Framework 4.6.1+ projects (on Linux/Mac with mono 4.6 as runtime) should be able to reference the `net46` version of the ClientAPI (only mono 5.4+ is compatible with `netstandard2.0` according to the compatibility matrix). This will maintain backward compatibility for mono 4.6 clients.

.NET Framework 4.6.1+ projects (on Linux/Mac with mono 5.4+ as runtime) should be able to reference the `netstandard2.0` ClientAPI library according to the compatibility matrix.
