### PR TITLE
Add Read Only Replica

### DIFF
--- a/src/EventStore.ClientAPI/ClientOperations/OperationBase.cs
+++ b/src/EventStore.ClientAPI/ClientOperations/OperationBase.cs
@@ -108,6 +108,10 @@ namespace EventStore.ClientAPI.ClientOperations {
 					return new InspectionResult(InspectionDecision.Reconnect, "NotHandled - NotMaster",
 						masterInfo.ExternalTcpEndPoint, masterInfo.ExternalSecureTcpEndPoint);
 
+				case ClientMessage.NotHandled.NotHandledReason.IsReadOnly:
+					Log.Error("Cannot perform operation as this node is Read Only");
+					return new InspectionResult(InspectionDecision.NotSupported, "This node is Read Only");
+
 				default:
 					Log.Error("Unknown NotHandledReason: {0}.", message.Reason);
 					return new InspectionResult(InspectionDecision.Retry, "NotHandled - <unknown>");

--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -199,6 +199,12 @@ namespace EventStore.ClientAPI {
 			if (useSslConnection)
 				Ensure.NotNullOrEmpty(targetHost, "targetHost");
 
+			if (nodePreference == NodePreference.ReadOnlyReplica && requireMaster) {
+				throw new ArgumentException($"Having the Node Preference set to {nodePreference} and Requires Master" +
+				                            $" to {requireMaster} will reconnect the client to a master node once" +
+				                            " an operation is performed.");
+			}
+
 			Log = log;
 			VerboseLogging = verboseLogging;
 			MaxQueueSize = maxQueueSize;

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -354,6 +354,15 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
+		/// Whether to prioritize choosing a read only replica that's alive from the known nodes. 
+		/// </summary>
+		/// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+		public ConnectionSettingsBuilder PreferReadOnlyReplica() {
+			_nodePreference = NodePreference.ReadOnlyReplica;
+			return this;
+		}
+
+		/// <summary>
 		/// Sets the well-known port on which the cluster gossip is taking place.
 		///
 		/// If you are using the commercial edition of Event Store HA, with Manager nodes in

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -359,6 +359,7 @@ namespace EventStore.ClientAPI {
 		/// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
 		public ConnectionSettingsBuilder PreferReadOnlyReplica() {
 			_nodePreference = NodePreference.ReadOnlyReplica;
+			_requireMaster = false;
 			return this;
 		}
 

--- a/src/EventStore.ClientAPI/DnsClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/DnsClusterSettingsBuilder.cs
@@ -79,6 +79,15 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
+		/// Whether to prioritize choosing a read only replica that's alive from the known nodes. 
+		/// </summary>
+		/// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+		public DnsClusterSettingsBuilder PreferReadOnlyReplica() {
+			_nodePreference = NodePreference.ReadOnlyReplica;
+			return this;
+		}
+
+		/// <summary>
 		/// Sets the well-known port on which the cluster gossip is taking place.
 		/// 
 		/// If you are using the commercial edition of Event Store HA, with Manager nodes in

--- a/src/EventStore.ClientAPI/Exceptions/OperationNotSupportedException.cs
+++ b/src/EventStore.ClientAPI/Exceptions/OperationNotSupportedException.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventStore.ClientAPI.Exceptions {
+	/// <summary>
+	/// Exception thrown if an operation is not supported by a node.
+	/// For example: Write operations are not supported by read only nodes.
+	/// </summary>
+	public class OperationNotSupportedException : EventStoreConnectionException {
+		/// <summary>
+		/// Constructs a new instance of <see cref="OperationNotSupportedException"/>.
+		/// </summary>
+		/// <param name="operation">The name of the operation attempted.</param>
+		/// <param name="reason">The reason the operation is not supported.</param>
+		public OperationNotSupportedException(string operation, string reason)
+			: base(string.Format("Operation '{0}' is not supported : {1}", operation, reason)) {
+		}
+
+		/// <summary>
+		/// Constructs a new instance of <see cref="OperationNotSupportedException"/>.
+		/// </summary>
+		/// <param name="operation">The name of the operation attempted.</param>
+		public OperationNotSupportedException(string operation)
+			: base(string.Format("Operation '{0}' is not supported", operation)) {
+		}
+	}
+}

--- a/src/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
@@ -118,6 +118,15 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
+		/// Whether to prioritize choosing a read only replica that's alive from the known nodes. 
+		/// </summary>
+		/// <returns>A <see cref="DnsClusterSettingsBuilder"/> for further configuration.</returns>
+		public GossipSeedClusterSettingsBuilder PreferReadOnlyReplica() {
+			_nodePreference = NodePreference.ReadOnlyReplica;
+			return this;
+		}
+
+		/// <summary>
 		/// Builds a <see cref="ClusterSettings"/> object from a <see cref="GossipSeedClusterSettingsBuilder"/>.
 		/// </summary>
 		/// <param name="builder"><see cref="GossipSeedClusterSettingsBuilder"/> from which to build a <see cref="ClusterSettings"/></param>

--- a/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
@@ -509,6 +509,11 @@ namespace EventStore.ClientAPI.Internal {
 						ReconnectTo(new NodeEndPoints(result.TcpEndPoint, result.SecureTcpEndPoint));
 						_operations.ScheduleOperationRetry(operation);
 						break;
+					case InspectionDecision.NotSupported:
+						operation.Operation.Fail(
+							new OperationNotSupportedException(operation.Operation.GetType().Name, result.Description));
+						_operations.RemoveOperation(operation);
+						break;
 					default: throw new Exception(string.Format("Unknown InspectionDecision: {0}", result.Decision));
 				}
 

--- a/src/EventStore.ClientAPI/Messages/ClientMessage.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessage.cs
@@ -1195,7 +1195,10 @@ namespace EventStore.ClientAPI.Messages
       TooBusy = 1,
             
       [ProtoEnum(Name=@"NotMaster", Value=2)]
-      NotMaster = 2
+      NotMaster = 2,
+            
+      [ProtoEnum(Name=@"IsReadOnly", Value=3)]
+      IsReadOnly = 3
     }
   
     private NotHandled() {}

--- a/src/EventStore.ClientAPI/Messages/ClusterMessages.cs
+++ b/src/EventStore.ClientAPI/Messages/ClusterMessages.cs
@@ -76,7 +76,10 @@ namespace EventStore.ClientAPI.Messages {
 			Master,
 			Manager,
 			ShuttingDown,
-			Shutdown
+			Shutdown,
+			ReadOnlyMasterless,
+			PreReadOnlyReplica,
+			ReadOnlyReplica
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/NodePreference.cs
+++ b/src/EventStore.ClientAPI/NodePreference.cs
@@ -22,6 +22,11 @@ namespace EventStore.ClientAPI {
 		/// <summary>
 		/// When attempting connnection, has no node preference.
 		/// </summary>
-		Random
+		Random,
+
+		/// <summary>
+		/// When attempting connection, prefers read only replicas.
+		/// </summary>
+		ReadOnlyReplica
 	}
 }

--- a/src/EventStore.ClientAPI/SystemData/InspectionDecision.cs
+++ b/src/EventStore.ClientAPI/SystemData/InspectionDecision.cs
@@ -4,6 +4,7 @@ namespace EventStore.ClientAPI.SystemData {
 		EndOperation,
 		Retry,
 		Reconnect,
-		Subscribed
+		Subscribed,
+		NotSupported
 	}
 }

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -286,6 +286,9 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.GossipTimeoutMsDescr, Opts.ClusterGroup)]
 		public int GossipTimeoutMs { get; set; }
 
+		[ArgDescription(Opts.ReadOnlyReplicaDescr, Opts.ClusterGroup)]
+		public bool ReadOnlyReplica { get; set; }
+
 		[ArgDescription(Opts.HistogramDescr, Opts.AppGroup)]
 		public bool EnableHistograms { get; set; }
 
@@ -343,6 +346,7 @@ namespace EventStore.ClusterNode {
 			ClusterDns = Opts.ClusterDnsDefault;
 			ClusterGossipPort = Opts.ClusterGossipPortDefault;
 			GossipSeed = Opts.GossipSeedDefault;
+			ReadOnlyReplica = Opts.ReadOnlyReplicaDefault;
 
 			StatsPeriodSec = Opts.StatsPeriodDefault;
 

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -171,6 +171,8 @@ namespace EventStore.ClusterNode {
 			VNodeBuilder builder;
 			if (options.ClusterSize > 1) {
 				builder = ClusterVNodeBuilder.AsClusterMember(options.ClusterSize);
+				if (options.ReadOnlyReplica)
+					builder.EnableReadOnlyReplica();
 			} else {
 				builder = ClusterVNodeBuilder.AsSingleNode();
 			}

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -168,6 +168,11 @@ namespace EventStore.ClusterNode {
 						"Usage of internal secure communication is specified, but no internal secure endpoint is specified!");
 			}
 
+			if (options.ReadOnlyReplica && options.ClusterSize <= 1) {
+				throw new Exception(
+					"This node cannot be configured as a Read Only Replica as these node types are only supported in a clustered configuration.");
+			}
+
 			VNodeBuilder builder;
 			if (options.ClusterSize > 1) {
 				builder = ClusterVNodeBuilder.AsClusterMember(options.ClusterSize);

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.Helpers {
 			IPAddress advertisedExtIPAddress = null, int advertisedExtHttpPort = 0,
 			int hashCollisionReadLimit = EventStore.Core.Util.Opts.HashCollisionReadLimitDefault,
 			byte indexBitnessVersion = EventStore.Core.Util.Opts.IndexBitnessVersionDefault,
-			string dbPath = "") {
+			string dbPath = "", bool isReadOnlyReplica = false) {
 			if (_running) throw new Exception("Previous MiniNode is still running!!!");
 			_running = true;
 
@@ -125,6 +125,8 @@ namespace EventStore.Core.Tests.Helpers {
 				builder.EnableTrustedAuth();
 			if (disableFlushToDisk)
 				builder.WithUnsafeDisableFlushToDisk();
+			if (isReadOnlyReplica)
+				builder.EnableReadOnlyReplica();
 
 			if (subsystems != null) {
 				foreach (var subsystem in subsystems) {

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -91,12 +91,16 @@ namespace EventStore.Core.Tests.Integration {
 			WaitHandle.WaitAll(new[] {_nodes[0].StartedEvent, _nodes[1].StartedEvent, _nodes[2].StartedEvent});
 			QueueStatsCollector.WaitIdle(waitForNonEmptyTf: true);
 
-			_conn = EventStoreConnection.Create(_nodes[0].ExternalTcpEndPoint);
+			_conn = CreateConnection();
 			_conn.ConnectAsync().Wait();
 
 			QueueStatsCollector.WaitIdle();
 
 			Given();
+		}
+
+		protected virtual IEventStoreConnection CreateConnection() {
+			return EventStoreConnection.Create(_nodes[0].ExternalTcpEndPoint);
 		}
 
 		protected virtual void BeforeNodesStart() {
@@ -115,7 +119,7 @@ namespace EventStore.Core.Tests.Integration {
 			WaitHandle.WaitAll(new[] {_nodes[nodeNum].StartedEvent});
 		}
 
-		private MiniClusterNode CreateNode(int index, Endpoints endpoints, IPEndPoint[] gossipSeeds, bool wait = true) {
+		protected virtual MiniClusterNode CreateNode(int index, Endpoints endpoints, IPEndPoint[] gossipSeeds, bool wait = true) {
 			var node = new MiniClusterNode(
 				PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp,
 				endpoints.ExternalTcp,

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						LastCommitPosition, WriterCheckpoint, ChaserCheckpoint,
 						-1,
 						-1,
-						Guid.Empty, 0)
+						Guid.Empty, 0, false)
 				})
 				.Union(clusterSettings.GroupMembers
 					.Select(x => MemberInfo.ForVNode(x.NodeInfo.InstanceId,
@@ -90,7 +90,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						LastCommitPosition, WriterCheckpoint, ChaserCheckpoint,
 						-1,
 						-1,
-						Guid.Empty, 0)));
+						Guid.Empty, 0, false)));
 
 			var ordered = members.OrderBy(x =>
 				string.Format("{0}:{1}", x.InternalHttpEndPoint.ToString(), x.InternalHttpEndPoint.Port));
@@ -174,7 +174,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						x.ExternalTcpEndPoint, x.ExternalSecureTcpEndPoint,
 						x.InternalHttpEndPoint, x.ExternalHttpEndPoint,
 						x.LastCommitPosition, x.WriterCheckpoint, x.ChaserCheckpoint,
-						x.EpochPosition, x.EpochNumber, x.EpochId, x.NodePriority));
+						x.EpochPosition, x.EpochNumber, x.EpochId, x.NodePriority, x.IsReadOnlyReplica));
 		}
 
 		public IEnumerable<MemberInfo> ListAliveMembers(Func<MemberInfo, bool> predicate = null) {

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/UpdateGossipProcessor.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/UpdateGossipProcessor.cs
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 							MemberInfo.ForVNode(previousMasterInfo.InstanceId, DateTime.UtcNow, VNodeState.Master,
 								previousMasterInfo.IsAlive,
 								masterEndPoint, null, masterEndPoint, null, masterEndPoint, masterEndPoint,
-								-1, 0, 0, -1, -1, Guid.Empty, 0);
+								-1, 0, 0, -1, -1, Guid.Empty, 0, false);
 					}
 				}
 			}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_with_1_known_when_started_and_set_full_imediately.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_with_1_known_when_started_and_set_full_imediately.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			return new[] {
 				MemberInfo.ForVNode(instance.InstanceId, DateTime.UtcNow, VNodeState.Unknown, true,
 					instance.EndPoint, null, instance.EndPoint, null, instance.EndPoint, instance.EndPoint,
-					-1, 0, 0, -1, -1, Guid.Empty, 0)
+					-1, 0, 0, -1, -1, Guid.Empty, 0, false)
 			};
 		}
 
@@ -47,7 +47,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 				return instances.Select((x, i) =>
 					MemberInfo.ForVNode(x.InstanceId, DateTime.UtcNow, VNodeState.Unknown, true,
 						x.EndPoint, null, x.EndPoint, null, x.EndPoint, x.EndPoint,
-						-1, 0, 0, -1, -1, Guid.Empty, 0)).ToArray();
+						-1, 0, 0, -1, -1, Guid.Empty, 0, false)).ToArray();
 			}
 
 			return null;

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_with_1_known_when_started_and_set_to_full_later.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/elections_service_5_nodes_with_1_known_when_started_and_set_to_full_later.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			return new[] {
 				MemberInfo.ForVNode(instance.InstanceId, DateTime.UtcNow, VNodeState.Unknown, true,
 					instance.EndPoint, null, instance.EndPoint, null, instance.EndPoint, instance.EndPoint,
-					-1, 0, 0, -1, -1, Guid.Empty, 0)
+					-1, 0, 0, -1, -1, Guid.Empty, 0, false)
 			};
 		}
 
@@ -49,7 +49,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 				return instances.Select((x, i) =>
 						MemberInfo.ForVNode(x.InstanceId, DateTime.UtcNow, VNodeState.Unknown, true,
 							x.EndPoint, null, x.EndPoint, null, x.EndPoint, x.EndPoint,
-							-1, 0, 0, -1, -1, Guid.Empty, 0))
+							-1, 0, 0, -1, -1, Guid.Empty, 0, false))
 					.ToArray();
 			}
 

--- a/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		[SetUp]
 		public void SetUp() {
 			var clusterSettingsFactory = new ClusterSettingsFactory();
-			var clusterSettings = clusterSettingsFactory.GetClusterSettings(1, 3);
+			var clusterSettings = clusterSettingsFactory.GetClusterSettings(1, 3, false);
 
 			_electionsUnit = new ElectionsServiceUnit(clusterSettings);
 
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		[Test]
-		public void elect_node_with_biggest_port_ip_for_equal_writerchecksums() {
+		public void elections_should_time_out() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
 		}
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		[SetUp]
 		public void SetUp() {
 			var clusterSettingsFactory = new ClusterSettingsFactory();
-			var clusterSettings = clusterSettingsFactory.GetClusterSettings(1, 3);
+			var clusterSettings = clusterSettingsFactory.GetClusterSettings(1, 3, false);
 
 			_electionsUnit = new ElectionsServiceUnit(clusterSettings);
 
@@ -67,7 +67,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		[Test]
-		public void elect_node_with_biggest_port_ip_for_equal_writerchecksums() {
+		public void elections_should_time_out() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
 		}
@@ -80,7 +80,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		[SetUp]
 		public void SetUp() {
 			var clusterSettingsFactory = new ClusterSettingsFactory();
-			var clusterSettings = clusterSettingsFactory.GetClusterSettings(1, 3);
+			var clusterSettings = clusterSettingsFactory.GetClusterSettings(1, 3, false);
 
 			_electionsUnit = new ElectionsServiceUnit(clusterSettings);
 			_electionsUnit.UpdateClusterMemberInfo(0, isAlive: false);
@@ -116,7 +116,56 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		[Test]
-		public void elect_node_with_biggest_port_ip_for_equal_writerchecksums() {
+		public void elections_should_time_out() {
+			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
+			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
+		}
+	}
+
+	[TestFixture]
+	public sealed class elections_service_should_be_stuck_with_live_node_and_read_only_replica{
+		private ElectionsServiceUnit _electionsUnit;
+
+		[SetUp]
+		public void SetUp() {
+			var clusterSettingsFactory = new ClusterSettingsFactory();
+			var clusterSettings = clusterSettingsFactory.GetClusterSettings(1, 4, true);
+
+			_electionsUnit = new ElectionsServiceUnit(clusterSettings);
+			_electionsUnit.UpdateClusterMemberInfo(0, isAlive: true);
+			_electionsUnit.UpdateClusterMemberInfo(1, isAlive: true);
+			// Kill the other two nodes in the cluster
+			_electionsUnit.UpdateClusterMemberInfo(2, isAlive: false);
+			_electionsUnit.UpdateClusterMemberInfo(3, isAlive: false);
+
+			StartElections();
+		}
+		
+		private void StartElections() {
+			var gossipUpdate = new GossipMessage.GossipUpdated(_electionsUnit.ClusterInfo);
+			_electionsUnit.Publish(gossipUpdate);
+
+			_electionsUnit.Publish(new ElectionMessage.StartElections());
+
+			_electionsUnit.RepublishFromPublisher();
+
+			_electionsUnit.RepublishFromPublisher();
+			Assert.That(_electionsUnit.Publisher.Messages.All(x => x is HttpMessage.SendOverHttp || x is TimerMessage.Schedule),
+				Is.True,
+				"Only OverHttp or Schedule messages are expected.");
+
+			_electionsUnit.RepublishFromPublisher();
+
+			_electionsUnit.RepublishFromPublisher();
+			Assert.That(_electionsUnit.Publisher.Messages.All(x => x is HttpMessage.SendOverHttp || x is TimerMessage.Schedule),
+				Is.True,
+				"Only OverHttp or Schedule messages are expected.");
+
+			_electionsUnit.RepublishFromPublisher();
+		}
+
+		[Test]
+		public void elections_should_time_out() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
 		}

--- a/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/CommitReplication/with_index_committer_service.cs
@@ -94,7 +94,7 @@ namespace EventStore.Core.Tests.Services.Replication.CommitReplication {
 			var masterIPEndPoint = new IPEndPoint(IPAddress.Loopback, 2113);
 			_service.Handle(new SystemMessage.BecomeSlave(Guid.NewGuid(), new VNodeInfo(Guid.NewGuid(), 1,
 				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint,
-				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint)));
+				masterIPEndPoint, masterIPEndPoint, masterIPEndPoint, false)));
 		}
 	}
 

--- a/src/EventStore.Core.Tests/Services/Replication/ReadOnlyReplica/connecting_to_read_only_replica.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReadOnlyReplica/connecting_to_read_only_replica.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Net;
+using EventStore.ClientAPI;
+using EventStore.ClientAPI.Exceptions;
+using EventStore.Core.Tests.ClientAPI.Helpers;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.Integration;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Replication.ReadOnlyReplica {
+
+	[TestFixture]
+	[Category("LongRunning")]
+	public class connecting_to_read_only_replica : specification_with_cluster {
+		protected override MiniClusterNode CreateNode(int index, Endpoints endpoints, IPEndPoint[] gossipSeeds, bool wait = true) {
+			var isReadOnly = index == 2;
+			var node = new MiniClusterNode(
+				PathName, index, endpoints.InternalTcp, endpoints.InternalTcpSec, endpoints.InternalHttp,
+				endpoints.ExternalTcp,
+				endpoints.ExternalTcpSec, endpoints.ExternalHttp, skipInitializeStandardUsersCheck: false,
+				subsystems: new ISubsystem[] { }, gossipSeeds: gossipSeeds, inMemDb: false,
+				readOnlyReplica: isReadOnly);
+			if (wait && !isReadOnly)
+				WaitIdle();
+			return node;
+		}
+
+		protected override IEventStoreConnection CreateConnection() {
+			var settings = ConnectionSettings.Create()
+			.PerformOnAnyNode();
+			return EventStoreConnection.Create(settings, _nodes[2].ExternalTcpEndPoint);
+		}
+
+		[Test]
+		public void append_to_stream_should_fail_with_not_supported_exception() {
+			const string stream = "append_to_stream_should_fail_with_not_supported_exception";
+			var append = _conn.AppendToStreamAsync(stream, ExpectedVersion.Any, new[] { TestEvent.NewTestEvent() });
+			Assert.That(() => append.Wait(),
+				Throws.Exception.TypeOf<AggregateException>().With.InnerException.TypeOf<OperationNotSupportedException>());
+		}
+
+		[Test]
+		public void delete_stream_should_fail_with_not_supported_exception() {
+			const string stream = "delete_stream_should_fail_with_not_supported_exception";
+			var delete = _conn.DeleteStreamAsync(stream, ExpectedVersion.Any);
+			Assert.That(() => delete.Wait(),
+				Throws.Exception.TypeOf<AggregateException>().With.InnerException.TypeOf<OperationNotSupportedException>());
+		}
+
+		[Test]
+		public void start_transaction_should_fail_with_not_supported_exception() {
+			const string stream = "start_transaction_should_fail_with_not_supported_exception";
+			var start = _conn.StartTransactionAsync(stream, ExpectedVersion.Any);
+			Assert.That(() => start.Wait(),
+				Throws.Exception.TypeOf<AggregateException>().With.InnerException.TypeOf<OperationNotSupportedException>());
+		}
+	}
+}

--- a/src/EventStore.Core/Cluster/MemberInfo.cs
+++ b/src/EventStore.Core/Cluster/MemberInfo.cs
@@ -28,13 +28,14 @@ namespace EventStore.Core.Cluster {
 		public readonly Guid EpochId;
 
 		public readonly int NodePriority;
+		public readonly bool IsReadOnlyReplica;
 
 		public static MemberInfo ForManager(Guid instanceId, DateTime timeStamp, bool isAlive,
 			IPEndPoint internalHttpEndPoint, IPEndPoint externalHttpEndPoint) {
 			return new MemberInfo(instanceId, timeStamp, VNodeState.Manager, true,
 				internalHttpEndPoint, null, externalHttpEndPoint, null,
 				internalHttpEndPoint, externalHttpEndPoint,
-				-1, -1, -1, -1, -1, Guid.Empty, 0);
+				-1, -1, -1, -1, -1, Guid.Empty, 0, false);
 		}
 
 		public static MemberInfo ForVNode(Guid instanceId,
@@ -53,7 +54,8 @@ namespace EventStore.Core.Cluster {
 			long epochPosition,
 			int epochNumber,
 			Guid epochId,
-			int nodePriority) {
+			int nodePriority,
+			bool isReadOnlyReplica) {
 			if (state == VNodeState.Manager)
 				throw new ArgumentException(string.Format("Wrong State for VNode: {0}", state), "state");
 			return new MemberInfo(instanceId, timeStamp, state, isAlive,
@@ -61,7 +63,7 @@ namespace EventStore.Core.Cluster {
 				externalTcpEndPoint, externalSecureTcpEndPoint,
 				internalHttpEndPoint, externalHttpEndPoint,
 				lastCommitPosition, writerCheckpoint, chaserCheckpoint,
-				epochPosition, epochNumber, epochId, nodePriority);
+				epochPosition, epochNumber, epochId, nodePriority, isReadOnlyReplica);
 		}
 
 		private MemberInfo(Guid instanceId, DateTime timeStamp, VNodeState state, bool isAlive,
@@ -69,7 +71,7 @@ namespace EventStore.Core.Cluster {
 			IPEndPoint externalTcpEndPoint, IPEndPoint externalSecureTcpEndPoint,
 			IPEndPoint internalHttpEndPoint, IPEndPoint externalHttpEndPoint,
 			long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint,
-			long epochPosition, int epochNumber, Guid epochId, int nodePriority) {
+			long epochPosition, int epochNumber, Guid epochId, int nodePriority, bool isReadOnlyReplica) {
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
 			Ensure.NotNull(internalHttpEndPoint, "internalHttpEndPoint");
@@ -97,6 +99,7 @@ namespace EventStore.Core.Cluster {
 			EpochId = epochId;
 
 			NodePriority = nodePriority;
+			IsReadOnlyReplica = isReadOnlyReplica;
 		}
 
 		internal MemberInfo(MemberInfoDto dto) {
@@ -123,6 +126,7 @@ namespace EventStore.Core.Cluster {
 			EpochNumber = dto.EpochNumber;
 			EpochId = dto.EpochId;
 			NodePriority = dto.NodePriority;
+			IsReadOnlyReplica = dto.IsReadOnlyReplica;
 		}
 
 		public bool Is(IPEndPoint endPoint) {
@@ -157,7 +161,8 @@ namespace EventStore.Core.Cluster {
 				epoch != null ? epoch.EpochPosition : EpochPosition,
 				epoch != null ? epoch.EpochNumber : EpochNumber,
 				epoch != null ? epoch.EpochId : EpochId,
-				NodePriority);
+				NodePriority,
+				IsReadOnlyReplica);
 		}
 
 		public override string ToString() {
@@ -192,7 +197,8 @@ namespace EventStore.Core.Cluster {
 			       && other.EpochPosition == EpochPosition
 			       && other.EpochNumber == EpochNumber
 			       && other.EpochId == EpochId
-			       && other.NodePriority == NodePriority;
+			       && other.NodePriority == NodePriority
+				   && other.IsReadOnlyReplica == IsReadOnlyReplica;
 		}
 
 		public override bool Equals(object obj) {

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -84,6 +84,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool GossipOnSingleNode;
 		public readonly bool FaultOutOfOrderProjections;
 		public readonly bool StructuredLog;
+		public readonly bool ReadOnlyReplica;
 
 		public ClusterVNodeSettings(Guid instanceId, int debugIndex,
 			IPEndPoint internalTcpEndPoint,
@@ -153,7 +154,8 @@ namespace EventStore.Core.Cluster.Settings {
 			bool faultOutOfOrderProjections = false,
 			bool structuredLog = false,
 			int maxAutoMergeIndexLevel = 1000,
-			bool disableFirstLevelHttpAuthorization = false) {
+			bool disableFirstLevelHttpAuthorization = false,
+			bool readOnlyReplica = false) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
@@ -182,7 +184,8 @@ namespace EventStore.Core.Cluster.Settings {
 			NodeInfo = new VNodeInfo(instanceId, debugIndex,
 				internalTcpEndPoint, internalSecureTcpEndPoint,
 				externalTcpEndPoint, externalSecureTcpEndPoint,
-				internalHttpEndPoint, externalHttpEndPoint);
+				internalHttpEndPoint, externalHttpEndPoint,
+				readOnlyReplica);
 			GossipAdvertiseInfo = gossipAdvertiseInfo;
 			IntHttpPrefixes = intHttpPrefixes;
 			ExtHttpPrefixes = extHttpPrefixes;
@@ -255,6 +258,7 @@ namespace EventStore.Core.Cluster.Settings {
 			MaxAutoMergeIndexLevel = maxAutoMergeIndexLevel;
 			FaultOutOfOrderProjections = faultOutOfOrderProjections;
 			StructuredLog = structuredLog;
+			ReadOnlyReplica = readOnlyReplica;
 		}
 
 		public override string ToString() {
@@ -299,7 +303,8 @@ namespace EventStore.Core.Cluster.Settings {
 			                     + "ReduceFileCachePressure: {38}\n"
 			                     + "InitializationThreads: {39}\n"
 			                     + "StructuredLog: {40}\n"
-								 + "DisableFirstLevelHttpAuthorization: {41}\n",
+								 + "DisableFirstLevelHttpAuthorization: {41}\n"
+								 + "ReadOnlyReplica: {42}\n",
 				NodeInfo.InstanceId,
 				NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
 				NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -319,7 +324,7 @@ namespace EventStore.Core.Cluster.Settings {
 				EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge,
 				ConnectionPendingSendBytesThreshold, ChunkInitialReaderCount,
 				ReduceFileCachePressure, InitializationThreads, StructuredLog,
-				DisableFirstLevelHttpAuthorization);
+				DisableFirstLevelHttpAuthorization, ReadOnlyReplica);
 		}
 	}
 }

--- a/src/EventStore.Core/Cluster/VNodeInfo.cs
+++ b/src/EventStore.Core/Cluster/VNodeInfo.cs
@@ -6,7 +6,8 @@ namespace EventStore.Core.Cluster {
 			return new VNodeInfo(member.InstanceId, 0,
 				member.InternalTcpEndPoint, member.InternalSecureTcpEndPoint,
 				member.ExternalTcpEndPoint, member.ExternalSecureTcpEndPoint,
-				member.InternalHttpEndPoint, member.ExternalHttpEndPoint);
+				member.InternalHttpEndPoint, member.ExternalHttpEndPoint,
+				member.IsReadOnlyReplica);
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -576,7 +576,8 @@ namespace EventStore.Core {
 				vNodeSettings.GossipAdvertiseInfo.ExternalTcp,
 				vNodeSettings.GossipAdvertiseInfo.ExternalSecureTcp,
 				vNodeSettings.GossipAdvertiseInfo.InternalHttp,
-				vNodeSettings.GossipAdvertiseInfo.ExternalHttp);
+				vNodeSettings.GossipAdvertiseInfo.ExternalHttp,
+				vNodeSettings.ReadOnlyReplica);
 			if (!isSingleNode) {
 				// MASTER REPLICATION
 				var masterReplicationService = new MasterReplicationService(_mainQueue, gossipInfo.InstanceId, db,

--- a/src/EventStore.Core/Data/VNodeInfo.cs
+++ b/src/EventStore.Core/Data/VNodeInfo.cs
@@ -12,11 +12,13 @@ namespace EventStore.Core.Data {
 		public readonly IPEndPoint ExternalSecureTcp;
 		public readonly IPEndPoint InternalHttp;
 		public readonly IPEndPoint ExternalHttp;
+		public readonly bool IsReadOnlyReplica;
 
 		public VNodeInfo(Guid instanceId, int debugIndex,
 			IPEndPoint internalTcp, IPEndPoint internalSecureTcp,
 			IPEndPoint externalTcp, IPEndPoint externalSecureTcp,
-			IPEndPoint internalHttp, IPEndPoint externalHttp) {
+			IPEndPoint internalHttp, IPEndPoint externalHttp,
+			bool isReadOnlyReplica) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcp, "internalTcp");
 			Ensure.NotNull(externalTcp, "externalTcp");
@@ -31,6 +33,7 @@ namespace EventStore.Core.Data {
 			ExternalSecureTcp = externalSecureTcp;
 			InternalHttp = internalHttp;
 			ExternalHttp = externalHttp;
+			IsReadOnlyReplica = isReadOnlyReplica;
 		}
 
 		public bool Is(IPEndPoint endPoint) {
@@ -45,14 +48,16 @@ namespace EventStore.Core.Data {
 
 		public override string ToString() {
 			return string.Format("InstanceId: {0:B}, InternalTcp: {1}, InternalSecureTcp: {2}, " +
-			                     "ExternalTcp: {3}, ExternalSecureTcp: {4}, InternalHttp: {5}, ExternalHttp: {6}",
+			                     "ExternalTcp: {3}, ExternalSecureTcp: {4}, InternalHttp: {5}, ExternalHttp: {6}," +
+								 "IsReadOnlyReplica: {7}",
 				InstanceId,
 				InternalTcp,
 				InternalSecureTcp,
 				ExternalTcp,
 				ExternalSecureTcp,
 				InternalHttp,
-				ExternalHttp);
+				ExternalHttp,
+				IsReadOnlyReplica);
 		}
 	}
 }

--- a/src/EventStore.Core/Data/VNodeState.cs
+++ b/src/EventStore.Core/Data/VNodeState.cs
@@ -10,14 +10,18 @@ namespace EventStore.Core.Data {
 		Master,
 		Manager,
 		ShuttingDown,
-		Shutdown
+		Shutdown,
+		ReadOnlyMasterless,
+		PreReadOnlyReplica,
+		ReadOnlyReplica,
 	}
 
 	public static class VNodeStateExtensions {
 		public static bool IsReplica(this VNodeState state) {
 			return state == VNodeState.CatchingUp
 			       || state == VNodeState.Clone
-			       || state == VNodeState.Slave;
+			       || state == VNodeState.Slave
+				   || state == VNodeState.ReadOnlyReplica;
 		}
 	}
 }

--- a/src/EventStore.Core/Messages/MemberInfoDto.cs
+++ b/src/EventStore.Core/Messages/MemberInfoDto.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Messages {
 		public Guid EpochId { get; set; }
 
 		public int NodePriority { get; set; }
+		public bool IsReadOnlyReplica { get; set; }
 
 		public MemberInfoDto() {
 		}
@@ -69,6 +70,7 @@ namespace EventStore.Core.Messages {
 			EpochId = member.EpochId;
 
 			NodePriority = member.NodePriority;
+			IsReadOnlyReplica = member.IsReadOnlyReplica;
 		}
 
 		public override string ToString() {
@@ -77,13 +79,14 @@ namespace EventStore.Core.Messages {
 			                     + "ExternalTcpIp: {7}, ExternalTcpPort: {8}, ExternalSecureTcpPort: {9}, "
 			                     + "InternalHttpIp: {10}, InternalHttpPort: {11}, ExternalHttpIp: {12}, ExternalHttpPort: {13}, "
 			                     + "LastCommitPosition: {14}, WriterCheckpoint: {15}, ChaserCheckpoint: {16}, "
-			                     + "EpochPosition: {17}, EpochNumber: {18}, EpochId: {19:B}, NodePriority: {20}",
+			                     + "EpochPosition: {17}, EpochNumber: {18}, EpochId: {19:B}, NodePriority: {20}, "
+			                     + "IsReadOnlyReplica: {21}",
 				InstanceId, TimeStamp, State, IsAlive,
 				InternalTcpIp, InternalTcpPort, InternalSecureTcpPort,
 				ExternalTcpIp, ExternalTcpPort, ExternalSecureTcpPort,
 				InternalHttpIp, InternalHttpPort, ExternalHttpIp, ExternalHttpPort,
 				LastCommitPosition, WriterCheckpoint, ChaserCheckpoint,
-				EpochPosition, EpochNumber, EpochId, NodePriority);
+				EpochPosition, EpochNumber, EpochId, NodePriority, IsReadOnlyReplica);
 		}
 	}
 }

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -220,6 +220,43 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class BecomeReadOnlyMasterless : StateChangeMessage {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public BecomeReadOnlyMasterless (Guid correlationId)
+				: base(correlationId, VNodeState.ReadOnlyMasterless) {
+			}
+		}
+
+		public class BecomePreReadOnlyReplica : ReplicaStateMessage {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public BecomePreReadOnlyReplica(Guid correlationId, VNodeInfo master)
+				: base(correlationId, VNodeState.PreReadOnlyReplica, master) {
+			}
+		}
+
+		public class BecomeReadOnlyReplica : ReplicaStateMessage {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public BecomeReadOnlyReplica(Guid correlationId, VNodeInfo master)
+				: base(correlationId, VNodeState.ReadOnlyReplica, master) {
+			}
+		}
+
+
 		public class ServiceShutdown : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Messages/TcpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDto.cs
@@ -1195,7 +1195,10 @@ namespace EventStore.Core.Messages
       TooBusy = 1,
             
       [ProtoEnum(Name=@"NotMaster", Value=2)]
-      NotMaster = 2
+      NotMaster = 2,
+            
+      [ProtoEnum(Name=@"IsReadOnly", Value=3)]
+      IsReadOnly = 3
     }
   
     private NotHandled() {}

--- a/src/EventStore.Core/Services/Gossip/NodeGossipService.cs
+++ b/src/EventStore.Core/Services/Gossip/NodeGossipService.cs
@@ -40,9 +40,11 @@ namespace EventStore.Core.Services.Gossip {
 
 		protected override MemberInfo GetInitialMe() {
 			var lastEpoch = _epochManager.GetLastEpoch();
+			var initialState = NodeInfo.IsReadOnlyReplica ?
+				VNodeState.ReadOnlyMasterless : VNodeState.Unknown;
 			return MemberInfo.ForVNode(NodeInfo.InstanceId,
 				DateTime.UtcNow,
-				VNodeState.Unknown,
+				initialState,
 				true,
 				NodeInfo.InternalTcp,
 				NodeInfo.InternalSecureTcp,
@@ -56,7 +58,8 @@ namespace EventStore.Core.Services.Gossip {
 				lastEpoch == null ? -1 : lastEpoch.EpochPosition,
 				lastEpoch == null ? -1 : lastEpoch.EpochNumber,
 				lastEpoch == null ? Guid.Empty : lastEpoch.EpochId,
-				_nodePriority);
+				_nodePriority,
+				NodeInfo.IsReadOnlyReplica);
 		}
 
 		protected override MemberInfo GetUpdatedMe(MemberInfo me) {

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -45,6 +45,8 @@ namespace EventStore.Core.Services {
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
 				case VNodeState.Slave:
+				case VNodeState.PreReadOnlyReplica:
+				case VNodeState.ReadOnlyReplica:
 					_masterInfo = ((SystemMessage.ReplicaStateMessage)message).Master;
 					break;
 				case VNodeState.Initializing:
@@ -54,6 +56,7 @@ namespace EventStore.Core.Services {
 				case VNodeState.Manager:
 				case VNodeState.ShuttingDown:
 				case VNodeState.Shutdown:
+				case VNodeState.ReadOnlyMasterless:
 					_masterInfo = null;
 					break;
 				default:

--- a/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
+++ b/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
@@ -201,6 +201,7 @@ namespace EventStore.Core.Services.Monitoring {
 				case VNodeState.CatchingUp:
 				case VNodeState.Clone:
 				case VNodeState.Slave:
+				case VNodeState.ReadOnlyReplica:
 				case VNodeState.Master: {
 					SetStatsStreamMetadata();
 					break;

--- a/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/MasterReplicationService.cs
@@ -514,7 +514,7 @@ namespace EventStore.Core.Services.Replication {
 		private void ManageNoQuorumDetection() {
 			if (_state == VNodeState.Master) {
 				var now = _stopwatch.Elapsed;
-				if (_subscriptions.Count >= _clusterSize / 2) // everything is ok
+				if (_subscriptions.Count(x => x.Value.IsPromotable) >= _clusterSize / 2) // everything is ok
 					_noQuorumTimestamp = TimeSpan.Zero;
 				else {
 					if (_noQuorumTimestamp == TimeSpan.Zero) {

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -197,7 +197,9 @@ namespace EventStore.Core.Services.Storage {
 
 		void IHandle<SystemMessage.WaitForChaserToCatchUp>.Handle(SystemMessage.WaitForChaserToCatchUp message) {
 			// if we are in states, that doesn't need to wait for chaser, ignore
-			if (_vnodeState != VNodeState.PreMaster && _vnodeState != VNodeState.PreReplica)
+			if (_vnodeState != VNodeState.PreMaster &&
+				_vnodeState != VNodeState.PreReplica &&
+				_vnodeState != VNodeState.PreReadOnlyReplica)
 				throw new Exception(string.Format("{0} appeared in {1} state.", message.GetType().Name, _vnodeState));
 
 			if (Writer.Checkpoint.Read() != Writer.Checkpoint.ReadNonFlushed())

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -365,6 +365,10 @@ namespace EventStore.Core.Util {
 		public const string GossipSeedDescr = "Endpoints for other cluster nodes from which to seed gossip";
 		public static readonly IPEndPoint[] GossipSeedDefault = new IPEndPoint[0];
 
+		public const string ReadOnlyReplicaDescr = 
+			"Sets this node as a read only replica that is not allowed to participate in elections or accept writes from clients.";
+		public static readonly bool ReadOnlyReplicaDefault = false;
+
 		/*
 		 *  MANAGER OPTIONS
 		 */

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -136,6 +136,8 @@ namespace EventStore.Core {
 
 		private bool _gossipOnSingleNode;
 
+		private bool _readOnlyReplica;
+
 		// ReSharper restore FieldCanBeMadeReadOnly.Local
 
 		protected VNodeBuilder() {
@@ -229,6 +231,8 @@ namespace EventStore.Core {
 			_faultOutOfOrderProjections = Opts.FaultOutOfOrderProjectionsDefault;
 			_reduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
 			_initializationThreads = Opts.InitializationThreadsDefault;
+
+			_readOnlyReplica = Opts.ReadOnlyReplicaDefault;
 		}
 
 		protected VNodeBuilder WithSingleNodeSettings() {
@@ -1211,6 +1215,16 @@ namespace EventStore.Core {
 			return this;
 		}
 
+		/// <summary>
+		/// Sets this node as a read only replica that is not allowed to participate in elections.
+		/// </summary>
+		/// <returns></returns>
+		public VNodeBuilder EnableReadOnlyReplica() {
+			_readOnlyReplica = true;
+
+			return this;
+		}
+
 		private void EnsureHttpPrefixes() {
 			if (_intHttpPrefixes == null || _intHttpPrefixes.IsEmpty())
 				_intHttpPrefixes = new List<string>();
@@ -1406,7 +1420,8 @@ namespace EventStore.Core {
 				_faultOutOfOrderProjections,
 				_structuredLog,
 				_maxAutoMergeIndexLevel,
-				_disableFirstLevelHttpAuthorization);
+				_disableFirstLevelHttpAuthorization,
+				_readOnlyReplica);
 
 			var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_starting_up.cs
@@ -55,7 +55,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system {
 						new IPEndPoint(IPAddress.Loopback, 1113),
 						new IPEndPoint(IPAddress.Loopback, 1114),
 						new IPEndPoint(IPAddress.Loopback, 1115),
-						new IPEndPoint(IPAddress.Loopback, 1116)
+						new IPEndPoint(IPAddress.Loopback, 1116),
+						false
 					)));
 				yield return (new SystemMessage.SystemCoreReady());
 				yield return Yield;

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -346,6 +346,7 @@ message NotHandled {
 		NotReady = 0;
 		TooBusy = 1;
 		NotMaster = 2;
+		IsReadOnly = 3;
 	}
 	
 	required NotHandledReason reason = 1;


### PR DESCRIPTION
A Read Only Replica is a clone that is not allowed to participate in elections.
Closes #263 and based on the PRs #1931 and #1751

### Server Changes:

Add option `read-only-replica` to set a node to a read only replica.

These nodes deny write and delete requests with `NotHandled.IsReadOnly`.
Clients can always read from these nodes.

Read only replicas do not participate in elections and go through different states to usual nodes.
The new states are:
1. ReadOnlyMasterless
2. PreReadOnlyReplica
3. ReadOnlyReplica

### .NET Client Changes:

Add `PreferReadOnlyReplica` option that prefers to connect to read only nodes if one is alive in the cluster.
Add `NotSupported` inspection decision and `OperationNotSupportedException`. These are used when trying to write to a read only node.

Embedded Client will simply error when NotHandled is returned.
This is the same behaviour as connecting to a non-master node with `PerformOnMasterOnly` enabled.

### HTTP Client Changes:

If a write returns `NotHandled.IsReadOnly`, an InternalServerError is returned with the master's url in the Location.
However, `NotHandled.IsMaster` always takes precedence if master was required for the request.

### Compatibility: 

Previous versions of the clients will only connect to a read only replica if `PerformOnAnyNode` and `PreferRandom` are enabled.
If a write is performed against a read only replica, the operation results in NotHandled.IsReadOnly, which older clients do not understand.
This will cause the operation to be retried until it hits the retry limit and errors.

Read only replicas are not compatible with previous versions of Event Store.