### PR TITLE
Ignore IsJson property in $by_correlation_id projection

### DIFF
--- a/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
+++ b/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
@@ -79,8 +79,6 @@ namespace EventStore.Projections.Core.Standard {
 			newState = null;
 			if (data.EventStreamId != data.PositionStreamId)
 				return false;
-			if (!data.IsJson)
-				return false;
 
 			JObject metadata = null;
 


### PR DESCRIPTION
Fixes #1875

**Issue**
Relying on `IsJson` to determine if the event's metadata is JSON is not appropriate. For e.g. this PR shows one example where a JSON string is not marked as `IsJson=True`: https://github.com/EventStore/EventStore/pull/1881

**Resolution**
This PR simply removes the check. The code will then try to parse the metadata as JSON and continue if successful.

**Upgrading EventStore with this PR may require a reset of the $by_correlation_id projection since the projection may fault with "An event emitted in recovery for stream <$bc-stream> differs from the originally emitted event"**