### PR TITLE
Use ExpectedVersion.NoStream instead of ExpectedVersion.EmptyStream

### DIFF
--- a/src/EventStore.ClientAPI/ExpectedVersion.cs
+++ b/src/EventStore.ClientAPI/ExpectedVersion.cs
@@ -29,7 +29,7 @@ namespace EventStore.ClientAPI {
 		/// <summary>
 		/// The stream should exist but be empty when writing. If it does not exist or is not empty treat that as a concurrency problem.
 		/// </summary>
-		[Obsolete("ExpectedVersion.EmptyStream has been deprecated. Use ExpectedVersion.NoStream instead")]
+	   [Obsolete("ExpectedVersion.EmptyStream has been deprecated. Use ExpectedVersion.NoStream instead")]
 		public const int EmptyStream = -1;
 
 		/// <summary>

--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream.cs
@@ -146,8 +146,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 				var x = TestEvent.NewTestEvent();
 				var events = new[] {x, x, x, x, x, x};
 				Assert.AreEqual(5,
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, events).Result.NextExpectedVersion);
-				var f = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, events).Result;
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, events).Result.NextExpectedVersion);
+				var f = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, events).Result;
 				Assert.AreEqual(5, f.NextExpectedVersion);
 			}
 		}
@@ -159,7 +159,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var append =
@@ -175,7 +175,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "should_return_log_position_when_writing";
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
-				var result = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent())
+				var result = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent())
 					.Result;
 				Assert.IsTrue(0 < result.LogPosition.PreparePosition);
 				Assert.IsTrue(0 < result.LogPosition.CommitPosition);
@@ -190,7 +190,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				try {
-					store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true).Wait();
+					store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true).Wait();
 				} catch (Exception exc) {
 					Console.WriteLine(exc);
 					Assert.Fail();
@@ -209,7 +209,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var append = store.AppendToStreamAsync(stream, 5, new[] {TestEvent.NewTestEvent()});
@@ -224,7 +224,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "should_append_with_correct_exp_ver_to_existing_stream";
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
-				store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+				store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Wait();
 
 				var append = store.AppendToStreamAsync(stream, 0, new[] {TestEvent.NewTestEvent()});
 				Assert.DoesNotThrow(append.Wait);
@@ -238,7 +238,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 				Assert.AreEqual(0,
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Result
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Result
 						.NextExpectedVersion);
 				Assert.AreEqual(1,
 					store.AppendToStreamAsync(stream, ExpectedVersion.Any, TestEvent.NewTestEvent()).Result
@@ -268,7 +268,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "should_append_with_stream_exists_exp_ver_to_existing_stream";
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
-				store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+				store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Wait();
 
 				var append = store.AppendToStreamAsync(stream, ExpectedVersion.StreamExists,
 					new[] {TestEvent.NewTestEvent()});
@@ -331,7 +331,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var append = store.AppendToStreamAsync(stream, ExpectedVersion.StreamExists,
@@ -348,7 +348,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: false);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: false);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var append = store.AppendToStreamAsync(stream, ExpectedVersion.StreamExists,
@@ -366,7 +366,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 				var events = Enumerable.Range(0, 100).Select(i => TestEvent.NewTestEvent(i.ToString(), i.ToString()));
 				Assert.AreEqual(99,
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, events).Result.NextExpectedVersion);
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, events).Result.NextExpectedVersion);
 			}
 		}
 
@@ -486,7 +486,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var append =
@@ -502,7 +502,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var append = store.AppendToStreamAsync(stream, ExpectedVersion.Any, new[] {TestEvent.NewTestEvent()});
@@ -517,7 +517,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var append = store.AppendToStreamAsync(stream, 5, new[] {TestEvent.NewTestEvent()});
@@ -532,7 +532,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 				Assert.AreEqual(0,
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Result
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Result
 						.NextExpectedVersion);
 				Assert.AreEqual(1,
 					store.AppendToStreamAsync(stream, 0, TestEvent.NewTestEvent()).Result.NextExpectedVersion);
@@ -545,7 +545,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 				Assert.AreEqual(0,
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Result
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Result
 						.NextExpectedVersion);
 				Assert.AreEqual(1,
 					store.AppendToStreamAsync(stream, ExpectedVersion.Any, TestEvent.NewTestEvent()).Result
@@ -558,7 +558,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "should_return_log_position_when_writing";
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
-				var result = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent())
+				var result = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent())
 					.Result;
 				Assert.IsTrue(0 < result.LogPosition.PreparePosition);
 				Assert.IsTrue(0 < result.LogPosition.CommitPosition);
@@ -571,7 +571,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 				Assert.AreEqual(0,
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Result
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Result
 						.NextExpectedVersion);
 
 				var append = store.AppendToStreamAsync(stream, 1, new[] {TestEvent.NewTestEvent()});
@@ -591,7 +591,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 				var events = Enumerable.Range(0, 100).Select(i => TestEvent.NewTestEvent(i.ToString(), i.ToString()));
 				Assert.AreEqual(99,
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, events).Result.NextExpectedVersion);
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, events).Result.NextExpectedVersion);
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream_with_hash_collision.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 				store.ConnectAsync().Wait();
 				//Write event to stream 1
 				Assert.AreEqual(0,
-					store.AppendToStreamAsync(stream1, ExpectedVersion.EmptyStream,
+					store.AppendToStreamAsync(stream1, ExpectedVersion.NoStream,
 						new EventData(Guid.NewGuid(), "TestEvent", true, null, null)).Result.NextExpectedVersion);
 				//Write 100 events to stream 2 which will have the same hash as stream 1.
 				for (int i = 0; i < 100; i++) {

--- a/src/EventStore.Core.Tests/ClientAPI/connect.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connect.cs
@@ -105,7 +105,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 					Assert.That(
 						() => connection
-							.AppendToStreamAsync("stream", ExpectedVersion.EmptyStream, TestEvent.NewTestEvent())
+							.AppendToStreamAsync("stream", ExpectedVersion.NoStream, TestEvent.NewTestEvent())
 							.Wait(),
 						Throws.Exception.InstanceOf<AggregateException>()
 							.With.InnerException.InstanceOf<InvalidOperationException>());

--- a/src/EventStore.Core.Tests/ClientAPI/deleting_stream.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/deleting_stream.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "which_already_exists_should_success_when_passed_empty_stream_expected_version";
 			using (var connection = BuildConnection(_node)) {
 				connection.ConnectAsync().Wait();
-				var delete = connection.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = connection.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 			}
 		}
@@ -70,7 +70,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				connection.ConnectAsync().Wait();
 
 				var result = connection
-					.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Result;
+					.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Result;
 				var delete = connection.DeleteStreamAsync(stream, 1, hardDelete: true).Result;
 
 				Assert.IsTrue(0 < result.LogPosition.PreparePosition);
@@ -85,7 +85,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var connection = BuildConnection(_node)) {
 				connection.ConnectAsync().Wait();
 
-				var delete = connection.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = connection.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var secondDelete = connection.DeleteStreamAsync(stream, ExpectedVersion.Any, hardDelete: true);

--- a/src/EventStore.Core.Tests/ClientAPI/read_all_events_backward_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_all_events_backward_should.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.Wait();
 
 			_testEvents = Enumerable.Range(0, 20).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-			_conn.AppendToStreamAsync("stream", ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync("stream", ExpectedVersion.NoStream, _testEvents).Wait();
 		}
 
 		[Test, Category("LongRunning")]

--- a/src/EventStore.Core.Tests/ClientAPI/read_all_events_forward_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_all_events_forward_should.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.Wait();
 
 			_testEvents = Enumerable.Range(0, 20).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-			_conn.AppendToStreamAsync("stream", ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync("stream", ExpectedVersion.NoStream, _testEvents).Wait();
 		}
 
 		[Test, Category("LongRunning")]

--- a/src/EventStore.Core.Tests/ClientAPI/read_all_events_forward_with_hard_deleted_stream_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_all_events_forward_with_hard_deleted_stream_should.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.Wait();
 
 			_testEvents = Enumerable.Range(0, 20).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-			_conn.AppendToStreamAsync("stream", ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync("stream", ExpectedVersion.NoStream, _testEvents).Wait();
 			_conn.DeleteStreamAsync("stream", ExpectedVersion.Any, hardDelete: true).Wait();
 		}
 

--- a/src/EventStore.Core.Tests/ClientAPI/read_all_events_forward_with_soft_deleted_stream_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_all_events_forward_with_soft_deleted_stream_should.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.Wait();
 
 			_testEvents = Enumerable.Range(0, 20).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-			_conn.AppendToStreamAsync("stream", ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync("stream", ExpectedVersion.NoStream, _testEvents).Wait();
 			_conn.DeleteStreamAsync("stream", ExpectedVersion.Any).Wait();
 		}
 

--- a/src/EventStore.Core.Tests/ClientAPI/read_event_stream_backward_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_event_stream_backward_should.cs
@@ -69,7 +69,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "read_event_stream_backward_should_notify_using_status_code_if_stream_was_deleted";
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var read = store.ReadStreamEventsBackwardAsync(stream, StreamPosition.End, 1, resolveLinkTos: false);
@@ -103,7 +103,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent((x + 1).ToString()))
 					.ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsBackwardAsync(stream, 1, 5, resolveLinkTos: false);
@@ -122,7 +122,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent((x + 1).ToString()))
 					.ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsBackwardAsync(stream, StreamPosition.End, testEvents.Length,
@@ -143,7 +143,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsBackwardAsync(stream, 7, 1, resolveLinkTos: false);
@@ -162,7 +162,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent((x + 1).ToString()))
 					.ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsBackwardAsync(stream, StreamPosition.Start, 1, resolveLinkTos: false);
@@ -180,7 +180,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsBackwardAsync(stream, StreamPosition.End, 1, resolveLinkTos: false);
@@ -198,7 +198,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsBackwardAsync(stream, 3, 2, resolveLinkTos: false);

--- a/src/EventStore.Core.Tests/ClientAPI/read_event_stream_forward_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_event_stream_forward_should.cs
@@ -69,7 +69,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "read_event_stream_forward_should_notify_using_status_code_if_stream_was_deleted";
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
-				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+				var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 				Assert.DoesNotThrow(delete.Wait);
 
 				var read = store.ReadStreamEventsForwardAsync(stream, 0, 1, resolveLinkTos: false);
@@ -102,7 +102,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				var write10 = store.AppendToStreamAsync(stream,
-					ExpectedVersion.EmptyStream,
+					ExpectedVersion.NoStream,
 					Enumerable.Range(0, 10).Select(x =>
 						TestEvent.NewTestEvent((x + 1).ToString(CultureInfo.InvariantCulture))));
 				Assert.DoesNotThrow(write10.Wait);
@@ -122,7 +122,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				var write10 = store.AppendToStreamAsync(stream,
-					ExpectedVersion.EmptyStream,
+					ExpectedVersion.NoStream,
 					Enumerable.Range(0, 10).Select(x =>
 						TestEvent.NewTestEvent((x + 1).ToString(CultureInfo.InvariantCulture))));
 				Assert.DoesNotThrow(write10.Wait);
@@ -154,7 +154,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsForwardAsync(stream, StreamPosition.Start, testEvents.Length,
@@ -173,7 +173,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsForwardAsync(stream, 5, 1, resolveLinkTos: false);
@@ -191,7 +191,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				store.ConnectAsync().Wait();
 
 				var testEvents = Enumerable.Range(0, 10).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, testEvents);
+				var write10 = store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, testEvents);
 				Assert.DoesNotThrow(write10.Wait);
 
 				var read = store.ReadStreamEventsForwardAsync(stream, 5, 2, resolveLinkTos: false);

--- a/src/EventStore.Core.Tests/ClientAPI/read_event_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_event_with_hash_collision.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 				store.ConnectAsync().Wait();
 				//Write event to stream 1
 				Assert.AreEqual(0,
-					store.AppendToStreamAsync(stream1, ExpectedVersion.EmptyStream,
+					store.AppendToStreamAsync(stream1, ExpectedVersion.NoStream,
 						new EventData(Guid.NewGuid(), "TestEvent", true, null, null)).Result.NextExpectedVersion);
 				//Write 100 events to stream 2 which will have the same hash as stream 1.
 				for (int i = 0; i < 100; i++) {

--- a/src/EventStore.Core.Tests/ClientAPI/read_stream_events_backward_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_stream_events_backward_with_hash_collision.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 				store.ConnectAsync().Wait();
 				//Write event to stream 1
 				Assert.AreEqual(0,
-					store.AppendToStreamAsync(stream1, ExpectedVersion.EmptyStream,
+					store.AppendToStreamAsync(stream1, ExpectedVersion.NoStream,
 						new EventData(Guid.NewGuid(), "TestEvent", true, null, null)).Result.NextExpectedVersion);
 				//Write 100 events to stream 2 which will have the same hash as stream 1.
 				for (int i = 0; i < 100; i++) {

--- a/src/EventStore.Core.Tests/ClientAPI/read_stream_events_forward_with_hash_collision.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_stream_events_forward_with_hash_collision.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 				store.ConnectAsync().Wait();
 				//Write event to stream 1
 				Assert.AreEqual(0,
-					store.AppendToStreamAsync(stream1, ExpectedVersion.EmptyStream,
+					store.AppendToStreamAsync(stream1, ExpectedVersion.NoStream,
 						new EventData(Guid.NewGuid(), "TestEvent", true, null, null)).Result.NextExpectedVersion);
 				//Write 100 events to stream 2 which will have the same hash as stream 1.
 				for (int i = 0; i < 100; i++) {

--- a/src/EventStore.Core.Tests/ClientAPI/read_stream_events_with_unresolved_linkto.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_stream_events_with_unresolved_linkto.cs
@@ -22,9 +22,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.Wait();
 
 			_testEvents = Enumerable.Range(0, 20).Select(x => TestEvent.NewTestEvent(x.ToString())).ToArray();
-			_conn.AppendToStreamAsync("stream", ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync("stream", ExpectedVersion.NoStream, _testEvents).Wait();
 			_conn.AppendToStreamAsync(
-					"links", ExpectedVersion.EmptyStream,
+					"links", ExpectedVersion.NoStream,
 					new EventData(
 						Guid.NewGuid(), EventStore.ClientAPI.Common.SystemEventTypes.LinkTo, false,
 						Encoding.UTF8.GetBytes("0@stream"), null))

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_should.cs
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 					appeared.Signal();
 					return Task.CompletedTask;
 				}, (s, r, e) => dropped.Signal()).Result) {
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Wait();
 					Assert.IsTrue(appeared.Wait(Timeout), "Appeared countdown event timed out.");
 				}
 			}
@@ -64,7 +64,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 					appeared.Signal();
 					return Task.CompletedTask;
 				}, (s, r, e) => dropped.Signal()).Result) {
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Wait();
 					Assert.IsTrue(appeared.Wait(Timeout), "Appeared countdown event timed out.");
 				}
 			}
@@ -99,7 +99,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 						return Task.CompletedTask;
 					},
 					(s, r, e) => dropped.Signal()).Result) {
-					store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true).Wait();
+					store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true).Wait();
 					Assert.IsTrue(appeared.Wait(Timeout), "Appeared countdown event timed out.");
 				}
 			}

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_all_should.cs
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 					return Task.CompletedTask;
 				}, (s, r, e) => dropped.Signal()).Result) {
 					var create =
-						store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent());
+						store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent());
 					Assert.IsTrue(create.Wait(Timeout), "StreamCreateAsync timed out.");
 
 					Assert.IsTrue(appeared.Wait(Timeout), "Appeared countdown event timed out.");
@@ -78,7 +78,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 						return Task.CompletedTask;
 					},
 					(s, r, e) => dropped.Signal()).Result) {
-					var delete = store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true);
+					var delete = store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true);
 					Assert.IsTrue(delete.Wait(Timeout), "DeleteStreamAsync timed out.");
 
 					Assert.IsTrue(appeared.Wait(Timeout), "Appeared countdown event didn't fire in time.");

--- a/src/EventStore.Core.Tests/ClientAPI/subscribe_to_stream_catching_up_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/subscribe_to_stream_catching_up_should.cs
@@ -82,7 +82,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 					_ => Log.Info("Live processing started."),
 					(_, __, ___) => dropped.Signal());
 
-				store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+				store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Wait();
 
 				if (!appeared.Wait(Timeout)) {
 					Assert.IsFalse(dropped.Wait(0), "Subscription was dropped prematurely.");
@@ -123,7 +123,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 					_ => Log.Info("Live processing started."),
 					(x, y, z) => dropped2.Set());
 
-				store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+				store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Wait();
 
 				if (!appeared.Wait(Timeout)) {
 					Assert.IsFalse(dropped1.Wait(0), "Subscription1 was dropped prematurely.");

--- a/src/EventStore.Core.Tests/ClientAPI/transaction.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/transaction.cs
@@ -191,8 +191,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "should_fail_to_commit_if_started_with_correct_ver_but_committing_with_bad";
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
-				using (var transaction = store.StartTransactionAsync(stream, ExpectedVersion.EmptyStream).Result) {
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, new[] {TestEvent.NewTestEvent()})
+				using (var transaction = store.StartTransactionAsync(stream, ExpectedVersion.NoStream).Result) {
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, new[] {TestEvent.NewTestEvent()})
 						.Wait();
 					transaction.WriteAsync(TestEvent.NewTestEvent()).Wait();
 					Assert.That(() => transaction.CommitAsync().Wait(),
@@ -208,7 +208,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
 				using (var transaction = store.StartTransactionAsync(stream, 0).Result) {
-					store.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, new[] {TestEvent.NewTestEvent()})
+					store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, new[] {TestEvent.NewTestEvent()})
 						.Wait();
 					transaction.WriteAsync(TestEvent.NewTestEvent()).Wait();
 					Assert.AreEqual(1, transaction.CommitAsync().Result.NextExpectedVersion);
@@ -222,9 +222,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "should_fail_to_commit_if_started_with_correct_ver_but_on_commit_stream_was_deleted";
 			using (var store = BuildConnection(_node)) {
 				store.ConnectAsync().Wait();
-				using (var transaction = store.StartTransactionAsync(stream, ExpectedVersion.EmptyStream).Result) {
+				using (var transaction = store.StartTransactionAsync(stream, ExpectedVersion.NoStream).Result) {
 					transaction.WriteAsync(TestEvent.NewTestEvent()).Wait();
-					store.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true).Wait();
+					store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true).Wait();
 					Assert.That(() => transaction.CommitAsync().Wait(),
 						Throws.Exception.TypeOf<AggregateException>().With.InnerException
 							.TypeOf<StreamDeletedException>());

--- a/src/EventStore.Core.Tests/ClientAPI/when_having_max_count_set_for_stream.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/when_having_max_count_set_for_stream.cs
@@ -22,11 +22,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 			_connection = TestConnection.Create(_node.TcpEndPoint);
 			_connection.ConnectAsync().Wait();
 
-			_connection.SetStreamMetadataAsync(Stream, ExpectedVersion.EmptyStream,
+			_connection.SetStreamMetadataAsync(Stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetMaxCount(3)).Wait();
 
 			_testEvents = Enumerable.Range(0, 5).Select(x => TestEvent.NewTestEvent(data: x.ToString())).ToArray();
-			_connection.AppendToStreamAsync(Stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_connection.AppendToStreamAsync(Stream, ExpectedVersion.NoStream, _testEvents).Wait();
 		}
 
 		[TearDown]

--- a/src/EventStore.Core.Tests/ClientAPI/when_having_truncatebefore_set_for_stream.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/when_having_truncatebefore_set_for_stream.cs
@@ -16,9 +16,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		[Test, Category("LongRunning"), Category("Network")]
 		public void read_event_respects_truncatebefore() {
 			const string stream = "read_event_respects_truncatebefore";
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadEventAsync(stream, 1, false).Result;
@@ -32,9 +32,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		[Test, Category("LongRunning"), Category("Network")]
 		public void read_stream_forward_respects_truncatebefore() {
 			const string stream = "read_stream_forward_respects_truncatebefore";
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsForwardAsync(stream, 0, 100, false).Result;
@@ -47,9 +47,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		[Test, Category("LongRunning"), Category("Network")]
 		public void read_stream_backward_respects_truncatebefore() {
 			const string stream = "read_stream_backward_respects_truncatebefore";
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsBackwardAsync(stream, -1, 100, false).Result;
@@ -63,9 +63,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void after_setting_less_strict_truncatebefore_read_event_reads_more_events() {
 			const string stream = "after_setting_less_strict_truncatebefore_read_event_reads_more_events";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadEventAsync(stream, 1, false).Result;
@@ -89,9 +89,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void after_setting_more_strict_truncatebefore_read_event_reads_less_events() {
 			const string stream = "after_setting_more_strict_truncatebefore_read_event_reads_less_events";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadEventAsync(stream, 1, false).Result;
@@ -115,9 +115,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void less_strict_max_count_doesnt_change_anything_for_event_read() {
 			const string stream = "less_strict_max_count_doesnt_change_anything_for_event_read";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadEventAsync(stream, 1, false).Result;
@@ -141,9 +141,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void more_strict_max_count_gives_less_events_for_event_read() {
 			const string stream = "more_strict_max_count_gives_less_events_for_event_read";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadEventAsync(stream, 1, false).Result;
@@ -168,9 +168,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void after_setting_less_strict_truncatebefore_read_stream_forward_reads_more_events() {
 			const string stream = "after_setting_less_strict_truncatebefore_read_stream_forward_reads_more_events";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsForwardAsync(stream, 0, 100, false).Result;
@@ -192,9 +192,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void after_setting_more_strict_truncatebefore_read_stream_forward_reads_less_events() {
 			const string stream = "after_setting_more_strict_truncatebefore_read_stream_forward_reads_less_events";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsForwardAsync(stream, 0, 100, false).Result;
@@ -216,9 +216,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void less_strict_max_count_doesnt_change_anything_for_stream_forward_read() {
 			const string stream = "less_strict_max_count_doesnt_change_anything_for_stream_forward_read";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsForwardAsync(stream, 0, 100, false).Result;
@@ -240,9 +240,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void more_strict_max_count_gives_less_events_for_stream_forward_read() {
 			const string stream = "more_strict_max_count_gives_less_events_for_stream_forward_read";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsForwardAsync(stream, 0, 100, false).Result;
@@ -264,9 +264,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void after_setting_less_strict_truncatebefore_read_stream_backward_reads_more_events() {
 			const string stream = "after_setting_less_strict_truncatebefore_read_stream_backward_reads_more_events";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsBackwardAsync(stream, -1, 100, false).Result;
@@ -288,9 +288,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void after_setting_more_strict_truncatebefore_read_stream_backward_reads_less_events() {
 			const string stream = "after_setting_more_strict_truncatebefore_read_stream_backward_reads_less_events";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsBackwardAsync(stream, -1, 100, false).Result;
@@ -312,9 +312,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void less_strict_max_count_doesnt_change_anything_for_stream_backward_read() {
 			const string stream = "less_strict_max_count_doesnt_change_anything_for_stream_backward_read";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsBackwardAsync(stream, -1, 100, false).Result;
@@ -336,9 +336,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void more_strict_max_count_gives_less_events_for_stream_backward_read() {
 			const string stream = "more_strict_max_count_gives_less_events_for_stream_backward_read";
 
-			_conn.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, _testEvents).Wait();
+			_conn.AppendToStreamAsync(stream, ExpectedVersion.NoStream, _testEvents).Wait();
 
-			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream,
+			_conn.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream,
 				StreamMetadata.Build().SetTruncateBefore(2)).Wait();
 
 			var res = _conn.ReadStreamEventsBackwardAsync(stream, -1, 100, false).Result;

--- a/src/EventStore.Core.Tests/ClientAPI/when_working_with_metadata.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/when_working_with_metadata.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void when_getting_metadata_for_an_existing_stream_and_no_metadata_exists() {
 			const string stream = "when_getting_metadata_for_an_existing_stream_and_no_metadata_exists";
 
-			_connection.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+			_connection.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Wait();
 
 			var meta = _connection.GetStreamMetadataAsRawBytesAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);

--- a/src/EventStore.Core.Tests/ClientAPI/when_working_with_stream_metadata_as_byte_array.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/when_working_with_stream_metadata_as_byte_array.cs
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void setting_empty_metadata_works() {
 			const string stream = "setting_empty_metadata_works";
 
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, (byte[])null).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, (byte[])null).Wait();
 
 			var meta = _connection.GetStreamMetadataAsRawBytesAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -52,7 +52,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "setting_metadata_few_times_returns_last_metadata";
 
 			var metadataBytes = Guid.NewGuid().ToByteArray();
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadataBytes).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadataBytes).Wait();
 			var meta = _connection.GetStreamMetadataAsRawBytesAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
 			Assert.AreEqual(false, meta.IsStreamDeleted);
@@ -101,7 +101,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void setting_metadata_for_not_existing_stream_works() {
 			const string stream = "setting_metadata_for_not_existing_stream_works";
 			var metadataBytes = Guid.NewGuid().ToByteArray();
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadataBytes).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadataBytes).Wait();
 
 			var meta = _connection.GetStreamMetadataAsRawBytesAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -118,7 +118,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				TestEvent.NewTestEvent()).Wait();
 
 			var metadataBytes = Guid.NewGuid().ToByteArray();
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadataBytes).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadataBytes).Wait();
 
 			var meta = _connection.GetStreamMetadataAsRawBytesAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -135,7 +135,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 			var metadataBytes = Guid.NewGuid().ToByteArray();
 			Assert.That(
-				() => _connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadataBytes).Wait(),
+				() => _connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadataBytes).Wait(),
 				Throws.Exception.InstanceOf<AggregateException>()
 					.With.InnerException.InstanceOf<StreamDeletedException>());
 		}
@@ -157,7 +157,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				"getting_metadata_for_deleted_stream_returns_empty_byte_array_and_signals_stream_deletion";
 
 			var metadataBytes = Guid.NewGuid().ToByteArray();
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadataBytes).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadataBytes).Wait();
 
 			_connection.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true).Wait();
 

--- a/src/EventStore.Core.Tests/ClientAPI/when_working_with_stream_metadata_as_structured_info.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/when_working_with_stream_metadata_as_structured_info.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void setting_empty_metadata_works() {
 			const string stream = "setting_empty_metadata_works";
 
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, StreamMetadata.Create()).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, StreamMetadata.Create()).Wait();
 
 			var meta = _connection.GetStreamMetadataAsRawBytesAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -54,7 +54,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "setting_metadata_few_times_returns_last_metadata_info";
 			var metadata =
 				StreamMetadata.Create(17, TimeSpan.FromSeconds(0xDEADBEEF), 10, TimeSpan.FromSeconds(0xABACABA));
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadata).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadata).Wait();
 
 			var meta = _connection.GetStreamMetadataAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -122,7 +122,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream = "setting_metadata_for_not_existing_stream_works";
 			var metadata =
 				StreamMetadata.Create(17, TimeSpan.FromSeconds(0xDEADBEEF), 10, TimeSpan.FromSeconds(0xABACABA));
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadata).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadata).Wait();
 
 			var meta = _connection.GetStreamMetadataAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -138,11 +138,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 		public void setting_metadata_for_existing_stream_works() {
 			const string stream = "setting_metadata_for_existing_stream_works";
 
-			_connection.AppendToStreamAsync(stream, ExpectedVersion.EmptyStream, TestEvent.NewTestEvent()).Wait();
+			_connection.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent()).Wait();
 
 			var metadata =
 				StreamMetadata.Create(17, TimeSpan.FromSeconds(0xDEADBEEF), 10, TimeSpan.FromSeconds(0xABACABA));
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadata).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadata).Wait();
 
 			var meta = _connection.GetStreamMetadataAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -189,9 +189,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 			var metadata =
 				StreamMetadata.Create(17, TimeSpan.FromSeconds(0xDEADBEEF), 10, TimeSpan.FromSeconds(0xABACABA));
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadata).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadata).Wait();
 
-			_connection.DeleteStreamAsync(stream, ExpectedVersion.EmptyStream, hardDelete: true).Wait();
+			_connection.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: true).Wait();
 
 			var meta = _connection.GetStreamMetadataAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -231,7 +231,7 @@ namespace EventStore.Core.Tests.ClientAPI {
                                                            }
                                                       }");
 
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, rawMeta).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, rawMeta).Wait();
 
 			var meta = _connection.GetStreamMetadataAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -284,7 +284,7 @@ namespace EventStore.Core.Tests.ClientAPI {
                                                                                                        ""subProperty"": 999
                                                                                                  }");
 
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadata).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadata).Wait();
 
 			var meta = _connection.GetStreamMetadataAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -321,7 +321,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.SetDeleteRoles(new[] {"d1", "d2", "d3", "d4"})
 				.SetMetadataWriteRoles(new[] {"mw1", "mw2"});
 
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, metadata).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, metadata).Wait();
 
 			var meta = _connection.GetStreamMetadataAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);
@@ -349,7 +349,7 @@ namespace EventStore.Core.Tests.ClientAPI {
                                                            }
                                                       }");
 
-			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.EmptyStream, rawMeta).Wait();
+			_connection.SetStreamMetadataAsync(stream, ExpectedVersion.NoStream, rawMeta).Wait();
 
 			var meta = _connection.GetStreamMetadataAsync(stream).Result;
 			Assert.AreEqual(stream, meta.Stream);


### PR DESCRIPTION
Since `ExpectedVersion.EmptyStream` is now obsolete, it gives warning when compiling the project. 
This pull request replaces `ExpectedVersion.EmptyStream` to `ExpectedVersion.NoStream` everywhere in the project. 