### PR TITLE
Add ability to fetch/update projection config through HTTP API

### DIFF
--- a/src/EventStore.ClientAPI/Projections/ProjectionConfig.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionConfig.cs
@@ -1,0 +1,72 @@
+using System;
+
+namespace EventStore.ClientAPI.Projections {
+	/// <summary>
+	/// Provides the configuration for a projection.
+	/// </summary>
+	public sealed class ProjectionConfig {
+		/// <summary>
+		/// Whether this projection can emit events using emit() or linkTo().
+		/// </summary>
+		public readonly bool EmitEnabled = false;
+		/// <summary>
+		/// Whether this projection tracks emitted streams. This enables you to delete a projection and all the streams that it has created.
+		/// </summary>
+		public readonly bool TrackEmittedStreams = false;
+		/// <summary>
+		/// Minimum time (in ms) after which to write a projection checkpoint.
+		/// </summary>
+		public readonly int CheckpointAfterMs = 0;
+		/// <summary>
+		/// Number of events that a projection can handle before attempting to write a checkpoint.
+		/// </summary>
+		public readonly int CheckpointHandledThreshold = 4000;
+		/// <summary>
+		/// Number of bytes a projection can process before attempting to write a checkpoint.
+		/// </summary>
+		public readonly int CheckpointUnhandledBytesThreshold = 10*1000*1000;
+		/// <summary>
+		/// Number of events that can be pending before the projection is temporarily paused.
+		/// </summary>
+		public readonly int PendingEventsThreshold = 5000;
+		/// <summary>
+		/// Maximum number of events the projection can write in a batch at a time.
+		/// </summary>
+		public readonly int MaxWriteBatchLength = 500;
+		/// <summary>
+		/// Maximum number of concurrent writes to allow for a projection.
+		/// </summary>
+		public readonly int MaxAllowedWritesInFlight = 0;
+
+		/// <summary>
+		/// create a new <see cref="ProjectionConfig"/> class.
+		/// </summary>
+		/// <param name="emitEnabled">Whether this projection can emit events using emit() or linkTo(). Default: false</param>
+		/// <param name="trackEmittedStreams">Whether this projection tracks emitted streams. Default: false</param>
+		/// <param name="checkpointAfterMs">Minimum time (in ms) after which to write a projection checkpoint. Default: 0 (disabled)</param>
+		/// <param name="checkpointHandledThreshold">Number of events that a projection can handle before attempting to write a checkpoint. Default: 4000</param>
+		/// <param name="checkpointUnhandledBytesThreshold">Number of bytes a projection can process before attempting to write a checkpoint. Default: 10000000 (10 MB)</param>
+		/// <param name="pendingEventsThreshold">Number of events that can be pending before the projection is temporarily paused. Default: 5000</param>
+		/// <param name="maxWriteBatchLength">Maximum number of events the projection can write in a batch at a time. Default: 500</param>
+		/// <param name="maxAllowedWritesInFlight">Maximum number of concurrent writes to allow for a projection. Default: 0 (Unbounded)</param>
+		public ProjectionConfig(
+			bool emitEnabled,
+			bool trackEmittedStreams,
+			int checkpointAfterMs,
+			int checkpointHandledThreshold,
+			int checkpointUnhandledBytesThreshold,
+			int pendingEventsThreshold,
+			int maxWriteBatchLength,
+			int maxAllowedWritesInFlight
+			) {
+			EmitEnabled = emitEnabled;
+			TrackEmittedStreams = trackEmittedStreams;
+			CheckpointAfterMs = checkpointAfterMs;
+			CheckpointHandledThreshold = checkpointHandledThreshold;
+			CheckpointUnhandledBytesThreshold = checkpointUnhandledBytesThreshold;
+			PendingEventsThreshold = pendingEventsThreshold;
+			MaxWriteBatchLength = maxWriteBatchLength;
+			MaxAllowedWritesInFlight = maxAllowedWritesInFlight;
+		}
+	}
+}

--- a/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
@@ -159,6 +159,23 @@ namespace EventStore.ClientAPI.Projections {
 				userCredentials, HttpStatusCode.OK);
 		}
 
+		public Task<ProjectionConfig> GetConfig(EndPoint endPoint, string name, UserCredentials userCredentials = null,
+			string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendGet(endPoint.ToHttpUrl(httpSchema, "/projection/{0}/config", name), userCredentials,
+				HttpStatusCode.OK)
+				.ContinueWith(x => {
+					if (x.IsFaulted) throw x.Exception;
+					var r = JObject.Parse(x.Result);
+					return r.ToObject<ProjectionConfig>();
+				});
+		}
+
+		public Task UpdateConfig(EndPoint endPoint, string name, ProjectionConfig config, UserCredentials userCredentials = null,
+			string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendPut(endPoint.ToHttpUrl(httpSchema, "/projection/{0}/config", name), JObject.FromObject(config).ToString(),
+				userCredentials, HttpStatusCode.OK);
+		}
+
 		private Task<string> SendGet(string url, UserCredentials userCredentials, int expectedCode) {
 			var source = TaskCompletionSourceFactory.Create<string>();
 			_client.Get(url,

--- a/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
@@ -285,5 +285,27 @@ namespace EventStore.ClientAPI.Projections {
 			Ensure.NotNullOrEmpty(name, "name");
 			return _client.Reset(_httpEndPoint, name, userCredentials, _httpSchema);
 		}
+
+		/// <summary>
+		/// Asynchronously gets the projection config.
+		/// </summary>
+		/// <param name="name">The name of the projection.</param>
+		/// <param name="userCredentials">Credentials for the operation.</param>
+		/// <returns>String of JSON containing projection config.</returns>
+		public Task<ProjectionConfig> GetConfigAsync(string name, UserCredentials userCredentials = null) {
+			Ensure.NotNullOrEmpty(name, "name");
+			return _client.GetConfig(_httpEndPoint, name, userCredentials, _httpSchema);
+		}
+
+		/// <summary>
+		/// Asynchronously updates the projection config.
+		/// </summary>
+		/// <param name="name">The name of the projection.</param>
+		/// <param name="config">The projection configuration.</param>
+		/// <param name="userCredentials">Credentials for the operation.</param>
+		public Task UpdateConfigAsync(string name, ProjectionConfig config, UserCredentials userCredentials = null) {
+			Ensure.NotNullOrEmpty(name, "name");
+			return _client.UpdateConfig(_httpEndPoint, name, config, userCredentials, _httpSchema);
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1695 

**Example Usage**

Setting up the projections Manager:
```
var projectionManager = new ProjectionsManager(new ConsoleLogger(), new IPEndPoint(IPAddress.Loopback, 2113), TimeSpan.FromSeconds(5));
```

Getting the config:
```
var config = projectionManager.GetConfigAsync("myprojection").Result;
```

Updating the config:
```
var newConfig = new ProjectionConfig(true, false, 111, 222, 333, 444, 555, 666);
projectionManager.UpdateConfigAsync("myprojection", newConfig).Wait();
```