### PR TITLE
Set default configuration to Debug if not specified

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
 	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 		<OutputPath>$(MSBuildThisFileDirectory)..\bin\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
 		<IntermediateOutputPath>$(MSBuildThisFileDirectory)\..\obj\$(Configuration)\$(MSBuildProjectName)\</IntermediateOutputPath>
 	</PropertyGroup>


### PR DESCRIPTION
This sets the configuration to `Debug` by default if building a single project and not specifying the configuration:

```
dotnet build src/EventStore.Core/EventStore.Core.csproj
```

(Output would previously go to bin/EventStore.Core, now goes to bin/Debug/EventStore.Core)