### PR TITLE
use the 5min default if no override was specified

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -208,7 +208,6 @@ namespace EventStore.ClusterNode {
 				.WithIndexMergeOptimization(options.OptimizeIndexMerge)
 				.WithSslTargetHost(options.SslTargetHost)
 				.RunProjections(options.RunProjections, options.ProjectionThreads, options.FaultOutOfOrderProjections)
-				.WithProjectionQueryExpirationOf(TimeSpan.FromMinutes(options.ProjectionsQueryExpiry))
 				.WithTfCachedChunks(options.CachedChunks)
 				.WithTfChunksCacheSize(options.ChunksCacheSize)
 				.WithStatsStorage(StatsStorage.StreamAndFile)
@@ -225,6 +224,10 @@ namespace EventStore.ClusterNode {
 				.WithChunkInitialReaderCount(options.ChunkInitialReaderCount)
 				.WithInitializationThreads(options.InitializationThreads)
 				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel);
+
+			if (options.ProjectionsQueryExpiry > 0) {
+				builder.WithProjectionQueryExpirationOf(TimeSpan.FromMinutes(options.ProjectionsQueryExpiry));
+			}
 
 			if (options.GossipSeed.Length > 0)
 				builder.WithGossipSeeds(options.GossipSeed);


### PR DESCRIPTION
Currently we're always overriding the default 5 minute expiration with 0 minutes if options.ProjectionsQueryExpiry has not been set.  

This was causing transient projections is our environment to expire before they were finished, even after less than a minute.  Since the projection was getting disposed of too early, it was causing the projection to fail and we were seeing InvalidOperationException: Disposed errors in the log from the V8ProjectionStateHandler