### PR TITLE
Added histogram measurement around resolving LinkTos

### DIFF
--- a/src/EventStore.Core/Services/Histograms/HistogramService.cs
+++ b/src/EventStore.Core/Services/Histograms/HistogramService.cs
@@ -54,6 +54,7 @@ namespace EventStore.Core.Services.Histograms {
 			CreateHistogram("reader-readevent");
 			CreateHistogram("reader-streamrange");
 			CreateHistogram("reader-allrange");
+			CreateHistogram("reader-linkto");
 			CreateHistogram("request-manager");
 			CreateHistogram("tcp-send");
 			CreateHistogram("http-send");

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Services.Storage {
 		private const int MaxPageSize = 4096;
 		private const string _readerReadHistogram = "reader-readevent";
 		private const string _readerStreamRangeHistogram = "reader-streamrange";
+		private const string _readerLinkToHistogram = "reader-linkto";
 		private const string _readerAllRangeHistogram = "reader-allrange";
 		private DateTime? _lastExpireTime = null;
 		private long _expiredBatchCount = 0;
@@ -71,7 +72,7 @@ namespace EventStore.Core.Services.Storage {
 				return;
 			}
 
-			using (HistogramService.Measure(_readerStreamRangeHistogram)) {
+			using (HistogramService.Measure(msg.ResolveLinkTos == true ? _readerLinkToHistogram : _readerStreamRangeHistogram)) {
 				var res = ReadStreamEventsForward(msg);
 				switch (res.Result) {
 					case ReadStreamResult.Success:
@@ -206,7 +207,7 @@ namespace EventStore.Core.Services.Storage {
 
 		private ClientMessage.ReadStreamEventsForwardCompleted ReadStreamEventsForward(
 			ClientMessage.ReadStreamEventsForward msg) {
-			using (HistogramService.Measure(_readerStreamRangeHistogram)) {
+			using (HistogramService.Measure(msg.ResolveLinkTos == true ? _readerLinkToHistogram : _readerStreamRangeHistogram)) {
 				var lastCommitPosition = _readIndex.LastReplicatedPosition;
 				try {
 					if (msg.MaxCount > MaxPageSize) {
@@ -243,7 +244,7 @@ namespace EventStore.Core.Services.Storage {
 
 		private ClientMessage.ReadStreamEventsBackwardCompleted ReadStreamEventsBackward(
 			ClientMessage.ReadStreamEventsBackward msg) {
-			using (HistogramService.Measure(_readerStreamRangeHistogram)) {
+			using (HistogramService.Measure(msg.ResolveLinkTos == true ? _readerLinkToHistogram : _readerStreamRangeHistogram)) {
 				var lastCommitPosition = _readIndex.LastReplicatedPosition;
 				try {
 					if (msg.MaxCount > MaxPageSize) {


### PR DESCRIPTION
Added histogram to get breakdown on read times when ResolveLinkTos is true vs normal reads. This will allow to compare the performance impacts of resolving linkTos.

Sample usage: Histogram can be called with curl http://localhost:2113/histogram/reader-linkto -u admin:changeit

Sample run resolving event from by_category stream vs reading from stream directly: 
reader-linkto
[Mean    =       22.645, StdDeviation   =        8.924]
[Max     =       51.053, Total count    =          168]
[Buckets =           20, SubBuckets     =         2048]
reader-streamrange
[Mean    =        0.396, StdDeviation   =        3.039]
[Max     =       37.356, Total count    =          396]
[Buckets =           20, SubBuckets     =         2048]
