### PR TITLE
Require master on all writes and deletes from projections

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -31,14 +31,14 @@ namespace EventStore.Projections.Core.Services.Processing {
 		public void Handle(ClientMessage.WriteEvents msg) {
 			_externalRequestQueue.Publish(
 				new ClientMessage.WriteEvents(
-					msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope), false,
+					msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope), true,
 					msg.EventStreamId, msg.ExpectedVersion, msg.Events, msg.User));
 		}
 
 		public void Handle(ClientMessage.DeleteStream msg) {
 			_externalRequestQueue.Publish(
 				new ClientMessage.DeleteStream(
-					msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope), false,
+					msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope), true,
 					msg.EventStreamId, msg.ExpectedVersion, msg.HardDelete, msg.User));
 		}
 


### PR DESCRIPTION
Projections only run on the master node, and writes published from projections should only be processed if they originate from the master node.
Setting `RequireMaster` to true for all writes and deletes from projections enforces this, causing writes to fail if the node is not in the master state when processing them.

### Current issue

It's possible for a deposed master to publish writes for emitted streams while it is shutting down the projections subsystem.
This is fine if the node is still in the `Master` state, as then it simply writes the emitted event to the transaction log, which will likely be truncated soon.

But when a master is deposed, it initially returns to the `PreReplica` state to subscribe to the new master.
In this state, it will forward writes to the new master node.

This means that the deposed master can forward writes based off its own data and state to the new master.
Usually this is harmless, but it can sometimes result in an `ExpectedVersion` error on the new master, or the projection faulting with `An event emitted in recover differs from a previously emitted event.`