### PR TITLE
Return a temporary redirect if requiring master

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -50,6 +50,7 @@ namespace EventStore.Core.Tests.Helpers {
 		private readonly string _dbPath;
 		private readonly bool _isReadOnlyReplica;
 		public ManualResetEvent StartedEvent;
+		public ManualResetEvent AdminUserCreatedEvent;
 
 		public VNodeState NodeState = VNodeState.Unknown;
 
@@ -131,6 +132,7 @@ namespace EventStore.Core.Tests.Helpers {
 			StartingTime.Start();
 
 			StartedEvent = new ManualResetEvent(false);
+			AdminUserCreatedEvent = new ManualResetEvent(false);
 			Node.MainBus.Subscribe(
 				new AdHocHandler<SystemMessage.StateChangeMessage>(m => { NodeState = _isReadOnlyReplica ?
 					VNodeState.ReadOnlyMasterless : VNodeState.Unknown; }));
@@ -144,6 +146,10 @@ namespace EventStore.Core.Tests.Helpers {
 					new AdHocHandler<SystemMessage.BecomeSlave>(m => {
 						NodeState = VNodeState.Slave;
 						StartedEvent.Set();
+				}));
+			Node.MainBus.Subscribe(
+				new AdHocHandler<UserManagementMessage.UserManagementServiceInitialized>(m => {
+					AdminUserCreatedEvent.Set();
 					}));
 			} else {
 				Node.MainBus.Subscribe(

--- a/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_slave.cs
+++ b/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_slave.cs
@@ -1,0 +1,190 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using EventStore.Core.Data;
+using EventStore.Core.Tests.Integration;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Http.Cluster {
+	[TestFixture]
+	[Category("LongRunning")]
+	public class when_requesting_from_slave : specification_with_cluster {
+		private const string TestStream = "test-stream";
+		private IPEndPoint _slaveEndPoint;
+		private IPEndPoint _masterEndPoint;
+
+		protected override void Given() {
+			var master = GetMaster();
+			if (!master.AdminUserCreatedEvent.WaitOne(TimeSpan.FromSeconds(5)))
+				Assert.Fail("Timed out waiting for admin user to be created.");
+			_slaveEndPoint = GetSlaves().First().ExternalHttpEndPoint;
+			_masterEndPoint = master.ExternalHttpEndPoint;
+		}
+
+		[Test]
+		public void post_events_should_succeed_when_master_not_required() {
+			var path = $"streams/{TestStream}";
+			var response = PostEvent(_slaveEndPoint, path, requireMaster: false);
+
+			Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+		}
+
+		[Test]
+		public void delete_stream_should_succeed_when_master_not_required() {
+			var path = $"streams/{TestStream}";
+			var response = DeleteStream(_slaveEndPoint, path, requireMaster: false);
+
+			Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+		}
+
+		[Test]
+		public void read_from_stream_forward_should_succeed_when_master_not_required() {
+			var path = $"streams/{TestStream}/0/forward/1";
+			var response = ReadStream(_slaveEndPoint, path, requireMaster: false);
+
+			Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+		}
+
+		[Test]
+		public void read_from_stream_backward_should_succeed_when_master_not_required() {
+			var path = $"streams/{TestStream}";
+			var response = ReadStream(_slaveEndPoint, path, requireMaster: false);
+
+			Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+		}
+
+		[Test]
+		public void read_from_all_forward_should_succeed_when_master_not_required() {
+			var path = $"streams/$all/00000000000000000000000000000000/forward/1";
+			var response = ReadStream(_slaveEndPoint, path, requireMaster: false);
+
+			Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+		}
+
+		[Test]
+		public void read_from_all_backward_should_succeed_when_master_not_required() {
+			var path = $"streams/$all";
+			var response = ReadStream(_slaveEndPoint, path, requireMaster: false);
+
+			Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+		}
+
+		[Test]
+		public void should_redirect_to_master_when_writing_with_requires_master() {
+			var path = $"streams/{TestStream}";
+			var response = PostEvent(_slaveEndPoint, path);
+
+			Assert.AreEqual(HttpStatusCode.TemporaryRedirect, response.StatusCode);
+			var masterLocation = CreateUri(_masterEndPoint, path);
+			Assert.AreEqual(masterLocation.ToString(), response.Headers["Location"]);
+		}
+
+		[Test]
+		public void should_redirect_to_master_when_deleting_with_requires_master() {
+			var path = $"streams/{TestStream}";
+			var response = DeleteStream(_slaveEndPoint, path, requireMaster: true);
+
+			Assert.AreEqual(HttpStatusCode.TemporaryRedirect, response.StatusCode);
+			var masterLocation = CreateUri(_masterEndPoint, path);
+			Assert.AreEqual(masterLocation.ToString(), response.Headers["Location"]);
+		}
+
+		[Test]
+		public void should_redirect_to_master_when_reading_from_stream_backwards_with_requires_master() {
+			var path = $"streams/{TestStream}";
+			var response = ReadStream(_slaveEndPoint, path, requireMaster: true);
+
+			Assert.AreEqual(HttpStatusCode.TemporaryRedirect, response.StatusCode);
+			var masterLocation = CreateUri(_masterEndPoint, path);
+			Assert.AreEqual(masterLocation.ToString(), response.Headers["Location"]);
+		}
+
+		[Test]
+		public void should_redirect_to_master_when_reading_from_stream_forwards_with_requires_master() {
+			var path = $"streams/{TestStream}/0/forward/1";
+			var response = ReadStream(_slaveEndPoint, path, requireMaster: true);
+
+			Assert.AreEqual(HttpStatusCode.TemporaryRedirect, response.StatusCode);
+			var masterLocation = CreateUri(_masterEndPoint, path);
+			Assert.AreEqual(masterLocation.ToString(), response.Headers["Location"]);
+		}
+
+		[Test]
+		public void should_redirect_to_master_when_reading_from_all_backwards_with_requires_master() {
+			var path = $"streams/$all";
+			var response = ReadStream(_slaveEndPoint, path, requireMaster: true);
+
+			Assert.AreEqual(HttpStatusCode.TemporaryRedirect, response.StatusCode);
+			var masterLocation = CreateUri(_masterEndPoint, path);
+			Assert.AreEqual(masterLocation.ToString(), response.Headers["Location"]);
+		}
+
+		[Test]
+		public void should_redirect_to_master_when_reading_from_all_forwards_with_requires_master() {
+			var path = $"streams/$all/00000000000000000000000000000000/forward/1";
+			var response = ReadStream(_slaveEndPoint, path, requireMaster: true);
+
+			Assert.AreEqual(HttpStatusCode.TemporaryRedirect, response.StatusCode);
+			var masterLocation = CreateUri(_masterEndPoint, path);
+			Assert.AreEqual(masterLocation.ToString(), response.Headers["Location"]);
+		}
+
+		private HttpWebResponse ReadStream(IPEndPoint nodeEndpoint, string path, bool requireMaster) {
+			var uri = CreateUri(nodeEndpoint, path);
+			var request = CreateRequest(uri, "GET", requireMaster);
+			request.Accept = "application/json";
+			return GetRequestResponse(request);
+		}
+
+		private HttpWebResponse DeleteStream(IPEndPoint nodeEndpoint, string path, bool requireMaster = true) {
+			var uri = CreateUri(nodeEndpoint, path);
+			var request = CreateRequest(uri, "DELETE", requireMaster);
+			return GetRequestResponse(request);
+		}
+
+		private HttpWebResponse PostEvent(IPEndPoint nodeEndpoint, string path, bool requireMaster = true) {
+			var uri = CreateUri(nodeEndpoint, path);
+			var request = CreateRequest(uri, "POST", requireMaster);
+
+			request.Headers.Add("ES-EventType", "SomeType");
+			request.Headers.Add("ES-ExpectedVersion", ExpectedVersion.Any.ToString());
+			request.Headers.Add("ES-EventId", Guid.NewGuid().ToString());
+
+			var data = Encoding.UTF8.GetBytes("{a : \"1\", b:\"3\", c:\"5\" }");
+			request.ContentLength = data.Length;
+			request.ContentType = "application/json";
+			request.GetRequestStream().Write(data, 0, data.Length);
+
+			return GetRequestResponse(request);
+		}
+
+		private HttpWebRequest CreateRequest(Uri uri, string method, bool requireMaster) {
+			var request = (HttpWebRequest)WebRequest.Create(uri);
+			request.Method = method;
+			request.AllowAutoRedirect = false;
+			request.Headers.Add("ES-RequireMaster", requireMaster ? "True" : "False");
+
+			request.UseDefaultCredentials = false;
+			request.Credentials = DefaultData.AdminNetworkCredentials;
+			request.PreAuthenticate = true;
+			return request;
+		}
+
+		private HttpWebResponse GetRequestResponse(HttpWebRequest request) {
+			HttpWebResponse response;
+			try {
+				response = (HttpWebResponse)request.GetResponse();
+			} catch (WebException ex) {
+				response = (HttpWebResponse)ex.Response;
+			}
+			return response;
+		}
+
+		private Uri CreateUri(IPEndPoint nodeEndpoint, string path) {
+			var uriBuilder = new UriBuilder("http", nodeEndpoint.Address.ToString(), nodeEndpoint.Port, path);
+			return uriBuilder.Uri;
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -244,7 +244,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 		}
 
-
 		[TestFixture, Category("LongRunning")]
 		public class when_reading_a_stream_forward_with_linkto : HttpSpecificationWithLinkToToEvents {
 			private JObject _feed;
@@ -288,6 +287,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 				Assert.AreEqual(MakeUrl("/streams/" + StreamName + "/1"), foo["uri"].ToString());
 			}
 		}
+
 
 		[TestFixture, Category("LongRunning")]
 		public class when_reading_a_stream_forward_with_linkto_with_at_sign_in_name : HttpBehaviorSpecification {
@@ -433,7 +433,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 		}
 
-
 		[TestFixture, Category("LongRunning")]
 		public class
 			when_reading_a_stream_forward_with_deleted_linktos_with_content_enabled :
@@ -467,7 +466,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 			}
 		}
 
-
 		[TestFixture, Category("LongRunning")]
 		public class when_reading_a_stream_backward_with_deleted_linktos : HttpSpecificationWithLinkToToDeletedEvents {
 			private JObject _feed;
@@ -497,7 +495,6 @@ namespace EventStore.Core.Tests.Http.Streams {
 				Assert.AreEqual(MakeUrl("/streams/" + DeletedStreamName + "/0"), foo["uri"].ToString());
 			}
 		}
-
 
 		[TestFixture, Category("LongRunning")]
 		public class
@@ -631,6 +628,130 @@ namespace EventStore.Core.Tests.Http.Streams {
 			public void should_return_not_modified() {
 				Assert.AreEqual(HttpStatusCode.NotModified, _lastResponse.StatusCode);
 			}
+		}
+	}
+
+	[TestFixture, Category("LongRunning")]
+	public class when_reading_the_all_stream_backward_with_resolve_link_to : HttpSpecificationWithLinkToToEvents {
+		private JObject _feed;
+		private List<JToken> _entries;
+
+		protected override void When() {
+			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "True"}};
+			_feed = GetJson<JObject>("/streams/$all",
+				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
+			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
+		}
+
+		[Test]
+		public void there_are_three_events_for_the_first_original_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(StreamName));
+			Assert.AreEqual(3, events.Count());
+		}
+		
+		[Test]
+		public void there_are_two_events_for_the_second_original_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(Stream2Name));
+			Assert.AreEqual(2, events.Count());
+		}
+		
+		[Test]
+		public void there_are_no_events_for_the_linked_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(LinkedStreamName));
+			Assert.IsEmpty(events);
+		}
+	}
+
+	[TestFixture, Category("LongRunning")]
+	public class when_reading_the_all_stream_backward_with_resolve_link_to_disabled : HttpSpecificationWithLinkToToEvents {
+		private JObject _feed;
+		private List<JToken> _entries;
+
+		protected override void When() {
+			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "False"}};
+			_feed = GetJson<JObject>("/streams/$all",
+				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
+			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
+		}
+
+		[Test]
+		public void there_are_two_events_for_the_first_original_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(StreamName));
+			Assert.AreEqual(2, events.Count());
+		}
+		
+		[Test]
+		public void there_is_one_event_for_the_second_original_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(Stream2Name));
+			Assert.AreEqual(1, events.Count());
+		}
+		
+		[Test]
+		public void there_are_two_events_for_the_linked_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(LinkedStreamName));
+			Assert.AreEqual(2, events.Count());
+		}
+	}
+		
+	[TestFixture, Category("LongRunning")]
+	public class when_reading_the_all_stream_forward_with_resolve_link_to : HttpSpecificationWithLinkToToEvents {
+		private JObject _feed;
+		private List<JToken> _entries;
+
+		protected override void When() {
+			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "True"}};
+			_feed = GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/20", 
+				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
+			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
+		}
+
+		[Test]
+		public void there_are_three_events_for_the_first_original_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(StreamName));
+			Assert.AreEqual(3, events.Count());
+		}
+		
+		[Test]
+		public void there_are_two_events_for_the_second_original_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(Stream2Name));
+			Assert.AreEqual(2, events.Count());
+		}
+		
+		[Test]
+		public void there_are_no_events_for_the_linked_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(LinkedStreamName));
+			Assert.IsEmpty(events);
+		}
+	}
+
+	[TestFixture, Category("LongRunning")]
+	public class when_reading_the_all_stream_forward_with_resolve_link_to_disabled : HttpSpecificationWithLinkToToEvents {
+		private JObject _feed;
+		private List<JToken> _entries;
+
+		protected override void When() {
+			var headers = new NameValueCollection {{"ES-ResolveLinkTos", "False"}};
+			_feed = GetJson<JObject>("/streams/$all/00000000000000000000037777777777/forward/20", 
+				ContentType.Json, DefaultData.AdminNetworkCredentials, headers);
+			_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
+		}
+
+		[Test]
+		public void there_are_two_events_for_the_first_original_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(StreamName));
+			Assert.AreEqual(2, events.Count());
+		}
+		
+		[Test]
+		public void there_is_one_event_for_the_second_original_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(Stream2Name));
+			Assert.AreEqual(1, events.Count());
+		}
+		
+		[Test]
+		public void there_are_two_events_for_the_linked_stream() {
+			var events = _entries.Where(x => x["title"].Value<string>().Contains(LinkedStreamName));
+			Assert.AreEqual(2, events.Count());
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_tcp_stats_from_stat_controller.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_tcp_stats_from_stat_controller.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using EventStore.ClientAPI;
+using EventStore.ClientAPI.Internal;
 using EventStore.Common.Utils;
 using EventStore.Core.Messages;
 using EventStore.Transport.Http;
@@ -19,11 +20,10 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		private PortableServer _portableServer;
 		private IPEndPoint _serverEndPoint;
 		private int _serverPort;
-		private IEventStoreConnection _connection;
 		private string _url;
 		private string _clientConnectionName = "test-connection";
 
-		private List<MonitoringMessage.TcpConnectionStats> _results = new List<MonitoringMessage.TcpConnectionStats>();
+		private MonitoringMessage.TcpConnectionStats _externalConnection;
 		private HttpResponse _response;
 
 		protected override void Given() {
@@ -31,21 +31,30 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 			_serverEndPoint = new IPEndPoint(IPAddress.Loopback, _serverPort);
 			_url = _HttpEndPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/stats/tcp");
 
-			var settings = ConnectionSettings.Create();
-			_connection = EventStoreConnection.Create(settings, _node.TcpEndPoint, _clientConnectionName);
-			_connection.ConnectAsync().Wait();
-
 			var testEvent = new EventData(Guid.NewGuid(), "TestEvent", true,
 				Encoding.ASCII.GetBytes("{'Test' : 'OneTwoThree'}"), null);
-			_connection.AppendToStreamAsync("tests", ExpectedVersion.Any, testEvent).Wait();
+			_conn.AppendToStreamAsync("tests", ExpectedVersion.Any, testEvent).Wait();
 
 			_portableServer = new PortableServer(_serverEndPoint);
 			_portableServer.SetUp();
 		}
 
+		protected override IEventStoreConnection BuildConnection(MiniNode node) {
+			var settings = ConnectionSettings.Create()
+				.UseCustomLogger(ClientApiLoggerBridge.Default)
+				.EnableVerboseLogging()
+				.LimitReconnectionsTo(10)
+				.SetReconnectionDelayTo(TimeSpan.Zero)
+				.SetTimeoutCheckPeriodTo(TimeSpan.FromMilliseconds(100))
+				.FailOnNoServerResponse();
+			return EventStoreConnection.Create(settings, node.TcpEndPoint.ToESTcpUri(), _clientConnectionName);
+		}
+
 		protected override void When() {
 			Func<HttpResponse, bool> verifier = response => {
-				_results = Codec.Json.From<List<MonitoringMessage.TcpConnectionStats>>(response.Body);
+				var results = Codec.Json.From<List<MonitoringMessage.TcpConnectionStats>>(response.Body);
+				_externalConnection = results.FirstOrDefault(r =>
+					r.IsExternalConnection && r.ClientConnectionName == _clientConnectionName);
 				_response = response;
 				return true;
 			};
@@ -60,30 +69,24 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		}
 
 		[Test]
-		public void should_return_the_external_connections() {
-			Assert.AreEqual(2, _results.Count(r => r.IsExternalConnection));
+		public void should_return_the_named_connection() {
+			Assert.NotNull(_externalConnection);
 		}
 
 		[Test]
 		public void should_return_the_total_number_of_bytes_sent_for_external_connections() {
-			Assert.Greater(_results.Sum(r => r.IsExternalConnection ? r.TotalBytesSent : 0), 0);
+			Assert.Greater(_externalConnection.TotalBytesSent, 0);
 		}
 
 		[Test]
 		public void should_return_the_total_number_of_bytes_received_from_external_connections() {
-			Assert.Greater(_results.Sum(r => r.IsExternalConnection ? r.TotalBytesReceived : 0), 0);
-		}
-
-		[Test]
-		public void should_have_set_the_client_connection_name() {
-			Assert.IsTrue(_results.Any(x => x.ClientConnectionName == _clientConnectionName));
+			Assert.Greater(_externalConnection.TotalBytesReceived, 0);
 		}
 
 		[OneTimeTearDown]
 		public override void TestFixtureTearDown() {
 			PortsHelper.ReturnPort(_serverPort);
 			_portableServer.TearDown();
-			_connection.Dispose();
 			base.TestFixtureTearDown();
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -301,8 +301,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				return;
 			}
 
-			if (!requireMaster && _httpForwarder.ForwardRequest(manager))
-				return;
 			PostEntry(manager, expectedVersion, requireMaster, stream, includedId, includedType);
 		}
 
@@ -338,8 +336,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				return;
 			}
 
-			if (!requireMaster && _httpForwarder.ForwardRequest(manager))
-				return;
 			PostEntry(manager, expectedVersion, requireMaster, stream, id, includedType);
 		}
 
@@ -368,8 +364,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				return;
 			}
 
-			if (!requireMaster && _httpForwarder.ForwardRequest(manager))
-				return;
 			var envelope = new SendToHttpEnvelope(_networkSendQueue, manager, Format.DeleteStreamCompleted,
 				Configure.DeleteStreamCompleted);
 			var corrId = Guid.NewGuid();
@@ -521,8 +515,6 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				return;
 			}
 
-			if (!requireMaster && _httpForwarder.ForwardRequest(manager))
-				return;
 			PostEntry(manager, expectedVersion, requireMaster, SystemStreams.MetastreamOf(stream), includedId,
 				includedType);
 		}
@@ -656,6 +648,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				return;
 			}
 
+			if (!GetResolveLinkTos(manager, out var resolveLinkTos)) {
+				SendBadRequest(manager, $"{SystemHeaders.ResolveLinkTos} header in wrong format.");
+			}
 			bool requireMaster;
 			if (!GetRequireMaster(manager, out requireMaster)) {
 				SendBadRequest(manager, string.Format("{0} header in wrong format.", SystemHeaders.RequireMaster));
@@ -668,8 +663,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				(args, msg) => Configure.ReadAllEventsBackwardCompleted(args, msg, position == TFPos.HeadOfTf));
 			var corrId = Guid.NewGuid();
 			Publish(new ClientMessage.ReadAllEventsBackward(corrId, corrId, envelope,
-				position.CommitPosition, position.PreparePosition, count,
-				requireMaster, true, GetETagTFPosition(manager), manager.User));
+				position.CommitPosition, position.PreparePosition, count, resolveLinkTos,
+				requireMaster, GetETagTFPosition(manager), manager.User));
 		}
 
 		private void GetAllEventsBackwardFiltered(HttpEntityManager manager, UriTemplateMatch match) {
@@ -728,6 +723,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				return SendBadRequest(manager, string.Format("Invalid position argument: {0}", pos));
 			if (!int.TryParse(cnt, out count) || count <= 0)
 				return SendBadRequest(manager, string.Format("Invalid count argument: {0}", cnt));
+			if (!GetResolveLinkTos(manager, out var resolveLinkTos))
+				return SendBadRequest(manager, $"{SystemHeaders.ResolveLinkTos} header in wrong format.");
 			bool requireMaster;
 			if (!GetRequireMaster(manager, out requireMaster))
 				return SendBadRequest(manager,
@@ -742,8 +739,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				(args, msg) => Configure.ReadAllEventsForwardCompleted(args, msg, headOfTf: false));
 			var corrId = Guid.NewGuid();
 			Publish(new ClientMessage.ReadAllEventsForward(corrId, corrId, envelope,
-				position.CommitPosition, position.PreparePosition, count,
-				requireMaster, true, GetETagTFPosition(manager), manager.User,
+				position.CommitPosition, position.PreparePosition, count, resolveLinkTos,
+				requireMaster, GetETagTFPosition(manager), manager.User,
 				longPollTimeout));
 			return new RequestParams((longPollTimeout ?? TimeSpan.Zero) + ESConsts.HttpTimeout);
 		}

--- a/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/HttpEntityManager.cs
@@ -143,7 +143,7 @@ namespace EventStore.Transport.Http.EntityManagement {
 			try {
 				HttpEntity.Response.AddHeader("Access-Control-Allow-Methods", string.Join(", ", _allowedMethods));
 				HttpEntity.Response.AddHeader("Access-Control-Allow-Headers",
-					"Content-Type, X-Requested-With, X-Forwarded-Host, X-Forwarded-Prefix, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion, ES-EventId, ES-EventType, ES-RequiresMaster, ES-HardDelete, ES-ResolveLinkTos");
+					"Content-Type, X-Requested-With, X-Forwarded-Host, X-Forwarded-Prefix, X-PINGOTHER, Authorization, ES-LongPoll, ES-ExpectedVersion, ES-EventId, ES-EventType, ES-RequireMaster, ES-HardDelete, ES-ResolveLinkTos");
 				HttpEntity.Response.AddHeader("Access-Control-Allow-Origin", "*");
 				HttpEntity.Response.AddHeader("Access-Control-Expose-Headers",
 					"Location, ES-Position, ES-CurrentVersion");


### PR DESCRIPTION
Add tests around requires master.
The requests now redirect rather than being forwarded.

Handle `ES-ResolveLinkTos` header correctly in $all.
Add tests around reading $all with `ResolveLinkTos`.