### PR TITLE
Increase the slow queue message threshold to 800ms for the MonitoringQueue

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -161,7 +161,7 @@ namespace EventStore.Core {
 			var monitoringInnerBus = new InMemoryBus("MonitoringInnerBus", watchSlowMsg: false);
 			var monitoringRequestBus = new InMemoryBus("MonitoringRequestBus", watchSlowMsg: false);
 			var monitoringQueue = new QueuedHandlerThreadPool(monitoringInnerBus, "MonitoringQueue", true,
-				TimeSpan.FromMilliseconds(100));
+				TimeSpan.FromMilliseconds(800));
 			var monitoring = new MonitoringService(monitoringQueue,
 				monitoringRequestBus,
 				_mainQueue,


### PR DESCRIPTION
Fixes #1913 

GetFreshStats() spawns child processes such as 'df' or 'free'. When the child process exits, it needs to close all its file descriptors. If the ulimit for number of open files is high (RLIMIT_NOFILE), this can take some time (up to ~500ms) and will fill in the logs with slow queue messages.

*Reproduction steps:*
$ ulimit -n 999999
$ <start eventstore with `--stats-period-sec 1`>

This will fill in the logs with messages like:
```
[01943,20,06:53:22.764] SLOW QUEUE MSG ["MonitoringQueue"]: "GetFreshStats" - 495ms. Q: 0/1.
```