### PR TITLE
Use expected version when writing to $projections-$all

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -82,6 +82,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			_bus.Subscribe<CoreProjectionManagementMessage.SlaveProjectionReaderAssigned>(_manager);
 			_bus.Subscribe<CoreProjectionStatusMessage.ProjectionWorkerStarted>(_manager);
 			_bus.Subscribe<ProjectionManagementMessage.Command.Post>(_manager);
+			_bus.Subscribe<ProjectionManagementMessage.Command.PostBatch>(_manager);
 			_bus.Subscribe<ProjectionManagementMessage.Command.UpdateQuery>(_manager);
 			_bus.Subscribe<ProjectionManagementMessage.Command.GetQuery>(_manager);
 			_bus.Subscribe<ProjectionManagementMessage.Command.Delete>(_manager);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
@@ -73,6 +73,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			_bus.Subscribe<CoreProjectionStatusMessage.ProjectionWorkerStarted>(_manager);
 
 			_bus.Subscribe<ProjectionManagementMessage.Command.Post>(_manager);
+			_bus.Subscribe<ProjectionManagementMessage.Command.PostBatch>(_manager);
 			_bus.Subscribe<ProjectionManagementMessage.Command.UpdateQuery>(_manager);
 			_bus.Subscribe<ProjectionManagementMessage.Command.GetQuery>(_manager);
 			_bus.Subscribe<ProjectionManagementMessage.Command.Delete>(_manager);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream_and_intialize_system_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_reading_registered_projections/with_no_stream_and_intialize_system_projections.cs
@@ -45,8 +45,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.when_re
 		public void it_should_write_the_system_projection_created_event() {
 			Assert.AreEqual(1, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Count(x =>
 				x.EventStreamId == ProjectionNamesBuilder.ProjectionsRegistrationStream &&
-				x.Events[0].EventType == ProjectionEventTypes.ProjectionCreated &&
-				Helper.UTF8NoBom.GetString(x.Events[0].Data) == _systemProjectionName));
+				x.Events.All(e => e.EventType == ProjectionEventTypes.ProjectionCreated) &&
+				x.Events.Any(e => Helper.UTF8NoBom.GetString(e.Data) == _systemProjectionName)));
 		}
 	}
 

--- a/src/EventStore.Projections.Core/Messages/Persisted/Responses/PostBatchCommand.cs
+++ b/src/EventStore.Projections.Core/Messages/Persisted/Responses/PostBatchCommand.cs
@@ -1,0 +1,22 @@
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Management;
+
+namespace EventStore.Projections.Core.Messages.Persisted.Responses {
+	public class PostBatchCommand {
+		public SerializedRunAs RunAs;
+		public ProjectionPost[] Projections;
+
+		public class ProjectionPost {
+			public string Name;
+			public SerializedRunAs RunAs;
+			public bool CheckpointsEnabled;
+			public bool TrackEmittedStreams;
+			public bool EmitEnabled;
+			public bool EnableRunAs;
+			public bool Enabled;
+			public string HandlerType;
+			public ProjectionMode Mode;
+			public string Query;
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -31,6 +31,53 @@ namespace EventStore.Projections.Core.Messages {
 				}
 			}
 
+			public class PostBatch : ControlMessage {
+				private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+				public override int MsgTypeId {
+					get { return TypeId; }
+				}
+
+				public ProjectionPost[] Projections { get; }
+
+				public PostBatch(
+					IEnvelope envelope, RunAs runAs, ProjectionPost[] projections)
+					: base(envelope, runAs) {
+						Projections = projections;
+				}
+
+				public class ProjectionPost
+				{
+					public ProjectionMode Mode { get; }
+					public RunAs RunAs {get;}
+					public string Name { get; }
+					public string HandlerType { get; }
+					public string Query { get; }
+					public bool Enabled { get;}
+					public bool CheckpointsEnabled{ get;}
+					public bool EmitEnabled { get; }
+					public bool EnableRunAs { get; }
+					public bool TrackEmittedStreams { get; }
+
+					public ProjectionPost(
+						ProjectionMode mode, RunAs runAs, string name, string handlerType, string query,
+						bool enabled, bool checkpointsEnabled, bool emitEnabled, bool enableRunAs,
+						bool trackEmittedStreams)
+					{
+						Mode = mode;
+						RunAs = runAs;
+						Name = name;
+						HandlerType = handlerType;
+						Query = query;
+						Enabled = enabled;
+						CheckpointsEnabled = checkpointsEnabled;
+						EmitEnabled = emitEnabled;
+						EnableRunAs = enableRunAs;
+						TrackEmittedStreams = trackEmittedStreams;
+					}
+				}
+			}
+
 			public class Post : ControlMessage {
 				private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -79,6 +79,7 @@ namespace EventStore.Projections.Core {
 			mainBus.Subscribe<SystemMessage.EpochWritten>(projectionManager);
 			if (runProjections >= ProjectionType.System) {
 				mainBus.Subscribe<ProjectionManagementMessage.Command.Post>(projectionManager);
+				mainBus.Subscribe<ProjectionManagementMessage.Command.PostBatch>(projectionManager);
 				mainBus.Subscribe<ProjectionManagementMessage.Command.UpdateQuery>(projectionManager);
 				mainBus.Subscribe<ProjectionManagementMessage.Command.GetQuery>(projectionManager);
 				mainBus.Subscribe<ProjectionManagementMessage.Command.Delete>(projectionManager);

--- a/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
@@ -167,6 +167,7 @@ namespace EventStore.Projections.Core {
 				coreInputBus.Subscribe<ProjectionManagementMessage.Command.GetState>(_coreResponseWriter);
 				coreInputBus.Subscribe<ProjectionManagementMessage.Command.GetStatistics>(_coreResponseWriter);
 				coreInputBus.Subscribe<ProjectionManagementMessage.Command.Post>(_coreResponseWriter);
+				coreInputBus.Subscribe<ProjectionManagementMessage.Command.PostBatch>(_coreResponseWriter);
 				coreInputBus.Subscribe<ProjectionManagementMessage.Command.Reset>(_coreResponseWriter);
 				coreInputBus.Subscribe<ProjectionManagementMessage.Command.SetRunAs>(_coreResponseWriter);
 				coreInputBus.Subscribe<ProjectionManagementMessage.Command.StartSlaveProjections>(_coreResponseWriter);

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -12,6 +12,10 @@ using EventStore.Projections.Core.Messages;
 
 namespace EventStore.Projections.Core {
 	public sealed class ProjectionsSubsystem : ISubsystem, IHandle<CoreProjectionStatusMessage.Stopped> {
+		public InMemoryBus MasterMainBus {
+			get { return _masterMainBus; }
+		}
+		
 		private readonly int _projectionWorkerThreadCount;
 		private readonly ProjectionType _runProjections;
 		private readonly bool _startStandardProjections;

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManagerResponseReader.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManagerResponseReader.cs
@@ -328,6 +328,22 @@ namespace EventStore.Projections.Core.Services.Management {
 							commandBody.IncludeDeleted));
 					break;
 				}
+				case "$post-batch": {
+					var commandBody = resolvedEvent.Event.Data.ParseJson<PostBatchCommand>();
+					var projections = new List<ProjectionManagementMessage.Command.PostBatch.ProjectionPost>();
+					foreach (var proj in commandBody.Projections) {
+						projections.Add(new ProjectionManagementMessage.Command.PostBatch.ProjectionPost(
+							proj.Mode, proj.RunAs, proj.Name, proj.HandlerType, proj.Query,
+							proj.Enabled, proj.CheckpointsEnabled,
+							proj.EmitEnabled, proj.EnableRunAs, proj.TrackEmittedStreams));
+					}
+					_publisher.Publish(
+						new ProjectionManagementMessage.Command.PostBatch(
+							new NoopEnvelope(),
+							commandBody.RunAs,
+							projections.ToArray()));
+					break;
+				}
 				case "$post": {
 					var commandBody = resolvedEvent.Event.Data.ParseJson<PostCommand>();
 					_publisher.Publish(


### PR DESCRIPTION
Fixes #1961 

Use the expected version of `$projections-$all` when writing `$ProjectionCreated` and `$ProjectionDeleted` events.

To allow for this, the process for handling the `$projections-$all` stream has been changed.

The original process was :

1. Read the possible stream (`$projections-{projection-name}`) to get the version.
2. Write the $ProjectionCreated event to `$projections-$all` using ExpectedVersion.Any.
3. Initialize the projection using the event number of the `$ProjectionCreated` event as the ID.

The new process for creating projections :

1. Write the `$ProjectionCreated` event in `$projections-$all` using the current expected version.
2. Handle the write complete and check if there was a timeout or WrongExpectedVersion :
	- On a timeout, retry the write with the same expected version.
	- On WrongExpectedVersion, trigger a read if the current version is greater than the expected version, and fail the original creation.
3. On a successful write, read the `$projections-$all` stream.
4. When the new `$ProjectionCreated` event is found, read the possible projection stream (`$projections-{projection_name}`) to get the version number.
   After handling all the events in the `$projections-$all` stream, update the expecte version.
5. Continue with creating the projection as before, using the event number of the `$ProjectionCreated` write as the ID.

The new process for deleting projections :

1. Write the `$ProjectionDeleted` event in `$projections-$all` using the expected version.
2. Handle the write completed and check if there was a timeout or WrongExpectedVersion :
	- On a timeout, retry the write with the same expected version.
	- On WrongExpectedVersion, trigger a read of `$projections-$all`. Retry the delete once the expected version has been updated.
3. On a successful write, remove the projection from the projections list.

System projections are also now posted as a batch.
In a future update, we can expose the batch creation of events over the HTTP and .NET APIs.

**Note**: With this fix, WrongExpectedVersion errors from creating a projection are pushed to the client.
They will need to retry the creation themselves.