### PR TITLE
Fix assertion regarding # of midpoints cached

### DIFF
--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -173,8 +173,8 @@ namespace EventStore.Core.Index {
 
 				_count = indexEntriesTotalSize / _indexEntrySize;
 
-				if (_version >= PTableVersions.IndexV4 && _count > 0 && _midpointsCached < 2) {
-					//if there is at least 1 index entry with version>=4, there should always be at least 2 midpoints cached
+				if (_version >= PTableVersions.IndexV4 && _count > 0 && _midpointsCached > 0 && _midpointsCached < 2) {
+					//if there is at least 1 index entry with version>=4 and there are cached midpoints, there should always be at least 2 midpoints cached
 					throw new CorruptIndexException(String.Format(
 						"Less than 2 midpoints cached in PTable. Index entries: {0}, Midpoints cached: {1}", _count,
 						_midpointsCached));


### PR DESCRIPTION
If this line is hit: https://github.com/EventStore/EventStore/blob/master/src/EventStore.Core/Index/PTableConstruction.cs#L514, no midpoints will be cached to the PTable file.

This will make the following assertion fail:
```
if (_version >= PTableVersions.IndexV4 && _count > 0 && _midpointsCached < 2)
```

*Resolution*
Check if there is at least one midpoint cached before applying the `_midpointsCached < 2` assertion.
