### PR TITLE
Persistent subscriptions in flight msgs

### DIFF
--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -120,6 +120,7 @@ namespace EventStore.Core.Messages {
 			public long LiveBufferCount { get; set; }
 			public int RetryBufferCount { get; set; }
 			public int TotalInFlightMessages { get; set; }
+			public int OutstandingMessagesCount { get; set; }
 			public string NamedConsumerStrategy { get; set; }
 			public int MaxSubscriberCount { get; set; }
 		}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -305,7 +305,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		public void AcknowledgeMessagesProcessed(Guid correlationId, Guid[] processedEventIds) {
 			lock (_lock) {
-				RemoveProcessingMessages(correlationId, processedEventIds);
+				RemoveProcessingMessages(processedEventIds);
 				TryMarkCheckpoint(false);
 				TryReadingNewBatch();
 				TryPushingMessagesToClients();
@@ -321,7 +321,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					HandleNackedMessage(action, id, reason);
 				}
 
-				RemoveProcessingMessages(correlationId, processedEventIds);
+				RemoveProcessingMessages(processedEventIds);
 				TryMarkCheckpoint(false);
 				TryReadingNewBatch();
 				TryPushingMessagesToClients();
@@ -377,7 +377,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 				lock (_lock) {
 					_outstandingMessages.Remove(e.OriginalEvent.EventId);
-					_pushClients.RemoveProcessingMessage(e.OriginalEvent.EventId);
+					_pushClients.RemoveProcessingMessages(e.OriginalEvent.EventId);
 					TryPushingMessagesToClients();
 				}
 			});
@@ -456,8 +456,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			//TODO CC Stop subscription?
 		}
 
-		private void RemoveProcessingMessages(Guid correlationId, Guid[] processedEventIds) {
-			_pushClients.RemoveProcessingMessages(correlationId, processedEventIds);
+		private void RemoveProcessingMessages(Guid[] processedEventIds) {
+			_pushClients.RemoveProcessingMessages(processedEventIds);
 			foreach (var id in processedEventIds) {
 				_outstandingMessages.Remove(id);
 			}
@@ -492,7 +492,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			Log.Debug("Retrying message {subscriptionId} {stream}/{eventNumber}", SubscriptionId,
 				@event.OriginalStreamId, @event.OriginalEventNumber);
 			_outstandingMessages.Remove(@event.OriginalEvent.EventId);
-			_pushClients.RemoveProcessingMessage(@event.OriginalEvent.EventId);
+			_pushClients.RemoveProcessingMessages(@event.OriginalEvent.EventId);
 			_streamBuffer.AddRetry(new OutstandingMessage(@event.OriginalEvent.EventId, null, @event, count + 1));
 		}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
@@ -55,15 +55,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			return _hash.Values;
 		}
 
-		public void RemoveProcessingMessages(Guid correlationId, Guid[] processedEventIds) {
-			PersistentSubscriptionClient client;
-			if (!_hash.TryGetValue(correlationId, out client)) return;
-			client.RemoveFromProcessing(processedEventIds);
-		}
-
-		public void RemoveProcessingMessage(Guid eventId) {
+		public void RemoveProcessingMessages(params Guid[] processedEventIds) {
 			foreach (var client in _hash.Values) {
-				if (client.RemoveFromProcessing(new[] {eventId})) return;
+				client.RemoveFromProcessing(processedEventIds);
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -94,7 +94,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				RetryBufferCount = _parent._streamBuffer.RetryBufferCount,
 				LiveBufferCount = _parent._streamBuffer.LiveBufferCount,
 				ExtraStatistics = _settings.ExtraStatistics,
-				TotalInFlightMessages = _parent.OutstandingMessageCount,
+				TotalInFlightMessages = totalInflight,
+				OutstandingMessagesCount = _parent.OutstandingMessageCount,
 				NamedConsumerStrategy = _settings.ConsumerStrategy.Name,
 				MaxSubscriberCount = _settings.MaxSubscriberCount
 			};

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -646,6 +646,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					LiveBufferCount = stat.LiveBufferCount,
 					RetryBufferCount = stat.RetryBufferCount,
 					TotalInFlightMessages = stat.TotalInFlightMessages,
+					OutstandingMessagesCount = stat.OutstandingMessagesCount,
 					ParkedMessageUri = MakeUrl(manager,
 						string.Format(parkedMessageUriTemplate, escapedStreamId, escapedGroupName)),
 					GetMessagesUri = MakeUrl(manager,
@@ -789,6 +790,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			public long LiveBufferCount { get; set; }
 			public int RetryBufferCount { get; set; }
 			public int TotalInFlightMessages { get; set; }
+			public int OutstandingMessagesCount { get; set; }
 			public List<ConnectionInfo> Connections { get; set; }
 		}
 


### PR DESCRIPTION
This is possibly related to issue #1392.
I'm keeping this PR in 2 commits for now, as the first commit makes the issue more obvious for testing.

The first commit in this PR: 
- Adds `outstandingMessagesCount` to persistent subscription stats
- Changes `totalInFlightMessages` to be the total count of in flight messages on the push clients.

Ideally, these two should be the same number, however it is possible for these two to get out of sync which causes problems.

---

It appears that the original connection does not always remove an event when it is retried.
If another connection then handles and acks that event, it is only removed from the second connection.
The original connection will still report the event as "in flight" and subtract it from its capacity.

This can lead to the connection's buffer filling up with events it can never complete.

---

The fix that I've proposed in this PR is to always remove completed events from all connections.
I'm not sure if this is the correct fix, but have not been able to reproduce the issue with the fix.

There is also likely to be an underlying issue that causes the events to be on multiple connections at once.

- Is there any case where having the same event on multiple connections would be expected/desirable?
- What *should* happen in the cases where an event is on two connections, and one connection acks it?