### PR TITLE
DRY ClusterDnsEndPointDiscoverer creation

### DIFF
--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -110,19 +110,7 @@ namespace EventStore.ClientAPI {
 					var clusterSettings = new ClusterSettings(uri.Host, connectionSettings.MaxDiscoverAttempts,
 						uri.Port,
 						connectionSettings.GossipTimeout, connectionSettings.NodePreference);
-					Ensure.NotNull(connectionSettings, "connectionSettings");
-					Ensure.NotNull(clusterSettings, "clusterSettings");
-
-					var endPointDiscoverer = new ClusterDnsEndPointDiscoverer(connectionSettings.Log,
-						clusterSettings.ClusterDns,
-						clusterSettings.MaxDiscoverAttempts,
-						clusterSettings.ExternalGossipPort,
-						clusterSettings.GossipSeeds,
-						clusterSettings.GossipTimeout,
-						clusterSettings.NodePreference);
-
-					return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
-						connectionName);
+					return Create(connectionSettings, clusterSettings, connectionName);
 				}
 
 				if (scheme == "tcp") {
@@ -139,19 +127,7 @@ namespace EventStore.ClientAPI {
 					connectionSettings.MaxDiscoverAttempts,
 					connectionSettings.GossipTimeout,
 					connectionSettings.NodePreference);
-				Ensure.NotNull(connectionSettings, "connectionSettings");
-				Ensure.NotNull(clusterSettings, "clusterSettings");
-
-				var endPointDiscoverer = new ClusterDnsEndPointDiscoverer(connectionSettings.Log,
-					clusterSettings.ClusterDns,
-					clusterSettings.MaxDiscoverAttempts,
-					clusterSettings.ExternalGossipPort,
-					clusterSettings.GossipSeeds,
-					clusterSettings.GossipTimeout,
-					clusterSettings.NodePreference);
-
-				return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
-					connectionName);
+				return Create(connectionSettings, clusterSettings, connectionName);
 			}
 
 			throw new Exception($"Must specify uri or gossip seeds");


### PR DESCRIPTION
This provides a minor tidyup which makes the code more legible wrt how the node preference is applied when using the `EventStoreConnection.Create(ConnectionSettings,ClusterSettings,string)` overload (which bit me, resulting in the need for https://github.com/jet/equinox/pull/135)