### PR TITLE
Fix $by_category processing of "stream deleted" events

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/handlers/categorize_events_by_stream_path.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/handlers/categorize_events_by_stream_path.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using EventStore.Core.Data;
 using EventStore.Projections.Core.Services.Processing;
 using EventStore.Projections.Core.Standard;
@@ -84,6 +85,138 @@ namespace EventStore.Projections.Core.Tests.Services.handlers {
 				Assert.AreEqual("$>", @event.EventType);
 				Assert.AreEqual("$ce-cat2", @event.StreamId);
 				Assert.AreEqual("10@cat1-stream1", @event.Data);
+			}
+		}
+
+		[TestFixture]
+		public class when_handling_normal_stream_metadata_event {
+			private CategorizeEventsByStreamPath _handler;
+			private string _state;
+			private EmittedEventEnvelope[] _emittedEvents;
+			private bool _result;
+
+			[SetUp]
+			public void when() {
+				_handler = new CategorizeEventsByStreamPath("-", Console.WriteLine);
+				_handler.Initialize();
+				string sharedState;
+				_result = _handler.ProcessEvent(
+					"", CheckpointTag.FromPosition(0, 200, 150), null,
+					new ResolvedEvent(
+						"$$cat3-stream3", 20, "$$cat3-stream3", 20, true, new TFPos(200, 150), Guid.NewGuid(),
+						"$metadata", true, "{}", "{}"), out _state, out sharedState, out _emittedEvents);
+			}
+
+			[Test]
+			public void result_is_true() {
+				Assert.IsTrue(_result);
+			}
+
+			[Test]
+			public void state_stays_null() {
+				Assert.IsNull(_state);
+			}
+
+			[Test]
+			public void does_not_emit_events() {
+				Assert.IsNull(_emittedEvents);
+			}
+		}
+
+[TestFixture]
+		public class when_handling_soft_deleted_stream_metadata_event {
+			private CategorizeEventsByStreamPath _handler;
+			private string _state;
+			private EmittedEventEnvelope[] _emittedEvents;
+			private bool _result;
+
+			[SetUp]
+			public void when() {
+				_handler = new CategorizeEventsByStreamPath("-", Console.WriteLine);
+				_handler.Initialize();
+				string sharedState;
+				_result = _handler.ProcessEvent(
+					"", CheckpointTag.FromPosition(0, 200, 150), null,
+					new ResolvedEvent(
+						"$$cat4-stream4", 20, "$$cat4-stream4", 20, true, new TFPos(200, 150), Guid.NewGuid(),
+						"$metadata", true, "{ \"$tb\": "+long.MaxValue+" }", "{}"), out _state, out sharedState, out _emittedEvents);
+			}
+
+			[Test]
+			public void result_is_true() {
+				Assert.IsTrue(_result);
+			}
+
+			[Test]
+			public void state_stays_null() {
+				Assert.IsNull(_state);
+			}
+
+			[Test]
+			public void emits_correct_link() {
+				Assert.NotNull(_emittedEvents);
+				Assert.AreEqual(1, _emittedEvents.Length);
+				var @event = _emittedEvents[0].Event;
+				Assert.AreEqual("$>", @event.EventType);
+				Assert.AreEqual("$ce-cat4", @event.StreamId);
+				Assert.AreEqual("20@$$cat4-stream4", @event.Data);
+				var metadata = new Dictionary<string,string>();
+				foreach(var kvp in @event.ExtraMetaData()){
+					metadata[kvp.Key] = kvp.Value;
+				}
+				Assert.NotNull(metadata["$o"]);
+				Assert.AreEqual("\"cat4-stream4\"", metadata["$o"]);
+				Assert.NotNull(metadata["$deleted"]);
+				Assert.AreEqual("-1", metadata["$deleted"]);
+			}
+		}
+
+[TestFixture]
+		public class when_handling_hard_deleted_stream_event {
+			private CategorizeEventsByStreamPath _handler;
+			private string _state;
+			private EmittedEventEnvelope[] _emittedEvents;
+			private bool _result;
+
+			[SetUp]
+			public void when() {
+				_handler = new CategorizeEventsByStreamPath("-", Console.WriteLine);
+				_handler.Initialize();
+				string sharedState;
+				_result = _handler.ProcessEvent(
+					"", CheckpointTag.FromPosition(0, 200, 150), null,
+					new ResolvedEvent(
+						"cat5-stream5", 20, "cat5-stream5", 20, true, new TFPos(200, 150), Guid.NewGuid(),
+						"$streamDeleted", true, "{}", "{}"), out _state, out sharedState, out _emittedEvents);
+			}
+
+			[Test]
+			public void result_is_true() {
+				Assert.IsTrue(_result);
+			}
+
+			[Test]
+			public void state_stays_null() {
+				Assert.IsNull(_state);
+			}
+
+			[Test]
+			public void emits_correct_link() {
+				Assert.NotNull(_emittedEvents);
+				Assert.AreEqual(1, _emittedEvents.Length);
+				var @event = _emittedEvents[0].Event;
+				Assert.AreEqual("$>", @event.EventType);
+				Assert.AreEqual("$ce-cat5", @event.StreamId);
+				Assert.AreEqual("20@cat5-stream5", @event.Data);
+
+				var metadata = new Dictionary<string,string>();
+				foreach(var kvp in @event.ExtraMetaData()){
+					metadata[kvp.Key] = kvp.Value;
+				}
+				Assert.NotNull(metadata["$o"]);
+				Assert.AreEqual("\"cat5-stream5\"", metadata["$o"]);
+				Assert.NotNull(metadata["$deleted"]);
+				Assert.AreEqual("-1", metadata["$deleted"]);
 			}
 		}
 	}

--- a/src/EventStore.Projections.Core/Standard/CategorizeEventsByStreamPath.cs
+++ b/src/EventStore.Projections.Core/Standard/CategorizeEventsByStreamPath.cs
@@ -51,11 +51,11 @@ namespace EventStore.Projections.Core.Standard {
 			newSharedState = null;
 			emittedEvents = null;
 			newState = null;
-			string positionStreamId;
+			string deletedStreamId;
 			var isStreamDeletedEvent = StreamDeletedHelper.IsStreamDeletedEvent(
-				data.PositionStreamId, data.EventType, data.Data, out positionStreamId);
+				data.PositionStreamId, data.EventType, data.Data, out deletedStreamId);
 
-			var category = _streamCategoryExtractor.GetCategoryByStreamId(positionStreamId);
+			var category = _streamCategoryExtractor.GetCategoryByStreamId(isStreamDeletedEvent?deletedStreamId:data.PositionStreamId);
 			if (category == null)
 				return true; // handled but not interesting
 
@@ -70,7 +70,7 @@ namespace EventStore.Projections.Core.Standard {
 				new EmittedEventEnvelope(
 					new EmittedLinkToWithRecategorization(
 						_categoryStreamPrefix + category, Guid.NewGuid(), linkTarget, eventPosition, expectedTag: null,
-						originalStreamId: positionStreamId, streamDeletedAt: isStreamDeletedEvent ? -1 : (int?)null))
+						originalStreamId: isStreamDeletedEvent?deletedStreamId:data.PositionStreamId, streamDeletedAt: isStreamDeletedEvent ? -1 : (int?)null))
 			};
 
 			return true;


### PR DESCRIPTION
The `$by_category` projection was designed to process "stream deleted" events (obtained from either the stream's metadata stream (checking for `$tb`) for soft deleted streams or verifying the `$streamDeleted` event from the stream itself for hard deletions). If such an event was found, it would be emitted to the `$ce-<category>` stream so that it could be processed on the client side to know the stream was deleted (by verifying the `$deleted` json property)

A bug in the above process would cause all stream metadata events to be emitted to the `$ce-<category>` stream instead of only stream deleted events. It is not harmful to have these extra events in the `$ce-category` but it can be confusing. Furthermore, if the metadata of the stream has changed, these events will appear as broken link tos in the emitted stream (since metadata streams have a max count of 1), causing more confusion.

The following example shows how it can happen with a combination of changing ACLs, the `$streams` projection and `$by_category` projection although there are other ways to reproduce it.

**Reproduction steps:**
1. Start EventStore with all projections stopped
2. Create a stream: `mycategory-stream` by adding an event
3. Edit ACL of stream `mycategory-stream`, setting everything to `$admins` (you can also add custom metadata to the stream, having the same effect)
This will create the `$$mycategory-stream` stream with event 0.
4. Start the `$streams` projection. This will create 2 events in `$streams` stream:
Event 0: Link to `0@mycategory-stream`
Event 1: Link to `0@$$mycategory-stream`
5. Start the `$by_category` projection. This will create 2 events in `$ce-mycategory`:
Event 0: Link to `0@mycategory-stream`
Event 1: Link to `0@$$mycategory-stream` <-- This is where the bug lies, the `$by_category` projection shouldn't have processed this event and emitted a link to `$ce-mycategory`

Extra steps to make a broken link:
6. Edit the ACL of stream `mycategory-stream` again (Just save it again)
This will create event 1 in `$$mycategory-stream`. At this point, `0@$$mycategory-stream` is no longer readable (because of max count of 1 on metadata streams)

7. Go to stream `$ce-mycategory`
A broken link will exist to `0@$$mycategory-stream` at event 1.

**Resolution**
Make sure only stream deleted events are emitted to `$ce-<category>`