### PR TITLE
Correct ExpectedVersion values

### DIFF
--- a/src/EventStore.ClientAPI/ExpectedVersion.cs
+++ b/src/EventStore.ClientAPI/ExpectedVersion.cs
@@ -33,7 +33,7 @@ namespace EventStore.ClientAPI
         /// <summary>
         /// The stream should exist and should be empty. If it does not exist or is not empty treat that as a concurrency problem.
         /// </summary>
-        public const int EmptyStream = -1;
+        public const int EmptyStream = 0;
 
         /// <summary>
         /// The stream should exist. If it or a metadata stream does not exist treat that as a concurrency problem.


### PR DESCRIPTION
This was also reported here - https://github.com/EventStore/EventStore/issues/1441

But I was reviewing something for docs and found the same inconsistency, if it is indeed an error, it seemed quick to fix, but maybe it's intentional.