### PR TITLE
Add an authorization layer to all HTTP endpoints

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -248,6 +248,9 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.AuthenticationConfigFileDescr, Opts.AuthGroup)]
 		public string AuthenticationConfig { get; set; }
 
+		[ArgDescription(Opts.DisableFirstLevelHttpAuthorizationDescr, Opts.AuthGroup)]
+		public bool DisableFirstLevelHttpAuthorization { get; set; }
+
 		[ArgDescription(Opts.PrepareTimeoutMsDescr, Opts.DbGroup)]
 		public int PrepareTimeoutMs { get; set; }
 
@@ -390,6 +393,7 @@ namespace EventStore.ClusterNode {
 
 			AuthenticationType = Opts.AuthenticationTypeDefault;
 			AuthenticationConfig = Opts.AuthenticationConfigFileDefault;
+			DisableFirstLevelHttpAuthorization = Opts.DisableFirstLevelHttpAuthorizationDefault;
 
 			UnsafeIgnoreHardDelete = Opts.UnsafeIgnoreHardDeleteDefault;
 			UnsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -298,6 +298,8 @@ namespace EventStore.ClusterNode {
 				builder.ReduceFileCachePressure();
 			if (options.StructuredLog)
 				builder.WithStructuredLogging(options.StructuredLog);
+			if(options.DisableFirstLevelHttpAuthorization)
+				builder.DisableFirstLevelHttpAuthorization();
 
 			if (options.IntSecureTcpPort > 0 || options.ExtSecureTcpPort > 0) {
 				if (!string.IsNullOrWhiteSpace(options.CertificateStoreLocation)) {

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/src/EventStore.Core.Tests/Http/BasicAuthentication/basic_authentication.cs
+++ b/src/EventStore.Core.Tests/Http/BasicAuthentication/basic_authentication.cs
@@ -3,17 +3,10 @@ using System.Net;
 using EventStore.Core.Services;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
+using EventStore.Core.Tests.Http.Users.users;
 
 namespace EventStore.Core.Tests.Http.BasicAuthentication {
 	namespace basic_authentication {
-		public abstract class with_admin_user : HttpBehaviorSpecification {
-			protected readonly ICredentials _admin = new NetworkCredential(
-				SystemUsers.Admin, SystemUsers.DefaultAdminPassword);
-
-			protected override bool GivenSkipInitializeStandardUsersCheck() {
-				return false;
-			}
-		}
 
 		[TestFixture, Category("LongRunning")]
 		class when_requesting_an_unprotected_resource : with_admin_user {
@@ -21,6 +14,7 @@ namespace EventStore.Core.Tests.Http.BasicAuthentication {
 			}
 
 			protected override void When() {
+				SetDefaultCredentials(null);
 				GetJson<JObject>("/test-anonymous");
 			}
 
@@ -41,6 +35,7 @@ namespace EventStore.Core.Tests.Http.BasicAuthentication {
 			}
 
 			protected override void When() {
+				SetDefaultCredentials(null);
 				GetJson<JObject>("/test1");
 			}
 

--- a/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
+++ b/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
@@ -39,6 +39,7 @@ namespace EventStore.Core.Tests.Http {
 		private Func<HttpWebRequest, byte[]> _dumpRequest2;
 		private string _tag;
 		private bool _createdMiniNode;
+		private ICredentials _defaultCredentials = null;
 
 		public override void TestFixtureSetUp() {
 			Helper.EatException(() => _dumpResponse = CreateDumpResponse());
@@ -129,6 +130,7 @@ namespace EventStore.Core.Tests.Http {
 		protected HttpWebRequest CreateRequest(
 			string path, string extra, string method, string contentType, ICredentials credentials = null,
 			NameValueCollection headers = null) {
+			credentials = credentials??_defaultCredentials;
 			var uri = MakeUrl(path, extra);
 			var request = WebRequest.Create(uri);
 			var httpWebRequest = (HttpWebRequest)request;
@@ -149,6 +151,7 @@ namespace EventStore.Core.Tests.Http {
 		}
 
 		protected HttpWebRequest CreateRequest(string path, string method, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var httpWebRequest = (HttpWebRequest)WebRequest.Create(MakeUrl(path));
 			httpWebRequest.Method = method;
 			httpWebRequest.UseDefaultCredentials = false;
@@ -178,6 +181,7 @@ namespace EventStore.Core.Tests.Http {
 		}
 
 		protected HttpWebResponse MakeJsonPut<T>(string path, T body, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRawJsonPostRequest(path, "PUT", body, credentials);
 			var httpWebResponse = GetRequestResponse(request);
 			return httpWebResponse;
@@ -185,24 +189,28 @@ namespace EventStore.Core.Tests.Http {
 
 
 		protected HttpWebResponse MakeJsonPost<T>(string path, T body, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRawJsonPostRequest(path, "POST", body, credentials);
 			var httpWebResponse = GetRequestResponse(request);
 			return httpWebResponse;
 		}
 
 		protected HttpWebResponse MakeArrayEventsPost<T>(string path, T body, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateEventsJsonPostRequest(path, "POST", body, credentials);
 			var response = GetRequestResponse(request);
 			return response;
 		}
 
 		protected HttpWebResponse MakeRawJsonPost<T>(string path, T body, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRawJsonPostRequest(path, "POST", body, credentials);
 			var httpWebResponse = GetRequestResponse(request);
 			return httpWebResponse;
 		}
 
 		protected JObject MakeJsonPostWithJsonResponse<T>(string path, T body, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRawJsonPostRequest(path, "POST", body, credentials);
 			_lastResponse = GetRequestResponse(request);
 			var memoryStream = new MemoryStream();
@@ -218,6 +226,7 @@ namespace EventStore.Core.Tests.Http {
 		}
 
 		protected JObject MakeJsonEventsPostWithJsonResponse<T>(string path, T body, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateEventsJsonPostRequest(path, "POST", body, credentials);
 			_lastResponse = GetRequestResponse(request);
 			var memoryStream = new MemoryStream();
@@ -234,41 +243,48 @@ namespace EventStore.Core.Tests.Http {
 
 
 		protected HttpWebResponse MakeEventsJsonPut<T>(string path, T body, ICredentials credentials) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateEventsJsonPostRequest(path, "PUT", body, credentials);
 			var httpWebResponse = GetRequestResponse(request);
 			return httpWebResponse;
 		}
 
 		protected HttpWebResponse MakeRawJsonPut<T>(string path, T body, ICredentials credentials) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRawJsonPostRequest(path, "PUT", body, credentials);
 			var httpWebResponse = GetRequestResponse(request);
 			return httpWebResponse;
 		}
 
 		protected HttpWebResponse MakeDelete(string path, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRequest(path, "DELETE", credentials);
 			var httpWebResponse = GetRequestResponse(request);
 			return httpWebResponse;
 		}
 
 		protected HttpWebResponse MakePost(string path, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateJsonPostRequest(path, credentials);
 			var httpWebResponse = GetRequestResponse(request);
 			return httpWebResponse;
 		}
 
 		protected XDocument GetAtomXml(Uri uri, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			Get(uri.ToString(), "", ContentType.Atom, credentials);
 			return XDocument.Parse(_lastResponseBody);
 		}
 
 		protected XDocument GetXml(Uri uri, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			Get(uri.ToString(), "", ContentType.Xml, credentials);
 			return XDocument.Parse(_lastResponseBody);
 		}
 
 		protected T GetJson<T>(string path, string accept = null, ICredentials credentials = null,
 			NameValueCollection headers = null) {
+			credentials = credentials??_defaultCredentials;
 			Get(path, "", accept, credentials, headers: headers);
 			try {
 				return _lastResponseBody.ParseJson<T>();
@@ -279,6 +295,7 @@ namespace EventStore.Core.Tests.Http {
 		}
 
 		protected T GetJson2<T>(string path, string extra, string accept = null, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			Get(path, extra, accept, credentials);
 			try {
 				return _lastResponseBody.ParseJson<T>();
@@ -305,6 +322,7 @@ namespace EventStore.Core.Tests.Http {
 
 		protected void Get(string path, string extra, string accept = null, ICredentials credentials = null,
 			bool setAcceptHeader = true, NameValueCollection headers = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRequest(path, extra, "GET", null, credentials, headers);
 			if (setAcceptHeader) {
 				request.Accept = accept ?? "application/json";
@@ -358,6 +376,7 @@ namespace EventStore.Core.Tests.Http {
 
 		protected HttpWebRequest CreateEventsJsonPostRequest<T>(
 			string path, string method, T body, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRequest(path, "", method, "application/vnd.eventstore.events+json", credentials);
 			request.GetRequestStream().WriteJson(body);
 			return request;
@@ -365,15 +384,19 @@ namespace EventStore.Core.Tests.Http {
 
 		protected HttpWebRequest CreateRawJsonPostRequest<T>(
 			string path, string method, T body, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRequest(path, "", method, "application/json", credentials);
 			request.GetRequestStream().WriteJson(body);
 			return request;
 		}
-
 		private HttpWebRequest CreateJsonPostRequest(string path, ICredentials credentials = null) {
+			credentials = credentials??_defaultCredentials;
 			var request = CreateRequest(path, "POST", credentials);
 			request.ContentLength = 0;
 			return request;
+		}
+		protected void SetDefaultCredentials(ICredentials credentials){
+			_defaultCredentials = credentials;
 		}
 
 		protected abstract void Given();

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/creating.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/creating.cs
@@ -77,11 +77,12 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 		}
 
 		protected override void When() {
+			SetDefaultCredentials(null);
 			_response = MakeJsonPut(
 				"/subscriptions/stream/groupname337",
 				new {
 					ResolveLinkTos = true
-				}, null);
+				});
 		}
 
 		[TearDown]

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/deleting.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/deleting.cs
@@ -61,6 +61,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 		}
 
 		protected override void When() {
+			SetDefaultCredentials(null);
 			var req = CreateRequest("/subscriptions/stream/groupname156", "DELETE");
 			_response = GetRequestResponse(req);
 		}

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/getting.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/getting.cs
@@ -80,6 +80,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 		}
 
 		protected override void When() {
+			SetDefaultCredentials(null);
 			GetJson<JObject>(
 				SubscriptionPath,
 				ContentType.CompetingJson);

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using HttpStatusCode = System.Net.HttpStatusCode;
 using System.Xml.Linq;
 using System.Threading.Tasks;
+using EventStore.Core.Tests.Http.Users.users;
 
 namespace EventStore.Core.Tests.Http.PersistentSubscription {
 	[TestFixture, Category("LongRunning")]
@@ -73,14 +74,14 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 	}
 
 	[TestFixture, Category("LongRunning")]
-	class when_getting_non_existent_single_statistics : HttpBehaviorSpecification {
+	class when_getting_non_existent_single_statistics : with_admin_user {
 		private HttpWebResponse _response;
 
 		protected override void Given() {
 		}
 
 		protected override void When() {
-			var request = CreateRequest("/subscriptions/fu/fubar", null, "GET", "text/xml", null);
+			var request = CreateRequest("/subscriptions/fu/fubar", null, "GET", "text/xml");
 			_response = GetRequestResponse(request);
 		}
 
@@ -91,7 +92,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 	}
 
 	[TestFixture, Category("LongRunning")]
-	class when_getting_non_existent_stream_statistics : HttpBehaviorSpecification {
+	class when_getting_non_existent_stream_statistics : with_admin_user {
 		private HttpWebResponse _response;
 
 		protected override void Given() {

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/updating.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/updating.cs
@@ -22,6 +22,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 		}
 
 		protected override void When() {
+			SetDefaultCredentials(null);
 			_response = MakeJsonPost(
 				"/subscriptions/stream/groupname337",
 				new {

--- a/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
+++ b/src/EventStore.Core.Tests/Http/StreamSecurity/stream_access.cs
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Http.StreamSecurity {
 							EventType = SystemEventTypes.StreamMetadata,
 							Data = new JRaw(jsonMetadata)
 						}
-					});
+					}, _admin);
 			}
 
 			[Test]

--- a/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/append_to_stream.cs
@@ -9,10 +9,11 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using EventStore.Core.Services;
 using HttpStatusCode = System.Net.HttpStatusCode;
+using EventStore.Core.Tests.Http.Users.users;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	namespace append_to_stream {
-		public abstract class ExpectedVersionSpecification : HttpBehaviorSpecification {
+		public abstract class ExpectedVersionSpecification : with_admin_user {
 			public string WrongExpectedVersionDesc {
 				get { return "Wrong expected EventNumber"; }
 			}

--- a/src/EventStore.Core.Tests/Http/Streams/basic.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/basic.cs
@@ -10,6 +10,7 @@ using HttpStatusCode = System.Net.HttpStatusCode;
 using System.Linq;
 using System.Xml.Linq;
 using System.IO;
+using EventStore.Core.Tests.Http.Users.users;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	namespace basic {
@@ -59,7 +60,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture]
-		public class when_posting_an_event_as_raw_json_without_eventtype : HttpBehaviorSpecification {
+		public class when_posting_an_event_as_raw_json_without_eventtype : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -78,7 +79,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture]
-		public class when_posting_an_event_to_idempotent_uri_as_events_array : HttpBehaviorSpecification {
+		public class when_posting_an_event_to_idempotent_uri_as_events_array : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -97,7 +98,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture]
-		public class when_posting_an_event_as_json_to_idempotent_uri_without_event_type : HttpBehaviorSpecification {
+		public class when_posting_an_event_as_json_to_idempotent_uri_without_event_type : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -117,7 +118,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 
 		[TestFixture]
-		public class when_posting_an_event_in_json_to_idempotent_uri_without_event_id : HttpBehaviorSpecification {
+		public class when_posting_an_event_in_json_to_idempotent_uri_without_event_id : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -153,7 +154,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture]
-		public class when_posting_an_event_as_raw_json_without_eventid : HttpBehaviorSpecification {
+		public class when_posting_an_event_as_raw_json_without_eventid : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -188,7 +189,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture]
-		public class when_posting_an_event_as_array_with_no_event_type : HttpBehaviorSpecification {
+		public class when_posting_an_event_as_array_with_no_event_type : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -208,7 +209,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 
 		[TestFixture]
-		public class when_posting_an_event_as_array : HttpBehaviorSpecification {
+		public class when_posting_an_event_as_array : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -238,7 +239,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_posting_an_event_as_array_to_stream_with_slash : HttpBehaviorSpecification {
+		public class when_posting_an_event_as_array_to_stream_with_slash : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -275,7 +276,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_deleting_to_stream_with_slash : HttpBehaviorSpecification {
+		public class when_deleting_to_stream_with_slash : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -304,7 +305,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_getting_from_stream_with_slash : HttpBehaviorSpecification {
+		public class when_getting_from_stream_with_slash : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -333,7 +334,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_getting_from_all_stream_with_slash : HttpBehaviorSpecification {
+		public class when_getting_from_all_stream_with_slash : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -363,7 +364,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_getting_from_encoded_all_stream_with_slash : HttpBehaviorSpecification {
+		public class when_getting_from_encoded_all_stream_with_slash : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -393,7 +394,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_posting_an_event_as_array_to_metadata_stream_with_slash : HttpBehaviorSpecification {
+		public class when_posting_an_event_as_array_to_metadata_stream_with_slash : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -425,7 +426,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 
 		[TestFixture, Category("LongRunning")]
-		public class when_getting_from_metadata_stream_with_slash : HttpBehaviorSpecification {
+		public class when_getting_from_metadata_stream_with_slash : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -456,7 +457,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 
 		[TestFixture, Category("LongRunning")]
-		public class when_posting_an_event_without_EventId_as_array : HttpBehaviorSpecification {
+		public class when_posting_an_event_without_EventId_as_array : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -475,7 +476,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_posting_an_event_without_EventType_as_array : HttpBehaviorSpecification {
+		public class when_posting_an_event_without_EventType_as_array : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -494,7 +495,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_posting_an_event_with_date_time : HttpBehaviorSpecification {
+		public class when_posting_an_event_with_date_time : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -530,7 +531,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture, Category("LongRunning")]
-		public class when_posting_an_events_as_array : HttpBehaviorSpecification {
+		public class when_posting_an_events_as_array : with_admin_user {
 			private HttpWebResponse _response;
 
 			protected override void Given() {
@@ -562,7 +563,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 		}
 
-		public abstract class HttpBehaviorSpecificationWithSingleEvent : HttpBehaviorSpecification {
+		public abstract class HttpBehaviorSpecificationWithSingleEvent : with_admin_user {
 			protected HttpWebResponse _response;
 
 			protected override void Given() {
@@ -578,7 +579,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		public class
 			when_requesting_a_single_event_that_is_deleted_linkto : HttpSpecificationWithLinkToToDeletedEvents {
 			protected override void When() {
-				Get("/streams/" + LinkedStreamName + "/0", "", "application/json");
+				Get("/streams/" + LinkedStreamName + "/0", "", "application/json", credentials: DefaultData.AdminNetworkCredentials);
 			}
 
 			[Test]
@@ -592,7 +593,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			when_requesting_a_single_event_that_is_maxcount_deleted_linkto :
 				SpecificationWithLinkToToMaxCountDeletedEvents {
 			protected override void When() {
-				Get("/streams/" + LinkedStreamName + "/0", "", "application/json");
+				Get("/streams/" + LinkedStreamName + "/0", "", "application/json", DefaultData.AdminNetworkCredentials);
 			}
 
 			[Test]
@@ -688,7 +689,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 		}
 
 		[TestFixture]
-		public class when_requesting_a_single_raw_event_in_the_stream_as_raw : HttpBehaviorSpecification {
+		public class when_requesting_a_single_raw_event_in_the_stream_as_raw : with_admin_user {
 			protected HttpWebResponse _response;
 			protected byte[] _data;
 

--- a/src/EventStore.Core.Tests/Http/Streams/description_document.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/description_document.cs
@@ -11,10 +11,12 @@ using Newtonsoft.Json.Linq;
 using HttpStatusCode = System.Net.HttpStatusCode;
 using EventStore.Core.Services.Transport.Http;
 using System.Collections.Generic;
+using EventStore.Core.Tests.Http.Users.users;
 
 namespace EventStore.Core.Tests.Http.Streams {
+
 	[TestFixture, Category("LongRunning")]
-	public class when_getting_a_stream_without_accept_header : HttpBehaviorSpecification {
+	public class when_getting_a_stream_without_accept_header : with_admin_user {
 		private JObject _descriptionDocument;
 		private List<JToken> _links;
 
@@ -39,7 +41,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[TestFixture, Category("LongRunning")]
-	public class when_getting_a_stream_with_description_document_media_type : HttpBehaviorSpecification {
+	public class when_getting_a_stream_with_description_document_media_type : with_admin_user {
 		private JObject _descriptionDocument;
 		private List<JToken> _links;
 
@@ -64,7 +66,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[TestFixture, Category("LongRunning")]
-	public class when_getting_description_document : HttpBehaviorSpecification {
+	public class when_getting_description_document : with_admin_user {
 		private JObject _descriptionDocument;
 		private List<JToken> _links;
 
@@ -117,7 +119,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 	}
 
 	[TestFixture, Category("LongRunning")]
-	public class when_getting_description_document_and_subscription_exists_for_stream : HttpBehaviorSpecification {
+	public class when_getting_description_document_and_subscription_exists_for_stream : with_admin_user {
 		private JObject _descriptionDocument;
 		private List<JToken> _links;
 		private JToken[] _subscriptions;

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -16,10 +16,11 @@ using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using System.Linq;
 using HttpStatusCode = System.Net.HttpStatusCode;
+using EventStore.Core.Tests.Http.Users.users;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	namespace feed {
-		public abstract class SpecificationWithLongFeed : HttpBehaviorSpecification {
+		public abstract class SpecificationWithLongFeed : with_admin_user {
 			protected int _numberOfEvents;
 
 			protected override void Given() {
@@ -219,7 +220,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			private List<JToken> _entries;
 
 			protected override void When() {
-				_feed = GetJson<JObject>("/streams/" + LinkedStreamName + "/0/forward/10", accept: ContentType.Json);
+				_feed = GetJson<JObject>("/streams/" + LinkedStreamName + "/0/forward/10", accept: ContentType.Json, credentials: DefaultData.AdminNetworkCredentials);
 				_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
 			}
 
@@ -442,7 +443,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			protected override void When() {
 				var uri = MakeUrl("/streams/" + LinkedStreamName + "/0/forward/10", "embed=content");
-				_feed = GetJson<JObject>(uri.ToString(), accept: ContentType.Json);
+				_feed = GetJson<JObject>(uri.ToString(), accept: ContentType.Json, credentials: DefaultData.AdminNetworkCredentials);
 				_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
 			}
 
@@ -473,7 +474,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			private List<JToken> _entries;
 
 			protected override void When() {
-				_feed = GetJson<JObject>("/streams/" + LinkedStreamName + "/0/backward/1", accept: ContentType.Json);
+				_feed = GetJson<JObject>("/streams/" + LinkedStreamName + "/0/backward/1", accept: ContentType.Json, credentials: DefaultData.AdminNetworkCredentials);
 				_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
 			}
 
@@ -507,7 +508,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 
 			protected override void When() {
 				var uri = MakeUrl("/streams/" + LinkedStreamName + "/0/backward/1", "embed=content");
-				_feed = GetJson<JObject>(uri.ToString(), accept: ContentType.Json);
+				_feed = GetJson<JObject>(uri.ToString(), accept: ContentType.Json, credentials: DefaultData.AdminNetworkCredentials);
 				_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
 			}
 
@@ -638,7 +639,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 namespace EventStore.Core.Tests.Http {
 	public class when_running_the_node_advertising_a_different_ip_as {
 		[TestFixture, Category("LongRunning")]
-		public class when_retrieving_feed_head_and_http_advertise_ip_is_set : HttpBehaviorSpecification {
+		public class when_retrieving_feed_head_and_http_advertise_ip_is_set : with_admin_user {
 			private JObject _feed;
 			private IPAddress advertisedAddress = IPAddress.Parse("192.168.10.1");
 			private int advertisedPort = 2116;

--- a/src/EventStore.Core.Tests/Http/Streams/idempotency.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/idempotency.cs
@@ -5,11 +5,12 @@ using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using HttpStatusCode = System.Net.HttpStatusCode;
+using EventStore.Core.Tests.Http.Users.users;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	namespace idempotency {
 		[SetUpFixture]
-		abstract class HttpBehaviorSpecificationOfSuccessfulCreateEvent : HttpBehaviorSpecification {
+		abstract class HttpBehaviorSpecificationOfSuccessfulCreateEvent : with_admin_user {
 			protected HttpWebResponse _response;
 
 			[OneTimeSetUp]

--- a/src/EventStore.Core.Tests/Http/Streams/metadata.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/metadata.cs
@@ -6,10 +6,11 @@ using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using System.Xml.Linq;
 using EventStore.Common.Utils;
+using EventStore.Core.Tests.Http.Users.users;
 
 namespace EventStore.Core.Tests.Http.Streams {
 	[TestFixture]
-	public class when_posting_metadata_as_json_to_non_existing_stream : HttpBehaviorSpecification {
+	public class when_posting_metadata_as_json_to_non_existing_stream : with_admin_user {
 		private HttpWebResponse _response;
 
 		protected override void Given() {

--- a/src/EventStore.Core.Tests/Http/TestController.cs
+++ b/src/EventStore.Core.Tests/Http/TestController.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Http {
 		private void Register(
 			IHttpService service, string uriTemplate, Action<HttpEntityManager, UriTemplateMatch> handler,
 			string httpMethod = HttpMethod.Get) {
-			Register(service, uriTemplate, httpMethod, handler, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding});
+			Register(service, uriTemplate, httpMethod, handler, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, AuthorizationLevel.None);
 		}
 
 		private void Test1Handler(HttpEntityManager http, UriTemplateMatch match) {

--- a/src/EventStore.Core.Tests/Http/Users/users.cs
+++ b/src/EventStore.Core.Tests/Http/Users/users.cs
@@ -7,11 +7,15 @@ using Newtonsoft.Json.Linq;
 
 namespace EventStore.Core.Tests.Http.Users {
 	namespace users {
-		abstract class with_admin_user : HttpBehaviorSpecification {
+		public abstract class with_admin_user : HttpBehaviorSpecification {
 			protected readonly ICredentials _admin = DefaultData.AdminNetworkCredentials;
 
 			protected override bool GivenSkipInitializeStandardUsersCheck() {
 				return false;
+			}
+
+			public with_admin_user(){
+				SetDefaultCredentials(_admin);
 			}
 		}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -1,0 +1,265 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using EventStore.Common.Utils;
+using EventStore.Core.Services.Transport.Http;
+using EventStore.Core.Tests.Integration;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Http {
+	public class Authorization : specification_with_cluster {
+		private Dictionary<string, HttpClient> _httpClients = new Dictionary<string, HttpClient>();
+		private TimeSpan _timeout = TimeSpan.FromSeconds(5);
+		private int _masterId;
+		
+		private HttpClient CreateHttpClient(string username, string password){
+			var httpClientHandler = new HttpClientHandler();
+			httpClientHandler.AllowAutoRedirect = false;
+
+			var client = new HttpClient(httpClientHandler);
+			client.Timeout = _timeout;
+			client.DefaultRequestHeaders.Authorization = 
+				new AuthenticationHeaderValue(
+					"Basic", System.Convert.ToBase64String(
+						System.Text.ASCIIEncoding.ASCII.GetBytes(
+						$"{username}:{password}")));
+
+			return client;
+		}
+
+		private int SendRequest(HttpClient client, HttpMethod method, string url, string body, string contentType){
+			var request = new HttpRequestMessage();
+			request.Method = method;
+			request.RequestUri = new Uri(url);
+
+			if(body != null){
+				var bodyBytes = Helper.UTF8NoBom.GetBytes(body);
+				var stream = new MemoryStream(bodyBytes);
+				var content = new StreamContent(stream);
+				content.Headers.ContentLength = bodyBytes.Length;
+				if(contentType != null)
+					content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+				request.Content = content;
+			}
+
+			var result = client.SendAsync(request).Result;
+			return (int) result.StatusCode;
+		}
+
+        private HttpMethod GetHttpMethod(string method)
+        {
+            switch(method){
+				case "GET":
+					return HttpMethod.Get;
+				case "POST":
+					return HttpMethod.Post;
+				case "PUT":
+					return HttpMethod.Put;
+				case "DELETE":
+					return HttpMethod.Delete;
+				default:
+					throw new Exception("Unknown Http Method");
+			}
+        }
+
+        private int GetAuthLevel(string userAuthorizationLevel)
+        {
+            switch(userAuthorizationLevel){
+				case "None":
+					return 0;
+				case "User":
+					return 1;
+				case "Ops":
+					return 2;
+				case "Admin":
+					return 3;
+				default:
+					throw new Exception("Unknown authorization level");
+			}
+        }
+		public void CreateUser(string username, string password){
+			for(int trial=1;trial<=5;trial++){
+				try{
+					var dataStr = string.Format("{{loginName: '{0}', fullName: '{1}', password: '{2}', groups: []}}", username, username, password);
+					var data = Helper.UTF8NoBom.GetBytes(dataStr);
+					var stream = new MemoryStream(data);
+					var content = new StreamContent(stream);
+					content.Headers.Add("Content-Type", "application/json");
+
+					var res = _httpClients["Admin"].PostAsync(
+						string.Format("http://{0}/users/", _nodes[_masterId].ExternalHttpEndPoint),
+						content
+					).Result;
+					res.EnsureSuccessStatusCode();
+					break;
+				}
+				catch(HttpRequestException){
+					if(trial == 5){
+						throw new Exception(string.Format("Error creating user: {0}", username));
+					}
+					Task.Delay(1000).Wait();
+				}
+			}
+		}
+
+		[OneTimeSetUp]
+		public override void TestFixtureSetUp() {
+			base.TestFixtureSetUp();
+
+			//find the master node
+			for(int i=0;i<_nodes.Length;i++){
+				if(_nodes[i].NodeState == Data.VNodeState.Master){
+					_masterId = i;
+					break;
+				}
+			}
+
+			_httpClients["Admin"] = CreateHttpClient("admin", "changeit");
+			_httpClients["Ops"] = CreateHttpClient("ops", "changeit");
+			CreateUser("user","changeit");
+			_httpClients["User"] = CreateHttpClient("user", "changeit");
+			_httpClients["None"] = new HttpClient();
+		}
+
+        [OneTimeTearDown]
+		public override void TestFixtureTearDown() {
+			foreach(var kvp in _httpClients){
+				kvp.Value.Dispose();
+			}
+			base.TestFixtureTearDown();
+		}
+
+		[Test, Combinatorial]
+		public void authorization_tests(
+			[Values(
+				"None",
+				"User",
+				"Ops",
+				"Admin"
+			)] string userAuthorizationLevel,
+			[Values(
+				false,
+				true
+			)] bool useInternalEndpoint,
+			[Values(
+				"/admin/shutdown;POST;Ops", /* this test is not executed for Ops and Admin to prevent the node from shutting down */
+				"/admin/scavenge?startFromChunk={startFromChunk}&threads={threads};POST;Ops",
+				"/admin/scavenge/{scavengeId};DELETE;Ops",
+				"/admin/mergeindexes;POST;Ops",
+				"/ping;GET;None",
+				"/info;GET;None",
+				"/info/options;GET;Ops",
+				"/stats;GET;None",
+				"/stats/replication;GET;None",
+				"/stats/tcp;GET;None",
+				"/stats/{*statPath};GET;None",
+				"/streams/{stream};POST;User",
+				"/streams/{stream};DELETE;User",
+				"/streams/{stream}/incoming/{guid};POST;User",
+				"/streams/{stream}/;POST;User",
+				"/streams/{stream}/;DELETE;User",
+				"/streams/{stream}/;GET;User",
+				"/streams/{stream}?embed={embed};GET;User",
+				"/streams/{stream}/{event}?embed={embed};GET;User",
+				"/streams/{stream}/{event}/{count}?embed={embed};GET;User",
+				"/streams/{stream}/{event}/backward/{count}?embed={embed};GET;User",
+				"/streams/{stream}/metadata;POST;User",
+				"/streams/{stream}/metadata/;POST;User",
+				"/streams/{stream}/metadata?embed={embed};GET;User",
+				"/streams/{stream}/metadata/?embed={embed};GET;User",
+				"/streams/{stream}/metadata/{event}?embed={embed};GET;User",
+				"/streams/{stream}/metadata/{event}/{count}?embed={embed};GET;User",
+				"/streams/{stream}/metadata/{event}/backward/{count}?embed={embed};GET;User",
+				"/streams/$all/;GET;User", /* only redirects, so "User" is allowed */
+				"/streams/%24all/;GET;User", /* only redirects, so "User" is allowed */
+				/* -- with default ACLs, only Admin should be able to read $all -- */
+				"/streams/$all?embed={embed};GET;Admin",
+				"/streams/$all/00000000000000000000000000000000/10?embed={embed};GET;Admin", /* /streams/$all/{position}/{count}?embed={embed} */
+				"/streams/$all/head/backward/10?embed={embed};GET;Admin", /* /streams/$all/{position}/backward/{count}?embed={embed} */
+				"/streams/%24all?embed={embed};GET;Admin",
+				"/streams/%24all/00000000000000000000000000000000/10?embed={embed};GET;Admin", /* /streams/%24all/{position}/{count}?embed={embed} */
+				"/streams/%24all/head/backward/10?embed={embed};GET;Admin", /* /streams/%24all/{position}/backward/{count}?embed={embed} */
+				/* ------------------------------------------------------------- */
+				"/gossip;GET;None",
+				"/gossip;POST;None",
+				"/elections/viewchange;POST;None",
+				"/elections/viewchangeproof;POST;None",
+				"/elections/prepare;POST;None",
+				"/elections/prepareok;POST;None",
+				"/elections/proposal;POST;None",
+				"/elections/accept;POST;None",
+				"/histogram/{name};GET;Ops",
+				"/subscriptions;GET;User",
+				"/subscriptions/{stream};GET;User",
+				"/subscriptions/{stream}/{subscription};PUT;Ops",
+				"/subscriptions/{stream}/{subscription};POST;Ops",
+				"/subscriptions/{stream}/{subscription};DELETE;Ops",
+				"/subscriptions/{stream}/{subscription};GET;User",
+				"/subscriptions/{stream}/{subscription}?embed={embed};GET;User",
+				"/subscriptions/{stream}/{subscription}/{count}?embed={embed};GET;User",
+				"/subscriptions/{stream}/{subscription}/info;GET;User",
+				"/subscriptions/{stream}/{subscription}/ack/{messageid};POST;User",
+				"/subscriptions/{stream}/{subscription}/nack/{messageid}?action={action};POST;User",
+				"/subscriptions/{stream}/{subscription}/ack?ids={messageids};POST;User",
+				"/subscriptions/{stream}/{subscription}/nack?ids={messageids}&action={action};POST;User",
+				"/subscriptions/{stream}/{subscription}/replayParked;POST;Ops",
+				"/users;GET;Admin",
+				"/users/;GET;Admin",
+				"/users/{login};GET;Admin",
+				"/users/$current;GET;User",
+				"/users;POST;Admin",
+				"/users/;POST;Admin",
+				"/users/{login};PUT;Admin",
+				"/users/{login};DELETE;Admin",
+				"/users/{login}/command/enable;POST;Admin",
+				"/users/{login}/command/disable;POST;Admin",
+				"/users/{login}/command/reset-password;POST;Admin",
+				"/users/{login}/command/change-password;POST;User",
+				"/web/{*remaining_path};GET;None",
+				";GET;None",
+				"/web;GET;None"
+			)] string httpEndpointDetails
+		){
+			/*use the master node endpoint to avoid any redirects*/
+			var nodeEndpoint = useInternalEndpoint? _nodes[_masterId].InternalHttpEndPoint: _nodes[_masterId].ExternalHttpEndPoint;
+			var httpEndpointTokens = httpEndpointDetails.Split(';');
+			var endpointUrl = httpEndpointTokens[0];
+			var httpMethod = GetHttpMethod(httpEndpointTokens[1]);
+			var requiredMinAuthorizationLevel = httpEndpointTokens[2];
+
+			/* this test was done manually for Admin and Ops */
+			if(endpointUrl=="/admin/shutdown" && (userAuthorizationLevel=="Admin" || userAuthorizationLevel=="Ops")){
+				return;
+			}
+
+			var url = string.Format("http://{0}{1}", nodeEndpoint, endpointUrl);
+			var body = GetData(httpMethod, endpointUrl);
+			var contentType = httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete ? "application/json" : null;
+			var statusCode = SendRequest(_httpClients[userAuthorizationLevel], httpMethod, url, body, contentType);
+
+			if(GetAuthLevel(userAuthorizationLevel) >= GetAuthLevel(requiredMinAuthorizationLevel)){
+				Assert.AreNotEqual(401, statusCode);
+			} else{
+				Assert.AreEqual(401, statusCode);
+			}
+		}
+
+        private string GetData(HttpMethod httpMethod, string url)
+        {
+            if(httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete){
+				if(url.Equals("/users/{login}/command/change-password") || url.Equals("/users/{login}/command/reset-password")){
+					return "{newPassword: \"changeit\"}";
+				}
+				else if(url.Equals("/users") || url.Equals("/users/")){
+					return "{loginName: \"test\", fullName: \"test\", password: \"changeit\", groups: []}";
+				}
+				return "{}";
+			} else {
+				return null;
+			}
+        }
+    }
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -46,7 +46,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 					{new AnonymousHttpAuthenticationProvider()};
 
 				_service = new HttpService(ServiceAccessibility.Private, _bus, new NaiveUriRouter(),
-					_multiQueuedHandler, false, null, 0, _serverEndPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA));
+					_multiQueuedHandler, false, null, 0, false, _serverEndPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA));
 				HttpService.CreateAndSubscribePipeline(pipelineBus, httpAuthenticationProviders);
 				_client = new HttpAsyncClient(_timeout);
 			}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
@@ -100,12 +100,12 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 
 		private void Register(string route, string verb) {
 			if (_router == null) {
-				_http.RegisterAction(new ControllerAction(route, verb, Codec.NoCodecs, SupportedCodecs), (x, y) => {
+				_http.RegisterAction(new ControllerAction(route, verb, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None), (x, y) => {
 					x.Reply(new byte[0], 200, "", "", Helper.UTF8NoBom, null, e => new Exception());
 					CountdownEvent.Signal();
 				});
 			} else {
-				_router.RegisterAction(new ControllerAction(route, verb, Codec.NoCodecs, SupportedCodecs), (x, y) => {
+				_router.RegisterAction(new ControllerAction(route, verb, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None), (x, y) => {
 					CountdownEvent.Signal();
 					return new RequestParams(TimeSpan.Zero);
 				});

--- a/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
@@ -134,7 +134,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 			var multiQueuedHandler = new MultiQueuedHandler(new IQueuedHandler[] {queue}, null);
 			var providers = new HttpAuthenticationProvider[] {new AnonymousHttpAuthenticationProvider()};
 			var httpService = new HttpService(ServiceAccessibility.Public, inputBus,
-				new TrieUriRouter(), multiQueuedHandler, false, null, 0, "http://localhost:12345/");
+				new TrieUriRouter(), multiQueuedHandler, false, null, 0, false, "http://localhost:12345/");
 			HttpService.CreateAndSubscribePipeline(bus, providers);
 
 			var fakeController = new FakeController(iterations, null);

--- a/src/EventStore.Core.Tests/Services/Transport/Http/uri_router_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/uri_router_should.cs
@@ -36,71 +36,71 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 
 			var p = new RequestParams(TimeSpan.Zero);
 			_router.RegisterAction(
-				new ControllerAction("/", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs), (x, y) => p);
+				new ControllerAction("/", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/{placeholder}", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs),
+				new ControllerAction("/{placeholder}", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
 				(x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/halt", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs),
+				new ControllerAction("/halt", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
 				(x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/streams/{stream}/{event}/backward/{count}?embed={embed}", HttpMethod.Get,
-					Codec.NoCodecs, FakeController.SupportedCodecs), (x, y) => p);
+					Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction(
 					"/projection/{name}?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}",
-					HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs), (x, y) => p);
+					HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/s/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/streams/$all/", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs),
+				new ControllerAction("/streams/$all/", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
 				(x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/streams/$$all", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs),
+				new ControllerAction("/streams/$$all", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
 				(x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/streams/$mono?param={param}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 
 			_router.RegisterAction(
-				new ControllerAction("/streams/test", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs),
+				new ControllerAction("/streams/test", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
 				(x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/streams/test", HttpMethod.Post, Codec.NoCodecs, FakeController.SupportedCodecs),
+				new ControllerAction("/streams/test", HttpMethod.Post, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
 				(x, y) => p);
 
 			_router.RegisterAction(
 				new ControllerAction("/t/{placeholder1}/{placholder2}/{placeholder3}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/{placeholder1}/{placholder2}/something", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/{placeholder1}/something/{placeholder3}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/{placeholder1}/something/something", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/something/{placholder2}/{placeholder3}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/something/{placholder2}/something", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/something/something/{placeholder3}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/something/something/something", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs), (x, y) => p);
+					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
 		}
 
 		[Test]
 		public void detect_duplicate_route() {
 			Assert.That(() =>
 					_router.RegisterAction(
-						new ControllerAction("/halt", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs),
+						new ControllerAction("/halt", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
 						(x, y) => new RequestParams(TimeSpan.Zero)),
 				Throws.Exception.InstanceOf<ArgumentException>().With.Message.EqualTo("Duplicate route."));
 		}
@@ -266,7 +266,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		public void match_greedy_route_in_the_root_to_any_path() {
 			var tmpRouter = _uriRouterFactory();
 			tmpRouter.RegisterAction(
-				new ControllerAction("/{*greedy}", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs),
+				new ControllerAction("/{*greedy}", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
 				(x, y) => new RequestParams(TimeSpan.Zero));
 
 			var match = tmpRouter.GetAllUriMatches(Uri("/"));

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -46,6 +46,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly StatsStorage StatsStorage;
 
 		public readonly IAuthenticationProviderFactory AuthenticationProviderFactory;
+		public readonly bool DisableFirstLevelHttpAuthorization;
 		public readonly bool DisableScavengeMerging;
 		public readonly int ScavengeHistoryMaxAge;
 		public bool AdminOnPublic;
@@ -149,7 +150,8 @@ namespace EventStore.Core.Cluster.Settings {
 			int initializationThreads = 1,
 			bool faultOutOfOrderProjections = false,
 			bool structuredLog = false,
-			int maxAutoMergeIndexLevel = 1000) {
+			int maxAutoMergeIndexLevel = 1000,
+			bool disableFirstLevelHttpAuthorization = false) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
@@ -212,6 +214,7 @@ namespace EventStore.Core.Cluster.Settings {
 			StatsStorage = statsStorage;
 
 			AuthenticationProviderFactory = authenticationProviderFactory;
+			DisableFirstLevelHttpAuthorization = disableFirstLevelHttpAuthorization;
 
 			NodePriority = nodePriority;
 			DisableScavengeMerging = disableScavengeMerging;
@@ -293,7 +296,8 @@ namespace EventStore.Core.Cluster.Settings {
 			                     + "ChunkInitialReaderCount: {37}\n"
 			                     + "ReduceFileCachePressure: {38}\n"
 			                     + "InitializationThreads: {39}\n"
-			                     + "StructuredLog: {40}\n",
+			                     + "StructuredLog: {40}\n"
+								 + "DisableFirstLevelHttpAuthorization: {41}\n",
 				NodeInfo.InstanceId,
 				NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
 				NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -312,7 +316,8 @@ namespace EventStore.Core.Cluster.Settings {
 				NodePriority, GossipInterval, GossipAllowedTimeDifference, GossipTimeout,
 				EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge,
 				ConnectionPendingSendBytesThreshold, ChunkInitialReaderCount,
-				ReduceFileCachePressure, InitializationThreads, StructuredLog);
+				ReduceFileCachePressure, InitializationThreads, StructuredLog,
+				DisableFirstLevelHttpAuthorization);
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -383,7 +383,7 @@ namespace EventStore.Core {
 			// EXTERNAL HTTP
 			_externalHttpService = new HttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
 				_workersHandler, vNodeSettings.LogHttpRequests, vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalIPAs,
-				vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalHttpPortAs, false, vNodeSettings.ExtHttpPrefixes);
+				vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalHttpPortAs, vNodeSettings.DisableFirstLevelHttpAuthorization, vNodeSettings.ExtHttpPrefixes);
 			_externalHttpService.SetupController(persistentSubscriptionController);
 			if (vNodeSettings.AdminOnPublic)
 				_externalHttpService.SetupController(adminController);
@@ -404,7 +404,7 @@ namespace EventStore.Core {
 				_internalHttpService = new HttpService(ServiceAccessibility.Private, _mainQueue, new TrieUriRouter(),
 					_workersHandler, vNodeSettings.LogHttpRequests,
 					vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalIPAs,
-					vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalHttpPortAs, false, vNodeSettings.IntHttpPrefixes);
+					vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalHttpPortAs, vNodeSettings.DisableFirstLevelHttpAuthorization, vNodeSettings.IntHttpPrefixes);
 				_internalHttpService.SetupController(adminController);
 				_internalHttpService.SetupController(pingController);
 				_internalHttpService.SetupController(infoController);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -383,7 +383,7 @@ namespace EventStore.Core {
 			// EXTERNAL HTTP
 			_externalHttpService = new HttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
 				_workersHandler, vNodeSettings.LogHttpRequests, vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalIPAs,
-				vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalHttpPortAs, vNodeSettings.ExtHttpPrefixes);
+				vNodeSettings.GossipAdvertiseInfo.AdvertiseExternalHttpPortAs, false, vNodeSettings.ExtHttpPrefixes);
 			_externalHttpService.SetupController(persistentSubscriptionController);
 			if (vNodeSettings.AdminOnPublic)
 				_externalHttpService.SetupController(adminController);
@@ -404,7 +404,7 @@ namespace EventStore.Core {
 				_internalHttpService = new HttpService(ServiceAccessibility.Private, _mainQueue, new TrieUriRouter(),
 					_workersHandler, vNodeSettings.LogHttpRequests,
 					vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalIPAs,
-					vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalHttpPortAs, vNodeSettings.IntHttpPrefixes);
+					vNodeSettings.GossipAdvertiseInfo.AdvertiseInternalHttpPortAs, false, vNodeSettings.IntHttpPrefixes);
 				_internalHttpService.SetupController(adminController);
 				_internalHttpService.SetupController(pingController);
 				_internalHttpService.SetupController(infoController);

--- a/src/EventStore.Core/Services/Transport/Http/AuthorizationLevel.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AuthorizationLevel.cs
@@ -1,0 +1,8 @@
+namespace EventStore.Core.Services.Transport.Http {
+	public enum AuthorizationLevel {
+		None,
+		User,
+		Ops,
+		Admin
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Http/ControllerAction.cs
+++ b/src/EventStore.Core/Services/Transport/Http/ControllerAction.cs
@@ -6,7 +6,7 @@ namespace EventStore.Core.Services.Transport.Http {
 	public class ControllerAction {
 		public readonly string UriTemplate;
 		public readonly string HttpMethod;
-
+		public readonly AuthorizationLevel RequiredAuthorizationLevel;
 		public readonly ICodec[] SupportedRequestCodecs;
 		public readonly ICodec[] SupportedResponseCodecs;
 		public readonly ICodec DefaultResponseCodec;
@@ -26,6 +26,7 @@ namespace EventStore.Core.Services.Transport.Http {
 			SupportedRequestCodecs = requestCodecs;
 			SupportedResponseCodecs = responseCodecs;
 			DefaultResponseCodec = responseCodecs.Length > 0 ? responseCodecs[0] : null;
+			RequiredAuthorizationLevel = AuthorizationLevel.None;
 		}
 
 		public bool Equals(ControllerAction other) {

--- a/src/EventStore.Core/Services/Transport/Http/ControllerAction.cs
+++ b/src/EventStore.Core/Services/Transport/Http/ControllerAction.cs
@@ -14,7 +14,8 @@ namespace EventStore.Core.Services.Transport.Http {
 		public ControllerAction(string uriTemplate,
 			string httpMethod,
 			ICodec[] requestCodecs,
-			ICodec[] responseCodecs) {
+			ICodec[] responseCodecs,
+			AuthorizationLevel requiredAuthorizationLevel) {
 			Ensure.NotNull(uriTemplate, "uriTemplate");
 			Ensure.NotNull(httpMethod, "httpMethod");
 			Ensure.NotNull(requestCodecs, "requestCodecs");
@@ -26,7 +27,7 @@ namespace EventStore.Core.Services.Transport.Http {
 			SupportedRequestCodecs = requestCodecs;
 			SupportedResponseCodecs = responseCodecs;
 			DefaultResponseCodec = responseCodecs.Length > 0 ? responseCodecs[0] : null;
-			RequiredAuthorizationLevel = AuthorizationLevel.None;
+			RequiredAuthorizationLevel = requiredAuthorizationLevel;
 		}
 
 		public bool Equals(ControllerAction other) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -21,16 +21,16 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		protected override void SubscribeCore(IHttpService service) {
 			service.RegisterAction(
-				new ControllerAction("/admin/shutdown", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs),
+				new ControllerAction("/admin/shutdown", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops),
 				OnPostShutdown);
 			service.RegisterAction(
 				new ControllerAction("/admin/scavenge?startFromChunk={startFromChunk}&threads={threads}",
-					HttpMethod.Post, Codec.NoCodecs, SupportedCodecs), OnPostScavenge);
+					HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops), OnPostScavenge);
 			service.RegisterAction(
 				new ControllerAction("/admin/scavenge/{scavengeId}", HttpMethod.Delete, Codec.NoCodecs,
-					SupportedCodecs), OnStopScavenge);
+					SupportedCodecs, AuthorizationLevel.Ops), OnStopScavenge);
 			service.RegisterAction(
-				new ControllerAction("/admin/mergeindexes", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs),
+				new ControllerAction("/admin/mergeindexes", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops),
 				OnPostMergeIndexes);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -97,65 +97,65 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		protected override void SubscribeCore(IHttpService http) {
 			// STREAMS
-			Register(http, "/streams/{stream}", HttpMethod.Post, PostEvents, AtomCodecs, AtomCodecs);
-			Register(http, "/streams/{stream}", HttpMethod.Delete, DeleteStream, Codec.NoCodecs, AtomCodecs);
+			Register(http, "/streams/{stream}", HttpMethod.Post, PostEvents, AtomCodecs, AtomCodecs, AuthorizationLevel.User);
+			Register(http, "/streams/{stream}", HttpMethod.Delete, DeleteStream, Codec.NoCodecs, AtomCodecs, AuthorizationLevel.User);
 
 			Register(http, "/streams/{stream}/incoming/{guid}", HttpMethod.Post, PostEventsIdempotent,
-				AtomCodecsWithoutBatches, AtomCodecsWithoutBatches);
+				AtomCodecsWithoutBatches, AtomCodecsWithoutBatches, AuthorizationLevel.User);
 
-			Register(http, "/streams/{stream}/", HttpMethod.Post, RedirectKeepVerb, AtomCodecs, AtomCodecs);
-			Register(http, "/streams/{stream}/", HttpMethod.Delete, RedirectKeepVerb, Codec.NoCodecs, AtomCodecs);
-			Register(http, "/streams/{stream}/", HttpMethod.Get, RedirectKeepVerb, Codec.NoCodecs, AtomCodecs);
+			Register(http, "/streams/{stream}/", HttpMethod.Post, RedirectKeepVerb, AtomCodecs, AtomCodecs, AuthorizationLevel.User);
+			Register(http, "/streams/{stream}/", HttpMethod.Delete, RedirectKeepVerb, Codec.NoCodecs, AtomCodecs, AuthorizationLevel.User);
+			Register(http, "/streams/{stream}/", HttpMethod.Get, RedirectKeepVerb, Codec.NoCodecs, AtomCodecs, AuthorizationLevel.User);
 
 			Register(http, "/streams/{stream}?embed={embed}", HttpMethod.Get, GetStreamEventsBackward, Codec.NoCodecs,
-				AtomWithHtmlCodecs);
+				AtomWithHtmlCodecs, AuthorizationLevel.User);
 
 			Register(http, "/streams/{stream}/{event}?embed={embed}", HttpMethod.Get, GetStreamEvent, Codec.NoCodecs,
-				DefaultCodecs);
+				DefaultCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/{stream}/{event}/{count}?embed={embed}", HttpMethod.Get, GetStreamEventsBackward,
-				Codec.NoCodecs, AtomWithHtmlCodecs);
+				Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/{stream}/{event}/backward/{count}?embed={embed}", HttpMethod.Get,
-				GetStreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetStreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			RegisterCustom(http, "/streams/{stream}/{event}/forward/{count}?embed={embed}", HttpMethod.Get,
-				GetStreamEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetStreamEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 
 			// METASTREAMS
-			Register(http, "/streams/{stream}/metadata", HttpMethod.Post, PostMetastreamEvent, AtomCodecs, AtomCodecs);
-			Register(http, "/streams/{stream}/metadata/", HttpMethod.Post, RedirectKeepVerb, AtomCodecs, AtomCodecs);
+			Register(http, "/streams/{stream}/metadata", HttpMethod.Post, PostMetastreamEvent, AtomCodecs, AtomCodecs, AuthorizationLevel.User);
+			Register(http, "/streams/{stream}/metadata/", HttpMethod.Post, RedirectKeepVerb, AtomCodecs, AtomCodecs, AuthorizationLevel.User);
 
 			Register(http, "/streams/{stream}/metadata?embed={embed}", HttpMethod.Get, GetMetastreamEvent,
-				Codec.NoCodecs, DefaultCodecs);
+				Codec.NoCodecs, DefaultCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/{stream}/metadata/?embed={embed}", HttpMethod.Get, RedirectKeepVerb,
-				Codec.NoCodecs, DefaultCodecs);
+				Codec.NoCodecs, DefaultCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/{stream}/metadata/{event}?embed={embed}", HttpMethod.Get, GetMetastreamEvent,
-				Codec.NoCodecs, DefaultCodecs);
+				Codec.NoCodecs, DefaultCodecs, AuthorizationLevel.User);
 
 			Register(http, "/streams/{stream}/metadata/{event}/{count}?embed={embed}", HttpMethod.Get,
-				GetMetastreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetMetastreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/{stream}/metadata/{event}/backward/{count}?embed={embed}", HttpMethod.Get,
-				GetMetastreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetMetastreamEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			RegisterCustom(http, "/streams/{stream}/metadata/{event}/forward/{count}?embed={embed}", HttpMethod.Get,
-				GetMetastreamEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetMetastreamEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 
 			// $ALL
-			Register(http, "/streams/$all/", HttpMethod.Get, RedirectKeepVerb, Codec.NoCodecs, AtomWithHtmlCodecs);
-			Register(http, "/streams/%24all/", HttpMethod.Get, RedirectKeepVerb, Codec.NoCodecs, AtomWithHtmlCodecs);
+			Register(http, "/streams/$all/", HttpMethod.Get, RedirectKeepVerb, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
+			Register(http, "/streams/%24all/", HttpMethod.Get, RedirectKeepVerb, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/$all?embed={embed}", HttpMethod.Get, GetAllEventsBackward, Codec.NoCodecs,
-				AtomWithHtmlCodecs);
+				AtomWithHtmlCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/$all/{position}/{count}?embed={embed}", HttpMethod.Get, GetAllEventsBackward,
-				Codec.NoCodecs, AtomWithHtmlCodecs);
+				Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/$all/{position}/backward/{count}?embed={embed}", HttpMethod.Get,
-				GetAllEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetAllEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			RegisterCustom(http, "/streams/$all/{position}/forward/{count}?embed={embed}", HttpMethod.Get,
-				GetAllEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetAllEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/%24all?embed={embed}", HttpMethod.Get, GetAllEventsBackward, Codec.NoCodecs,
-				AtomWithHtmlCodecs);
+				AtomWithHtmlCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/%24all/{position}/{count}?embed={embed}", HttpMethod.Get, GetAllEventsBackward,
-				Codec.NoCodecs, AtomWithHtmlCodecs);
+				Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			Register(http, "/streams/%24all/{position}/backward/{count}?embed={embed}", HttpMethod.Get,
-				GetAllEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetAllEventsBackward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 			RegisterCustom(http, "/streams/%24all/{position}/forward/{count}?embed={embed}", HttpMethod.Get,
-				GetAllEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs);
+				GetAllEventsForward, Codec.NoCodecs, AtomWithHtmlCodecs, AuthorizationLevel.User);
 		}
 
 		private bool GetDescriptionDocument(HttpEntityManager manager, UriTemplateMatch match) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
@@ -29,7 +29,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			RegisterRedirectAction(service, "/web", "/web/index.html");
 
 			service.RegisterAction(
-				new ControllerAction("/sys/subsystems", HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.Json}),
+				new ControllerAction("/sys/subsystems", HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.Json}, AuthorizationLevel.Ops),
 				OnListNodeSubsystems);
 		}
 
@@ -50,7 +50,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					fromUrl,
 					HttpMethod.Get,
 					Codec.NoCodecs,
-					new ICodec[] {Codec.ManualEncoding}),
+					new ICodec[] {Codec.ManualEncoding},
+					AuthorizationLevel.None),
 				(http, match) => http.ReplyTextContent(
 					"Moved", 302, "Found", "text/plain",
 					new[] {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -54,21 +54,21 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		protected void Register(IHttpService service, string uriTemplate, string httpMethod,
-			Action<HttpEntityManager, UriTemplateMatch> handler, ICodec[] requestCodecs, ICodec[] responseCodecs) {
-			service.RegisterAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs),
+			Action<HttpEntityManager, UriTemplateMatch> handler, ICodec[] requestCodecs, ICodec[] responseCodecs, AuthorizationLevel requiredAuthorizationLevel) {
+			service.RegisterAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs, requiredAuthorizationLevel),
 				handler);
 		}
 
 		protected void RegisterCustom(IHttpService service, string uriTemplate, string httpMethod,
 			Func<HttpEntityManager, UriTemplateMatch, RequestParams> handler,
-			ICodec[] requestCodecs, ICodec[] responseCodecs) {
-			service.RegisterCustomAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs),
+			ICodec[] requestCodecs, ICodec[] responseCodecs, AuthorizationLevel requiredAuthorizationLevel) {
+			service.RegisterCustomAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs, requiredAuthorizationLevel),
 				handler);
 		}
 
-		protected void RegisterUrlBased(IHttpService service, string uriTemplate, string httpMethod,
+		protected void RegisterUrlBased(IHttpService service, string uriTemplate, string httpMethod, AuthorizationLevel requiredAuthorizationLevel,
 			Action<HttpEntityManager, UriTemplateMatch> action) {
-			Register(service, uriTemplate, httpMethod, action, Codec.NoCodecs, DefaultCodecs);
+			Register(service, uriTemplate, httpMethod, action, Codec.NoCodecs, DefaultCodecs, requiredAuthorizationLevel);
 		}
 
 		protected static string MakeUrl(HttpEntityManager http, string path) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/ElectController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/ElectController.cs
@@ -31,22 +31,22 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		protected override void SubscribeCore(IHttpService service) {
 			service.RegisterAction(
-				new ControllerAction("/elections/viewchange", HttpMethod.Post, SupportedCodecs, SupportedCodecs),
+				new ControllerAction("/elections/viewchange", HttpMethod.Post, SupportedCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnPostViewChange);
 			service.RegisterAction(
-				new ControllerAction("/elections/viewchangeproof", HttpMethod.Post, SupportedCodecs, SupportedCodecs),
+				new ControllerAction("/elections/viewchangeproof", HttpMethod.Post, SupportedCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnPostViewChangeProof);
 			service.RegisterAction(
-				new ControllerAction("/elections/prepare", HttpMethod.Post, SupportedCodecs, SupportedCodecs),
+				new ControllerAction("/elections/prepare", HttpMethod.Post, SupportedCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnPostPrepare);
 			service.RegisterAction(
-				new ControllerAction("/elections/prepareok", HttpMethod.Post, SupportedCodecs, SupportedCodecs),
+				new ControllerAction("/elections/prepareok", HttpMethod.Post, SupportedCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnPostPrepareOk);
 			service.RegisterAction(
-				new ControllerAction("/elections/proposal", HttpMethod.Post, SupportedCodecs, SupportedCodecs),
+				new ControllerAction("/elections/proposal", HttpMethod.Post, SupportedCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnPostProposal);
 			service.RegisterAction(
-				new ControllerAction("/elections/accept", HttpMethod.Post, SupportedCodecs, SupportedCodecs),
+				new ControllerAction("/elections/accept", HttpMethod.Post, SupportedCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnPostAccept);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
@@ -33,11 +33,11 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		protected override void SubscribeCore(IHttpService service) {
-			service.RegisterAction(new ControllerAction("/gossip", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs),
+			service.RegisterAction(new ControllerAction("/gossip", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnGetGossip);
 			if (service.Accessibility == ServiceAccessibility.Private)
 				service.RegisterAction(
-					new ControllerAction("/gossip", HttpMethod.Post, SupportedCodecs, SupportedCodecs), OnPostGossip);
+					new ControllerAction("/gossip", HttpMethod.Post, SupportedCodecs, SupportedCodecs, AuthorizationLevel.None), OnPostGossip);
 		}
 
 		public void SubscribeSenders(HttpMessagePipe pipe) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/HistogramController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/HistogramController.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		public void Subscribe(IHttpService service) {
 			Ensure.NotNull(service, "service");
 			service.RegisterAction(
-				new ControllerAction("/histogram/{name}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs),
+				new ControllerAction("/histogram/{name}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops),
 				OnGetHistogram);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/HttpHelpers.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/HttpHelpers.cs
@@ -13,7 +13,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					fromUrl,
 					HttpMethod.Get,
 					Codec.NoCodecs,
-					new ICodec[] {Codec.ManualEncoding}),
+					new ICodec[] {Codec.ManualEncoding},
+					AuthorizationLevel.None),
 				(http, match) => http.ReplyTextContent(
 					"Moved", 302, "Found", "text/plain",
 					new[] {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -29,10 +29,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		public void Subscribe(IHttpService service) {
 			Ensure.NotNull(service, "service");
-			service.RegisterAction(new ControllerAction("/info", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs),
+			service.RegisterAction(new ControllerAction("/info", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnGetInfo);
 			service.RegisterAction(
-				new ControllerAction("/info/options", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs), OnGetOptions);
+				new ControllerAction("/info/options", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops), OnGetOptions);
 		}
 
 
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		private void OnGetOptions(HttpEntityManager entity, UriTemplateMatch match) {
-			if (entity.User != null && entity.User.IsInRole(SystemRoles.Admins)) {
+			if (entity.User != null && (entity.User.IsInRole(SystemRoles.Operations) || entity.User.IsInRole(SystemRoles.Admins))) {
 				entity.ReplyTextContent(Codec.Json.To(Filter(GetOptionsInfo(_options), new[] {"CertificatePassword"})),
 					HttpStatusCode.OK,
 					"OK",

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -36,32 +36,32 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		protected override void SubscribeCore(IHttpService service) {
-			Register(service, "/subscriptions", HttpMethod.Get, GetAllSubscriptionInfo, Codec.NoCodecs, DefaultCodecs);
+			Register(service, "/subscriptions", HttpMethod.Get, GetAllSubscriptionInfo, Codec.NoCodecs, DefaultCodecs, AuthorizationLevel.User);
 			Register(service, "/subscriptions/{stream}", HttpMethod.Get, GetSubscriptionInfoForStream, Codec.NoCodecs,
-				DefaultCodecs);
+				DefaultCodecs, AuthorizationLevel.User);
 			Register(service, "/subscriptions/{stream}/{subscription}", HttpMethod.Put, PutSubscription, DefaultCodecs,
-				DefaultCodecs);
+				DefaultCodecs, AuthorizationLevel.Ops);
 			Register(service, "/subscriptions/{stream}/{subscription}", HttpMethod.Post, PostSubscription,
-				DefaultCodecs, DefaultCodecs);
-			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}", HttpMethod.Delete, DeleteSubscription);
+				DefaultCodecs, DefaultCodecs, AuthorizationLevel.Ops);
+			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}", HttpMethod.Delete, AuthorizationLevel.Ops, DeleteSubscription);
 			Register(service, "/subscriptions/{stream}/{subscription}", HttpMethod.Get, GetNextNMessages,
-				Codec.NoCodecs, AtomCodecs);
+				Codec.NoCodecs, AtomCodecs, AuthorizationLevel.User);
 			Register(service, "/subscriptions/{stream}/{subscription}?embed={embed}", HttpMethod.Get, GetNextNMessages,
-				Codec.NoCodecs, AtomCodecs);
+				Codec.NoCodecs, AtomCodecs, AuthorizationLevel.User);
 			Register(service, "/subscriptions/{stream}/{subscription}/{count}?embed={embed}", HttpMethod.Get,
-				GetNextNMessages, Codec.NoCodecs, AtomCodecs);
+				GetNextNMessages, Codec.NoCodecs, AtomCodecs, AuthorizationLevel.User);
 			Register(service, "/subscriptions/{stream}/{subscription}/info", HttpMethod.Get, GetSubscriptionInfo,
-				Codec.NoCodecs, DefaultCodecs);
-			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack/{messageid}", HttpMethod.Post,
+				Codec.NoCodecs, DefaultCodecs, AuthorizationLevel.User);
+			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack/{messageid}", HttpMethod.Post, AuthorizationLevel.User,
 				AckMessage);
 			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/nack/{messageid}?action={action}",
-				HttpMethod.Post, NackMessage);
-			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack?ids={messageids}", HttpMethod.Post,
+				HttpMethod.Post, AuthorizationLevel.User, NackMessage);
+			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/ack?ids={messageids}", HttpMethod.Post, AuthorizationLevel.User,
 				AckMessages);
 			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/nack?ids={messageids}&action={action}",
-				HttpMethod.Post, NackMessages);
+				HttpMethod.Post, AuthorizationLevel.User, NackMessages);
 			RegisterUrlBased(service, "/subscriptions/{stream}/{subscription}/replayParked", HttpMethod.Post,
-				ReplayParkedMessages);
+				AuthorizationLevel.User, ReplayParkedMessages);
 		}
 
 		private static ClientMessages.NakAction GetNackAction(HttpEntityManager manager, UriTemplateMatch match,

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PingController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PingController.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		public void Subscribe(IHttpService service) {
 			Ensure.NotNull(service, "service");
-			service.RegisterAction(new ControllerAction("/ping", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs),
+			service.RegisterAction(new ControllerAction("/ping", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnGetPing);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
@@ -21,15 +21,15 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		protected override void SubscribeCore(IHttpService service) {
 			Ensure.NotNull(service, "service");
 
-			service.RegisterAction(new ControllerAction("/stats", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs),
+			service.RegisterAction(new ControllerAction("/stats", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnGetFreshStats);
 			service.RegisterAction(
-				new ControllerAction("/stats/replication", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs),
+				new ControllerAction("/stats/replication", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnGetReplicationStats);
-			service.RegisterAction(new ControllerAction("/stats/tcp", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs),
+			service.RegisterAction(new ControllerAction("/stats/tcp", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnGetTcpConnectionStats);
 			service.RegisterAction(
-				new ControllerAction("/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs),
+				new ControllerAction("/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
 				OnGetFreshStats);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/UsersController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/UsersController.cs
@@ -21,20 +21,20 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		protected override void SubscribeCore(IHttpService service) {
-			RegisterUrlBased(service, "/users", HttpMethod.Get, GetUsers);
-			RegisterUrlBased(service, "/users/", HttpMethod.Get, GetUsers);
-			RegisterUrlBased(service, "/users/{login}", HttpMethod.Get, GetUser);
-			RegisterUrlBased(service, "/users/$current", HttpMethod.Get, GetCurrentUser);
-			Register(service, "/users", HttpMethod.Post, PostUser, DefaultCodecs, DefaultCodecs);
-			Register(service, "/users/", HttpMethod.Post, PostUser, DefaultCodecs, DefaultCodecs);
-			Register(service, "/users/{login}", HttpMethod.Put, PutUser, DefaultCodecs, DefaultCodecs);
-			RegisterUrlBased(service, "/users/{login}", HttpMethod.Delete, DeleteUser);
-			RegisterUrlBased(service, "/users/{login}/command/enable", HttpMethod.Post, PostCommandEnable);
-			RegisterUrlBased(service, "/users/{login}/command/disable", HttpMethod.Post, PostCommandDisable);
+			RegisterUrlBased(service, "/users", HttpMethod.Get, AuthorizationLevel.Admin, GetUsers);
+			RegisterUrlBased(service, "/users/", HttpMethod.Get, AuthorizationLevel.Admin, GetUsers);
+			RegisterUrlBased(service, "/users/{login}", HttpMethod.Get, AuthorizationLevel.Admin, GetUser);
+			RegisterUrlBased(service, "/users/$current", HttpMethod.Get, AuthorizationLevel.User, GetCurrentUser);
+			Register(service, "/users", HttpMethod.Post, PostUser, DefaultCodecs, DefaultCodecs, AuthorizationLevel.Admin);
+			Register(service, "/users/", HttpMethod.Post, PostUser, DefaultCodecs, DefaultCodecs, AuthorizationLevel.Admin);
+			Register(service, "/users/{login}", HttpMethod.Put, PutUser, DefaultCodecs, DefaultCodecs, AuthorizationLevel.Admin);
+			RegisterUrlBased(service, "/users/{login}", HttpMethod.Delete, AuthorizationLevel.Admin, DeleteUser);
+			RegisterUrlBased(service, "/users/{login}/command/enable", HttpMethod.Post, AuthorizationLevel.Admin, PostCommandEnable);
+			RegisterUrlBased(service, "/users/{login}/command/disable", HttpMethod.Post, AuthorizationLevel.Admin, PostCommandDisable);
 			Register(service, "/users/{login}/command/reset-password", HttpMethod.Post, PostCommandResetPassword,
-				DefaultCodecs, DefaultCodecs);
+				DefaultCodecs, DefaultCodecs, AuthorizationLevel.Admin);
 			Register(service, "/users/{login}/command/change-password", HttpMethod.Post, PostCommandChangePassword,
-				DefaultCodecs, DefaultCodecs);
+				DefaultCodecs, DefaultCodecs, AuthorizationLevel.User);
 		}
 
 		private void GetUsers(HttpEntityManager http, UriTemplateMatch match) {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLog.cs
@@ -39,7 +39,14 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public void ScavengeStarted() {
 			var metadataEventId = Guid.NewGuid();
 			var metaStreamId = SystemStreams.MetastreamOf(_streamName);
-			var metadata = new StreamMetadata(maxAge: _scavengeHistoryMaxAge);
+			var acl = new StreamAcl(
+				new string[]{"$ops"},
+				new string[]{},
+				new string[]{},
+				new string[]{},
+				new string[]{}
+			);
+			var metadata = new StreamMetadata(maxAge: _scavengeHistoryMaxAge, acl: acl);
 			var metaStreamEvent = new Event(metadataEventId, SystemEventTypes.StreamMetadata, isJson: true,
 				data: metadata.ToJsonBytes(), metadata: null);
 			_ioDispatcher.WriteEvent(metaStreamId, ExpectedVersion.Any, metaStreamEvent, SystemAccount.Principal, m => {

--- a/src/EventStore.Core/Util/MiniWeb.cs
+++ b/src/EventStore.Core/Util/MiniWeb.cs
@@ -29,7 +29,7 @@ namespace EventStore.Core.Util {
 			var pattern = _localWebRootPath + "/{*remaining_path}";
 			Logger.Trace("Binding MiniWeb to {path}", pattern);
 			service.RegisterAction(
-				new ControllerAction(pattern, HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}),
+				new ControllerAction(pattern, HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, AuthorizationLevel.None),
 				OnStaticContent);
 		}
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Util {
 		public const string AppGroup = "Application Options";
 		public const string DbGroup = "Database Options";
 		public const string ProjectionsGroup = "Projections Options";
-		public const string AuthGroup = "Authentication Options";
+		public const string AuthGroup = "Authentication/Authorization Options";
 		public const string InterfacesGroup = "Interface Options";
 		public const string CertificatesGroup = "Certificate Options";
 		public const string ClusterGroup = "Cluster Options";
@@ -400,7 +400,7 @@ namespace EventStore.Core.Util {
 		public static readonly bool OptimizeIndexMergeDefault = false;
 
 		/*
-		 * Authentication Options
+		 * Authentication/Authorization Options
 		 */
 		public const string AuthenticationTypeDescr = "The type of authentication to use.";
 		public static readonly string AuthenticationTypeDefault = "internal";
@@ -409,6 +409,9 @@ namespace EventStore.Core.Util {
 			"Path to the configuration file for authentication configuration (if applicable).";
 
 		public static readonly string AuthenticationConfigFileDefault = string.Empty;
+
+		public const string DisableFirstLevelHttpAuthorizationDescr = "Disables first level authorization checks on all HTTP endpoints. This option can be enabled for backwards compatibility with EventStore 5.0.1 or earlier.";
+		public static readonly bool DisableFirstLevelHttpAuthorizationDefault = false;
 
 		/*
 		 * Scavenge options

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -75,6 +75,7 @@ namespace EventStore.Core {
 		protected StatsStorage _statsStorage;
 
 		protected IAuthenticationProviderFactory _authenticationProviderFactory;
+		protected bool _disableFirstLevelHttpAuthorization;
 		protected bool _disableScavengeMerging;
 		protected int _scavengeHistoryMaxAge;
 		protected bool _adminOnPublic;
@@ -186,6 +187,7 @@ namespace EventStore.Core {
 			_statsPeriod = TimeSpan.FromSeconds(Opts.StatsPeriodDefault);
 
 			_authenticationProviderFactory = new InternalAuthenticationProviderFactory();
+			_disableFirstLevelHttpAuthorization = Opts.DisableFirstLevelHttpAuthorizationDefault;
 			_disableScavengeMerging = Opts.DisableScavengeMergeDefault;
 			_scavengeHistoryMaxAge = Opts.ScavengeHistoryMaxAgeDefault;
 			_adminOnPublic = Opts.AdminOnExtDefault;
@@ -978,6 +980,16 @@ namespace EventStore.Core {
 		}
 
 		/// <summary>
+		/// Disables first level authorization checks on all HTTP endpoints.
+		/// </summary>
+		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+		public VNodeBuilder DisableFirstLevelHttpAuthorization()
+		{
+			_disableFirstLevelHttpAuthorization = true;
+			return this;
+		}
+
+		/// <summary>
 		/// Sets whether or not to use unbuffered/directio
 		/// </summary>
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
@@ -1380,7 +1392,8 @@ namespace EventStore.Core {
 				_initializationThreads,
 				_faultOutOfOrderProjections,
 				_structuredLog,
-				_maxAutoMergeIndexLevel);
+				_maxAutoMergeIndexLevel,
+				_disableFirstLevelHttpAuthorization);
 
 			var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -17,6 +17,7 @@ using EventStore.Projections.Core.Services.Processing;
 using NUnit.Framework;
 using ResolvedEvent = EventStore.ClientAPI.ResolvedEvent;
 using EventStore.ClientAPI.Projections;
+using System.Threading.Tasks;
 
 namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster {
 	[Category("ClientAPI")]
@@ -126,6 +127,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster {
 		}
 
 		protected void EnableStandardProjections() {
+			Task.Delay(4000).Wait(); /* workaround for race condition when a projection is in LoadStopped() state and it is enabled */
 			EnableProjection(ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection);
 			EnableProjection(ProjectionNamesBuilder.StandardProjections.EventByTypeStandardProjection);
 			EnableProjection(ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection);
@@ -145,6 +147,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster {
 
 		protected void EnableProjection(string name) {
 			_manager.EnableAsync(name, _admin).Wait();
+			Task.Delay(1000).Wait(); /* workaround for race condition when multiple projections are being enabled simultaneously */
 		}
 
 		protected void DisableProjection(string name) {

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -146,7 +146,16 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster {
 		}
 
 		protected void EnableProjection(string name) {
-			_manager.EnableAsync(name, _admin).Wait();
+			for(int i=1;i<=10;i++){
+				try{
+					_manager.EnableAsync(name, _admin).Wait();
+				}
+				catch(Exception e){
+					if(i==10) throw e;
+					Task.Delay(5000).Wait();
+				}
+			}
+
 			Task.Delay(1000).Wait(); /* workaround for race condition when multiple projections are being enabled simultaneously */
 		}
 

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/Cluster/specification_with_standard_projections_runnning.cs
@@ -56,7 +56,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI.Cluster {
 		public override void TestFixtureSetUp() {
 			base.TestFixtureSetUp();
 #if (!DEBUG)
-            throw new NotSupportedException("These tests require DEBUG conditional");
+            Assert.Ignore("These tests require DEBUG conditional");
 #else
 			QueueStatsCollector.InitializeIdleDetection();
 			_nodeEndpoints[0] = new Endpoints(

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System.ServiceModel" />
+		<Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/src/EventStore.Projections.Core.Tests/Services/http_service/authorization_tests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/http_service/authorization_tests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using EventStore.Common.Utils;
+using EventStore.Core.Services.Transport.Http;
+using EventStore.Core.Tests.Integration;
+using EventStore.Projections.Core.Tests.ClientAPI.Cluster;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.Transport.Http {
+	public class Authorization : specification_with_standard_projections_runnning {
+		private Dictionary<string, HttpClient> _httpClients = new Dictionary<string, HttpClient>();
+		private TimeSpan _timeout = TimeSpan.FromSeconds(10);
+		private int _masterId;
+		
+		private HttpClient CreateHttpClient(string username, string password){
+			var httpClientHandler = new HttpClientHandler();
+			httpClientHandler.AllowAutoRedirect = false;
+
+			var client = new HttpClient(httpClientHandler);
+			client.Timeout = _timeout;
+			client.DefaultRequestHeaders.Authorization = 
+				new AuthenticationHeaderValue(
+					"Basic", System.Convert.ToBase64String(
+						System.Text.ASCIIEncoding.ASCII.GetBytes(
+						$"{username}:{password}")));
+
+			return client;
+		}
+
+		private int SendRequest(HttpClient client, HttpMethod method, string url, string body, string contentType){
+			var request = new HttpRequestMessage();
+			request.Method = method;
+			request.RequestUri = new Uri(url);
+
+			if(body != null){
+				var bodyBytes = Helper.UTF8NoBom.GetBytes(body);
+				var stream = new MemoryStream(bodyBytes);
+				var content = new StreamContent(stream);
+				content.Headers.ContentLength = bodyBytes.Length;
+				if(contentType != null)
+					content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+				request.Content = content;
+			}
+
+			var result = client.SendAsync(request).Result;
+			return (int) result.StatusCode;
+		}
+
+        private HttpMethod GetHttpMethod(string method)
+        {
+            switch(method){
+				case "GET":
+					return HttpMethod.Get;
+				case "POST":
+					return HttpMethod.Post;
+				case "PUT":
+					return HttpMethod.Put;
+				case "DELETE":
+					return HttpMethod.Delete;
+				default:
+					throw new Exception("Unknown Http Method");
+			}
+        }
+
+        private int GetAuthLevel(string userAuthorizationLevel)
+        {
+            switch(userAuthorizationLevel){
+				case "None":
+					return 0;
+				case "User":
+					return 1;
+				case "Ops":
+					return 2;
+				case "Admin":
+					return 3;
+				default:
+					throw new Exception("Unknown authorization level");
+			}
+        }
+		public void CreateUser(string username, string password){
+			for(int trial=1;trial<=5;trial++){
+				try{
+					var dataStr = string.Format("{{loginName: '{0}', fullName: '{1}', password: '{2}', groups: []}}", username, username, password);
+					var data = Helper.UTF8NoBom.GetBytes(dataStr);
+					var stream = new MemoryStream(data);
+					var content = new StreamContent(stream);
+					content.Headers.Add("Content-Type", "application/json");
+
+					var res = _httpClients["Admin"].PostAsync(
+						string.Format("http://{0}/users/", _nodes[_masterId].ExternalHttpEndPoint),
+						content
+					).Result;
+					res.EnsureSuccessStatusCode();
+					break;
+				}
+				catch(HttpRequestException){
+					if(trial == 5){
+						throw new Exception(string.Format("Error creating user: {0}", username));
+					}
+					Task.Delay(1000).Wait();
+				}
+			}
+		}
+
+		protected override void Given() {
+			base.Given();
+			//find the master node
+			for(int i=0;i<_nodes.Length;i++){
+				if(_nodes[i].NodeState == EventStore.Core.Data.VNodeState.Master){
+					_masterId = i;
+					break;
+				}
+			}
+
+			_httpClients["Admin"] = CreateHttpClient("admin", "changeit");
+			_httpClients["Ops"] = CreateHttpClient("ops", "changeit");
+			CreateUser("user","changeit");
+			_httpClients["User"] = CreateHttpClient("user", "changeit");
+			_httpClients["None"] = new HttpClient();
+		}
+
+        [OneTimeTearDown]
+		public override void TestFixtureTearDown() {
+			foreach(var kvp in _httpClients){
+				kvp.Value.Dispose();
+			}
+			base.TestFixtureTearDown();
+		}
+
+		[Test, Combinatorial]
+		public void authorization_tests(
+			[Values(
+				"None",
+				"User",
+				"Ops",
+				"Admin"
+			)] string userAuthorizationLevel,
+			[Values(
+				false,
+				true
+			)] bool useInternalEndpoint,
+			[Values(
+				"/web/es/js/projections/{*remaining_path};GET;None",
+				"/web/es/js/projections/v8/Prelude/{*remaining_path};GET;None",
+				"/web/projections;GET;None",
+				"/projections;GET;User",
+				"/projections/any;GET;User",
+				"/projections/all-non-transient;GET;User",
+				"/projections/transient;GET;User",
+				"/projections/onetime;GET;User",
+				"/projections/continuous;GET;User",
+				"/projections/transient?name=name&type=type&enabled={enabled};POST;User", /* /projections/transient?name={name}&type={type}&enabled={enabled} */
+				"/projections/onetime?name=name&type=type&enabled={enabled}&checkpoints={checkpoints}&emit={emit}&trackemittedstreams={trackemittedstreams};POST;Ops", /* /projections/onetime?name={name}&type={type}&enabled={enabled}&checkpoints={checkpoints}&emit={emit}&trackemittedstreams={trackemittedstreams} */
+				"/projections/continuous?name=name&type=type&enabled={enabled}&emit={emit}&trackemittedstreams={trackemittedstreams};POST;Ops", /* /projections/continuous?name={name}&type={type}&enabled={enabled}&emit={emit}&trackemittedstreams={trackemittedstreams} */
+				"/projection/name/query?config={config};GET;User", /* /projection/{name}/query?config={config} */
+				"/projection/name/query?type={type}&emit={emit};PUT;User", /* /projection/{name}/query?type={type}&emit={emit} */
+				"/projection/name;GET;User", /* /projection/{name} */
+				"/projection/name?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}&deleteEmittedStreams={deleteEmittedStreams};DELETE;Ops", /* /projection/{name}?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}&deleteEmittedStreams={deleteEmittedStreams} */
+				"/projection/name/statistics;GET;User", /* projection/{name}/statistics */
+				"/projections/read-events;POST;User",
+				"/projection/{name}/state?partition={partition};GET;User",
+				"/projection/{name}/result?partition={partition};GET;User",
+				"/projection/{name}/command/disable?enableRunAs={enableRunAs};POST;User",
+				"/projection/{name}/command/enable?enableRunAs={enableRunAs};POST;User",
+				"/projection/{name}/command/reset?enableRunAs={enableRunAs};POST;User",
+				"/projection/{name}/command/abort?enableRunAs={enableRunAs};POST;User",
+				"/projection/{name}/config;GET;Ops",
+				"/projection/{name}/config;PUT;Ops"
+				/*"/sys/subsystems;GET;Ops"*/ /* this endpoint has been commented since this controller is not registered when using a MiniNode */
+			)] string httpEndpointDetails
+		){
+			/*use the master node endpoint to avoid any redirects*/
+			var nodeEndpoint = useInternalEndpoint? _nodes[_masterId].InternalHttpEndPoint: _nodes[_masterId].ExternalHttpEndPoint;
+			var httpEndpointTokens = httpEndpointDetails.Split(';');
+			var endpointUrl = httpEndpointTokens[0];
+			var httpMethod = GetHttpMethod(httpEndpointTokens[1]);
+			var requiredMinAuthorizationLevel = httpEndpointTokens[2];
+
+			var url = string.Format("http://{0}{1}", nodeEndpoint, endpointUrl);
+			var body = GetData(httpMethod, endpointUrl);
+			var contentType = httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete ? "application/json" : null;
+			var statusCode = SendRequest(_httpClients[userAuthorizationLevel], httpMethod, url, body, contentType);
+
+			if(GetAuthLevel(userAuthorizationLevel) >= GetAuthLevel(requiredMinAuthorizationLevel)){
+				Assert.AreNotEqual(401, statusCode);
+			} else{
+				Assert.AreEqual(401, statusCode);
+			}
+		}
+
+        private string GetData(HttpMethod httpMethod, string url)
+        {
+            if(httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put || httpMethod == HttpMethod.Delete){
+				return "{}";
+			} else {
+				return null;
+			}
+        }
+    }
+}

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -647,8 +647,10 @@ namespace EventStore.Projections.Core.Messages {
 				Command.ControlMessage message, bool replace = false) {
 				if (mode > ProjectionMode.Transient && readWrite == ReadWrite.Write
 				                                    && (message.RunAs == null || message.RunAs.Principal == null
-				                                                              || !message.RunAs.Principal.IsInRole(
-					                                                              SystemRoles.Admins))) {
+				                                                              || !(
+																					   message.RunAs.Principal.IsInRole(SystemRoles.Admins)
+																			  		|| message.RunAs.Principal.IsInRole(SystemRoles.Operations)
+																				  ))) {
 					message.Envelope.ReplyWith(new NotAuthorized());
 					return false;
 				}

--- a/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
+++ b/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
@@ -49,54 +49,54 @@ namespace EventStore.Projections.Core.Services.Http {
 			HttpHelpers.RegisterRedirectAction(service, "/web/projections", "/web/projections.htm");
 
 			Register(service, "/projections",
-				HttpMethod.Get, OnProjections, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding});
+				HttpMethod.Get, OnProjections, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, AuthorizationLevel.User);
 			Register(service, "/projections/any",
-				HttpMethod.Get, OnProjectionsGetAny, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionsGetAny, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projections/all-non-transient",
-				HttpMethod.Get, OnProjectionsGetAllNonTransient, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionsGetAllNonTransient, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projections/transient",
-				HttpMethod.Get, OnProjectionsGetTransient, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionsGetTransient, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projections/onetime",
-				HttpMethod.Get, OnProjectionsGetOneTime, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionsGetOneTime, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projections/continuous",
-				HttpMethod.Get, OnProjectionsGetContinuous, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionsGetContinuous, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projections/transient?name={name}&type={type}&enabled={enabled}",
-				HttpMethod.Post, OnProjectionsPostTransient, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs);
+				HttpMethod.Post, OnProjectionsPostTransient, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.User);
 			Register(service,
 				"/projections/onetime?name={name}&type={type}&enabled={enabled}&checkpoints={checkpoints}&emit={emit}&trackemittedstreams={trackemittedstreams}",
-				HttpMethod.Post, OnProjectionsPostOneTime, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs);
+				HttpMethod.Post, OnProjectionsPostOneTime, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.Ops);
 			Register(service,
 				"/projections/continuous?name={name}&type={type}&enabled={enabled}&emit={emit}&trackemittedstreams={trackemittedstreams}",
-				HttpMethod.Post, OnProjectionsPostContinuous, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs);
+				HttpMethod.Post, OnProjectionsPostContinuous, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.Ops);
 			Register(service, "/projection/{name}/query?config={config}",
-				HttpMethod.Get, OnProjectionQueryGet, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding});
+				HttpMethod.Get, OnProjectionQueryGet, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, AuthorizationLevel.User);
 			Register(service, "/projection/{name}/query?type={type}&emit={emit}",
-				HttpMethod.Put, OnProjectionQueryPut, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs);
+				HttpMethod.Put, OnProjectionQueryPut, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.User); /* source of transient projections can be set by a normal user. Authorization checks are done internally for non-transient projections. */
 			Register(service, "/projection/{name}",
-				HttpMethod.Get, OnProjectionStatusGet, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionStatusGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service,
 				"/projection/{name}?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}&deleteEmittedStreams={deleteEmittedStreams}",
-				HttpMethod.Delete, OnProjectionDelete, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Delete, OnProjectionDelete, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops);
 			Register(service, "/projection/{name}/statistics",
-				HttpMethod.Get, OnProjectionStatisticsGet, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionStatisticsGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projections/read-events",
-				HttpMethod.Post, OnProjectionsReadEvents, SupportedCodecs, SupportedCodecs);
+				HttpMethod.Post, OnProjectionsReadEvents, SupportedCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projection/{name}/state?partition={partition}",
-				HttpMethod.Get, OnProjectionStateGet, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionStateGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projection/{name}/result?partition={partition}",
-				HttpMethod.Get, OnProjectionResultGet, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionResultGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
 			Register(service, "/projection/{name}/command/disable?enableRunAs={enableRunAs}",
-				HttpMethod.Post, OnProjectionCommandDisable, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Post, OnProjectionCommandDisable, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User); /* transient projections can be stopped by a normal user. Authorization checks are done internally for non-transient projections.*/
 			Register(service, "/projection/{name}/command/enable?enableRunAs={enableRunAs}",
-				HttpMethod.Post, OnProjectionCommandEnable, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Post, OnProjectionCommandEnable, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User); /* transient projections can be enabled by a normal user. Authorization checks are done internally for non-transient projections.*/
 			Register(service, "/projection/{name}/command/reset?enableRunAs={enableRunAs}",
-				HttpMethod.Post, OnProjectionCommandReset, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Post, OnProjectionCommandReset, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User); /* transient projections can be reset by a normal user (when debugging). Authorization checks are done internally for non-transient projections.*/
 			Register(service, "/projection/{name}/command/abort?enableRunAs={enableRunAs}",
-				HttpMethod.Post, OnProjectionCommandAbort, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Post, OnProjectionCommandAbort, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User); /* transient projections can be aborted by a normal user. Authorization checks are done internally for non-transient projections.*/
 			Register(service, "/projection/{name}/config",
-				HttpMethod.Get, OnProjectionConfigGet, Codec.NoCodecs, SupportedCodecs);
+				HttpMethod.Get, OnProjectionConfigGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops);
 			Register(service, "/projection/{name}/config",
-				HttpMethod.Put, OnProjectionConfigPut, SupportedCodecs, SupportedCodecs);
+				HttpMethod.Put, OnProjectionConfigPut, SupportedCodecs, SupportedCodecs, AuthorizationLevel.Ops);
 		}
 
 		private void OnProjections(HttpEntityManager http, UriTemplateMatch match) {

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
@@ -238,10 +238,10 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 			if (_stopOnEof) {
 				_eofReached = true;
-				_publisher.Publish(
-					new EventReaderSubscriptionMessage.NotAuthorized(
-						_subscriptionId, _positionTracker.LastTag, _progress, _subscriptionMessageSequenceNumber++));
 			}
+			_publisher.Publish(
+				new EventReaderSubscriptionMessage.NotAuthorized(
+					_subscriptionId, _positionTracker.LastTag, _progress, _subscriptionMessageSequenceNumber++));
 		}
 
 		public void Handle(ReaderSubscriptionMessage.EventReaderStarting message) {


### PR DESCRIPTION
This PR adds an authorization layer to all HTTP endpoints.
- The `HTTPService` will now first check if the current user is authorized for the specified action before calling the endpoint handler. If the user is not authorized, error code 401 will be immediately returned. Of course, more authorization checks are already done further down the code but this serves as a first layer of security.
- Since some of these changes are breaking (particularly for non-authenticated users), a command line option called `DisableFirstLevelHttpAuthorization` has been added to disable this layer of authorization
- Tests have been added for all endpoints except for a few specific cases (de920aad157c3343a7e39f8df79885462f0d1207 and 35317a1fd5df84146b18140c95092dd7cbf51c43)
- The role of the $ops user has been made more consistent: An $ops user is now allowed to do everything that an admin can do except User Management and reading from system streams (except for $scavenges and $scavenges-<scavenge id> streams). These new permissions were thus set (previously 401 but now allowed):
  - 6ecb660d109b3823429fcf02738e22556a6fa080 Allow ops to create/edit/delete & replay parked messages for persistent subscriptions 
  - ec7d7fa8082346618d9c71f31e6098cb4b6d23fa Allow ops to create all projection types
  - c285e5acb45180caa625d5f7e66c95e2a1887466 Set ACL to allow ops to read $scavenges and $scavenges-<scavenge id> streams (this is required to view scavenge history in the UI)

- Breaking changes: Non-authenticated users are now allowed to only access `/info`, `/ping`, `/stats`, `/elections`, `/gossip` and static web content. `/elections` and `/gossip` POST are only allowed on the internal http service.
- Corresponding UI changes: https://github.com/EventStore/EventStore.UI/pull/223

Fixes #1778 