### PR TITLE
Fix UnbufferedFileStream.SetLength() bug

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/Unbuffered/UnbufferedTests.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Unbuffered/UnbufferedTests.cs
@@ -18,6 +18,195 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 		}
 
 		[Test]
+		public void when_expanding_an_aligned_file_by_one_page() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(0, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize, stream.Position); //verify position
+			stream.SetLength(initialFileSize + 4096); //expand file by 4KB
+			Assert.AreEqual(initialFileSize, stream.Position); //position should not change
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize + 4096, new FileInfo(filename).Length); //file size should increase by 4KB
+		}
+
+		[Test]
+		public void when_expanding_an_aligned_file_by_one_byte_less_than_one_page() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(0, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize, stream.Position); //verify position
+			stream.SetLength(initialFileSize + 4095); //expand file by 4KB - 1
+			Assert.AreEqual(initialFileSize, stream.Position); //position should not change
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize + 4096, new FileInfo(filename).Length); //file size should increase by 4KB
+		}
+
+		[Test]
+		public void when_expanding_an_aligned_file_by_one_byte_more_than_one_page() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(0, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize, stream.Position); //verify position
+			stream.SetLength(initialFileSize + 4097); //expand file by 4KB + 1
+			Assert.AreEqual(initialFileSize, stream.Position); //position should not change
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize + 4096 * 2, new FileInfo(filename).Length); //file size should increase by 4KB x 2
+		}
+
+		[Test]
+		public void when_expanding_an_aligned_file_by_one_byte() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(0, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize, stream.Position); //verify position
+			stream.SetLength(initialFileSize + 1); //expand file by 1 byte
+			Assert.AreEqual(initialFileSize, stream.Position); //position should not change
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize + 4096, new FileInfo(filename).Length); //file size should increase by 4KB
+		}
+
+		[Test]
+		public void when_truncating_an_aligned_file_by_one_page() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(0, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize, stream.Position); //verify position
+			stream.SetLength(initialFileSize - 4096); //truncate file by 4KB
+			Assert.AreEqual(initialFileSize - 4096, stream.Position); //position should decrease by 4KB
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize - 4096, new FileInfo(filename).Length); //file size should decrease by 4KB
+		}
+
+		[Test]
+		public void when_truncating_an_aligned_file_by_one_page_and_position_one_page_from_eof() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(-4096, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize - 4096, stream.Position); //verify position
+			stream.SetLength(initialFileSize - 4096); //truncate file by 4KB
+			Assert.AreEqual(initialFileSize - 4096, stream.Position); //position should not change
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize - 4096, new FileInfo(filename).Length); //file size should decrease by 4KB
+		}
+
+		[Test]
+		public void when_truncating_an_aligned_file_by_one_byte_less_than_a_page() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(0, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize, stream.Position); //verify position
+			stream.SetLength(initialFileSize - 4095); //truncate file by 4KB - 1
+			Assert.AreEqual(initialFileSize, stream.Position); //position should not change
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize, new FileInfo(filename).Length); //file size should not change
+		}
+
+		[Test]
+		public void when_truncating_an_aligned_file_by_one_byte_more_than_a_page() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(0, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize, stream.Position); //verify position
+			stream.SetLength(initialFileSize - 4097); //truncate file by 4KB + 1
+			Assert.AreEqual(initialFileSize - 4096, stream.Position); //position should decrease by 4KB 
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize - 4096, new FileInfo(filename).Length); //file size should decrease by 4KB
+		}
+
+		[Test]
+		public void when_truncating_an_aligned_file_by_one_byte() {
+			var filename = GetFilePathFor(Guid.NewGuid().ToString());
+
+			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
+				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+			
+			var initialFileSize = 4096 * 1024;
+			stream.SetLength(initialFileSize); //initial size of 4MB
+
+			stream.Seek(0, SeekOrigin.End);
+
+			Assert.AreEqual(initialFileSize, stream.Position); //verify position
+			stream.SetLength(initialFileSize - 1); //truncate file by 1 byte
+			Assert.AreEqual(initialFileSize, stream.Position); //position should not change
+			
+			stream.Close();
+
+			Assert.AreEqual(initialFileSize, new FileInfo(filename).Length); //file size should not change
+		}
+
+		[Test]
 		public void when_writing_less_than_buffer() {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(255);

--- a/src/EventStore.Core/TransactionLog/Unbuffered/UnbufferedFileStream.cs
+++ b/src/EventStore.Core/TransactionLog/Unbuffered/UnbufferedFileStream.cs
@@ -156,7 +156,8 @@ namespace EventStore.Core.TransactionLog.Unbuffered {
 			var aligned = GetLowestAlignment(value);
 			aligned = aligned == value ? aligned : aligned + _blockSize;
 			NativeFile.SetFileSize(_handle, aligned);
-			Seek(0, SeekOrigin.Begin);
+			if(Position > aligned)
+				Seek(aligned, SeekOrigin.Begin);
 		}
 
 		public override int Read(byte[] buffer, int offset, int count) {


### PR DESCRIPTION
This is a critical bug that affects versions 4.1.0 up to 5.0.1

**Prerequisites:**
- Unbuffered set to `True` in config

**Symptoms:**
The following fatal exception occurs when completing a chunk file (while writing the footer):
```
DEBUG TFChunk             ] Buffer size is 268423040

EXCEPTION OCCURRED
System.NotSupportedException: Unable to expand length of this stream beyond its capacity.
   at System.IO.UnmanagedMemoryStream.Write(Byte[] buffer, Int32 offset, Int32 count)
   at EventStore.Core.TransactionLog.Chunks.TFChunk.TFChunk.WriteRawData(WriterWorkItem workItem, Byte[] buf, Int32 len) in TFChunk.cs
```

Subsequent restarts of the node show the following stack trace:
```
[PID:06428:001 2019.05.10 08:22:00.387 FATAL ProgramBase`1       ] Unhandled exception while starting application:
EXCEPTION OCCURRED
EventStore.Core.Exceptions.CorruptDatabaseException: Corrupt database detected. ---> EventStore.Core.Exceptions.InvalidFileException: Exception of type 'EventStore.Core.Exceptions.InvalidFileException' was thrown.
   --- End of inner exception stack trace ---
```

**Root cause:**
The position of an unbuffered file stream was wrongly being set to 0 when the stream was resized.
The bug was first triggered when this commit was introduced: https://github.com/EventStore/EventStore/commit/d100bf213d655fdedc60a9657c7dd990a25a4e07 due to [this resize operation](https://github.com/EventStore/EventStore/commit/d100bf213d655fdedc60a9657c7dd990a25a4e07#diff-9906bfb99c1b4f17ed2f491ac6a107caR862)

**Resolution:**
Move the position to the end of the stream only if it has been truncated according to https://docs.microsoft.com/en-us/dotnet/api/system.io.filestream.setlength
*If the given value is less than the current length of the stream, the stream is truncated. In this scenario, if the current position is greater than the new length, the current position is moved to the last byte of the stream. If the given value is larger than the current length of the stream, the stream is expanded, and the current position remains the same.*