### PR TITLE
Persistent subscriptions: Ignore replayed events during checkpointing

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/OutstandingMessageCacheTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/OutstandingMessageCacheTests.cs
@@ -100,6 +100,20 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 		}
 
 		[Test]
+		public void lowest_ignores_replayed_events() {
+			var cache = new OutstandingMessageCache();
+			//normal event:
+			var id1 = Guid.NewGuid();
+			cache.StartMessage(new OutstandingMessage(id1, null, Helper.BuildFakeEvent(id1, "type", "name", 10), 0),
+				DateTime.Now);
+			//replayed event:
+			var id2 = Guid.NewGuid();
+			cache.StartMessage(new OutstandingMessage(id2, null, Helper.BuildFakeEvent(id2, "type", "$persistentsubscription-name::group-parked", 9), 0),
+				DateTime.Now);
+			Assert.AreEqual(10, cache.GetLowestPosition());
+		}
+
+		[Test]
 		public void get_expired_messages_returns_max_value_on_empty_cache() {
 			var cache = new OutstandingMessageCache();
 			Assert.AreEqual(0, cache.GetMessagesExpiringBefore(DateTime.Now).Count());

--- a/src/EventStore.Core/Services/PersistentSubscription/OutstandingMessage.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/OutstandingMessage.cs
@@ -7,6 +7,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		public readonly PersistentSubscriptionClient HandlingClient;
 		public readonly int RetryCount;
 		public readonly Guid EventId;
+		public readonly bool IsReplayedEvent;
 
 		public OutstandingMessage(Guid eventId, PersistentSubscriptionClient handlingClient,
 			ResolvedEvent resolvedEvent, int retryCount) : this() {
@@ -14,6 +15,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			HandlingClient = handlingClient;
 			ResolvedEvent = resolvedEvent;
 			RetryCount = retryCount;
+			IsReplayedEvent = resolvedEvent.OriginalStreamId.StartsWith("$persistentsubscription-") && resolvedEvent.OriginalStreamId.EndsWith("-parked");
 		}
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/OutstandingMessageCache.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/OutstandingMessageCache.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 	public class OutstandingMessageCache {
 		private readonly Dictionary<Guid, Tuple<DateTime, OutstandingMessage>> _outstandingRequests;
 		private readonly SortedDictionary<Tuple<DateTime, RetryableMessage>, bool> _byTime;
-		private readonly SortedList<long, long> _bySequences;
+		private readonly SortedList<long, OutstandingMessage> _bySequences;
 
 		public class ByTypeComparer : IComparer<Tuple<DateTime, RetryableMessage>> {
 			public int Compare(Tuple<DateTime, RetryableMessage> x, Tuple<DateTime, RetryableMessage> y) {
@@ -28,7 +28,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		public OutstandingMessageCache() {
 			_outstandingRequests = new Dictionary<Guid, Tuple<DateTime, OutstandingMessage>>();
 			_byTime = new SortedDictionary<Tuple<DateTime, RetryableMessage>, bool>(new ByTypeComparer());
-			_bySequences = new SortedList<long, long>();
+			_bySequences = new SortedList<long, OutstandingMessage>();
 		}
 
 		public int Count {
@@ -53,7 +53,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			if (_outstandingRequests.ContainsKey(message.EventId))
 				return StartMessageResult.SkippedDuplicate;
 			_outstandingRequests[message.EventId] = new Tuple<DateTime, OutstandingMessage>(expires, message);
-			_bySequences.Add(message.ResolvedEvent.OriginalEventNumber, message.ResolvedEvent.OriginalEventNumber);
+			_bySequences.Add(message.ResolvedEvent.OriginalEventNumber, message);
 			_byTime.Add(new Tuple<DateTime, RetryableMessage>(expires, new RetryableMessage(message.EventId, expires)),
 				false);
 
@@ -82,9 +82,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public long GetLowestPosition() {
-			//TODO is there a better way of doing this?
-			if (_bySequences.Count == 0) return long.MaxValue;
-			return _bySequences.Values[0];
+			var result = long.MaxValue;
+			foreach(var x in _bySequences){
+				if(!x.Value.IsReplayedEvent)
+					return x.Value.ResolvedEvent.OriginalEventNumber;
+			}
+			return result;
 		}
 
 		public bool GetMessageById(Guid id, out OutstandingMessage outstandingMessage) {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -181,7 +181,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					if (result == ConsumerPushResult.Sent) {
 						messagePointer.MarkSent();
 						MarkBeginProcessing(message);
-						_lastKnownMessage = Math.Max(_lastKnownMessage, message.ResolvedEvent.OriginalEventNumber);
+						if(!message.IsReplayedEvent)
+							_lastKnownMessage = Math.Max(_lastKnownMessage, message.ResolvedEvent.OriginalEventNumber);
 					} else if (result == ConsumerPushResult.Skipped) {
 						// The consumer strategy skipped the message so leave it in the buffer and continue.
 					} else if (result == ConsumerPushResult.NoMoreCapacity) {
@@ -213,8 +214,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				foreach (var messagePointer in _streamBuffer.Scan().Take(count)) {
 					messagePointer.MarkSent();
 					MarkBeginProcessing(messagePointer.Message);
-					_lastKnownMessage = Math.Max(_lastKnownMessage,
-						messagePointer.Message.ResolvedEvent.OriginalEventNumber);
+					if(!messagePointer.Message.IsReplayedEvent)
+						_lastKnownMessage = Math.Max(_lastKnownMessage,messagePointer.Message.ResolvedEvent.OriginalEventNumber);
 					yield return messagePointer.Message.ResolvedEvent;
 				}
 			}

--- a/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/StreamBuffer.cs
@@ -134,8 +134,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public long GetLowestRetry() {
-			if (_retry.Count == 0) return long.MaxValue;
-			return _retry.Min(x => x.ResolvedEvent.OriginalEventNumber);
+			long result = long.MaxValue;
+			foreach(var x in _retry){
+				if(!x.IsReplayedEvent)
+					result = Math.Min(result, x.ResolvedEvent.OriginalEventNumber);
+			}
+			return result;
 		}
 
 		public struct OutstandingMessagePointer {


### PR DESCRIPTION
Fixes #500 

This PR fixes a bug occurring in persistent subscription where an invalid checkpoint is written when parked events are replayed and the size of the parked stream is larger than the size of the original stream. 

Replaying parked messages multiple times will make the issue more likely to happen (assuming the parked stream is not empty).

*Symptoms*
- In the Persistent subscription dashboard, Negative values appear for `# of msgs` and `Current` is greater than `Known`

*Root cause*
Event number of parked stream is being checkpointed by the persistent subscription

*Impact*
- Persistent subscription checkpoint is written with a value ahead of last stream's event number (The checkpoint is actually set to the parked stream event number instead of the original stream's event number)
- Restarting a node after a wrong checkpoint may cause events to be missed by the subscription. 

*Reproduction steps*
1. Create a persistent subscription with settings: 
 - Stream: `x`
 - Group: `group`
 - Message Timeout: 1 ms
 - Checkpoint after: 1 ms
 - Min checkpoint count: 1
 - Max checkpoint count: 1

2. Connect a client with `autoAck: true`.

3. Write 10 events to stream `x`. The client should receive all events.

4. Verify that checkpoint is set to 9 in stream: `$persistentsubscription-x::group-checkpoint`

5. Stop the client, set `autoAck: false` and start the client again.

6. Write 10 events to stream `x`.
All events should be parked in  `$persistentsubscription-x::group-parked` and checkpoint should be set to 19 in `$persistentsubscription-x::group-checkpoint`

Now comes the important part:
7. Replay all parked events. This should not affect the checkpoint stream since we're only replaying events that have already been processed. As long as the size of the parked stream `$persistentsubscription-x::group-parked` is smaller than the original stream `x`, the checkpoint will not be written.

Replay parked events a few more times and you should see a checkpoint being written with the event number from the parked stream in `$persistentsubscription-x::group-checkpoint`. The UI will also start showing `Current` > `Known` and negative values for `# of msgs`.

*Resolution*
Ignore replayed/parked events when checkpointing by adding an `IsReplayedEvent` property to `OutstandingMessage` class
