### PR TITLE
Dont attempt to handle dates when deserializing projection state

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/partition_state/partition_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/partition_state/partition_state.cs
@@ -49,6 +49,12 @@ namespace EventStore.Projections.Core.Tests.Services.partition_state {
 			}
 
 			[Test]
+			public void dates() {
+				foreach(var info in TimeZoneInfo.GetSystemTimeZones())
+					AssertCorrect($@"[""{DateTimeOffset.UtcNow.ToOffset(info.BaseUtcOffset):yyyy-MM-ddThh:mm:sszzz}""]");
+			}
+
+			[Test]
 			public void null_deserialization() {
 				var deserialized = PartitionState.Deserialize(null, CheckpointTag.FromPosition(0, 100, 50));
 				Assert.AreEqual("", deserialized.State);

--- a/src/EventStore.Projections.Core/Services/Processing/PartitionState.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/PartitionState.cs
@@ -1,11 +1,16 @@
 using System;
-using System.IO;
 using EventStore.Common.Utils;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 
 namespace EventStore.Projections.Core.Services.Processing {
 	public class PartitionState {
+		private static readonly JsonSerializerSettings JsonSettings = new JsonSerializerSettings {
+			DateParseHandling = DateParseHandling.None,
+		};
+		
 		public bool IsChanged(PartitionState newState) {
 			return State != newState.State || Result != newState.Result;
 		}
@@ -18,7 +23,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			JToken result = null;
 
 			if (!string.IsNullOrEmpty(serializedState)) {
-				var deserialized = JsonConvert.DeserializeObject(serializedState);
+				var deserialized = JsonConvert.DeserializeObject(serializedState, JsonSettings);
 				var array = deserialized as JArray;
 				if (array != null && array.Count > 0) {
 					state = array[0] as JToken;


### PR DESCRIPTION
Fixes #2065
When we deserialize a projection's state, we need to not parse dates.