### PR TITLE
Add client connection name to persistent subscription info.

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedPersistentSubscription.cs
@@ -15,9 +15,10 @@ namespace EventStore.ClientAPI.Embedded {
 		private readonly int _bufferSize;
 		private readonly Func<EventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> _eventAppeared;
 		private string _subscriptionId;
+		private string _connectionName;
 
 		public EmbeddedPersistentSubscription(
-			ILogger log, IPublisher publisher, Guid connectionId,
+			ILogger log, IPublisher publisher, Guid connectionId, string connectionName,
 			TaskCompletionSource<PersistentEventStoreSubscription> source, string subscriptionId, string streamId,
 			UserCredentials userCredentials, IAuthenticationProvider authenticationProvider, int bufferSize,
 			Func<EventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> eventAppeared,
@@ -29,6 +30,7 @@ namespace EventStore.ClientAPI.Embedded {
 			_authenticationProvider = authenticationProvider;
 			_bufferSize = bufferSize;
 			_eventAppeared = eventAppeared;
+			_connectionName = connectionName;
 		}
 
 		protected override PersistentEventStoreSubscription CreateVolatileSubscription(long lastCommitPosition,
@@ -42,7 +44,7 @@ namespace EventStore.ClientAPI.Embedded {
 			Publisher.PublishWithAuthentication(_authenticationProvider, _userCredentials,
 				ex => DropSubscription(EventStore.Core.Services.SubscriptionDropReason.AccessDenied, ex),
 				user => new ClientMessage.ConnectToPersistentSubscription(correlationId, correlationId,
-					new PublishEnvelope(Publisher, true), ConnectionId, _subscriptionId, StreamId, _bufferSize,
+					new PublishEnvelope(Publisher, true), ConnectionId, _connectionName, _subscriptionId, StreamId, _bufferSize,
 					String.Empty,
 					user));
 		}

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriber.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedSubscriber.cs
@@ -17,14 +17,16 @@ namespace EventStore.ClientAPI.Embedded {
 		private readonly IAuthenticationProvider _authenticationProvider;
 		private readonly ILogger _log;
 		private readonly Guid _connectionId;
+		private readonly string _connectionName;
 
 
 		public EmbeddedSubscriber(IPublisher publisher, IAuthenticationProvider authenticationProvider, ILogger log,
-			Guid connectionId) {
+			Guid connectionId, string connectionName) {
 			_publisher = publisher;
 			_authenticationProvider = authenticationProvider;
 			_log = log;
 			_connectionId = connectionId;
+			_connectionName = connectionName;
 			_subscriptions = new EmbeddedSubcriptionsManager();
 		}
 
@@ -87,7 +89,7 @@ namespace EventStore.ClientAPI.Embedded {
 			Func<EventStoreSubscription, PersistentSubscriptionResolvedEvent, Task> eventAppeared,
 			Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped, int maxRetries,
 			TimeSpan operationTimeout) {
-			var subscription = new EmbeddedPersistentSubscription(_log, _publisher, _connectionId, source,
+			var subscription = new EmbeddedPersistentSubscription(_log, _publisher, _connectionId, _connectionName, source,
 				subscriptionId, streamId, userCredentials, _authenticationProvider, bufferSize, eventAppeared,
 				subscriptionDropped, maxRetries, operationTimeout);
 

--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -77,7 +77,7 @@ namespace EventStore.ClientAPI.Embedded {
 			_authenticationProvider = authenticationProvider;
 			_subscriptionBus = new InMemoryBus("Embedded Client Subscriptions");
 			_subscriptions =
-				new EmbeddedSubscriber(_subscriptionBus, _authenticationProvider, _settings.Log, connectionId);
+				new EmbeddedSubscriber(_subscriptionBus, _authenticationProvider, _settings.Log, connectionId, connectionName);
 
 			_subscriptionBus.Subscribe<ClientMessage.SubscriptionConfirmation>(_subscriptions);
 			_subscriptionBus.Subscribe<ClientMessage.SubscriptionDropped>(_subscriptions);

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -129,7 +129,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.WithMessageParker(new FakeMessageParker())
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 0));
 			Assert.AreEqual(1, envelope.Replies.Count);
 		}
@@ -148,8 +148,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.PreferRoundRobin()
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope2, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope2, 10, "foo", "bar");
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 0));
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 1));
 			Assert.AreEqual(1, envelope1.Replies.Count);
@@ -170,8 +170,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.PreferDispatchToSingle()
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope2, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope2, 10, "foo", "bar");
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 0));
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 1));
 			Assert.AreEqual(2, envelope1.Replies.Count);
@@ -190,7 +190,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.WithMessageParker(new FakeMessageParker())
 					.StartFromBeginning());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			sub.HandleReadCompleted(new[] {Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 0)}, 1, false);
 			Assert.AreEqual(1, envelope1.Replies.Count);
 		}
@@ -207,7 +207,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.WithMessageParker(new FakeMessageParker())
 					.StartFromBeginning());
 			Assert.DoesNotThrow(() => {
-				sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+				sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 				sub.HandleReadCompleted(new[] {Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 0)}, 1,
 					false);
 			});
@@ -225,7 +225,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.WithMessageParker(new FakeMessageParker())
 					.StartFromBeginning());
 			Assert.DoesNotThrow(() => {
-				sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+				sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 				sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 0));
 			});
 		}
@@ -245,8 +245,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.PreferRoundRobin()
 					.StartFromBeginning());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope2, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope2, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -272,8 +272,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.PreferDispatchToSingle()
 					.StartFromBeginning());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope2, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope2, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -333,7 +333,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			//a subscriber coming in a while later, should receive all 3 events
 			await Task.Delay(500).ContinueWith((action) => {
 				//add a subscriber
-				sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope, 10, "foo", "bar");
+				sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope, 10, "foo", "bar");
 
 				//all 3 events should be received by the subscriber
 				Assert.AreEqual(3, envelope.Replies.Count);
@@ -487,8 +487,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(20));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(id, "type", "streamName", 0),
@@ -515,8 +515,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(20));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(id, "type", "streamName", 0),
@@ -542,8 +542,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(1));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -571,8 +571,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(1));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -601,8 +601,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(1));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(id, "type", "streamName", 0),
@@ -631,8 +631,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(1));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			var id3 = Guid.NewGuid();
@@ -663,8 +663,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(1));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			var id3 = Guid.NewGuid();
@@ -696,8 +696,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(1));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			var id3 = Guid.NewGuid();
@@ -727,8 +727,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(5));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -758,8 +758,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.MaximumToCheckPoint(5));
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -821,7 +821,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 			var clientConnectionId = Guid.NewGuid();
 			var clientCorrelationId = Guid.NewGuid();
-			sub.AddClient(clientCorrelationId, clientConnectionId, new FakeEnvelope(), 10, "foo", "bar");
+			sub.AddClient(clientCorrelationId, clientConnectionId, "connection-1", new FakeEnvelope(), 10, "foo", "bar");
 
 			//send events 1-3, ACK event 1 only and Mark checkpoint
 			sub.HandleReadCompleted(new[] {
@@ -873,7 +873,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 			var clientConnectionId = Guid.NewGuid();
 			var clientCorrelationId = Guid.NewGuid();
-			sub.AddClient(clientCorrelationId, clientConnectionId, new FakeEnvelope(), 10, "foo", "bar");
+			sub.AddClient(clientCorrelationId, clientConnectionId, "connection-1", new FakeEnvelope(), 10, "foo", "bar");
 
 			//handle event number 10@streamName
 			var readEventId = Guid.NewGuid();
@@ -898,7 +898,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			sub.RetryAllParkedMessages();
 
 			//handle parked event 15@$persistentsubscription-streamName::groupName-parked
-			//this should send the parked event to the retry buffer. 
+			//this should send the parked event to the retry buffer.
 			sub.HandleParkedReadCompleted(new[] {
 				parkedEvent,
 			},16,true,17);
@@ -997,7 +997,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning()
 					.WithMessageTimeoutOf(TimeSpan.FromSeconds(3)));
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -1025,8 +1025,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning()
 					.WithMessageTimeoutOf(TimeSpan.FromSeconds(1)));
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 1, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 1, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 1, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", envelope1, 1, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -1116,7 +1116,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.WithMaxRetriesOf(0)
 					.WithMessageTimeoutOf(TimeSpan.FromSeconds(1)));
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(id1, "type", "streamName", 0),
@@ -1144,7 +1144,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.WithMaxRetriesOf(0)
 					.WithMessageTimeoutOf(TimeSpan.FromSeconds(1)));
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -1176,7 +1176,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.WithMessageTimeoutOf(TimeSpan.Zero)
 					.StartFromBeginning());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 2, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 2, "foo", "bar");
 
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName", 0),
@@ -1216,7 +1216,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning()
 					.DontTimeoutMessages());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
@@ -1247,7 +1247,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning());
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(id1, "type", "streamName", 0),
@@ -1273,7 +1273,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning());
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(id1, "type", "streamName", 0),
@@ -1298,7 +1298,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning());
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(id1, "type", "streamName", 0),
@@ -1323,7 +1323,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning());
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			sub.HandleReadCompleted(new[] {
 				Helper.BuildFakeEvent(id1, "type", "streamName", 0),
@@ -1351,7 +1351,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning());
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 10, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 10, "foo", "bar");
 			var id1 = Guid.NewGuid();
 			var ev = Helper.BuildFakeEvent(id1, "type", "streamName", 0);
 			sub.HandleReadCompleted(new[] {
@@ -1387,7 +1387,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromBeginning());
 			reader.Load(null);
 			var corrid = Guid.NewGuid();
-			sub.AddClient(corrid, Guid.NewGuid(), envelope1, 1, "foo", "bar");
+			sub.AddClient(corrid, Guid.NewGuid(), "connection-1", envelope1, 1, "foo", "bar");
 
 			var id1 = Guid.NewGuid();
 			var id2 = Guid.NewGuid();
@@ -1420,7 +1420,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.WithMessageParker(new FakeMessageParker())
 					.WithCheckpointWriter(new FakeCheckpointWriter(x => { })));
 
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), new FakeEnvelope(), 1, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", new FakeEnvelope(), 1, "foo", "bar");
 			Assert.IsTrue(sub.HasClients);
 			Assert.AreEqual(1, sub.ClientCount);
 		}
@@ -1445,9 +1445,9 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 			fakeCheckpointReader.Load(null);
 
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
 			var client2Id = Guid.NewGuid();
-			sub.AddClient(client2Id, Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+			sub.AddClient(client2Id, Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 
 			Assert.IsTrue(sub.HasClients);
@@ -1484,9 +1484,9 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 			fakeCheckpointReader.Load(null);
 
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
 			var connectionId = Guid.NewGuid();
-			sub.AddClient(Guid.NewGuid(), connectionId, client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), connectionId, "connection-2", client2Envelope, 10, "foo", "bar");
 
 			Assert.IsTrue(sub.HasClients);
 			Assert.AreEqual(2, sub.ClientCount);

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -24,8 +24,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0));
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 1));
@@ -64,8 +64,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0));
 
@@ -103,8 +103,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0,
 				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0)));
@@ -146,8 +146,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0,
 				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
@@ -189,9 +189,9 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
 			var client2Id = Guid.NewGuid();
-			sub.AddClient(client2Id, Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+			sub.AddClient(client2Id, Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0,
 				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
@@ -224,8 +224,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new ByLengthHasher()))
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1", 0));
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11", 1));
@@ -237,7 +237,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			Assert.AreEqual(3, client1Envelope.Replies.Count);
 			Assert.AreEqual(3, client2Envelope.Replies.Count);
 
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client3Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-3", client3Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1", 6));
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11", 7));
@@ -267,7 +267,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.StartFromCurrent());
 			reader.Load(null);
 			var conn1Id = Guid.NewGuid();
-			sub.AddClient(Guid.NewGuid(), conn1Id, client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), conn1Id, "connection-1", client1Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "1", 0));
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildFakeEvent(Guid.NewGuid(), "type", "11", 1));
@@ -276,7 +276,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			Assert.AreEqual(3, client1Envelope.Replies.Count);
 
 			var conn2Id = Guid.NewGuid();
-			sub.AddClient(Guid.NewGuid(), conn2Id, client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), conn2Id, "connection-2", client2Envelope, 10, "foo", "bar");
 
 			Assert.AreEqual(3, client1Envelope.Replies.Count);
 			Assert.AreEqual(0, client2Envelope.Replies.Count);
@@ -302,9 +302,9 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 					.CustomConsumerStrategy(new PinnedPersistentSubscriptionConsumerStrategy(new XXHashUnsafe()))
 					.StartFromCurrent());
 			reader.Load(null);
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client1Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-1", client1Envelope, 10, "foo", "bar");
 			var client2Id = Guid.NewGuid();
-			sub.AddClient(Guid.NewGuid(), client2Id, client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), client2Id, "connection-2", client2Envelope, 10, "foo", "bar");
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 0,
 				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-1", 0), false));
@@ -339,12 +339,12 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			var sub = new Core.Services.PersistentSubscription.PersistentSubscription(settings);
 			reader.Load(null);
 			var client1Id = Guid.NewGuid();
-			sub.AddClient(Guid.NewGuid(), client1Id, client1Envelope, 14, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), client1Id, "connection-1", client1Envelope, 14, "foo", "bar");
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
 
 			var client2Id = Guid.NewGuid();
-			sub.AddClient(Guid.NewGuid(), client2Id, client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), client2Id, "connection-2", client2Envelope, 10, "foo", "bar");
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
 
@@ -375,11 +375,11 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			var sub = new Core.Services.PersistentSubscription.PersistentSubscription(settings);
 			reader.Load(null);
 			var client1Id = Guid.NewGuid();
-			sub.AddClient(Guid.NewGuid(), client1Id, client1Envelope, 14, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), client1Id, "connection-1", client1Envelope, 14, "foo", "bar");
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
 
 			var client2Id = Guid.NewGuid();
-			sub.AddClient(Guid.NewGuid(), client2Id, client2Envelope, 10, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), client2Id, "connection-2", client2Envelope, 10, "foo", "bar");
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
 
@@ -420,11 +420,11 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			var sub = new Core.Services.PersistentSubscription.PersistentSubscription(settings);
 			reader.Load(null);
 			var correlationId1 = Guid.NewGuid();
-			sub.AddClient(correlationId1, Guid.NewGuid(), client1Envelope, 14, "foo", "bar");
+			sub.AddClient(correlationId1, Guid.NewGuid(), "connection-1", client1Envelope, 14, "foo", "bar");
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
 
 			var correlationId2 = Guid.NewGuid();
-			sub.AddClient(correlationId2, Guid.NewGuid(), client2Envelope, 10, "foo", "bar");
+			sub.AddClient(correlationId2, Guid.NewGuid(), "connection-2", client2Envelope, 10, "foo", "bar");
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
 
@@ -466,9 +466,9 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			reader.Load(null);
 
 			var correlationId = Guid.NewGuid();
-			sub.AddClient(correlationId, Guid.NewGuid(), client1Envelope, 1, "foo", "bar");
+			sub.AddClient(correlationId, Guid.NewGuid(), "connection-1", client1Envelope, 1, "foo", "bar");
 
-			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), client2Envelope, 1, "foo", "bar");
+			sub.AddClient(Guid.NewGuid(), Guid.NewGuid(), "connection-2", client2Envelope, 1, "foo", "bar");
 
 
 			var message1 = Guid.NewGuid();

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -895,6 +895,7 @@ namespace EventStore.Core.Messages {
 			}
 
 			public readonly Guid ConnectionId;
+			public readonly string ConnectionName;
 			public readonly string SubscriptionId;
 			public readonly string EventStreamId;
 			public readonly int AllowedInFlightMessages;
@@ -902,6 +903,7 @@ namespace EventStore.Core.Messages {
 
 			public ConnectToPersistentSubscription(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 				Guid connectionId,
+				string connectionName,
 				string subscriptionId, string eventStreamId, int allowedInFlightMessages, string from, IPrincipal user)
 				: base(internalCorrId, correlationId, envelope, user) {
 				Ensure.NotEmptyGuid(connectionId, "connectionId");
@@ -909,6 +911,7 @@ namespace EventStore.Core.Messages {
 				Ensure.Nonnegative(allowedInFlightMessages, "AllowedInFlightMessages");
 				SubscriptionId = subscriptionId;
 				ConnectionId = connectionId;
+				ConnectionName = connectionName;
 				AllowedInFlightMessages = allowedInFlightMessages;
 				EventStreamId = eventStreamId;
 				From = from;

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -134,6 +134,7 @@ namespace EventStore.Core.Messages {
 			public List<Measurement> ObservedMeasurements { get; set; }
 			public int AvailableSlots { get; set; }
 			public int InFlightMessages { get; set; }
+			public string ConnectionName { get; set; }
 		}
 
 		public class GetFreshStats : Message {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -229,10 +229,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					: DateTime.UtcNow + _settings.MessageTimeout);
 		}
 
-		public void AddClient(Guid correlationId, Guid connectionId, IEnvelope envelope, int maxInFlight, string user,
+		public void AddClient(Guid correlationId, Guid connectionId, string connectionName, IEnvelope envelope, int maxInFlight, string user,
 			string @from) {
 			lock (_lock) {
-				var client = new PersistentSubscriptionClient(correlationId, connectionId, envelope, maxInFlight, user,
+				var client = new PersistentSubscriptionClient(correlationId, connectionId, connectionName, envelope, maxInFlight, user,
 					@from, _totalTimeWatch, _settings.ExtraStatistics);
 				_pushClients.AddClient(client);
 				TryPushingMessagesToClients();

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClient.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClient.cs
@@ -12,6 +12,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		private readonly Guid _correlationId;
 		private readonly Guid _connectionId;
+		private readonly string _connectionName;
 		private readonly IEnvelope _envelope;
 		private int _allowedMessages;
 		public readonly string Username;
@@ -22,6 +23,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		public PersistentSubscriptionClient(Guid correlationId,
 			Guid connectionId,
+			string connectionName,
 			IEnvelope envelope,
 			int inFlightMessages,
 			string username,
@@ -30,6 +32,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			bool extraStatistics) {
 			_correlationId = correlationId;
 			_connectionId = connectionId;
+			_connectionName = connectionName;
 			_envelope = envelope;
 			_allowedMessages = inFlightMessages;
 			Username = username;
@@ -55,6 +58,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		public Guid ConnectionId {
 			get { return _connectionId; }
+		}
+
+		public string ConnectionName {
+			get { return _connectionName; }
 		}
 
 		public long TotalItems {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -445,7 +445,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					lastEventNumber);
 			message.Envelope.ReplyWith(subscribedMessage);
 			var name = message.User == null ? "anonymous" : message.User.Identity.Name;
-			subscription.AddClient(message.CorrelationId, message.ConnectionId, message.Envelope,
+			subscription.AddClient(message.CorrelationId, message.ConnectionId, message.ConnectionName, message.Envelope,
 				message.AllowedInFlightMessages, name, message.From);
 		}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -66,7 +66,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					InFlightMessages = conn.InflightMessages,
 					AvailableSlots = conn.AvailableSlots,
 					CountSinceLastMeasurement = connLastItems,
-					ObservedMeasurements = stats
+					ObservedMeasurements = stats,
+					ConnectionName = conn.ConnectionName,
 				});
 			}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -680,7 +680,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 							TotalItemsProcessed = connection.TotalItems,
 							AvailableSlots = connection.AvailableSlots,
 							InFlightMessages = connection.InFlightMessages,
-							ExtraStatistics = connection.ObservedMeasurements ?? new List<Measurement>()
+							ExtraStatistics = connection.ObservedMeasurements ?? new List<Measurement>(),
+							ConnectionName = connection.ConnectionName,
 						});
 					}
 				}
@@ -803,6 +804,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			public List<Measurement> ExtraStatistics { get; set; }
 			public int AvailableSlots { get; set; }
 			public int InFlightMessages { get; set; }
+			public string ConnectionName { get; set; }
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -557,7 +557,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			var dto = package.Data.Deserialize<TcpClientMessageDto.ConnectToPersistentSubscription>();
 			if (dto == null) return null;
 			return new ClientMessage.ConnectToPersistentSubscription(Guid.NewGuid(), package.CorrelationId, envelope,
-				connection.ConnectionId, dto.SubscriptionId, dto.EventStreamId, dto.AllowedInFlightMessages,
+				connection.ConnectionId, connection.ClientConnectionName, dto.SubscriptionId, dto.EventStreamId, dto.AllowedInFlightMessages,
 				connection.RemoteEndPoint.ToString(), user);
 		}
 


### PR DESCRIPTION
Greetings,

Recently, I proposed that [feature request] as it will provide more detailed monitoring metrics (Something my current job needs).

Thanks for your time.

<img width="549" alt="Screenshot 2019-09-17 at 23 58 55" src="https://user-images.githubusercontent.com/144545/65082944-7cea3380-d9a7-11e9-8f04-3bbf52bc59ea.png">
<img width="1582" alt="Screenshot 2019-09-18 at 00 00 32" src="https://user-images.githubusercontent.com/144545/65082945-7cea3380-d9a7-11e9-993b-457fbfede69e.png">

[feature request]: https://groups.google.com/forum/#!topic/event-store/rayXu0cUSl4