### PR TITLE
Make subscriptions timeout when connection is in Connection state, as operation do

### DIFF
--- a/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
@@ -295,6 +295,7 @@ namespace EventStore.ClientAPI.Internal {
 						else {
 							RaiseReconnecting();
 							_operations.CheckTimeoutsAndRetry(_connection);
+							_subscriptions.CheckTimeoutsAndRetry(_connection);
 							DiscoverEndPoint(null);
 						}
 					}


### PR DESCRIPTION
In `TimerTick` method, operation and subscription timeouts are checked when connection is healthy. But if the connection is reconnecting, only operation timeouts are checked, while subscription timeouts are not. This leads to infinitely hanging subscibe operation when connection is down, as in this [issue by me](https://github.com/EventStore/EventStore/issues/1954). I added subscription timeout check to timer tick on reconnection