### PR TITLE
Stop writing stats to the database

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -222,7 +222,7 @@ namespace EventStore.ClusterNode {
 				.WithProjectionQueryExpirationOf(TimeSpan.FromMinutes(options.ProjectionsQueryExpiry))
 				.WithTfCachedChunks(options.CachedChunks)
 				.WithTfChunksCacheSize(options.ChunksCacheSize)
-				.WithStatsStorage(StatsStorage.StreamAndFile)
+				.WithStatsStorage(StatsStorage.File)
 				.AdvertiseInternalIPAs(options.IntIpAdvertiseAs)
 				.AdvertiseExternalIPAs(options.ExtIpAdvertiseAs)
 				.AdvertiseInternalHttpPortAs(options.IntHttpPortAdvertiseAs)


### PR DESCRIPTION
Fixes #2025
We have this option. Or we can completely remove the code that allows us to toggle where we want to persist the stats.