### PR TITLE
Fixes issues with protobuf lock contention

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -4,6 +4,8 @@ using System.Net.Sockets;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Internal;
 using System;
+using System.Runtime.ExceptionServices;
+using EventStore.ClientAPI.Messages;
 using EventStore.ClientAPI.SystemData;
 
 namespace EventStore.ClientAPI
@@ -13,6 +15,7 @@ namespace EventStore.ClientAPI
     /// </summary>
     public static class EventStoreConnection
     {
+	    private static readonly ExceptionDispatchInfo SerializationInitializationError = ClientMessage.InitializeSerializers();
         /// <summary>
         /// Creates a new <see cref="IEventStoreConnection"/> to single node using default <see cref="ConnectionSettings"/>
         /// </summary>
@@ -81,7 +84,8 @@ namespace EventStore.ClientAPI
         public static IEventStoreConnection Create(ConnectionSettings connectionSettings, Uri uri,
             string connectionName = null)
         {
-            connectionSettings = connectionSettings ?? ConnectionSettings.Default;
+	        SerializationInitializationError?.Throw();
+	        connectionSettings = connectionSettings ?? ConnectionSettings.Default;
             if (uri != null)
             {
                 var scheme = uri.Scheme.ToLower();

--- a/src/EventStore.ClientAPI/Messages/ClientMessagesExtensions.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessagesExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
+using System.Runtime.ExceptionServices;
+using EventStore.ClientAPI.Internal;
 
 namespace EventStore.ClientAPI.Messages
 {
@@ -22,6 +25,35 @@ namespace EventStore.ClientAPI.Messages
 
                 public IPEndPoint ExternalHttpEndPoint { get { return new IPEndPoint(IPAddress.Parse(ExternalHttpAddress), ExternalHttpPort); } }
             }
+        }
+
+        public static ExceptionDispatchInfo InitializeSerializers()
+        {
+	        try
+	        {
+		        foreach (var type in typeof(ClientMessage).GetNestedTypes())
+		        {
+			        for (int i = 0; i < 12; i++)
+			        {
+				        try
+				        {
+					        ProtoBuf.Serializer.NonGeneric.PrepareSerializer(type);
+					        break;
+				        }
+				        catch (TimeoutException) when (i < 11
+				        ) //if we are on the 11th try, we have taken 1 min trying to get the lock... may as well throw and die
+				        {
+				        }
+			        }
+
+		        }
+
+		        return null;
+	        }
+	        catch (Exception ex)
+	        {
+		        return ExceptionDispatchInfo.Capture(ex);
+	        }
         }
     }
 }


### PR DESCRIPTION
 - Retries 12 times. This will add a maximum of 1 min to startup if
 there is heavy contention
 - Uses a static field initializer, this will help make sure that
 for most applications this code will be run very early in it's
 lifecycle, probably before any multithreading happens
 - if we can't initialize inside 1 minute, there is probably something
 very broken in the client app so we will always throw the error when
 calling create
 - this issue should completely go away if we internalize protobuf