### PR TITLE
Updating test client

### DIFF
--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -92,8 +92,10 @@ namespace EventStore.TestClient
 
         public int Run()
         {
-            if (!InteractiveMode)
-                return Execute(Options.Command.ToArray());
+            if (!InteractiveMode){
+                var args = ParseCommandLine(Options.Command[0]);
+                return Execute(args);
+            }
 
             new Thread(() =>
             {

--- a/src/EventStore.TestClient/Commands/RunTestScenarios/ScenarioBase.cs
+++ b/src/EventStore.TestClient/Commands/RunTestScenarios/ScenarioBase.cs
@@ -137,7 +137,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
                                         .LimitRetriesForOperationTo(maxReconnections)
                                         .LimitReconnectionsTo(maxOperationRetries)
                                         .FailOnNoServerResponse(),
-                    new Uri(string.Format("tcp://{0}:{1}", _nodeConnection.IpAddress, _nodeConnection.TcpPort)),
+                    new Uri(string.Format("tcp://admin:changeit@{0}:{1}", _nodeConnection.IpAddress, _nodeConnection.TcpPort)),
                     string.Format("ESConn-{0}", i));
                 _connections[i].Closed += (s, e) => Log.Debug("[SCENARIO] {connection} closed.", e.Connection.ConnectionName);
                 _connections[i].Connected += (s, e) => Log.Debug("[SCENARIO] {connection} connected to [{remoteEndPoint}].", e.Connection.ConnectionName, e.RemoteEndPoint);
@@ -311,7 +311,9 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
         private int StartNewNode()
         {
             var clientFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-
+            //../../EventStore.ClusterNode/net471/EventStore.ClusterNode.exe
+            var clusterNodeFolder = System.IO.Directory.GetParent(System.IO.Directory.GetParent(clientFolder).FullName)
+                                    + "/EventStore.ClusterNode/net471/";
             string fileName;
             string argumentsHead;
 
@@ -320,15 +322,15 @@ namespace EventStore.TestClient.Commands.RunTestScenarios
             {
                 Log.Info("Mono at {pathToMono} will be used.", pathToMono);
                 fileName = pathToMono;
-                argumentsHead = string.Format("--debug --gc=sgen {0}", Path.Combine(clientFolder, "EventStore.SingleNode.exe"));
+                argumentsHead = string.Format("--debug --gc=sgen {0}", Path.Combine(clusterNodeFolder, "EventStore.ClusterNode.exe"));
             }
             else
             {
-                fileName = Path.Combine(clientFolder, "EventStore.SingleNode.exe");
+                fileName = Path.Combine(clusterNodeFolder, "EventStore.ClusterNode.exe");
                 argumentsHead = "";
             }
 
-            var arguments = string.Format("{0} --run-projections --ip {1} -t {2} -h {3} --db {4}",
+            var arguments = string.Format("{0} --run-projections=all --ext-ip {1} --ext-tcp-port {2} --ext-http-port {3} --db {4}",
                                           argumentsHead,
                                           _nodeConnection.IpAddress,
                                           _nodeConnection.TcpPort,

--- a/src/EventStore.TestClient/CommandsProcessor.cs
+++ b/src/EventStore.TestClient/CommandsProcessor.cs
@@ -36,12 +36,25 @@ namespace EventStore.TestClient
             if (usageProcessor)
                 _regCommandsProcessor = processor;
         }
-
+        private static string[] ParseCommandLine(string line)
+        {
+            return line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+        }
         public bool TryProcess(CommandProcessorContext context, string[] args, out int exitCode)
         {
+            
+            var commands = ParseCommandLine(args[0].ToUpper());
+            var commandName = commands[0];
+            var commandArgs = commands.Skip(1).ToArray();
+            
+
+            /*
             var commandName = args[0].ToUpper();
             var commandArgs = args.Skip(1).ToArray();
+            */
 
+            _log.Info("commandName {name}",commandName);
+            _log.Info("commandArgs {args}",commandArgs);
             ICmdProcessor commandProcessor;
             if (!_processors.TryGetValue(commandName, out commandProcessor))
             {

--- a/src/EventStore.TestClient/CommandsProcessor.cs
+++ b/src/EventStore.TestClient/CommandsProcessor.cs
@@ -42,19 +42,9 @@ namespace EventStore.TestClient
         }
         public bool TryProcess(CommandProcessorContext context, string[] args, out int exitCode)
         {
-            
-            var commands = ParseCommandLine(args[0].ToUpper());
-            var commandName = commands[0];
-            var commandArgs = commands.Skip(1).ToArray();
-            
-
-            /*
             var commandName = args[0].ToUpper();
             var commandArgs = args.Skip(1).ToArray();
-            */
-
-            _log.Info("commandName {name}",commandName);
-            _log.Info("commandArgs {args}",commandArgs);
+            
             ICmdProcessor commandProcessor;
             if (!_processors.TryGetValue(commandName, out commandProcessor))
             {


### PR DESCRIPTION
**Scenarios**
- Changing StartNewNode to point to new folder directory of EventStore ClusterNode 
- Change old ES arguments to new ones

**Command Line**
- Command line arguments for "command" was not being parsed. Now it is possible to call for example: mono bin/Release/EventStore.TestClient/net471/EventStore.TestClient.exe --command="RT 1 1 5 10 1 MassProjectionsScenario 1" directly. This should help with automating benchmarks