### PR TITLE
Concurrent queue fixes

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriptionBase.cs
@@ -126,7 +126,7 @@ namespace EventStore.ClientAPI.Embedded
                 }
 
                 Interlocked.Exchange(ref _actionExecuting, 0);
-            } while (_actionQueue.Count > 0 && Interlocked.CompareExchange(ref _actionExecuting, 1, 0) == 0);
+            } while (!_actionQueue.IsEmpty && Interlocked.CompareExchange(ref _actionExecuting, 1, 0) == 0);
         }
 
         public abstract void Start(Guid correlationId);

--- a/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Utils;
+using EventStore.ClientAPI.Common.Utils.Threading;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.Messages;
 using EventStore.ClientAPI.SystemData;
@@ -29,7 +30,7 @@ namespace EventStore.ClientAPI.ClientOperations
         private readonly bool _verboseLogging;
         protected readonly Func<TcpPackageConnection> _getConnection;
         private readonly int _maxQueueSize = 2000;
-        private readonly ConcurrentQueue<Func<Task>> _actionQueue = new ConcurrentQueue<Func<Task>>();
+        private readonly ConcurrentQueueWrapper<Func<Task>> _actionQueue = new ConcurrentQueueWrapper<Func<Task>>();
         private int _actionExecuting;
         private T _subscription;
         private int _unsubscribed;

--- a/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/SubscriptionOperation.cs
@@ -284,7 +284,7 @@ namespace EventStore.ClientAPI.ClientOperations
                 }
 
                 Interlocked.Exchange(ref _actionExecuting, 0);
-            } while (_actionQueue.Count > 0 && Interlocked.CompareExchange(ref _actionExecuting, 1, 0) == 0);
+            } while (!_actionQueue.IsEmpty && Interlocked.CompareExchange(ref _actionExecuting, 1, 0) == 0);
         }
     }
 

--- a/src/EventStore.ClientAPI/Common/Utils/Threading/ConcurrentQueueWrapper.cs
+++ b/src/EventStore.ClientAPI/Common/Utils/Threading/ConcurrentQueueWrapper.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace EventStore.ClientAPI.Common.Utils.Threading
+{
+    //Workaround for: https://github.com/dotnet/corefx/issues/29759
+    //As from mono 5.2 and .NET Core 2.0, ConcurrentQueue.Count has knowingly been made slower (in some cases, O(N)) in favor of faster Enqueue() and Dequeue() operations (See: https://github.com/dotnet/corefx/issues/29759#issuecomment-390435245)
+    //This wrapper implements a workaround by maintaining the queue count at the expense of a slightly slower Enqueue()/Dequeue()
+    //Interlocked.Increment/Decrement operations are of the order of 36-90 cycles (similar to a division operation) which is good enough in our case.
+    class ConcurrentQueueWrapper<T>: ConcurrentQueue<T>
+    {
+        private volatile int _queueCount = 0;
+
+        public new bool IsEmpty{
+            get{
+                return _queueCount == 0;
+            }
+        }
+
+        public new int Count{
+            get{
+                return _queueCount;
+            }
+        }
+
+        //Note: The count is not updated atomically together with dequeueing.
+        //This means that the count will be eventually consistent but it's not an issue since between the Count call and any other operation items may be enqueued or dequeued anyway and the count will no longer be valid.
+        public new bool TryDequeue(out T result){
+            var dequeued = base.TryDequeue(out result);
+            if(dequeued)
+                Interlocked.Decrement(ref _queueCount);
+            return dequeued;
+        }
+
+        //Note: The count is not updated atomically together with dequeueing.
+        //This means that the count will be eventually consistent but it's not an issue since between the Count call and any other operation items may be enqueued or dequeued anyway and the count will no longer be valid.
+        public new void Enqueue(T item){
+            base.Enqueue(item);
+            Interlocked.Increment(ref _queueCount);
+        }
+    }
+}
+/*
+//For future reference, the following code can be used to test if the problem is still occuring.
+//Running the application should make the Main thread use 100% CPU and is very very slow.
+//The code has been tested on Mono 5.2-5.16 (the issue does not occur on earlier versions) and .NET Core 2.0 - .NET Core 3.0 preview
+
+using System;
+using System.Threading;
+using System.Collections.Concurrent;
+
+public class Program
+{
+    private static ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+    private static volatile bool exit = false;
+
+    public static void Main(string[] args)
+    {
+        Thread t = new Thread(AddEventsThread);
+        t.Name = "AddEventsThread";
+        t.Start();
+
+        Thread.Sleep(5000); //wait for 5 seconds to make sure the AddEventsThread thread has started
+        var queueCount = 0L;
+        var totalElapsed = 0L;
+
+        Console.WriteLine("Starting to hammer queue.Count.");
+
+        for(int i=0;i<1000000;i++){
+            var start = DateTime.UtcNow.Ticks;
+            queueCount = queue.Count;
+            totalElapsed += DateTime.UtcNow.Ticks - start;
+        }
+
+        Console.Out.WriteLine("Total Elapsed: {0}, Queue Count: {1}", totalElapsed, queueCount);
+        exit = true;
+    }
+
+    public static void AddEventsThread(){
+        while(!exit){
+            Console.WriteLine("Enqueing");
+            for(int i=0;i<50000 && !exit;i++){
+                queue.Enqueue(50);
+                Thread.Sleep(1);
+            }
+            Console.WriteLine("Dequeing");
+            for(int i=0;i<50000 && !exit;i++){
+                int result;
+                queue.TryDequeue(out result);
+                Thread.Sleep(1);
+            }
+        }
+    }
+}
+*/

--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -1,4 +1,5 @@
 using EventStore.ClientAPI.Common.Utils;
+using EventStore.ClientAPI.Common.Utils.Threading;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.SystemData;
 using System;
@@ -59,7 +60,7 @@ namespace EventStore.ClientAPI
         /// </summary>
         protected readonly bool Verbose;
 
-        private readonly ConcurrentQueue<ResolvedEvent> _liveQueue = new ConcurrentQueue<ResolvedEvent>();
+        private readonly ConcurrentQueueWrapper<ResolvedEvent> _liveQueue = new ConcurrentQueueWrapper<ResolvedEvent>();
         private EventStoreSubscription _subscription;
         private DropData _dropData;
         private volatile bool _allowProcessing;

--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -332,7 +332,7 @@ namespace EventStore.ClientAPI
                     }
                 }
                 Interlocked.CompareExchange(ref _isProcessing, 0, 1);
-            } while (_liveQueue.Count > 0 && Interlocked.CompareExchange(ref _isProcessing, 1, 0) == 0);
+            } while (!_liveQueue.IsEmpty && Interlocked.CompareExchange(ref _isProcessing, 1, 0) == 0);
         }
 
         internal void DropSubscription(SubscriptionDropReason reason, Exception error)

--- a/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
+++ b/src/EventStore.ClientAPI/EventStorePersistentSubscriptionBase.cs
@@ -234,7 +234,7 @@ namespace EventStore.ClientAPI
                     }
                 }
                 Interlocked.CompareExchange(ref _isProcessing, 0, 1);
-            } while (_queue.Count > 0 && Interlocked.CompareExchange(ref _isProcessing, 1, 0) == 0);
+            } while (!_queue.IsEmpty && Interlocked.CompareExchange(ref _isProcessing, 1, 0) == 0);
         }
 
         

--- a/src/EventStore.ClientAPI/Internal/OperationsManager.cs
+++ b/src/EventStore.ClientAPI/Internal/OperationsManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using EventStore.ClientAPI.ClientOperations;
 using EventStore.ClientAPI.Common.Utils;
+using EventStore.ClientAPI.Common.Utils.Threading;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.Transport.Tcp;
 
@@ -55,7 +56,7 @@ namespace EventStore.ClientAPI.Internal
         private readonly string _connectionName;
         private readonly ConnectionSettings _settings;
         private readonly Dictionary<Guid, OperationItem> _activeOperations = new Dictionary<Guid, OperationItem>();
-        private readonly ConcurrentQueue<OperationItem> _waitingOperations = new ConcurrentQueue<OperationItem>();
+        private readonly ConcurrentQueueWrapper<OperationItem> _waitingOperations = new ConcurrentQueueWrapper<OperationItem>();
         private readonly List<OperationItem> _retryPendingOperations = new List<OperationItem>();
         private readonly object _lock = new object();
         private int _totalOperationCount;

--- a/src/EventStore.ClientAPI/Internal/SimpleQueuedHandler.cs
+++ b/src/EventStore.ClientAPI/Internal/SimpleQueuedHandler.cs
@@ -42,7 +42,7 @@ namespace EventStore.ClientAPI.Internal
                 }
 
                 Interlocked.Exchange(ref _isProcessing, 0);
-            } while (_messageQueue.Count > 0 && Interlocked.CompareExchange(ref _isProcessing, 1, 0) == 0);
+            } while (!_messageQueue.IsEmpty && Interlocked.CompareExchange(ref _isProcessing, 1, 0) == 0);
         }
     }
 }

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -130,7 +130,7 @@ namespace EventStore.ClientAPI.Transport.Tcp
         {
             lock (_sendLock)
             {
-                if (_isSending || _sendQueue.Count == 0 || _socket == null) return;
+                if (_isSending || _sendQueue.IsEmpty || _socket == null) return;
                 if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
                 _isSending = true;
             }

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using EventStore.ClientAPI.Common;
 using EventStore.ClientAPI.Common.Utils;
 using System.Collections.Concurrent;
+using EventStore.ClientAPI.Common.Utils.Threading;
 
 namespace EventStore.ClientAPI.Transport.Tcp
 {
@@ -55,7 +56,7 @@ namespace EventStore.ClientAPI.Transport.Tcp
         private SocketAsyncEventArgs _receiveSocketArgs;
         private SocketAsyncEventArgs _sendSocketArgs;
 
-        private readonly ConcurrentQueue<ArraySegment<byte>> _sendQueue = new ConcurrentQueue<ArraySegment<byte>>();
+        private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _sendQueue = new ConcurrentQueueWrapper<ArraySegment<byte>>();
         private readonly Queue<ArraySegment<byte>> _receiveQueue = new Queue<ArraySegment<byte>>();
         private readonly MemoryStream _memoryStream = new MemoryStream();
 

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionLockless.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionLockless.cs
@@ -6,6 +6,7 @@ using System.Net.Sockets;
 using System.Threading;
 using EventStore.ClientAPI.Common.Utils;
 using System.Collections.Concurrent;
+using EventStore.ClientAPI.Common.Utils.Threading;
 
 namespace EventStore.ClientAPI.Transport.Tcp
 {
@@ -52,8 +53,8 @@ namespace EventStore.ClientAPI.Transport.Tcp
         private SocketAsyncEventArgs _receiveSocketArgs;
         private SocketAsyncEventArgs _sendSocketArgs;
 
-        private readonly ConcurrentQueue<ArraySegment<byte>> _sendQueue = new ConcurrentQueue<ArraySegment<byte>>();
-        private readonly ConcurrentQueue<ArraySegment<byte>> _receiveQueue = new ConcurrentQueue<ArraySegment<byte>>();
+        private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _sendQueue = new ConcurrentQueueWrapper<ArraySegment<byte>>();
+        private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _receiveQueue = new ConcurrentQueueWrapper<ArraySegment<byte>>();
         private readonly MemoryStream _memoryStream = new MemoryStream();
 
         private int _sending;

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionLockless.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionLockless.cs
@@ -131,9 +131,9 @@ namespace EventStore.ClientAPI.Transport.Tcp
 
         private void TrySend()
         {
-            while (_sendQueue.Count > 0 && Interlocked.CompareExchange(ref _sending, 1, 0) == 0)
+            while (!_sendQueue.IsEmpty && Interlocked.CompareExchange(ref _sending, 1, 0) == 0)
             {
-                if (_sendQueue.Count > 0 && _sendSocketArgs != null)
+                if (!_sendQueue.IsEmpty && _sendSocketArgs != null)
                 {
                     //if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
 
@@ -257,9 +257,9 @@ namespace EventStore.ClientAPI.Transport.Tcp
 
         private void TryDequeueReceivedData()
         {
-            while (_receiveQueue.Count > 0 && Interlocked.CompareExchange(ref _receiving, 1, 0) == 0)
+            while (!_receiveQueue.IsEmpty && Interlocked.CompareExchange(ref _receiving, 1, 0) == 0)
             {
-                if (_receiveQueue.Count > 0 && _receiveCallback != null)
+                if (!_receiveQueue.IsEmpty && _receiveCallback != null)
                 {
                     var callback = Interlocked.Exchange(ref _receiveCallback, null);
                     if (callback == null)

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using EventStore.ClientAPI.Common;
 using EventStore.ClientAPI.Common.Utils;
 using System.Collections.Concurrent;
+using EventStore.ClientAPI.Common.Utils.Threading;
 
 namespace EventStore.ClientAPI.Transport.Tcp
 {
@@ -51,8 +52,8 @@ namespace EventStore.ClientAPI.Transport.Tcp
         private readonly Guid _connectionId;
         private readonly ILogger _log;
 
-        private readonly ConcurrentQueue<ArraySegment<byte>> _sendQueue = new ConcurrentQueue<ArraySegment<byte>>();
-        private readonly ConcurrentQueue<ArraySegment<byte>> _receiveQueue = new ConcurrentQueue<ArraySegment<byte>>();
+        private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _sendQueue = new ConcurrentQueueWrapper<ArraySegment<byte>>();
+        private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _receiveQueue = new ConcurrentQueueWrapper<ArraySegment<byte>>();
         private readonly MemoryStream _memoryStream = new MemoryStream();
 
         private readonly object _streamLock = new object();

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
@@ -238,7 +238,7 @@ namespace EventStore.ClientAPI.Transport.Tcp
         {
             lock (_streamLock)
             {
-                if (_isSending || _sendQueue.Count == 0 || _sslStream == null || !_isAuthenticated) return;
+                if (_isSending || _sendQueue.IsEmpty || _sslStream == null || !_isAuthenticated) return;
                 if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
                 _isSending = true;
             }
@@ -392,7 +392,7 @@ namespace EventStore.ClientAPI.Transport.Tcp
                 return;
             do
             {
-                if (_receiveQueue.Count > 0 && _receiveCallback != null)
+                if (!_receiveQueue.IsEmpty && _receiveCallback != null)
                 {
                     var callback = Interlocked.Exchange(ref _receiveCallback, null);
                     if (callback == null)
@@ -418,7 +418,7 @@ namespace EventStore.ClientAPI.Transport.Tcp
                     NotifyReceiveDispatched(bytes);
                 }
                 Interlocked.Exchange(ref _receiveHandling, 0);
-            } while (_receiveQueue.Count > 0
+            } while (!_receiveQueue.IsEmpty
                      && _receiveCallback != null
                      && Interlocked.CompareExchange(ref _receiveHandling, 1, 0) == 0);
         }

--- a/src/EventStore.Common/Utils/ConcurrentQueueWrapper.cs
+++ b/src/EventStore.Common/Utils/ConcurrentQueueWrapper.cs
@@ -1,0 +1,96 @@
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace EventStore.Common.Utils
+{
+    //Workaround for: https://github.com/dotnet/corefx/issues/29759
+    //As from mono 5.2 and .NET Core 2.0, ConcurrentQueue.Count has knowingly been made slower (in some cases, O(N)) in favor of faster Enqueue() and Dequeue() operations (See: https://github.com/dotnet/corefx/issues/29759#issuecomment-390435245)
+    //This wrapper implements a workaround by maintaining the queue count at the expense of a slightly slower Enqueue()/Dequeue()
+    //Interlocked.Increment/Decrement operations are of the order of 36-90 cycles (similar to a division operation) which is good enough in our case.
+    public class ConcurrentQueueWrapper<T>: ConcurrentQueue<T>
+    {
+        private volatile int _queueCount = 0;
+
+        public new bool IsEmpty{
+            get{
+                return _queueCount == 0;
+            }
+        }
+
+        public new int Count{
+            get{
+                return _queueCount;
+            }
+        }
+
+        //Note: The count is not updated atomically together with dequeueing.
+        //This means that the count will be eventually consistent but it's not an issue since between the Count call and any other operation items may be enqueued or dequeued anyway and the count will no longer be valid.
+        public new bool TryDequeue(out T result){
+            var dequeued = base.TryDequeue(out result);
+            if(dequeued)
+                Interlocked.Decrement(ref _queueCount);
+            return dequeued;
+        }
+
+        //Note: The count is not updated atomically together with dequeueing.
+        //This means that the count will be eventually consistent but it's not an issue since between the Count call and any other operation items may be enqueued or dequeued anyway and the count will no longer be valid.
+        public new void Enqueue(T item){
+            base.Enqueue(item);
+            Interlocked.Increment(ref _queueCount);
+        }
+    }
+}
+
+/*
+//For future reference, the following code can be used to test if the problem is still occuring.
+//Running the application should make the Main thread use 100% CPU and is very very slow.
+//The code has been tested on Mono 5.2-5.16 (the issue does not occur on earlier versions) and .NET Core 2.0 - .NET Core 3.0 preview
+
+using System;
+using System.Threading;
+using System.Collections.Concurrent;
+
+public class Program
+{
+    private static ConcurrentQueue<int> queue = new ConcurrentQueue<int>();
+    private static volatile bool exit = false;
+
+    public static void Main(string[] args)
+    {
+        Thread t = new Thread(AddEventsThread);
+        t.Name = "AddEventsThread";
+        t.Start();
+
+        Thread.Sleep(5000); //wait for 5 seconds to make sure the AddEventsThread thread has started
+        var queueCount = 0L;
+        var totalElapsed = 0L;
+
+        Console.WriteLine("Starting to hammer queue.Count.");
+
+        for(int i=0;i<1000000;i++){
+            var start = DateTime.UtcNow.Ticks;
+            queueCount = queue.Count;
+            totalElapsed += DateTime.UtcNow.Ticks - start;
+        }
+
+        Console.Out.WriteLine("Total Elapsed: {0}, Queue Count: {1}", totalElapsed, queueCount);
+        exit = true;
+    }
+
+    public static void AddEventsThread(){
+        while(!exit){
+            Console.WriteLine("Enqueing");
+            for(int i=0;i<50000 && !exit;i++){
+                queue.Enqueue(50);
+                Thread.Sleep(1);
+            }
+            Console.WriteLine("Dequeing");
+            for(int i=0;i<50000 && !exit;i++){
+                int result;
+                queue.TryDequeue(out result);
+                Thread.Sleep(1);
+            }
+        }
+    }
+}
+*/

--- a/src/EventStore.Core/Bus/QueuedHandlerAutoReset.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerAutoReset.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Bus
         private readonly bool _watchSlowMsg;
         private readonly TimeSpan _slowMsgThreshold;
 
-        private readonly ConcurrentQueue<Message> _queue = new ConcurrentQueue<Message>();
+        private readonly ConcurrentQueueWrapper<Message> _queue = new ConcurrentQueueWrapper<Message>();
         private readonly AutoResetEvent _msgAddEvent = new AutoResetEvent(false);
 
         private Thread _thread;

--- a/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Bus
         private readonly bool _watchSlowMsg;
         private readonly TimeSpan _slowMsgThreshold;
 
-        private readonly ConcurrentQueue<Message> _queue = new ConcurrentQueue<Message>();
+        private readonly ConcurrentQueueWrapper<Message> _queue = new ConcurrentQueueWrapper<Message>();
         private readonly ManualResetEventSlim _msgAddEvent = new ManualResetEventSlim(false, 1);
 
         private Thread _thread;

--- a/src/EventStore.Core/Bus/QueuedHandlerPulse.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerPulse.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Bus
         private readonly bool _watchSlowMsg;
         private readonly TimeSpan _slowMsgThreshold;
 
-        private readonly ConcurrentQueue<Message> _queue = new ConcurrentQueue<Message>();
+        private readonly ConcurrentQueueWrapper<Message> _queue = new ConcurrentQueueWrapper<Message>();
 
         private Thread _thread;
         private volatile bool _stop;

--- a/src/EventStore.Core/Bus/QueuedHandlerSleep.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerSleep.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Bus
         private readonly bool _watchSlowMsg;
         private readonly TimeSpan _slowMsgThreshold;
 
-        private readonly ConcurrentQueue<Message> _queue = new ConcurrentQueue<Message>();
+        private readonly ConcurrentQueueWrapper<Message> _queue = new ConcurrentQueueWrapper<Message>();
 
         private Thread _thread;
         private volatile bool _stop;

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Bus
         private readonly bool _watchSlowMsg;
         private readonly TimeSpan _slowMsgThreshold;
 
-        private readonly ConcurrentQueue<Message> _queue = new ConcurrentQueue<Message>();
+        private readonly ConcurrentQueueWrapper<Message> _queue = new ConcurrentQueueWrapper<Message>();
 
         private volatile bool _stop;
         private readonly ManualResetEventSlim _stopped = new ManualResetEventSlim(true);

--- a/src/EventStore.Core/DataStructures/PairingHeap.cs
+++ b/src/EventStore.Core/DataStructures/PairingHeap.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using EventStore.Common.Utils;
 
 namespace EventStore.Core.DataStructures
 {
@@ -166,7 +167,7 @@ namespace EventStore.Core.DataStructures
 #if USE_POOL
         private class ObjectPool<TItem> where TItem : class
         {
-            private readonly ConcurrentQueue<TItem> _items = new ConcurrentQueue<TItem>();
+            private readonly ConcurrentQueueWrapper<TItem> _items = new ConcurrentQueueWrapper<TItem>();
 
             private readonly int _count;
             private readonly Func<TItem> _creator;

--- a/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
+++ b/src/EventStore.Core/Services/Storage/IndexCommitterService.cs
@@ -44,7 +44,7 @@ namespace EventStore.Core.Services.Storage
 
         public string Name { get { return _queueStats.Name; } }
         private readonly QueueStatsCollector _queueStats = new QueueStatsCollector("Index Committer");
-        private readonly ConcurrentQueue<StorageMessage.CommitAck> _replicatedQueue = new ConcurrentQueue<StorageMessage.CommitAck>();
+        private readonly ConcurrentQueueWrapper<StorageMessage.CommitAck> _replicatedQueue = new ConcurrentQueueWrapper<StorageMessage.CommitAck>();
         private readonly ConcurrentDictionary<long, PendingTransaction> _pendingTransactions =
                             new ConcurrentDictionary<long, PendingTransaction>();
 
@@ -100,7 +100,7 @@ namespace EventStore.Core.Services.Storage
 #if DEBUG
                         _queueStats.Dequeued(replicatedMessage);
 #endif
-                        _queueStats.ProcessingStarted(replicatedMessage.GetType(), 0);
+                        _queueStats.ProcessingStarted(replicatedMessage.GetType(), _replicatedQueue.Count);
                         ProcessCommitReplicated(replicatedMessage);
                         _queueStats.ProcessingEnded(1);
                     }

--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Services.TimerService
     {
         public string Name { get { return _queueStats.Name; } }
 
-        private readonly ConcurrentQueue<ScheduledTask> _pending = new ConcurrentQueue<ScheduledTask>();
+        private readonly ConcurrentQueueWrapper<ScheduledTask> _pending = new ConcurrentQueueWrapper<ScheduledTask>();
         private readonly PairingHeap<ScheduledTask> _tasks = new PairingHeap<ScheduledTask>((x, y) => x.DueTime < y.DueTime);
 
         private readonly ITimeProvider _timeProvider;

--- a/src/EventStore.Transport.Http/AsyncQueuedBufferWriter.cs
+++ b/src/EventStore.Transport.Http/AsyncQueuedBufferWriter.cs
@@ -97,7 +97,7 @@ namespace EventStore.Transport.Http
                 }
 
                 Interlocked.Exchange(ref _processing, 0);
-                proceed = _queue.Count > 0 && Interlocked.CompareExchange(ref _processing, 1, 0) == 0;
+                proceed = !_queue.IsEmpty && Interlocked.CompareExchange(ref _processing, 1, 0) == 0;
             }
         }
 

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -67,7 +67,7 @@ namespace EventStore.Transport.Tcp
         private SocketAsyncEventArgs _receiveSocketArgs;
         private SocketAsyncEventArgs _sendSocketArgs;
 
-        private readonly ConcurrentQueue<ArraySegment<byte>> _sendQueue = new ConcurrentQueue<ArraySegment<byte>>();
+        private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _sendQueue = new ConcurrentQueueWrapper<ArraySegment<byte>>();
         private readonly Queue<ReceivedData> _receiveQueue = new Queue<ReceivedData>();
         private readonly MemoryStream _memoryStream = new MemoryStream();
 

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -136,7 +136,7 @@ namespace EventStore.Transport.Tcp
         {
             lock (_sendLock)
             {
-                if (_isSending || _sendQueue.Count == 0 || _socket == null) return;
+                if (_isSending || _sendQueue.IsEmpty || _socket == null) return;
                 if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
                 _isSending = true;
             }

--- a/src/EventStore.Transport.Tcp/TcpConnectionLockless.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionLockless.cs
@@ -75,8 +75,8 @@ namespace EventStore.Transport.Tcp
         private SocketAsyncEventArgs _receiveSocketArgs;
         private SocketAsyncEventArgs _sendSocketArgs;
 
-        private readonly ConcurrentQueue<ArraySegment<byte>> _sendQueue = new ConcurrentQueue<ArraySegment<byte>>();
-        private readonly ConcurrentQueue<ReceivedData> _receiveQueue = new ConcurrentQueue<ReceivedData>();
+        private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _sendQueue = new ConcurrentQueueWrapper<ArraySegment<byte>>();
+        private readonly ConcurrentQueueWrapper<ReceivedData> _receiveQueue = new ConcurrentQueueWrapper<ReceivedData>();
         private readonly MemoryStream _memoryStream = new MemoryStream();
 
         private int _sending;

--- a/src/EventStore.Transport.Tcp/TcpConnectionLockless.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionLockless.cs
@@ -149,9 +149,9 @@ namespace EventStore.Transport.Tcp
 
         private void TrySend()
         {
-            while (_sendQueue.Count > 0 && Interlocked.CompareExchange(ref _sending, 1, 0) == 0)
+            while (!_sendQueue.IsEmpty && Interlocked.CompareExchange(ref _sending, 1, 0) == 0)
             {
-                if (_sendQueue.Count > 0 && _sendSocketArgs != null)
+                if (!_sendQueue.IsEmpty && _sendSocketArgs != null)
                 {
                     //if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
 
@@ -277,9 +277,9 @@ namespace EventStore.Transport.Tcp
 
         private void TryDequeueReceivedData()
         {
-            while (_receiveQueue.Count > 0 && Interlocked.CompareExchange(ref _receiving, 1, 0) == 0)
+            while (!_receiveQueue.IsEmpty && Interlocked.CompareExchange(ref _receiving, 1, 0) == 0)
             {
-                if (_receiveQueue.Count > 0 && _receiveCallback != null)
+                if (!_receiveQueue.IsEmpty && _receiveCallback != null)
                 {
                     var callback = Interlocked.Exchange(ref _receiveCallback, null);
                     if (callback == null)

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -332,7 +332,7 @@ namespace EventStore.Transport.Tcp
         {
             lock (_streamLock)
             {
-                if (_isSending || _sendQueue.Count == 0 || _sslStream == null || !_isAuthenticated) return;
+                if (_isSending || _sendQueue.IsEmpty || _sslStream == null || !_isAuthenticated) return;
                 if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
                 _isSending = true;
             }
@@ -489,7 +489,7 @@ namespace EventStore.Transport.Tcp
                 return;
             do
             {
-                if (_receiveQueue.Count > 0 && _receiveCallback != null)
+                if (!_receiveQueue.IsEmpty && _receiveCallback != null)
                 {
                     var callback = Interlocked.Exchange(ref _receiveCallback, null);
                     if (callback == null)
@@ -522,7 +522,7 @@ namespace EventStore.Transport.Tcp
                     NotifyReceiveDispatched(bytes);
                 }
                 Interlocked.Exchange(ref _receiveHandling, 0);
-            } while (_receiveQueue.Count > 0
+            } while (!_receiveQueue.IsEmpty
                      && _receiveCallback != null
                      && Interlocked.CompareExchange(ref _receiveHandling, 1, 0) == 0);
         }

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -79,8 +79,8 @@ namespace EventStore.Transport.Tcp
         private readonly bool _verbose;
         public string _clientConnectionName;
 
-        private readonly ConcurrentQueue<ArraySegment<byte>> _sendQueue = new ConcurrentQueue<ArraySegment<byte>>();
-        private readonly ConcurrentQueue<ReceivedData> _receiveQueue = new ConcurrentQueue<ReceivedData>();
+        private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _sendQueue = new ConcurrentQueueWrapper<ArraySegment<byte>>();
+        private readonly ConcurrentQueueWrapper<ReceivedData> _receiveQueue = new ConcurrentQueueWrapper<ReceivedData>();
         private readonly MemoryStream _memoryStream = new MemoryStream();
 
         private readonly object _streamLock = new object();


### PR DESCRIPTION
**Symptoms:**
- Random write speeds slow down (by ~6x). On my laptop (Core i7-7700HQ) write speeds drop down from 20k/s to 3k/s since `concurrentQueue.Count` is called in every iteration of `QueuedHandlerMRES`.

Thanks to @Lougarou and @avish0694 for helping out with tests and implementation of fix.

**Affected Versions/OS:**
- Only 5.0.0-RC1 and 5.0.0-RC2
- mono: Linux and macOS. Windows is not affected.

**Issue:**
This is a workaround for: https://github.com/dotnet/corefx/issues/29759

As from mono 5.2 and .NET Core 2.0, `ConcurrentQueue.Count` has knowingly been made slower (in some cases, O(N)) in favor of faster Enqueue() and Dequeue() operations (See: https://github.com/dotnet/corefx/issues/29759#issuecomment-390435245). It can be very very slow in some cases as demonstrated by this proof of concept:
[Program.cs.zip](https://github.com/EventStore/EventStore/files/2795010/Program.cs.zip)


**How EventStore is affected**
The queue count is required in most of our queues for queue length stats. It's also required in some places where the queue size is bounded by a max size (most notably in the ClientAPI)

**Fixes**
- 6dea568a217cf675728ece5490c4fbff740609f5 This PR implements a workaround by implementing a wrapper: `ConcurrentQueueWrapper` that maintains the queue count at the expense of a slightly slower `Enqueue()`/`TryDequeue()`. `Interlocked.Increment`/`Interlocked.Decrement` operations are of the order of 36-90 cycles (similar to a division operation) which is good enough in our case.
- f860b502e85b674f1a882a6b2f7d53ce9b0f309f, cafd3635034769efc8d4316c9ffee35bb5f55a9f The wrapper is applied everywhere we're calling `.Count` on a `ConcurrentQueue`
- fbd446d5e558a80030fdab13196962637fbdf017 Every `q.Count() > 0` check is replaced by `!q.IsEmpty` which is not affected by this issue.

