### PR TITLE
Try to deserialize data or metadata string to JSON object when writing through HTTP API

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
@@ -162,10 +162,23 @@ namespace EventStore.Core.Services.Transport.Http {
 			if (obj is JObject || obj is JArray) {
 				isJson = true;
 				return Helper.UTF8NoBom.GetBytes(Codec.Json.To(obj));
+			} else if(obj is string){
+				try{
+					var jsonObject = JsonConvert.DeserializeObject((string)obj);
+					if(jsonObject is JObject || jsonObject is JArray){
+						isJson = true;
+						return Helper.UTF8NoBom.GetBytes(Codec.Json.To(jsonObject));
+					}
+					else
+						throw new JsonException();
+				}
+				catch(JsonException){
+					isJson = false;
+					return Helper.UTF8NoBom.GetBytes((obj as string));
+				}
 			}
-
 			isJson = false;
-			return Helper.UTF8NoBom.GetBytes((obj as string) ?? string.Empty);
+			return Helper.UTF8NoBom.GetBytes(string.Empty);
 		}
 	}
 }


### PR DESCRIPTION
**Issue**

Writing the following event with escaped JSON string does not mark the event with the `IsJson=True`  flag internally:
```
[
  {
    "eventId": "769fbc2b-762d-4fc9-9fab-d4fc1fd4e4b6",
    "eventType": "someType",
    "data": "{\"testdata\":\"testvalue\"}",
    "metadata": "{\"testmetadata\":\"testvalue\"}"
  }
]
```

This one on the other hand, does mark the event with the `IsJson=True` flag:
```
[
  {
    "eventId": "769fbc2b-762d-4fc9-9fab-d4fc1fd4e4b6",
    "eventType": "someType",
    "data": {"testdata":"testvalue"},
    "metadata": {"testmetadata":"testvalue"}
  }
]
```

Test query (you can then subscribe to the stream to see if IsJson=True or False):
```
curl -i -d "@event.txt" "http://127.0.0.1:2113/streams/mystream" -H "Content-Type:application/vnd.eventstore.event+json"
```

**Resolution**
Try to parse strings as JSON object in the AutoEventConverter and if successful, mark the event with `IsJson=True`
