### PR TITLE
remove uncatchable exception

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -207,7 +207,6 @@ namespace EventStore.ClientAPI {
 					await SubscribeToStreamAsync().ConfigureAwait(false);
 				} catch (Exception ex) {
 					DropSubscription(SubscriptionDropReason.CatchUpError, ex);
-					throw;
 				}
 			} else {
 				DropSubscription(SubscriptionDropReason.UserInitiated, null);

--- a/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
@@ -70,11 +70,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 				throw expectedException;
 			});
 
-			AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+			AssertStartCompletesAndDropsSubscriptionWithException(expectedException);
 		}
 
-		private void AssertStartFailsAndDropsSubscriptionWithException(ApplicationException expectedException) {
-			Assert.That(() => _subscription.StartAsync().Wait(TimeoutMs), Throws.TypeOf<AggregateException>());
+		private void AssertStartCompletesAndDropsSubscriptionWithException(ApplicationException expectedException) {
+			Assert.That(() => _subscription.StartAsync().Wait(TimeoutMs));
 			Assert.That(_isDropped);
 			Assert.That(_dropReason, Is.EqualTo(SubscriptionDropReason.CatchUpError));
 			Assert.That(_dropException, Is.SameAs(expectedException));
@@ -94,7 +94,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				return taskCompletionSource.Task;
 			});
 
-			AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+			AssertStartCompletesAndDropsSubscriptionWithException(expectedException);
 		}
 
 		[Test]
@@ -119,7 +119,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				}
 			});
 
-			AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+			AssertStartCompletesAndDropsSubscriptionWithException(expectedException);
 			Assert.That(_raisedEvents.Count, Is.EqualTo(1));
 		}
 
@@ -148,7 +148,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				}
 			});
 
-			AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+			AssertStartCompletesAndDropsSubscriptionWithException(expectedException);
 			Assert.That(_raisedEvents.Count, Is.EqualTo(1));
 		}
 
@@ -168,7 +168,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				throw expectedException;
 			});
 
-			AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+			AssertStartCompletesAndDropsSubscriptionWithException(expectedException);
 			Assert.That(_raisedEvents.Count, Is.EqualTo(1));
 		}
 
@@ -191,7 +191,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				return taskCompletionSource.Task;
 			});
 
-			AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+			AssertStartCompletesAndDropsSubscriptionWithException(expectedException);
 			Assert.That(_raisedEvents.Count, Is.EqualTo(1));
 		}
 
@@ -220,7 +220,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				return taskCompletionSource.Task;
 			});
 
-			AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+			AssertStartCompletesAndDropsSubscriptionWithException(expectedException);
 			Assert.That(_raisedEvents.Count, Is.EqualTo(1));
 		}
 
@@ -253,7 +253,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				return taskCompletionSource.Task;
 			});
 
-			AssertStartFailsAndDropsSubscriptionWithException(expectedException);
+			AssertStartCompletesAndDropsSubscriptionWithException(expectedException);
 			Assert.That(_raisedEvents.Count, Is.EqualTo(1));
 		}
 


### PR DESCRIPTION
EventStoreCatchUpSubscription threw an exception in order to error out the result of StartAsync - this API is internal and in all cases except the tests, the result is thrown away meaning that the exception which was thrown went unobserved. By removing the expectation on that exception from the tests while preserving all the valid expectations around errors being notified through the API, its possible to remove the problematic throw.