### PR TITLE
Mark ExpectedVersion.EmptyStream as obsolete

### DIFF
--- a/src/EventStore.ClientAPI/ExpectedVersion.cs
+++ b/src/EventStore.ClientAPI/ExpectedVersion.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace EventStore.ClientAPI {
 	/// <summary>
 	/// Constants used for expected version control
@@ -27,6 +29,7 @@ namespace EventStore.ClientAPI {
 		/// <summary>
 		/// The stream should exist but be empty when writing. If it does not exist or is not empty treat that as a concurrency problem.
 		/// </summary>
+		[Obsolete("ExpectedVersion.EmptyStream has been deprecated. Use ExpectedVersion.NoStream instead")]
 		public const int EmptyStream = -1;
 
 		/// <summary>

--- a/src/EventStore.Core/Data/ExpectedVersion.cs
+++ b/src/EventStore.Core/Data/ExpectedVersion.cs
@@ -4,7 +4,6 @@ namespace EventStore.Core.Data {
 
 		public const long NoStream = -1;
 
-		//public const int EmptyStream = 0;
 		public const long Invalid = -3;
 		public const long StreamExists = -4;
 	}


### PR DESCRIPTION
Fixes #1441, Fixes #1950 

ExpectedVersion.EmptyStream is deprecated.
It will be removed in the next major version.