### PR TITLE
Manually trigger large Index Merges

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 TestResult.xml
 *.nupkg
 /packages
+# The packages folder can be ignored because of Package Restore
+**/packages/*
+# except build/, which is used as an MSBuild target.
+!**/packages/build/
 /Logs
 /Data
 /Data-logs

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -242,6 +242,9 @@ namespace EventStore.ClusterNode
 
         [ArgDescription(Opts.StructuredLogDescr, Opts.DbGroup)]
         public bool StructuredLog { get; set; }
+		
+		[ArgDescription(Opts.AutomergeIndexesDescr, Opts.DbGroup)]
+        public bool AutomergeIndexes { get; set; }
 
         public ClusterNodeOptions()
         {
@@ -362,6 +365,8 @@ namespace EventStore.ClusterNode
 
             ConnectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
             ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
+
+            AutomergeIndexes = Opts.AutomergeIndexesDefault;
         }
     }
 }

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -243,8 +243,8 @@ namespace EventStore.ClusterNode
         [ArgDescription(Opts.StructuredLogDescr, Opts.DbGroup)]
         public bool StructuredLog { get; set; }
 		
-		[ArgDescription(Opts.AutomergeIndexesDescr, Opts.DbGroup)]
-        public bool AutomergeIndexes { get; set; }
+		[ArgDescription(Opts.AutoMergeIndexesDescr, Opts.DbGroup)]
+        public bool AutoMergeIndexes { get; set; }
 
         public ClusterNodeOptions()
         {
@@ -366,7 +366,7 @@ namespace EventStore.ClusterNode
             ConnectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
             ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
 
-            AutomergeIndexes = Opts.AutomergeIndexesDefault;
+            AutoMergeIndexes = Opts.AutoMergeIndexesDefault;
         }
     }
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -218,7 +218,8 @@ namespace EventStore.ClusterNode
                         .HavingReaderThreads(options.ReaderThreadsCount)
                         .WithConnectionPendingSendBytesThreshold(options.ConnectionPendingSendBytesThreshold)
                         .WithChunkInitialReaderCount(options.ChunkInitialReaderCount)
-                        .WithInitializationThreads(options.InitializationThreads);
+                        .WithInitializationThreads(options.InitializationThreads)
+                        .WithAutoMergeIndexes(options.AutomergeIndexes);
 
             if(options.GossipSeed.Length > 0)
                 builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -219,7 +219,7 @@ namespace EventStore.ClusterNode
                         .WithConnectionPendingSendBytesThreshold(options.ConnectionPendingSendBytesThreshold)
                         .WithChunkInitialReaderCount(options.ChunkInitialReaderCount)
                         .WithInitializationThreads(options.InitializationThreads)
-                        .WithAutoMergeIndexes(options.AutomergeIndexes);
+                        .WithAutoMergeIndexes(options.AutoMergeIndexes);
 
             if(options.GossipSeed.Length > 0)
                 builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.Core.Tests/Services/Replication/CommitReplication/when_constructing_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CommitReplication/when_constructing_index_committer_service.cs
@@ -8,11 +8,8 @@ using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.Services.Replication;
 using NUnit.Framework;
-using EventStore.Core.Services.Storage.ReaderIndex;
-using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services.Storage;
 using EventStore.Core.Tests.Services.Storage;
-using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Tests.Services.Replication.CommitReplication
 {
@@ -25,42 +22,41 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication
         protected InMemoryBus _publisher = new InMemoryBus("publisher");
         protected FakeIndexCommitter _indexCommitter = new FakeIndexCommitter();
         protected ITableIndex _tableIndex = new FakeTableIndex();
-        protected ITFChunkScavengerLogManager _tfChunkScavengerLogManager = new FakeTfChunkLogManager();
 
         [Test]
         public void null_index_committer_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(null, _publisher, _replicationCheckpoint, _writerCheckpoint, _commitCount, _tableIndex, _tfChunkScavengerLogManager));
+            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(null, _publisher, _replicationCheckpoint, _writerCheckpoint, _commitCount, _tableIndex));
         }
 
         [Test]
         public void null_publisher_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, null, _replicationCheckpoint, _writerCheckpoint, _commitCount, _tableIndex, _tfChunkScavengerLogManager));
+            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, null, _replicationCheckpoint, _writerCheckpoint, _commitCount, _tableIndex));
         }
 
         [Test]
         public void null_writer_checkpoint_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, null, _commitCount, _tableIndex, _tfChunkScavengerLogManager));
+            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, null, _commitCount, _tableIndex));
         }
 
         [Test]
         public void null_replication_checkpoint_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, _publisher, null, _writerCheckpoint, _commitCount, _tableIndex, _tfChunkScavengerLogManager));
+            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, _publisher, null, _writerCheckpoint, _commitCount, _tableIndex));
         }
 
         [Test]
         public void commit_count_of_zero_throws_argument_out_of_range_exception()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, 0, _tableIndex, _tfChunkScavengerLogManager));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, 0, _tableIndex));
         }
 
         [Test]
         public void negative_commit_count_throws_argument_out_of_range_exception()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, -1, _tableIndex, _tfChunkScavengerLogManager));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, -1, _tableIndex));
         }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Replication/CommitReplication/when_constructing_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CommitReplication/when_constructing_index_committer_service.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
+using EventStore.Core.Index;
 using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.Services.Replication;
@@ -10,6 +11,8 @@ using NUnit.Framework;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services.Storage;
+using EventStore.Core.Tests.Services.Storage;
+using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Tests.Services.Replication.CommitReplication
 {
@@ -21,41 +24,43 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication
         protected ICheckpoint _writerCheckpoint = new InMemoryCheckpoint(0);
         protected InMemoryBus _publisher = new InMemoryBus("publisher");
         protected FakeIndexCommitter _indexCommitter = new FakeIndexCommitter();
+        protected ITableIndex _tableIndex = new FakeTableIndex();
+        protected ITFChunkScavengerLogManager _tfChunkScavengerLogManager = new FakeTfChunkLogManager();
 
         [Test]
         public void null_index_committer_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(null, _publisher, _replicationCheckpoint, _writerCheckpoint, _commitCount));
+            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(null, _publisher, _replicationCheckpoint, _writerCheckpoint, _commitCount, _tableIndex, _tfChunkScavengerLogManager));
         }
 
         [Test]
         public void null_publisher_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, null, _replicationCheckpoint, _writerCheckpoint, _commitCount));
+            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, null, _replicationCheckpoint, _writerCheckpoint, _commitCount, _tableIndex, _tfChunkScavengerLogManager));
         }
 
         [Test]
         public void null_writer_checkpoint_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, null, _commitCount));
+            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, null, _commitCount, _tableIndex, _tfChunkScavengerLogManager));
         }
 
         [Test]
         public void null_replication_checkpoint_throws_argument_null_exception()
         {
-            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, _publisher, null, _writerCheckpoint, _commitCount));
+            Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(_indexCommitter, _publisher, null, _writerCheckpoint, _commitCount, _tableIndex, _tfChunkScavengerLogManager));
         }
 
         [Test]
         public void commit_count_of_zero_throws_argument_out_of_range_exception()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, 0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, 0, _tableIndex, _tfChunkScavengerLogManager));
         }
 
         [Test]
         public void negative_commit_count_throws_argument_out_of_range_exception()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, -1, _tableIndex, _tfChunkScavengerLogManager));
         }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
@@ -45,7 +45,7 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication
             _tableIndex = new FakeTableIndex();
             _tfChunkScavengerLogManager = new FakeTfChunkLogManager();
             _service = new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint,
-                _commitCount, _tableIndex, _tfChunkScavengerLogManager);
+                _commitCount, _tableIndex);
             _service.Init(0);
             When();
         }

--- a/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
+using EventStore.Core.Index;
 using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.Services.Replication;
@@ -10,6 +11,8 @@ using NUnit.Framework;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services.Storage;
+using EventStore.Core.Tests.Services.Storage;
+using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Tests.Services.Replication.CommitReplication
 {
@@ -19,6 +22,7 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication
         protected string _eventStreamId = "test_stream";
         protected int _commitCount = 2;
         protected long _replicationPosition = 0;
+        protected ITableIndex _tableIndex;
 
         protected ICheckpoint _replicationCheckpoint;
         protected ICheckpoint _writerCheckpoint;
@@ -27,6 +31,7 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication
 
         protected IndexCommitterService _service;
         protected FakeIndexCommitter _indexCommitter;
+        protected ITFChunkScavengerLogManager _tfChunkScavengerLogManager;
 
         protected int _expectedCommitReplicatedMessages;
 
@@ -37,7 +42,10 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication
             _replicationCheckpoint = new InMemoryCheckpoint(_replicationPosition);
             _writerCheckpoint = new InMemoryCheckpoint(0);
             _publisher.Subscribe(new AdHocHandler<StorageMessage.CommitReplicated>(m => _handledMessages.Add(m)));
-            _service = new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint, _commitCount);
+            _tableIndex = new FakeTableIndex();
+            _tfChunkScavengerLogManager = new FakeTfChunkLogManager();
+            _service = new IndexCommitterService(_indexCommitter, _publisher, _replicationCheckpoint, _writerCheckpoint,
+                _commitCount, _tableIndex, _tfChunkScavengerLogManager);
             _service.Init(0);
             When();
         }

--- a/src/EventStore.Core.Tests/Services/Replication/FakeTfChunkLogManager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/FakeTfChunkLogManager.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using EventStore.Core.Tests.TransactionLog.Scavenging.Helpers;
+using EventStore.Core.TransactionLog.Chunks;
+
+namespace EventStore.Core.Tests.Services.Replication
+{
+    public class FakeTfChunkLogManager : ITFChunkScavengerLogManager
+    {
+        public void Initialise()
+        {
+           
+        }
+
+        public ITFChunkScavengerLog CreateLog()
+        {
+            return new FakeTFScavengerLog();
+        }
+    }
+
+    public class FakeTfChunkScavengerLog : ITFChunkScavengerLog
+    {
+        public void IndexTableScavenged(int level, int index, TimeSpan elapsed, long entriesDeleted, long entriesKept,
+            long spaceSaved)
+        {
+           
+        }
+
+        public void IndexTableNotScavenged(int level, int index, TimeSpan elapsed, long entriesKept, string errorMessage)
+        {
+            
+        }
+
+        public string ScavengeId { get; }
+        public long SpaceSaved { get; }
+        public void ScavengeStarted()
+        {
+            
+        }
+
+        public void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved)
+        {
+            
+        }
+
+        public void ChunksNotScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, string errorMessage)
+        {
+           
+        }
+
+        public void ChunksMerged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved)
+        {
+            
+        }
+
+        public void ChunksNotMerged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, string errorMessage)
+        {
+           
+        }
+
+        public void ScavengeCompleted(ScavengeResult result, string error, TimeSpan elapsed)
+        {
+          
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -65,7 +65,7 @@ namespace EventStore.Core.Tests.Services.Storage
             return Task.CompletedTask;
         }
 
-        public bool IsBackgroungTaskRunning
+        public bool IsBackgroundTaskRunning
         {
             get { return false; }
         }

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -58,5 +58,10 @@ namespace EventStore.Core.Tests.Services.Storage
         {
             ScavengeCount++;
         }
+
+        public void MergeIndexes()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -64,5 +64,10 @@ namespace EventStore.Core.Tests.Services.Storage
         {
             return Task.CompletedTask;
         }
+
+        public bool IsBackgroungTaskRunning
+        {
+            get { return false; }
+        }
     }
 }

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 using EventStore.Core.Index;
 
 namespace EventStore.Core.Tests.Services.Storage
@@ -59,9 +60,9 @@ namespace EventStore.Core.Tests.Services.Storage
             ScavengeCount++;
         }
 
-        public void MergeIndexes()
+        public Task MergeIndexes()
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -79,8 +79,10 @@ namespace EventStore.Core.Cluster.Settings
         public readonly bool SkipIndexScanOnReads;
         public readonly bool ReduceFileCachePressure;
         public readonly int InitializationThreads;
+        public readonly bool AutoMergeIndexes;
+
         public readonly bool GossipOnSingleNode;
-        public readonly bool FaultOutOfOrderProjections;
+		public readonly bool FaultOutOfOrderProjections;
         public readonly bool StructuredLog;
         public ClusterVNodeSettings(Guid instanceId, int debugIndex,
                                     IPEndPoint internalTcpEndPoint,
@@ -147,7 +149,8 @@ namespace EventStore.Core.Cluster.Settings
                                     bool reduceFileCachePressure = false,
                                     int initializationThreads = 1,
                                     bool faultOutOfOrderProjections = false,
-                                    bool structuredLog = false)
+                                    bool structuredLog = false,
+									bool autoMergeIndexes = true)
         {
             Ensure.NotEmptyGuid(instanceId, "instanceId");
             Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -243,7 +246,7 @@ namespace EventStore.Core.Cluster.Settings
             SkipIndexScanOnReads = skipIndexScanOnReads;
             ReduceFileCachePressure = reduceFileCachePressure;
             InitializationThreads = initializationThreads;
-
+            AutoMergeIndexes = autoMergeIndexes;
             FaultOutOfOrderProjections = faultOutOfOrderProjections;
         }
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -228,12 +228,8 @@ namespace EventStore.Core
             _mainBus.Subscribe<SystemMessage.BecomeShutdown>(storageReader);
             monitoringRequestBus.Subscribe<MonitoringMessage.InternalStatsRequest>(storageReader);
 
-            // IO DISPATCHER
-            var ioDispatcher = new IODispatcher(_mainQueue, new PublishEnvelope(_mainQueue));
-            var scavengerLogManager = new TFChunkScavengerLogManager(_nodeInfo.ExternalHttp.ToString(), TimeSpan.FromDays(vNodeSettings.ScavengeHistoryMaxAge), ioDispatcher);
-
             var indexCommitterService = new IndexCommitterService(readIndex.IndexCommitter, _mainQueue,
-                db.Config.ReplicationCheckpoint, db.Config.WriterCheckpoint, vNodeSettings.CommitAckCount, tableIndex, scavengerLogManager);
+                db.Config.ReplicationCheckpoint, db.Config.WriterCheckpoint, vNodeSettings.CommitAckCount, tableIndex);
             AddTask(indexCommitterService.Task);
 
             _mainBus.Subscribe<SystemMessage.StateChangeMessage>(indexCommitterService);
@@ -456,6 +452,8 @@ namespace EventStore.Core
             subscrBus.Subscribe<StorageMessage.EventCommitted>(subscription);
 
             // PERSISTENT SUBSCRIPTIONS
+            // IO DISPATCHER
+            var ioDispatcher = new IODispatcher(_mainQueue, new PublishEnvelope(_mainQueue));
             _mainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
             _mainBus.Subscribe<ClientMessage.WriteEventsCompleted>(ioDispatcher.Writer);
             _mainBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(ioDispatcher.ForwardReader);
@@ -505,6 +503,7 @@ namespace EventStore.Core
             perSubscrBus.Subscribe<SubscriptionMessage.PersistentSubscriptionTimerTick>(persistentSubscription);
 
             // STORAGE SCAVENGER
+            var scavengerLogManager = new TFChunkScavengerLogManager(_nodeInfo.ExternalHttp.ToString(), TimeSpan.FromDays(vNodeSettings.ScavengeHistoryMaxAge), ioDispatcher);
             var storageScavenger = new StorageScavenger(db,
                                                         tableIndex,
                                                         readIndex,
@@ -514,7 +513,6 @@ namespace EventStore.Core
                                                         unsafeIgnoreHardDeletes: vNodeSettings.UnsafeIgnoreHardDeletes);
 
             // ReSharper disable RedundantTypeArgumentsOfMethod
-            //_mainBus.Subscribe<ClientMessage.MergeIndexes>(storageScavenger);
             _mainBus.Subscribe<ClientMessage.ScavengeDatabase>(storageScavenger);
             _mainBus.Subscribe<ClientMessage.StopDatabaseScavenge>(storageScavenger);
             _mainBus.Subscribe<SystemMessage.StateChangeMessage>(storageScavenger);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -193,7 +193,9 @@ namespace EventStore.Core
                                             inMem: db.Config.InMemDb,
                                             skipIndexVerify: vNodeSettings.SkipIndexVerify,
                                             indexCacheDepth: vNodeSettings.IndexCacheDepth,
-                                            initializationThreads: vNodeSettings.InitializationThreads);
+                                            initializationThreads: vNodeSettings.InitializationThreads,
+                                            additionalReclaim: false, 
+                                            autoMergeIndexes: vNodeSettings.AutoMergeIndexes);
 			var readIndex = new ReadIndex(_mainQueue,
                                           readerPool,
                                           tableIndex,
@@ -508,7 +510,8 @@ namespace EventStore.Core
                                                         !vNodeSettings.DisableScavengeMerging,
                                                         unsafeIgnoreHardDeletes: vNodeSettings.UnsafeIgnoreHardDeletes);
 
-			// ReSharper disable RedundantTypeArgumentsOfMethod
+            // ReSharper disable RedundantTypeArgumentsOfMethod
+            _mainBus.Subscribe<ClientMessage.MergeIndexes>(storageScavenger);
             _mainBus.Subscribe<ClientMessage.ScavengeDatabase>(storageScavenger);
             _mainBus.Subscribe<ClientMessage.StopDatabaseScavenge>(storageScavenger);
             _mainBus.Subscribe<SystemMessage.StateChangeMessage>(storageScavenger);

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -21,5 +21,6 @@ namespace EventStore.Core.Index
         IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null);
 
         void Scavenge(IIndexScavengerLog log, CancellationToken ct);
+        void MergeIndexes();
     }
 }

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -23,6 +23,6 @@ namespace EventStore.Core.Index
 
         void Scavenge(IIndexScavengerLog log, CancellationToken ct);
         Task MergeIndexes();
-        bool IsBackgroungTaskRunning { get; }
+        bool IsBackgroundTaskRunning { get; }
     }
 }

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace EventStore.Core.Index
 {
@@ -21,6 +22,6 @@ namespace EventStore.Core.Index
         IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null);
 
         void Scavenge(IIndexScavengerLog log, CancellationToken ct);
-        void MergeIndexes();
+        Task MergeIndexes();
     }
 }

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -23,5 +23,6 @@ namespace EventStore.Core.Index
 
         void Scavenge(IIndexScavengerLog log, CancellationToken ct);
         Task MergeIndexes();
+        bool IsBackgroungTaskRunning { get; }
     }
 }

--- a/src/EventStore.Core/Index/IndexMap.cs
+++ b/src/EventStore.Core/Index/IndexMap.cs
@@ -417,8 +417,9 @@ namespace EventStore.Core.Index
 
             if (mergeIndexes)
             {
-                if (autoMergeIndexes)
-                    tables = Flatted(tables);
+                // Flat the levels if we are in manual merge indexes mode
+                if (!autoMergeIndexes)
+                    tables = new List<List<PTable>> {tables.SelectMany(a => a).ToList()};
 
                 for (int level = 0; level < tables.Count; level++)
                 {
@@ -436,14 +437,6 @@ namespace EventStore.Core.Index
             
             var indexMap = new IndexMap(Version, tables, prepareCheckpoint, commitCheckpoint, _maxTablesPerLevel);
             return new MergeResult(indexMap, toDelete);
-        }
-
-        private static List<List<PTable>> Flatted(IEnumerable<List<PTable>> tables)
-        {
-            var flattened = new List<PTable>();
-            foreach (var t in tables.Where(a => a.Any()))
-                flattened.AddRange(t);
-            return new List<List<PTable>> {flattened};
         }
 
         public ScavengeResult Scavenge(Guid toScavenge, CancellationToken ct,

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -235,6 +235,12 @@ namespace EventStore.Core.Index
      
         public Task MergeIndexes()
         {
+            if (_autoMergeIndexes)
+            {
+                Log.Warn("Manual Indexes Merge is not allowed when AutoMergeIndexes option is true");
+                return Task.CompletedTask;
+            }
+
             return Task.Run(() =>
             {
                 try

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -249,7 +249,7 @@ namespace EventStore.Core.Index
             }, CancellationToken.None); 
         }
 
-        public bool IsBackgroungTaskRunning
+        public bool IsBackgroundTaskRunning
         {
             get { return _backgroundRunning; }
         }

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -249,6 +249,11 @@ namespace EventStore.Core.Index
             }, CancellationToken.None); 
         }
 
+        public bool IsBackgroungTaskRunning
+        {
+            get { return _backgroundRunning; }
+        }
+
         private void TryProcessAwaitingTables(long commitPos, long prepareCheckpoint, bool mergeIndexes)
         {
             lock (_awaitingTablesLock)

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -332,7 +332,7 @@ namespace EventStore.Core.Index
                             (streamId, currentHash) => UpgradeHash(streamId, currentHash),
                             entry => reader.ExistsAt(entry.Position),
                             entry => ReadEntry(reader, entry.Position), _fileNameProvider, _ptableVersion,
-                            _indexCacheDepth, _skipIndexVerify, mergeIndexes);
+                            _indexCacheDepth, _skipIndexVerify, mergeIndexes, _autoMergeIndexes);
                     }
 
                     _indexMap = mergeResult.MergedMap;

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -237,7 +237,7 @@ namespace EventStore.Core.Index
         {
             if (_autoMergeIndexes)
             {
-                Log.Warn("Manual Indexes Merge is not allowed when AutoMergeIndexes option is true");
+                Log.Error("Manual Indexes Merge is not allowed when AutoMergeIndexes option is true");
                 return Task.CompletedTask;
             }
 

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1361,6 +1361,49 @@ namespace EventStore.Core.Messages
             }
         }
 
+        public class MergeIndexes : Message
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly IEnvelope Envelope;
+            public readonly Guid CorrelationId;
+            public readonly IPrincipal User;
+
+            public MergeIndexes(IEnvelope envelope, Guid correlationId, IPrincipal user)
+            {
+                Ensure.NotNull(envelope, "envelope");
+                Envelope = envelope;
+                CorrelationId = correlationId;
+                User = user;
+            }
+        }
+
+        public class MergeIndexesResponse : Message
+        {
+            private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+            public override int MsgTypeId { get { return TypeId; } }
+
+            public readonly Guid CorrelationId;
+            public readonly MergeIndexesResult Result;
+
+            public MergeIndexesResponse(Guid correlationId, MergeIndexesResult result)
+            {
+                CorrelationId = correlationId;
+                Result = result;
+            }
+
+            public override string ToString()
+            {
+                return String.Format("Result: {0}", Result);
+            }
+
+            public enum MergeIndexesResult
+            {
+                Started
+            }
+        }
+
         public class ScavengeDatabase: Message
         {
             private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);

--- a/src/EventStore.Core/Messages/MergeIndexesResultDto.cs
+++ b/src/EventStore.Core/Messages/MergeIndexesResultDto.cs
@@ -1,0 +1,16 @@
+﻿namespace EventStore.Core.Messages
+{
+    public class MergeIndexesResultDto
+    {
+        public string MergeIndexesId { get; set; }
+
+        public MergeIndexesResultDto()
+        {
+        }
+
+        public MergeIndexesResultDto(string mergeIndexesId)
+        {
+            MergeIndexesId = mergeIndexesId;
+        }
+    }
+}

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -12,9 +12,7 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.LogRecords;
 using System.Threading.Tasks;
-using System.Security.Principal;
 using EventStore.Core.Index;
-using EventStore.Core.Messaging;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Services.Storage
@@ -452,7 +450,6 @@ namespace EventStore.Core.Services.Storage
 
         public void Handle(ClientMessage.MergeIndexes message)
         {
-            if (!IsAllowed(message.User, message.CorrelationId, message.Envelope)) return;
             if (_mergeIndexesTask != null && _mergeIndexesTask.Status == TaskStatus.Running)
             {
                 Log.Info("Index Merge Operation already running...");
@@ -470,17 +467,6 @@ namespace EventStore.Core.Services.Storage
         {
             message.Envelope.ReplyWith(new ClientMessage.MergeIndexesResponse(message.CorrelationId,
                 ClientMessage.MergeIndexesResponse.MergeIndexesResult.Started));
-        }
-
-        private bool IsAllowed(IPrincipal user, Guid correlationId, IEnvelope envelope)
-        {
-            if (user == null || (!user.IsInRole(SystemRoles.Admins) && !user.IsInRole(SystemRoles.Operations)))
-            {
-                envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(correlationId, ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Unauthorized, null));
-                return false;
-            }
-
-            return true;
         }
     }
 }

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -446,9 +446,9 @@ namespace EventStore.Core.Services.Storage
 
         public void Handle(ClientMessage.MergeIndexes message)
         {
-            if (_tableIndex.IsBackgroungTaskRunning)
+            if (_tableIndex.IsBackgroundTaskRunning)
             {
-                Log.Info("Index Merge Operation already running...");
+                Log.Info("A background operation is already running...");
                 MakeReplyForMergeIndexes(message);
                 return;
             }

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -15,7 +15,6 @@ namespace EventStore.Core.Services.Storage
 {
 
     public class StorageScavenger : 
-        IHandle<ClientMessage.MergeIndexes>,
         IHandle<ClientMessage.ScavengeDatabase>, 
         IHandle<ClientMessage.StopDatabaseScavenge>, 
         IHandle<SystemMessage.StateChangeMessage>
@@ -53,18 +52,6 @@ namespace EventStore.Core.Services.Storage
             if (message.State == VNodeState.Master || message.State == VNodeState.Slave)
             {
                 _logManager.Initialise();
-            }
-        }
-
-        public void Handle(ClientMessage.MergeIndexes message)
-        {
-            if (IsAllowed(message.User, message.CorrelationId, message.Envelope))
-            {
-                var tfChunkScavengerLog = _logManager.CreateLog();
-                var mergeIndexes = new TFChunkScavenger(_db, tfChunkScavengerLog, _tableIndex, _readIndex);
-                mergeIndexes.MergeIndexes();
-                message.Envelope.ReplyWith(new ClientMessage.MergeIndexesResponse(message.CorrelationId,
-                    ClientMessage.MergeIndexesResponse.MergeIndexesResult.Started));
             }
         }
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -76,21 +76,6 @@ namespace EventStore.Core.TransactionLog.Chunks
             }
         }
 
-        public Task MergeIndexes()
-        {
-            return Task.Factory.StartNew(() =>
-            {
-                try
-                {
-                    _tableIndex.MergeIndexes();
-                }
-                catch (Exception exc)
-                {
-                    Log.ErrorException(exc, "MERGING INDEXES: error while merging indexes.");
-                }
-            }, TaskCreationOptions.LongRunning);
-        }
-
         public Task Scavenge(bool alwaysKeepScavenged, bool mergeChunks, int startFromChunk = 0, CancellationToken ct = default(CancellationToken))
         {
             Ensure.Nonnegative(startFromChunk, nameof(startFromChunk));

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -76,6 +76,21 @@ namespace EventStore.Core.TransactionLog.Chunks
             }
         }
 
+        public Task MergeIndexes()
+        {
+            return Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    _tableIndex.MergeIndexes();
+                }
+                catch (Exception exc)
+                {
+                    Log.ErrorException(exc, "MERGING INDEXES: error while merging indexes.");
+                }
+            }, TaskCreationOptions.LongRunning);
+        }
+
         public Task Scavenge(bool alwaysKeepScavenged, bool mergeChunks, int startFromChunk = 0, CancellationToken ct = default(CancellationToken))
         {
             Ensure.Nonnegative(startFromChunk, nameof(startFromChunk));

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -363,5 +363,10 @@ namespace EventStore.Core.Util
 
 	    public const string AuthenticationConfigFileDescr = "Path to the configuration file for authentication configuration (if applicable).";
 		public static readonly string AuthenticationConfigFileDefault = string.Empty;
+        /*
+         * Scavenge options
+         */
+        public const string AutomergeIndexesDescr = "During an Index Merge operation, writes can be slowed down. Set this to false if you want to trigger manually the Index Merge operation";
+        public static readonly bool AutomergeIndexesDefault = true;
     }
 }

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -366,7 +366,7 @@ namespace EventStore.Core.Util
         /*
          * Scavenge options
          */
-        public const string AutomergeIndexesDescr = "During an Index Merge operation, writes can be slowed down. Set this to false if you want to trigger manually the Index Merge operation";
-        public static readonly bool AutomergeIndexesDefault = true;
+        public const string AutoMergeIndexesDescr = "During an Index Merge operation, writes can be slowed down. Set this to false if you want to trigger manually the Index Merge operation";
+        public static readonly bool AutoMergeIndexesDefault = true;
     }
 }

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -132,6 +132,7 @@ namespace EventStore.Core
         protected bool _skipIndexScanOnReads;
         private bool _reduceFileCachePressure;
         private int _initializationThreads;
+        private bool _autoMergeIndexes;
 
         private bool _gossipOnSingleNode;
 
@@ -1096,6 +1097,17 @@ namespace EventStore.Core
         }
 
         /// <summary>
+        /// Sets if we want the Merge Index operation to happen automatically
+        /// </summary>
+        /// <param name="autoMergeIndexes">The value to set autoMergeIndexes true or false</param>
+        /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+        public VNodeBuilder WithAutoMergeIndexes(bool autoMergeIndexes)
+        {
+            _autoMergeIndexes = autoMergeIndexes;
+            return this;
+        }
+
+        /// <summary>
         /// Sets the Server SSL Certificate
         /// </summary>
         /// <param name="sslCertificate">The server SSL certificate to use</param>
@@ -1454,7 +1466,8 @@ namespace EventStore.Core
                     _skipIndexScanOnReads,
                     _reduceFileCachePressure,
                     _initializationThreads,
-                    _faultOutOfOrderProjections);
+                    _faultOutOfOrderProjections,
+					_autoMergeIndexes);
             
             var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1467,6 +1467,7 @@ namespace EventStore.Core
                     _reduceFileCachePressure,
                     _initializationThreads,
                     _faultOutOfOrderProjections,
+                    _structuredLog,
 					_autoMergeIndexes);
             
             var infoController = new InfoController(options, _projectionType);


### PR DESCRIPTION
Implemented new admin/mergeindexes http endpoint to trigger large Index Merge manually
Added a new AutomergeIndexes boolean option to deactivate the automatic index merges (default: true)

Fixes https://github.com/EventStore/EventStore/issues/1738

To test this PR 
1) set the new option AutomergeIndexes: False or --automerge-indexes=false
2) flood the test database with millions of test events
3) verify that the indexes are not automatically merged
4) make an http POST to the new endpoint: http://youreventstore:2113/admin/mergeindexes
5) verify that the indexes are merged
