### PR TITLE
StreamEventReader Fix (no InvalidOperationException)

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
@@ -39,7 +39,7 @@ namespace EventStore.ClientAPI.Embedded
         protected override void SetUpProjectionsIfNeeded()
         {
             _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType,
-                            _startStandardProjections, _projectionsQueryExpiry, _failOutoforderProjections));
+                            _startStandardProjections, _projectionsQueryExpiry, _faultOutOfOrderProjections));
         }
     }
 }

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedVNodeBuilder.cs
@@ -39,7 +39,7 @@ namespace EventStore.ClientAPI.Embedded
         protected override void SetUpProjectionsIfNeeded()
         {
             _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType,
-                            _startStandardProjections, _projectionsQueryExpiry));
+                            _startStandardProjections, _projectionsQueryExpiry, _failOutoforderProjections));
         }
     }
 }

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -152,8 +152,8 @@ namespace EventStore.ClusterNode
         public int WorkerThreads { get; set; }
         [ArgDescription(Opts.ProjectionsQueryExpiryDescr, Opts.ProjectionsGroup)]
         public int ProjectionsQueryExpiry { get; set; }
-        [ArgDescription(Opts.FailOutoforderProjectionsDescr, Opts.ProjectionsGroup)]
-        public bool FailOutoforderProjections { get; set; }
+        [ArgDescription(Opts.FaultOutOfOrderProjectionsDescr, Opts.ProjectionsGroup)]
+        public bool FaultOutOfOrderProjections { get; set; }
 
         [ArgDescription(Opts.IntHttpPrefixesDescr, Opts.InterfacesGroup)]
         public string[] IntHttpPrefixes { get; set; }
@@ -285,7 +285,7 @@ namespace EventStore.ClusterNode
             SkipDbVerify = Opts.SkipDbVerifyDefault;
             RunProjections = Opts.RunProjectionsDefault;
             ProjectionThreads = Opts.ProjectionThreadsDefault;
-            FailOutoforderProjections = Opts.FailOutoforderProjectionsDefault;
+            FaultOutOfOrderProjections = Opts.FaultOutOfOrderProjectionsDefault;
             WorkerThreads = Opts.WorkerThreadsDefault;
             BetterOrdering = Opts.BetterOrderingDefault;
 

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -152,6 +152,8 @@ namespace EventStore.ClusterNode
         public int WorkerThreads { get; set; }
         [ArgDescription(Opts.ProjectionsQueryExpiryDescr, Opts.ProjectionsGroup)]
         public int ProjectionsQueryExpiry { get; set; }
+        [ArgDescription(Opts.FailOutoforderProjectionsDescr, Opts.ProjectionsGroup)]
+        public bool FailOutoforderProjections { get; set; }
 
         [ArgDescription(Opts.IntHttpPrefixesDescr, Opts.InterfacesGroup)]
         public string[] IntHttpPrefixes { get; set; }
@@ -283,6 +285,7 @@ namespace EventStore.ClusterNode
             SkipDbVerify = Opts.SkipDbVerifyDefault;
             RunProjections = Opts.RunProjectionsDefault;
             ProjectionThreads = Opts.ProjectionThreadsDefault;
+            FailOutoforderProjections = Opts.FailOutoforderProjectionsDefault;
             WorkerThreads = Opts.WorkerThreadsDefault;
             BetterOrdering = Opts.BetterOrderingDefault;
 

--- a/src/EventStore.ClusterNode/ClusterVNodeBuilder.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeBuilder.cs
@@ -36,7 +36,7 @@ namespace EventStore.ClusterNode
         protected override void SetUpProjectionsIfNeeded()
         {
             _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType,
-                            _startStandardProjections, _projectionsQueryExpiry));
+                            _startStandardProjections, _projectionsQueryExpiry, _failOutoforderProjections));
         }
     }
 }

--- a/src/EventStore.ClusterNode/ClusterVNodeBuilder.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeBuilder.cs
@@ -36,7 +36,7 @@ namespace EventStore.ClusterNode
         protected override void SetUpProjectionsIfNeeded()
         {
             _subsystems.Add(new ProjectionsSubsystem(_projectionsThreads, _projectionType,
-                            _startStandardProjections, _projectionsQueryExpiry, _failOutoforderProjections));
+                            _startStandardProjections, _projectionsQueryExpiry, _faultOutOfOrderProjections));
         }
     }
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -202,7 +202,7 @@ namespace EventStore.ClusterNode
                         .WithIndexCacheDepth(options.IndexCacheDepth)
                         .WithIndexMergeOptimization(options.OptimizeIndexMerge)
                         .WithSslTargetHost(options.SslTargetHost)
-                        .RunProjections(options.RunProjections, options.ProjectionThreads)
+                        .RunProjections(options.RunProjections, options.ProjectionThreads, options.FailOutoforderProjections)
                         .WithProjectionQueryExpirationOf(TimeSpan.FromMinutes(options.ProjectionsQueryExpiry))
                         .WithTfCachedChunks(options.CachedChunks)
                         .WithTfChunksCacheSize(options.ChunksCacheSize)

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -202,7 +202,7 @@ namespace EventStore.ClusterNode
                         .WithIndexCacheDepth(options.IndexCacheDepth)
                         .WithIndexMergeOptimization(options.OptimizeIndexMerge)
                         .WithSslTargetHost(options.SslTargetHost)
-                        .RunProjections(options.RunProjections, options.ProjectionThreads, options.FailOutoforderProjections)
+                        .RunProjections(options.RunProjections, options.ProjectionThreads, options.FaultOutOfOrderProjections)
                         .WithProjectionQueryExpirationOf(TimeSpan.FromMinutes(options.ProjectionsQueryExpiry))
                         .WithTfCachedChunks(options.CachedChunks)
                         .WithTfChunksCacheSize(options.ChunksCacheSize)

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -82,7 +82,7 @@ namespace EventStore.Core.Cluster.Settings
 
         public readonly bool GossipOnSingleNode;
 
-        public readonly bool FailOutoforderProjections;
+        public readonly bool FaultOutOfOrderProjections;
 
         public ClusterVNodeSettings(Guid instanceId, int debugIndex,
                                     IPEndPoint internalTcpEndPoint,
@@ -148,7 +148,7 @@ namespace EventStore.Core.Cluster.Settings
                                     bool skipIndexScanOnReads = false,
                                     bool reduceFileCachePressure = false,
                                     int initializationThreads = 1,
-                                    bool failOutOfOrderProjections = false)
+                                    bool faultOutOfOrderProjections = false)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -245,7 +245,7 @@ namespace EventStore.Core.Cluster.Settings
             ReduceFileCachePressure = reduceFileCachePressure;
             InitializationThreads = initializationThreads;
 
-            FailOutoforderProjections = failOutOfOrderProjections;
+            FaultOutOfOrderProjections = faultOutOfOrderProjections;
         }
 
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -82,6 +82,8 @@ namespace EventStore.Core.Cluster.Settings
 
         public readonly bool GossipOnSingleNode;
 
+        public readonly bool FailOutoforderProjections;
+
         public ClusterVNodeSettings(Guid instanceId, int debugIndex,
                                     IPEndPoint internalTcpEndPoint,
                                     IPEndPoint internalSecureTcpEndPoint,
@@ -145,7 +147,8 @@ namespace EventStore.Core.Cluster.Settings
                                     bool gossipOnSingleNode = false,
                                     bool skipIndexScanOnReads = false,
                                     bool reduceFileCachePressure = false,
-                                    int initializationThreads = 1)
+                                    int initializationThreads = 1,
+                                    bool failOutOfOrderProjections = false)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -241,6 +244,8 @@ namespace EventStore.Core.Cluster.Settings
             SkipIndexScanOnReads = skipIndexScanOnReads;
             ReduceFileCachePressure = reduceFileCachePressure;
             InitializationThreads = initializationThreads;
+
+            FailOutoforderProjections = failOutOfOrderProjections;
         }
 
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -130,6 +130,9 @@ namespace EventStore.Core.Util
         public const string ProjectionThreadsDescr = "The number of threads to use for projections.";
         public const int    ProjectionThreadsDefault = 3;
 
+        public const string FailOutoforderProjectionsDescr = "Fail the projection if the Event number that was expected in the stream differs from what is received. This may happen if events have been deleted or expired";
+        public const bool FailOutoforderProjectionsDefault = false;
+
         public const string ProjectionsQueryExpiryDescr = "The number of minutes a query can be idle before it expires";
         public const int    ProjectionsQueryExpiryDefault = 5;
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -130,8 +130,8 @@ namespace EventStore.Core.Util
         public const string ProjectionThreadsDescr = "The number of threads to use for projections.";
         public const int    ProjectionThreadsDefault = 3;
 
-        public const string FailOutoforderProjectionsDescr = "Fail the projection if the Event number that was expected in the stream differs from what is received. This may happen if events have been deleted or expired";
-        public const bool FailOutoforderProjectionsDefault = false;
+        public const string FaultOutOfOrderProjectionsDescr = "Fault the projection if the Event number that was expected in the stream differs from what is received. This may happen if events have been deleted or expired";
+        public const bool FaultOutOfOrderProjectionsDefault = false;
 
         public const string ProjectionsQueryExpiryDescr = "The number of minutes a query can be idle before it expires";
         public const int    ProjectionsQueryExpiryDefault = 5;

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -114,6 +114,7 @@ namespace EventStore.Core
         protected ProjectionType _projectionType;
         protected int _projectionsThreads;
         protected TimeSpan _projectionsQueryExpiry;
+        protected bool _failOutoforderProjections;
 
         protected TFChunkDb _db;
         protected ClusterVNodeSettings _vNodeSettings;
@@ -221,6 +222,7 @@ namespace EventStore.Core
             _skipIndexScanOnReads = Opts.SkipIndexScanOnReadsDefault;
             _chunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
             _projectionsQueryExpiry = TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault);
+            _failOutoforderProjections = Opts.FailOutoforderProjectionsDefault;
             _reduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
             _initializationThreads = Opts.InitializationThreadsDefault;
         }
@@ -268,10 +270,11 @@ namespace EventStore.Core
         /// <param name="projectionType">The mode in which to run the projections system</param>
         /// <param name="numberOfThreads">The number of threads to use for projections. Defaults to 3.</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-        public VNodeBuilder RunProjections(ProjectionType projectionType, int numberOfThreads = Opts.ProjectionThreadsDefault)
+        public VNodeBuilder RunProjections(ProjectionType projectionType, int numberOfThreads = Opts.ProjectionThreadsDefault, bool failOutoforderProjections = Opts.FailOutoforderProjectionsDefault)
         {
             _projectionType = projectionType;
             _projectionsThreads = numberOfThreads;
+            _failOutoforderProjections = failOutoforderProjections;
             return this;
         }
 
@@ -1438,7 +1441,8 @@ namespace EventStore.Core
                     _gossipOnSingleNode,
                     _skipIndexScanOnReads,
                     _reduceFileCachePressure,
-                    _initializationThreads);
+                    _initializationThreads,
+                    _failOutoforderProjections);
             
             var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -114,7 +114,7 @@ namespace EventStore.Core
         protected ProjectionType _projectionType;
         protected int _projectionsThreads;
         protected TimeSpan _projectionsQueryExpiry;
-        protected bool _failOutoforderProjections;
+        protected bool _faultOutOfOrderProjections;
 
         protected TFChunkDb _db;
         protected ClusterVNodeSettings _vNodeSettings;
@@ -222,7 +222,7 @@ namespace EventStore.Core
             _skipIndexScanOnReads = Opts.SkipIndexScanOnReadsDefault;
             _chunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
             _projectionsQueryExpiry = TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault);
-            _failOutoforderProjections = Opts.FailOutoforderProjectionsDefault;
+            _faultOutOfOrderProjections = Opts.FaultOutOfOrderProjectionsDefault;
             _reduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
             _initializationThreads = Opts.InitializationThreadsDefault;
         }
@@ -270,11 +270,11 @@ namespace EventStore.Core
         /// <param name="projectionType">The mode in which to run the projections system</param>
         /// <param name="numberOfThreads">The number of threads to use for projections. Defaults to 3.</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-        public VNodeBuilder RunProjections(ProjectionType projectionType, int numberOfThreads = Opts.ProjectionThreadsDefault, bool failOutoforderProjections = Opts.FailOutoforderProjectionsDefault)
+        public VNodeBuilder RunProjections(ProjectionType projectionType, int numberOfThreads = Opts.ProjectionThreadsDefault, bool faultOutOfOrderProjections = Opts.FaultOutOfOrderProjectionsDefault)
         {
             _projectionType = projectionType;
             _projectionsThreads = numberOfThreads;
-            _failOutoforderProjections = failOutoforderProjections;
+            _faultOutOfOrderProjections = faultOutOfOrderProjections;
             return this;
         }
 
@@ -1442,7 +1442,7 @@ namespace EventStore.Core
                     _skipIndexScanOnReads,
                     _reduceFileCachePressure,
                     _initializationThreads,
-                    _failOutoforderProjections);
+                    _faultOutOfOrderProjections);
             
             var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -112,7 +112,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
         private MiniClusterNode CreateNode(int index, Endpoints endpoints, IPEndPoint[] gossipSeeds)
         {
             _projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
-                            startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+                            startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), 
+                            failOutoforderProjections: Opts.FailOutoforderProjectionsDefault);
             var node = new MiniClusterNode(
                 PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp, endpoints.ExternalTcp,
                 endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false,

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -113,7 +113,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster
         {
             _projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
                             startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), 
-                            failOutoforderProjections: Opts.FailOutoforderProjectionsDefault);
+                            faultOutOfOrderProjections: Opts.FaultOutOfOrderProjectionsDefault);
             var node = new MiniClusterNode(
                 PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp, endpoints.ExternalTcp,
                 endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false,

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/ProjectionsManagerTestSuiteMarkerBase.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/ProjectionsManagerTestSuiteMarkerBase.cs
@@ -45,7 +45,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
         protected void CreateNode()
 		{
             var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
-                    startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+                    startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+                    failOutoforderProjections: Opts.FailOutoforderProjectionsDefault);
             Node = new MiniNode(
                 PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { projections });
             Node.Start();

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/ProjectionsManagerTestSuiteMarkerBase.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/ProjectionsManagerTestSuiteMarkerBase.cs
@@ -46,7 +46,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
 		{
             var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
                     startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
-                    failOutoforderProjections: Opts.FailOutoforderProjectionsDefault);
+                    faultOutOfOrderProjections: Opts.FaultOutOfOrderProjectionsDefault);
             Node = new MiniNode(
                 PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { projections });
             Node.Start();

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
@@ -96,7 +96,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
         protected MiniNode CreateNode()
         {
             var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
-                                startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+                                startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), 
+                                failOutoforderProjections: Opts.FailOutoforderProjectionsDefault);
             return new MiniNode(
             PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { projections });
         }

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/projectionsManager/SpecificationWithNodeAndProjectionsManager.cs
@@ -96,8 +96,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.projectionsManager
         protected MiniNode CreateNode()
         {
             var projections = new ProjectionsSubsystem(1, runProjections: ProjectionType.All,
-                                startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), 
-                                failOutoforderProjections: Opts.FailOutoforderProjectionsDefault);
+                                startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+                                faultOutOfOrderProjections: Opts.FaultOutOfOrderProjectionsDefault);
             return new MiniNode(
             PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { projections });
         }

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -90,8 +90,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
         {
             var projectionWorkerThreadCount = GivenWorkerThreadCount();
             _projections = new ProjectionsSubsystem(projectionWorkerThreadCount, runProjections: ProjectionType.All,
-                            startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), 
-                            failOutoforderProjections: Opts.FailOutoforderProjectionsDefault);
+                            startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault),
+                            faultOutOfOrderProjections: Opts.FaultOutOfOrderProjectionsDefault);
             _node = new MiniNode(
                 PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { _projections });
             _node.Start();

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/specification_with_standard_projections_runnning.cs
@@ -90,7 +90,8 @@ namespace EventStore.Projections.Core.Tests.ClientAPI
         {
             var projectionWorkerThreadCount = GivenWorkerThreadCount();
             _projections = new ProjectionsSubsystem(projectionWorkerThreadCount, runProjections: ProjectionType.All,
-                            startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+                            startStandardProjections: false, projectionQueryExpiry: TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault), 
+                            failOutoforderProjections: Opts.FailOutoforderProjectionsDefault);
             _node = new MiniNode(
                 PathName, inMemDb: true, skipInitializeStandardUsersCheck: false, subsystems: new ISubsystem[] { _projections });
             _node.Start();

--- a/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
@@ -73,7 +73,7 @@ namespace EventStore.Projections.Core.Tests.Services
             _bus.Subscribe(_consumer);
             ICheckpoint writerCheckpoint = new InMemoryCheckpoint(1000);
             var ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_bus));
-            _readerService = new EventReaderCoreService(_bus, ioDispatcher, 10, writerCheckpoint, runHeadingReader: true);
+            _readerService = new EventReaderCoreService(_bus, ioDispatcher, 10, writerCheckpoint, runHeadingReader: true, failOutoforderProjections: true);
             _subscriptionDispatcher =
                 new ReaderSubscriptionDispatcher(_bus);
             _spoolProcessingResponseDispatcher = new SpooledStreamReadingDispatcher(_bus);

--- a/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/TestFixtureWithProjectionCoreService.cs
@@ -73,7 +73,7 @@ namespace EventStore.Projections.Core.Tests.Services
             _bus.Subscribe(_consumer);
             ICheckpoint writerCheckpoint = new InMemoryCheckpoint(1000);
             var ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_bus));
-            _readerService = new EventReaderCoreService(_bus, ioDispatcher, 10, writerCheckpoint, runHeadingReader: true, failOutoforderProjections: true);
+            _readerService = new EventReaderCoreService(_bus, ioDispatcher, 10, writerCheckpoint, runHeadingReader: true, faultOutOfOrderProjections: true);
             _subscriptionDispatcher =
                 new ReaderSubscriptionDispatcher(_bus);
             _spoolProcessingResponseDispatcher = new SpooledStreamReadingDispatcher(_bus);

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/TestFixtureWithEventReaderService.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/TestFixtureWithEventReaderService.cs
@@ -33,7 +33,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader
 
             ICheckpoint writerCheckpoint = new InMemoryCheckpoint(1000);
             _readerService = new EventReaderCoreService(
-                GetInputQueue(), _ioDispatcher, 10, writerCheckpoint, runHeadingReader: GivenHeadingReaderRunning());
+                GetInputQueue(), _ioDispatcher, 10, writerCheckpoint, runHeadingReader: GivenHeadingReaderRunning(), failOutoforderProjections: true);
             _subscriptionDispatcher =
                 new ReaderSubscriptionDispatcher(GetInputQueue());
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/TestFixtureWithEventReaderService.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/TestFixtureWithEventReaderService.cs
@@ -33,7 +33,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader
 
             ICheckpoint writerCheckpoint = new InMemoryCheckpoint(1000);
             _readerService = new EventReaderCoreService(
-                GetInputQueue(), _ioDispatcher, 10, writerCheckpoint, runHeadingReader: GivenHeadingReaderRunning(), failOutoforderProjections: true);
+                GetInputQueue(), _ioDispatcher, 10, writerCheckpoint, runHeadingReader: GivenHeadingReaderRunning(), faultOutOfOrderProjections: true);
             _subscriptionDispatcher =
                 new ReaderSubscriptionDispatcher(GetInputQueue());
 

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs
@@ -100,11 +100,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
         {
             long eventSequenceNumber = _fromSequenceNumber+5;
 
-            Assert.Throws<InvalidOperationException>(() => {
-                HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
-                //to trigger event delivery:
-                HandleEvents(_streamNames[1],100,101);    
-            });
+            HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
+            //to trigger event delivery:
+            HandleEvents(_streamNames[1],100,101);    
+            
             Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
         }
 
@@ -113,24 +112,22 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
         {
             long eventSequenceNumber = _fromSequenceNumber-1;
 
-            Assert.Throws<InvalidOperationException>(() => {
-                HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
-                //to trigger event delivery:
-                HandleEvents(_streamNames[1],100,101);                 
-            });
+            HandleEvents(_streamNames[0],eventSequenceNumber,eventSequenceNumber);
+            //to trigger event delivery:
+            HandleEvents(_streamNames[1],100,101);                 
+            
             Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
         }
 
         [Test]
-        public void events_after_first_event_should_be_in_sequence()
-        {            
-            Assert.Throws<InvalidOperationException>(() => {
-                //_fromSequenceNumber+2 has been omitted
-                HandleEvents(_streamNames[0],new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
-                //to trigger event delivery:
-                HandleEvents(_streamNames[1],100,101);                  
-            });
-            Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
+        public void events_after_first_event_should_not_be_in_sequence()
+        {   
+            //_fromSequenceNumber+2 has been omitted
+            HandleEvents(_streamNames[0],new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
+            //to trigger event delivery:
+            HandleEvents(_streamNames[1],100,101);                  
+          
+            Assert.AreEqual(2, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_at_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_at_event_zero.cs
@@ -108,15 +108,25 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
         }
 
         [Test]
-        public void events_after_first_event_should_be_in_sequence()
-        {            
-            Assert.Throws<InvalidOperationException>(() => {
-                //_fromSequenceNumber+2 has been omitted
-                HandleEvents(_streamNames[0],new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
-                //to trigger event delivery:
-                HandleEvents(_streamNames[1],100,101);
-            });
-            Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());
+        public void events_after_first_event_should_not_be_in_sequence()
+        {    
+            //_fromSequenceNumber+2 has been omitted
+            HandleEvents(_streamNames[0],new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
+            //to trigger event delivery:
+            HandleEvents(_streamNames[1],100,101);
+            
+            Assert.AreEqual(2, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());
+        }
+
+        [Test]
+        public void events_fault_message_for_out_of_sequence_events_should_be()
+        {
+            //_fromSequenceNumber+2 has been omitted
+            HandleEvents(_streamNames[0], new long[] { _fromSequenceNumber, _fromSequenceNumber + 1, _fromSequenceNumber + 3, _fromSequenceNumber + 4 });
+            //to trigger event delivery:
+            HandleEvents(_streamNames[1], 100, 101);
+
+            Assert.IsTrue(HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().First().Reason.Contains(" was expected in the stream "));
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_stream_event_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_read_completed_stream_event_reader.cs
@@ -116,7 +116,6 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         public void cannot_handle_repeated_read_events_completed()
         {
             var correlationId = _consumer.HandledMessages.OfType<ClientMessage.ReadStreamEventsForward>().Last().CorrelationId;
-            Assert.Throws<InvalidOperationException>(() => {
             _edp.Handle(
                 new ClientMessage.ReadStreamEventsForwardCompleted(
                     correlationId, "stream", 100, 100, ReadStreamResult.Success,
@@ -129,7 +128,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
                             PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
                             "event_type", new byte[0], new byte[0]))
                         }, null, false, "", 11, 10, true, 100));
-            });
+            Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());
         }
 
         [Test]

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs
@@ -89,10 +89,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         public void should_not_allow_first_event_to_be_greater_than_sequence_number()
         {
             long eventSequenceNumber = _fromSequenceNumber+5;
-
-            Assert.Throws<InvalidOperationException>(() => {
-                HandleEvents(eventSequenceNumber,eventSequenceNumber);
-            });
+            
+            HandleEvents(eventSequenceNumber,eventSequenceNumber);
 
             Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
         }
@@ -101,23 +99,19 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         public void should_not_allow_first_event_to_be_less_than_sequence_number()
         {
             long eventSequenceNumber = _fromSequenceNumber-1;
-
-            Assert.Throws<InvalidOperationException>(() => {
-                HandleEvents(eventSequenceNumber,eventSequenceNumber);
-            });
+            
+            HandleEvents(eventSequenceNumber,eventSequenceNumber);
             
             Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());
         }
 
         [Test]
-        public void events_after_first_event_should_be_in_sequence()
-        {            
-            Assert.Throws<InvalidOperationException>(() => {
-                //_fromSequenceNumber+2 has been omitted
-                HandleEvents(new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
-            });
-
-            Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
+        public void events_after_second_event_should_not_be_in_sequence()
+        {
+            //_fromSequenceNumber+2 has been omitted
+            HandleEvents(new long[] { _fromSequenceNumber, _fromSequenceNumber + 1, _fromSequenceNumber + 3, _fromSequenceNumber + 4 });
+            
+            Assert.AreEqual(2, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_after_event_zero.cs
@@ -107,7 +107,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
 
         [Test]
         public void events_after_second_event_should_not_be_in_sequence()
-        {
+        {   
             //_fromSequenceNumber+2 has been omitted
             HandleEvents(new long[] { _fromSequenceNumber, _fromSequenceNumber + 1, _fromSequenceNumber + 3, _fromSequenceNumber + 4 });
             

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_at_event_zero.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_streams_with_deleted_events_and_reader_starting_at_event_zero.cs
@@ -96,14 +96,12 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader
         }
 
         [Test]
-        public void events_after_first_event_should_be_in_sequence()
-        {            
-            Assert.Throws<InvalidOperationException>(() => {
-                //_fromSequenceNumber+2 has been omitted
-                HandleEvents(new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
-            });
+        public void events_after_second_event_should_not_be_in_sequence()
+        {   
+            //_fromSequenceNumber+2 has been omitted
+            HandleEvents(new long[]{_fromSequenceNumber,_fromSequenceNumber+1,_fromSequenceNumber+3,_fromSequenceNumber+4});
             
-            Assert.AreEqual(1, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
+            Assert.AreEqual(2, HandledMessages.OfType<ReaderSubscriptionMessage.Faulted>().Count());            
         }
     }
 }

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -151,7 +151,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 _ioDispatcher,
                 10,
                 writerCheckpoint,
-                runHeadingReader: true, failOutoforderProjections: true);
+                runHeadingReader: true, faultOutOfOrderProjections: true);
             _subscriptionDispatcher = new ReaderSubscriptionDispatcher(inputQueue);
             var spoolProcessingResponseDispatcher = new SpooledStreamReadingDispatcher(GetInputQueue());
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -151,7 +151,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager
                 _ioDispatcher,
                 10,
                 writerCheckpoint,
-                runHeadingReader: true);
+                runHeadingReader: true, failOutoforderProjections: true);
             _subscriptionDispatcher = new ReaderSubscriptionDispatcher(inputQueue);
             var spoolProcessingResponseDispatcher = new SpooledStreamReadingDispatcher(GetInputQueue());
 

--- a/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
@@ -40,7 +40,7 @@ namespace EventStore.Projections.Core
                     coreQueue,
                     standardComponents.TimeProvider,
                     coreTimeoutSchedulers[coreQueues.Count],
-                    projectionsStandardComponents.RunProjections);
+                    projectionsStandardComponents.RunProjections, projectionsStandardComponents.FailOutoforderProjections);
                 projectionNode.SetupMessaging(coreInputBus);
 
                 var forwarder = new RequestResponseQueueForwarder(

--- a/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
@@ -40,7 +40,7 @@ namespace EventStore.Projections.Core
                     coreQueue,
                     standardComponents.TimeProvider,
                     coreTimeoutSchedulers[coreQueues.Count],
-                    projectionsStandardComponents.RunProjections, projectionsStandardComponents.FailOutoforderProjections);
+                    projectionsStandardComponents.RunProjections, projectionsStandardComponents.FaultOutOfOrderProjections);
                 projectionNode.SetupMessaging(coreInputBus);
 
                 var forwarder = new RequestResponseQueueForwarder(

--- a/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
@@ -33,8 +33,6 @@ namespace EventStore.Projections.Core
         private readonly ProjectionCoreResponseWriter _coreResponseWriter;
         private readonly SlaveProjectionResponseWriter _slaveProjectionResponseWriter;
 
-        private readonly bool _failOutoforderProjections;
-
         public ProjectionWorkerNode(
             Guid workerId,
             TFChunkDb db,
@@ -42,10 +40,9 @@ namespace EventStore.Projections.Core
             ITimeProvider timeProvider,
             ISingletonTimeoutScheduler timeoutScheduler,
             ProjectionType runProjections,
-            bool failOutoforderProjections)
+            bool faultOutOfOrderProjections)
         {
             _runProjections = runProjections;
-            _failOutoforderProjections = failOutoforderProjections;
             Ensure.NotNull(db, "db");
 
             _coreOutput = new InMemoryBus("Core Output");
@@ -60,8 +57,8 @@ namespace EventStore.Projections.Core
                 _ioDispatcher,
                 10,
                 db.Config.WriterCheckpoint,
-                runHeadingReader: runProjections >= ProjectionType.System, 
-                failOutoforderProjections: _failOutoforderProjections);
+                runHeadingReader: runProjections >= ProjectionType.System,
+                faultOutOfOrderProjections: faultOutOfOrderProjections);
 
             _feedReaderService = new FeedReaderService(_subscriptionDispatcher, timeProvider);
             if (runProjections >= ProjectionType.System)

--- a/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
+++ b/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
@@ -12,19 +12,22 @@ namespace EventStore.Projections.Core
         private readonly InMemoryBus _masterOutputBus;
         private readonly IQueuedHandler _masterInputQueue;
         private readonly InMemoryBus _masterMainBus;
+        private readonly bool _failOutoforderProjections;
 
         public ProjectionsStandardComponents(
             int projectionWorkerThreadCount,
             ProjectionType runProjections,
             InMemoryBus masterOutputBus,
             IQueuedHandler masterInputQueue,
-            InMemoryBus masterMainBus)
+            InMemoryBus masterMainBus,
+            bool failOutoforderProjections)
         {
             _projectionWorkerThreadCount = projectionWorkerThreadCount;
             _runProjections = runProjections;
             _masterOutputBus = masterOutputBus;
             _masterInputQueue = masterInputQueue;
             _masterMainBus = masterMainBus;
+            _failOutoforderProjections = failOutoforderProjections;
         }
 
         public int ProjectionWorkerThreadCount
@@ -50,6 +53,11 @@ namespace EventStore.Projections.Core
         public InMemoryBus MasterMainBus
         {
             get { return _masterMainBus; }
+        }
+
+        public bool FailOutoforderProjections
+        {
+            get { return _failOutoforderProjections; }
         }
     }
 }

--- a/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
+++ b/src/EventStore.Projections.Core/ProjectionsStandardComponents.cs
@@ -12,7 +12,7 @@ namespace EventStore.Projections.Core
         private readonly InMemoryBus _masterOutputBus;
         private readonly IQueuedHandler _masterInputQueue;
         private readonly InMemoryBus _masterMainBus;
-        private readonly bool _failOutoforderProjections;
+        private readonly bool _faultOutOfOrderProjections;
 
         public ProjectionsStandardComponents(
             int projectionWorkerThreadCount,
@@ -20,14 +20,14 @@ namespace EventStore.Projections.Core
             InMemoryBus masterOutputBus,
             IQueuedHandler masterInputQueue,
             InMemoryBus masterMainBus,
-            bool failOutoforderProjections)
+            bool faultOutOfOrderProjections)
         {
             _projectionWorkerThreadCount = projectionWorkerThreadCount;
             _runProjections = runProjections;
             _masterOutputBus = masterOutputBus;
             _masterInputQueue = masterInputQueue;
             _masterMainBus = masterMainBus;
-            _failOutoforderProjections = failOutoforderProjections;
+            _faultOutOfOrderProjections = faultOutOfOrderProjections;
         }
 
         public int ProjectionWorkerThreadCount
@@ -55,9 +55,9 @@ namespace EventStore.Projections.Core
             get { return _masterMainBus; }
         }
 
-        public bool FailOutoforderProjections
+        public bool FaultOutOfOrderProjections
         {
-            get { return _failOutoforderProjections; }
+            get { return _faultOutOfOrderProjections; }
         }
     }
 }

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -27,8 +27,10 @@ namespace EventStore.Projections.Core
         private Dictionary<Guid, IPublisher> _queueMap;
         private bool _subsystemStarted;
 
+        private readonly bool _failOutoforderProjections;
+
         public ProjectionsSubsystem(int projectionWorkerThreadCount, ProjectionType runProjections,
-            bool startStandardProjections, TimeSpan projectionQueryExpiry)
+            bool startStandardProjections, TimeSpan projectionQueryExpiry, bool failOutoforderProjections)
         {
             if (runProjections <= ProjectionType.System)
                 _projectionWorkerThreadCount = 1;
@@ -38,6 +40,7 @@ namespace EventStore.Projections.Core
             _runProjections = runProjections;
             _startStandardProjections = startStandardProjections;
             _projectionsQueryExpiry = projectionQueryExpiry;
+            _failOutoforderProjections = failOutoforderProjections;
         }
 
         public void Register(StandardComponents standardComponents)
@@ -51,7 +54,7 @@ namespace EventStore.Projections.Core
                 _runProjections,
                 _masterOutputBus,
                 _masterInputQueue,
-                _masterMainBus);
+                _masterMainBus, _failOutoforderProjections);
 
             CreateAwakerService(standardComponents);
             _coreQueues = ProjectionCoreWorkersNode.CreateCoreWorkers(standardComponents, projectionsStandardComponents);

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -27,10 +27,10 @@ namespace EventStore.Projections.Core
         private Dictionary<Guid, IPublisher> _queueMap;
         private bool _subsystemStarted;
 
-        private readonly bool _failOutoforderProjections;
+        private readonly bool _faultOutOfOrderProjections;
 
         public ProjectionsSubsystem(int projectionWorkerThreadCount, ProjectionType runProjections,
-            bool startStandardProjections, TimeSpan projectionQueryExpiry, bool failOutoforderProjections)
+            bool startStandardProjections, TimeSpan projectionQueryExpiry, bool faultOutOfOrderProjections)
         {
             if (runProjections <= ProjectionType.System)
                 _projectionWorkerThreadCount = 1;
@@ -40,7 +40,7 @@ namespace EventStore.Projections.Core
             _runProjections = runProjections;
             _startStandardProjections = startStandardProjections;
             _projectionsQueryExpiry = projectionQueryExpiry;
-            _failOutoforderProjections = failOutoforderProjections;
+            _faultOutOfOrderProjections = faultOutOfOrderProjections;
         }
 
         public void Register(StandardComponents standardComponents)
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core
                 _runProjections,
                 _masterOutputBus,
                 _masterInputQueue,
-                _masterMainBus, _failOutoforderProjections);
+                _masterMainBus, _faultOutOfOrderProjections);
 
             CreateAwakerService(standardComponents);
             _coreQueues = ProjectionCoreWorkersNode.CreateCoreWorkers(standardComponents, projectionsStandardComponents);

--- a/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
@@ -262,6 +262,13 @@ namespace EventStore.Projections.Core.Services.Processing
             if (!_eventReaderSubscriptions.TryGetValue(message.CorrelationId, out projectionId))
                 return; // unsubscribed
 
+            if (message.Reason.Contains("was expected in the stream"))
+            {
+                // Log without fault the projection
+                _logger.Debug(message.Reason);
+                return;
+            }
+
             var subscription = _subscriptions[projectionId];
             Handle(new ReaderSubscriptionManagement.Unsubscribe(subscription.SubscriptionId));
             _publisher.Publish(new EventReaderSubscriptionMessage.Failed(subscription.SubscriptionId,message.Reason));            

--- a/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
@@ -48,11 +48,11 @@ namespace EventStore.Projections.Core.Services.Processing
         private readonly HeadingEventReader _headingEventReader;
         private readonly ICheckpoint _writerCheckpoint;
         private readonly bool _runHeadingReader;
-        private readonly bool _failOutoforderProjections;
+        private readonly bool _faultOutOfOrderProjections;
 
         public EventReaderCoreService(
             IPublisher publisher, IODispatcher ioDispatcher, int eventCacheSize,
-            ICheckpoint writerCheckpoint, bool runHeadingReader, bool failOutoforderProjections)
+            ICheckpoint writerCheckpoint, bool runHeadingReader, bool faultOutOfOrderProjections)
         {
             _publisher = publisher;
             _ioDispatcher = ioDispatcher;
@@ -60,7 +60,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 _headingEventReader = new HeadingEventReader(eventCacheSize, _publisher);
             _writerCheckpoint = writerCheckpoint;
             _runHeadingReader = runHeadingReader;
-            _failOutoforderProjections = failOutoforderProjections;
+            _faultOutOfOrderProjections = faultOutOfOrderProjections;
         }
 
         public void Handle(ReaderSubscriptionManagement.Pause message)
@@ -263,7 +263,7 @@ namespace EventStore.Projections.Core.Services.Processing
             if (!_eventReaderSubscriptions.TryGetValue(message.CorrelationId, out projectionId))
                 return; // unsubscribed
 
-            if (!_failOutoforderProjections && message.Reason.Contains("was expected in the stream"))
+            if (!_faultOutOfOrderProjections && message.Reason.Contains("was expected in the stream"))
             {
                 // Log without fault the projection
                 _logger.Trace(message.Reason);

--- a/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
@@ -48,11 +48,11 @@ namespace EventStore.Projections.Core.Services.Processing
         private readonly HeadingEventReader _headingEventReader;
         private readonly ICheckpoint _writerCheckpoint;
         private readonly bool _runHeadingReader;
-
+        private readonly bool _failOutoforderProjections;
 
         public EventReaderCoreService(
             IPublisher publisher, IODispatcher ioDispatcher, int eventCacheSize,
-            ICheckpoint writerCheckpoint, bool runHeadingReader)
+            ICheckpoint writerCheckpoint, bool runHeadingReader, bool failOutoforderProjections)
         {
             _publisher = publisher;
             _ioDispatcher = ioDispatcher;
@@ -60,6 +60,7 @@ namespace EventStore.Projections.Core.Services.Processing
                 _headingEventReader = new HeadingEventReader(eventCacheSize, _publisher);
             _writerCheckpoint = writerCheckpoint;
             _runHeadingReader = runHeadingReader;
+            _failOutoforderProjections = failOutoforderProjections;
         }
 
         public void Handle(ReaderSubscriptionManagement.Pause message)
@@ -262,10 +263,10 @@ namespace EventStore.Projections.Core.Services.Processing
             if (!_eventReaderSubscriptions.TryGetValue(message.CorrelationId, out projectionId))
                 return; // unsubscribed
 
-            if (message.Reason.Contains("was expected in the stream"))
+            if (!_failOutoforderProjections && message.Reason.Contains("was expected in the stream"))
             {
                 // Log without fault the projection
-                _logger.Debug(message.Reason);
+                _logger.Trace(message.Reason);
                 return;
             }
 


### PR DESCRIPTION
Fix scenario when $maxAge/$MaxCount are set on the original stream and events are written while the projection is stopped. 
To manually reproduce:
1. stop the projection
2. write events on the original stream
3. start the projection
4. write other events on the original stream
5 (original code) the projection goes in Fault state + thrown an InvalidOperationException 
5 (with this fix) the projection keep working and log the error 

Fixes https://github.com/EventStore/EventStore/issues/1468

This PR introduce a new option: FaultOutOfOrderProjections (default true)
FaultOutOfOrderProjections=true: the projection that process an event with a not expected number will go in Fault state and a reset is required
FaultOutOfOrderProjections=false: the projection that process an event with a not expected number will keep going working and the error * will be logged

*Event number {0} was expected in the stream {1}, but event number {2} was received. This may happen if events have been deleted from the beginning of your stream, please reset your projection.