### PR TITLE
Move code comments to correct place

### DIFF
--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpStats.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpStats.cs
@@ -2,61 +2,18 @@
 
 namespace EventStore.ClientAPI.Transport.Tcp {
 	internal class TcpStats {
-		///<summary>
-		///Number of TCP connections to Event Store
-		///</summary>
+
 		public readonly int Connections;
-
-		///<summary>
-		///Total bytes sent from TCP connections
-		///</summary>
 		public readonly long SentBytesTotal;
-
-		///<summary>
-		///Total bytes received by TCP connections
-		///</summary>
 		public readonly long ReceivedBytesTotal;
-
-		///<summary>
-		///Total bytes sent to TCP connections since last run
-		///</summary>
 		public readonly long SentBytesSinceLastRun;
-
-		///<summary>
-		///Total bytes received by TCP connections since last run
-		///</summary>
 		public readonly long ReceivedBytesSinceLastRun;
-
-		///<summary>
-		///Sending speed in bytes per second
-		///</summary>
 		public readonly double SendingSpeed;
-
-		/// <summary>
-		/// Receiving speed in bytes per second
-		/// </summary>
 		public readonly double ReceivingSpeed;
-
-		///<summary>
-		///Number of bytes waiting to be sent to connections
-		///</summary>
 		public readonly long PendingSend;
-
-		///<summary>
-		///Number of bytes sent to connections but not yet acknowledged by the receiving party
-		///</summary>
 		public readonly long InSend;
-
-		///<summary>
-		///Number of bytes waiting to be received by connections
-		///</summary>
 		public readonly long PendingReceived;
-
-		///<summary>
-		///Time elapsed since last stats read
-		///</summary>
 		public readonly TimeSpan MeasureTime;
-
 
 		public TcpStats(int connections,
 			long sentBytesTotal,

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpStats.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpStats.cs
@@ -32,9 +32,9 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		///</summary>
 		public readonly double SendingSpeed;
 
-		///<summary>
-		///Receiving speed in bytes per second
-		///</summary>
+		/// <summary>
+		/// Receiving speed in bytes per second
+		/// </summary>
 		public readonly double ReceivingSpeed;
 
 		///<summary>

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -71,9 +71,6 @@ namespace EventStore.Core.Cluster.Settings {
 
 		public readonly bool BetterOrdering;
 		public readonly string Index;
-		///<summary>
-		///Current thread count
-		///</summary>
 		public readonly int ReaderThreadsCount;
 		public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
 		public readonly bool AlwaysKeepScavenged;

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -71,6 +71,9 @@ namespace EventStore.Core.Cluster.Settings {
 
 		public readonly bool BetterOrdering;
 		public readonly string Index;
+		///<summary>
+		///Current thread count
+		///</summary>
 		public readonly int ReaderThreadsCount;
 		public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
 		public readonly bool AlwaysKeepScavenged;

--- a/src/EventStore.Core/Services/Monitoring/Stats/GcStats.cs
+++ b/src/EventStore.Core/Services/Monitoring/Stats/GcStats.cs
@@ -1,14 +1,44 @@
 ﻿namespace EventStore.Core.Services.Monitoring.Stats {
 	public class GcStats {
+		/// <summary>
+		/// Number of Gen 0 Collections.
+		/// </summary>
 		public readonly long Gen0ItemsCount;
+		/// <summary>
+		/// Number of Gen 1 Collections.
+		/// </summary>
 		public readonly long Gen1ItemsCount;
+		/// <summary>
+		/// Number of Gen 2 Collections.
+		/// </summary>
 		public readonly long Gen2ItemsCount;
+		/// <summary>
+		/// Gen 0 heap size.
+		/// </summary>
 		public readonly long Gen0Size;
+		/// <summary>
+		/// Gen 1 heap size.
+		/// </summary>
 		public readonly long Gen1Size;
+		/// <summary>
+		/// Gen 2 heap size.
+		/// </summary>
 		public readonly long Gen2Size;
+		/// <summary>
+		/// Large Object Heap size.
+		/// </summary>
 		public readonly long LargeHeapSize;
+		/// <summary>
+		/// Memory allocation speed.
+		/// </summary>
 		public readonly float AllocationSpeed;
+		/// <summary>
+		/// % of Time in GC.
+		/// </summary>
 		public readonly float TimeInGc;
+		/// <summary>
+		/// Total Bytes in all Heaps.
+		/// </summary>
 		public readonly long TotalBytesInHeaps;
 
 		public GcStats(long gcGen0Items,

--- a/src/EventStore.Transport.Tcp/TcpStats.cs
+++ b/src/EventStore.Transport.Tcp/TcpStats.cs
@@ -2,19 +2,49 @@ using System;
 
 namespace EventStore.Transport.Tcp {
 	public class TcpStats {
+		///<summary>
+		///Number of TCP connections to Event Store
+		///</summary>
 		public readonly int Connections;
+		///<summary>
+		///Total bytes sent from TCP connections
+		///</summary>
 		public readonly long SentBytesTotal;
+		///<summary>
+		///Total bytes received by TCP connections
+		///</summary>
 		public readonly long ReceivedBytesTotal;
+		///<summary>
+		///Total bytes sent to TCP connections since last run
+		///</summary>
 		public readonly long SentBytesSinceLastRun;
+		///<summary>
+		///Total bytes received by TCP connections since last run
+		///</summary>
 		public readonly long ReceivedBytesSinceLastRun;
+		///<summary>
+		///Sending speed in bytes per second
+		///</summary>
 		public readonly double SendingSpeed;
-		/// <summary>
-		/// Receiving speed in bytes per second.
-		/// </summary>
+		///<summary>
+		///Receiving speed in bytes per second.
+		///</summary>
 		public readonly double ReceivingSpeed;
+		///<summary>
+		///Number of bytes waiting to be sent to connections
+		///</summary>
 		public readonly long PendingSend;
+		///<summary>
+		///Number of bytes sent to connections but not yet acknowledged by the receiving party
+		///</summary>
 		public readonly long InSend;
+		///<summary>
+		///Number of bytes waiting to be received by connections
+		///</summary>
 		public readonly long PendingReceived;
+		///<summary>
+		///Time elapsed since last stats read
+		///</summary>
 		public readonly TimeSpan MeasureTime;
 
 		public TcpStats(int connections,

--- a/src/EventStore.Transport.Tcp/TcpStats.cs
+++ b/src/EventStore.Transport.Tcp/TcpStats.cs
@@ -8,6 +8,9 @@ namespace EventStore.Transport.Tcp {
 		public readonly long SentBytesSinceLastRun;
 		public readonly long ReceivedBytesSinceLastRun;
 		public readonly double SendingSpeed;
+		/// <summary>
+		/// Receiving speed in bytes per second.
+		/// </summary>
 		public readonly double ReceivingSpeed;
 		public readonly long PendingSend;
 		public readonly long InSend;


### PR DESCRIPTION
Turns out that code comments are in the wrong places for DocFX to auto generate documentation. This PR moves them.