### PR TITLE
Change post scavenge merge process to ignore startFromChunk

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
@@ -22,6 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
         public event EventHandler<EventArgs> CompletedCallback;
 
         public IList<ScavengedLog> Scavenged { get; } = new List<ScavengedLog>(); 
+        public IList<ScavengedLog> Merged { get; } = new List<ScavengedLog>(); 
         public IList<IndexScavengedLog> ScavengedIndices { get; } = new List<IndexScavengedLog>(); 
 
         public void ScavengeStarted()
@@ -49,14 +50,14 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers
         public void ChunksMerged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved)
         {
             var scavengedLog = new ScavengedLog(chunkStartNumber, chunkEndNumber, true, "");
-            Scavenged.Add(scavengedLog);
+            Merged.Add(scavengedLog);
             ChunkScavenged?.Invoke(this, scavengedLog);
         }
 
         public void ChunksNotMerged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, string errorMessage)
         {
             var scavengedLog = new ScavengedLog(chunkStartNumber, chunkEndNumber, false, "");
-            Scavenged.Add(scavengedLog);
+            Merged.Add(scavengedLog);
             ChunkScavenged?.Invoke(this, scavengedLog);
         }
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_completed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_completed.cs
@@ -24,12 +24,19 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging
         }
 
         [Test]
-        public void scavenge_record_for_all_completed_chunks_plus_merge()
+        public void scavenge_record_for_all_completed_chunks()
         {
-            Assert.That(Log.Scavenged, Has.Count.EqualTo(3));
+            Assert.That(Log.Scavenged, Has.Count.EqualTo(2));
             Assert.That(Log.Scavenged[0].Scavenged, Is.True);
             Assert.That(Log.Scavenged[1].Scavenged, Is.True);
-            Assert.That(Log.Scavenged[2].Scavenged, Is.True);
+        }
+
+
+        [Test]
+        public void merge_record_for_all_completed_merged()
+        {
+            Assert.That(Log.Merged, Has.Count.EqualTo(1));
+            Assert.That(Log.Merged[0].Scavenged, Is.True);
         }
 
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_from_chunk_number.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_from_chunk_number.cs
@@ -36,6 +36,14 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging
             Assert.That(Log.Scavenged[0].ChunkEnd, Is.EqualTo(1));
         }
 
+        [Test]
+        public void scavenge_record_for_chunks_all()
+        {
+            Assert.That(Log.Merged, Has.Count.EqualTo(1));
+            Assert.That(Log.Merged[0].Scavenged, Is.True);
+            Assert.That(Log.Merged[0].ChunkStart, Is.EqualTo(0));
+            Assert.That(Log.Merged[0].ChunkEnd, Is.EqualTo(1));
+        }
 
         [Test]
         public void calls_scavenge_on_the_table_index()

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_succeeds_without_error.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_succeeds_without_error.cs
@@ -28,18 +28,24 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging
         }
 
         [Test]
-        public void scavenge_record_for_all_completed_chunks_plus_merge()
+        public void scavenge_record_for_all_completed_chunks()
         {
-            Assert.That(Log.Scavenged, Has.Count.EqualTo(3));
+            Assert.That(Log.Scavenged, Has.Count.EqualTo(2));
             Assert.That(Log.Scavenged[0].Scavenged, Is.True);
             Assert.That(Log.Scavenged[0].ChunkStart, Is.EqualTo(0));
             Assert.That(Log.Scavenged[0].ChunkEnd, Is.EqualTo(0));            
             Assert.That(Log.Scavenged[1].Scavenged, Is.True);
             Assert.That(Log.Scavenged[1].ChunkStart, Is.EqualTo(1));
             Assert.That(Log.Scavenged[1].ChunkEnd, Is.EqualTo(1));
-            Assert.That(Log.Scavenged[2].Scavenged, Is.True);
-            Assert.That(Log.Scavenged[2].ChunkStart, Is.EqualTo(0));
-            Assert.That(Log.Scavenged[2].ChunkEnd, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void merge_record_for_all_completed_merges()
+        {
+            Assert.That(Log.Merged, Has.Count.EqualTo(1));
+            Assert.That(Log.Merged[0].Scavenged, Is.True);
+            Assert.That(Log.Merged[0].ChunkStart, Is.EqualTo(0));
+            Assert.That(Log.Merged[0].ChunkEnd, Is.EqualTo(1));
         }
 
         [Test]

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -166,7 +166,7 @@ namespace EventStore.Core.TransactionLog.Chunks
 
                     var chunksToMerge = new List<TFChunk.TFChunk>();
                     long totalDataSize = 0;
-                    foreach (var chunk in GetAllChunks(startFromChunk))
+                    foreach (var chunk in GetAllChunks(0))
                     {
                         ct.ThrowIfCancellationRequested();
 


### PR DESCRIPTION
Whilst doing a lot of scavenging of large databases we've come across the following; if you stop a scavenge and then restart it (using startFromChunk), the chunks scavenged the first time will not be merged. This is a pain as it requires the whole database to be scavenged in one to allow the merge of chunks at the start. 

Therefore, I've raised this small PR to ignore the startFromChunk for the merge phase of a scavenge.