### PR TITLE
Rebase and changes to PR 1647

### DIFF
--- a/src/EventStore.Common/Options/EventStoreOptions.cs
+++ b/src/EventStore.Common/Options/EventStoreOptions.cs
@@ -31,7 +31,8 @@ namespace EventStore.Common.Options
             var commandline = CommandLine.Parse<TOptions>(args).Normalize();
             var commanddict = commandline.ToDictionary(x => x.Name.ToLower());
             yield return commandline;
-            yield return EnvironmentVariables.Parse<TOptions>(x => NameTranslators.PrefixEnvironmentVariable(x, environmentPrefix).ToUpper());
+            yield return EnvironmentVariables.Parse<TOptions>(x => NameTranslators.PrefixEnvironmentVariable(x, environmentPrefix).ToUpper())
+                .Select(v => EnvironmentVariables.ParseReferenceEnvironmentVariable(v));
             var configFile = commanddict.ContainsKey("config") ?
                              commanddict["config"].Value as string : null;
             if (configFile == null && File.Exists(defaultConfigLocation))

--- a/src/EventStore.Common/Options/EventStoreOptions.cs
+++ b/src/EventStore.Common/Options/EventStoreOptions.cs
@@ -31,8 +31,7 @@ namespace EventStore.Common.Options
             var commandline = CommandLine.Parse<TOptions>(args).Normalize();
             var commanddict = commandline.ToDictionary(x => x.Name.ToLower());
             yield return commandline;
-            yield return EnvironmentVariables.Parse<TOptions>(x => NameTranslators.PrefixEnvironmentVariable(x, environmentPrefix).ToUpper())
-                .Select(v => EnvironmentVariables.ParseReferenceEnvironmentVariable(v));
+            yield return EnvironmentVariables.Parse<TOptions>(x => NameTranslators.PrefixEnvironmentVariable(x, environmentPrefix).ToUpper());
             var configFile = commanddict.ContainsKey("config") ?
                              commanddict["config"].Value as string : null;
             if (configFile == null && File.Exists(defaultConfigLocation))

--- a/src/EventStore.Rags.Tests/EnvironmentTests/when_referenced_environment_variable_is_parsed.cs
+++ b/src/EventStore.Rags.Tests/EnvironmentTests/when_referenced_environment_variable_is_parsed.cs
@@ -1,0 +1,44 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventStore.Rags.Tests.EnvironmentTests
+{
+    [TestFixture]
+    public class when_referenced_environment_variable_is_parsed
+    {
+        [Test]
+        public void should_return_the_referenced_environment_variable()
+        {
+            Environment.SetEnvironmentVariable("EVENTSTORE_NAME", "${env:TEST_REFERENCE_VAR}", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TEST_REFERENCE_VAR", "foo", EnvironmentVariableTarget.Process);
+
+            var envVariable = Environment.GetEnvironmentVariable("EVENTSTORE_NAME");
+            var result = EnvironmentVariables.Parse<TestType>(x => NameTranslators.PrefixEnvironmentVariable(x, "EVENTSTORE_"));
+            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual("Name", result.First().Name);
+            Assert.AreEqual(false, result.First().IsTyped);
+            Assert.AreEqual("foo", result.First().Value.ToString());
+            Assert.AreEqual(true, result.First().IsReference);
+            Environment.SetEnvironmentVariable("EVENTSTORE_NAME", null, EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("TEST_REFERENCE_VAR", null, EnvironmentVariableTarget.Process);
+        }
+
+        [Test]
+        public void should_return_null_if_referenced_environment_variable_does_not_exist()
+        {
+            Environment.SetEnvironmentVariable("EVENTSTORE_NAME", "${env:TEST_REFERENCE_VAR}", EnvironmentVariableTarget.Process);
+            var envVariable = Environment.GetEnvironmentVariable("EVENTSTORE_NAME");
+            var result = EnvironmentVariables.Parse<TestType>(x => NameTranslators.PrefixEnvironmentVariable(x, "EVENTSTORE_"));
+            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual("Name", result.First().Name);
+            Assert.AreEqual(false, result.First().IsTyped);
+            Assert.AreEqual(null, result.First().Value);
+            Assert.AreEqual(true, result.First().IsReference);
+            Environment.SetEnvironmentVariable("EVENTSTORE_NAME", null, EnvironmentVariableTarget.Process);
+        }
+    }
+}

--- a/src/EventStore.Rags/EnvironmentVariables.cs
+++ b/src/EventStore.Rags/EnvironmentVariables.cs
@@ -1,19 +1,29 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace EventStore.Rags
 {
     public static class EnvironmentVariables 
     {
+        static readonly Regex _regex = new Regex(@"^\[(\w+)]$");
+
         public static IEnumerable<OptionSource> Parse<TOptions>(Func<string, string> nameTranslator) where TOptions : class
         {
             return
-                (from property in typeof (TOptions).GetProperties()
-                    let environmentVariableName = nameTranslator(property.Name)
-                    let environmentVariableValue = Environment.GetEnvironmentVariable(environmentVariableName.ToUpper())
-                    where !String.IsNullOrEmpty(environmentVariableValue)
-                    select OptionSource.String("Environment Variable", property.Name, environmentVariableValue));
+                (from property in typeof(TOptions).GetProperties()
+                 let environmentVariableName = nameTranslator(property.Name)
+                 let environmentVariableValue = Environment.GetEnvironmentVariable(environmentVariableName.ToUpper())
+                 where !String.IsNullOrEmpty(environmentVariableValue)
+                 select OptionSource.String("Environment Variable", property.Name, environmentVariableValue, _regex.IsMatch(environmentVariableValue)));
+        }
+
+        public static OptionSource ParseReferenceEnvironmentVariable(OptionSource source)
+        {
+            if (!source.IsReference) return source;
+            source.Value = Environment.GetEnvironmentVariable(_regex.Match(source.Value.ToString()).Groups[1].Value);
+            return source;
         }
     }
 }

--- a/src/EventStore.Rags/EnvironmentVariables.cs
+++ b/src/EventStore.Rags/EnvironmentVariables.cs
@@ -7,7 +7,7 @@ namespace EventStore.Rags
 {
     public static class EnvironmentVariables 
     {
-        static readonly Regex _regex = new Regex(@"^\[(\w+)]$");
+        static readonly Regex _regex = new Regex(@"^\$\{env\:(\w+)\}$");
 
         public static IEnumerable<OptionSource> Parse<TOptions>(Func<string, string> nameTranslator) where TOptions : class
         {
@@ -16,7 +16,9 @@ namespace EventStore.Rags
                  let environmentVariableName = nameTranslator(property.Name)
                  let environmentVariableValue = Environment.GetEnvironmentVariable(environmentVariableName.ToUpper())
                  where !String.IsNullOrEmpty(environmentVariableValue)
-                 select OptionSource.String("Environment Variable", property.Name, environmentVariableValue, _regex.IsMatch(environmentVariableValue)));
+                 select ParseReferenceEnvironmentVariable(
+                     OptionSource.String("Environment Variable", property.Name, environmentVariableValue, _regex.IsMatch(environmentVariableValue)
+                )));
         }
 
         public static OptionSource ParseReferenceEnvironmentVariable(OptionSource source)

--- a/src/EventStore.Rags/OptionSource.cs
+++ b/src/EventStore.Rags/OptionSource.cs
@@ -1,28 +1,32 @@
-﻿namespace EventStore.Rags
+﻿using System.Text.RegularExpressions;
+
+namespace EventStore.Rags
 {
     public struct OptionSource 
     {
         public string Source;
         public string Name;
         public bool IsTyped;
+        public bool IsReference;
         public object Value;
 
-        public static OptionSource Typed(string source, string name, object value)
+        public static OptionSource Typed(string source, string name, object value, bool isReference = false)
         {
-            return new OptionSource(source, name, true, value);
+            return new OptionSource(source, name, true, value, isReference);
         }
 
-        public static OptionSource String(string source, string name, object value)
+        public static OptionSource String(string source, string name, object value, bool isReference = false)
         {
-            return new OptionSource(source, name, false, value);
+            return new OptionSource(source, name, false, value, isReference);
         }
 
-        public OptionSource(string source, string name, bool isTyped, object value)
+        public OptionSource(string source, string name, bool isTyped, object value, bool isReference = false)
         {
             Source = source;
             Name = name;
             IsTyped = isTyped;
             Value = value;
+            IsReference = isReference;
         }
     }
 }


### PR DESCRIPTION
Thanks to @hanxinimm for this nice feature!

This is a rebase of https://github.com/EventStore/EventStore/pull/1647 with some changes:
- The format is now: `${env:<Referenced_Env_Var>}` instead of `[<Referenced_Env_Var>]`
- Tests added

The PR basically allows you to reference another environment variable. It may be useful to reference existing IP address environment variables set in containers (like Service Fabric's `Fabric_NodeIPOrFQDN`)

**Test example:**
Linux
```
export HELLO=All
export EVENTSTORE_RUN_PROJECTIONS=\${env:HELLO}
```

Windows
```
set HELLO=All
set EVENTSTORE_RUN_PROJECTIONS=${env:HELLO}
```

Then run an EventStore node and it should apply the `RunProjections=All` configuration.