### PR TITLE
Fixes CheckTimeoutsAndRetry to be able to work if the connection is null

### DIFF
--- a/src/EventStore.ClientAPI/Internal/OperationsManager.cs
+++ b/src/EventStore.ClientAPI/Internal/OperationsManager.cs
@@ -92,13 +92,11 @@ namespace EventStore.ClientAPI.Internal
 
         public void CheckTimeoutsAndRetry(TcpPackageConnection connection)
         {
-            Ensure.NotNull(connection, "connection");
-
             var retryOperations = new List<OperationItem>();
             var removeOperations = new List<OperationItem>();
             foreach (var operation in _activeOperations.Values)
             {
-                if (operation.ConnectionId != connection.ConnectionId)
+                if (connection != null && operation.ConnectionId != connection.ConnectionId)
                 {
                     retryOperations.Add(operation);
                 }
@@ -121,13 +119,16 @@ namespace EventStore.ClientAPI.Internal
                 }
             }
 
-            foreach (var operation in retryOperations)
-            {
-                ScheduleOperationRetry(operation);
-            }
             foreach (var operation in removeOperations)
             {
                 RemoveOperation(operation);
+            }
+
+            if (connection == null) return;
+
+            foreach (var operation in retryOperations)
+            {
+                ScheduleOperationRetry(operation);
             }
 
             if (_retryPendingOperations.Count > 0)


### PR DESCRIPTION
When reconnecting, the connection will be null, but we still want to be
able to timeout operations while reconnecting otherwise the client will
wait until reconnection before the operations get timed out.

In the case the connection is null, retries get ignored and no operations
get scheduled, but operations will still timeout

Signed-off-by: James Geall <jageall@gmail.com>