### PR TITLE
Bug fix: ConcurrentQueueWrapper can return negative count

### DIFF
--- a/src/EventStore.ClientAPI/Common/Utils/Threading/ConcurrentQueueWrapper.cs
+++ b/src/EventStore.ClientAPI/Common/Utils/Threading/ConcurrentQueueWrapper.cs
@@ -10,11 +10,14 @@ namespace EventStore.ClientAPI.Common.Utils.Threading {
 		private volatile int _queueCount = 0;
 
 		public new bool IsEmpty {
-			get { return _queueCount == 0; }
+			get { return _queueCount <= 0; }
 		}
 
 		public new int Count {
-			get { return _queueCount; }
+			get {
+				int curCount = _queueCount;
+				return curCount < 0 ? 0 : curCount;
+			}
 		}
 
 		//Note: The count is not updated atomically together with dequeueing.

--- a/src/EventStore.Common/Utils/ConcurrentQueueWrapper.cs
+++ b/src/EventStore.Common/Utils/ConcurrentQueueWrapper.cs
@@ -10,11 +10,14 @@ namespace EventStore.Common.Utils {
 		private volatile int _queueCount = 0;
 
 		public new bool IsEmpty {
-			get { return _queueCount == 0; }
+			get { return _queueCount <= 0; }
 		}
 
 		public new int Count {
-			get { return _queueCount; }
+			get {
+				int curCount = _queueCount;
+				return curCount < 0 ? 0 : curCount;
+			}
 		}
 
 		//Note: The count is not updated atomically together with dequeueing.

--- a/src/EventStore.Core.Tests/ClientAPI/DataStructures/concurrent_queue_wrapper_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/DataStructures/concurrent_queue_wrapper_should.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading;
+using EventStore.ClientAPI.Common.Utils.Threading;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientAPI.DataStructures {
+	[TestFixture]
+	public class concurrent_queue_wrapper_should {
+		[Test]
+		public void return_correct_counts_and_values_1() {
+			var queue = new ConcurrentQueueWrapper<int>();
+			Assert.AreEqual(0, queue.Count);
+			queue.Enqueue(1234);
+			Assert.AreEqual(1, queue.Count);
+			queue.Enqueue(12345);
+			Assert.AreEqual(2, queue.Count);
+
+			int val;
+			Assert.AreEqual(true, queue.TryDequeue(out val));
+			Assert.AreEqual(1234, val);
+			Assert.AreEqual(1, queue.Count);
+
+			Assert.AreEqual(true, queue.TryDequeue(out val));
+			Assert.AreEqual(12345, val);
+			Assert.AreEqual(0, queue.Count);
+
+			Assert.AreEqual(false, queue.TryDequeue(out val));
+			Assert.AreEqual(false, queue.TryDequeue(out val));
+		}
+
+		[Test]
+		public void return_correct_counts_and_values_2() {
+			var queue = new ConcurrentQueueWrapper<int>();
+			for (int i = 1; i <= 1000; i++) {
+				queue.Enqueue(i);
+				Assert.AreEqual(i, queue.Count);
+			}
+
+			int x;
+			for (int i = 1; i <= 1000; i++) {
+				Assert.AreEqual(true, queue.TryDequeue(out x));
+				Assert.AreEqual(i, x);
+				Assert.AreEqual(1000-i, queue.Count);
+			}
+		}
+	}
+
+	[TestFixture]
+	public class concurrent_queue_wrapper_with_parallel_dequeues_should {
+		private ConcurrentQueueWrapper<int> _concurrentQueue;
+		private const int TOTAL_ENQUEUED_ITEMS = 1000000;
+		private const int NUM_THREADS = 4;
+		private volatile bool _seenNegativeCount;
+		private volatile int _totalDequeued;
+
+		public concurrent_queue_wrapper_with_parallel_dequeues_should() {
+			_concurrentQueue = new ConcurrentQueueWrapper<int>();
+			_seenNegativeCount = false;
+			_totalDequeued = 0;
+		}
+
+		private void DequeueThread() {
+			int x;
+			while (_totalDequeued < TOTAL_ENQUEUED_ITEMS) {
+				var dequeued = _concurrentQueue.TryDequeue(out x);
+				if (_concurrentQueue.Count < 0) _seenNegativeCount = true;
+				if (dequeued) Interlocked.Increment(ref _totalDequeued);
+			}
+		}
+
+		[Test]
+		public void always_return_non_negative_count() {
+			var threads = new Thread[NUM_THREADS];
+			for (int i = 0; i < NUM_THREADS; i++) {
+				threads[i] = new Thread(DequeueThread);
+				threads[i].Start();
+			}
+
+			int x;
+			for (int i = 0; i < TOTAL_ENQUEUED_ITEMS; i++) {
+				_concurrentQueue.Enqueue(1);
+				var dequeued = _concurrentQueue.TryDequeue(out x);
+				if (dequeued) Interlocked.Increment(ref _totalDequeued);
+			}
+
+			for(int i=0;i<NUM_THREADS;i++)
+				threads[i].Join(TimeSpan.FromSeconds(5));
+
+			Assert.AreEqual(false, _seenNegativeCount);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/DataStructures/concurrent_queue_wrapper_should.cs
+++ b/src/EventStore.Core.Tests/DataStructures/concurrent_queue_wrapper_should.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Threading;
+using EventStore.Common.Utils;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.DataStructures {
+	[TestFixture]
+	public class concurrent_queue_wrapper_should {
+		[Test]
+		public void return_correct_counts_and_values_1() {
+			var queue = new ConcurrentQueueWrapper<int>();
+			Assert.AreEqual(0, queue.Count);
+			queue.Enqueue(1234);
+			Assert.AreEqual(1, queue.Count);
+			queue.Enqueue(12345);
+			Assert.AreEqual(2, queue.Count);
+
+			int val;
+			Assert.AreEqual(true, queue.TryDequeue(out val));
+			Assert.AreEqual(1234, val);
+			Assert.AreEqual(1, queue.Count);
+
+			Assert.AreEqual(true, queue.TryDequeue(out val));
+			Assert.AreEqual(12345, val);
+			Assert.AreEqual(0, queue.Count);
+
+			Assert.AreEqual(false, queue.TryDequeue(out val));
+			Assert.AreEqual(false, queue.TryDequeue(out val));
+		}
+
+		[Test]
+		public void return_correct_counts_and_values_2() {
+			var queue = new ConcurrentQueueWrapper<int>();
+			for (int i = 1; i <= 1000; i++) {
+				queue.Enqueue(i);
+				Assert.AreEqual(i, queue.Count);
+			}
+
+			int x;
+			for (int i = 1; i <= 1000; i++) {
+				Assert.AreEqual(true, queue.TryDequeue(out x));
+				Assert.AreEqual(i, x);
+				Assert.AreEqual(1000-i, queue.Count);
+			}
+		}
+	}
+
+	[TestFixture]
+	public class concurrent_queue_wrapper_with_parallel_dequeues_should {
+		private ConcurrentQueueWrapper<int> _concurrentQueue;
+		private const int TOTAL_ENQUEUED_ITEMS = 1000000;
+		private const int NUM_THREADS = 4;
+		private volatile bool _seenNegativeCount;
+		private volatile int _totalDequeued;
+
+		public concurrent_queue_wrapper_with_parallel_dequeues_should() {
+			_concurrentQueue = new ConcurrentQueueWrapper<int>();
+			_seenNegativeCount = false;
+			_totalDequeued = 0;
+		}
+
+		private void DequeueThread() {
+			int x;
+			while (_totalDequeued < TOTAL_ENQUEUED_ITEMS) {
+				var dequeued = _concurrentQueue.TryDequeue(out x);
+				if (_concurrentQueue.Count < 0) _seenNegativeCount = true;
+				if (dequeued) Interlocked.Increment(ref _totalDequeued);
+			}
+		}
+
+		[Test]
+		public void always_return_non_negative_count() {
+			var threads = new Thread[NUM_THREADS];
+			for (int i = 0; i < NUM_THREADS; i++) {
+				threads[i] = new Thread(DequeueThread);
+				threads[i].Start();
+			}
+
+			int x;
+			for (int i = 0; i < TOTAL_ENQUEUED_ITEMS; i++) {
+				_concurrentQueue.Enqueue(1);
+				var dequeued = _concurrentQueue.TryDequeue(out x);
+				if (dequeued) Interlocked.Increment(ref _totalDequeued);
+			}
+
+			for(int i=0;i<NUM_THREADS;i++)
+				threads[i].Join(TimeSpan.FromSeconds(5));
+
+			Assert.AreEqual(false, _seenNegativeCount);
+		}
+	}
+}


### PR DESCRIPTION
This bug affects EventStore version 5+ where ConcurrentQueueWrapper was added.
The following scenario can result in a negative count on the ConcurrentQueueWrapper class:

Assuming that we start with an empty queue, `q`:
1. `q.Enqueue(T item)` is called which under the hood calls `base.Enqueue(item)` but `Interlocked.Increment(ref _queueCount);` is not called yet.
2. In parallel, on another thread, `q.TryDequeue(out T result)` is called which calls `base.TryDequeue()` and `Interlocked.Decrement(ref _queueCount)`
3. `_queueCount` will be equal to -1 at this point and any call to `q.Count` will return this negative value.

A failing test has been added: `EventStore.Core.Tests.DataStructures.concurrent_queue_wrapper_with_parallel_dequeues_should.always_return_non_negative_count`

This can cause a fatal exception in TcpConnectionSsl (we've seen at least one case so far):
https://github.com/EventStore/EventStore/blob/master/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs#L448
```
var res = new List<ReceivedData>(_receiveQueue.Count);
```
Initializing the list with a negative value will throw a fatal, unhandled exception.

