### PR TITLE
Fix issue where proto3 clients could not subscribe to $all

### DIFF
--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -458,7 +458,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			var dto = package.Data.Deserialize<TcpClientMessageDto.SubscribeToStream>();
 			if (dto == null) return null;
 			return new ClientMessage.SubscribeToStream(Guid.NewGuid(), package.CorrelationId, envelope,
-				connection.ConnectionId, dto.EventStreamId, dto.ResolveLinkTos, user);
+				connection.ConnectionId, dto.EventStreamId??string.Empty /*workaround to allow proto3 clients*/, dto.ResolveLinkTos, user);
 		}
 
 		private ClientMessage.UnsubscribeFromStream UnwrapUnsubscribeFromStream(TcpPackage package, IEnvelope envelope,


### PR DESCRIPTION
Fixes: #1677 

An empty string to SubscribeToStream() is interpreted as subscribing to $all by EventStore.

We currently use proto2 on server side.
In proto3, default values (empty string for strings) are omitted and not serialized on the wire (also explained by @prolic in the above issue):
https://developers.google.com/protocol-buffers/docs/proto3#default

This means that a proto3 client trying to subscribe to $all with a proto2 server will result in a `null` value for the stream id when deserialized on the server side.

The patch simply sets the stream id back to an empty string if it's null.

