### PR TITLE
Setting to override http client & setting to enable tls based gossip comms

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
+using EventStore.ClientAPI.Transport.Http;
 
 namespace EventStore.ClientAPI {
 	/// <summary>
@@ -32,6 +33,11 @@ namespace EventStore.ClientAPI {
 		/// The <see cref="ILogger"/> that this connection will use.
 		/// </summary>
 		public readonly ILogger Log;
+
+		/// <summary>
+		/// Allows overriding the HTTPClient <see cref="IHttpClient"/>
+		/// </summary>
+		public IHttpClient CustomHttpClient { get; set; }
 
 		/// <summary>
 		/// Whether to use excessive logging of <see cref="EventStoreConnection"/> internal logic.
@@ -144,7 +150,7 @@ namespace EventStore.ClientAPI {
 		public readonly TimeSpan GossipTimeout;
 
 		/// <summary>
-		/// Whether to randomly choose a node that's alive from the known nodes. 
+		/// Whether to randomly choose a node that's alive from the known nodes.
 		/// </summary>
 		public readonly NodePreference NodePreference;
 
@@ -177,7 +183,9 @@ namespace EventStore.ClientAPI {
 			int maxDiscoverAttempts,
 			int externalGossipPort,
 			TimeSpan gossipTimeout,
-			NodePreference nodePreference) {
+			NodePreference nodePreference,
+			IHttpClient customHttpClient) {
+
 			Ensure.NotNull(log, "log");
 			Ensure.Positive(maxQueueSize, "maxQueueSize");
 			Ensure.Positive(maxConcurrentItems, "maxConcurrentItems");
@@ -190,6 +198,7 @@ namespace EventStore.ClientAPI {
 						maxRetries));
 			if (useSslConnection)
 				Ensure.NotNullOrEmpty(targetHost, "targetHost");
+
 			Log = log;
 			VerboseLogging = verboseLogging;
 			MaxQueueSize = maxQueueSize;
@@ -216,6 +225,7 @@ namespace EventStore.ClientAPI {
 			ExternalGossipPort = externalGossipPort;
 			GossipTimeout = gossipTimeout;
 			NodePreference = nodePreference;
+			CustomHttpClient = customHttpClient;
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -336,7 +336,7 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
-		/// Whether to randomly choose a node that's alive from the known nodes. 
+		/// Whether to randomly choose a node that's alive from the known nodes.
 		/// </summary>
 		/// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
 		public ConnectionSettingsBuilder PreferRandomNode() {
@@ -345,7 +345,7 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
-		/// Whether to prioritize choosing a slave node that's alive from the known nodes. 
+		/// Whether to prioritize choosing a slave node that's alive from the known nodes.
 		/// </summary>
 		/// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
 		public ConnectionSettingsBuilder PreferSlaveNode() {
@@ -355,11 +355,11 @@ namespace EventStore.ClientAPI {
 
 		/// <summary>
 		/// Sets the well-known port on which the cluster gossip is taking place.
-		/// 
+		///
 		/// If you are using the commercial edition of Event Store HA, with Manager nodes in
 		/// place, this should be the port number of the External HTTP port on which the
 		/// managers are running.
-		/// 
+		///
 		/// If you are using the open source edition of Event Store HA, this should be the
 		/// External HTTP port that the nodes are running on. If you cannot use a well-known
 		/// port for this across all nodes, you can instead use gossip seed discovery and set
@@ -375,7 +375,7 @@ namespace EventStore.ClientAPI {
 
 		/// <summary>
 		/// Sets gossip seed endpoints for the client.
-		/// 
+		///
 		/// <note>
 		/// This should be the external HTTP endpoint of the server, as it is required
 		/// for the client to exchange gossip with the server. The standard port is 2113.
@@ -388,10 +388,29 @@ namespace EventStore.ClientAPI {
 		/// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
 		/// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
 		public ConnectionSettingsBuilder SetGossipSeedEndPoints(params IPEndPoint[] gossipSeeds) {
+			return SetGossipSeedEndPoints(false, gossipSeeds);
+		}
+
+		/// <summary>
+		/// Sets gossip seed endpoints for the client.
+		///
+		/// <note>
+		/// This should be the external HTTP endpoint of the server, as it is required
+		/// for the client to exchange gossip with the server. The standard port is 2113.
+		/// </note>
+		///
+		/// If the server requires a specific Host header to be sent as part of the gossip
+		/// request, use the overload of this method taking <see cref="GossipSeed" /> instead.
+		/// </summary>
+		/// <param name="seedOverTls">Specifies that eventstore should use https when connecting to gossip</param>
+		/// <param name="gossipSeeds"><see cref="IPEndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
+		/// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
+		/// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
+		public ConnectionSettingsBuilder SetGossipSeedEndPoints(bool seedOverTls, params IPEndPoint[] gossipSeeds) {
 			if (gossipSeeds == null || gossipSeeds.Length == 0)
 				throw new ArgumentException("Empty FakeDnsEntries collection.");
 
-			_gossipSeeds = gossipSeeds.Select(x => new GossipSeed(x)).ToArray();
+			_gossipSeeds = gossipSeeds.Select(x => new GossipSeed(x, seedOverTls: seedOverTls)).ToArray();
 
 			return this;
 		}

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -4,6 +4,7 @@ using System.Net;
 using EventStore.ClientAPI.Common.Log;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
+using EventStore.ClientAPI.Transport.Http;
 
 namespace EventStore.ClientAPI {
 	/// <summary>
@@ -40,9 +41,15 @@ namespace EventStore.ClientAPI {
 		private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
 		private GossipSeed[] _gossipSeeds;
 		private NodePreference _nodePreference = NodePreference.Master;
+		private IHttpClient _customHttpClient = null;
 
 
 		internal ConnectionSettingsBuilder() {
+		}
+
+		public ConnectionSettingsBuilder UseCustomHttpClient(IHttpClient client) {
+			_customHttpClient = client;
+			return this;
 		}
 
 		/// <summary>
@@ -442,7 +449,8 @@ namespace EventStore.ClientAPI {
 				_maxDiscoverAttempts,
 				_gossipExternalHttpPort,
 				_gossipTimeout,
-				_nodePreference);
+				_nodePreference,
+				_customHttpClient);
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -103,7 +103,7 @@ namespace EventStore.ClientAPI {
 						connectionSettings.ClientConnectionTimeout, connectionSettings.ClusterDns,
 						connectionSettings.GossipSeeds, connectionSettings.MaxDiscoverAttempts,
 						connectionSettings.ExternalGossipPort, connectionSettings.GossipTimeout,
-						connectionSettings.NodePreference);
+						connectionSettings.NodePreference, connectionSettings.CustomHttpClient);
 				}
 
 				if (scheme == "discover") {
@@ -191,7 +191,7 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
-		/// Creates a new <see cref="IEventStoreConnection"/> to EventStore cluster 
+		/// Creates a new <see cref="IEventStoreConnection"/> to EventStore cluster
 		/// using specific <see cref="ConnectionSettings"/> and <see cref="ClusterSettings"/>
 		/// </summary>
 		/// <param name="connectionSettings">The <see cref="ConnectionSettings"/> to apply to the new connection</param>

--- a/src/EventStore.ClientAPI/GossipSeed.cs
+++ b/src/EventStore.ClientAPI/GossipSeed.cs
@@ -7,12 +7,17 @@ namespace EventStore.ClientAPI {
 	public class GossipSeed {
 		/// <summary>
 		/// The <see cref="IPEndPoint"/> for the External HTTP endpoint of the gossip seed.
-		/// 
+		///
 		/// The HTTP endpoint is used rather than the TCP endpoint because it is required
 		/// for the client to exchange gossip with the server. The standard port which should be
 		/// used here is 2113.
 		/// </summary>
 		public readonly IPEndPoint EndPoint;
+
+		/// <summary>
+		/// If Gossip should be requested
+		/// </summary>
+		public readonly bool SeedOverTls;
 
 		/// <summary>
 		/// The host header to be sent when requesting gossip.
@@ -24,9 +29,11 @@ namespace EventStore.ClientAPI {
 		/// </summary>
 		/// <param name="endPoint">The <see cref="IPEndPoint"/> for the External HTTP endpoint of the gossip seed. The standard port is 2113.</param>
 		/// <param name="hostHeader">The host header to be sent when requesting gossip. Defaults to String.Empty</param>
-		public GossipSeed(IPEndPoint endPoint, string hostHeader = "") {
+		/// <param name="seedOverTls">Specifies that eventstore should use https when connecting to gossip</param>
+		public GossipSeed(IPEndPoint endPoint, string hostHeader = "", bool seedOverTls = false) {
 			EndPoint = endPoint;
 			HostHeader = hostHeader;
+			SeedOverTls = seedOverTls;
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
@@ -13,12 +13,13 @@ namespace EventStore.ClientAPI {
 		private int _maxDiscoverAttempts = Consts.DefaultMaxClusterDiscoverAttempts;
 		private NodePreference _nodePreference = NodePreference.Master;
 
+
 		/// <summary>
 		/// Sets gossip seed endpoints for the client.
 		/// TODO: This was a note.
 		/// This should be the external HTTP endpoint of the server, as it is required
 		/// for the client to exchange gossip with the server. The standard port is 2113.
-		/// 
+		///
 		/// If the server requires a specific Host header to be sent as part of the gossip
 		/// request, use the overload of this method taking <see cref="GossipSeed" /> instead.
 		/// </summary>
@@ -26,10 +27,27 @@ namespace EventStore.ClientAPI {
 		/// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
 		/// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
 		public GossipSeedClusterSettingsBuilder SetGossipSeedEndPoints(params IPEndPoint[] gossipSeeds) {
+			return SetGossipSeedEndPoints(false, gossipSeeds);
+		}
+
+		/// <summary>
+		/// Sets gossip seed endpoints for the client.
+		/// TODO: This was a note.
+		/// This should be the external HTTP endpoint of the server, as it is required
+		/// for the client to exchange gossip with the server. The standard port is 2113.
+		///
+		/// If the server requires a specific Host header to be sent as part of the gossip
+		/// request, use the overload of this method taking <see cref="GossipSeed" /> instead.
+		/// </summary>
+		/// <param name="tlsTerminatedEndpoints">Specifies that eventstore should use https when connecting to gossip</param>
+		/// <param name="gossipSeeds"><see cref="IPEndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
+		/// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
+		/// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
+		public GossipSeedClusterSettingsBuilder SetGossipSeedEndPoints(bool tlsTerminatedEndpoints, params IPEndPoint[] gossipSeeds) {
 			if (gossipSeeds == null || gossipSeeds.Length == 0)
 				throw new ArgumentException("Empty FakeDnsEntries collection.");
 
-			_gossipSeeds = gossipSeeds.Select(x => new GossipSeed(x)).ToArray();
+			_gossipSeeds = gossipSeeds.Select(x => new GossipSeed(x, seedOverTls: tlsTerminatedEndpoints)).ToArray();
 
 			return this;
 		}
@@ -82,7 +100,7 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
-		/// Whether to randomly choose a node that's alive from the known nodes. 
+		/// Whether to randomly choose a node that's alive from the known nodes.
 		/// </summary>
 		/// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
 		public GossipSeedClusterSettingsBuilder PreferRandomNode() {
@@ -91,7 +109,7 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
-		/// Whether to prioritize choosing a slave node that's alive from the known nodes. 
+		/// Whether to prioritize choosing a slave node that's alive from the known nodes.
 		/// </summary>
 		/// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
 		public GossipSeedClusterSettingsBuilder PreferSlaveNode() {

--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -170,7 +170,7 @@ namespace EventStore.ClientAPI.Internal {
 			ClusterMessages.ClusterInfoDto result = null;
 			var completed = new ManualResetEventSlim(false);
 
-			var url = endPoint.EndPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/gossip?format=json");
+			var url = endPoint.EndPoint.ToHttpUrl(endPoint.SeedOverTls ? EndpointExtensions.HTTPS_SCHEMA : EndpointExtensions.HTTP_SCHEMA, "/gossip?format=json");
 			_client.Get(
 				url,
 				null,

--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using EventStore.ClientAPI;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.Messages;
@@ -19,7 +18,7 @@ namespace EventStore.ClientAPI.Internal {
 		private readonly int _managerExternalHttpPort;
 		private readonly GossipSeed[] _gossipSeeds;
 
-		private readonly HttpAsyncClient _client;
+		private readonly IHttpClient _client;
 		private ClusterMessages.MemberInfoDto[] _oldGossip;
 		private TimeSpan _gossipTimeout;
 
@@ -31,7 +30,8 @@ namespace EventStore.ClientAPI.Internal {
 			int managerExternalHttpPort,
 			GossipSeed[] gossipSeeds,
 			TimeSpan gossipTimeout,
-			NodePreference nodePreference) {
+			NodePreference nodePreference,
+			IHttpClient client = null) {
 			Ensure.NotNull(log, "log");
 
 			_log = log;
@@ -40,7 +40,7 @@ namespace EventStore.ClientAPI.Internal {
 			_managerExternalHttpPort = managerExternalHttpPort;
 			_gossipSeeds = gossipSeeds;
 			_gossipTimeout = gossipTimeout;
-			_client = new HttpAsyncClient(_gossipTimeout);
+			_client = client ?? new HttpAsyncClient(_gossipTimeout);
 			_nodePreference = nodePreference;
 		}
 

--- a/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
@@ -11,12 +11,12 @@ using EventStore.ClientAPI.Common.Utils.Threading;
 
 namespace EventStore.ClientAPI.Projections {
 	internal class ProjectionsClient {
-		private readonly HttpAsyncClient _client;
+		private readonly IHttpClient _client;
 		private readonly TimeSpan _operationTimeout;
 
-		public ProjectionsClient(ILogger log, TimeSpan operationTimeout) {
+		public ProjectionsClient(ILogger log, TimeSpan operationTimeout, IHttpClient client) {
 			_operationTimeout = operationTimeout;
-			_client = new HttpAsyncClient(_operationTimeout);
+			_client = client ?? new HttpAsyncClient(_operationTimeout);
 		}
 
 		public Task Enable(EndPoint endPoint, string name, UserCredentials userCredentials = null,

--- a/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
@@ -21,20 +21,21 @@ namespace EventStore.ClientAPI.Projections {
 		/// </summary>
 		/// <param name="log">An instance of <see cref="ILogger"/> to use for logging.</param>
 		/// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
+		/// <param name="client"></param>
 		/// <param name="httpSchema">HTTP endpoint schema http|https.</param>
 		/// <param name="operationTimeout"></param>
 		public ProjectionsManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout,
-			string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			IHttpClient client = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			Ensure.NotNull(log, "log");
 			Ensure.NotNull(httpEndPoint, "httpEndPoint");
 
-			_client = new ProjectionsClient(log, operationTimeout);
+			_client = new ProjectionsClient(log, operationTimeout, client);
 			_httpEndPoint = httpEndPoint;
 			_httpSchema = httpSchema;
 		}
 
 		/// <summary>
-		/// Asynchronously enables a projection 
+		/// Asynchronously enables a projection
 		/// </summary>
 		/// <param name="name">The name of the projection.</param>
 		/// <param name="userCredentials">Credentials for a user with permission to enable a projection</param>
@@ -254,7 +255,7 @@ namespace EventStore.ClientAPI.Projections {
 
 
 		/// <summary>
-		/// Asynchronously deletes a projection 
+		/// Asynchronously deletes a projection
 		/// </summary>
 		/// <param name="name">The name of the projection.</param>
 		/// <param name="userCredentials">Credentials for a user with permission to delete a projection</param>
@@ -264,7 +265,7 @@ namespace EventStore.ClientAPI.Projections {
 		}
 
 		/// <summary>
-		/// Asynchronously deletes a projection 
+		/// Asynchronously deletes a projection
 		/// </summary>
 		/// <param name="name">The name of the projection.</param>
 		/// <param name="deleteEmittedStreams">Whether to delete the streams that were emitted by this projection.</param>

--- a/src/EventStore.ClientAPI/Projections/QueryManager.cs
+++ b/src/EventStore.ClientAPI/Projections/QueryManager.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.Common.Utils.Threading;
 using EventStore.ClientAPI.SystemData;
+using EventStore.ClientAPI.Transport.Http;
 using Newtonsoft.Json.Linq;
 
 namespace EventStore.ClientAPI.Projections {
@@ -22,10 +23,11 @@ namespace EventStore.ClientAPI.Projections {
 		/// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
 		/// <param name="projectionOperationTimeout">Timeout of projection API operations</param>
 		/// <param name="queryTimeout">Timeout of query execution</param>
+		/// <param name="client">Overrideable HTTP Client Handler</param>
 		public QueryManager(ILogger log, EndPoint httpEndPoint, TimeSpan projectionOperationTimeout,
-			TimeSpan queryTimeout) {
+			TimeSpan queryTimeout, IHttpClient client = null) {
 			_queryTimeout = queryTimeout;
-			_projectionsManager = new ProjectionsManager(log, httpEndPoint, projectionOperationTimeout);
+			_projectionsManager = new ProjectionsManager(log, httpEndPoint, projectionOperationTimeout, client);
 		}
 
 		/// <summary>

--- a/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
@@ -9,7 +9,7 @@ using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace EventStore.ClientAPI.Transport.Http {
-	internal class HttpAsyncClient {
+	public class HttpAsyncClient : IHttpClient {
 		private static readonly UTF8Encoding UTF8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 		private HttpClient _client;
 
@@ -18,8 +18,8 @@ namespace EventStore.ClientAPI.Transport.Http {
 			ServicePointManager.DefaultConnectionLimit = 800;
 		}
 
-		public HttpAsyncClient(TimeSpan timeout) {
-			_client = new HttpClient();
+		public HttpAsyncClient(TimeSpan timeout, HttpClientHandler clientHandler = null) {
+			_client = clientHandler == null ? new HttpClient() : new HttpClient(clientHandler);
 			_client.Timeout = timeout;
 		}
 

--- a/src/EventStore.ClientAPI/Transport.Http/HttpResponse.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/HttpResponse.cs
@@ -3,7 +3,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 
 namespace EventStore.ClientAPI.Transport.Http {
-	internal class HttpResponse {
+	public class HttpResponse {
 		public readonly string CharacterSet;
 
 		public readonly string ContentEncoding;

--- a/src/EventStore.ClientAPI/Transport.Http/IHttpClient.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/IHttpClient.cs
@@ -1,0 +1,20 @@
+using System;
+using EventStore.ClientAPI.SystemData;
+
+namespace EventStore.ClientAPI.Transport.Http
+{
+	public interface IHttpClient {
+		void Get(string url, UserCredentials userCredentials,
+			Action<HttpResponse> onSuccess, Action<Exception> onException,
+			string hostHeader = "");
+
+		void Post(string url, string body, string contentType, UserCredentials userCredentials,
+			Action<HttpResponse> onSuccess, Action<Exception> onException);
+
+		void Delete(string url, UserCredentials userCredentials,
+			Action<HttpResponse> onSuccess, Action<Exception> onException);
+
+		void Put(string url, string body, string contentType, UserCredentials userCredentials,
+			Action<HttpResponse> onSuccess, Action<Exception> onException);
+	}
+}

--- a/src/EventStore.ClientAPI/UserManagement/UsersClient.cs
+++ b/src/EventStore.ClientAPI/UserManagement/UsersClient.cs
@@ -12,13 +12,13 @@ using EventStore.ClientAPI.Common.Utils.Threading;
 
 namespace EventStore.ClientAPI.UserManagement {
 	internal class UsersClient {
-		private readonly HttpAsyncClient _client;
+		private readonly IHttpClient _client;
 
 		private readonly TimeSpan _operationTimeout;
 
-		public UsersClient(ILogger log, TimeSpan operationTimeout) {
+		public UsersClient(ILogger log, TimeSpan operationTimeout, IHttpClient client) {
 			_operationTimeout = operationTimeout;
-			_client = new HttpAsyncClient(_operationTimeout);
+			_client = client ?? new HttpAsyncClient(_operationTimeout);
 		}
 
 		public Task Enable(EndPoint endPoint, string login, UserCredentials userCredentials = null) {

--- a/src/EventStore.ClientAPI/UserManagement/UsersClient.cs
+++ b/src/EventStore.ClientAPI/UserManagement/UsersClient.cs
@@ -21,23 +21,23 @@ namespace EventStore.ClientAPI.UserManagement {
 			_client = client ?? new HttpAsyncClient(_operationTimeout);
 		}
 
-		public Task Enable(EndPoint endPoint, string login, UserCredentials userCredentials = null) {
-			return SendPost(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}/command/enable", login),
+		public Task Enable(EndPoint endPoint, string login, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendPost(endPoint.ToHttpUrl(httpSchema, "/users/{0}/command/enable", login),
 				string.Empty, userCredentials, HttpStatusCode.OK);
 		}
 
-		public Task Disable(EndPoint endPoint, string login, UserCredentials userCredentials = null) {
-			return SendPost(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}/command/disable", login),
+		public Task Disable(EndPoint endPoint, string login, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendPost(endPoint.ToHttpUrl(httpSchema, "/users/{0}/command/disable", login),
 				string.Empty, userCredentials, HttpStatusCode.OK);
 		}
 
-		public Task Delete(EndPoint endPoint, string login, UserCredentials userCredentials = null) {
-			return SendDelete(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}", login), userCredentials,
+		public Task Delete(EndPoint endPoint, string login, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendDelete(endPoint.ToHttpUrl(httpSchema, "/users/{0}", login), userCredentials,
 				HttpStatusCode.OK);
 		}
 
-		public Task<List<UserDetails>> ListAll(EndPoint endPoint, UserCredentials userCredentials = null) {
-			return SendGet(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/"), userCredentials,
+		public Task<List<UserDetails>> ListAll(EndPoint endPoint, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendGet(endPoint.ToHttpUrl(httpSchema, "/users/"), userCredentials,
 					HttpStatusCode.OK)
 				.ContinueWith(x => {
 					if (x.IsFaulted) throw x.Exception;
@@ -46,8 +46,8 @@ namespace EventStore.ClientAPI.UserManagement {
 				});
 		}
 
-		public Task<UserDetails> GetCurrentUser(EndPoint endPoint, UserCredentials userCredentials = null) {
-			return SendGet(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/$current"), userCredentials,
+		public Task<UserDetails> GetCurrentUser(EndPoint endPoint, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendGet(endPoint.ToHttpUrl(httpSchema, "/users/$current"), userCredentials,
 					HttpStatusCode.OK)
 				.ContinueWith(x => {
 					if (x.IsFaulted) throw x.Exception;
@@ -56,8 +56,8 @@ namespace EventStore.ClientAPI.UserManagement {
 				});
 		}
 
-		public Task<UserDetails> GetUser(EndPoint endPoint, string login, UserCredentials userCredentials = null) {
-			return SendGet(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}", login), userCredentials,
+		public Task<UserDetails> GetUser(EndPoint endPoint, string login, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendGet(endPoint.ToHttpUrl(httpSchema, "/users/{0}", login), userCredentials,
 					HttpStatusCode.OK)
 				.ContinueWith(x => {
 					if (x.IsFaulted) throw x.Exception;
@@ -67,33 +67,33 @@ namespace EventStore.ClientAPI.UserManagement {
 		}
 
 		public Task CreateUser(EndPoint endPoint, UserCreationInformation newUser,
-			UserCredentials userCredentials = null) {
+			UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			var userJson = newUser.ToJson();
-			return SendPost(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/"), userJson, userCredentials,
+			return SendPost(endPoint.ToHttpUrl(httpSchema, "/users/"), userJson, userCredentials,
 				HttpStatusCode.Created);
 		}
 
 		public Task UpdateUser(EndPoint endPoint, string login, UserUpdateInformation updatedUser,
-			UserCredentials userCredentials) {
-			return SendPut(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}", login),
+			UserCredentials userCredentials, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			return SendPut(endPoint.ToHttpUrl(httpSchema, "/users/{0}", login),
 				updatedUser.ToJson(), userCredentials, HttpStatusCode.OK);
 		}
 
 		public Task ChangePassword(EndPoint endPoint, string login, ChangePasswordDetails changePasswordDetails,
-			UserCredentials userCredentials) {
+			UserCredentials userCredentials, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			return SendPost(
-				endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}/command/change-password", login),
+				endPoint.ToHttpUrl(httpSchema, "/users/{0}/command/change-password", login),
 				changePasswordDetails.ToJson(), userCredentials, HttpStatusCode.OK);
 		}
 
 		public Task ResetPassword(EndPoint endPoint, string login, ResetPasswordDetails resetPasswordDetails,
-			UserCredentials userCredentials = null) {
+			UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			return SendPost(
-				endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}/command/reset-password", login),
+				endPoint.ToHttpUrl(httpSchema, "/users/{0}/command/reset-password", login),
 				resetPasswordDetails.ToJson(), userCredentials, HttpStatusCode.OK);
 		}
 
-		private Task<string> SendGet(string url, UserCredentials userCredentials, int expectedCode) {
+		private Task<string> SendGet(string url, UserCredentials userCredentials, int expectedCode, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			var source = TaskCompletionSourceFactory.Create<string>();
 			_client.Get(url,
 				userCredentials,
@@ -113,7 +113,7 @@ namespace EventStore.ClientAPI.UserManagement {
 			return source.Task;
 		}
 
-		private Task<string> SendDelete(string url, UserCredentials userCredentials, int expectedCode) {
+		private Task<string> SendDelete(string url, UserCredentials userCredentials, int expectedCode, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			var source = TaskCompletionSourceFactory.Create<string>();
 			_client.Delete(url,
 				userCredentials,
@@ -133,7 +133,7 @@ namespace EventStore.ClientAPI.UserManagement {
 			return source.Task;
 		}
 
-		private Task SendPut(string url, string content, UserCredentials userCredentials, int expectedCode) {
+		private Task SendPut(string url, string content, UserCredentials userCredentials, int expectedCode, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			var source = TaskCompletionSourceFactory.Create<object>();
 			_client.Put(url,
 				content,
@@ -155,7 +155,7 @@ namespace EventStore.ClientAPI.UserManagement {
 			return source.Task;
 		}
 
-		private Task SendPost(string url, string content, UserCredentials userCredentials, int expectedCode) {
+		private Task SendPost(string url, string content, UserCredentials userCredentials, int expectedCode, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			var source = TaskCompletionSourceFactory.Create<object>();
 			_client.Post(url,
 				content,

--- a/src/EventStore.ClientAPI/UserManagement/UsersManager.cs
+++ b/src/EventStore.ClientAPI/UserManagement/UsersManager.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
+using EventStore.ClientAPI.Transport.Http;
 
 namespace EventStore.ClientAPI.UserManagement {
 	/// <summary>
@@ -14,6 +15,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		private readonly UsersClient _client;
 
 		private readonly EndPoint _httpEndPoint;
+		private string _httpSchema;
 
 		/// <summary>
 		/// Creates a new instance of <see cref="UsersManager"/>.
@@ -21,12 +23,14 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <param name="log">An instance of <see cref="ILogger"/> to use for logging.</param>
 		/// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
 		/// <param name="operationTimeout"></param>
-		public UsersManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout) {
+		/// <param name="tlsTerminatedEndpoint"></param>
+		public UsersManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout, bool tlsTerminatedEndpoint = false, IHttpClient client = null) {
 			Ensure.NotNull(log, "log");
 			Ensure.NotNull(httpEndPoint, "httpEndPoint");
 
-			_client = new UsersClient(log, operationTimeout);
+			_client = new UsersClient(log, operationTimeout, client);
 			_httpEndPoint = httpEndPoint;
+			_httpSchema = tlsTerminatedEndpoint ? EndpointExtensions.HTTPS_SCHEMA : EndpointExtensions.HTTP_SCHEMA;
 		}
 
 		/// <summary>
@@ -37,7 +41,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <returns>A task representing the operation.</returns>
 		public Task EnableAsync(string login, UserCredentials userCredentials = null) {
 			Ensure.NotNullOrEmpty(login, "login");
-			return _client.Enable(_httpEndPoint, login, userCredentials);
+			return _client.Enable(_httpEndPoint, login, userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -48,7 +52,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <returns>A task representing the operation.</returns>
 		public Task DisableAsync(string login, UserCredentials userCredentials = null) {
 			Ensure.NotNullOrEmpty(login, "login");
-			return _client.Disable(_httpEndPoint, login, userCredentials);
+			return _client.Disable(_httpEndPoint, login, userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -59,7 +63,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <returns>A task representing the operation.</returns>
 		public Task DeleteUserAsync(string login, UserCredentials userCredentials = null) {
 			Ensure.NotNullOrEmpty(login, "login");
-			return _client.Delete(_httpEndPoint, login, userCredentials);
+			return _client.Delete(_httpEndPoint, login, userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -68,7 +72,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <param name="userCredentials">Credentials for the operation.</param>
 		/// <returns>String of JSON containing user full names and logins.</returns>
 		public Task<List<UserDetails>> ListAllAsync(UserCredentials userCredentials = null) {
-			return _client.ListAll(_httpEndPoint, userCredentials);
+			return _client.ListAll(_httpEndPoint, userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -77,7 +81,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <param name="userCredentials">Credentials for the operation.</param>
 		/// <returns>A <see cref="UserDetails"/> object for the currently logged in user.</returns>
 		public Task<UserDetails> GetCurrentUserAsync(UserCredentials userCredentials) {
-			return _client.GetCurrentUser(_httpEndPoint, userCredentials);
+			return _client.GetCurrentUser(_httpEndPoint, userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -88,7 +92,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <returns>A <see cref="UserDetails"/> object for the user</returns>
 		public Task<UserDetails> GetUserAsync(string login, UserCredentials userCredentials) {
 			Ensure.NotNullOrEmpty(login, "login");
-			return _client.GetUser(_httpEndPoint, login, userCredentials);
+			return _client.GetUser(_httpEndPoint, login, userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -107,7 +111,7 @@ namespace EventStore.ClientAPI.UserManagement {
 			Ensure.NotNull(groups, "groups");
 			Ensure.NotNullOrEmpty(password, "password");
 			return _client.CreateUser(_httpEndPoint, new UserCreationInformation(login, fullName, groups, password),
-				userCredentials);
+				userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -124,7 +128,7 @@ namespace EventStore.ClientAPI.UserManagement {
 			Ensure.NotNullOrEmpty(fullName, "fullName");
 			Ensure.NotNull(groups, "groups");
 			return _client.UpdateUser(_httpEndPoint, login, new UserUpdateInformation(fullName, groups),
-				userCredentials);
+				userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -141,7 +145,7 @@ namespace EventStore.ClientAPI.UserManagement {
 			Ensure.NotNullOrEmpty(oldPassword, "oldPassword");
 			Ensure.NotNullOrEmpty(newPassword, "newPassword");
 			return _client.ChangePassword(_httpEndPoint, login, new ChangePasswordDetails(oldPassword, newPassword),
-				userCredentials);
+				userCredentials, _httpSchema);
 		}
 
 		/// <summary>
@@ -154,7 +158,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		public Task ResetPasswordAsync(string login, string newPassword, UserCredentials userCredentials = null) {
 			Ensure.NotNullOrEmpty(login, "login");
 			Ensure.NotNullOrEmpty(newPassword, "newPassword");
-			return _client.ResetPassword(_httpEndPoint, login, new ResetPasswordDetails(newPassword), userCredentials);
+			return _client.ResetPassword(_httpEndPoint, login, new ResetPasswordDetails(newPassword), userCredentials, _httpSchema);
 		}
 	}
 }

--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Threading;
@@ -13,6 +12,7 @@ using EventStore.Transport.Tcp;
 using EventStore.Transport.Tcp.Formatting;
 using EventStore.Transport.Tcp.Framing;
 using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
+using ILogger = EventStore.Common.Log.ILogger;
 
 namespace EventStore.TestClient {
 	public class Client {
@@ -47,6 +47,7 @@ namespace EventStore.TestClient {
 			InteractiveMode = options.Command.IsEmpty();
 
 			RegisterProcessors();
+
 		}
 
 		private void RegisterProcessors() {


### PR DESCRIPTION
Adds the ability to tell GES to use load seeds over HTTPS (as settings and via extension method) 
`SetGossipSeedEndPoints(seedOverTls: true, params IPEndPoint[] gossipSeeds)`

Adds the ability to pass in a custom httpclient or use the built in implementation and override the http client handler `HttpAsyncClient(TimeSpan timeout, HttpClientHandler clientHandler = null)`

The interface addition would duplicate one thats in `EventStore.Transport.Http` which wasn't intentional but from the dependencies I assume its correct to duplicate this rather than create a dependency.

ref: https://github.com/EventStore/ClientAPI.NetCore/pull/29