### PR TITLE
Changed IPEndPoint to Endpoint for UsersManagement

### DIFF
--- a/src/EventStore.ClientAPI/UserManagement/UsersClient.cs
+++ b/src/EventStore.ClientAPI/UserManagement/UsersClient.cs
@@ -21,22 +21,22 @@ namespace EventStore.ClientAPI.UserManagement {
 			_client = new HttpAsyncClient(_operationTimeout);
 		}
 
-		public Task Enable(IPEndPoint endPoint, string login, UserCredentials userCredentials = null) {
+		public Task Enable(EndPoint endPoint, string login, UserCredentials userCredentials = null) {
 			return SendPost(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}/command/enable", login),
 				string.Empty, userCredentials, HttpStatusCode.OK);
 		}
 
-		public Task Disable(IPEndPoint endPoint, string login, UserCredentials userCredentials = null) {
+		public Task Disable(EndPoint endPoint, string login, UserCredentials userCredentials = null) {
 			return SendPost(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}/command/disable", login),
 				string.Empty, userCredentials, HttpStatusCode.OK);
 		}
 
-		public Task Delete(IPEndPoint endPoint, string login, UserCredentials userCredentials = null) {
+		public Task Delete(EndPoint endPoint, string login, UserCredentials userCredentials = null) {
 			return SendDelete(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}", login), userCredentials,
 				HttpStatusCode.OK);
 		}
 
-		public Task<List<UserDetails>> ListAll(IPEndPoint endPoint, UserCredentials userCredentials = null) {
+		public Task<List<UserDetails>> ListAll(EndPoint endPoint, UserCredentials userCredentials = null) {
 			return SendGet(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/"), userCredentials,
 					HttpStatusCode.OK)
 				.ContinueWith(x => {
@@ -46,7 +46,7 @@ namespace EventStore.ClientAPI.UserManagement {
 				});
 		}
 
-		public Task<UserDetails> GetCurrentUser(IPEndPoint endPoint, UserCredentials userCredentials = null) {
+		public Task<UserDetails> GetCurrentUser(EndPoint endPoint, UserCredentials userCredentials = null) {
 			return SendGet(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/$current"), userCredentials,
 					HttpStatusCode.OK)
 				.ContinueWith(x => {
@@ -56,7 +56,7 @@ namespace EventStore.ClientAPI.UserManagement {
 				});
 		}
 
-		public Task<UserDetails> GetUser(IPEndPoint endPoint, string login, UserCredentials userCredentials = null) {
+		public Task<UserDetails> GetUser(EndPoint endPoint, string login, UserCredentials userCredentials = null) {
 			return SendGet(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}", login), userCredentials,
 					HttpStatusCode.OK)
 				.ContinueWith(x => {
@@ -66,27 +66,27 @@ namespace EventStore.ClientAPI.UserManagement {
 				});
 		}
 
-		public Task CreateUser(IPEndPoint endPoint, UserCreationInformation newUser,
+		public Task CreateUser(EndPoint endPoint, UserCreationInformation newUser,
 			UserCredentials userCredentials = null) {
 			var userJson = newUser.ToJson();
 			return SendPost(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/"), userJson, userCredentials,
 				HttpStatusCode.Created);
 		}
 
-		public Task UpdateUser(IPEndPoint endPoint, string login, UserUpdateInformation updatedUser,
+		public Task UpdateUser(EndPoint endPoint, string login, UserUpdateInformation updatedUser,
 			UserCredentials userCredentials) {
 			return SendPut(endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}", login),
 				updatedUser.ToJson(), userCredentials, HttpStatusCode.OK);
 		}
 
-		public Task ChangePassword(IPEndPoint endPoint, string login, ChangePasswordDetails changePasswordDetails,
+		public Task ChangePassword(EndPoint endPoint, string login, ChangePasswordDetails changePasswordDetails,
 			UserCredentials userCredentials) {
 			return SendPost(
 				endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}/command/change-password", login),
 				changePasswordDetails.ToJson(), userCredentials, HttpStatusCode.OK);
 		}
 
-		public Task ResetPassword(IPEndPoint endPoint, string login, ResetPasswordDetails resetPasswordDetails,
+		public Task ResetPassword(EndPoint endPoint, string login, ResetPasswordDetails resetPasswordDetails,
 			UserCredentials userCredentials = null) {
 			return SendPost(
 				endPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/users/{0}/command/reset-password", login),

--- a/src/EventStore.ClientAPI/UserManagement/UsersManager.cs
+++ b/src/EventStore.ClientAPI/UserManagement/UsersManager.cs
@@ -13,7 +13,7 @@ namespace EventStore.ClientAPI.UserManagement {
 	public class UsersManager {
 		private readonly UsersClient _client;
 
-		private readonly IPEndPoint _httpEndPoint;
+		private readonly EndPoint _httpEndPoint;
 
 		/// <summary>
 		/// Creates a new instance of <see cref="UsersManager"/>.
@@ -21,7 +21,7 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <param name="log">An instance of <see cref="ILogger"/> to use for logging.</param>
 		/// <param name="httpEndPoint">HTTP endpoint of an Event Store server.</param>
 		/// <param name="operationTimeout"></param>
-		public UsersManager(ILogger log, IPEndPoint httpEndPoint, TimeSpan operationTimeout) {
+		public UsersManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout) {
 			Ensure.NotNull(log, "log");
 			Ensure.NotNull(httpEndPoint, "httpEndPoint");
 


### PR DESCRIPTION
Changed IPEndPoint to Endpoint for UsersManagement to be able to use DnsEndPoints as well and be compatible with the archived ClientAPI.NetCore again