### PR TITLE
Allowing checkpoint func to be optional in server side filtering

### DIFF
--- a/src/EventStore.ClientAPI/IEventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/IEventStoreConnection.cs
@@ -345,8 +345,8 @@ namespace EventStore.ClientAPI {
 			bool resolveLinkTos,
 			Filter filter,
 			Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
-			Func<EventStoreSubscription, Position, Task> checkpointReached,
-			int checkpointInterval,
+			Func<EventStoreSubscription, Position, Task> checkpointReached = null,
+			int? checkpointInterval = null,
 			Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
 			UserCredentials userCredentials = null);
 		

--- a/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/catch_up_subscription_handles_errors.cs
@@ -569,8 +569,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 		public Task<EventStoreSubscription> SubscribeToAllFilteredAsync(bool resolveLinkTos, Filter filter,
 			Func<EventStoreSubscription, ResolvedEvent, Task> eventAppeared,
-			Func<EventStoreSubscription, Position, Task> checkpointReached,
-			int checkpointInterval,
+			Func<EventStoreSubscription, Position, Task> checkpointReached = null,
+			int? checkpointInterval = null,
 			Action<EventStoreSubscription, SubscriptionDropReason, Exception> subscriptionDropped = null,
 			UserCredentials userCredentials = null) {
 			throw new NotImplementedException();

--- a/src/EventStore.Core/Services/SubscriptionsService.cs
+++ b/src/EventStore.Core/Services/SubscriptionsService.cs
@@ -30,6 +30,7 @@ namespace EventStore.Core.Services {
 		IHandle<SubscriptionMessage.CheckPollTimeout>,
 		IHandle<StorageMessage.EventCommitted> {
 		public const string AllStreamsSubscriptionId = ""; // empty stream id means subscription to all streams
+		private const int DontReportCheckpointReached = -1;
 
 		private static readonly ILogger Log = LogManager.GetLoggerFor<SubscriptionsService>();
 		private static readonly TimeSpan TimeoutPeriod = TimeSpan.FromSeconds(1);
@@ -298,6 +299,9 @@ namespace EventStore.Core.Services {
 					subscr.Envelope.ReplyWith(new ClientMessage.StreamEventAppeared(subscr.CorrelationId, pair));
 				}
 
+				if (subscr.CheckpointInterval == DontReportCheckpointReached) 
+					continue;
+				
 				subscr.CheckpointIntervalCurrent++;
 
 				if (subscr.CheckpointInterval != null &&


### PR DESCRIPTION
If the user doesn't provide a checkpointReached func we will send across a checkpoint interval of -1. This will stop the checkpoint reached method from being sent by the server