### PR TITLE
Changed type of IPEndpoint to Endpoint on QueryManager 

### DIFF
--- a/src/EventStore.ClientAPI/Projections/QueryManager.cs
+++ b/src/EventStore.ClientAPI/Projections/QueryManager.cs
@@ -22,7 +22,7 @@ namespace EventStore.ClientAPI.Projections {
 		/// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
 		/// <param name="projectionOperationTimeout">Timeout of projection API operations</param>
 		/// <param name="queryTimeout">Timeout of query execution</param>
-		public QueryManager(ILogger log, IPEndPoint httpEndPoint, TimeSpan projectionOperationTimeout,
+		public QueryManager(ILogger log, EndPoint httpEndPoint, TimeSpan projectionOperationTimeout,
 			TimeSpan queryTimeout) {
 			_queryTimeout = queryTimeout;
 			_projectionsManager = new ProjectionsManager(log, httpEndPoint, projectionOperationTimeout);


### PR DESCRIPTION
This keeps the constructor in-line with `ProjectionsManager` which `QueryManager` uses internally. This enables the use of `DnsEndPoint`. 

This is also a backwards compatible change. (https://docs.microsoft.com/en-us/dotnet/api/system.net.endpoint?view=netframework-4.7.1)