### PR TITLE
FailOnNoServerResponse Fix

### DIFF
--- a/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
@@ -312,6 +312,7 @@ namespace EventStore.ClientAPI.Internal
                         else
                         {
                             RaiseReconnecting();
+                            _operations.CheckTimeoutsAndRetry(_connection);
                             DiscoverEndPoint(null);
                         }
                     }


### PR DESCRIPTION
FailOnNoServerResponse does not fail on no server response
Fixes https://github.com/EventStore/EventStore/issues/1767

The CheckTimeoutsAndRetry method was not invoked during reconnection

To test this, set the FailOnNoServerResponse=true on the client side and try to connect or reconnect to a non working EventStore