### PR TITLE
Matrixify CI Builds

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -134,194 +134,112 @@ jobs:
       artifactName: macos-mono516-release
       pathToPublish: '$(Build.SourcesDirectory)/bin/'
 
-- job: centos7_x64_debug
-  displayName: 'Centos 7 x64 Debug'
-  timeoutInMinutes: 20
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - bash: docker pull eventstore/eventstore-ci-centos7:latest
-    displayName: Pull Docker image for build
-    failOnStderr: false
-  - task: Docker@1
-    displayName: Compile in CentOS 7 Container
-    inputs:
-      command: 'run'
-      imageName: 'eventstore/eventstore-ci-centos7:latest'
-      runInBackground: false
-      volumes: '$(Build.SourcesDirectory):/work'
-      envVars: |
-        FrameworkPathOverride=/usr/lib/mono/4.7.1-api
-        EventStoreBuildConfig=Debug
-      containerCommand: ci/ap-build-linux.sh
-      workingDirectory: '/work'
-  - task: Docker@1
-    displayName: Test in CentOS 7 Container
-    inputs:
-      command: run
-      imageName: eventstore/eventstore-ci-centos7:latest
-      runInBackground: false
-      volumes: '$(Build.SourcesDirectory):/work'
-      envVars: |
-        FrameworkPathOverride=/usr/lib/mono/4.7.1-api
-        EventStoreBuildConfig=Debug
-      containerCommand: ci/ap-test-linux.sh
-      workingDirectory: '/work'
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testRunTitle: "Centos 7 (Mono 5.16)"
-      platform: "Centos 7"
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-  - task: PublishBuildArtifacts@1
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
-    displayName: Publish Artifacts
-    inputs:
-      artifactName: centos7-mono516-debug
-      pathToPublish: '$(Build.SourcesDirectory)/bin/'
+- job: centos_x64
+  strategy:
+    matrix:
+      DEBUG:
+        Configuration: debug
+      RELEASE:
+        Configuration: release
 
-- job: centos7_x64_release
-  displayName: 'Centos 7 x64 Release'
+  displayName: Centos 7 x64
   timeoutInMinutes: 20
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-  - bash: docker pull eventstore/eventstore-ci-centos7:latest
-    displayName: Pull Docker image for build
-    failOnStderr: false
-  - task: Docker@1
-    displayName: Compile in CentOS 7 Container
-    inputs:
-      command: 'run'
-      imageName: 'eventstore/eventstore-ci-centos7:latest'
-      runInBackground: false
-      volumes: '$(Build.SourcesDirectory):/work'
-      envVars: |
-        FrameworkPathOverride=/usr/lib/mono/4.7.1-api
-        EventStoreBuildConfig=Release
-      containerCommand: ci/ap-build-linux.sh
-      workingDirectory: '/work'
-  - task: Docker@1
-    displayName: Test in CentOS 7 Container
-    inputs:
-      command: run
-      imageName: eventstore/eventstore-ci-centos7:latest
-      runInBackground: false
-      volumes: '$(Build.SourcesDirectory):/work'
-      envVars: |
-        FrameworkPathOverride=/usr/lib/mono/4.7.1-api
-        EventStoreBuildConfig=Release
-      containerCommand: ci/ap-test-linux.sh
-      workingDirectory: '/work'
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testRunTitle: "Centos 7 (Mono 5.16)"
-      platform: "Centos 7"
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-  - task: PublishBuildArtifacts@1
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
-    displayName: Publish Artifacts
-    inputs:
-      artifactName: centos7-mono516-release
-      pathToPublish: '$(Build.SourcesDirectory)/bin/'
+    - bash: docker pull eventstore/eventstore-ci-centos7:latest
+      displayName: Pull Docker image for build
+      failOnStderr: false
+    - task: Docker@1
+      displayName: Compile in CentOS 7 Container
+      inputs:
+        command: 'run'
+        imageName: 'eventstore/eventstore-ci-centos7:latest'
+        runInBackground: false
+        volumes: '$(Build.SourcesDirectory):/work'
+        envVars: |
+          FrameworkPathOverride=/usr/lib/mono/4.7.1-api
+          EventStoreBuildConfig=$(Configuration)
+        containerCommand: ci/ap-build-linux.sh
+        workingDirectory: '/work'
+    - task: Docker@1
+      displayName: Test in CentOS 7 Container
+      inputs:
+        command: run
+        imageName: eventstore/eventstore-ci-centos7:latest
+        runInBackground: false
+        volumes: '$(Build.SourcesDirectory):/work'
+        envVars: |
+          FrameworkPathOverride=/usr/lib/mono/4.7.1-api
+          EventStoreBuildConfig=$(Configuration)
+        containerCommand: ci/ap-test-linux.sh
+        workingDirectory: '/work'
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      condition: succeededOrFailed()
+      inputs:
+        testRunTitle: "Centos 7 (Mono 5.16)"
+        platform: "Centos 7"
+        testRunner: VSTest
+        testResultsFiles: '**/*.trx'
+    - task: PublishBuildArtifacts@1
+      condition: eq(variables['System.PullRequest.IsFork'], 'False')
+      displayName: Publish Artifacts
+      inputs:
+        artifactName: centos7-mono516-${{ variables['Configuration'] }}
+        pathToPublish: '$(Build.SourcesDirectory)/bin/'
 
-- job: ubuntu1404_x64_debug
-  displayName: 'Ubuntu 14.04 x64 Debug'
-  timeoutInMinutes: 20
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - bash: docker pull eventstore/eventstore-ci-ubuntu-14.04:latest
-    displayName: Pull Docker image for build
-    failOnStderr: false
-  - task: Docker@1
-    displayName: Compile in Ubuntu 14.04 Container
-    inputs:
-      command: 'run'
-      imageName: 'eventstore/eventstore-ci-ubuntu-14.04:latest'
-      runInBackground: false
-      volumes: '$(Build.SourcesDirectory):/work'
-      envVars: |
-        FrameworkPathOverride=/usr/lib/mono/4.7.1-api
-        EventStoreBuildConfig=Debug
-      containerCommand: ci/ap-build-linux.sh
-      workingDirectory: '/work'
-  - task: Docker@1
-    displayName: Test in Ubuntu 14.04 Container
-    inputs:
-      command: run
-      imageName: eventstore/eventstore-ci-ubuntu-14.04:latest
-      runInBackground: false
-      volumes: '$(Build.SourcesDirectory):/work'
-      envVars: |
-        FrameworkPathOverride=/usr/lib/mono/4.7.1-api
-        EventStoreBuildConfig=Debug
-      containerCommand: ci/ap-test-linux.sh
-      workingDirectory: '/work'
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testRunTitle: "Ubuntu 14.04 (Mono 5.16)"
-      platform: "Ubuntu 14.04"
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-  - task: PublishBuildArtifacts@1
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
-    displayName: Publish Artifacts
-    inputs:
-      artifactName: ubuntu1404-mono516-debug
-      pathToPublish: '$(Build.SourcesDirectory)/bin/'
+- job: ubuntu_x64
+  strategy:
+    matrix:
+      DEBUG:
+        Configuration: debug
+      RELEASE:
+        Configuration: release
 
-- job: ubuntu1404_x64_release
-  displayName: 'Ubuntu 14.04 x64 Release'
+  displayName: Ubuntu 14.04 x64
   timeoutInMinutes: 20
   pool:
     vmImage: 'ubuntu-16.04'
   steps:
-  - bash: docker pull eventstore/eventstore-ci-ubuntu-14.04:latest
-    displayName: Pull Docker image for build
-    failOnStderr: false
-  - task: Docker@1
-    displayName: Compile in Ubuntu 14.04 Container
-    inputs:
-      command: 'run'
-      imageName: 'eventstore/eventstore-ci-ubuntu-14.04:latest'
-      runInBackground: false
-      volumes: '$(Build.SourcesDirectory):/work'
-      envVars: |
-        FrameworkPathOverride=/usr/lib/mono/4.7.1-api
-        EventStoreBuildConfig=Release
-      containerCommand: ci/ap-build-linux.sh
-      workingDirectory: '/work'
-  - task: Docker@1
-    displayName: Test in Ubuntu 14.04 Container
-    inputs:
-      command: run
-      imageName: eventstore/eventstore-ci-ubuntu-14.04:latest
-      runInBackground: false
-      volumes: '$(Build.SourcesDirectory):/work'
-      envVars: |
-        FrameworkPathOverride=/usr/lib/mono/4.7.1-api
-        EventStoreBuildConfig=Release
-      containerCommand: ci/ap-test-linux.sh
-      workingDirectory: '/work'
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testRunTitle: "Ubuntu 14.04 (Mono 5.16)"
-      platform: "Ubuntu 14.04"
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-  - task: PublishBuildArtifacts@1
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
-    displayName: Publish Artifacts
-    inputs:
-      artifactName: ubuntu1404-mono516-release
-      pathToPublish: '$(Build.SourcesDirectory)/bin/'
+    - bash: docker pull eventstore/eventstore-ci-ubuntu-14.04:latest
+      displayName: Pull Docker image for build
+      failOnStderr: false
+    - task: Docker@1
+      displayName: Compile in Ubuntu 14.04 Container
+      inputs:
+        command: 'run'
+        imageName: 'eventstore/eventstore-ci-ubuntu-14.04:latest'
+        runInBackground: false
+        volumes: '$(Build.SourcesDirectory):/work'
+        envVars: |
+          FrameworkPathOverride=/usr/lib/mono/4.7.1-api
+          EventStoreBuildConfig=$(Configuration)
+        containerCommand: ci/ap-build-linux.sh
+        workingDirectory: '/work'
+    - task: Docker@1
+      displayName: Test in Ubuntu 14.04 Container
+      inputs:
+        command: run
+        imageName: eventstore/eventstore-ci-ubuntu-14.04:latest
+        runInBackground: false
+        volumes: '$(Build.SourcesDirectory):/work'
+        envVars: |
+          FrameworkPathOverride=/usr/lib/mono/4.7.1-api
+          EventStoreBuildConfig=$(Configuration)
+        containerCommand: ci/ap-test-linux.sh
+        workingDirectory: '/work'
+    - task: PublishTestResults@2
+      displayName: Publish Test Results
+      condition: succeededOrFailed()
+      inputs:
+        testRunTitle: "Ubuntu 14.04 (Mono 5.16)"
+        platform: "Ubuntu 14.04"
+        testRunner: VSTest
+        testResultsFiles: '**/*.trx'
+    - task: PublishBuildArtifacts@1
+      condition: eq(variables['System.PullRequest.IsFork'], 'False')
+      displayName: Publish Artifacts
+      inputs:
+        artifactName: ubuntu1404-mono516-${{ variables['Configuration'] }}
+        pathToPublish: '$(Build.SourcesDirectory)/bin/'

--- a/ci.yml
+++ b/ci.yml
@@ -2,21 +2,27 @@ resources:
 - repo: self
 
 jobs:
-- job: windows_x64_debug
-  displayName: 'Windows x64 Debug'
+- job: windows_x64
+  strategy:
+    matrix:
+      DEBUG:
+        Configuration: debug
+      RELEASE:
+        Configuration: release
+  displayName: 'Windows x64'
   timeoutInMinutes: 30
   pool:
     vmImage: 'vs2017-win2016'
   steps:
   - powershell: |
-      dotnet build -c Debug src\EventStore.sln
+      dotnet build -c $(Configuration) src\EventStore.sln
       if (-Not $?) { throw "Exit code is $?" }
     workingDirectory: $(Build.SourcesDirectory)
     displayName: Compile
   - powershell: |
       (Get-ChildItem -Attributes Directory src | % FullName) -Match '.Tests' | `
         ForEach-Object {
-          dotnet test -v normal -c Debug --no-build --logger trx $_ -- RunConfiguration.TargetPlatform=x64
+          dotnet test -v normal -c $(Configuration) --no-build --logger trx $_ -- RunConfiguration.TargetPlatform=x64
           if (-Not $?) { throw "Exit code is $?" }
         }
     workingDirectory: $(Build.SourcesDirectory)
@@ -34,43 +40,9 @@ jobs:
     condition: eq(variables['System.PullRequest.IsFork'], 'False')
     displayName: Publish Artifacts
     inputs:
-      artifactName: windows-net471-debug
+      artifactName: windows-net471-{{ variables['Configuration'] }}
       pathToPublish: '$(Build.SourcesDirectory)\bin\'
 
-- job: windows_x64_release
-  displayName: 'Windows x64 Release'
-  timeoutInMinutes: 30
-  pool:
-    vmImage: 'vs2017-win2016'
-  steps:
-  - powershell: |
-      dotnet build -c Release src\EventStore.sln
-      if (-Not $?) { throw "Exit code is $?" }
-    workingDirectory: $(Build.SourcesDirectory)
-    displayName: Compile
-  - powershell: |
-      (Get-ChildItem -Attributes Directory src | % FullName) -Match '.Tests' | `
-        ForEach-Object {
-          dotnet test -v normal -c Release --no-build --logger trx $_ -- RunConfiguration.TargetPlatform=x64
-          if (-Not $?) { throw "Exit code is $?" }
-        }
-    workingDirectory: $(Build.SourcesDirectory)
-    displayName: Test
-    errorActionPreference: Stop
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testRunTitle: "Windows (.NET Framework)"
-      platform: "Windows"
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-  - task: PublishBuildArtifacts@1
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
-    displayName: Publish Artifacts
-    inputs:
-      artifactName: windows-net471-release
-      pathToPublish: '$(Build.SourcesDirectory)\bin\'
 
 - job: macos_x64_debug
   displayName: 'macOS x64 Debug'

--- a/ci.yml
+++ b/ci.yml
@@ -43,20 +43,25 @@ jobs:
       artifactName: windows-net471-{{ variables['Configuration'] }}
       pathToPublish: '$(Build.SourcesDirectory)\bin\'
 
-
-- job: macos_x64_debug
-  displayName: 'macOS x64 Debug'
+- job: macos_x64
+  strategy:
+    matrix:
+      DEBUG:
+        Configuration: debug
+      RELEASE:
+        Configuration: release
+  displayName: 'macOS x64'
   timeoutInMinutes: 20
   pool:
     vmImage: 'macOS 10.13'
   steps:
   - bash: . '$(Build.SourcesDirectory)/ci/ap-setup-osx.sh'
     displayName: Setup
-  - bash: dotnet build -c Debug src/EventStore.sln
+  - bash: dotnet build -c $(Configuration) src/EventStore.sln
     env:
       FrameworkPathOverride: /Library/Frameworks/Mono.framework/Versions/5.16.0/lib/mono/4.7.1-api
     displayName: Compile
-  - bash: find ./src -maxdepth 1 -type d -name "*.Tests" -print0| xargs -0 -n1 dotnet test -v normal -c Debug --logger trx
+  - bash: find ./src -maxdepth 1 -type d -name "*.Tests" -print0| xargs -0 -n1 dotnet test -v normal -c $(Configuration) --logger trx
     env:
       FrameworkPathOverride: /Library/Frameworks/Mono.framework/Versions/5.16.0/lib/mono/4.7.1-api
     displayName: Run Tests
@@ -72,38 +77,7 @@ jobs:
     condition: eq(variables['System.PullRequest.IsFork'], 'False')
     displayName: Publish Artifacts
     inputs:
-      artifactName: macos-mono516-debug
-      pathToPublish: '$(Build.SourcesDirectory)/bin/'
-
-- job: macos_x64_release
-  displayName: 'macOS x64 Release'
-  timeoutInMinutes: 20
-  pool:
-    vmImage: 'macOS 10.13'
-  steps:
-  - bash: . '$(Build.SourcesDirectory)/ci/ap-setup-osx.sh'
-    displayName: Setup
-  - bash: dotnet build -c Release src/EventStore.sln
-    env:
-      FrameworkPathOverride: /Library/Frameworks/Mono.framework/Versions/5.16.0/lib/mono/4.7.1-api
-    displayName: Compile
-  - bash: find ./src -maxdepth 1 -type d -name "*.Tests" -print0| xargs -0 -n1 dotnet test -v normal -c Release --logger trx
-    env:
-      FrameworkPathOverride: /Library/Frameworks/Mono.framework/Versions/5.16.0/lib/mono/4.7.1-api
-    displayName: Run Tests
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testRunTitle: "MacOS 10.13 (Mono 5.16)"
-      platform: "MacOS 10.13"
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-  - task: PublishBuildArtifacts@1
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
-    displayName: Publish Artifacts
-    inputs:
-      artifactName: macos-mono516-release
+      artifactName: macos-mono516-{{ variables['Configuration'] }}
       pathToPublish: '$(Build.SourcesDirectory)/bin/'
 
 - job: centos_x64


### PR DESCRIPTION
This is related to my work on #1996. There I have decided to use an environment variable to control which `IHttpServer` is tested. I naïvely ran the test suite twice, but that caused some builds to time out.

I could have also simply copied and pasted the build jobs, but then we'd have a total of **16** jobs which is a bit much.

So instead I decided to leverage the matrix feature. This way our jobs can be kept to a maximum of 4 (or 3 if we merge the Centos and Ubuntu jobs).