### PR TITLE
Do not publish StorageMessage.EventCommitted messages when rebuilding index (1.8x index rebuild speedup)

### DIFF
--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -226,6 +226,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
             if (Interlocked.CompareExchange(ref _lastCommitPosition, newLastCommitPosition, lastCommitPosition) != lastCommitPosition)
                 throw new Exception("Concurrency error in ReadIndex.Commit: _lastCommitPosition was modified during Commit execution!");
 
+            if(!_indexRebuild)
             for (int i = 0, n = indexEntries.Count; i < n; ++i)
             {
                 _bus.Publish(
@@ -323,6 +324,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex
             if (Interlocked.CompareExchange(ref _lastCommitPosition, newLastCommitPosition, lastCommitPosition) != lastCommitPosition)
                 throw new Exception("Concurrency error in ReadIndex.Commit: _lastCommitPosition was modified during Commit execution!");
 
+            if(!_indexRebuild)
             for (int i = 0, n = indexEntries.Count; i < n; ++i)
             {
                 _bus.Publish(


### PR DESCRIPTION
*Symptops:*
- Can take 1-2 minutes for a database to startup even after index rebuild of partial MemTable is complete.
- 100% MainQueue usage during and after index rebuild for around 1.5 minutes
- EventStore UI unresponsive during these ~1.5 minutes

*Description*
- Publishing `StorageMessage.EventCommitted` messages during index rebuilds are unnecessary (since these are not live events) and cause slow startup times when there are many events to rebuild.

- It is particularly visible after the switch to mono 5.16 since the main queue subscribers initialize faster and the event committed messages are actually processed by all subscribers. It can be reproduced quite reliably (~80% of the time) when there are just less than 1M events - an almost full MemTable - to be rebuilt. There is a race condition between the subscribers initializing and subscribing to the MainQueue and the StorageMessage.EventCommitted messages being published. When the subscribers have already initialized and subscribed it can take up to ~1.5 minutes to start up, during which EventStore is unresponsive. If subscribers haven't yet initialized, the startup is done in less than 5-10 seconds.

- This fix consequently also speeds up **Full index rebuilds** by approximately 1.8x (11M records in the example below):
**4.1.1-hotfix1, Mono 4.6.2, before fix:**
ReadIndex rebuilding done: total processed 11963929 records, time elapsed: 00:01:41.7778130.
**5.0.0 RC2, Mono 5.16, before fix:**
ReadIndex rebuilding done: total processed 11963981 records, time elapsed: 00:01:29.4323720.
**5.0.0 RC2, Mono 5.16, after fix:**
ReadIndex rebuilding done: total processed 11964084 records, time elapsed: 00:00:49.3172040.
