### PR TITLE
Migrate LLP->Ltd, .org->.com

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -95,7 +95,7 @@ Function Patch-VersionInfo {
         $branchPattern = 'public static readonly string Branch = ".*";'
         $commitHashPattern = 'public static readonly string Hashtag = ".*";'
         $timestampPattern = 'public static readonly string Timestamp = ".*";'
-        
+
         $edited = (Get-Content $versionInfoFilePath) | ForEach-Object {
             % {$_ -replace "\/\*+.*\*+\/", "" } |
             % {$_ -replace "\/\/+.*$", "" } |
@@ -161,8 +161,8 @@ Function Start-Build{
 
     #Configuration
     $productName = "Event Store Open Source"
-    $companyName = "Event Store LLP"
-    $copyright = "Copyright 2018 Event Store LLP. All rights reserved."
+    $companyName = "Event Store Ltd"
+    $copyright = "Copyright 2018 Event Store Ltd. All rights reserved."
     $platform = "x64"
 
     $baseDirectory = $PSScriptRoot
@@ -179,12 +179,12 @@ Function Start-Build{
 
     Write-Info "Version: $Version"
     Write-Info "Platform: $platform"
-    Write-Info "Configuration: $Configuration"    
+    Write-Info "Configuration: $Configuration"
     Write-Info "Build UI: $BuildUI"
 
     #Build Event Store UI
     if ($BuildUI -eq "yes") {
-        #Build the UI    
+        #Build the UI
         if (Test-Path $uiDistDirectory) {
             Remove-Item -Recurse -Force $uiDistDirectory
         }
@@ -196,7 +196,7 @@ Function Start-Build{
             Exec { bower install --allow-root }
             Exec { npm install gulp@~3.8.8 -g }
             Exec { npm install }
-            Exec { gulp dist }        
+            Exec { gulp dist }
             Exec { mv es-dist $uiDistDirectory }
         Pop-Location
     }
@@ -208,7 +208,7 @@ Function Start-Build{
     $commitHash = Get-GitCommitHash
     $timestamp = Get-GitTimestamp
     $branchName = Get-GitBranchOrTag
-    
+
     $assemblyInfos = Get-ChildItem -Recurse -Filter AssemblyInfo.cs
     $versionInfoFile = Resolve-Path (Join-Path $srcDirectory (Join-Path "EventStore.Common" (Join-Path "Utils" "VersionInfo.cs"))) -Relative
     try {

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,8 @@
 
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PRODUCTNAME="Event Store Open Source"
-COMPANYNAME="Event Store LLP"
-COPYRIGHT="Copyright 2018 Event Store LLP. All rights reserved."
+COMPANYNAME="Event Store Ltd"
+COPYRIGHT="Copyright 2018 Event Store Ltd. All rights reserved."
 
 
 # ------------ End of configuration -------------
@@ -14,7 +14,7 @@ NET_FRAMEWORK_API="4.7.1-api"
 MONO_LIB_DIR_LINUX="/usr/lib/mono"
 MONO_LIB_DIR_MAC="/Library/Frameworks/Mono.framework/Versions/5.16.0/lib/mono"
 
-function usage() {    
+function usage() {
 cat <<EOF
 Usage:
   $0 [<version=0.0.0.0>] [<configuration=Debug|Release>] [<build_ui=yes|no>] [<mono_lib_dir_override>]

--- a/etc/EventStore.UpgradeProjections/Properties/AssemblyInfo.cs
+++ b/etc/EventStore.UpgradeProjections/Properties/AssemblyInfo.cs
@@ -1,42 +1,12 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-//
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-//
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-using System.Reflection;
+﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("EventStore.UpgradeProjections")]
 [assembly: AssemblyDescription("Event Store Projections Upgrade Tool (v1.x -> 2.0.0)")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.UpgradeProjections")]
-[assembly: AssemblyCopyright("Copyright © 2013 Event Store LLP")]
+[assembly: AssemblyCopyright("Copyright © 2019 Event Store Ltd")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/scripts/build-js1/build-js1-linux/build-js1-linux/build-js1-linux.sh
+++ b/scripts/build-js1/build-js1-linux/build-js1-linux/build-js1-linux.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # File License:
-#     Copyright 2018, Event Store LLP
+#     Copyright 2018, Event Store Ltd
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
 #     you may not use this file except in compliance with the License.

--- a/scripts/build-js1/build-js1-mac/build-js1-mac.sh
+++ b/scripts/build-js1/build-js1-mac/build-js1-mac.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # File License:
-#     Copyright 2018, Event Store LLP
+#     Copyright 2018, Event Store Ltd
 #
 #     Licensed under the Apache License, Version 2.0 (the "License");
 #     you may not use this file except in compliance with the License.

--- a/scripts/nuget-clientapi/EventStore.Client.Embedded.nuspec
+++ b/scripts/nuget-clientapi/EventStore.Client.Embedded.nuspec
@@ -3,15 +3,15 @@
   <metadata>
     <id>EventStore.Client.Embedded</id>
     <version>0.0.0</version>
-    <authors>Event Store LLP</authors>
-    <owners>Event Store LLP</owners>
+    <authors>Event Store Ltd</authors>
+    <owners>Event Store Ltd</owners>
     <licenseUrl>https://github.com/EventStore/EventStore/blob/master/LICENSE.md</licenseUrl>
-    <projectUrl>https://eventstore.org</projectUrl>
-    <iconUrl>https://eventstore.org/images/ouro.svg</iconUrl>
+    <projectUrl>https://eventstore.com</projectUrl>
+    <iconUrl>https://eventstore.com/images/ouro.svg</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The embedded client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</description>
+    <description>The embedded client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.com/</description>
     <releaseNotes>Embedded Client API for version 4 of Event Store</releaseNotes>
-    <copyright>Copyright 2012-2018 Event Store LLP</copyright>
+    <copyright>Copyright 2012-2019 Event Store Ltd</copyright>
     <tags>eventstore client embedded</tags>
     <dependencies>
       <dependency id="EventStore.Client" version="[$version$]" />

--- a/scripts/nuget-clientapi/EventStore.Client.nuspec
+++ b/scripts/nuget-clientapi/EventStore.Client.nuspec
@@ -3,15 +3,15 @@
   <metadata>
     <id>EventStore.Client</id>
     <version>0.0.0</version>
-    <authors>Event Store LLP</authors>
-    <owners>Event Store LLP</owners>
+    <authors>Event Store Ltd</authors>
+    <owners>Event Store Ltd</owners>
     <licenseUrl>https://github.com/EventStore/EventStore/blob/master/LICENSE.md</licenseUrl>
-    <projectUrl>https://eventstore.org</projectUrl>
-    <iconUrl>https://eventstore.org/images/ouro.svg</iconUrl>
+    <projectUrl>https://eventstore.com</projectUrl>
+    <iconUrl>https://eventstore.com/images/ouro.svg</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>The client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</description>
+    <description>The client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.com/</description>
     <releaseNotes>Client API for version 4 of Event Store</releaseNotes>
-    <copyright>Copyright 2012-2018 Event Store LLP</copyright>
+    <copyright>Copyright 2012-2019 Event Store Ltd</copyright>
     <tags>eventstore client</tags>
     <dependencies>
     </dependencies>

--- a/src/EventStore.BufferManagement.Tests/Properties/AssemblyInfo.cs
+++ b/src/EventStore.BufferManagement.Tests/Properties/AssemblyInfo.cs
@@ -5,9 +5,9 @@ using NUnit.Framework;
 [assembly: AssemblyTitle("EventStore.BufferManagement.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.BufferManagement.Tests")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.BufferManagement/Properties/AssemblyInfo.cs
+++ b/src/EventStore.BufferManagement/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.BufferManagement")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.BufferManagement")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>EventStore.Client.Embedded</PackageId>
-    <Authors>Event Store LLP</Authors>
+    <Authors>Event Store Ltd</Authors>
     <PackageLicenseUrl>https://github.com/EventStore/EventStore/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://eventstore.org</PackageProjectUrl>
-    <PackageIconUrl>https://eventstore.org/images/ouro.svg</PackageIconUrl>
+    <PackageProjectUrl>https://eventstore.com</PackageProjectUrl>
+    <PackageIconUrl>https://eventstore.com/images/ouro.svg</PackageIconUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>The embedded client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</Description>
-    <PackageReleaseNotes>https://eventstore.org/blog/</PackageReleaseNotes>
-    <Copyright>Copyright 2012-2018 Event Store LLP</Copyright>
+    <Description>The embedded client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.com/</Description>
+    <PackageReleaseNotes>https://eventstore.com/blog/</PackageReleaseNotes>
+    <Copyright>Copyright 2012-2019 Event Store Ltd</Copyright>
     <PackageTags>eventstore client embedded</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/EventStore.ClientAPI.Embedded/Properties/AssemblyInfo.cs
+++ b/src/EventStore.ClientAPI.Embedded/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.ClientAPI")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.ClientAPI")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -6,14 +6,14 @@
   </PropertyGroup>
   <PropertyGroup>
     <PackageId>EventStore.Client</PackageId>
-    <Authors>Event Store LLP</Authors>
+    <Authors>Event Store Ltd</Authors>
     <PackageLicenseUrl>https://github.com/EventStore/EventStore/blob/master/LICENSE.md</PackageLicenseUrl>
-    <PackageProjectUrl>https://eventstore.org</PackageProjectUrl>
-    <PackageIconUrl>https://eventstore.org/images/ouro.svg</PackageIconUrl>
+    <PackageProjectUrl>https://eventstore.com</PackageProjectUrl>
+    <PackageIconUrl>https://eventstore.com/images/ouro.svg</PackageIconUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>The client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.org/</Description>
-    <PackageReleaseNotes>https://eventstore.org/blog/</PackageReleaseNotes>
-    <Copyright>Copyright 2012-2018 Event Store LLP</Copyright>
+    <Description>The client API for Event Store. Get the open source or commercial versions of Event Store server from https://eventstore.com/</Description>
+    <PackageReleaseNotes>https://eventstore.com/</PackageReleaseNotes>
+    <Copyright>Copyright 2012-2018 Event Store Ltd</Copyright>
     <PackageTags>eventstore client</PackageTags>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/src/EventStore.ClientAPI/Properties/AssemblyInfo.cs
+++ b/src/EventStore.ClientAPI/Properties/AssemblyInfo.cs
@@ -5,9 +5,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.ClientAPI")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.ClientAPI")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.ClusterNode.Web/Properties/AssemblyInfo.cs
+++ b/src/EventStore.ClusterNode.Web/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.ClusterNode.Web")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.ClusterNode.Web")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.ClusterNode/Properties/AssemblyInfo.cs
+++ b/src/EventStore.ClusterNode/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.ClusterNode")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.ClusterNode")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Common/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Common/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Common")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Common")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Core.Tests/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Core.Tests/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Core.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Core.Tests")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Core/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Core/Properties/AssemblyInfo.cs
@@ -5,9 +5,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Core")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Core")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Native/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Native/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Native")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Native")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Projections.Core.Tests/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Projections.Core.Tests/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Projections.Core.Tests")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Projections.Core.Tests")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/specification_with_projection_core_service_command_reader.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/specification_with_projection_core_service_command_reader.cs
@@ -1,32 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Projections.Core.Messages;

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/specification_with_projection_core_service_command_reader_started.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/specification_with_projection_core_service_command_reader_started.cs
@@ -1,32 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.Core.Data;

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_creating.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_creating.cs
@@ -1,33 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-
-
-using System;
+﻿using System;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Tests.Services.core_projection;
 using NUnit.Framework;

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_receiving_a_command.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_receiving_a_command.cs
@@ -1,32 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-
-using System;
+﻿using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_starting.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service_command_reader/when_starting.cs
@@ -1,32 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using EventStore.Projections.Core.Messages;
 using NUnit.Framework;
 using System;

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/specification_with_projection_manager_response_reader_started.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/projection_manager_response_reader/specification_with_projection_manager_response_reader_started.cs
@@ -1,32 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager.projection_manager_response_reader

--- a/src/EventStore.Projections.Core/Prelude/1Prelude.js
+++ b/src/EventStore.Projections.Core/Prelude/1Prelude.js
@@ -1,31 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-"use strict";
+﻿"use strict";
 
 // these $ globals are defined by external environment
 // they are redefined here to make R# like tools understand them
@@ -45,7 +18,7 @@ function initializeModules() {
     modules.$load_module = _load_module;
 
     return modules;
-} 
+}
 
 function initializeProjections() {
     var projections = _load_module('Projections');
@@ -58,7 +31,7 @@ var eventProcessor;
 function scope($on, $notify) {
     eventProcessor = projections.createEventProcessor(log, $notify);
     eventProcessor.register_command_handlers($on);
-    
+
     function queryLog(message) {
         if (typeof message === "string")
             _log(message);
@@ -200,9 +173,9 @@ function scope($on, $notify) {
 
     function fromStreams(streams) {
         var arr = Array.isArray(streams) ? streams : arguments;
-        for (var i = 0; i < arr.length; i++) 
+        for (var i = 0; i < arr.length; i++)
             eventProcessor.fromStream(arr[i]);
- 
+
         return {
             partitionBy: partitionBy,
             when: when,
@@ -237,7 +210,7 @@ function scope($on, $notify) {
                 if (p1.indexOf("$") !== 0 || p1 === "$correlationId")
                     m[p1] = em[p1];
 
-        if (metadata) 
+        if (metadata)
             for (var p2 in metadata)
                 if (p2.indexOf("$") !== 0)
                     m[p2] = metadata[p2];
@@ -270,7 +243,7 @@ function scope($on, $notify) {
         fromStreamsMatching: fromStreamsMatching,
 
         options: options,
-        emit: emit, 
+        emit: emit,
         linkTo: linkTo,
         copyTo: copyTo,
         linkStreamTo: linkStreamTo,

--- a/src/EventStore.Projections.Core/Prelude/Modules.js
+++ b/src/EventStore.Projections.Core/Prelude/Modules.js
@@ -1,31 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-"use strict";
+﻿"use strict";
 
 var $modules = (function () {
     var loadedModules = {};

--- a/src/EventStore.Projections.Core/Prelude/ModulesExecuted.js
+++ b/src/EventStore.Projections.Core/Prelude/ModulesExecuted.js
@@ -1,31 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-"use strict";
+﻿"use strict";
 
 
 var modules = (function () {

--- a/src/EventStore.Projections.Core/Prelude/Projections.js
+++ b/src/EventStore.Projections.Core/Prelude/Projections.js
@@ -1,31 +1,4 @@
-﻿// Copyright (c) 2012, Event Store LLP
-// All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are
-// met:
-// 
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright
-// notice, this list of conditions and the following disclaimer in the
-// documentation and/or other materials provided with the distribution.
-// Neither the name of the Event Store LLP nor the names of its
-// contributors may be used to endorse or promote products derived from
-// this software without specific prior written permission
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-// 
-"use strict";
+﻿"use strict";
 
 var $projections = {
     createEventProcessor: function (_log, _notify) {

--- a/src/EventStore.Projections.Core/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Projections.Core/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Projections.Core")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Projections.Core")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Projections.v8Integration/EventStore.Projections.v8Integration.rc
+++ b/src/EventStore.Projections.v8Integration/EventStore.Projections.v8Integration.rc
@@ -15,7 +15,7 @@
 #define EVENTSTORE_FILEVERSION_STR "0.0.0.0"
 #define EVENTSTORE_FILEVERSION 0,0,0,0
 #define EVENTSTORE_COMMITNUMBER_STR "0.0.0.0.projections@ca77a64828e0a45c11922f08f5da0ce9ffceead2@Tue, 3 Dec 2013 10:47:57 +0200"
-#define EVENTSTORE_COPYRIGHT_STR "Copyright 2012 Event Store LLP. All rights reserved."
+#define EVENTSTORE_COPYRIGHT_STR "Copyright 2012-2019 Event Store Ltd. All rights reserved."
 
 
 
@@ -46,7 +46,7 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
 			VALUE "Comments", EVENTSTORE_COMMITNUMBER_STR
-			VALUE "CompanyName", "Event Store LLP"
+			VALUE "CompanyName", "Event Store Ltd"
             VALUE "FileDescription", "Event Store Projections - V8 Integration"
             VALUE "FileVersion", EVENTSTORE_FILEVERSION_STR
             VALUE "InternalName", "EventStore.Projections.V8Integration"
@@ -62,7 +62,7 @@ BEGIN
     END
 END
 
-#endif    
+#endif
 
 
 
@@ -78,25 +78,25 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
 
 
 
-1 TEXTINCLUDE 
+1 TEXTINCLUDE
 BEGIN
     "resource.h\0"
 END
 
-2 TEXTINCLUDE 
+2 TEXTINCLUDE
 BEGIN
     "\0"
 END
 
-3 TEXTINCLUDE 
+3 TEXTINCLUDE
 BEGIN
     "\r\n"
     "\0"
 END
 
-#endif    
+#endif
 
-#endif    
+#endif
 
 
 
@@ -109,5 +109,5 @@ END
 
 
 
-#endif    
+#endif
 

--- a/src/EventStore.Rags/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Rags/Properties/AssemblyInfo.cs
@@ -2,15 +2,15 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("EventStore.Rags")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Rags")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -18,8 +18,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("0.0.0.0")]
 [assembly: AssemblyFileVersion("0.0.0.0")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 

--- a/src/EventStore.TestClient/Properties/AssemblyInfo.cs
+++ b/src/EventStore.TestClient/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Client")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Client")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Transport.Http/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Transport.Http/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Transport.Http")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Transport.Http")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/EventStore.Transport.Tcp/Properties/AssemblyInfo.cs
+++ b/src/EventStore.Transport.Tcp/Properties/AssemblyInfo.cs
@@ -4,9 +4,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("EventStore.Transport.Tcp")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Event Store LLP")]
+[assembly: AssemblyCompany("Event Store Ltd")]
 [assembly: AssemblyProduct("EventStore.Transport.Tcp")]
-[assembly: AssemblyCopyright("Copyright © Event Store LLP. All rights reserved.")]
+[assembly: AssemblyCopyright("Copyright © Event Store Ltd. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
This commit tidies up the move from Event Store LLP to Event Store Ltd, from eventstore.org to eventstore.com, and tidies up some of the older-style per-file licensing and copyright dates.