### PR TITLE
ReadReplica role (former Non Promotable Clone)

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -305,6 +305,9 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.MaxAutoMergeIndexLevelDescr, Opts.DbGroup)]
 		public int MaxAutoMergeIndexLevel { get; set; }
 
+		[ArgDescription(Opts.ReadReplicaDescr, Opts.ClusterGroup)]
+		public bool ReadReplica { get; set; }
+
 		public ClusterNodeOptions() {
 			Config = "";
 			Help = Opts.ShowHelpDefault;
@@ -427,6 +430,8 @@ namespace EventStore.ClusterNode {
 			ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
 
 			MaxAutoMergeIndexLevel = Opts.MaxAutoMergeIndexLevelDefault;
+
+			ReadReplica = Opts.ReadReplicaDefault;
 		}
 	}
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -170,7 +170,9 @@ namespace EventStore.ClusterNode {
 
 			VNodeBuilder builder;
 			if (options.ClusterSize > 1) {
-				builder = ClusterVNodeBuilder.AsClusterMember(options.ClusterSize);
+				builder = ClusterVNodeBuilder
+					.AsClusterMember(options.ClusterSize)
+					.AsReadReplica(options.ReadReplica);
 			} else {
 				builder = ClusterVNodeBuilder.AsSingleNode();
 			}

--- a/src/EventStore.ClusterNode/Properties/launchSettings.json
+++ b/src/EventStore.ClusterNode/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "EventStore.ClusterNode": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -78,12 +78,11 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			if (selfIndex < 0 || selfIndex >= nodesCount)
 				throw new ArgumentOutOfRangeException("selfIndex", "Index of self should be in range of created nodes");
 
-
 			var clusterManager = GetLoopbackForPort(ManagerPort);
 
 			var nodes = new List<ClusterVNodeSettings>();
 			for (var i = 0; i < nodesCount; i++) {
-				nodes.Add(i == selfIndex ? CreateVNode(i, false) : CreateVNode(i));
+				nodes.Add(i == selfIndex ? CreateVNode(i, true) : CreateVNode(i));
 			}
 
 			var self = nodes[selfIndex];

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using EventStore.Common.Utils;
@@ -14,6 +15,10 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		private const int StartingPort = 1002;
 
 		private static ClusterVNodeSettings CreateVNode(int nodeNumber) {
+			return CreateVNode(nodeNumber, Opts.ReadReplicaDefault);
+		}
+
+		private static ClusterVNodeSettings CreateVNode(int nodeNumber, bool isReadReplica) {
 			int tcpIntPort = StartingPort + nodeNumber * 2,
 				tcpExtPort = tcpIntPort + 1,
 				httpIntPort = tcpIntPort + 10,
@@ -40,7 +45,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				TimeSpan.FromSeconds(10),
 				TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false,
 				false, false,
-				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ChunkInitialReaderCountDefault);
+				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ChunkInitialReaderCountDefault, null, Opts.HistogramEnabledDefault, Opts.SkipDbVerifyDefault,
+				Opts.IndexCacheDepthDefault, Opts.IndexBitnessVersionDefault, Opts.OptimizeIndexMergeDefault, null,
+				Opts.UnsafeIgnoreHardDeleteDefault, Opts.BetterOrderingDefault, Opts.ReaderThreadsCountDefault,
+				Opts.AlwaysKeepScavengedDefault, Opts.GossipOnSingleNodeDefault, Opts.SkipIndexScanOnReadsDefault,
+				Opts.ReduceFileCachePressureDefault, Opts.InitializationThreadsDefault, Opts.FaultOutOfOrderProjectionsDefault,
+				Opts.StructuredLogDefault, Opts.MaxAutoMergeIndexLevelDefault, isReadReplica);
 
 			return vnode;
 		}
@@ -61,6 +71,25 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var others = nodes.Where((x, i) => i != selfIndex).ToArray();
 
 			var settings = new ClusterSettings("test-dns", clusterManager, self, others, nodes.Length);
+			return settings;
+		}
+
+		public ClusterSettings GetClusterSettingsWithSelfAsReadReplica(int selfIndex, int nodesCount) {
+			if (selfIndex < 0 || selfIndex >= nodesCount)
+				throw new ArgumentOutOfRangeException("selfIndex", "Index of self should be in range of created nodes");
+
+
+			var clusterManager = GetLoopbackForPort(ManagerPort);
+
+			var nodes = new List<ClusterVNodeSettings>();
+			for (var i = 0; i < nodesCount; i++) {
+				nodes.Add(i == selfIndex ? CreateVNode(i, false) : CreateVNode(i));
+			}
+
+			var self = nodes[selfIndex];
+			var others = nodes.Where((x, i) => i != selfIndex).ToArray();
+
+			var settings = new ClusterSettings("test-dns", clusterManager, self, others, nodes.Count);
 			return settings;
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 
 		private static ClusterVNodeSettings CreateVNode(int nodeNumber, bool isReadReplica) {
 			int tcpIntPort = StartingPort + nodeNumber * 2,
-				tcpExtPort = tcpIntPort + 1,
+					tcpExtPort = tcpIntPort + 1,
 				httpIntPort = tcpIntPort + 10,
 				httpExtPort = tcpIntPort + 11;
 

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				.Union(new[] {
 					MemberInfo.ForVNode(clusterSettings.Self.NodeInfo.InstanceId,
 						InitialDate,
-						VNodeState.Unknown,
+						clusterSettings.Self.NodeInfo.IsReadReplica ? VNodeState.ReadReplica : VNodeState.Unknown,
 						true,
 						clusterSettings.Self.NodeInfo.InternalTcp,
 						clusterSettings.Self.NodeInfo.InternalSecureTcp,

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsAndGossipTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsAndGossipTestCase.cs
@@ -72,7 +72,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			var members = _createInitialGossip(instance, allInstances.ToArray());
 			_updateGossipProcessor.SetInitialData(allInstances, members);
 
-			return new GossipMessage.GossipUpdated(new ClusterInfo(members));
+			return new GossipMessage.GossipUpdated(new ClusterInfo(members),
+				new ClusterInfo(_createInitialGossip(instance, allInstances.ToArray())));
 		}
 
 		protected override SendOverHttpProcessor GetSendOverHttpProcessor() {

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
@@ -33,6 +33,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 
 		private readonly List<ElectionsInstance> _instances = new List<ElectionsInstance>();
 
+		private readonly bool _isReadReplica;
+
 		public RandomizedElectionsTestCase(int maxIterCnt,
 			int instancesCnt,
 			double httpLossProbability,
@@ -40,7 +42,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			int httpMaxDelay,
 			int timerMinDelay,
 			int timerMaxDelay,
-			int? rndSeed = null) {
+			int? rndSeed = null,
+			bool isReadReplica = false) {
 			RndSeed = rndSeed ?? Math.Abs(Environment.TickCount);
 			Rnd = new Random(RndSeed);
 
@@ -51,6 +54,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			HttpMaxDelay = httpMaxDelay;
 			_timerMinDelay = timerMinDelay;
 			_timerMaxDelay = timerMaxDelay;
+			_isReadReplica = isReadReplica;
 
 			Runner = new RandomTestRunner(_maxIterCnt);
 			Logger = new ElectionsLogger();
@@ -64,7 +68,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 				var outputBus = new InMemoryBus(string.Format("ELECTIONS-OUTPUT-BUS-{0}", i));
 				var endPoint = new IPEndPoint(BaseEndPoint.Address, BaseEndPoint.Port + i);
 				var nodeInfo = new VNodeInfo(Guid.NewGuid(), 0, endPoint, endPoint, endPoint, endPoint, endPoint,
-					endPoint);
+					endPoint, _isReadReplica);
 				_instances.Add(new ElectionsInstance(nodeInfo.InstanceId, endPoint, inputBus, outputBus));
 
 				sendOverHttpHandler.RegisterEndPoint(endPoint, inputBus);
@@ -110,7 +114,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			var members = allInstances.Select(
 				x => MemberInfo.ForVNode(x.InstanceId, DateTime.UtcNow, VNodeState.Unknown, true,
 					x.EndPoint, null, x.EndPoint, null, x.EndPoint, x.EndPoint, -1, 0, 0, -1, -1, Guid.Empty, 0));
-			var gossip = new GossipMessage.GossipUpdated(new ClusterInfo(members.ToArray()));
+			var gossip = new GossipMessage.GossipUpdated(new ClusterInfo(members.ToArray()), new ClusterInfo());
 			return gossip;
 		}
 

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/UpdateGossipProcessor.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/UpdateGossipProcessor.cs
@@ -74,7 +74,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 					_sendOverHttpProcessor.RegisterEndpointToSkip(memberInfo.ExternalTcpEndPoint, !memberInfo.IsAlive);
 				}
 
-				var updateGossipMessage = new GossipMessage.GossipUpdated(new ClusterInfo(updatedGossip));
+				var updateGossipMessage = new GossipMessage.GossipUpdated(new ClusterInfo(updatedGossip),
+					new ClusterInfo(_initialGossip));
 
 				_enqueue(item, updateGossipMessage);
 				_previousGossip[item.EndPoint] = updatedGossip;

--- a/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using EventStore.Core.Cluster;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Helpers;
@@ -20,7 +21,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		private void ProcessElections() {
-			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo);
+			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo, new ClusterInfo());
 			_electionsUnit.Publish(gossipUpdate);
 
 			_electionsUnit.Publish(new ElectionMessage.StartElections());
@@ -50,7 +51,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		private void ProcessElections() {
-			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo);
+			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo, new ClusterInfo());
 			_electionsUnit.Publish(gossipUpdate);
 
 			_electionsUnit.Publish(new ElectionMessage.StartElections());
@@ -91,7 +92,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		private void ProcessElections() {
-			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo);
+			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo, new ClusterInfo());
 			_electionsUnit.Publish(gossipUpdate);
 
 			_electionsUnit.Publish(new ElectionMessage.StartElections());
@@ -119,6 +120,60 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		public void elect_node_with_biggest_port_ip_for_equal_writerchecksums() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
+		}
+
+		[TestFixture]
+		public sealed class elections_service_should_not_elect_nonpromotableclone {
+			private ElectionsServiceUnit _electionsUnit;
+			private const int SelfIndex = 0;
+			private const int View = 2;
+
+			[SetUp]
+			public void SetUp() {
+				var clusterSettingsFactory = new ClusterSettingsFactory();
+				var clusterSettings = clusterSettingsFactory.GetClusterSettingsWithSelfAsReadReplica(SelfIndex, 3);
+
+				_electionsUnit = new ElectionsServiceUnit(clusterSettings);
+				_electionsUnit.UpdateClusterMemberInfo(0, isAlive: true);
+				_electionsUnit.UpdateClusterMemberInfo(1, isAlive: true);
+				_electionsUnit.UpdateClusterMemberInfo(2, isAlive: false);
+
+				StartElections();
+				Prepare(SelfIndex, View);
+			}
+
+			private void StartElections() {
+				var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo, new ClusterInfo());
+				_electionsUnit.Publish(gossipUpdate);
+
+				_electionsUnit.Publish(new ElectionMessage.StartElections());
+
+				_electionsUnit.RepublishFromPublisher();
+
+				_electionsUnit.RepublishFromPublisher();
+				Assert.That(_electionsUnit.Publisher.Messages.All(x => x is HttpMessage.SendOverHttp || x is TimerMessage.Schedule),
+					Is.True,
+					"Only OverHttp or Schedule messages are expected.");
+
+				_electionsUnit.RepublishFromPublisher();
+
+				_electionsUnit.RepublishFromPublisher();
+				Assert.That(_electionsUnit.Publisher.Messages.All(x => x is HttpMessage.SendOverHttp || x is TimerMessage.Schedule),
+					Is.True,
+					"Only OverHttp or Schedule messages are expected.");
+
+				_electionsUnit.RepublishFromPublisher();
+			}
+
+			private void Prepare(int selfIndex, int view) {
+				_electionsUnit.Publish(new ElectionMessage.Prepare(_electionsUnit.ClusterInfo.Members[selfIndex].InstanceId,
+					_electionsUnit.ClusterInfo.Members[selfIndex].ExternalTcpEndPoint, view));
+			}
+
+			[Test]
+			public void prepare_node_for_election_fail_if_read_replica() {
+				Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.PrepareKo>());
+			}
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
@@ -131,12 +131,9 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			[SetUp]
 			public void SetUp() {
 				var clusterSettingsFactory = new ClusterSettingsFactory();
-				var clusterSettings = clusterSettingsFactory.GetClusterSettingsWithSelfAsReadReplica(SelfIndex, 3);
+				var clusterSettings = clusterSettingsFactory.GetClusterSettingsWithSelfAsReadReplica(SelfIndex, 3); 
 
 				_electionsUnit = new ElectionsServiceUnit(clusterSettings);
-				_electionsUnit.UpdateClusterMemberInfo(0, isAlive: true);
-				_electionsUnit.UpdateClusterMemberInfo(1, isAlive: true);
-				_electionsUnit.UpdateClusterMemberInfo(2, isAlive: false);
 
 				StartElections();
 				Prepare(SelfIndex, View);

--- a/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
@@ -123,7 +123,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		[TestFixture]
-		public sealed class elections_service_should_not_elect_nonpromotableclone {
+		public sealed class elections_service_should_not_elect_readreplica {
 			private ElectionsServiceUnit _electionsUnit;
 			private const int SelfIndex = 0;
 			private const int View = 2;

--- a/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
@@ -94,7 +94,7 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication {
 			var masterIPEndPoint = new IPEndPoint(IPAddress.Loopback, 2113);
 			_service.Handle(new SystemMessage.BecomeSlave(Guid.NewGuid(), new VNodeInfo(Guid.NewGuid(), 1,
 				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint,
-				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint)));
+				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint, true)));
 		}
 	}
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -83,6 +83,8 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool FaultOutOfOrderProjections;
 		public readonly bool StructuredLog;
 
+		public readonly bool IsReadReplica;
+
 		public ClusterVNodeSettings(Guid instanceId, int debugIndex,
 			IPEndPoint internalTcpEndPoint,
 			IPEndPoint internalSecureTcpEndPoint,
@@ -149,7 +151,8 @@ namespace EventStore.Core.Cluster.Settings {
 			int initializationThreads = 1,
 			bool faultOutOfOrderProjections = false,
 			bool structuredLog = false,
-			int maxAutoMergeIndexLevel = 1000) {
+			int maxAutoMergeIndexLevel = 1000,
+			bool isReadReplica = false) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
@@ -178,7 +181,8 @@ namespace EventStore.Core.Cluster.Settings {
 			NodeInfo = new VNodeInfo(instanceId, debugIndex,
 				internalTcpEndPoint, internalSecureTcpEndPoint,
 				externalTcpEndPoint, externalSecureTcpEndPoint,
-				internalHttpEndPoint, externalHttpEndPoint);
+				internalHttpEndPoint, externalHttpEndPoint,
+				isReadReplica);
 			GossipAdvertiseInfo = gossipAdvertiseInfo;
 			IntHttpPrefixes = intHttpPrefixes;
 			ExtHttpPrefixes = extHttpPrefixes;
@@ -249,6 +253,7 @@ namespace EventStore.Core.Cluster.Settings {
 			MaxAutoMergeIndexLevel = maxAutoMergeIndexLevel;
 			FaultOutOfOrderProjections = faultOutOfOrderProjections;
 			StructuredLog = structuredLog;
+			IsReadReplica = isReadReplica;
 		}
 
 
@@ -293,7 +298,8 @@ namespace EventStore.Core.Cluster.Settings {
 			                     + "ChunkInitialReaderCount: {37}\n"
 			                     + "ReduceFileCachePressure: {38}\n"
 			                     + "InitializationThreads: {39}\n"
-			                     + "StructuredLog: {40}\n",
+			                     + "StructuredLog: {40}\n"
+			                     + "IsReadReplica: {41}\n",
 				NodeInfo.InstanceId,
 				NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
 				NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -312,7 +318,7 @@ namespace EventStore.Core.Cluster.Settings {
 				NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout,
 				EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge,
 				ConnectionPendingSendBytesThreshold, ChunkInitialReaderCount,
-				ReduceFileCachePressure, InitializationThreads, StructuredLog);
+				ReduceFileCachePressure, InitializationThreads, StructuredLog, IsReadReplica);
 		}
 	}
 }

--- a/src/EventStore.Core/Cluster/VNodeInfo.cs
+++ b/src/EventStore.Core/Cluster/VNodeInfo.cs
@@ -2,11 +2,11 @@ using EventStore.Core.Data;
 
 namespace EventStore.Core.Cluster {
 	public static class VNodeInfoHelper {
-		public static VNodeInfo FromMemberInfo(MemberInfo member) {
+		public static VNodeInfo FromMemberInfo(MemberInfo member, bool isReadReplica) {
 			return new VNodeInfo(member.InstanceId, 0,
 				member.InternalTcpEndPoint, member.InternalSecureTcpEndPoint,
 				member.ExternalTcpEndPoint, member.ExternalSecureTcpEndPoint,
-				member.InternalHttpEndPoint, member.ExternalHttpEndPoint);
+				member.InternalHttpEndPoint, member.ExternalHttpEndPoint, isReadReplica);
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -573,7 +573,8 @@ namespace EventStore.Core {
 				vNodeSettings.GossipAdvertiseInfo.ExternalTcp,
 				vNodeSettings.GossipAdvertiseInfo.ExternalSecureTcp,
 				vNodeSettings.GossipAdvertiseInfo.InternalHttp,
-				vNodeSettings.GossipAdvertiseInfo.ExternalHttp);
+				vNodeSettings.GossipAdvertiseInfo.ExternalHttp,
+				_nodeInfo.IsReadReplica);
 			if (!isSingleNode) {
 				// MASTER REPLICATION
 				var masterReplicationService = new MasterReplicationService(_mainQueue, gossipInfo.InstanceId, db,

--- a/src/EventStore.Core/Data/VNodeInfo.cs
+++ b/src/EventStore.Core/Data/VNodeInfo.cs
@@ -12,11 +12,12 @@ namespace EventStore.Core.Data {
 		public readonly IPEndPoint ExternalSecureTcp;
 		public readonly IPEndPoint InternalHttp;
 		public readonly IPEndPoint ExternalHttp;
+		public readonly bool IsReadReplica;
 
 		public VNodeInfo(Guid instanceId, int debugIndex,
 			IPEndPoint internalTcp, IPEndPoint internalSecureTcp,
 			IPEndPoint externalTcp, IPEndPoint externalSecureTcp,
-			IPEndPoint internalHttp, IPEndPoint externalHttp) {
+			IPEndPoint internalHttp, IPEndPoint externalHttp, bool isReadReplica) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcp, "internalTcp");
 			Ensure.NotNull(externalTcp, "externalTcp");
@@ -31,6 +32,7 @@ namespace EventStore.Core.Data {
 			ExternalSecureTcp = externalSecureTcp;
 			InternalHttp = internalHttp;
 			ExternalHttp = externalHttp;
+			IsReadReplica = isReadReplica;
 		}
 
 		public bool Is(IPEndPoint endPoint) {

--- a/src/EventStore.Core/Data/VNodeState.cs
+++ b/src/EventStore.Core/Data/VNodeState.cs
@@ -10,14 +10,16 @@ namespace EventStore.Core.Data {
 		Master,
 		Manager,
 		ShuttingDown,
-		Shutdown
+		Shutdown,
+		ReadReplica
 	}
 
 	public static class VNodeStateExtensions {
 		public static bool IsReplica(this VNodeState state) {
 			return state == VNodeState.CatchingUp
 			       || state == VNodeState.Clone
-			       || state == VNodeState.Slave;
+				   || state == VNodeState.Slave
+			       || state == VNodeState.ReadReplica;
 		}
 	}
 }

--- a/src/EventStore.Core/Messages/ElectionMessage.cs
+++ b/src/EventStore.Core/Messages/ElectionMessage.cs
@@ -205,6 +205,51 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class PrepareKo : Message {
+			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+			public override int MsgTypeId { get { return TypeId; } }
+
+			public readonly int View;
+			public readonly Guid ServerId;
+			public readonly IPEndPoint ServerInternalHttp;
+			public readonly int EpochNumber;
+			public readonly long EpochPosition;
+			public readonly Guid EpochId;
+			public readonly long LastCommitPosition;
+			public readonly long WriterCheckpoint;
+			public readonly long ChaserCheckpoint;
+			public readonly int NodePriority;
+
+			public PrepareKo(int view,
+				Guid serverId,
+				IPEndPoint serverInternalHttp,
+				int epochNumber,
+				long epochPosition,
+				Guid epochId,
+				long lastCommitPosition,
+				long writerCheckpoint,
+				long chaserCheckpoint,
+				int nodePriority) {
+				View = view;
+				ServerId = serverId;
+				ServerInternalHttp = serverInternalHttp;
+				EpochNumber = epochNumber;
+				EpochPosition = epochPosition;
+				EpochId = epochId;
+				LastCommitPosition = lastCommitPosition;
+				WriterCheckpoint = writerCheckpoint;
+				ChaserCheckpoint = chaserCheckpoint;
+				NodePriority = nodePriority;
+			}
+
+			public override string ToString() {
+				return string.Format("---- PrepareKo (NPC): view {0}, serverId {1}, serverInternalHttp {2}, epochNumber {3}, " +
+				                     "epochPosition {4}, epochId {5}, lastCommitPosition {6}, writerCheckpoint {7}, chaserCheckpoint {8}, nodePriority: {9}",
+					View, ServerId, ServerInternalHttp, EpochNumber,
+					EpochPosition, EpochId, LastCommitPosition, WriterCheckpoint, ChaserCheckpoint, NodePriority);
+			}
+		}
+
 		public class Proposal : Message {
 			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Messages/GossipMessage.cs
+++ b/src/EventStore.Core/Messages/GossipMessage.cs
@@ -99,6 +99,7 @@ namespace EventStore.Core.Messages {
 			var newOtherMembers = new List<MemberInfo>();
 			foreach (var memberInfo in cluster.Members) {
 				// TODO add a version in memberInfo to avoid adapt names for compatible nodes
+				// Set state==clone if this node is ReadReplica to keep compatibility with older nodes
 				if (memberInfo.State == VNodeState.ReadReplica) {
 					newOtherMembers.Add(memberInfo.Updated(VNodeState.Clone, memberInfo.IsAlive, memberInfo.LastCommitPosition,
 						memberInfo.WriterCheckpoint, memberInfo.ChaserCheckpoint));

--- a/src/EventStore.Core/Messages/GossipMessage.cs
+++ b/src/EventStore.Core/Messages/GossipMessage.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using EventStore.Core.Cluster;
+using EventStore.Core.Data;
 using EventStore.Core.Messaging;
 
 namespace EventStore.Core.Messages {
@@ -55,7 +57,7 @@ namespace EventStore.Core.Messages {
 
 			public GossipReceived(IEnvelope envelope, ClusterInfo clusterInfo, IPEndPoint server) {
 				Envelope = envelope;
-				ClusterInfo = clusterInfo;
+				ClusterInfo = AdaptNames(clusterInfo);
 				Server = server;
 			}
 		}
@@ -71,7 +73,7 @@ namespace EventStore.Core.Messages {
 			public readonly IPEndPoint ServerEndPoint;
 
 			public SendGossip(ClusterInfo clusterInfo, IPEndPoint serverEndPoint) {
-				ClusterInfo = clusterInfo;
+				ClusterInfo = AdaptNames(clusterInfo);
 				ServerEndPoint = serverEndPoint;
 			}
 		}
@@ -84,10 +86,27 @@ namespace EventStore.Core.Messages {
 			}
 
 			public readonly ClusterInfo ClusterInfo;
+			public readonly ClusterInfo OldClusterInfo;
 
-			public GossipUpdated(ClusterInfo clusterInfo) {
+			public GossipUpdated(ClusterInfo clusterInfo, ClusterInfo oldClusterInfo) {
 				ClusterInfo = clusterInfo;
+				ClusterInfo = AdaptNames(clusterInfo);
+				OldClusterInfo = oldClusterInfo;
 			}
+		}
+
+		private static ClusterInfo AdaptNames(ClusterInfo cluster) {
+			var newOtherMembers = new List<MemberInfo>();
+			foreach (var memberInfo in cluster.Members) {
+				// TODO add a version in memberInfo to avoid adapt names for compatible nodes
+				if (memberInfo.State == VNodeState.ReadReplica) {
+					newOtherMembers.Add(memberInfo.Updated(VNodeState.Clone, memberInfo.IsAlive, memberInfo.LastCommitPosition,
+						memberInfo.WriterCheckpoint, memberInfo.ChaserCheckpoint));
+				} else {
+					newOtherMembers.Add(memberInfo);
+				}
+			}
+			return new ClusterInfo(newOtherMembers);
 		}
 
 		public class GossipSendFailed : Message {

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -209,6 +209,17 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class BecomeReadReplica : ReplicaStateMessage {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public BecomeReadReplica(Guid correlationId, VNodeInfo master) : base(correlationId, VNodeState.ReadReplica, master) {
+			}
+		}
+
 		public class BecomeSlave : ReplicaStateMessage {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -271,7 +271,7 @@ namespace EventStore.Core.Services {
 				_publisher.Publish(new HttpMessage.SendOverHttp(message.ServerInternalHttp,
 					CreatePrepareOk(message.View), DateTime.Now.Add(LeaderElectionProgressTimeout)));
 			} else {
-				Log.Info("ELECTIONS: I'm a READ REPLICA and I can't be a candidate [{0}]", message.ServerInternalHttp);
+				//Log.Debug("ELECTIONS: I'm a READ REPLICA and I can't be a candidate [{0}]", message.ServerInternalHttp);
 				_publisher.Publish(CreatePrepareKo(message.View));
 			}
 		}
@@ -293,10 +293,10 @@ namespace EventStore.Core.Services {
 		}
 
 		private void ShiftToRegNonLeader() {
-			Log.Debug("ELECTIONS: (V={lastAttemptedView}) SHIFT TO REG_NONLEADER.", _lastAttemptedView);
 			// If I'm a READ REPLICA I can't set my state as leader and send proposals
 			if (_nodeInfo.IsReadReplica)
 				return;
+			Log.Debug("ELECTIONS: (V={lastAttemptedView}) SHIFT TO REG_NONLEADER.", _lastAttemptedView);
 			_state = ElectionsState.NonLeader;
 			_lastInstalledView = _lastAttemptedView;
 		}

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -295,7 +295,7 @@ namespace EventStore.Core.Services {
 		private void ShiftToRegNonLeader() {
 			Log.Debug("ELECTIONS: (V={lastAttemptedView}) SHIFT TO REG_NONLEADER.", _lastAttemptedView);
 			// If I'm a READ REPLICA I can't set my state as leader and send proposals
-			if (!_nodeInfo.IsReadReplica)
+			if (_nodeInfo.IsReadReplica)
 				return;
 			_state = ElectionsState.NonLeader;
 			_lastInstalledView = _lastAttemptedView;
@@ -392,8 +392,8 @@ namespace EventStore.Core.Services {
 				x.IsAlive && x.InstanceId == _lastElectedMaster && x.State == VNodeState.Master);
 			if (master != null) {
 				if (candidate.InstanceId == master.InstanceId
-				    || candidate.EpochNumber > master.EpochNumber
-				    || (candidate.EpochNumber == master.EpochNumber && candidate.EpochId != master.EpochId))
+					|| candidate.EpochNumber > master.EpochNumber
+					|| (candidate.EpochNumber == master.EpochNumber && candidate.EpochId != master.EpochId))
 					return true;
 
 				Log.Debug(

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -480,8 +480,9 @@ namespace EventStore.Core.Services {
 			if (_acceptsReceived.Add(message.ServerId) && _acceptsReceived.Count == _clusterSize / 2 + 1) {
 				var master = _servers.FirstOrDefault(x => x.InstanceId == _masterProposal.InstanceId);
 				if (master != null) {
+					if (_nodeInfo.IsReadReplica && _nodeInfo.InstanceId.Equals(_masterProposal.InstanceId)) 
+						return;
 					_master = _masterProposal.InstanceId;
-					// TODO consider refactoring here when there is no quorum because ReadReplica nodes: stop this log and not publishing ElectionsDone
 					Log.Info("ELECTIONS: (V={view}) DONE. ELECTED MASTER = {masterInfo}. ME={ownInfo}.", message.View,
 						FormatNodeInfo(_masterProposal), FormatNodeInfo(GetOwnInfo()));
 					_lastElectedMaster = _master;

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -44,6 +44,7 @@ namespace EventStore.Core.Services {
 				case VNodeState.PreReplica:
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
+				case VNodeState.ReadReplica:
 				case VNodeState.Slave:
 					_masterInfo = ((SystemMessage.ReplicaStateMessage)message).Master;
 					break;

--- a/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
+++ b/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
@@ -200,6 +200,7 @@ namespace EventStore.Core.Services.Monitoring {
 			switch (message.State) {
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
+				case VNodeState.ReadReplica:
 				case VNodeState.Slave:
 				case VNodeState.Master: {
 					SetStatsStreamMetadata();

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -102,6 +102,7 @@ namespace EventStore.Core.Services.Replication {
 				}
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
+				case VNodeState.ReadReplica:
 				case VNodeState.Slave: {
 					// nothing changed, essentially
 					break;
@@ -188,7 +189,7 @@ namespace EventStore.Core.Services.Replication {
 			SendTcpMessage(_connection,
 				new ReplicationMessage.SubscribeReplica(
 					logPosition, chunk.ChunkHeader.ChunkId, epochs, _nodeInfo.InternalTcp,
-					message.MasterId, message.SubscriptionId, isPromotable: true));
+					message.MasterId, message.SubscriptionId, isPromotable: !_nodeInfo.IsReadReplica));
 		}
 
 		public void Handle(ReplicationMessage.AckLogPosition message) {
@@ -221,6 +222,7 @@ namespace EventStore.Core.Services.Replication {
 
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
+				case VNodeState.ReadReplica:
 				case VNodeState.Slave: {
 					Debug.Assert(_connection != null, "Connection manager is null in slave/clone/catching up state");
 					SendTcpMessage(_connection, message.Message);

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -669,7 +669,7 @@ namespace EventStore.Core.Services.VNode {
 				Log.Debug("There is NO MASTER or MASTER is DEAD according to GOSSIP. Starting new elections. MASTER: [{0}].", _master);
 				_mainQueue.Publish(new ElectionMessage.StartElections());
 			} else if (CantBePartOfQuorumIfNonPromotable(message.OldClusterInfo, message.ClusterInfo)) {
-				Log.Debug("I'm a ReadReplica and I can't be part of the quorum. Starting new elections. MASTER: [{0}].", _master);
+				//Log.Debug("I'm a ReadReplica and I can't be part of the quorum. Starting new elections. MASTER: [{0}].", _master);
 				_mainQueue.Publish(new ElectionMessage.StartElections());
 			}
 

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -113,15 +113,15 @@ namespace EventStore.Core.Services.VNode {
 				.InState(VNodeState.Unknown)
 				.WhenOther().ForwardTo(_outputBus)
 				.InStates(VNodeState.Initializing, VNodeState.Master, VNodeState.PreMaster,
-					VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave)
+					VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave, VNodeState.ReadReplica)
 				.When<SystemMessage.BecomeUnknown>().Do(Handle)
 				.InAllStatesExcept(VNodeState.Unknown,
 					VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave,
-					VNodeState.Master)
+					VNodeState.Master, VNodeState.ReadReplica)
 				.When<ClientMessage.ReadRequestMessage>()
 				.Do(msg => DenyRequestBecauseNotReady(msg.Envelope, msg.CorrelationId))
 				.InAllStatesExcept(VNodeState.Master,
-					VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave)
+					VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave, VNodeState.ReadReplica)
 				.When<ClientMessage.WriteRequestMessage>()
 				.Do(msg => DenyRequestBecauseNotReady(msg.Envelope, msg.CorrelationId))
 				.InState(VNodeState.Master)
@@ -140,7 +140,7 @@ namespace EventStore.Core.Services.VNode {
 				.When<ClientMessage.UpdatePersistentSubscription>().ForwardTo(_outputBus)
 				.When<ClientMessage.DeletePersistentSubscription>().ForwardTo(_outputBus)
 				.InStates(VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave,
-					VNodeState.Unknown)
+					VNodeState.Unknown, VNodeState.ReadReplica)
 				.When<ClientMessage.ReadEvent>().Do(HandleAsNonMaster)
 				.When<ClientMessage.ReadStreamEventsForward>().Do(HandleAsNonMaster)
 				.When<ClientMessage.ReadStreamEventsBackward>().Do(HandleAsNonMaster)
@@ -150,7 +150,8 @@ namespace EventStore.Core.Services.VNode {
 				.When<ClientMessage.ConnectToPersistentSubscription>().Do(HandleAsNonMaster)
 				.When<ClientMessage.UpdatePersistentSubscription>().Do(HandleAsNonMaster)
 				.When<ClientMessage.DeletePersistentSubscription>().Do(HandleAsNonMaster)
-				.InStates(VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave)
+				.InStates(VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, 
+					VNodeState.Slave, VNodeState.ReadReplica)
 				.When<ClientMessage.WriteEvents>().Do(HandleAsNonMaster)
 				.When<ClientMessage.TransactionStart>().Do(HandleAsNonMaster)
 				.When<ClientMessage.TransactionWrite>().Do(HandleAsNonMaster)
@@ -172,11 +173,14 @@ namespace EventStore.Core.Services.VNode {
 				.When<ElectionMessage.ElectionsDone>().Do(Handle)
 				.InStates(VNodeState.Unknown,
 					VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave,
-					VNodeState.PreMaster, VNodeState.Master)
+					VNodeState.PreMaster, VNodeState.Master, VNodeState.ReadReplica)
 				.When<SystemMessage.BecomePreReplica>().Do(Handle)
 				.When<SystemMessage.BecomePreMaster>().Do(Handle)
 				.InStates(VNodeState.PreReplica, VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave)
 				.When<GossipMessage.GossipUpdated>().Do(HandleAsNonMaster)
+				.When<SystemMessage.VNodeConnectionLost>().Do(Handle)
+				.InStates(VNodeState.ReadReplica)
+				.When<GossipMessage.GossipUpdated>().Do(HandleAsReadReplica)
 				.When<SystemMessage.VNodeConnectionLost>().Do(Handle)
 				.InAllStatesExcept(VNodeState.PreReplica, VNodeState.PreMaster)
 				.When<SystemMessage.WaitForChaserToCatchUp>().Ignore()
@@ -195,13 +199,15 @@ namespace EventStore.Core.Services.VNode {
 				.When<ReplicationMessage.SubscribeToMaster>().Ignore()
 				.When<ReplicationMessage.ReplicaSubscriptionRetry>().Ignore()
 				.When<ReplicationMessage.ReplicaSubscribed>().Ignore()
-				.InStates(VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave)
+				.InStates(VNodeState.CatchingUp, VNodeState.Clone, 
+					VNodeState.Slave, VNodeState.ReadReplica)
 				.When<ReplicationMessage.CreateChunk>().Do(ForwardReplicationMessage)
 				.When<ReplicationMessage.RawChunkBulk>().Do(ForwardReplicationMessage)
 				.When<ReplicationMessage.DataChunkBulk>().Do(ForwardReplicationMessage)
 				.When<ReplicationMessage.AckLogPosition>().ForwardTo(_outputBus)
 				.WhenOther().ForwardTo(_outputBus)
-				.InAllStatesExcept(VNodeState.CatchingUp, VNodeState.Clone, VNodeState.Slave)
+				.InAllStatesExcept(VNodeState.CatchingUp, VNodeState.Clone, 
+					VNodeState.Slave, VNodeState.ReadReplica)
 				.When<ReplicationMessage.CreateChunk>().Ignore()
 				.When<ReplicationMessage.RawChunkBulk>().Ignore()
 				.When<ReplicationMessage.DataChunkBulk>().Ignore()
@@ -210,6 +216,7 @@ namespace EventStore.Core.Services.VNode {
 				.When<ReplicationMessage.CloneAssignment>().Do(Handle)
 				.When<ReplicationMessage.SlaveAssignment>().Do(Handle)
 				.When<SystemMessage.BecomeClone>().Do(Handle)
+				.When<SystemMessage.BecomeReadReplica>().Do(Handle)
 				.When<SystemMessage.BecomeSlave>().Do(Handle)
 				.InState(VNodeState.Clone)
 				.When<ReplicationMessage.SlaveAssignment>().Do(Handle)
@@ -317,6 +324,19 @@ namespace EventStore.Core.Services.VNode {
 			_outputBus.Publish(message);
 		}
 
+		private void Handle(SystemMessage.BecomeReadReplica message) {
+			if (_master == null)
+				throw new Exception("_master == null");
+			if (_stateCorrelationId != message.CorrelationId)
+				return;
+
+			Log.Info("========== [{0}] IS READ REPLICA... MASTER IS [{1},{2:B}]",
+				_nodeInfo.InternalHttp, _master.InternalHttp, _master.InstanceId);
+
+			_state = VNodeState.ReadReplica;
+			_outputBus.Publish(message);
+		}
+
 		private void Handle(SystemMessage.BecomeSlave message) {
 			if (_master == null) throw new Exception("_master == null");
 			if (_stateCorrelationId != message.CorrelationId)
@@ -397,7 +417,7 @@ namespace EventStore.Core.Services.VNode {
 				return;
 			}
 
-			_master = VNodeInfoHelper.FromMemberInfo(message.Master);
+			_master = VNodeInfoHelper.FromMemberInfo(message.Master, false);
 			_subscriptionId = Guid.NewGuid();
 			_stateCorrelationId = Guid.NewGuid();
 			_outputBus.Publish(message);
@@ -641,6 +661,32 @@ namespace EventStore.Core.Services.VNode {
 			_outputBus.Publish(message);
 		}
 
+		private void HandleAsReadReplica(GossipMessage.GossipUpdated message) {
+			if (_master == null)
+				throw new Exception("_master == null");
+			var master = message.ClusterInfo.Members.FirstOrDefault(x => x.InstanceId == _master.InstanceId);
+			if (master == null || !master.IsAlive) {
+				Log.Debug("There is NO MASTER or MASTER is DEAD according to GOSSIP. Starting new elections. MASTER: [{0}].", _master);
+				_mainQueue.Publish(new ElectionMessage.StartElections());
+			} else if (CantBePartOfQuorumIfNonPromotable(message.OldClusterInfo, message.ClusterInfo)) {
+				Log.Debug("I'm a ReadReplica and I can't be part of the quorum. Starting new elections. MASTER: [{0}].", _master);
+				_mainQueue.Publish(new ElectionMessage.StartElections());
+			}
+
+			_outputBus.Publish(message);
+		}
+
+		private bool CantBePartOfQuorumIfNonPromotable(ClusterInfo old, ClusterInfo current) {
+			if (!_nodeInfo.IsReadReplica)
+				return false;
+			var previousCandidates = old.Members.Count(a =>
+				a.IsAlive && (a.State != VNodeState.Clone || a.State != VNodeState.ReadReplica) && a.InstanceId != _nodeInfo.InstanceId);
+			var currentCandidates = current.Members.Count(a =>
+				a.IsAlive && (a.State != VNodeState.Clone || a.State != VNodeState.ReadReplica) && a.State != VNodeState.Master &&
+				a.InstanceId != _nodeInfo.InstanceId);
+			return previousCandidates > 0 && currentCandidates == 0;
+		}
+
 		private void Handle(SystemMessage.NoQuorumMessage message) {
 			Log.Info("=== NO QUORUM EMERGED WITHIN TIMEOUT... RETIRING...");
 			_fsm.Handle(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
@@ -723,14 +769,23 @@ namespace EventStore.Core.Services.VNode {
 
 		private void Handle(ReplicationMessage.CloneAssignment message) {
 			if (IsLegitimateReplicationMessage(message)) {
-				Log.Info(
-					"========== [{internalHttp}] CLONE ASSIGNMENT RECEIVED FROM [{internalTcp},{internalSecureTcp},{masterId:B}].",
-					_nodeInfo.InternalHttp,
-					_master.InternalTcp,
-					_master.InternalSecureTcp == null ? "n/a" : _master.InternalSecureTcp.ToString(),
-					message.MasterId);
 				_outputBus.Publish(message);
-				_fsm.Handle(new SystemMessage.BecomeClone(_stateCorrelationId, _master));
+				if (!_nodeInfo.IsReadReplica) {
+					Log.Info(
+						"========== [{internalHttp}] CLONE ASSIGNMENT RECEIVED FROM [{internalTcp},{internalSecureTcp},{masterId:B}].",
+						_nodeInfo.InternalHttp,
+						_master.InternalTcp,
+						_master.InternalSecureTcp == null ? "n/a" : _master.InternalSecureTcp.ToString(),
+						message.MasterId);
+					_fsm.Handle(new SystemMessage.BecomeClone(_stateCorrelationId, _master));
+				} else {
+					Log.Info("========== [{0}] (READ REPLICA) CLONE ASSIGNMENT RECEIVED FROM [{1},{2},{3:B}].",
+						_nodeInfo.InternalHttp,
+						_master.InternalTcp,
+						_master.InternalSecureTcp == null ? "n/a" : _master.InternalSecureTcp.ToString(),
+						message.MasterId);
+					_fsm.Handle(new SystemMessage.BecomeReadReplica(_stateCorrelationId, _master));
+				}
 			}
 		}
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -360,6 +360,8 @@ namespace EventStore.Core.Util {
 		public const string GossipSeedDescr = "Endpoints for other cluster nodes from which to seed gossip";
 		public static readonly IPEndPoint[] GossipSeedDefault = new IPEndPoint[0];
 
+		public const string ReadReplicaDescr = "Whether or not this node is allowed to join into elections if true this node is just an async replica";
+		public static readonly bool ReadReplicaDefault = false;
 		/*
 		 *  MANAGER OPTIONS
 		 */

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -134,6 +134,8 @@ namespace EventStore.Core {
 
 		private bool _gossipOnSingleNode;
 
+		protected bool _isReadReplica;
+
 		// ReSharper restore FieldCanBeMadeReadOnly.Local
 
 		protected VNodeBuilder() {
@@ -225,6 +227,12 @@ namespace EventStore.Core {
 			_faultOutOfOrderProjections = Opts.FaultOutOfOrderProjectionsDefault;
 			_reduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
 			_initializationThreads = Opts.InitializationThreadsDefault;
+			_isReadReplica = Opts.ReadReplicaDefault;
+		}
+
+		public VNodeBuilder AsReadReplica(bool value) {
+			_isReadReplica = value;
+			return this;
 		}
 
 		protected VNodeBuilder WithSingleNodeSettings() {
@@ -1380,7 +1388,8 @@ namespace EventStore.Core {
 				_initializationThreads,
 				_faultOutOfOrderProjections,
 				_structuredLog,
-				_maxAutoMergeIndexLevel);
+				_maxAutoMergeIndexLevel,
+				_isReadReplica);
 
 			var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
@@ -55,7 +55,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system {
 						new IPEndPoint(IPAddress.Loopback, 1113),
 						new IPEndPoint(IPAddress.Loopback, 1114),
 						new IPEndPoint(IPAddress.Loopback, 1115),
-						new IPEndPoint(IPAddress.Loopback, 1116)
+						new IPEndPoint(IPAddress.Loopback, 1116),
+						true
 					)));
 				yield return (new SystemMessage.SystemCoreReady());
 				yield return Yield;


### PR DESCRIPTION
There is a new ReadReplica config setting (default false)
When it is set to true, the node does not participate in the election process as a candidate and it does not allow the cluster to stay up if there are not enough (other) nodes to form a quorum
Added a new test for the ElectionService changes (more tests can be added... as usual)

To test this PR, run a cluster of 3 nodes. The nodes could be any previous version.
Once that the cluster is up and running, run a node using this PR code with ReadReplica setting set to true. Remember to keep the clustersize 3 and use the same gossip port of the other nodes in order to join the existing cluster.
You can verify that the node is recognise as ReadReplica looking at the logs and it does not participate as a candidate in the Election Process when you shut down the other nodes for testing.

Closes #1751 