### PR TITLE
Introduce election behaviour tests

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/ManualQueue.cs
+++ b/src/EventStore.Core.Tests/Helpers/ManualQueue.cs
@@ -46,7 +46,7 @@ namespace EventStore.Core.Tests.Helpers {
 				var orderedTimerMessages = _timerQueue.OrderBy(v => v.Scheduled.Add(v.Message.TriggerAfter)).ToArray();
 				_timerQueue.Clear();
 				foreach (var timerMessage in orderedTimerMessages) {
-					if (timerMessage.Scheduled.Add(timerMessage.Message.TriggerAfter) <= _time.Now)
+					if (timerMessage.Scheduled.Add(timerMessage.Message.TriggerAfter) <= _time.UtcNow)
 						timerMessage.Message.Reply();
 					else
 						_timerQueue.Add(timerMessage);
@@ -75,7 +75,7 @@ namespace EventStore.Core.Tests.Helpers {
 		}
 
 		public void Handle(TimerMessage.Schedule message) {
-			_timerQueue.Add(new InternalSchedule(message, _time.Now));
+			_timerQueue.Add(new InternalSchedule(message, _time.UtcNow));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -98,7 +98,7 @@ namespace EventStore.Core.Tests.Helpers {
 				list.Count,
 				new PrepareLogRecord(
 					_fakePosition, Guid.NewGuid(), Guid.NewGuid(), _fakePosition, 0, streamId, list.Count - 1,
-					_timeProvider.Now,
+					_timeProvider.UtcNow,
 					PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | (isJson ? PrepareFlags.IsJson : 0),
 					eventType, Helper.UTF8NoBom.GetBytes(eventData),
 					eventMetadata == null ? new byte[0] : Helper.UTF8NoBom.GetBytes(eventMetadata)));
@@ -422,7 +422,7 @@ namespace EventStore.Core.Tests.Helpers {
 						record =
 							new EventRecord(
 								eventNumber, tfPosition, correlationId, e.EventId, tfPosition, 0, streamId,
-								ExpectedVersion.Any, _timeProvider.Now,
+								ExpectedVersion.Any, _timeProvider.UtcNow,
 								PrepareFlags.SingleWrite | (e.IsJson ? PrepareFlags.IsJson : PrepareFlags.None),
 								e.EventType, e.Data, e.Metadata)
 					}); //NOTE: DO NOT MAKE ARRAY 

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithReadWriteDispatchers.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithReadWriteDispatchers.cs
@@ -92,7 +92,7 @@ namespace EventStore.Core.Tests.Helpers {
 
 		protected void WhenLoop(IEnumerable<WhenStep> steps) {
 			foreach (var step in steps) {
-				_timeProvider.AddTime(TimeSpan.FromMilliseconds(10));
+				_timeProvider.AddToUtcTime(TimeSpan.FromMilliseconds(10));
 				if (step.Action != null) {
 					step.Action();
 				}

--- a/src/EventStore.Core.Tests/Infrastructure/EqualityComparers.cs
+++ b/src/EventStore.Core.Tests/Infrastructure/EqualityComparers.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+
+namespace EventStore.Core.Tests.Infrastructure {
+	public class ReflectionBasedEqualityComparer : IComparer {
+		private static bool ReflectionEquals(object x, object y) {
+			if (ReferenceEquals(x, y))
+				return true;
+
+			if (ReferenceEquals(x, null))
+				return false;
+
+			if (ReferenceEquals(y, null))
+				return false;
+
+			var type = x.GetType();
+
+			if (type != y.GetType())
+				return false;
+
+			if (x == y)
+				return true;
+
+			if (type.IsValueType)
+				return x.Equals(y);
+
+			if (type == typeof(string)) {
+				return x.Equals(y);
+			}
+
+			if (typeof(Array).IsAssignableFrom(type)) {
+				var dx = (Array)x;
+				var dy = (Array)y;
+				if (dx.Length != dy.Length) {
+					return false;
+				}
+
+				return ((IStructuralEquatable)dx).Equals(dy, StructuralComparisons.StructuralEqualityComparer);
+			}
+
+			if (typeof(IDictionary).IsAssignableFrom(type)) {
+				var dx = (IDictionary)x;
+				var dy = (IDictionary)y;
+
+				if (dx.Count != dy.Count) {
+					return false;
+				}
+
+				foreach (DictionaryEntry entry in dx) {
+					if (!dy.Contains(entry.Key) || !Instance.Equals(entry.Value, dy[entry.Key])) {
+						return false;
+					}
+				}
+
+				return true;
+			}
+
+			var fieldValues = type.GetFields(BindingFlags.Instance | BindingFlags.Public).Select(field => new {
+				member = (MemberInfo)field,
+				x = field.GetValue(x),
+				y = field.GetValue(y)
+			});
+
+			var propertyValues = type.GetProperties(BindingFlags.Instance | BindingFlags.Public).Select(property => new {
+				member = (MemberInfo)property,
+				x = property.GetValue(x),
+				y = property.GetValue(y)
+			});
+
+			var values = fieldValues.Concat(propertyValues);
+
+			var differences = values.Where(value => !ReflectionEquals(value.x, value.y)).ToList();
+
+			return !differences.Any();
+		}
+
+		private new bool Equals(object x, object y) => ReflectionEquals(x, y);
+		public int Compare(object x, object y) => ReflectionEquals(x, y) ? 0 : 1;
+		public static readonly ReflectionBasedEqualityComparer Instance = new ReflectionBasedEqualityComparer();
+	}
+}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.TransactionLog.Checkpoint;
 
 namespace EventStore.Core.Tests.Services.ElectionsService {
@@ -44,7 +45,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new InMemoryCheckpoint(WriterCheckpoint),
 				new InMemoryCheckpoint(ChaserCheckpoint),
 				new FakeEpochManager(),
-				() => -1, 0);
+				() => -1, 0, new FakeTimeProvider());
 			ElectionsService.SubscribeMessages(_bus);
 
 			InputMessages = new List<Message>();

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -1,0 +1,1295 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using EventStore.Core.Bus;
+using EventStore.Core.Cluster;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Infrastructure;
+using EventStore.Core.TransactionLog.Checkpoint;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.ElectionsService {
+	public abstract class ElectionsFixture {
+		protected readonly VNodeInfo _node;
+		protected readonly VNodeInfo _nodeTwo;
+		protected readonly VNodeInfo _nodeThree;
+		public Func<DateTime> GetUtcNow;
+		public Core.Services.ElectionsService SUT;
+		protected IBus _bus;
+		protected FakePublisher _publisher;
+		protected Guid _epochId;
+
+		protected static Func<int, bool, VNodeInfo> NodeFactory = (id, isReadOnlyReplica) => new VNodeInfo(
+			Guid.Parse($"00000000-0000-0000-0000-00000000000{id}"), id,
+			new IPEndPoint(IPAddress.Loopback, id),
+			new IPEndPoint(IPAddress.Loopback, id),
+			new IPEndPoint(IPAddress.Loopback, id),
+			new IPEndPoint(IPAddress.Loopback, id),
+			new IPEndPoint(IPAddress.Loopback, id),
+			new IPEndPoint(IPAddress.Loopback, id), isReadOnlyReplica);
+
+		protected static readonly Func<VNodeInfo, DateTime, VNodeState, bool, Guid, MemberInfo> MemberInfoFromVNode =
+			(nodeInfo, timestamp, state, isAlive, epochId) => MemberInfo.ForVNode(
+				nodeInfo.InstanceId, timestamp, state, isAlive,
+				nodeInfo.InternalTcp,
+				nodeInfo.InternalSecureTcp, nodeInfo.ExternalTcp, nodeInfo.ExternalSecureTcp,
+				nodeInfo.InternalHttp,
+				nodeInfo.ExternalHttp, 0, 0, 0, 0, 0, epochId, 0,
+				nodeInfo.IsReadOnlyReplica);
+
+		protected ElectionsFixture(VNodeInfo node, VNodeInfo nodeTwo, VNodeInfo nodeThree) {
+			var now = DateTime.UtcNow;
+			GetUtcNow = () => now;
+			_publisher = new FakePublisher();
+			_bus = new InMemoryBus("Test");
+			_epochId = Guid.NewGuid();
+
+			_node = node;
+			_nodeTwo = nodeTwo;
+			_nodeThree = nodeThree;
+			SUT = new Core.Services.ElectionsService(_publisher, _node, 3,
+				new InMemoryCheckpoint(0),
+				new InMemoryCheckpoint(0),
+				new FakeEpochManager(), () => 0L, 0, GetUtcNow);
+
+			SUT.SubscribeMessages(_bus);
+		}
+	}
+
+	public class when_starting_elections : ElectionsFixture {
+		public when_starting_elections()
+			: base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_send_view_change_to_other_members() {
+			SUT.Handle(new ElectionMessage.StartElections());
+
+			var expected = new Message[] {
+				TimerMessage.Schedule.Create(
+					Core.Services.ElectionsService.SendViewChangeProofInterval,
+					new PublishEnvelope(_publisher),
+					new ElectionMessage.SendViewChangeProof()),
+				TimerMessage.Schedule.Create(
+					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					new PublishEnvelope(_publisher),
+					new ElectionMessage.ElectionsTimedOut(0)),
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.ViewChange(_node.InstanceId, _node.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.ViewChange(_node.InstanceId, _node.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+			};
+			Assert.That(_publisher.Messages, Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_starting_elections_for_readonly_replica : ElectionsFixture {
+		public when_starting_elections_for_readonly_replica()
+			: base(NodeFactory(3, true), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_send_view_change_to_other_members() {
+			SUT.Handle(new ElectionMessage.StartElections());
+
+			var expected = new Message[] {
+				TimerMessage.Schedule.Create(
+					Core.Services.ElectionsService.SendViewChangeProofInterval,
+					new PublishEnvelope(_publisher),
+					new ElectionMessage.SendViewChangeProof()),
+				TimerMessage.Schedule.Create(
+					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					new PublishEnvelope(_publisher),
+					new ElectionMessage.ElectionsTimedOut(0)),
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.ViewChange(_node.InstanceId, _node.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.ViewChange(_node.InstanceId, _node.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+			};
+			Assert.That(_publisher.Messages, Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_starting_elections_after_elections_have_started : ElectionsFixture {
+		public when_starting_elections_after_elections_have_started()
+			: base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_starting_elections() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.StartElections());
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_node_is_shutting_down_and_starting_elections : ElectionsFixture {
+		public when_node_is_shutting_down_and_starting_elections()
+			: base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_starting_elections() {
+			SUT.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false));
+			SUT.Handle(new ElectionMessage.StartElections());
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_node_is_shutting_down_and_elections_timed_out : ElectionsFixture {
+		public when_node_is_shutting_down_and_elections_timed_out() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_elections_timed_out() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+			SUT.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false));
+			SUT.Handle(new ElectionMessage.ElectionsTimedOut(0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+	
+	public class when_elections_timeout_for_a_different_view_than_last_attempted_view : ElectionsFixture {
+		public when_elections_timeout_for_a_different_view_than_last_attempted_view() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_elections_timed_out() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.ElectionsTimedOut(1));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+	
+	public class when_elections_timeout : ElectionsFixture {
+		public when_elections_timeout() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_send_new_view_change_to_other_members() {
+			var view = 0;
+			var newView = view + 1;
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.ElectionsTimedOut(view));
+
+			var expected = new Message[] {
+				TimerMessage.Schedule.Create(
+					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					new PublishEnvelope(_publisher),
+					new ElectionMessage.ElectionsTimedOut(1)),
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.ViewChange(_node.InstanceId, _node.InternalHttp, newView),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.ViewChange(_node.InstanceId, _node.InternalHttp, newView),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+			};
+			Assert.That(_publisher.Messages, Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+	
+	public class when_node_is_shutting_down_and_view_change_proof_is_triggered : ElectionsFixture {
+		public when_node_is_shutting_down_and_view_change_proof_is_triggered() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_view_change_proof() {
+			SUT.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false));
+			SUT.Handle(new ElectionMessage.SendViewChangeProof());
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+	
+	public class when_view_change_proof_is_triggered_and_the_first_election_has_not_completed : ElectionsFixture {
+		public when_view_change_proof_is_triggered_and_the_first_election_has_not_completed() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_schedule_another_view_change_proof() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.SendViewChangeProof());
+
+			var expected = new Message[] {
+				TimerMessage.Schedule.Create(
+					Core.Services.ElectionsService.SendViewChangeProofInterval,
+					new PublishEnvelope(_publisher),
+					new ElectionMessage.SendViewChangeProof()),
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_view_change_proof_is_triggered_and_the_first_election_has_completed : ElectionsFixture {
+		public when_view_change_proof_is_triggered_and_the_first_election_has_completed() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_send_view_change_proof_to_other_members() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+			var proposalHttpMessage = _publisher.Messages.OfType<HttpMessage.SendOverHttp>()
+				.FirstOrDefault(x => x.Message is ElectionMessage.Proposal);
+			var proposalMessage = (ElectionMessage.Proposal)proposalHttpMessage.Message;
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				proposalMessage.MasterId, proposalMessage.MasterInternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.SendViewChangeProof());
+
+			var expected = new Message[] {
+				TimerMessage.Schedule.Create(
+					Core.Services.ElectionsService.SendViewChangeProofInterval,
+					new PublishEnvelope(_publisher),
+					new ElectionMessage.SendViewChangeProof()),
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.ViewChangeProof(_node.InstanceId, _node.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.ViewChangeProof(_node.InstanceId, _node.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout))
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_receiving_view_change_and_shutting_down : ElectionsFixture {
+		public when_receiving_view_change_and_shutting_down() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_the_view_change() {
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false));
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, -2));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_view_change_and_idle : ElectionsFixture {
+		public when_receiving_view_change_and_idle() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_the_view_change() {
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, -2));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_view_change_for_an_earlier_view_than_installed : ElectionsFixture {
+		public when_receiving_view_change_for_an_earlier_view_than_installed() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_the_view_change() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, -2));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_view_change_for_a_later_view_than_last_attempted_view : ElectionsFixture {
+		public when_receiving_a_view_change_for_a_later_view_than_last_attempted_view() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_send_view_change_to_other_members() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 10));
+
+			var expected = new Message[] {
+				TimerMessage.Schedule.Create(
+					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					new PublishEnvelope(_publisher),
+					new ElectionMessage.ElectionsTimedOut(10)),
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.ViewChange(_node.InstanceId, _node.InternalHttp, 10),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.ViewChange(_node.InstanceId, _node.InternalHttp, 10),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+			};
+
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_receiving_view_change_from_majority_and_acceptor_of_the_current_view : ElectionsFixture {
+		public when_receiving_view_change_from_majority_and_acceptor_of_the_current_view() :
+			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_not_initiate_prepare_phase() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_view_change_from_majority_for_readonly_replica : ElectionsFixture {
+		public when_receiving_view_change_from_majority_for_readonly_replica() :
+			base(NodeFactory(3, true), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_not_consider_readonly_replica_as_leader_of_elections_and_send_prepares_to_other_members() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_view_change_from_majority : ElectionsFixture {
+		public when_receiving_view_change_from_majority() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_send_prepares_to_other_members() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+
+			var expected = new[] {
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.Prepare(_node.InstanceId, _node.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.Prepare(_node.InstanceId, _node.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout))
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_receiving_a_prepare_when_node_is_shutting_down : ElectionsFixture {
+		public when_receiving_a_prepare_when_node_is_shutting_down() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_the_prepare() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.Prepare(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_prepare_for_the_same_node : ElectionsFixture {
+		public when_receiving_a_prepare_for_the_same_node() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_the_prepare() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Prepare(_node.InstanceId, _node.InternalHttp, 0));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_prepare_not_for_the_last_attempted_view : ElectionsFixture {
+		public when_receiving_a_prepare_not_for_the_last_attempted_view() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_the_prepare() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Prepare(_nodeThree.InstanceId, _nodeThree.InternalHttp, 1));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_prepare_from_an_unknown_node : ElectionsFixture {
+		public when_receiving_a_prepare_from_an_unknown_node() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_the_prepare() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Prepare(Guid.NewGuid(), new IPEndPoint(IPAddress.Loopback, 1114), 0));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_prepare_for_a_readonly_replica : ElectionsFixture {
+		public when_receiving_a_prepare_for_a_readonly_replica() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_the_prepare() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Prepare(_node.InstanceId, _node.InternalHttp, 0));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_prepare : ElectionsFixture {
+		public when_receiving_a_prepare() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_reply_with_prepare_ok() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Prepare(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+
+			var expected = new Message[] {
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.PrepareOk(0,
+						_node.InstanceId, _node.InternalHttp, -1, -1, Guid.Empty, 0, 0, 0, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+	
+	public class when_receiving_a_prepare_and_readonly_replica : ElectionsFixture {
+		public when_receiving_a_prepare_and_readonly_replica() :
+			base(NodeFactory(3, true), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_prepare() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Prepare(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_prepare_ok_and_node_is_shutting_down : ElectionsFixture {
+		public when_receiving_prepare_ok_and_node_is_shutting_down() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_prepare_ok() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false));
+
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_prepare_ok_and_elections_have_not_started : ElectionsFixture {
+		public when_receiving_prepare_ok_and_elections_have_not_started() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_prepare_ok() {
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_prepare_ok_for_not_the_current_attempted_view : ElectionsFixture {
+		public when_receiving_prepare_ok_for_not_the_current_attempted_view() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_prepare_ok() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.PrepareOk(-1, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_duplicate_prepare_ok : ElectionsFixture {
+		public when_receiving_a_duplicate_prepare_ok() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_prepare_ok() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _node.InstanceId, _node.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_majority_prepare_ok : ElectionsFixture {
+		public when_receiving_majority_prepare_ok() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_send_proposal_to_other_members() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+
+			var proposalHttpMessage = _publisher.Messages.OfType<HttpMessage.SendOverHttp>()
+				.FirstOrDefault(x => x.Message is ElectionMessage.Proposal);
+			var proposalMessage = (ElectionMessage.Proposal)proposalHttpMessage.Message;
+
+			var expected = new[] {
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.Proposal(_node.InstanceId, _node.InternalHttp,
+						proposalMessage.MasterId,
+						proposalMessage.MasterInternalHttp, 0, 0, 0, _epochId, 0, 0, 0, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.Proposal(_node.InstanceId, _node.InternalHttp,
+						proposalMessage.MasterId,
+						proposalMessage.MasterInternalHttp, 0, 0, 0, _epochId, 0, 0, 0, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout))
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_node_is_shutting_down_and_receive_a_proposal : ElectionsFixture {
+		public when_node_is_shutting_down_and_receive_a_proposal() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_proposal() {
+			SUT.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false));
+			SUT.Handle(new ElectionMessage.Proposal(_node.InstanceId, _node.InternalHttp,
+				_node.InstanceId,
+				_node.InternalHttp, 0, 0, 0, _epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_proposal_from_the_same_node : ElectionsFixture {
+		public when_receiving_a_proposal_from_the_same_node() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_proposal() {
+			SUT.Handle(new ElectionMessage.Proposal(_node.InstanceId, _node.InternalHttp,
+				_node.InstanceId,
+				_node.InternalHttp, 0, 0, 0, _epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages,
+				"Nodes do not send proposals to themselves, they accept their own proposal implicitly.");
+		}
+	}
+
+	public class when_receiving_a_proposal_and_an_acceptor_of_the_current_view : ElectionsFixture {
+		public when_receiving_a_proposal_and_an_acceptor_of_the_current_view() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_proposal() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Proposal(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_node.InstanceId,
+				_node.InternalHttp, 0, 0, 0, _epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_proposal_not_for_the_current_installed_view : ElectionsFixture {
+		public when_receiving_a_proposal_not_for_the_current_installed_view() :
+			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_proposal() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.Prepare(_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Proposal(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_node.InstanceId,
+				_node.InternalHttp, 1, 0, 0, _epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_proposal_from_an_unknown_node : ElectionsFixture {
+		public when_receiving_a_proposal_from_an_unknown_node() :
+			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_proposal() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.Prepare(_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Proposal(Guid.NewGuid(), new IPEndPoint(IPAddress.Loopback, 4),
+				_node.InstanceId,
+				_node.InternalHttp, 0, 0, 0, _epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_proposal_for_an_unknown_node : ElectionsFixture {
+		public when_receiving_a_proposal_for_an_unknown_node() :
+			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_proposal() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.Prepare(_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Proposal(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				Guid.NewGuid(),
+				new IPEndPoint(IPAddress.Loopback, 4), 0, 0, 0, _epochId, 0, 0, 0, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_receiving_a_proposal : ElectionsFixture {
+		public when_receiving_a_proposal() :
+			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_send_an_acceptance_to_other_members() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.Prepare(_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Proposal(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_nodeThree.InstanceId,
+				_nodeThree.InternalHttp, 0, 0, 0, _epochId, 0, 0, 0, 0));
+
+			var expected = new Message[] {
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.Accept(_node.InstanceId, _node.InternalHttp,
+						_nodeThree.InstanceId,
+						_nodeThree.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.Accept(_node.InstanceId, _node.InternalHttp,
+						_nodeThree.InstanceId,
+						_nodeThree.InternalHttp, 0),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new ElectionMessage.ElectionsDone(0,
+					MemberInfo.ForVNode(
+						_nodeThree.InstanceId, GetUtcNow(), VNodeState.Unknown, true,
+						_nodeThree.InternalTcp,
+						_nodeThree.InternalSecureTcp, _nodeThree.ExternalTcp, _nodeThree.ExternalSecureTcp,
+						_nodeThree.InternalHttp,
+						_nodeThree.ExternalHttp, 0, 0, 0, 0, 0, _epochId, 0,
+						_nodeThree.IsReadOnlyReplica)),
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_node_is_shutting_down_and_receiving_accept : ElectionsFixture {
+		public when_node_is_shutting_down_and_receiving_accept() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_accept() {
+			SUT.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), false, false));
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+	
+	public class when_receiving_accept_for_not_the_current_installed_view : ElectionsFixture {
+		public when_receiving_accept_for_not_the_current_installed_view() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_accept() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_nodeThree.InstanceId, _nodeThree.InternalHttp, 1));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+	
+	public class when_receiving_accept_without_a_master_having_been_proposed : ElectionsFixture {
+		public when_receiving_accept_without_a_master_having_been_proposed() :
+			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_accept() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.Prepare(_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+	
+	public class when_receiving_accept_and_master_proposal_does_not_match_accept_master : ElectionsFixture {
+		public when_receiving_accept_and_master_proposal_does_not_match_accept_master() :
+			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_accept() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.Prepare(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.Proposal(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				Guid.NewGuid(),
+				new IPEndPoint(IPAddress.Loopback, 4), 0, 0, 0, _epochId, 0, 0, 0, 0));
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+	
+	public class when_receiving_majority_accept : ElectionsFixture {
+		public when_receiving_majority_accept() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_complete_elections() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+			var proposalHttpMessage = _publisher.Messages.OfType<HttpMessage.SendOverHttp>()
+				.FirstOrDefault(x => x.Message is ElectionMessage.Proposal);
+			var proposalMessage = (ElectionMessage.Proposal)proposalHttpMessage.Message;
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				proposalMessage.MasterId, proposalMessage.MasterInternalHttp, 0));
+
+			var expected = new[] {
+				new ElectionMessage.ElectionsDone(0,
+					MemberInfo.ForVNode(
+						_nodeTwo.InstanceId, GetUtcNow(), VNodeState.Unknown, true,
+						_nodeTwo.InternalTcp,
+						_nodeTwo.InternalSecureTcp, _nodeTwo.ExternalTcp, _nodeTwo.ExternalSecureTcp,
+						_nodeTwo.InternalHttp,
+						_nodeTwo.ExternalHttp, 0, 0, 0, 0, 0, _epochId, 0,
+						_nodeTwo.IsReadOnlyReplica)),
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_elections_timeout_and_not_electing_leader : ElectionsFixture {
+		public when_elections_timeout_and_not_electing_leader() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_timeout() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+			var proposalHttpMessage = _publisher.Messages.OfType<HttpMessage.SendOverHttp>()
+				.FirstOrDefault(x => x.Message is ElectionMessage.Proposal);
+			var proposalMessage = (ElectionMessage.Proposal)proposalHttpMessage.Message;
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				proposalMessage.MasterId, proposalMessage.MasterInternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.ElectionsTimedOut(0));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_updating_node_priority : ElectionsFixture {
+		public when_updating_node_priority() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_broadcast_node_priority_update() {
+			var nodePriority = 5;
+			SUT.Handle(new ClientMessage.SetNodePriority(nodePriority));
+
+			var expected = new[] {
+				new GossipMessage.UpdateNodePriority(nodePriority)
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_resigning_node_and_node_is_not_the_current_master : ElectionsFixture {
+		public when_resigning_node_and_node_is_not_the_current_master() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_resign_node_message() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+			var proposalHttpMessage = _publisher.Messages.OfType<HttpMessage.SendOverHttp>()
+				.FirstOrDefault(x => x.Message is ElectionMessage.Proposal);
+			var proposalMessage = (ElectionMessage.Proposal)proposalHttpMessage.Message;
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				proposalMessage.MasterId, proposalMessage.MasterInternalHttp, 0));
+			_publisher.Messages.Clear();
+			SUT.Handle(new ClientMessage.ResignNode());
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+
+	public class when_resigning_node_and_is_the_current_master : ElectionsFixture {
+		public when_resigning_node_and_is_the_current_master() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_initiate_master_resignation_and_inform_other_nodes() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, -1, 0,
+				_epochId, -1, -1, -1, -1));
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_node.InstanceId, _node.InternalHttp, 0));
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ClientMessage.ResignNode());
+
+			var expected = new Message[] {
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.MasterIsResigning(_node.InstanceId, _node.InternalHttp),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+				new HttpMessage.SendOverHttp(_nodeThree.InternalHttp,
+					new ElectionMessage.MasterIsResigning(_node.InstanceId, _node.InternalHttp),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+	
+	public class when_receiving_master_is_resigning_and_readonly_replica : ElectionsFixture {
+		public when_receiving_master_is_resigning_and_readonly_replica() :
+			base(NodeFactory(1, true), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_ignore_master_is_resigning() {
+			SUT.Handle(new ElectionMessage.MasterIsResigning(_nodeTwo.InstanceId, _nodeTwo.InternalHttp));
+
+			Assert.IsEmpty(_publisher.Messages);
+		}
+	}
+	
+	public class when_receiving_master_is_resigning : ElectionsFixture {
+		public when_receiving_master_is_resigning() :
+			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_reply_with_master_is_resigning_ok() {
+			SUT.Handle(new ElectionMessage.MasterIsResigning(_nodeTwo.InstanceId, _nodeTwo.InternalHttp));
+
+			var expected = new Message[] {
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp,
+					new ElectionMessage.MasterIsResigningOk(
+						_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+						_node.InstanceId, _node.InternalHttp),
+					GetUtcNow().Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_resigning_node_and_majority_resigning_ok_received : ElectionsFixture {
+		public when_resigning_node_and_majority_resigning_ok_received() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_initiate_master_resignation() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, -1, 0,
+				_epochId, -1, -1, -1, -1));
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_node.InstanceId, _node.InternalHttp, 0));
+			SUT.Handle(new ClientMessage.ResignNode());
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.MasterIsResigningOk(
+				_node.InstanceId,
+				_node.InternalHttp,
+				_nodeTwo.InstanceId,
+				_nodeTwo.InternalHttp));
+
+			var expected = new Message[] {
+				new SystemMessage.InitiateMasterResignation(),
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+
+	public class when_electing_a_master_and_master_node_resigned : ElectionsFixture {
+		public when_electing_a_master_and_master_node_resigned() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			SUT.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, GetUtcNow(), VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, GetUtcNow(), VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_attempt_not_to_elect_previously_elected_master() {
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0));
+			SUT.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, -1, 0,
+				_epochId, -1, -1, -1, -1));
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ClientMessage.ResignNode());
+			SUT.Handle(new ElectionMessage.MasterIsResigningOk(
+				_node.InstanceId,
+				_node.InternalHttp,
+				_nodeTwo.InstanceId,
+				_nodeTwo.InternalHttp));
+			_publisher.Messages.Clear();
+
+			SUT.Handle(new ElectionMessage.StartElections());
+			SUT.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 3));
+			SUT.Handle(new ElectionMessage.PrepareOk(3, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+			var proposalHttpMessage = _publisher.Messages.OfType<HttpMessage.SendOverHttp>()
+				.FirstOrDefault(x => x.Message is ElectionMessage.Proposal);
+			var proposalMessage = (ElectionMessage.Proposal)proposalHttpMessage.Message;
+			_publisher.Messages.Clear();
+			SUT.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
+				proposalMessage.MasterId, proposalMessage.MasterInternalHttp, 3));
+
+			var expected = new[] {
+				new ElectionMessage.ElectionsDone(3,
+					MemberInfo.ForVNode(
+						_nodeTwo.InstanceId, GetUtcNow(), VNodeState.Unknown, true,
+						_nodeTwo.InternalTcp,
+						_nodeTwo.InternalSecureTcp, _nodeTwo.ExternalTcp, _nodeTwo.ExternalSecureTcp,
+						_nodeTwo.InternalHttp,
+						_nodeTwo.ExternalHttp, 0, 0, 0, 0, 0, _epochId, 0,
+						_nodeTwo.IsReadOnlyReplica)),
+			};
+			Assert.That(_publisher.Messages,
+				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -1197,7 +1197,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.MasterIsResigningOk(
 						_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
 						_node.InstanceId, _node.InternalHttp),
-					_timeProvider.UtcNow.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
 			};
 			Assert.That(_publisher.Messages,
 				Is.EquivalentTo(expected).Using(ReflectionBasedEqualityComparer.Instance));

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -443,7 +443,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 
 		[Test]
-		public void should_not_consider_readonly_replica_as_leader_of_elections_and_send_prepares_to_other_members() {
+		public void should_ignore_view_change() {
 			_sut.Handle(new ElectionMessage.StartElections());
 			_publisher.Messages.Clear();
 
@@ -785,8 +785,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 	}
 
-	public class when_receiving_a_proposal_and_an_acceptor_of_the_current_view : ElectionsFixture {
-		public when_receiving_a_proposal_and_an_acceptor_of_the_current_view() :
+	public class when_receiving_a_proposal_as_the_acceptor_of_the_current_view : ElectionsFixture {
+		public when_receiving_a_proposal_as_the_acceptor_of_the_current_view() :
 			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
 			_sut.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
 				MemberInfoFromVNode(_node, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId),
@@ -878,8 +878,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		}
 	}
 
-	public class when_receiving_a_proposal : ElectionsFixture {
-		public when_receiving_a_proposal() :
+	public class when_receiving_a_proposal_as_acceptor : ElectionsFixture {
+		public when_receiving_a_proposal_as_acceptor() :
 			base(NodeFactory(1, false), NodeFactory(2, false), NodeFactory(3, false)) {
 			_sut.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
 				MemberInfoFromVNode(_node, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId),

--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -59,7 +59,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					writerCheckpoint,
 					readerCheckpoint,
 					epochManager,
-					() => -1, 0);
+					() => -1, 0, new FakeTimeProvider());
 				electionsService.SubscribeMessages(inputBus);
 
 				outputBus.Subscribe<HttpMessage.SendOverHttp>(this);

--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -282,7 +282,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 
 			var isLegit = SUT.IsLegitimateMaster(1, EndpointForNode(tc.ProposingNode),
 				IdForNode(tc.ProposingNode), mc, members, null, localNode,
-				ownInfo);
+				ownInfo, resigningMaster);
 
 			Assert.True(isLegit);
 		}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Cluster;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Tests.Infrastructure;
+using EventStore.Core.Tests.Services.TimeService;
 using EventStore.Core.TransactionLog.Checkpoint;
 
 namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
@@ -79,7 +80,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 					new InMemoryCheckpoint(),
 					new InMemoryCheckpoint(),
 					new FakeEpochManager(),
-					() => -1, 0);
+					() => -1, 0, new FakeTimeProvider());
 				electionsService.SubscribeMessages(inputBus);
 
 				outputBus.Subscribe(sendOverHttpHandler);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -611,7 +611,7 @@ namespace EventStore.Core {
 
 			var electionsService = new ElectionsService(_mainQueue, gossipInfo, vNodeSettings.ClusterNodeCount,
 				db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint,
-				epochManager, () => readIndex.LastCommitPosition, vNodeSettings.NodePriority);
+				epochManager, () => readIndex.LastCommitPosition, vNodeSettings.NodePriority, _timeProvider);
 			electionsService.SubscribeMessages(_mainBus);
 			if (!isSingleNode || vNodeSettings.GossipOnSingleNode) {
 				// GOSSIP

--- a/src/EventStore.Core/Messages/ElectionMessage.cs
+++ b/src/EventStore.Core/Messages/ElectionMessage.cs
@@ -335,6 +335,39 @@ namespace EventStore.Core.Messages {
 				return $"---- MasterIsResigning: serverId {MasterId}";
 			}
 		}
+		
+		public class MasterIsResigningOk : Message {
+			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public readonly Guid MasterId;
+			public readonly IPEndPoint MasterInternalHttp;
+			public readonly Guid ServerId;
+			public readonly IPEndPoint ServerInternalHttp;
+			
+			public MasterIsResigningOk(ElectionMessageDto.MasterIsResigningOkDto dto) {
+				MasterId = dto.MasterId;
+				MasterInternalHttp = new IPEndPoint(IPAddress.Parse(dto.MasterInternalHttpAddress),
+					dto.MasterInternalHttpPort);
+				ServerId = dto.ServerId;
+				ServerInternalHttp = new IPEndPoint(IPAddress.Parse(dto.ServerInternalHttpAddress),
+					dto.ServerInternalHttpPort);
+			}
+
+			public MasterIsResigningOk(Guid masterId, IPEndPoint masterInternalHttp, Guid serverId, IPEndPoint serverInternalHttp) {
+				MasterId = masterId;
+				MasterInternalHttp = masterInternalHttp;
+				ServerId = serverId;
+				ServerInternalHttp = serverInternalHttp;
+			}
+
+			public override string ToString() {
+				return $"---- MasterIsResigningOk: serverId {ServerId}";
+			}
+		}
 
 		public class ElectionsDone : Message {
 			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);

--- a/src/EventStore.Core/Messages/ElectionMessageDtos.cs
+++ b/src/EventStore.Core/Messages/ElectionMessageDtos.cs
@@ -180,5 +180,25 @@ namespace EventStore.Core.Messages {
 				MasterInternalHttpPort = message.MasterInternalHttp.Port;
 			}
 		}
+		
+		public class MasterIsResigningOkDto {
+			public Guid MasterId { get; set; }
+			public string MasterInternalHttpAddress { get; set; }
+			public int MasterInternalHttpPort { get; set; }
+			public Guid ServerId { get; set; }
+			public string ServerInternalHttpAddress { get; set; }
+			public int ServerInternalHttpPort { get; set; }
+			public MasterIsResigningOkDto() {
+			}
+
+			public MasterIsResigningOkDto(ElectionMessage.MasterIsResigningOk message) {
+				ServerId = message.ServerId;
+				ServerInternalHttpAddress = message.ServerInternalHttp.Address.ToString();
+				ServerInternalHttpPort = message.ServerInternalHttp.Port;
+				MasterId = message.MasterId;
+				MasterInternalHttpAddress = message.MasterInternalHttp.Address.ToString();
+				MasterInternalHttpPort = message.MasterInternalHttp.Port;
+			}
+		}
 	}
 }

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Services {
 		Idle,
 		ElectingLeader,
 		Leader,
-		NonLeader,
+		Acceptor,
 		Shutdown
 	}
 
@@ -35,13 +35,15 @@ namespace EventStore.Core.Services {
 		IHandle<ElectionMessage.Accept>,
 		IHandle<ClientMessage.SetNodePriority>,
 		IHandle<ClientMessage.ResignNode>,
-		IHandle<ElectionMessage.MasterIsResigning> {
-		private static readonly TimeSpan LeaderElectionProgressTimeout = TimeSpan.FromMilliseconds(1000);
-		private static readonly TimeSpan SendViewChangeProofInterval = TimeSpan.FromMilliseconds(5000);
+		IHandle<ElectionMessage.MasterIsResigning>,
+		IHandle<ElectionMessage.MasterIsResigningOk> {
+		public static readonly TimeSpan LeaderElectionProgressTimeout = TimeSpan.FromMilliseconds(1000);
+		public static readonly TimeSpan SendViewChangeProofInterval = TimeSpan.FromMilliseconds(5000);
 
 		private static readonly ILogger Log = LogManager.GetLoggerFor<ElectionsService>();
 		private static readonly IPEndPointComparer IPComparer = new IPEndPointComparer();
 
+		private readonly Func<DateTime> _getUtcNow;
 		private readonly IPublisher _publisher;
 		private readonly IEnvelope _publisherEnvelope;
 		private readonly VNodeInfo _nodeInfo;
@@ -61,6 +63,7 @@ namespace EventStore.Core.Services {
 		private readonly Dictionary<Guid, ElectionMessage.PrepareOk> _prepareOkReceived =
 			new Dictionary<Guid, ElectionMessage.PrepareOk>();
 
+		private readonly HashSet<Guid> _masterIsResigningOkReceived = new HashSet<Guid>();
 		private readonly HashSet<Guid> _acceptsReceived = new HashSet<Guid>();
 
 		private MasterCandidate _masterProposal;
@@ -77,15 +80,16 @@ namespace EventStore.Core.Services {
 			ICheckpoint chaserCheckpoint,
 			IEpochManager epochManager,
 			Func<long> getLastCommitPosition,
-			int nodePriority) {
-			Ensure.NotNull(publisher, "publisher");
-			Ensure.NotNull(nodeInfo, "nodeInfo");
-			Ensure.Positive(clusterSize, "clusterSize");
-			Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
-			Ensure.NotNull(chaserCheckpoint, "chaserCheckpoint");
-			Ensure.NotNull(epochManager, "epochManager");
-			Ensure.NotNull(getLastCommitPosition, "getLastCommitPosition");
+			int nodePriority, Func<DateTime> getUtcNow = null) {
+			Ensure.NotNull(publisher, nameof(publisher));
+			Ensure.NotNull(nodeInfo, nameof(nodeInfo));
+			Ensure.Positive(clusterSize, nameof(clusterSize));
+			Ensure.NotNull(writerCheckpoint, nameof(writerCheckpoint));
+			Ensure.NotNull(chaserCheckpoint, nameof(chaserCheckpoint));
+			Ensure.NotNull(epochManager, nameof(epochManager));
+			Ensure.NotNull(getLastCommitPosition, nameof(getLastCommitPosition));
 
+			_getUtcNow = getUtcNow ?? (() => DateTime.Now);
 			_publisher = publisher;
 			_nodeInfo = nodeInfo;
 			_publisherEnvelope = new PublishEnvelope(_publisher);
@@ -124,36 +128,60 @@ namespace EventStore.Core.Services {
 			subscriber.Subscribe<ElectionMessage.Proposal>(this);
 			subscriber.Subscribe<ElectionMessage.Accept>(this);
 			subscriber.Subscribe<ElectionMessage.MasterIsResigning>(this);
+			subscriber.Subscribe<ElectionMessage.MasterIsResigningOk>(this);
 			subscriber.Subscribe<ClientMessage.SetNodePriority>(this);
 			subscriber.Subscribe<ClientMessage.ResignNode>(this);
 		}
 
-		public void Handle(ClientMessage.SetNodePriority message)
-		{
+		public void Handle(ClientMessage.SetNodePriority message) {
 			Log.Debug("Setting Node Priority to {nodePriority}.", message.NodePriority);
 			_nodePriority = message.NodePriority;
 			_publisher.Publish(new GossipMessage.UpdateNodePriority(_nodePriority));
 		}
 
-		public void Handle(ClientMessage.ResignNode message)
-		{
+		public void Handle(ClientMessage.ResignNode message) {
 			if (_master != null && _nodeInfo.InstanceId == _master) {
-				Log.Info("ELECTIONS: INITIATING RESIGNATION OF THE MASTER NODE");
-				_publisher.Publish(new SystemMessage.InitiateMasterResignation());
-				var masterIsResigningMessage = new ElectionMessage.MasterIsResigning(
+				_resigningMasterInstanceId = _master;
+				var masterIsResigningMessageOk = new ElectionMessage.MasterIsResigningOk(
+					_nodeInfo.InstanceId,
+					_nodeInfo.InternalHttp,
 					_nodeInfo.InstanceId,
 					_nodeInfo.InternalHttp);
-				Handle(masterIsResigningMessage);
-				SendToAllExceptMe(masterIsResigningMessage);
+				Handle(masterIsResigningMessageOk);
+				SendToAllExceptMe(new ElectionMessage.MasterIsResigning(
+					_nodeInfo.InstanceId, _nodeInfo.InternalHttp));
 			} else {
 				Log.Info("ELECTIONS: ONLY MASTER RESIGNATION IS SUPPORTED AT THE MOMENT. IGNORING RESIGNATION.");
 			}
 		}
 
 		public void Handle(ElectionMessage.MasterIsResigning message) {
-			Log.Debug("ELECTIONS: RESIGNATION FROM [{masterInternalHttp}, {masterId:B}].",
+			if (_nodeInfo.IsReadOnlyReplica) {
+				Log.Debug(
+					"ELECTIONS: THIS NODE IS A READ ONLY REPLICA. IT IS NOT ALLOWED TO VOTE AND THEREFOR NOT ALLOWED TO ACKNOWLEDGE MASTER RESIGNATION.");
+				return;
+			}
+			Log.Debug("ELECTIONS: MASTER IS RESIGNING [{masterInternalHttp}, {masterId:B}].",
 				message.MasterInternalHttp, message.MasterId);
+			var masterIsResigningMessageOk = new ElectionMessage.MasterIsResigningOk(
+				message.MasterId,
+				message.MasterInternalHttp,
+				_nodeInfo.InstanceId,
+				_nodeInfo.InternalHttp);
 			_resigningMasterInstanceId = message.MasterId;
+			_publisher.Publish(new HttpMessage.SendOverHttp(message.MasterInternalHttp, masterIsResigningMessageOk,
+				_getUtcNow().Add(LeaderElectionProgressTimeout)));
+		}
+
+		public void Handle(ElectionMessage.MasterIsResigningOk message) {
+			if (_masterIsResigningOkReceived.Add(message.ServerId) &&
+			    _masterIsResigningOkReceived.Count == _clusterSize / 2 + 1) {
+				_masterIsResigningOkReceived.Clear();
+				Log.Debug(
+					"ELECTIONS: MAJORITY OF ACCEPTANCE OF RESIGNATION OF MASTER [{masterInternalHttp}, {masterId:B}]. NOW INITIATING MASTER RESIGNATION.",
+					message.MasterInternalHttp, message.MasterId);
+				_publisher.Publish(new SystemMessage.InitiateMasterResignation());
+			}
 		}
 
 		public void Handle(SystemMessage.BecomeShuttingDown message) {
@@ -214,7 +242,7 @@ namespace EventStore.Core.Services {
 		private void SendToAllExceptMe(Message message) {
 			foreach (var server in _servers.Where(x => x.InstanceId != _nodeInfo.InstanceId)) {
 				_publisher.Publish(new HttpMessage.SendOverHttp(server.InternalHttpEndPoint, message,
-					DateTime.Now.Add(LeaderElectionProgressTimeout)));
+					_getUtcNow().Add(LeaderElectionProgressTimeout)));
 			}
 		}
 
@@ -271,12 +299,14 @@ namespace EventStore.Core.Services {
 					"ELECTIONS: (IV={installedView}) VIEWCHANGEPROOF FROM [{serverInternalHttp}, {serverId:B}]. JUMPING TO NON-LEADER STATE.",
 					message.InstalledView, message.ServerInternalHttp, message.ServerId);
 
-				ShiftToRegNonLeader();
+				ShiftToAcceptor();
 			}
 		}
 
 		private bool AmILeaderOf(int lastAttemptedView) {
-			var leader = _servers[lastAttemptedView % _servers.Length];
+			var serversExcludingNonPotentialLeaders = _servers.Where(x => !x.IsReadOnlyReplica).ToArray();
+			var leader =
+				serversExcludingNonPotentialLeaders[lastAttemptedView % serversExcludingNonPotentialLeaders.Length];
 			return leader.InstanceId == _nodeInfo.InstanceId;
 		}
 
@@ -301,15 +331,16 @@ namespace EventStore.Core.Services {
 				_lastAttemptedView, message.ServerInternalHttp, message.ServerId);
 
 			if (_state == ElectionsState.ElectingLeader) // install the view
-				ShiftToRegNonLeader();
+				ShiftToAcceptor();
 
 			if (_nodeInfo.IsReadOnlyReplica) {
 				Log.Info("ELECTIONS: READ ONLY REPLICA CAN'T BE A CANDIDATE [{0}]", message.ServerInternalHttp);
 				return;
 			}
+
 			var prepareOk = CreatePrepareOk(message.View);
 			_publisher.Publish(new HttpMessage.SendOverHttp(message.ServerInternalHttp, prepareOk,
-				DateTime.Now.Add(LeaderElectionProgressTimeout)));
+				_getUtcNow().Add(LeaderElectionProgressTimeout)));
 		}
 
 		private ElectionMessage.PrepareOk CreatePrepareOk(int view) {
@@ -320,10 +351,10 @@ namespace EventStore.Core.Services {
 				ownInfo.NodePriority);
 		}
 
-		private void ShiftToRegNonLeader() {
-			Log.Debug("ELECTIONS: (V={lastAttemptedView}) SHIFT TO REG_NONLEADER.", _lastAttemptedView);
+		private void ShiftToAcceptor() {
+			Log.Debug("ELECTIONS: (V={lastAttemptedView}) SHIFT TO REG_ACCEPTOR.", _lastAttemptedView);
 
-			_state = ElectionsState.NonLeader;
+			_state = ElectionsState.Acceptor;
 			_lastInstalledView = _lastAttemptedView;
 		}
 
@@ -340,15 +371,17 @@ namespace EventStore.Core.Services {
 			if (!_prepareOkReceived.ContainsKey(msg.ServerId)) {
 				_prepareOkReceived.Add(msg.ServerId, msg);
 				if (_prepareOkReceived.Count == _clusterSize / 2 + 1)
-					ShiftToRegLeader();
+					ShiftToLeader();
 			}
 		}
 
-		private void ShiftToRegLeader() {
+		private void ShiftToLeader() {
 			if (_nodeInfo.IsReadOnlyReplica) {
-				Log.Debug("ELECTIONS: (V={lastAttemptedView}) NOT SHIFTING TO REG_LEADER AS I'M READONLY.", _lastAttemptedView);
+				Log.Debug("ELECTIONS: (V={lastAttemptedView}) NOT SHIFTING TO REG_LEADER AS I'M READONLY.",
+					_lastAttemptedView);
 				return;
 			}
+
 			Log.Debug("ELECTIONS: (V={lastAttemptedView}) SHIFT TO REG_LEADER.", _lastAttemptedView);
 
 			_state = ElectionsState.Leader;
@@ -359,7 +392,8 @@ namespace EventStore.Core.Services {
 			_acceptsReceived.Clear();
 			_masterProposal = null;
 
-			var master = GetBestMasterCandidate(_prepareOkReceived, _servers, _lastElectedMaster, _resigningMasterInstanceId);
+			var master = GetBestMasterCandidate(_prepareOkReceived, _servers, _lastElectedMaster,
+				_resigningMasterInstanceId);
 			if (master == null) {
 				Log.Trace("ELECTIONS: (V={lastAttemptedView}) NO MASTER CANDIDATE WHEN TRYING TO SEND PROPOSAL.",
 					_lastAttemptedView);
@@ -381,7 +415,8 @@ namespace EventStore.Core.Services {
 			SendToAllExceptMe(proposal);
 		}
 
-		public static MasterCandidate GetBestMasterCandidate(Dictionary<Guid, ElectionMessage.PrepareOk> received, MemberInfo[] servers, Guid? lastElectedMaster, Guid? resigningMasterInstanceId) {
+		public static MasterCandidate GetBestMasterCandidate(Dictionary<Guid, ElectionMessage.PrepareOk> received,
+			MemberInfo[] servers, Guid? lastElectedMaster, Guid? resigningMasterInstanceId) {
 			if (lastElectedMaster.HasValue && lastElectedMaster.Value != resigningMasterInstanceId) {
 				if (received.TryGetValue(lastElectedMaster.Value, out var masterMsg)) {
 					return new MasterCandidate(masterMsg.ServerId, masterMsg.ServerInternalHttp,
@@ -416,14 +451,16 @@ namespace EventStore.Core.Services {
 		}
 
 		public static bool IsLegitimateMaster(int view, IPEndPoint proposingServerEndPoint, Guid proposingServerId,
-			MasterCandidate candidate, MemberInfo[] servers, Guid? lastElectedMaster, VNodeInfo nodeInfo, MasterCandidate ownInfo) {
+			MasterCandidate candidate, MemberInfo[] servers, Guid? lastElectedMaster, VNodeInfo nodeInfo,
+			MasterCandidate ownInfo,
+			Guid? resigningMaster) {
 			var master = servers.FirstOrDefault(x =>
 				x.IsAlive && x.InstanceId == lastElectedMaster && x.State == VNodeState.Master);
 
-			if (master != null) {
+			if (master != null && master.InstanceId != resigningMaster) {
 				if (candidate.InstanceId == master.InstanceId
-					|| candidate.EpochNumber > master.EpochNumber
-					|| (candidate.EpochNumber == master.EpochNumber && candidate.EpochId != master.EpochId))
+				    || candidate.EpochNumber > master.EpochNumber
+				    || (candidate.EpochNumber == master.EpochNumber && candidate.EpochId != master.EpochId))
 					return true;
 
 				Log.Debug(
@@ -463,7 +500,7 @@ namespace EventStore.Core.Services {
 		public void Handle(ElectionMessage.Proposal message) {
 			if (_state == ElectionsState.Shutdown) return;
 			if (message.ServerId == _nodeInfo.InstanceId) return;
-			if (_state != ElectionsState.NonLeader) return;
+			if (_state != ElectionsState.Acceptor) return;
 			if (message.View != _lastInstalledView) return;
 			if (_servers.All(x => x.InstanceId != message.ServerId)) return;
 			if (_servers.All(x => x.InstanceId != message.MasterId)) return;
@@ -471,16 +508,18 @@ namespace EventStore.Core.Services {
 			var candidate = new MasterCandidate(message.MasterId, message.MasterInternalHttp,
 				message.EpochNumber, message.EpochPosition, message.EpochId,
 				message.LastCommitPosition, message.WriterCheckpoint, message.ChaserCheckpoint, message.NodePriority);
-			
+
 			var ownInfo = GetOwnInfo();
 			if (!IsLegitimateMaster(message.View, message.ServerInternalHttp, message.ServerId,
-									candidate, _servers, _lastElectedMaster, _nodeInfo, ownInfo))
+				candidate, _servers, _lastElectedMaster, _nodeInfo, ownInfo,
+				_resigningMasterInstanceId))
 				return;
 
 			Log.Debug(
 				"ELECTIONS: (V={lastAttemptedView}) PROPOSAL FROM [{serverInternalHttp},{serverId:B}] M={candidateInfo}. ME={ownInfo}, NodePriority={priority}",
 				_lastAttemptedView,
-				message.ServerInternalHttp, message.ServerId, FormatNodeInfo(candidate), FormatNodeInfo(GetOwnInfo()), message.NodePriority);
+				message.ServerInternalHttp, message.ServerId, FormatNodeInfo(candidate), FormatNodeInfo(GetOwnInfo()),
+				message.NodePriority);
 
 			if (_masterProposal == null) {
 				_masterProposal = candidate;

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -172,7 +172,7 @@ namespace EventStore.Core.Services {
 				_nodeInfo.InternalHttp);
 			_resigningMasterInstanceId = message.MasterId;
 			_publisher.Publish(new HttpMessage.SendOverHttp(message.MasterInternalHttp, masterIsResigningMessageOk,
-				_timeProvider.UtcNow.Add(LeaderElectionProgressTimeout)));
+				_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)));
 		}
 
 		public void Handle(ElectionMessage.MasterIsResigningOk message) {

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -164,6 +164,7 @@ namespace EventStore.Core.Services {
 					"ELECTIONS: THIS NODE IS A READ ONLY REPLICA. IT IS NOT ALLOWED TO VOTE AND THEREFORE NOT ALLOWED TO ACKNOWLEDGE MASTER RESIGNATION.");
 				return;
 			}
+
 			Log.Debug("ELECTIONS: MASTER IS RESIGNING [{masterInternalHttp}, {masterId:B}].",
 				message.MasterInternalHttp, message.MasterId);
 			var masterIsResigningMessageOk = new ElectionMessage.MasterIsResigningOk(
@@ -171,7 +172,7 @@ namespace EventStore.Core.Services {
 				message.MasterInternalHttp,
 				_nodeInfo.InstanceId,
 				_nodeInfo.InternalHttp);
-			
+
 			_resigningMasterInstanceId = message.MasterId;
 			_publisher.Publish(new HttpMessage.SendOverHttp(message.MasterInternalHttp, masterIsResigningMessageOk,
 				_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)));
@@ -337,7 +338,8 @@ namespace EventStore.Core.Services {
 				ShiftToAcceptor();
 
 			if (_nodeInfo.IsReadOnlyReplica) {
-				Log.Info("ELECTIONS: READ ONLY REPLICA CAN'T BE A CANDIDATE [{0}]", message.ServerInternalHttp);
+				Log.Info("ELECTIONS: READ ONLY REPLICA, NOT ACCEPTING PREPARE, NOT ELIGIBLE TO VOTE [{0}]",
+					_nodeInfo.InternalHttp);
 				return;
 			}
 

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -161,7 +161,7 @@ namespace EventStore.Core.Services {
 		public void Handle(ElectionMessage.MasterIsResigning message) {
 			if (_nodeInfo.IsReadOnlyReplica) {
 				Log.Debug(
-					"ELECTIONS: THIS NODE IS A READ ONLY REPLICA. IT IS NOT ALLOWED TO VOTE AND THEREFOR NOT ALLOWED TO ACKNOWLEDGE MASTER RESIGNATION.");
+					"ELECTIONS: THIS NODE IS A READ ONLY REPLICA. IT IS NOT ALLOWED TO VOTE AND THEREFORE NOT ALLOWED TO ACKNOWLEDGE MASTER RESIGNATION.");
 				return;
 			}
 			Log.Debug("ELECTIONS: MASTER IS RESIGNING [{masterInternalHttp}, {masterId:B}].",

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -149,6 +149,7 @@ namespace EventStore.Core.Services {
 					_nodeInfo.InternalHttp,
 					_nodeInfo.InstanceId,
 					_nodeInfo.InternalHttp);
+				_masterIsResigningOkReceived.Clear();
 				Handle(masterIsResigningMessageOk);
 				SendToAllExceptMe(new ElectionMessage.MasterIsResigning(
 					_nodeInfo.InstanceId, _nodeInfo.InternalHttp));
@@ -170,6 +171,7 @@ namespace EventStore.Core.Services {
 				message.MasterInternalHttp,
 				_nodeInfo.InstanceId,
 				_nodeInfo.InternalHttp);
+			
 			_resigningMasterInstanceId = message.MasterId;
 			_publisher.Publish(new HttpMessage.SendOverHttp(message.MasterInternalHttp, masterIsResigningMessageOk,
 				_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)));
@@ -178,7 +180,6 @@ namespace EventStore.Core.Services {
 		public void Handle(ElectionMessage.MasterIsResigningOk message) {
 			if (_masterIsResigningOkReceived.Add(message.ServerId) &&
 			    _masterIsResigningOkReceived.Count == _clusterSize / 2 + 1) {
-				_masterIsResigningOkReceived.Clear();
 				Log.Debug(
 					"ELECTIONS: MAJORITY OF ACCEPTANCE OF RESIGNATION OF MASTER [{masterInternalHttp}, {masterId:B}]. NOW INITIATING MASTER RESIGNATION.",
 					message.MasterInternalHttp, message.MasterId);

--- a/src/EventStore.Core/Services/TimerService/ITimeProvider.cs
+++ b/src/EventStore.Core/Services/TimerService/ITimeProvider.cs
@@ -2,6 +2,7 @@
 
 namespace EventStore.Core.Services.TimerService {
 	public interface ITimeProvider {
-		DateTime Now { get; }
+		DateTime UtcNow { get; }
+		DateTime LocalTime { get; }
 	}
 }

--- a/src/EventStore.Core/Services/TimerService/RealTimeProvider.cs
+++ b/src/EventStore.Core/Services/TimerService/RealTimeProvider.cs
@@ -2,8 +2,12 @@
 
 namespace EventStore.Core.Services.TimerService {
 	public class RealTimeProvider : ITimeProvider {
-		public DateTime Now {
+		public DateTime UtcNow {
 			get { return DateTime.UtcNow; }
+		}
+		
+		public DateTime LocalTime {
+			get { return DateTime.Now; }
 		}
 	}
 }

--- a/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/ThreadBasedScheduler.cs
@@ -45,7 +45,7 @@ namespace EventStore.Core.Services.TimerService {
 		}
 
 		public void Schedule(TimeSpan after, Action<IScheduler, object> callback, object state) {
-			_pending.Enqueue(new ScheduledTask(_timeProvider.Now.Add(after), callback, state));
+			_pending.Enqueue(new ScheduledTask(_timeProvider.UtcNow.Add(after), callback, state));
 		}
 
 		private void DoTiming() {
@@ -68,7 +68,7 @@ namespace EventStore.Core.Services.TimerService {
 
 					_queueStats.ProcessingStarted<ExecuteScheduledTasks>(_tasks.Count);
 					int processed = 0;
-					while (_tasks.Count > 0 && _tasks.FindMin().DueTime <= _timeProvider.Now) {
+					while (_tasks.Count > 0 && _tasks.FindMin().DueTime <= _timeProvider.UtcNow) {
 						processed += 1;
 						var scheduledTask = _tasks.DeleteMin();
 						scheduledTask.Action(this, scheduledTask.State);

--- a/src/EventStore.Core/Services/TimerService/TimerBasedScheduler.cs
+++ b/src/EventStore.Core/Services/TimerService/TimerBasedScheduler.cs
@@ -27,13 +27,13 @@ namespace EventStore.Core.Services.TimerService {
 
 		public void Schedule(TimeSpan after, Action<IScheduler, object> callback, object state) {
 			lock (_queueLock) {
-				_tasks.Add(new ScheduledTask(_timeProvider.Now.Add(after), callback, state));
+				_tasks.Add(new ScheduledTask(_timeProvider.UtcNow.Add(after), callback, state));
 				ResetTimer();
 			}
 		}
 
 		protected void ProcessOperations() {
-			while (_tasks.Count > 0 && _tasks.FindMin().DueTime <= _timeProvider.Now) {
+			while (_tasks.Count > 0 && _tasks.FindMin().DueTime <= _timeProvider.UtcNow) {
 				var scheduledTask = _tasks.DeleteMin();
 				scheduledTask.Action(this, scheduledTask.State);
 			}
@@ -49,7 +49,7 @@ namespace EventStore.Core.Services.TimerService {
 		private void ResetTimer() {
 			if (_tasks.Count > 0) {
 				var tuple = _tasks.FindMin();
-				_timer.FireIn((int)(tuple.DueTime - _timeProvider.Now).TotalMilliseconds, OnTimerFired);
+				_timer.FireIn((int)(tuple.DueTime - _timeProvider.UtcNow).TotalMilliseconds, OnTimerFired);
 			} else {
 				_timer.FireIn(Timeout.Infinite, OnTimerFired);
 			}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_tf_based_read_completes_before_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_tf_based_read_completes_before_timeout.cs
@@ -46,13 +46,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 				EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 					new EventRecord(
 						1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "test_stream", ExpectedVersion.Any,
-						_fakeTimeProvider.Now,
+						_fakeTimeProvider.UtcNow,
 						PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 						"eventTypeOne", new byte[] {1}, new byte[] {2}), 100),
 				EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 					new EventRecord(
 						2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "test_stream", ExpectedVersion.Any,
-						_fakeTimeProvider.Now,
+						_fakeTimeProvider.UtcNow,
 						PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 						"eventTypeTwo", new byte[] {1}, new byte[] {2}), 200),
 			});

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_tf_based_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_event_reader/when_tf_based_read_timeout_occurs.cs
@@ -49,13 +49,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 				ResolvedEvent.ForUnresolvedEvent(
 					new EventRecord(
 						1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "test_stream", ExpectedVersion.Any,
-						_fakeTimeProvider.Now,
+						_fakeTimeProvider.UtcNow,
 						PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 						"eventTypeOne", new byte[] {1}, new byte[] {2}), 100),
 				ResolvedEvent.ForUnresolvedEvent(
 					new EventRecord(
 						2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "test_stream", ExpectedVersion.Any,
-						_fakeTimeProvider.Now,
+						_fakeTimeProvider.UtcNow,
 						PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 						"eventTypeTwo", new byte[] {1}, new byte[] {2}), 200),
 			});

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/reordering.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/reordering.cs
@@ -125,7 +125,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 
 				yield return Yield;
 
-				_timeProvider.AddTime(TimeSpan.FromMilliseconds(300));
+				_timeProvider.AddToUtcTime(TimeSpan.FromMilliseconds(300));
 
 				yield return Yield;
 			}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_eof_for_all_streams_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_handling_eof_for_all_streams_and_idle_eof.cs
@@ -51,7 +51,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 						ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2})),
 					}, null, false, "", 2, 1, true, 200));
@@ -64,7 +64,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 						ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								2, 100, Guid.NewGuid(), _secondEventId, 100, 0, "b", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2})),
 					}, null, false, "", 3, 2, true, 200));
@@ -80,7 +80,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 				new ClientMessage.ReadStreamEventsForwardCompleted(
 					correlationId, "b", 100, 100, ReadStreamResult.Success, new ResolvedEvent[] { }, null, false, "", 3,
 					2, true, 400));
-			_fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
+			_fakeTimeProvider.AddToUtcTime(TimeSpan.FromMilliseconds(500));
 			correlationId = ((ClientMessage.ReadStreamEventsForward)(_consumer.HandledMessages
 				.OfType<AwakeServiceMessage.SubscribeAwake>().Last().ReplyWithMessage)).CorrelationId;
 			_edp.Handle(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_onetime_reader_handles_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/when_onetime_reader_handles_eof.cs
@@ -51,7 +51,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 						ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2})),
 					}, null, false, "", 2, 1, true, 200));
@@ -64,7 +64,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 						ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								2, 100, Guid.NewGuid(), _secondEventId, 100, 0, "b", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2})),
 					}, null, false, "", 3, 2, true, 200));

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_eof_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/stream_reader/when_handling_eof_and_idle_eof.cs
@@ -64,7 +64,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.stream_reader 
 				new ClientMessage.ReadStreamEventsForwardCompleted(
 					correlationId, "stream", 100, 100, ReadStreamResult.Success,
 					new ResolvedEvent[] { }, null, false, "", 12, 11, true, 400));
-			_fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
+			_fakeTimeProvider.AddToUtcTime(TimeSpan.FromMilliseconds(500));
 			correlationId = ((ClientMessage.ReadStreamEventsForward)(_consumer.HandledMessages
 				.OfType<AwakeServiceMessage.SubscribeAwake>().Last().ReplyWithMessage)).CorrelationId;
 			_edp.Handle(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_eof_and_idle_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_eof_and_idle_eof.cs
@@ -44,13 +44,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 100),
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "b", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 200),
 					}, null, false, 100,
@@ -61,7 +61,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 					correlationId, ReadAllResult.Success, null,
 					new EventStore.Core.Data.ResolvedEvent[0], null, false, 100, new TFPos(), new TFPos(), new TFPos(),
 					500));
-			_fakeTimeProvider.AddTime(TimeSpan.FromMilliseconds(500));
+			_fakeTimeProvider.AddToUtcTime(TimeSpan.FromMilliseconds(500));
 			correlationId = ((ClientMessage.ReadAllEventsForward)(_consumer.HandledMessages
 				.OfType<AwakeServiceMessage.SubscribeAwake>().Last().ReplyWithMessage)).CorrelationId;
 			_edp.Handle(

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_hard_deleted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_hard_deleted.cs
@@ -44,13 +44,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 						ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 100),
 						ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								SystemEventTypes.StreamDeleted, new byte[] {1}, new byte[] {2}), 200),
 					}, null, false, 100,

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_soft_deleted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_handling_stream_soft_deleted.cs
@@ -45,13 +45,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 						ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 100),
 						ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "$$a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								SystemEventTypes.StreamMetadata,
 								new StreamMetadata(truncateBefore: EventNumber.DeletedStream).ToJsonBytes(),

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_onetime_reader_handles_eof.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_onetime_reader_handles_eof.cs
@@ -43,13 +43,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								1, 50, Guid.NewGuid(), _firstEventId, 50, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 100),
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								2, 150, Guid.NewGuid(), _secondEventId, 150, 0, "b", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 200),
 					}, null, false, 100, new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_completes_before_timeout.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_completes_before_timeout.cs
@@ -38,13 +38,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 100),
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "b", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 200),
 					}, null, false, 100, new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_timeout_occurs.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/transaction_file_reader/when_read_timeout_occurs.cs
@@ -41,13 +41,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.transaction_fi
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								1, 50, Guid.NewGuid(), Guid.NewGuid(), 50, 0, "a", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 100),
 						EventStore.Core.Data.ResolvedEvent.ForUnresolvedEvent(
 							new EventRecord(
 								2, 150, Guid.NewGuid(), Guid.NewGuid(), 150, 0, "b", ExpectedVersion.Any,
-								_fakeTimeProvider.Now,
+								_fakeTimeProvider.UtcNow,
 								PrepareFlags.SingleWrite | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd,
 								"event_type1", new byte[] {1}, new byte[] {2}), 200),
 					}, null, false, 100, new TFPos(200, 150), new TFPos(500, -1), new TFPos(100, 50), 500));

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_after_specified_time_elapses.cs
@@ -21,7 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
 					"bad-event-type", false, new byte[0], new byte[0]));
 			_checkpointHandler.HandledMessages.Clear();
-			((FakeTimeProvider)_timeProvider).AddTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
+			((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
@@ -59,7 +59,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
 					"bad-event-type", false, new byte[0], new byte[0]));
 			_checkpointHandler.HandledMessages.Clear();
-			((FakeTimeProvider)_timeProvider).AddTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
+			((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(400, 400), "test-stream", 1, false, Guid.NewGuid(),

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_enough_events_for_a_checkpoint_before_specified_time_elapses.cs
@@ -21,7 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
 					"bad-event-type", false, new byte[0], new byte[0]));
 			_checkpointHandler.HandledMessages.Clear();
-			((FakeTimeProvider)_timeProvider).AddTime(TimeSpan.FromMilliseconds(_checkpointAfterMs));
+			((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
@@ -59,7 +59,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					Guid.NewGuid(), new TFPos(300, 300), "test-stream", 1, false, Guid.NewGuid(),
 					"bad-event-type", false, new byte[0], new byte[0]));
 			_checkpointHandler.HandledMessages.Clear();
-			((FakeTimeProvider)_timeProvider).AddTime(TimeSpan.FromMilliseconds(_checkpointAfterMs));
+			((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs));
 			_subscription.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					Guid.NewGuid(), new TFPos(400, 400), "test-stream", 1, false, Guid.NewGuid(),

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
@@ -182,7 +182,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
 						_reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false,
 						Guid.NewGuid(),
 						"type", false, new byte[0], new byte[0], 100, 33.3f));
-				_timeProvider.AddTime(TimeSpan.FromMinutes(6));
+				_timeProvider.AddToUtcTime(TimeSpan.FromMinutes(6));
 				yield return Yield;
 				foreach (var m in _consumer.HandledMessages.OfType<TimerMessage.Schedule>().ToArray())
 					m.Envelope.ReplyWith(m.ReplyMessage);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/an_expired_projection.cs
@@ -31,7 +31,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query {
 						_reader, new TFPos(100, 50), new TFPos(100, 50), "stream", 1, "stream", 1, false,
 						Guid.NewGuid(),
 						"type", false, new byte[0], new byte[0], 100, 33.3f));
-				_timeProvider.AddTime(TimeSpan.FromMinutes(6));
+				_timeProvider.AddToUtcTime(TimeSpan.FromMinutes(6));
 				yield return Yield;
 				foreach (var m in _consumer.HandledMessages.OfType<TimerMessage.Schedule>().ToArray())
 					m.Envelope.ReplyWith(m.ReplyMessage);

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -169,7 +169,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			_slaveMasterCorrelationId = slaveMasterCorrelationId;
 			_getStateDispatcher = getStateDispatcher;
 			_getResultDispatcher = getResultDispatcher;
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 			_ioDispatcher = ioDispatcher;
 			_projectionsQueryExpiry = projectionQueryExpiry;
 		}
@@ -306,7 +306,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.GetState message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 			if (_state >= ManagedProjectionState.Running) {
 				_getStateDispatcher.Publish(
 					new CoreProjectionManagementMessage.GetState(Guid.NewGuid(), Id, message.Partition, _workerId),
@@ -321,7 +321,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.GetResult message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 			if (_state >= ManagedProjectionState.Running) {
 				_getResultDispatcher.Publish(
 					new CoreProjectionManagementMessage.GetResult(Guid.NewGuid(), Id, message.Partition, _workerId),
@@ -337,7 +337,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.GetQuery message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 
 			var emitEnabled = PersistedProjectionState.EmitEnabled ?? false;
 
@@ -359,7 +359,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.UpdateQuery message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 
 			Prepared = false;
 			UpdateQuery(message);
@@ -369,7 +369,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.Disable message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 			SetLastReplyEnvelope(message.Envelope);
 			Disable();
 			UpdateProjectionVersion();
@@ -377,7 +377,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.Abort message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 			UpdateProjectionVersion();
 			SetLastReplyEnvelope(message.Envelope);
 			Disable();
@@ -385,7 +385,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.Enable message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 			if (Enabled
 			    && !(_state == ManagedProjectionState.Completed || _state == ManagedProjectionState.Faulted
 			                                                    || _state == ManagedProjectionState.Aborted ||
@@ -405,7 +405,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.SetRunAs message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 			Prepared = false;
 			SetRunAs(message);
 			UpdateProjectionVersion();
@@ -417,7 +417,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			if ((_state != ManagedProjectionState.Stopped && _state != ManagedProjectionState.Faulted) &&
 			    Mode != ProjectionMode.Transient)
 				throw new InvalidOperationException("Cannot delete a projection that hasn't been stopped or faulted.");
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 
 			PersistedProjectionState.DeleteCheckpointStream = message.DeleteCheckpointStream;
 			PersistedProjectionState.DeleteStateStream = message.DeleteStateStream;
@@ -445,7 +445,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.GetConfig message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 
 			var emitEnabled = PersistedProjectionState.EmitEnabled ?? false;
 			var trackEmittedStreams = PersistedProjectionState.TrackEmittedStreams ?? false;
@@ -464,7 +464,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			    Mode != ProjectionMode.Transient)
 				throw new InvalidOperationException(
 					"Cannot update the config of a projection that hasn't been stopped or faulted.");
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 
 			PersistedProjectionState.EmitEnabled = message.EmitEnabled;
 			PersistedProjectionState.TrackEmittedStreams = message.TrackEmittedStreams;
@@ -521,7 +521,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.Reset message) {
-			_lastAccessed = _timeProvider.Now;
+			_lastAccessed = _timeProvider.UtcNow;
 			Prepared = false;
 			_pendingWritePersistedState = true;
 			Reset();
@@ -597,7 +597,7 @@ namespace EventStore.Projections.Core.Services.Management {
 
 		private bool IsExpiredProjection() {
 			return Mode == ProjectionMode.Transient && !_isSlave &&
-			       _lastAccessed.Add(_projectionsQueryExpiry) < _timeProvider.Now && _persistedStateLoaded;
+			       _lastAccessed.Add(_projectionsQueryExpiry) < _timeProvider.UtcNow && _persistedStateLoaded;
 		}
 
 		public void InitializeNew(PersistedState persistedState, IEnvelope replyEnvelope) {

--- a/src/EventStore.Projections.Core/Services/Processing/AllStreamsCatalogEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/AllStreamsCatalogEventReader.cs
@@ -136,7 +136,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				: base(
 					reader,
 					new ReaderSubscriptionMessage.EventReaderIdle(
-						reader.EventReaderCorrelationId, reader._timeProvider.Now)) {
+						reader.EventReaderCorrelationId, reader._timeProvider.UtcNow)) {
 			}
 		}
 

--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
@@ -698,7 +698,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 			private void SendIdle() {
 				_publisher.Publish(
-					new ReaderSubscriptionMessage.EventReaderIdle(_reader.EventReaderCorrelationId, _timeProvider.Now));
+					new ReaderSubscriptionMessage.EventReaderIdle(_reader.EventReaderCorrelationId, _timeProvider.UtcNow));
 			}
 
 			public override void Dispose() {

--- a/src/EventStore.Projections.Core/Services/Processing/ExternallyFedByStreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ExternallyFedByStreamEventReader.cs
@@ -89,7 +89,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		private void SendIdle() {
 			_publisher.Publish(
-				new ReaderSubscriptionMessage.EventReaderIdle(EventReaderCorrelationId, _timeProvider.Now));
+				new ReaderSubscriptionMessage.EventReaderIdle(EventReaderCorrelationId, _timeProvider.UtcNow));
 		}
 
 		private void ReadDataStreamCompleted(ClientMessage.ReadStreamEventsForwardCompleted completed) {

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamEventReader.cs
@@ -183,7 +183,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		private void CheckIdle() {
 			if (_eofs.All(v => v.Value))
 				_publisher.Publish(
-					new ReaderSubscriptionMessage.EventReaderIdle(EventReaderCorrelationId, _timeProvider.Now));
+					new ReaderSubscriptionMessage.EventReaderIdle(EventReaderCorrelationId, _timeProvider.UtcNow));
 		}
 
 		private void ProcessBuffers() {

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
@@ -106,7 +106,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 			var eventCheckpointTag = _positionTagger.MakeCheckpointTag(_positionTracker.LastTag, message);
 			_positionTracker.UpdateByCheckpointTagForward(eventCheckpointTag);
-			var now = _timeProvider.Now;
+			var now = _timeProvider.UtcNow;
 			var timeDifference = now - _lastCheckpointTime;
 			if (_eventFilter.Passes(
 				message.Data.ResolvedLinkTo, message.Data.PositionStreamId, message.Data.EventType,
@@ -145,7 +145,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		}
 
 		private void PublishProgress(float roundedProgress) {
-			var now = _timeProvider.Now;
+			var now = _timeProvider.UtcNow;
 			if (now - _lastProgressPublished > TimeSpan.FromMilliseconds(500)) {
 				_lastProgressPublished = now;
 				_progress = roundedProgress;
@@ -178,7 +178,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					_subscriptionId, _positionTracker.LastTag, message.Progress,
 					_subscriptionMessageSequenceNumber++));
 			_eventsSinceLastCheckpointSuggestedOrStart = 0;
-			_lastCheckpointTime = _timeProvider.Now;
+			_lastCheckpointTime = _timeProvider.UtcNow;
 		}
 
 		public IEventReader CreatePausedEventReader(IPublisher publisher, IODispatcher ioDispatcher,

--- a/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
@@ -143,7 +143,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		private void SendIdle() {
 			_publisher.Publish(
-				new ReaderSubscriptionMessage.EventReaderIdle(EventReaderCorrelationId, _timeProvider.Now));
+				new ReaderSubscriptionMessage.EventReaderIdle(EventReaderCorrelationId, _timeProvider.UtcNow));
 		}
 
 		protected override void RequestEvents() {

--- a/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
@@ -99,7 +99,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		private void SendIdle() {
 			_publisher.Publish(
-				new ReaderSubscriptionMessage.EventReaderIdle(EventReaderCorrelationId, _timeProvider.Now));
+				new ReaderSubscriptionMessage.EventReaderIdle(EventReaderCorrelationId, _timeProvider.UtcNow));
 		}
 
 		protected override void RequestEvents() {


### PR DESCRIPTION
 Improve tests around elections

- Wait for majority of nodes to acknowledge the resigning master
- Rename NonLeader to Acceptor.
- Exclude ReadOnlyReplica from acknowleding a master resignation.
It does not vote in elections.
- Exclude ReadOnlyReplica from the list of servers to which a
leader for the current round of elections is picked. Since read only
replicas dont handle prepare oks which is sent as replies for the
prepares.