### PR TITLE
Improved liveness determination for nodes

### DIFF
--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -1254,7 +1254,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			_sut.Handle(new ElectionMessage.PrepareOk(0, _nodeTwo.InstanceId, _nodeTwo.InternalHttp, -1, 0,
 				_epochId, -1, -1, -1, -1));
 			_sut.Handle(new ElectionMessage.Accept(_nodeTwo.InstanceId, _nodeTwo.InternalHttp,
-				_nodeThree.InstanceId, _nodeThree.InternalHttp, 0));
+				_node.InstanceId, _node.InternalHttp, 0));
 			_publisher.Messages.Clear();
 
 			_sut.Handle(new ClientMessage.ResignNode());

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -630,6 +630,7 @@ namespace EventStore.Core {
 				_mainBus.Subscribe<GossipMessage.UpdateNodePriority>(gossip);
 				_mainBus.Subscribe<SystemMessage.VNodeConnectionEstablished>(gossip);
 				_mainBus.Subscribe<SystemMessage.VNodeConnectionLost>(gossip);
+				_mainBus.Subscribe<ElectionMessage.ElectionsDone>(gossip);
 			}
 
 			AddTasks(_workersHandler.Start());

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -179,10 +179,16 @@ namespace EventStore.Core.Services {
 		}
 
 		public void Handle(ElectionMessage.MasterIsResigningOk message) {
+			Log.Debug(
+				"ELECTIONS: MASTER IS RESIGNING OK FROM [{serverInternalHttp},{serverId:B}] M=[{masterInternalHttp},{masterId:B}]).",
+				message.ServerInternalHttp,
+				message.ServerId,
+				message.MasterInternalHttp,
+				message.MasterId);
 			if (_masterIsResigningOkReceived.Add(message.ServerId) &&
-			    _masterIsResigningOkReceived.Count == _clusterSize / 2 + 1) {
+					_masterIsResigningOkReceived.Count == _clusterSize / 2 + 1) {
 				Log.Debug(
-					"ELECTIONS: MAJORITY OF ACCEPTANCE OF RESIGNATION OF MASTER [{masterInternalHttp}, {masterId:B}]. NOW INITIATING MASTER RESIGNATION.",
+					"ELECTIONS: MAJORITY OF ACCEPTANCE OF RESIGNATION OF MASTER [{masterInternalHttp},{masterId:B}]. NOW INITIATING MASTER RESIGNATION.",
 					message.MasterInternalHttp, message.MasterId);
 				_publisher.Publish(new SystemMessage.InitiateMasterResignation());
 			}

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -132,7 +132,8 @@ namespace EventStore.Core.Services.Replication {
 		}
 
 		private void OnConnectionClosed(TcpConnectionManager manager, SocketError socketError) {
-			_publisher.Publish(new SystemMessage.VNodeConnectionLost(manager.RemoteEndPoint, manager.ConnectionId));
+			if(socketError != SocketError.Success)
+				_publisher.Publish(new SystemMessage.VNodeConnectionLost(manager.RemoteEndPoint, manager.ConnectionId));
 		}
 
 		public void Handle(ReplicationMessage.ReconnectToMaster message) {

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -45,6 +45,10 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			get { return _clientConnectionName; }
 		}
 
+		public SocketError CloseReason {
+			get { return _closeReason; }
+		}
+
 		private readonly ITcpConnection _connection;
 		private readonly IEnvelope _tcpEnvelope;
 		private readonly IPublisher _publisher;
@@ -68,6 +72,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private readonly IAuthenticationProvider _authProvider;
 		private UserCredentials _defaultUser;
 		private TcpServiceType _serviceType;
+		private SocketError _closeReason;
 
 		public TcpConnectionManager(string connectionName,
 			TcpServiceType serviceType,
@@ -197,6 +202,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 				"Connection '{connectionName}{clientConnectionName}' [{remoteEndPoint}, {connectionId:B}] closed: {e}.",
 				ConnectionName, ClientConnectionName.IsEmptyString() ? string.Empty : ":" + ClientConnectionName,
 				connection.RemoteEndPoint, ConnectionId, socketError);
+			_closeReason = socketError;
 			if (_connectionClosed != null)
 				_connectionClosed(this, socketError);
 		}


### PR DESCRIPTION
There are 2 places inside of Event Store where we publish the
VNodeConnectionLost message. MasterReplicationService and
ReplicaService.

The ReplicaService's responsibility is to subscribe to Master amongst
other things.

When the ReplicaService changes state, it will disconnect and reconnect
to master. It terminates the connection cleanly. As a result, we publish
a `VNodeConnectionLost` which the `GossipService` uses as the truth that
the node is dead, which in fact it's not.

The suggested change here is not publish this message if the
connection was terminate cleanly. This will avoid false positives for
nodes being marked as dead.

The Master Replication Service's responsbility is to ensure that it has
a quorum of replicas to replicate it's log to.

When it checks the connection statuses of the list of subscriptions it
has, it publishes a `VNodeConnectionLost` will mark a node as dead which
it might not be as it might have been a replica that disconnected
cleanly.

The suggested change here is similar to above with the ReplicaService.
We want to publish if the connection was not terminated succesfully.
We want to publish this message still as it will result in a much faster
result than waiting for a gossip to fail to determine if a node is alive
or not.

When Elections are done, we can safely update our view of the cluster as
we know who master is. We now do this in the GossipService.