### PR TITLE
Fix structured log option default

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -359,6 +359,7 @@ namespace EventStore.ClusterNode
             SkipIndexScanOnReads = Opts.SkipIndexScanOnReadsDefault;
             ReduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
             InitializationThreads = Opts.InitializationThreadsDefault;
+            StructuredLog = Opts.StructuredLogDefault;
 
             ConnectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
             ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -285,7 +285,7 @@ namespace EventStore.ClusterNode
             if (options.ReduceFileCachePressure)
                 builder.ReduceFileCachePressure();
             if (options.StructuredLog)
-                builder.StructuredLog(options.StructuredLog);
+                builder.WithStructuredLogging(options.StructuredLog);
 
             if (options.IntSecureTcpPort > 0 || options.ExtSecureTcpPort > 0)
             {

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -245,6 +245,7 @@ namespace EventStore.Core.Cluster.Settings
             InitializationThreads = initializationThreads;
 
             FaultOutOfOrderProjections = faultOutOfOrderProjections;
+            StructuredLog = structuredLog;
         }
 
 
@@ -289,7 +290,8 @@ namespace EventStore.Core.Cluster.Settings
                                  + "ConnectionPendingSendBytesThreshold: {36}\n"
                                  + "ChunkInitialReaderCount: {37}\n"
                                  + "ReduceFileCachePressure: {38}\n"
-                                 + "InitializationThreads: {39}\n",
+                                 + "InitializationThreads: {39}\n"
+                                 + "StructuredLog: {40}\n",
                                  NodeInfo.InstanceId,
                                  NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
                                  NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -308,7 +310,7 @@ namespace EventStore.Core.Cluster.Settings
                                  NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout,
                                  EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge,
                                  ConnectionPendingSendBytesThreshold, ChunkInitialReaderCount,
-                                 ReduceFileCachePressure, InitializationThreads);
+                                 ReduceFileCachePressure, InitializationThreads, StructuredLog);
         }
     }
 }

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Util
 
         public const string LogsDescr = "Path where to keep log files.";
         public const string StructuredLogDescr = "Enable structured logging.";
-        public const bool StructuredLog = false;
+        public const bool StructuredLogDefault = false;
 
         public const string ConfigsDescr = "Configuration files.";
         public static readonly string[] ConfigsDefault = new string[0];

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -248,9 +248,9 @@ namespace EventStore.Core
         /// <summary>
         /// Enable structured logging
         /// </summary>
-        /// <param name="StructuredLog">Enable structured logging</param>
+        /// <param name="structuredLog">Enable structured logging</param>
         /// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-        public VNodeBuilder StructuredLog(bool structuredLog)
+        public VNodeBuilder WithStructuredLogging(bool structuredLog)
         {
             _structuredLog = structuredLog;
             return this;
@@ -1454,7 +1454,8 @@ namespace EventStore.Core
                     _skipIndexScanOnReads,
                     _reduceFileCachePressure,
                     _initializationThreads,
-                    _faultOutOfOrderProjections);
+                    _faultOutOfOrderProjections,
+                    _structuredLog);
             
             var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -148,7 +148,7 @@ namespace EventStore.Core
             _cachedChunks = Opts.CachedChunksDefault;
             _inMemoryDb = true;
             _projectionType = ProjectionType.None;
-            _structuredLog = Opts.StructuredLog;
+            _structuredLog = Opts.StructuredLogDefault;
 
             _externalTcp = new IPEndPoint(Opts.ExternalIpDefault, Opts.ExternalTcpPortDefault);
             _externalSecureTcp = null;


### PR DESCRIPTION
- Rename `StructuredLog` to `StructuredLogDefault` (for consistency with other options)
- Assign `StructuredLog` to default value in ClusterNodeOptions constructor

Thanks to @riccardone for noticing this.