### PR TITLE
Set spin count to 1 in ManualResetEventSlim

### DIFF
--- a/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Bus
         private readonly TimeSpan _slowMsgThreshold;
 
         private readonly ConcurrentQueue<Message> _queue = new ConcurrentQueue<Message>();
-        private readonly ManualResetEventSlim _msgAddEvent = new ManualResetEventSlim(false);
+        private readonly ManualResetEventSlim _msgAddEvent = new ManualResetEventSlim(false, 1);
 
         private Thread _thread;
         private volatile bool _stop;

--- a/src/EventStore.Core/Bus/QueuedHandlerMRESWithMPSC.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRESWithMPSC.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Bus
         // assuming 8bytes per object ref its ~1MB.
         private readonly MPSCMessageQueue _queue = new MPSCMessageQueue(128*1024);
 
-        private readonly ManualResetEventSlim _msgAddEvent = new ManualResetEventSlim(false);
+        private readonly ManualResetEventSlim _msgAddEvent = new ManualResetEventSlim(false, 1);
 
         private Thread _thread;
         private volatile bool _stop;

--- a/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
@@ -64,7 +64,7 @@ namespace EventStore.Core.Services.Replication
         private volatile bool _newSubscriptions;
         private TimeSpan _noQuorumTimestamp = TimeSpan.Zero;
         private bool _noQuorumNotified;
-        private ManualResetEventSlim _flushSignal = new ManualResetEventSlim();
+        private ManualResetEventSlim _flushSignal = new ManualResetEventSlim(false, 1);
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
         public Task Task { get {return _tcs.Task;} }
         

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -49,7 +49,7 @@ namespace EventStore.Core.Services.Storage
                             new ConcurrentDictionary<long, PendingTransaction>();
 
         private readonly CommitAckLinkedList _commitAcks = new CommitAckLinkedList();
-        private readonly ManualResetEventSlim _addMsgSignal = new ManualResetEventSlim();
+        private readonly ManualResetEventSlim _addMsgSignal = new ManualResetEventSlim(false, 1);
         private TimeSpan _waitTimeoutMs = TimeSpan.FromMilliseconds(100);
         private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
         public Task Task { get {return _tcs.Task;} }

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Services.Storage
 
         private static readonly int TicksPerMs = (int) (Stopwatch.Frequency / 1000);
         private static readonly int MinFlushDelay = 2 * TicksPerMs;
-        private static readonly ManualResetEventSlim FlushSignal = new ManualResetEventSlim();
+        private static readonly ManualResetEventSlim FlushSignal = new ManualResetEventSlim(false, 1);
         private static readonly TimeSpan FlushWaitTimeout = TimeSpan.FromMilliseconds(10);
 
         public string Name => _queueStats.Name;


### PR DESCRIPTION
**Symptoms:**
- High CPU usage when idle (particularly for StorageChaser,~40% CPU when idle)

This PR fixes performance issues seen after introducing [this commit](https://github.com/EventStore/EventStore/commit/05e6df242da837979e2209441d5e129c023891f2) which was hoping that the issues seen earlier with `ManualResetEventSlim` on mono were fixed in mono 5.16.

The same high CPU usage symptoms were seen earlier in this commit and the workaround was to use `AutoResetEvent`:
https://github.com/EventStore/EventStore/commit/95be10a0e40c85e1a32fbb760abbaea3ca4f7949

After experimentation, setting the spinCount to 1 drops the CPU usage to 0-5% and write speeds increase by approximately 50% (atleast on my laptop).

It seems that default spin count of 10 used by mono was too high, causing excess spinning (this was manually verified by setting the spin count to 10):
https://github.com/mono/mono/blob/master/mcs/class/referencesource/mscorlib/system/threading/ManualResetEventSlim.cs#L57 