### PR TITLE
Prevent browser to invoke basic auth popup

### DIFF
--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -148,7 +148,7 @@ namespace EventStore.Transport.Http.EntityManagement {
 				HttpEntity.Response.AddHeader("Access-Control-Expose-Headers",
 					"Location, ES-Position, ES-CurrentVersion");
 				if (HttpEntity.Response.StatusCode == HttpStatusCode.Unauthorized)
-					HttpEntity.Response.AddHeader("WWW-Authenticate", "Basic realm=\"ES\"");
+					HttpEntity.Response.AddHeader("WWW-Authenticate", "BasicCustom realm=\"ES\"");
 			} catch (ObjectDisposedException) {
 				// ignore
 			} catch (Exception e) {


### PR DESCRIPTION
Popup appears when logging in with wrong username and password

Tested on Windows/Mac/Linux

- [x] Chrome

- [x] FireFox

- [x] Internet Explorer
