### PR TITLE
EventStore.ClientAPI, EventStore.ClientAPI.Embedded and EventStore.Native project file updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ dotnet test src/EventStore.Core.Tests/EventStore.Core.Tests.csproj -- RunConfigu
 dotnet test src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj -- RunConfiguration.TargetPlatform=x64
 ```
 
+## Building the EventStore Client / Embedded Client
+You can build the client / embedded client with the steps below. This will generate a nuget package file (.nupkg) that you can include in your project.
+#### Client
+```
+dotnet pack -c Release src/EventStore.ClientAPI/EventStore.ClientAPI.csproj /p:Version=5.0.0
+```
+
+#### Embedded Client
+```
+dotnet pack -c Release src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj /p:Version=5.0.0
+```
+
+
 ## Building the EventStore web UI
 The web UI is prebuilt and the files are located under [src/EventStore.ClusterNode.Web/clusternode-web](src/EventStore.ClusterNode.Web/clusternode-web).
 If you want to build the web UI, please consult this [repository](https://github.com/EventStore/EventStore.UI) which is also a git submodule of the current repository located under `src/EventStore.UI`.

--- a/src/EventStore.ClientAPI.Embedded/EventStore.Client.Embedded.targets
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.Client.Embedded.targets
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <IsMac>false</IsMac>
+        <IsMac Condition="('$(OS)' == 'Unix') And (Exists ('/Library/Frameworks'))">true</IsMac>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="$(MSBuildThisFileDirectory)..\Prelude\**\*">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>Prelude/%(RecursiveDir)%(Filename)%(Extension)</Link>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
+        <Content Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\native\js1.dll">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>js1.dll</Link>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(OS)' == 'Unix' And '$(IsMac)' == 'false' ">
+        <Content Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\native\libjs1.so">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>libjs1.so</Link>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup Condition=" '$(OS)' == 'Unix' And '$(IsMac)' == 'true'">
+        <Content Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\native\libjs1.dylib">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <Link>libjs1.dylib</Link>
+        </Content>
+    </ItemGroup>
+</Project>

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net471</TargetFramework>
     <Platform>x64</Platform>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>EventStore.Client.Embedded</PackageId>
@@ -21,10 +22,10 @@
     <DocumentationFile>$(OutputPath)\EventStore.ClientAPI.Embedded.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj" />
-    <ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
-    <ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
-    <ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" />
+    <ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj" PrivateAssets="All" />
+    <ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" PrivateAssets="All" />
+    <ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" PrivateAssets="All" />
+    <ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
       <Content Include="..\EventStore.Projections.Core\Prelude\**\*">
@@ -49,6 +50,12 @@
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
   </ItemGroup>
+  <!-- workaround for https://github.com/nuget/home/issues/3891 -->
+  <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference'))" />
+    </ItemGroup>
+  </Target>
   <ItemGroup>
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -58,6 +58,10 @@
           <PackagePath>runtimes/osx-x64/native/libjs1.dylib</PackagePath>
           <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
+      <Content Include="EventStore.Client.Embedded.targets">
+          <Pack>true</Pack>
+          <PackagePath>/build</PackagePath>
+      </Content>
   </ItemGroup>
   <!-- workaround for https://github.com/nuget/home/issues/3891 -->
   <Target Name="CopyProjectReferencesToPackage" DependsOnTargets="ResolveReferences">

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -14,7 +14,7 @@
     <PackageIconUrl>https://eventstore.org/images/ouro.svg</PackageIconUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>The embedded client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</Description>
-    <PackageReleaseNotes>Embedded Client API for version 4 of Event Store</PackageReleaseNotes>
+    <PackageReleaseNotes>https://eventstore.org/blog/</PackageReleaseNotes>
     <Copyright>Copyright 2012-2018 Event Store LLP</Copyright>
     <PackageTags>eventstore client embedded</PackageTags>
   </PropertyGroup>

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -5,6 +5,18 @@
     <Platform>x64</Platform>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>EventStore.Client.Embedded</PackageId>
+    <Authors>Event Store LLP</Authors>
+    <PackageLicenseUrl>https://github.com/EventStore/EventStore/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageProjectUrl>https://eventstore.org</PackageProjectUrl>
+    <PackageIconUrl>https://eventstore.org/images/ouro.svg</PackageIconUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <Description>The embedded client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</Description>
+    <PackageReleaseNotes>Embedded Client API for version 4 of Event Store</PackageReleaseNotes>
+    <Copyright>Copyright 2012-2018 Event Store LLP</Copyright>
+    <PackageTags>eventstore client embedded</PackageTags>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DocumentationFile>$(OutputPath)\EventStore.ClientAPI.Embedded.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -26,6 +26,9 @@
     <ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
     <ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" />
   </ItemGroup>
+  <ItemGroup>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
+  </ItemGroup>
   <!-- TODO(jen20): Investigate whcih of these are correct -->
   <Target Name="CopyDependencies"
           BeforeTargets="BeforeBuild">

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -28,6 +28,15 @@
     <ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="HdrHistogram" Version="2.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="NLog" Version="4.5.10" />
+    <PackageReference Include="protobuf-net" Version="2.4.0" />
+    <PackageReference Include="YamlDotNet" Version="5.2.1" />
+    <!-- This has intentionally not been included since Mono.Posix never required at runtime on Windows. On Linux/Mac, Mono.Posix.dll exists as part of the mono runtime -->
+    <!-- <PackageReference Include="Mono.Posix" Version="5.4.0.201" /> -->
+  </ItemGroup>
+  <ItemGroup>
       <Content Include="..\EventStore.Projections.Core\Prelude\**\*">
         <Pack>true</Pack>
         <PackagePath>Prelude</PackagePath>

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -27,26 +27,29 @@
     <ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
+      <Content Include="..\EventStore.Projections.Core\Prelude\**\*">
+        <Pack>true</Pack>
+        <PackagePath>Prelude</PackagePath>
+        <Link>Prelude/%(RecursiveDir)%(Filename)%(Extension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="..\libs\x64\win\js1.dll">
+          <Pack>true</Pack>
+          <PackagePath>runtimes/win-x64/native/js1.dll</PackagePath>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="..\libs\x64\linux\libjs1.so">
+          <Pack>true</Pack>
+          <PackagePath>runtimes/linux-x64/native/libjs1.so</PackagePath>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Include="..\libs\x64\mac\libjs1.dylib">
+          <Pack>true</Pack>
+          <PackagePath>runtimes/osx-x64/native/libjs1.dylib</PackagePath>
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+  </ItemGroup>
+  <ItemGroup>
       <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
-  <!-- TODO(jen20): Investigate whcih of these are correct -->
-  <Target Name="CopyDependencies"
-          BeforeTargets="BeforeBuild">
-    <Copy ContinueOnError="ErrorAndStop"
-          SourceFiles="..\libs\x64\linux\libjs1.so"
-          DestinationFolder="$(OutDir)"
-          Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'false'" />
-    <Copy ContinueOnError="ErrorAndStop"
-          SourceFiles="..\libs\x64\mac\libjs1.dylib"
-          DestinationFolder="$(OutDir)"
-          Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'true'" />
-    <Copy ContinueOnError="ErrorAndStop"
-          SourceFiles="..\libs\x64\win\js1.dll"
-          DestinationFolder="$(OutDir)"
-          Condition=" '$(OS)' == 'Windows_NT' " />
-    <Copy ContinueOnError="ErrorAndStop"
-          SourceFiles="..\libs\x64\win\js1.pdb"
-          DestinationFolder="$(OutDir)" />
-              
-  </Target>
 </Project>

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -12,7 +12,7 @@
     <PackageIconUrl>https://eventstore.org/images/ouro.svg</PackageIconUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>The client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</Description>
-    <PackageReleaseNotes>Client API for version 4 of Event Store</PackageReleaseNotes>
+    <PackageReleaseNotes>https://eventstore.org/blog/</PackageReleaseNotes>
     <Copyright>Copyright 2012-2018 Event Store LLP</Copyright>
     <PackageTags>eventstore client</PackageTags>
   </PropertyGroup>

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
       <PackageReference Include="protobuf-net" Version="2.4.0" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System.Net.Http" />

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -4,6 +4,18 @@
     <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  <PropertyGroup>
+    <PackageId>EventStore.Client</PackageId>
+    <Authors>Event Store LLP</Authors>
+    <PackageLicenseUrl>https://github.com/EventStore/EventStore/blob/master/LICENSE.md</PackageLicenseUrl>
+    <PackageProjectUrl>https://eventstore.org</PackageProjectUrl>
+    <PackageIconUrl>https://eventstore.org/images/ouro.svg</PackageIconUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <Description>The client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</Description>
+    <PackageReleaseNotes>Client API for version 4 of Event Store</PackageReleaseNotes>
+    <Copyright>Copyright 2012-2018 Event Store LLP</Copyright>
+    <PackageTags>eventstore client</PackageTags>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DocumentationFile>$(OutputPath)\EventStore.ClientAPI.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/EventStore.Native/EventStore.Native.csproj
+++ b/src/EventStore.Native/EventStore.Native.csproj
@@ -5,9 +5,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <!--Unfortunately, Mono.Posix.NETStandard forwards to Mono.Posix when compiling for net471, which doesn't necessarily exist on windows-->
+      <Reference Include="Mono.Posix" Condition="$(OS) != 'Windows_NT'" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Mono.Posix" Version="5.4.0.201" Condition="'$(OS)' == 'Windows_NT'" />
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" Condition="$(OS) != 'Windows_NT'" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />


### PR DESCRIPTION
- **Client and Embedded Client:** Add nuget package information to EventStore.Client and EventStore.Client.Embedded csproj files to be able to build nuget package with `dotnet pack`
- **Client and Embedded Client:** Add Sourcelink. Fixes #1740, thanks @ppumkin
- **Client and Embedded Client:** Add blog url as release note
- **Embedded Client:** Add projection libraries for all operating systems. Projection libraries, preludes,etc. are included in the embedded client nupkg in the correct folder depending on the runtime. (Embedded client is now compatible with Windows, Linux and Mac OS X)
- **EventStore.Native**: Use local Mono.Posix Reference for Linux and Mac instead of referencing Mono.Posix.NetStandard
- **Embedded Client:** Add nuget package references so that dependencies are downloaded (except Mono.Posix since on Windows Mono.Posix code is never executed. On Linux/Mac the local Mono.Posix mono assembly should be loaded)

The following command can be used to build the nuget package file:
```
dotnet pack -c Release src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj -o ./packages /p:Version=5.0.0
```