### PR TITLE
Fix test client bug

### DIFF
--- a/src/EventStore.TestClient/Commands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodProcessor.cs
@@ -20,8 +20,6 @@ namespace EventStore.TestClient.Commands {
 			get { return "WRFL"; }
 		}
 
-		private RequestMonitor _monitor = new RequestMonitor();
-
 		public bool Execute(CommandProcessorContext context, string[] args) {
 			int clientsCnt = 1;
 			long requestsCnt = 5000;
@@ -46,12 +44,13 @@ namespace EventStore.TestClient.Commands {
 				}
 			}
 
-			WriteFlood(context, clientsCnt, requestsCnt, streamsCnt, size, batchSize);
+			var monitor = new RequestMonitor();
+			WriteFlood(context, clientsCnt, requestsCnt, streamsCnt, size, batchSize, monitor);
 			return true;
 		}
 
 		private void WriteFlood(CommandProcessorContext context, int clientsCnt, long requestsCnt, int streamsCnt,
-			int size, int batchSize) {
+			int size, int batchSize, RequestMonitor monitor) {
 			context.IsAsync();
 
 			var doneEvent = new ManualResetEventSlim(false);
@@ -85,7 +84,7 @@ namespace EventStore.TestClient.Commands {
 						}
 
 						var dto = pkg.Data.Deserialize<TcpClientMessageDto.WriteEventsCompleted>();
-						_monitor.EndOperation(pkg.CorrelationId);
+						monitor.EndOperation(pkg.CorrelationId);
 						switch (dto.Result) {
 							case TcpClientMessageDto.OperationResult.Success:
 								Interlocked.Add(ref succ, batchSize);
@@ -157,7 +156,7 @@ namespace EventStore.TestClient.Commands {
 							events,
 							false);
 						var package = new TcpPackage(TcpCommand.WriteEvents, corrid, write.Serialize());
-						_monitor.StartOperation(corrid);
+						monitor.StartOperation(corrid);
 						client.EnqueueSend(package.AsByteArray());
 
 						var localSent = Interlocked.Increment(ref sent);
@@ -203,7 +202,7 @@ namespace EventStore.TestClient.Commands {
 			PerfUtils.LogTeamCityGraphData(
 				string.Format("{0}-c{1}-r{2}-st{3}-s{4}-failureSuccessRate", Keyword, clientsCnt, requestsCnt,
 					streamsCnt, size), failuresRate);
-			_monitor.GetMeasurementDetails();
+			monitor.GetMeasurementDetails();
 			if (Interlocked.Read(ref succ) != requestsCnt)
 				context.Fail(reason: "There were errors or not all requests completed.");
 			else


### PR DESCRIPTION
Credits go to @gregoryyoung for discovering this bug in the test client!

The same data is reused across different `WRFL` and `RDFL` runs when computing the percentiles since the `RequestMonitor` is not reinitialized.

**Reproduction steps:**
Run `WRFL 1 10000` a few times, you will notice that the `Highest :` percentile time always increases monotically.