### PR TITLE
StreamEventReader Fix

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs
@@ -35,11 +35,12 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
             _edp.Resume();
         }
 
-        private void HandleEvents(long[] eventNumbers){
+        private void HandleEvents(long[] eventNumbers, int nextEventNumber = -1){
             string eventType = "event_type";
             List<ResolvedEvent> events = new List<ResolvedEvent>();
 
             foreach(long eventNumber in eventNumbers){
+                
                 events.Add(
                     ResolvedEvent.ForUnresolvedEvent(
                         new EventRecord(
@@ -51,8 +52,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                 );
             }
 
-            var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
-
+            var correlationId = _edp.PendingRequestCorrelationId;
             long start, end;
             if(eventNumbers.Length > 0){
                 start = eventNumbers[0];
@@ -65,7 +65,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
 
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
-                    correlationId, _streamName, start, 100, ReadStreamResult.Success,events.ToArray(), null, false, "", start+1, end, true, 200)
+                    correlationId, _streamName, start, 100, ReadStreamResult.Success,events.ToArray(), null, false, "", nextEventNumber!=-1?nextEventNumber:start+1, end, true, 200)
             );            
         }
 
@@ -91,6 +91,18 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
             long eventSequenceNumber = _fromSequenceNumber+5;
 
             Assert.Throws<InvalidOperationException>(() => {
+                HandleEvents(eventSequenceNumber,eventSequenceNumber);
+            });
+
+            Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
+        }
+        [Test]
+        public void should_not_allow_first_event_to_be_greater_than_sequence_number_when_first_read_eof()
+        {
+            long eventSequenceNumber = _fromSequenceNumber+5;
+
+            Assert.Throws<InvalidOperationException>(() => {
+                HandleEvents(new long[0],_fromSequenceNumber+5);
                 HandleEvents(eventSequenceNumber,eventSequenceNumber);
             });
 


### PR DESCRIPTION
Fixes StreamEventReader bug when end of stream is met when reading from a stream with deleted events($MaxAge/$MaxCount) using read and check positions instead of a single variable. Also added unit tests.

Reproduction Steps:
1. Create a continuous projection from one stream
2. Stream has maxage or maxcount
3. Append events to stream
4. Stop projection and wait for events to get appended and events to get deleted
5. Start projection. 
Without fix no exception is thrown, with fix Event Store should throw: "Event number x was expected in the stream y, but event number z was received. This may happen if events have been deleted from the beginning of your stream, please reset your projection."

Might be related to https://github.com/EventStore/EventStore/issues/1468
