### PR TITLE
Make ResolvedIndexedEvent's event field optional.

### DIFF
--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -35,7 +35,7 @@ message EventRecord {
 }
 
 message ResolvedIndexedEvent {
-	required EventRecord event = 1;
+	optional EventRecord event = 1;
 	optional EventRecord link = 2;
 }
 


### PR DESCRIPTION
This change reflects the reality that `ResolvedIndexedEvent` 's event field **can** be optional in some situations.

For example if you read `$streams` stream and one of the listed streams got deleted, the associated `ResolvedIndexedEvent` resulting from a `ReadStreamEventsCompleted` will only have its `link` defined.

The old behaviour was causing wrong protobuf generation if you use the official `protoc` program. In the example I mentioned, protobuf code generated by `protoc` will throw `MessageNotInitialized` because the `ResolveIndexedEvent` message didn't comply with the protobuf declaration file.

note: I don't understand the edit at the end of the file, I edited the code directly on Github.