### PR TITLE
Client subscription partition tolerance

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -180,6 +180,9 @@ namespace EventStore.ClientAPI {
 			if (Verbose)
 				Log.Debug("Catch-up Subscription {0} to {1}: unhooking from connection.Connected.", SubscriptionName,
 					IsSubscribedToAll ? "<all>" : StreamId);
+			Interlocked.Exchange(ref _dropData, null); //clear drop 
+			Interlocked.Exchange(ref _isDropped, 0);
+			
 			_connection.Connected -= OnReconnect;
 			RunSubscriptionAsync();
 		}

--- a/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+++ b/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
@@ -180,8 +180,16 @@ namespace EventStore.ClientAPI {
 			if (Verbose)
 				Log.Debug("Catch-up Subscription {0} to {1}: unhooking from connection.Connected.", SubscriptionName,
 					IsSubscribedToAll ? "<all>" : StreamId);
-			Interlocked.Exchange(ref _dropData, null); //clear drop 
-			Interlocked.Exchange(ref _isDropped, 0);
+
+			DropData dropData;
+			do {
+				dropData = _dropData;
+			} while (Interlocked.CompareExchange(ref _dropData, null, dropData) != dropData);
+
+			int isDropped;
+			do {
+				isDropped = _isDropped;
+			} while (Interlocked.CompareExchange(ref _isDropped, 0, isDropped) != isDropped);
 			
 			_connection.Connected -= OnReconnect;
 			RunSubscriptionAsync();

--- a/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
@@ -209,6 +209,7 @@ namespace EventStore.ClientAPI.Internal {
 					connection.RemoteEndPoint, connection.LocalEndPoint);
 				return;
 			}
+			var wasConnected = Interlocked.CompareExchange(ref _wasConnected, 0, 1) == 1;
 
 			_state = ConnectionState.Connecting;
 			_connectingPhase = ConnectingPhase.Reconnecting;
@@ -219,7 +220,7 @@ namespace EventStore.ClientAPI.Internal {
 			_subscriptions.PurgeSubscribedAndDroppedSubscriptions(_connection.ConnectionId);
 			_reconnInfo = new ReconnectionInfo(_reconnInfo.ReconnectionAttempt, _stopwatch.Elapsed);
 
-			if (Interlocked.CompareExchange(ref _wasConnected, 0, 1) == 1) {
+			if (wasConnected) {
 				RaiseDisconnected(connection.RemoteEndPoint);
 			}
 		}


### PR DESCRIPTION
Correct 2 issues that seem to have the most significat effect on client connections with intermitted client connectivity issues.

On reconnect the Dropped data and Dropped flag are not always reset leading to race conditions that will fail to process a subsequent drop event corrrectly

There is a race condition where if a dropped connection resets the catchup subscription might not be cleaned up correctly.