### PR TITLE
Fix idempotent writes for cases where events have not yet been replicated

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTFReader.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTFReader.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using EventStore.Core.TransactionLog;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.Tests.Services.Storage {
+	public class FakeInMemoryTfReader : ITransactionFileReader {
+		private Dictionary<long, LogRecord> _records = new Dictionary<long, LogRecord>();
+		private long _curPosition = 0;
+		private int _recordOffset;
+
+		public FakeInMemoryTfReader(int recordOffset){
+			_recordOffset = recordOffset;
+		}
+
+		public void AddRecord(LogRecord record, long position){
+			_records.Add(position, record);
+		}
+
+		public void Reposition(long position) {
+			_curPosition = position;
+		}
+
+		public SeqReadResult TryReadNext() {
+			if(_records.ContainsKey(_curPosition)){
+				var pos = _curPosition;
+				_curPosition += _recordOffset;
+				return new SeqReadResult(true, false, _records[pos], _recordOffset, pos, pos + _recordOffset);
+			} else{
+				return new SeqReadResult(false, false, null, 0, 0, 0);
+			}
+		}
+
+		public SeqReadResult TryReadPrev() {
+			throw new NotImplementedException();
+		}
+
+		public RecordReadResult TryReadAt(long position) {
+			if(_records.ContainsKey(position)){
+				return new RecordReadResult(true, 0, _records[position], 0);
+			} else{
+				return new RecordReadResult(false, 0, _records[position], 0);
+			}
+		}
+
+		public bool ExistsAt(long position) {
+			return _records.ContainsKey(position);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Index;
+
+namespace EventStore.Core.Tests.Services.Storage {
+	public class FakeInMemoryTableIndex : ITableIndex
+	{
+		public long CommitCheckpoint => throw new NotImplementedException();
+
+		public long PrepareCheckpoint => throw new NotImplementedException();
+
+		public bool IsBackgroundTaskRunning => throw new NotImplementedException();
+
+		private Dictionary<string, List<IndexKey> > _indexEntries = new Dictionary<string, List<IndexKey> >();
+		public void Add(long commitPos, string streamId, long version, long position)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void AddEntries(long commitPos, IList<IndexKey> entries)
+		{
+			foreach(var entry in entries){
+				if(!_indexEntries.ContainsKey(entry.StreamId))
+					_indexEntries[entry.StreamId] = new List<IndexKey>();
+				_indexEntries[entry.StreamId].Add(entry);
+			}
+		}
+
+		public void Close(bool removeFiles = true)
+		{
+		}
+
+		public IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null)
+		{
+			var entries = new List<IndexEntry>();
+			if(_indexEntries.ContainsKey(streamId)){
+				foreach(var entry in _indexEntries[streamId]){
+					if(startVersion <= entry.Version && entry.Version <= endVersion)
+						entries.Add(new IndexEntry(entry.Hash, entry.Version, entry.Position));
+				}
+			}
+			return entries;
+		}
+
+		public void Initialize(long chaserCheckpoint)
+		{
+		}
+
+		public Task MergeIndexes()
+		{
+			throw new NotImplementedException();
+		}
+
+		public void Scavenge(IIndexScavengerLog log, CancellationToken ct)
+		{
+			throw new NotImplementedException();
+		}
+
+		public bool TryGetLatestEntry(string streamId, out IndexEntry entry)
+		{
+			if(_indexEntries.ContainsKey(streamId)){
+				var entries = _indexEntries[streamId];
+				var lastEntry = entries[entries.Count - 1];
+				entry = new IndexEntry(lastEntry.Hash, lastEntry.Version, lastEntry.Position);
+				return true;
+			}
+			else{
+				entry = new IndexEntry();
+				return false;
+			}
+		}
+
+		public bool TryGetOldestEntry(string streamId, out IndexEntry entry)
+		{
+			throw new NotImplementedException();
+		}
+
+		public bool TryGetOneValue(string streamId, long version, out long position)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/Idempotency/when_writing_a_second_batch_of_events_after_the_first_batch_has_been_replicated.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Idempotency/when_writing_a_second_batch_of_events_after_the_first_batch_has_been_replicated.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.Idempotency {
+	[TestFixture]
+	public class when_writing_a_second_batch_of_events_after_the_first_batch_has_been_replicated : WriteEventsToIndexScenario{
+		private const int _numEvents = 10;
+		private List<Guid> _eventIds = new List<Guid>();
+        public override void WriteEvents()
+        {
+			var expectedEventNumber = -1;
+			var transactionPosition = 1000;
+			var eventTypes = new List<string>();
+			
+			for(var i=0;i<_numEvents;i++){
+				_eventIds.Add(Guid.NewGuid());
+				eventTypes.Add("type");
+			}
+
+			var prepares = CreatePrepareLogRecords("stream", expectedEventNumber, eventTypes, _eventIds, transactionPosition);
+			var commit = CreateCommitLogRecord(transactionPosition + 1000 * _numEvents, transactionPosition, expectedEventNumber + _numEvents);
+			
+			/*First batch write: committed to db and index*/
+			WriteToDB(prepares);
+			PreCommitToIndex(prepares);
+			
+			WriteToDB(commit);
+			PreCommitToIndex(commit);
+			
+			CommitToIndex(prepares);
+			CommitToIndex(commit);
+        }
+
+		[Test]
+		public void check_commit_with_same_expectedversion_should_return_idempotent_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", -1, _eventIds);
+			Assert.AreEqual(CommitDecision.Idempotent, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_expectedversion_any_should_return_idempotent_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", ExpectedVersion.Any, _eventIds);
+			Assert.AreEqual(CommitDecision.Idempotent, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_next_expectedversion_should_return_ok_decision() {
+			var commitCheckResult = _indexWriter.CheckCommit("stream", _numEvents-1, _eventIds);
+			Assert.AreEqual(CommitDecision.Ok, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_incorrect_expectedversion_should_return_wrongexpectedversion_decision() {
+			var commitCheckResult = _indexWriter.CheckCommit("stream", _numEvents, _eventIds);
+			Assert.AreEqual(CommitDecision.WrongExpectedVersion, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_same_expectedversion_but_different_non_first_event_id_should_return_corruptedidempotency_decision() {
+			/*Second, idempotent write but one of the event ids is different*/
+			var ids = new List<Guid>();
+			foreach(var id in _eventIds)
+				ids.Add(id);
+			
+			ids[ids.Count-2] = Guid.NewGuid();
+
+			var commitCheckResult = _indexWriter.CheckCommit("stream", -1, ids);
+			Assert.AreEqual(CommitDecision.CorruptedIdempotency, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_same_expectedversion_but_different_first_event_id_should_return_wrongexpectedversion_decision() {
+			/*Second, idempotent write but one of the event ids is different*/
+			var ids = new List<Guid>();
+			foreach(var id in _eventIds)
+				ids.Add(id);
+			
+			ids[0] = Guid.NewGuid();
+
+			var commitCheckResult = _indexWriter.CheckCommit("stream", -1, ids);
+			Assert.AreEqual(CommitDecision.WrongExpectedVersion, commitCheckResult.Decision);
+		}
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/Idempotency/when_writing_a_second_batch_of_events_after_the_first_batch_has_not_yet_been_replicated.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Idempotency/when_writing_a_second_batch_of_events_after_the_first_batch_has_not_yet_been_replicated.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.Idempotency {
+	[TestFixture]
+	public class when_writing_a_second_batch_of_events_after_the_first_batch_has_not_yet_been_replicated : WriteEventsToIndexScenario{
+		private const int _numEvents = 10;
+		private List<Guid> _eventIds = new List<Guid>();
+        public override void WriteEvents()
+        {
+			var expectedEventNumber = -1;
+			var transactionPosition = 1000;
+			var eventTypes = new List<string>();
+			
+			for(var i=0;i<_numEvents;i++){
+				_eventIds.Add(Guid.NewGuid());
+				eventTypes.Add("type");
+			}
+
+			var prepares = CreatePrepareLogRecords("stream", expectedEventNumber, eventTypes, _eventIds, transactionPosition);
+			var commit = CreateCommitLogRecord(transactionPosition + 1000 * _numEvents, transactionPosition, expectedEventNumber + _numEvents);
+			
+			/*First batch write: committed to db and pre-committed to index but not yet committed to index*/
+			WriteToDB(prepares);
+			PreCommitToIndex(prepares);
+			
+			WriteToDB(commit);
+			PreCommitToIndex(commit);
+        }
+
+		[Test]
+		public void check_commit_with_same_expectedversion_should_return_idempotentnotready_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", -1, _eventIds);
+			Assert.AreEqual(CommitDecision.IdempotentNotReady, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_expectedversion_any_should_return_idempotentnotready_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", ExpectedVersion.Any, _eventIds);
+			Assert.AreEqual(CommitDecision.IdempotentNotReady, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_next_expectedversion_should_return_ok_decision() {
+			var commitCheckResult = _indexWriter.CheckCommit("stream", _numEvents-1, _eventIds);
+			Assert.AreEqual(CommitDecision.Ok, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_incorrect_expectedversion_should_return_wrongexpectedversion_decision() {
+			var commitCheckResult = _indexWriter.CheckCommit("stream", _numEvents, _eventIds);
+			Assert.AreEqual(CommitDecision.WrongExpectedVersion, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_same_expectedversion_but_different_non_first_event_id_should_return_corruptedidempotency_decision() {
+			/*Second, idempotent write but one of the event ids is different*/
+			var ids = new List<Guid>();
+			foreach(var id in _eventIds)
+				ids.Add(id);
+			
+			ids[ids.Count-2] = Guid.NewGuid();
+
+			var commitCheckResult = _indexWriter.CheckCommit("stream", -1, ids);
+			Assert.AreEqual(CommitDecision.CorruptedIdempotency, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_same_expectedversion_but_different_first_event_id_should_return_wrongexpectedversion_decision() {
+			/*Second, idempotent write but one of the event ids is different*/
+			var ids = new List<Guid>();
+			foreach(var id in _eventIds)
+				ids.Add(id);
+			
+			ids[0] = Guid.NewGuid();
+
+			var commitCheckResult = _indexWriter.CheckCommit("stream", -1, ids);
+			Assert.AreEqual(CommitDecision.WrongExpectedVersion, commitCheckResult.Decision);
+		}
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/Idempotency/when_writing_a_second_event_after_the_first_event_has_been_replicated.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Idempotency/when_writing_a_second_event_after_the_first_event_has_been_replicated.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.Idempotency {
+	[TestFixture]
+	public class when_writing_a_second_event_after_the_first_event_has_been_replicated : WriteEventsToIndexScenario{
+		private Guid _eventId = Guid.NewGuid();
+        public override void WriteEvents()
+        {
+			var expectedEventNumber = -1;
+			var transactionPosition = 1000;
+			var prepares = CreatePrepareLogRecord("stream", expectedEventNumber, "type", _eventId, transactionPosition);
+			var commit = CreateCommitLogRecord(transactionPosition + RecordOffset, transactionPosition, expectedEventNumber + 1);
+			
+			/*First write: committed to db and index*/
+			WriteToDB(prepares);
+			PreCommitToIndex(prepares);
+			
+			WriteToDB(commit);
+			PreCommitToIndex(commit);
+			
+			CommitToIndex(prepares);
+			CommitToIndex(commit);
+        }
+
+		[Test]
+		public void check_commit_with_same_expectedversion_should_return_idempotent_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", -1, new Guid[] { _eventId });
+			Assert.AreEqual(CommitDecision.Idempotent, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_expectedversion_any_should_return_idempotent_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", ExpectedVersion.Any, new Guid[] { _eventId });
+			Assert.AreEqual(CommitDecision.Idempotent, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_next_expectedversion_should_return_ok_decision() {
+			var commitCheckResult = _indexWriter.CheckCommit("stream", 0, new Guid[] { _eventId });
+			Assert.AreEqual(CommitDecision.Ok, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_incorrect_expectedversion_should_return_wrongexpectedversion_decision() {
+			var commitCheckResult = _indexWriter.CheckCommit("stream", 1, new Guid[] { _eventId });
+			Assert.AreEqual(CommitDecision.WrongExpectedVersion, commitCheckResult.Decision);
+		}
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/Idempotency/when_writing_a_second_event_after_the_first_event_has_not_yet_been_replicated.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Idempotency/when_writing_a_second_event_after_the_first_event_has_not_yet_been_replicated.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.Idempotency {
+	[TestFixture]
+	public class when_writing_a_second_event_after_the_first_event_has_not_yet_been_replicated : WriteEventsToIndexScenario{
+		private Guid _eventId = Guid.NewGuid();
+        public override void WriteEvents()
+        {
+			var expectedEventNumber = -1;
+			var transactionPosition = 1000;
+			var prepares = CreatePrepareLogRecord("stream", expectedEventNumber, "type", _eventId, transactionPosition);
+			var commit = CreateCommitLogRecord(transactionPosition + RecordOffset, transactionPosition, expectedEventNumber + 1);
+			
+			/*First write: committed to db and pre-committed to index but not yet committed to index*/
+			WriteToDB(prepares);
+			PreCommitToIndex(prepares);
+			
+			WriteToDB(commit);
+			PreCommitToIndex(commit);
+        }
+
+		[Test]
+		public void check_commit_with_same_expectedversion_should_return_idempotentnotready_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", -1, new Guid[] { _eventId });
+			Assert.AreEqual(CommitDecision.IdempotentNotReady, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_expectedversion_any_should_return_idempotentnotready_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", ExpectedVersion.Any, new Guid[] { _eventId });
+			Assert.AreEqual(CommitDecision.IdempotentNotReady, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_next_expectedversion_should_return_ok_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", 0, new Guid[] { _eventId });
+			Assert.AreEqual(CommitDecision.Ok, commitCheckResult.Decision);
+		}
+
+		[Test]
+		public void check_commit_with_incorrect_expectedversion_should_return_wrongexpectedversion_decision() {
+			/*Second, idempotent write*/
+			var commitCheckResult = _indexWriter.CheckCommit("stream", 1, new Guid[] { _eventId });
+			Assert.AreEqual(CommitDecision.WrongExpectedVersion, commitCheckResult.Decision);
+		}
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.DataStructures;
+using EventStore.Core.Index;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.TransactionLog;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage {
+	[TestFixture]
+	public abstract class WriteEventsToIndexScenario {
+		protected InMemoryBus _publisher;
+		protected ITransactionFileReader _tfReader;
+		protected ITableIndex _tableIndex;
+		protected IIndexBackend _indexBackend;
+		protected IIndexReader _indexReader;
+		protected IIndexWriter _indexWriter;
+		protected IIndexCommitter _indexCommitter;
+		protected ObjectPool<ITransactionFileReader> _readerPool;
+		protected const int RecordOffset = 1000;
+		public IList<PrepareLogRecord> CreatePrepareLogRecord(string stream, int expectedVersion, string eventType, Guid eventId, long transactionPosition){
+			return new PrepareLogRecord[]{
+				new PrepareLogRecord (
+					transactionPosition,
+					Guid.NewGuid(),
+					eventId,
+					transactionPosition,
+					0,
+					stream,
+					expectedVersion,
+					DateTime.Now,
+					PrepareFlags.SingleWrite | PrepareFlags.IsCommitted,
+					eventType,
+					new byte[0],
+					new byte[0]
+				)
+			};
+		}
+
+		public IList<PrepareLogRecord> CreatePrepareLogRecords(string stream, int expectedVersion, IList<string> eventTypes, IList<Guid> eventIds, long transactionPosition){
+			if(eventIds.Count != eventTypes.Count)
+				throw new Exception("eventType and eventIds length mismatch!");
+			if(eventIds.Count == 0)
+				throw new Exception("eventIds is empty");
+			if(eventIds.Count == 1)
+				return CreatePrepareLogRecord(stream, expectedVersion, eventTypes[0], eventIds[0], transactionPosition);
+
+			var numEvents = eventTypes.Count;
+
+			var prepares = new List<PrepareLogRecord>();
+			for(var i=0;i<numEvents;i++){
+				PrepareFlags flags = PrepareFlags.Data | PrepareFlags.IsCommitted;
+				if(i==0) flags |= PrepareFlags.TransactionBegin;
+				if(i==numEvents-1) flags |= PrepareFlags.TransactionEnd;
+
+				prepares.Add(
+					new PrepareLogRecord (
+						transactionPosition + RecordOffset * i,
+						Guid.NewGuid(),
+						eventIds[i],
+						transactionPosition,
+						i,
+						stream,
+						expectedVersion+i,
+						DateTime.Now,
+						flags,
+						eventTypes[i],
+						new byte[0],
+						new byte[0]
+					)
+				);
+			}
+
+			return prepares;
+		}
+
+		public CommitLogRecord CreateCommitLogRecord(long logPosition, long transactionPosition, long firstEventNumber){
+			return new CommitLogRecord (logPosition, Guid.NewGuid(), transactionPosition, DateTime.Now, 0);
+		}
+
+		public void WriteToDB(IList<PrepareLogRecord> prepares){
+			foreach(var prepare in prepares){
+				((FakeInMemoryTfReader)_tfReader).AddRecord(prepare, prepare.LogPosition);
+			}
+		}
+
+		public void WriteToDB(CommitLogRecord commit){
+			((FakeInMemoryTfReader)_tfReader).AddRecord(commit, commit.LogPosition);
+		}
+
+		public void PreCommitToIndex(IList<PrepareLogRecord> prepares){
+			_indexWriter.PreCommit(prepares);
+		}
+
+		public void PreCommitToIndex(CommitLogRecord commitLogRecord){
+			_indexWriter.PreCommit(commitLogRecord);
+		}
+
+		public void CommitToIndex(IList<PrepareLogRecord> prepares){
+			_indexCommitter.Commit(prepares, false, false);
+		}
+
+		public void CommitToIndex(CommitLogRecord commitLogRecord){
+			_indexCommitter.Commit(commitLogRecord, false, false);
+		}
+
+		public abstract void WriteEvents();
+
+        [OneTimeSetUp]
+		public virtual void TestFixtureSetUp() {
+			_publisher = new InMemoryBus("publisher");
+			_tfReader = new FakeInMemoryTfReader(RecordOffset);
+			_tableIndex = new FakeInMemoryTableIndex();
+			_readerPool = new ObjectPool<ITransactionFileReader>(
+				"ReadIndex readers pool", 5, 100,
+				() => _tfReader);
+			_indexBackend = new IndexBackend(_readerPool, 100000, 100000);
+			_indexReader = new IndexReader(_indexBackend, _tableIndex, new StreamMetadata(maxCount: 100000), 100, false);
+			_indexWriter = new IndexWriter(_indexBackend, _indexReader);
+			_indexCommitter = new IndexCommitter(_publisher, _indexBackend, _indexReader, _tableIndex, false);
+
+			WriteEvents();
+		}
+
+		[OneTimeTearDown]
+		public virtual void TestFixtureTearDown() {
+			_readerPool.Dispose();
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/CommitDecision.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/CommitDecision.cs
@@ -5,6 +5,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		Deleted,
 		Idempotent,
 		CorruptedIdempotency,
-		InvalidTransaction
+		InvalidTransaction,
+		IdempotentNotReady
 	}
 }

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -533,6 +533,10 @@ namespace EventStore.Core.Services.Storage {
 				case CommitDecision.InvalidTransaction:
 					envelope.ReplyWith(new StorageMessage.InvalidTransaction(correlationId));
 					break;
+				case CommitDecision.IdempotentNotReady:
+					//just drop the write and wait for the client to retry
+					Log.Debug("Dropping idempotent write to stream {@stream}, startEventNumber: {@startEventNumber}, endEventNumber: {@endEventNumber} since the original write has not yet been replicated.", result.EventStreamId, result.StartEventNumber, result.EndEventNumber);
+					break;
 				default:
 					throw new ArgumentOutOfRangeException();
 			}


### PR DESCRIPTION
The following scenario can occur in a cluster (let's assume a 3 node cluster in this example):
- Client tries to write an event A
- The master receives event A, write it locally which is replicated and waits for commit acks from slaves
- Both slaves go down at approximately same time and a quorum number of commit acks are never received by the master (in a 3 node cluster, one commit ack from a slave would be enough)
- Client sees a timeout and tries to write event A again
- The master sees it as an idempotent write and immediately replies success although the event has not yet been replicated.
- If we elaborate the scenario further more and assume the master then goes down and the two slaves come up and form a cluster, this event will be lost since the original master will truncate when rejoining the cluster.

*Proposed fix (in commit a0533bc1abed18edc58c025d5cc03589b4165524)*
- Before returning `CommitDecision.Idempotent`, verify if the event has been committed to the index (which is an indicator of whether the write has been replicated: as from v4.1.0 events are committed to the index on the master only when enough commit acks have been received to prevent dirty reads from the master)
- Otherwise, return a new decision: `CommitDecision.IdempotentNotReady`
- Handle `CommitDecision.IdempotentNotReady` by just dropping the write and wait for the client to try again.

*Tests*
Several tests have also been added around idempotency.