### PR TITLE
Fix max object pool size

### DIFF
--- a/src/EventStore.Core.Tests/Constants.cs
+++ b/src/EventStore.Core.Tests/Constants.cs
@@ -1,0 +1,24 @@
+using EventStore.Core.Settings;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Util;
+
+namespace EventStore.Core.Tests {
+	public class Constants {
+		public const int PTableInitialReaderCount = ESConsts.PTableInitialReaderCount;
+
+		public const int PTableMaxReaderCountDefault = 	1 /* StorageWriter */
+		                                                + 1 /* StorageChaser */
+		                                                + 1 /* Projections */
+		                                                + TFChunkScavenger.MaxThreadCount /* Scavenging (1 per thread) */
+		                                                + 1 /* Subscription LinkTos resolving */
+		                                                + Opts.ReaderThreadsCountDefault
+		                                                + 5 /* just in case reserve :) */;
+
+		public const int TFChunkInitialReaderCountDefault = Opts.ChunkInitialReaderCountDefault;
+
+		public const int TFChunkMaxReaderCountDefault = PTableMaxReaderCountDefault
+		                                                + 2 /* for caching/uncaching, populating midpoints */
+		                                                + 1 /* for epoch manager usage of elections/replica service */
+		                                                + 1 /* for epoch manager usage of master replication service */;
+	}
+}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -24,7 +24,12 @@ using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.Services.Transport.Http.Controllers;
 using EventStore.Core.Util;
 using EventStore.Core.Data;
+<<<<<<< HEAD
 using Microsoft.AspNetCore.Hosting;
+=======
+using EventStore.Core.Settings;
+using EventStore.Core.Tests.TransactionLog;
+>>>>>>> fd41da2... Compute TFChunk max reader count based on number of reader threads specified in configuration
 
 namespace EventStore.Core.Tests.Helpers {
 	public class MiniClusterNode {
@@ -228,7 +233,7 @@ VNodeState.ReadOnlyMasterless : VNodeState.Unknown;
 
 			var nodeConfig = new TFChunkDbConfig(
 				dbPath, new VersionedPatternFileNamingStrategy(dbPath, "chunk-"), chunkSize, chunksCacheSize, writerChk,
-				chaserChk, epochChk, truncateChk, replicationCheckpoint, Opts.ChunkInitialReaderCountDefault, inMemDb);
+				chaserChk, epochChk, truncateChk, replicationCheckpoint, TFChunkHelper.TFChunkInitialReaderCountDefault, TFChunkHelper.TFChunkMaxReaderCountDefault, inMemDb);
 			return nodeConfig;
 		}
 	}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -111,7 +111,8 @@ namespace EventStore.Core.Tests.Helpers {
 				startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false,
 				connectionPendingSendBytesThreshold: Opts.ConnectionPendingSendBytesThresholdDefault,
 				connectionQueueSizeThreshold: Opts.ConnectionQueueSizeThresholdDefault,
-				readOnlyReplica: readOnlyReplica);
+				readOnlyReplica: readOnlyReplica,
+				ptableMaxReaderCount: Constants.PTableMaxReaderCountDefault);
 			_isReadOnlyReplica = readOnlyReplica;
 
 			Log.Info(
@@ -230,7 +231,7 @@ VNodeState.ReadOnlyMasterless : VNodeState.Unknown;
 
 			var nodeConfig = new TFChunkDbConfig(
 				dbPath, new VersionedPatternFileNamingStrategy(dbPath, "chunk-"), chunkSize, chunksCacheSize, writerChk,
-				chaserChk, epochChk, truncateChk, replicationCheckpoint, TFChunkHelper.TFChunkInitialReaderCountDefault, TFChunkHelper.TFChunkMaxReaderCountDefault, inMemDb);
+				chaserChk, epochChk, truncateChk, replicationCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, inMemDb);
 			return nodeConfig;
 		}
 	}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -24,12 +24,9 @@ using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.Services.Transport.Http.Controllers;
 using EventStore.Core.Util;
 using EventStore.Core.Data;
-<<<<<<< HEAD
 using Microsoft.AspNetCore.Hosting;
-=======
 using EventStore.Core.Settings;
 using EventStore.Core.Tests.TransactionLog;
->>>>>>> fd41da2... Compute TFChunk max reader count based on number of reader threads specified in configuration
 
 namespace EventStore.Core.Tests.Helpers {
 	public class MiniClusterNode {
@@ -114,7 +111,7 @@ namespace EventStore.Core.Tests.Helpers {
 				startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false,
 				connectionPendingSendBytesThreshold: Opts.ConnectionPendingSendBytesThresholdDefault,
 				connectionQueueSizeThreshold: Opts.ConnectionQueueSizeThresholdDefault,
-				chunkInitialReaderCount: Opts.ChunkInitialReaderCountDefault, readOnlyReplica: readOnlyReplica);
+				readOnlyReplica: readOnlyReplica);
 			_isReadOnlyReplica = readOnlyReplica;
 
 			Log.Info(

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_set.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_set.cs
@@ -37,12 +37,12 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 			var first = _map;
 			if (_result != null)
 				first = _result.MergedMap;
-			var pTable = PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify);
+			var pTable = PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 			_result = first.AddPTable(pTable,
 				10, 20, UpgradeHash, ExistsAt, RecordExistsAt, _fileNameProvider, _ptableVersion,
 				0, 0, skipIndexVerify: _skipIndexVerify);
 			for (int i = 3; i <= count * 2; i += 2) {
-				pTable = PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify);
+				pTable = PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 				_result = _result.MergedMap.AddPTable(
 					pTable,
 					i * 10, (i + 1) * 10, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),

--- a/src/EventStore.Core.Tests/Index/IndexMapTestFactory.cs
+++ b/src/EventStore.Core.Tests/Index/IndexMapTestFactory.cs
@@ -10,9 +10,10 @@ namespace EventStore.Core.Tests.Index {
 		public static IndexMap FromFile(string filename, int maxTablesPerLevel = 4,
 			bool loadPTables = true, int cacheDepth = 16, bool skipIndexVerify = false,
 			int threads = 1,
-			int maxAutoMergeLevel = int.MaxValue) {
+			int maxAutoMergeLevel = int.MaxValue,
+			int pTableMaxReaderCount = Constants.PTableMaxReaderCountDefault) {
 			return IndexMap.FromFile(filename, maxTablesPerLevel, loadPTables, cacheDepth, skipIndexVerify, threads,
-				maxAutoMergeLevel);
+				maxAutoMergeLevel, pTableMaxReaderCount);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Index/IndexV1/PTableReadScenario.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/PTableReadScenario.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 
 			AddItemsForScenario(table);
 
-			PTable = PTable.FromMemtable(table, Filename, cacheDepth: _midpointCacheDepth,
+			PTable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, cacheDepth: _midpointCacheDepth,
 				skipIndexVerify: _skipIndexVerify);
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_four_tables_per_level_causes_merge.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_four_tables_per_level_causes_merge.cs
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			memtable.Add(0, 1, 0);
 
 			_result = _map.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 1, 2,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 1, 2,
 				(streamId, hash) => hash,
 				_ => true,
 				_ => new System.Tuple<string, bool>("", true),
@@ -54,21 +54,21 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 3, 4,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 3, 4,
 				(streamId, hash) => hash,
 				_ => true, _ => new System.Tuple<string, bool>("", true), new GuidFilenameProvider(PathName),
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 4, 5,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 4, 5,
 				(streamId, hash) => hash,
 				_ => true, _ => new System.Tuple<string, bool>("", true), new GuidFilenameProvider(PathName),
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 1,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 1,
 				(streamId, hash) => hash,
 				_ => true, _ => new System.Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile),
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_two_tables_per_level_causes_double_merge.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_two_tables_per_level_causes_double_merge.cs
@@ -43,25 +43,25 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			memtable.Add(0, 1, 0);
 
 			_result = _map.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				10, 20, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
 				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				20, 30, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
 				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				30, 40, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
 				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				50, 60, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
 				new FakeFilenameProvider(_mergeFile + ".firstmerge", _mergeFile), _ptableVersion,
 				_maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_item_to_empty_index_map.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_item_to_empty_index_map.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_map = IndexMapTestFactory.FromFile(_filename);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 1, 0);
-			var table = PTable.FromMemtable(memtable, _tablename, skipIndexVerify: _skipIndexVerify);
+			var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 			_result = _map.AddPTable(table, 7, 11, (streamId, hash) => hash, _ => true,
 				_ => new System.Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
 				_maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_sixteen_items_to_empty_index_map_with_four_tables_per_level_causes_double_merge.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_sixteen_items_to_empty_index_map_with_four_tables_per_level_causes_double_merge.cs
@@ -45,82 +45,82 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			memtable.Add(0, 1, 0);
 			var guidFilename = new GuidFilenameProvider(PathName);
 			_result = _map.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 0, 0,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
 				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify), 1, 2,
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 1, 2,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true),
 				new FakeFilenameProvider(_finalmergefile, _finalmergefile2), _ptableVersion, 4, 0,
 				skipIndexVerify: _skipIndexVerify);

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_two_items_to_empty_index_map_with_two_tables_per_level_causes_merge.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_two_items_to_empty_index_map_with_two_tables_per_level_causes_merge.cs
@@ -42,13 +42,13 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			memtable.Add(0, 1, 0);
 
 			_result = _map.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				123, 321, (streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true),
 				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			_result = _result.MergedMap.AddPTable(
-				PTable.FromMemtable(memtable, GetTempFilePath(), skipIndexVerify: _skipIndexVerify),
+				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				100, 400, (streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true),
 				new FakeFilenameProvider(_mergeFile), _ptableVersion, _maxAutoMergeIndexLevel, 0,
 				skipIndexVerify: _skipIndexVerify);

--- a/src/EventStore.Core.Tests/Index/IndexV1/corrupt_index_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/corrupt_index_should.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			}
 
 			string pTableFilename = GetTempFilePath();
-			var pTable = PTable.FromMemtable(memTable, pTableFilename, depth);
+			var pTable = PTable.FromMemtable(memTable, pTableFilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth);
 			pTable.Dispose();
 			return pTableFilename;
 		}
@@ -174,7 +174,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			bool skipIndexVerify) {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "notMultipleIndexEntrySize");
-			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 		}
 
 		[TestCase(PTableVersions.IndexV1, false)]
@@ -189,7 +189,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			bool skipIndexVerify) {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
-			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 		}
 
 
@@ -199,7 +199,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			bool skipIndexVerify) {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "midpointItemIndexesNotAscendingOrder");
-			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 		}
 
 		[TestCase(PTableVersions.IndexV1, true)]
@@ -211,7 +211,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
 			//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-			PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+			PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 			Assert.Throws<MaybeCorruptIndexException>(() =>
 				pTable.GetRange(GetOriginalHash(numIndexEntries / 2, version), 1, 1));
 			pTable.Dispose();
@@ -226,7 +226,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "maxOutMiddleEntries");
 			//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-			PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+			PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 			Assert.Throws<MaybeCorruptIndexException>(() =>
 				pTable.GetRange(GetOriginalHash(numIndexEntries / 2, version), 1, 1));
 			pTable.Dispose();
@@ -241,7 +241,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
 			//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-			PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+			PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 			IndexEntry entry;
 			Assert.Throws<MaybeCorruptIndexException>(() =>
 				pTable.TryGetLatestEntry(GetOriginalHash(numIndexEntries / 2, version), out entry));
@@ -257,7 +257,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "maxOutMiddleEntries");
 			//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-			PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+			PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 			IndexEntry entry;
 			Assert.Throws<MaybeCorruptIndexException>(() =>
 				pTable.TryGetLatestEntry(GetOriginalHash(numIndexEntries / 2, version), out entry));
@@ -273,7 +273,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
 			//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-			PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+			PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 			IndexEntry entry;
 			Assert.Throws<MaybeCorruptIndexException>(() =>
 				pTable.TryGetOldestEntry(GetOriginalHash(numIndexEntries / 2, version), out entry));
@@ -289,7 +289,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "maxOutMiddleEntries");
 			//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-			PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+			PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 			IndexEntry entry;
 			Assert.Throws<MaybeCorruptIndexException>(() =>
 				pTable.TryGetOldestEntry(GetOriginalHash(numIndexEntries / 2, version), out entry));
@@ -305,7 +305,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "zeroOutMiddleEntries");
 			//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-			PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+			PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 			long position;
 			Assert.Throws<MaybeCorruptIndexException>(() =>
 				pTable.TryGetOneValue(GetOriginalHash(numIndexEntries / 2, version), 1, out position));
@@ -321,7 +321,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "maxOutMiddleEntries");
 			//loading with a depth of 1 should load only 2 midpoints (first and last index entry)
-			PTable pTable = PTable.FromFile(ptableFileName, 1, skipIndexVerify);
+			PTable pTable = PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 1, skipIndexVerify);
 			long position;
 			Assert.Throws<MaybeCorruptIndexException>(() =>
 				pTable.TryGetOneValue(GetOriginalHash(numIndexEntries / 2, version), 1, out position));
@@ -333,7 +333,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void throw_exception_on_invalid_ptable_filenumber_in_footer(byte version, bool skipIndexVerify) {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "footerFileType");
-			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 		}
 
 		[TestCase(PTableVersions.IndexV4, false)]
@@ -341,7 +341,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void throw_exception_on_header_footer_version_mismatch(byte version, bool skipIndexVerify) {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "footerVersion");
-			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 		}
 
 		[TestCase(PTableVersions.IndexV4, false)]
@@ -349,7 +349,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void throw_exception_if_negative_index_entries_size(byte version, bool skipIndexVerify) {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "negativeIndexEntriesSize");
-			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 		}
 
 		[TestCase(PTableVersions.IndexV4, false)]
@@ -357,7 +357,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void throw_exception_if_less_than_2_midpoints_cached(byte version, bool skipIndexVerify) {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "lessThan2Midpoints");
-			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 		}
 
 		[TestCase(PTableVersions.IndexV4, false)]
@@ -365,7 +365,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void throw_exception_if_more_midpoints_than_index_entries(byte version, bool skipIndexVerify) {
 			string ptableFileName = ConstructPTable(version);
 			CorruptPTableFile(ptableFileName, version, "moreMidpointsThanIndexEntries");
-			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, depth, skipIndexVerify));
+			Assert.Throws<CorruptIndexException>(() => PTable.FromFile(ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Index/IndexV1/destroying_ptable.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/destroying_ptable.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var mtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			mtable.Add(0x010100000000, 0x0001, 0x0001);
 			mtable.Add(0x010500000000, 0x0001, 0x0002);
-			_table = PTable.FromMemtable(mtable, Filename, skipIndexVerify: _skipIndexVerify);
+			_table = PTable.FromMemtable(mtable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 			_table.MarkForDestruction();
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/index_map_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/index_map_should.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 
 			var memTable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memTable.Add(0, 1, 2);
-			_ptable = PTable.FromMemtable(memTable, _ptableFileName);
+			_ptable = PTable.FromMemtable(memTable, _ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 		}
 
 		[TearDown]

--- a/src/EventStore.Core.Tests/Index/IndexV1/index_map_should_detect_corruption.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/index_map_should_detect_corruption.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 0, 0);
 			memtable.Add(1, 1, 100);
-			_ptable = PTable.FromMemtable(memtable, _ptableFileName, skipIndexVerify: _skipIndexVerify);
+			_ptable = PTable.FromMemtable(memtable, _ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 
 			indexMap = indexMap.AddPTable(_ptable, 0, 0, (streamId, hash) => hash, _ => true,
 				_ => new Tuple<string, bool>("", true), new GuidFilenameProvider(PathName), _ptableVersion,

--- a/src/EventStore.Core.Tests/Index/IndexV1/opening_a_ptable_with_more_than_32bits_of_records.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/opening_a_ptable_with_more_than_32bits_of_records.cs
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_size = _ptableCount * (long)_indexEntrySize + PTableHeader.Size + PTable.MD5Size;
 			Console.WriteLine("Creating PTable at {0}. Size of PTable: {1}", Filename, _size);
 			CreatePTableFile(Filename, _size, _indexEntrySize);
-			_ptable = PTable.FromFile(Filename, 22, false);
+			_ptable = PTable.FromFile(Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 22, false);
 		}
 
 		public static void CreatePTableFile(string filename, long ptableSize, int indexEntrySize, int cacheDepth = 16) {

--- a/src/EventStore.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				memTable.Add((uint)rnd.Next(), rnd.Next(0, 1 << 20), Math.Abs(rnd.Next() * rnd.Next()));
 			}
 
-			var ptable = PTable.FromMemtable(memTable, file, depth, skipIndexVerify: _skipIndexVerify);
+			var ptable = PTable.FromMemtable(memTable, file, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, skipIndexVerify: _skipIndexVerify);
 			return ptable;
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/ptable_range_query_tests.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/ptable_range_query_tests.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			table.Add(0x010300000000, 0x0001, 0xFFF1);
 			table.Add(0x010300000000, 0x0003, 0xFFF3);
 			table.Add(0x010300000000, 0x0005, 0xFFF5);
-			_ptable = PTable.FromMemtable(table, Filename, cacheDepth: 0, skipIndexVerify: _skipIndexVerify);
+			_ptable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, cacheDepth: 0, skipIndexVerify: _skipIndexVerify);
 		}
 
 		public override void TestFixtureTearDown() {

--- a/src/EventStore.Core.Tests/Index/IndexV1/ptable_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/ptable_should.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 
 			var table = new HashListMemTable(_ptableVersion, maxSize: 10);
 			table.Add(0x010100000000, 0x0001, 0x0001);
-			_ptable = PTable.FromMemtable(table, Filename, cacheDepth: 0, skipIndexVerify: _skipIndexVerify);
+			_ptable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, cacheDepth: 0, skipIndexVerify: _skipIndexVerify);
 		}
 
 		public override void TestFixtureTearDown() {

--- a/src/EventStore.Core.Tests/Index/IndexV1/saving_index_with_single_item_to_a_file.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/saving_index_with_single_item_to_a_file.cs
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_map = IndexMapTestFactory.FromFile(_filename, maxAutoMergeLevel: _maxAutoMergeIndexLevel);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 2, 7);
-			var table = PTable.FromMemtable(memtable, _tablename);
+			var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 			_result = _map.AddPTable(table, 7, 11, (streamId, hash) => hash, _ => true,
 				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
 			_result.MergedMap.SaveToFile(_filename);

--- a/src/EventStore.Core.Tests/Index/IndexV1/saving_index_with_six_items_to_a_file.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/saving_index_with_six_items_to_a_file.cs
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_map = IndexMapTestFactory.FromFile(_filename, maxTablesPerLevel: 4);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 2, 123);
-			var table = PTable.FromMemtable(memtable, _tablename);
+			var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 			_result = _map.AddPTable(table, 0, 0, (streamId, hash) => hash, _ => true,
 				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
 				_maxAutoMergeIndexLevel, 0);

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_on_range_query.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_on_range_query.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				() => new HashListMemTable(version: _ptableVersion, maxSize: 40),
 				() => { throw new InvalidOperationException(); },
 				_ptableVersion,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 20,
 				skipIndexVerify: _skipIndexVerify);
 			_tableIndex.Initialize(long.MaxValue);

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_on_try_get_one_value_query.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_on_try_get_one_value_query.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				() => new HashListMemTable(_ptableVersion, maxSize: 10),
 				() => fakeReader,
 				_ptableVersion,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 5,
 				skipIndexVerify: _skipIndexVerify);
 			_tableIndex.Initialize(long.MaxValue);

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_should.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				() => new HashListMemTable(_ptableVersion, maxSize: 20),
 				() => { throw new InvalidOperationException(); },
 				_ptableVersion,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 10,
 				skipIndexVerify: _skipIndexVerify);
 			_tableIndex.Initialize(long.MaxValue);

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_with_corrupt_index_entries_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_with_corrupt_index_entries_should.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				() => new HashListMemTable(version, maxSize: NumIndexEntries),
 				() => fakeReader,
 				version,
-				int.MaxValue,
+				int.MaxValue, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: NumIndexEntries,
 				skipIndexVerify: skipIndexVerify);
 			_tableIndex.Initialize(long.MaxValue);
@@ -69,7 +69,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				() => new HashListMemTable(version, maxSize: NumIndexEntries),
 				() => fakeReader,
 				version,
-				int.MaxValue,
+				int.MaxValue, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: NumIndexEntries,
 				skipIndexVerify: skipIndexVerify,
 				indexCacheDepth: 8);

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_with_two_ptables_and_memtable_on_range_query.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_with_two_ptables_and_memtable_on_range_query.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				() => new HashListMemTable(_ptableVersion, maxSize: 10),
 				() => fakeReader,
 				_ptableVersion,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 2,
 				skipIndexVerify: _skipIndexVerify);

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_header_is_corrupt_on_disk.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_header_is_corrupt_on_disk.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var mtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			mtable.Add(0x010100000000, 0x0001, 0x0001);
 			mtable.Add(0x010500000000, 0x0001, 0x0002);
-			_table = PTable.FromMemtable(mtable, _filename);
+			_table = PTable.FromMemtable(mtable, _filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 			_table.Dispose();
 			File.Copy(_filename, _copiedfilename);
 			using (var f = new FileStream(_copiedfilename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite)) {
@@ -39,14 +39,14 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 
 		[Test]
 		public void the_hash_is_invalid() {
-			var exc = Assert.Throws<CorruptIndexException>(() => _table = PTable.FromFile(_copiedfilename, 16, false));
+			var exc = Assert.Throws<CorruptIndexException>(() => _table = PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 16, false));
 			Assert.IsInstanceOf<HashValidationException>(exc.InnerException);
 		}
 
 		[Test]
 		public void no_error_if_index_verification_disabled() {
 			Assert.DoesNotThrow(
-				() => _table = PTable.FromFile(_copiedfilename, 16, true)
+				() => _table = PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 16, true)
 			);
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_is_corrupt_on_disk.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_is_corrupt_on_disk.cs
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var mtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			mtable.Add(0x010100000000, 0x0001, 0x0001);
 			mtable.Add(0x010500000000, 0x0001, 0x0002);
-			_table = PTable.FromMemtable(mtable, _filename);
+			_table = PTable.FromMemtable(mtable, _filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 			_table.Dispose();
 			File.Copy(_filename, _copiedfilename);
 			using (var f = new FileStream(_copiedfilename, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite)) {
@@ -49,7 +49,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 
 		[Test]
 		public void the_hash_is_invalid() {
-			var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(_copiedfilename, 16, false));
+			var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 16, false));
 			Assert.IsInstanceOf<HashValidationException>(exc.InnerException);
 		}
 	}

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_is_loaded_from_disk.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_a_ptable_is_loaded_from_disk.cs
@@ -52,7 +52,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 				mtable.Add(streamId, eventNumber, logPosition);
 			}
 
-			_table = PTable.FromMemtable(mtable, _filename, skipIndexVerify: _skipIndexVerify);
+			_table = PTable.FromMemtable(mtable, _filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 			_table.Dispose();
 			File.Copy(_filename, _copiedfilename);
 		}
@@ -60,8 +60,8 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		[Test]
 		public void same_midpoints_are_loaded_when_enabling_or_disabling_index_verification() {
 			for (int depth = 2; depth <= 20; depth++) {
-				var ptableWithMD5Verification = PTable.FromFile(_copiedfilename, depth, false);
-				var ptableWithoutVerification = PTable.FromFile(_copiedfilename, depth, true);
+				var ptableWithMD5Verification = PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, false);
+				var ptableWithoutVerification = PTable.FromFile(_copiedfilename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, depth, true);
 				var midPoints1 = ptableWithMD5Verification.GetMidPoints();
 				var midPoints2 = ptableWithoutVerification.GetMidPoints();
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_creating_ptable_from_memtable.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_creating_ptable_from_memtable.cs
@@ -25,21 +25,21 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		[Test]
 		public void null_file_throws_null_exception() {
 			Assert.Throws<ArgumentNullException>(() =>
-				PTable.FromMemtable(new HashListMemTable(_ptableVersion, maxSize: 10), null,
+				PTable.FromMemtable(new HashListMemTable(_ptableVersion, maxSize: 10), null, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 					skipIndexVerify: _skipIndexVerify));
 		}
 
 		[Test]
 		public void null_memtable_throws_null_exception() {
 			Assert.Throws<ArgumentNullException>(() =>
-				PTable.FromMemtable(null, "C:\\foo.txt", skipIndexVerify: _skipIndexVerify));
+				PTable.FromMemtable(null, "C:\\foo.txt", Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 		}
 
 		[Test]
 		public void wait_for_destroy_will_timeout() {
 			var table = new HashListMemTable(_ptableVersion, maxSize: 10);
 			table.Add(0x010100000000, 0x0001, 0x0001);
-			var ptable = PTable.FromMemtable(table, Filename, skipIndexVerify: _skipIndexVerify);
+			var ptable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 			Assert.Throws<TimeoutException>(() => ptable.WaitForDisposal(1));
 
 			// tear down
@@ -73,7 +73,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			table.Add(0x010500000000, 0x0001, 0x0002);
 			table.Add(0x010200000000, 0x0001, 0x0003);
 			table.Add(0x010200000000, 0x0002, 0x0003);
-			using (var sstable = PTable.FromMemtable(table, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var sstable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				var fileinfo = new FileInfo(Filename);
 				var midpointsCached = PTable.GetRequiredMidpointCountCached(4, _ptableVersion);
 				Assert.AreEqual(
@@ -99,7 +99,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			table.Add(0x010200000000, 0x0001, 0x0003);
 			table.Add(0x010200000000, 0x0002, 0x0003);
 			Assert.DoesNotThrow(() => {
-				using (var sstable = PTable.FromMemtable(table, Filename, skipIndexVerify: false)) {
+				using (var sstable = PTable.FromMemtable(table, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: false)) {
 				}
 			});
 		}

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_merging_four_ptables.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_merging_four_ptables.cs
@@ -41,12 +41,12 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 					table.Add((ulong)(0x010100000000 << (j + 1)), i + 1, i * j);
 				}
 
-				_tables.Add(PTable.FromMemtable(table, _files[i], skipIndexVerify: _skipIndexVerify));
+				_tables.Add(PTable.FromMemtable(table, _files[i], Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			}
 
 			_files.Add(GetTempFilePath());
 			_newtable = PTable.MergeTo(_tables, _files[4], (streamId, hash) => hash << 32 | hasher.Hash(streamId),
-				_ => true, _ => new System.Tuple<string, bool>("", true), _ptableVersion,
+				_ => true, _ => new System.Tuple<string, bool>("", true), _ptableVersion, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify);
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_merging_ptables.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_merging_ptables.cs
@@ -29,15 +29,15 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			table.Add(0x010200000000, 0, 0x0102);
 			table.Add(0x010300000000, 0, 0x0103);
 			table.Add(0x010400000000, 0, 0x0104);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			table = new HashListMemTable(PTableVersions.IndexV1, maxSize: 20);
 			table.Add(0x010500000000, 0, 0x0105);
 			table.Add(0x010600000000, 0, 0x0106);
 			table.Add(0x010700000000, 0, 0x0107);
 			table.Add(0x010800000000, 0, 0x0108);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			_newtable = PTable.MergeTo(_tables, GetTempFilePath(), (streamId, hash) => hash + 1, x => true,
-				x => new Tuple<string, bool>(x.Stream.ToString(), true), PTableVersions.IndexV1,
+				x => new Tuple<string, bool>(x.Stream.ToString(), true), PTableVersions.IndexV1, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify);
 		}
 
@@ -92,15 +92,15 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			table.Add(0x010200000000, 0, 0x0102);
 			table.Add(0x010300000000, 0, 0x0103);
 			table.Add(0x010400000000, 0, 0x0104);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			table = new HashListMemTable(PTableVersions.IndexV1, maxSize: 20);
 			table.Add(0x010500000000, 0, 0x0105);
 			table.Add(0x010600000000, 0, 0x0106);
 			table.Add(0x010700000000, 0, 0x0107);
 			table.Add(0x010800000000, 0, 0x0108);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			_newtable = PTable.MergeTo(_tables, GetTempFilePath(), (streamId, hash) => hash + 1, x => true,
-				x => new Tuple<string, bool>(x.Stream.ToString(), true), PTableVersions.IndexV3,
+				x => new Tuple<string, bool>(x.Stream.ToString(), true), PTableVersions.IndexV3, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify);
 		}
 
@@ -155,21 +155,21 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			table.Add(0x010200000000, 0, 0x010200000000);
 			table.Add(0x010300000000, 0, 0x010300000000);
 			table.Add(0x010400000000, 0, 0x010400000000);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			table = new HashListMemTable(PTableVersions.IndexV1, maxSize: 20);
 			table.Add(0x010500000000, 0, 0x010500000000);
 			table.Add(0x010600000000, 0, 0x010600000000);
 			table.Add(0x010700000000, 0, 0x010700000000);
 			table.Add(0x010800000000, 0, 0x010800000000);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			table = new HashListMemTable(PTableVersions.IndexV2, maxSize: 20);
 			table.Add(0x010900000000, 0, 0x010900000000);
 			table.Add(0x101000000000, 0, 0x101000000000);
 			table.Add(0x111000000000, 0, 0x111000000000);
 			table.Add(0x121000000000, 0, 0x121000000000);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			_newtable = PTable.MergeTo(_tables, GetTempFilePath(), (streamId, hash) => hash + 1, x => true,
-				x => new Tuple<string, bool>(x.Stream.ToString(), true), PTableVersions.IndexV2,
+				x => new Tuple<string, bool>(x.Stream.ToString(), true), PTableVersions.IndexV2, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify);
 		}
 
@@ -235,17 +235,17 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			table.Add(0x010200000000, 2, 7);
 			table.Add(0x010400000000, 0, 8);
 			table.Add(0x010400000000, 1, 9);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			table = new HashListMemTable(PTableVersions.IndexV1, maxSize: 20);
 			table.Add(0x010100000000, 1, 10);
 			table.Add(0x010100000000, 2, 11);
 			table.Add(0x010500000000, 1, 12);
 			table.Add(0x010500000000, 2, 13);
 			table.Add(0x010500000000, 3, 14);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			_newtable = PTable.MergeTo(_tables, GetTempFilePath(),
 				(streamId, hash) => hash << 32 | hasher.Hash(streamId), x => x.Position % 2 == 0,
-				x => new Tuple<string, bool>(x.Stream.ToString(), x.Position % 2 == 0), PTableVersions.IndexV2,
+				x => new Tuple<string, bool>(x.Stream.ToString(), x.Position % 2 == 0), PTableVersions.IndexV2, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify);
 		}
 
@@ -309,24 +309,24 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			table.Add(0x010200000000, 0, 2);
 			table.Add(0x010300000000, 0, 3);
 			table.Add(0x010300000000, 1, 4);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			table = new HashListMemTable(PTableVersions.IndexV2, maxSize: 20);
 			table.Add(0x010100000000, 2, 5);
 			table.Add(0x010200000000, 1, 6);
 			table.Add(0x010200000000, 2, 7);
 			table.Add(0x010400000000, 0, 8);
 			table.Add(0x010400000000, 1, 9);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			table = new HashListMemTable(PTableVersions.IndexV1, maxSize: 20);
 			table.Add(0x010100000000, 1, 10);
 			table.Add(0x010100000000, 2, 11);
 			table.Add(0x010500000000, 1, 12);
 			table.Add(0x010500000000, 2, 13);
 			table.Add(0x010500000000, 3, 14);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath()));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault));
 			_newtable = PTable.MergeTo(_tables, GetTempFilePath(),
 				(streamId, hash) => hash << 32 | hasher.Hash(streamId), x => x.Position % 2 == 0,
-				x => new Tuple<string, bool>(x.Stream.ToString(), x.Position % 2 == 0), PTableVersions.IndexV2,
+				x => new Tuple<string, bool>(x.Stream.ToString(), x.Position % 2 == 0), PTableVersions.IndexV2, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify);
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_merging_ptables_with_entries_to_nonexisting_record.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_merging_ptables_with_entries_to_nonexisting_record.cs
@@ -37,12 +37,12 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 					table.Add((ulong)(0x010100000000 << i), j, i * 10 + j);
 				}
 
-				_tables.Add(PTable.FromMemtable(table, _files[i], skipIndexVerify: _skipIndexVerify));
+				_tables.Add(PTable.FromMemtable(table, _files[i], Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			}
 
 			_files.Add(GetTempFilePath());
 			_newtable = PTable.MergeTo(_tables, _files[4], (streamId, hash) => hash, x => x.Position % 2 == 0,
-				x => new Tuple<string, bool>("", x.Position % 2 == 0), _ptableVersion,
+				x => new Tuple<string, bool>("", x.Position % 2 == 0), _ptableVersion, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify);
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_merging_two_ptables.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_merging_two_ptables.cs
@@ -38,12 +38,12 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 					table.Add((ulong)(0x010100000000 << (j + 1)), i + 1, i * j);
 				}
 
-				_tables.Add(PTable.FromMemtable(table, _files[i], skipIndexVerify: _skipIndexVerify));
+				_tables.Add(PTable.FromMemtable(table, _files[i], Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			}
 
 			_files.Add(GetTempFilePath());
 			_newtable = PTable.MergeTo(_tables, _files[2], (streamId, hash) => hash, x => true,
-				x => new System.Tuple<string, bool>("", true), _ptableVersion, skipIndexVerify: _skipIndexVerify);
+				x => new System.Tuple<string, bool>("", true), _ptableVersion, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 		}
 
 		[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_latest_entry.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_latest_entry.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void nothing_is_found_on_empty_stream() {
 			var memTable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memTable.Add(0x010100000000, 0x01, 0xffff);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsFalse(ptable.TryGetLatestEntry(0x12, out entry));
 			}
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void single_item_is_latest() {
 			var memTable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memTable.Add(0x010100000000, 0x01, 0xffff);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsTrue(ptable.TryGetLatestEntry(0x010100000000, out entry));
 				Assert.AreEqual(GetHash(0x010100000000), entry.Stream);
@@ -52,7 +52,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var memTable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memTable.Add(0x010100000000, 0x01, 0xffff);
 			memTable.Add(0x010100000000, 0x02, 0xfff2);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsTrue(ptable.TryGetLatestEntry(0x010100000000, out entry));
 				Assert.AreEqual(GetHash(0x010100000000), entry.Stream);
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			memTable.Add(0x010100000000, 0x02, 0xfff2);
 			memTable.Add(0x010100000000, 0x01, 0xfff3);
 			memTable.Add(0x010100000000, 0x02, 0xfff4);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsTrue(ptable.TryGetLatestEntry(0x010100000000, out entry));
 				Assert.AreEqual(GetHash(0x010100000000), entry.Stream);
@@ -83,7 +83,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			memTable.Add(0x010100000000, 0x01, 0xfff1);
 			memTable.Add(0x010100000000, 0x01, 0xfff3);
 			memTable.Add(0x010100000000, 0x01, 0xfff5);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsTrue(ptable.TryGetLatestEntry(0x010100000000, out entry));
 				Assert.AreEqual(GetHash(0x010100000000), entry.Stream);

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_oldest_entry.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_trying_to_get_oldest_entry.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void nothing_is_found_on_empty_stream() {
 			var memTable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memTable.Add(0x010100000000, 0x01, 0xffff);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsFalse(ptable.TryGetOldestEntry(0x12, out entry));
 			}
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		public void single_item_is_latest() {
 			var memTable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memTable.Add(0x010100000000, 0x01, 0xffff);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsTrue(ptable.TryGetOldestEntry(0x010100000000, out entry));
 				Assert.AreEqual(GetHash(0x010100000000), entry.Stream);
@@ -52,7 +52,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var memTable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memTable.Add(0x010100000000, 0x01, 0xffff);
 			memTable.Add(0x010100000000, 0x02, 0xfff2);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsTrue(ptable.TryGetOldestEntry(0x010100000000, out entry));
 				Assert.AreEqual(GetHash(0x010100000000), entry.Stream);
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			memTable.Add(0x010100000000, 0x02, 0xfff2);
 			memTable.Add(0x010100000000, 0x01, 0xfff3);
 			memTable.Add(0x010100000000, 0x02, 0xfff4);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsTrue(ptable.TryGetOldestEntry(0x010100000000, out entry));
 				Assert.AreEqual(GetHash(0x010100000000), entry.Stream);
@@ -83,7 +83,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			memTable.Add(0x010100000000, 0x01, 0xfff1);
 			memTable.Add(0x010100000000, 0x01, 0xfff3);
 			memTable.Add(0x010100000000, 0x01, 0xfff5);
-			using (var ptable = PTable.FromMemtable(memTable, Filename, skipIndexVerify: _skipIndexVerify)) {
+			using (var ptable = PTable.FromMemtable(memTable, Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify)) {
 				IndexEntry entry;
 				Assert.IsTrue(ptable.TryGetOldestEntry(0x010100000000, out entry));
 				Assert.AreEqual(GetHash(0x010100000000), entry.Stream);

--- a/src/EventStore.Core.Tests/Index/IndexV2/table_index_hash_collision_when_upgrading_to_64bit.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/table_index_hash_collision_when_upgrading_to_64bit.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 				() => new HashListMemTable(PTableVersions.IndexV1, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV1,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 5 + _extraStreamHashesAtBeginning + _extraStreamHashesAtEnd,
 				maxTablesPerLevel: 2);
 			_tableIndex.Initialize(long.MaxValue);
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 				() => new HashListMemTable(_ptableVersion, maxSize: 5),
 				() => fakeReader,
 				_ptableVersion,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 5,
 				maxTablesPerLevel: 2);
 			_tableIndex.Initialize(long.MaxValue);

--- a/src/EventStore.Core.Tests/Index/IndexV2/table_index_when_merging_upgrading_to_64bit_if_entry_doesnt_exist_drops_entry_and_carries_on.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/table_index_when_merging_upgrading_to_64bit_if_entry_doesnt_exist_drops_entry_and_carries_on.cs
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 				() => new HashListMemTable(PTableVersions.IndexV1, maxSize: 3),
 				() => fakeReader,
 				PTableVersions.IndexV1,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 3,
 				maxTablesPerLevel: 2);
 			_tableIndex.Initialize(long.MaxValue);
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 				() => new HashListMemTable(_ptableVersion, maxSize: 3),
 				() => fakeReader,
 				_ptableVersion,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 3,
 				maxTablesPerLevel: 2);
 			_tableIndex.Initialize(long.MaxValue);

--- a/src/EventStore.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Index.IndexV3 {
 				() => new HashListMemTable(PTableVersions.IndexV2, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV2,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 5,
 				maxTablesPerLevel: 2);
 			_tableIndex.Initialize(long.MaxValue);
@@ -49,7 +49,7 @@ namespace EventStore.Core.Tests.Index.IndexV3 {
 				() => new HashListMemTable(_ptableVersion, maxSize: 5),
 				() => fakeReader,
 				_ptableVersion,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 5,
 				maxTablesPerLevel: 2);
 			_tableIndex.Initialize(long.MaxValue);

--- a/src/EventStore.Core.Tests/Index/IndexV4/when_merging_ptables_vx_to_v4.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV4/when_merging_ptables_vx_to_v4.cs
@@ -46,7 +46,7 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 				table.Add(0x0104, 0, 0x0104);
 			}
 
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			table = new HashListMemTable(_fromVersion, maxSize: 20);
 
 			if (_fromVersion == PTableVersions.IndexV1) {
@@ -61,10 +61,10 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 				table.Add(0x0108, 0, 0x0108);
 			}
 
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			_newtableFile = GetTempFilePath();
 			_newtable = PTable.MergeTo(_tables, _newtableFile, (streamId, hash) => hash + 1, x => true,
-				x => new Tuple<string, bool>(x.Stream.ToString(), true), PTableVersions.IndexV4,
+				x => new Tuple<string, bool>(x.Stream.ToString(), true), PTableVersions.IndexV4, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				skipIndexVerify: _skipIndexVerify);
 		}
 
@@ -165,25 +165,25 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 			table.Add(0x010200000000, 0, 2);
 			table.Add(0x010300000000, 0, 3);
 			table.Add(0x010300000000, 1, 4);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			table = new HashListMemTable(_fromVersion, maxSize: 20);
 			table.Add(0x010100000000, 2, 5);
 			table.Add(0x010200000000, 1, 6);
 			table.Add(0x010200000000, 2, 7);
 			table.Add(0x010400000000, 0, 8);
 			table.Add(0x010400000000, 1, 9);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			table = new HashListMemTable(_fromVersion, maxSize: 20);
 			table.Add(0x010100000000, 1, 10);
 			table.Add(0x010100000000, 2, 11);
 			table.Add(0x010500000000, 1, 12);
 			table.Add(0x010500000000, 2, 13);
 			table.Add(0x010500000000, 3, 14);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			_newtableFile = GetTempFilePath();
 			_newtable = PTable.MergeTo(_tables, _newtableFile, (streamId, hash) => hash << 32 | hasher.Hash(streamId),
 				x => x.Position % 2 == 0, x => new Tuple<string, bool>(x.Stream.ToString(), x.Position % 2 == 0),
-				PTableVersions.IndexV4, skipIndexVerify: _skipIndexVerify);
+				PTableVersions.IndexV4, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 		}
 
 		[OneTimeTearDown]
@@ -278,25 +278,25 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 			table.Add(0x010200000000, 0, 2);
 			table.Add(0x010300000000, 0, 3);
 			table.Add(0x010300000000, 1, 4);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			table = new HashListMemTable(_fromVersion, maxSize: 20);
 			table.Add(0x010100000000, 2, 5);
 			table.Add(0x010200000000, 1, 6);
 			table.Add(0x010200000000, 2, 7);
 			table.Add(0x010400000000, 0, 8);
 			table.Add(0x010400000000, 1, 9);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			table = new HashListMemTable(_fromVersion, maxSize: 20);
 			table.Add(0x010100000000, 1, 10);
 			table.Add(0x010100000000, 2, 11);
 			table.Add(0x010500000000, 1, 12);
 			table.Add(0x010500000000, 2, 13);
 			table.Add(0x010500000000, 3, 14);
-			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), skipIndexVerify: _skipIndexVerify));
+			_tables.Add(PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify));
 			_newtableFile = GetTempFilePath();
 			_newtable = PTable.MergeTo(_tables, _newtableFile, (streamId, hash) => hash << 32 | hasher.Hash(streamId),
 				x => x.Position % 2 == 0, x => new Tuple<string, bool>(x.Stream.ToString(), x.Position % 2 == 0),
-				PTableVersions.IndexV4, skipIndexVerify: _skipIndexVerify);
+				PTableVersions.IndexV4, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 		}
 
 		[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/Index/IndexVAny/when_opening_ptable_without_right_flag_in_header.cs
+++ b/src/EventStore.Core.Tests/Index/IndexVAny/when_opening_ptable_without_right_flag_in_header.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.Index.IndexVAny {
 
 		[Test]
 		public void the_invalid_file_exception_is_thrown() {
-			var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(Filename, 16, false));
+			var exc = Assert.Throws<CorruptIndexException>(() => PTable.FromFile(Filename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, 16, false));
 			Assert.IsInstanceOf<InvalidFileException>(exc.InnerException);
 		}
 	}

--- a/src/EventStore.Core.Tests/Index/IndexVAny/when_opening_v1_indexmap.cs
+++ b/src/EventStore.Core.Tests/Index/IndexVAny/when_opening_v1_indexmap.cs
@@ -52,7 +52,7 @@ namespace EventStore.Core.Tests.Index.IndexVAny {
 			await base.TestFixtureSetUp();
 
 			_filename = GetFilePathFor("indexfile");
-			var empty = IndexMap.CreateEmpty(2, maxTableLevelsForAutomaticMerge: 4);
+			var empty = IndexMap.CreateEmpty(2, 4, Constants.PTableMaxReaderCountDefault);
 			empty.SaveToFile(_filename);
 		}
 

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5, skipIndexVerify: _skipIndexVerify);
 			_tableIndex.Initialize(long.MaxValue);
@@ -62,7 +62,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_and_another_table_is_completed_during.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_and_another_table_is_completed_during.cs
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 			_tableIndex.Initialize(long.MaxValue);
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_scavenging_table.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_scavenging_table.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 			_tableIndex.Initialize(long.MaxValue);
@@ -62,7 +62,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_waiting_for_lock.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_waiting_for_lock.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 			_tableIndex.Initialize(long.MaxValue);
@@ -58,7 +58,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_fails.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_fails.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 					throw new Exception("Expected exception");
 				},
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 			_tableIndex.Initialize(long.MaxValue);
@@ -64,7 +64,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,
 				maxTablesPerLevel: 5);
 

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_v1_index.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_v1_index.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			table.Add(0x010200000000, 0, 2);
 			table.Add(0x010300000000, 0, 3);
 			table.Add(0x010300000000, 1, 4);
-			_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+			_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 			long spaceSaved;
 			_upgradeHash = (streamId, hash) => hash << 32 | hasher.Hash(streamId);
@@ -44,7 +44,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			Func<IndexEntry, Tuple<string, bool>> readRecord = x =>
 				new Tuple<string, bool>(x.Stream.ToString(), x.Position % 2 == 0);
 			_newtable = PTable.Scavenged(_oldTable, GetTempFilePath(), _upgradeHash, existsAt, readRecord, _newVersion,
-				out spaceSaved, skipIndexVerify: _skipIndexVerify);
+				out spaceSaved, skipIndexVerify: _skipIndexVerify, initialReaders: Constants.PTableInitialReaderCount, maxReaders: Constants.PTableMaxReaderCountDefault);
 		}
 
 		[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_an_index.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_an_index.cs
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			table.Add(0x010200000000, 0, 2);
 			table.Add(0x010300000000, 0, 3);
 			table.Add(0x010300000000, 1, 4);
-			_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+			_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 			long spaceSaved;
 			Func<IndexEntry, bool> existsAt = x => x.Position % 2 == 0;
@@ -40,7 +40,8 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			};
 
 			_newtable = PTable.Scavenged(_oldTable, GetTempFilePath(), upgradeHash, existsAt, readRecord,
-				PTableVersions.IndexV4, out spaceSaved, skipIndexVerify: _skipIndexVerify);
+				PTableVersions.IndexV4, out spaceSaved, skipIndexVerify: _skipIndexVerify,
+				initialReaders: Constants.PTableInitialReaderCount, maxReaders: Constants.PTableMaxReaderCountDefault);
 		}
 
 		[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_an_index_fails.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_an_index_fails.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			table.Add(0x010200000000, 0, 2);
 			table.Add(0x010300000000, 0, 3);
 			table.Add(0x010300000000, 1, 4);
-			_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+			_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 			long spaceSaved;
 			Func<IndexEntry, bool> existsAt = x => { throw new Exception("Expected exception"); };
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			_expectedOutputFile = GetTempFilePath();
 			Assert.That(
 				() => PTable.Scavenged(_oldTable, _expectedOutputFile, upgradeHash, existsAt, readRecord,
-					PTableVersions.IndexV4, out spaceSaved),
+					PTableVersions.IndexV4, out spaceSaved, initialReaders: Constants.PTableInitialReaderCount, maxReaders: Constants.PTableMaxReaderCountDefault),
 				Throws.Exception.With.Message.EqualTo("Expected exception"));
 		}
 

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_an_index_is_cancelled.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_an_index_is_cancelled.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			table.Add(0x010200000000, 0, 2);
 			table.Add(0x010300000000, 0, 3);
 			table.Add(0x010300000000, 1, 4);
-			_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+			_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 			var cancellationTokenSource = new CancellationTokenSource();
 			long spaceSaved;
@@ -36,7 +36,8 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			_expectedOutputFile = GetTempFilePath();
 			Assert.That(
 				() => PTable.Scavenged(_oldTable, _expectedOutputFile, upgradeHash, existsAt, readRecord,
-					PTableVersions.IndexV4, out spaceSaved, ct: cancellationTokenSource.Token),
+					PTableVersions.IndexV4, out spaceSaved, ct: cancellationTokenSource.Token,
+					initialReaders: Constants.PTableInitialReaderCount, maxReaders: Constants.PTableMaxReaderCountDefault),
 				Throws.InstanceOf<OperationCanceledException>());
 		}
 

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_an_index_removes_nothing.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_an_index_removes_nothing.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			table.Add(0x010200000000, 0, 2);
 			table.Add(0x010300000000, 0, 3);
 			table.Add(0x010300000000, 1, 4);
-			_oldTable = PTable.FromMemtable(table, GetTempFilePath());
+			_oldTable = PTable.FromMemtable(table, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
 
 			long spaceSaved;
 			Func<IndexEntry, bool> existsAt = x => true;
@@ -43,7 +43,8 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 
 			_expectedOutputFile = GetTempFilePath();
 			_newtable = PTable.Scavenged(_oldTable, _expectedOutputFile, upgradeHash, existsAt, readRecord,
-				PTableVersions.IndexV4, out spaceSaved, skipIndexVerify: _skipIndexVerify);
+				PTableVersions.IndexV4, out spaceSaved, skipIndexVerify: _skipIndexVerify,
+				initialReaders: Constants.PTableInitialReaderCount, maxReaders: Constants.PTableMaxReaderCountDefault);
 		}
 
 		[OneTimeTearDown]

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -39,6 +39,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false,
 				false, false,
 				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ConnectionQueueSizeThresholdDefault,
+				Constants.PTableMaxReaderCountDefault,
 				readOnlyReplica: isReadOnlyReplica);
 
 			return vnode;

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -39,7 +39,6 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false,
 				false, false,
 				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ConnectionQueueSizeThresholdDefault,
-				Opts.ChunkInitialReaderCountDefault,
 				readOnlyReplica: isReadOnlyReplica);
 
 			return vnode;

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -126,7 +126,9 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 				() => new HashListMemTable(IndexBitnessVersion, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				IndexBitnessVersion,
-				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
+				int.MaxValue,
+				Constants.PTableMaxReaderCountDefault,
+				MaxEntriesInMemTable);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,
@@ -157,7 +159,9 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 				() => new HashListMemTable(IndexBitnessVersion, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				IndexBitnessVersion,
-				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
+				int.MaxValue,
+				Constants.PTableMaxReaderCountDefault,
+				MaxEntriesInMemTable);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -126,7 +126,7 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 				() => new HashListMemTable(IndexBitnessVersion, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				IndexBitnessVersion,
-				MaxEntriesInMemTable);
+				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,
@@ -157,7 +157,7 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 				() => new HashListMemTable(IndexBitnessVersion, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				IndexBitnessVersion,
-				MaxEntriesInMemTable);
+				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 				() => new HashListMemTable(PTableVersions.IndexV1, maxSize: _maxMemTableSize),
 				() => _fakeReader,
 				PTableVersions.IndexV1,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: _maxMemTableSize,
 				maxTablesPerLevel: 2);
 			_tableIndex.Initialize(long.MaxValue);
@@ -228,7 +228,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 				() => new HashListMemTable(PTableVersions.IndexV2, maxSize: _maxMemTableSize),
 				() => _fakeReader,
 				PTableVersions.IndexV2,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: _maxMemTableSize,
 				maxTablesPerLevel: 2);
 			_tableIndex.Initialize(long.MaxValue);

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -79,7 +79,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				() => new HashListMemTable(IndexBitnessVersion, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				IndexBitnessVersion,
-				MaxEntriesInMemTable);
+				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -79,7 +79,9 @@ namespace EventStore.Core.Tests.Services.Storage {
 				() => new HashListMemTable(IndexBitnessVersion, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				IndexBitnessVersion,
-				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
+				int.MaxValue,
+				Constants.PTableMaxReaderCountDefault,
+				MaxEntriesInMemTable);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -56,7 +56,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				() => new HashListMemTable(PTableVersions.IndexV3, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				PTableVersions.IndexV3,
-				MaxEntriesInMemTable);
+				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -56,7 +56,9 @@ namespace EventStore.Core.Tests.Services.Storage {
 				() => new HashListMemTable(PTableVersions.IndexV3, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				PTableVersions.IndexV3,
-				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
+				int.MaxValue,
+				Constants.PTableMaxReaderCountDefault,
+				MaxEntriesInMemTable);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -54,7 +54,9 @@ namespace EventStore.Core.Tests.Services.Storage {
 				() => new HashListMemTable(PTableVersions.IndexV2, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				PTableVersions.IndexV2,
-				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
+				int.MaxValue,
+				Constants.PTableMaxReaderCountDefault,
+				MaxEntriesInMemTable);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				() => new HashListMemTable(PTableVersions.IndexV2, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				PTableVersions.IndexV2,
-				MaxEntriesInMemTable);
+				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
 
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Storage.Transactions {
 				() => new HashListMemTable(PTableVersions.IndexV2, maxSize: MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				PTableVersions.IndexV2,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: MaxEntriesInMemTable);
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,

--- a/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
@@ -88,7 +88,10 @@ namespace EventStore.Core.Tests.TransactionLog.Optimization {
 		private TFChunk CreateChunk(int chunkNumber, bool scavenged, out List<PosMap> posmap) {
 			var map = new List<PosMap>();
 			var chunk = TFChunk.CreateNew(GetFilePathFor("chunk-" + chunkNumber + "-" + Guid.NewGuid()), 1024 * 1024,
-				chunkNumber, chunkNumber, scavenged, false, false, false, 5, false);
+				chunkNumber, chunkNumber, scavenged, false, false, false,
+				TFChunkHelper.TFChunkInitialReaderCountDefault,
+				TFChunkHelper.TFChunkMaxReaderCountDefault,
+				false);
 			long offset = chunkNumber * 1024 * 1024;
 			long logPos = 0 + offset;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {

--- a/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
@@ -89,8 +89,8 @@ namespace EventStore.Core.Tests.TransactionLog.Optimization {
 			var map = new List<PosMap>();
 			var chunk = TFChunk.CreateNew(GetFilePathFor("chunk-" + chunkNumber + "-" + Guid.NewGuid()), 1024 * 1024,
 				chunkNumber, chunkNumber, scavenged, false, false, false,
-				TFChunkHelper.TFChunkInitialReaderCountDefault,
-				TFChunkHelper.TFChunkMaxReaderCountDefault,
+				Constants.TFChunkInitialReaderCountDefault,
+				Constants.TFChunkMaxReaderCountDefault,
 				false);
 			long offset = chunkNumber * 1024 * 1024;
 			long logPos = 0 + offset;

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -6,7 +6,6 @@ using EventStore.Core.DataStructures;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
 using EventStore.Core.Services.Storage.ReaderIndex;
-using EventStore.Core.Settings;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Chunks;
@@ -50,7 +49,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 
 			var indexPath = Path.Combine(PathName, "index");
 			var readerPool = new ObjectPool<ITransactionFileReader>(
-				"ReadIndex readers pool", ESConsts.PTableInitialReaderCount, ESConsts.PTableMaxReaderCount,
+				"ReadIndex readers pool", Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault,
 				() => new TFChunkReader(_dbResult.Db, _dbResult.Db.Config.WriterCheckpoint));
 			var lowHasher = new XXHashUnsafe();
 			var highHasher = new Murmur3AUnsafe();
@@ -58,7 +57,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 				() => new HashListMemTable(PTableVersions.IndexV3, maxSize: 200),
 				() => new TFReaderLease(readerPool),
 				PTableVersions.IndexV3,
-				5,
+				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 100,
 				maxTablesPerLevel: 2);
 			ReadIndex = new ReadIndex(new NoopPublisher(), readerPool, tableIndex, 100, true, _metastreamMaxCount,

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -12,8 +12,8 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 		public void is_fully_resident_in_memory_when_cached() {
 			var map = new List<PosMap>();
 			var chunk = TFChunk.CreateNew(Filename, 1024 * 1024, 0, 0, true, false, false, false,
-				TFChunkHelper.TFChunkInitialReaderCountDefault,
-				TFChunkHelper.TFChunkMaxReaderCountDefault,
+				Constants.TFChunkInitialReaderCountDefault,
+				Constants.TFChunkMaxReaderCountDefault,
 				false);
 			long logPos = 0;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -11,7 +11,10 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 		[Test]
 		public void is_fully_resident_in_memory_when_cached() {
 			var map = new List<PosMap>();
-			var chunk = TFChunk.CreateNew(Filename, 1024 * 1024, 0, 0, true, false, false, false, 5, false);
+			var chunk = TFChunk.CreateNew(Filename, 1024 * 1024, 0, 0, true, false, false, false,
+				TFChunkHelper.TFChunkInitialReaderCountDefault,
+				TFChunkHelper.TFChunkMaxReaderCountDefault,
+				false);
 			long logPos = 0;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {
 				map.Add(new PosMap(logPos, (int)logPos));

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -1,3 +1,4 @@
+using EventStore.Core.Settings;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
@@ -6,6 +7,11 @@ using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog {
 	public static class TFChunkHelper {
+		public const int TFChunkInitialReaderCountDefault = Opts.ChunkInitialReaderCountDefault;
+		public const int TFChunkMaxReaderCountDefault = ESConsts.PTableMaxReaderCount
+		                                                + 2 /* for caching/uncaching, populating midpoints */
+		                                                + 1 /* for epoch manager usage of elections/replica service */
+		                                                + 1 /* for epoch manager usage of master replication service */;
 		public static TFChunkDbConfig CreateDbConfig(string pathName, long writerCheckpointPosition,
 			long chaserCheckpointPosition = 0,
 			long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000) {
@@ -18,7 +24,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(epochCheckpointPosition),
 				new InMemoryCheckpoint(truncateCheckpoint),
 				new InMemoryCheckpoint(-1),
-				Opts.ChunkInitialReaderCountDefault);
+				TFChunkInitialReaderCountDefault,
+				TFChunkMaxReaderCountDefault);
 		}
 
 		public static TFChunkDbConfig CreateDbConfig(string pathName, ICheckpoint writerCheckpoint,
@@ -33,13 +40,14 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				replicationCheckpoint,
-				Opts.ChunkInitialReaderCountDefault);
+				TFChunkInitialReaderCountDefault,
+				TFChunkMaxReaderCountDefault);
 		}
 
 		public static TFChunk CreateNewChunk(string fileName, int chunkSize = 4096, bool isScavenged = false) {
 			return TFChunk.CreateNew(fileName, chunkSize, 0, 0,
 				isScavenged: isScavenged, inMem: false, unbuffered: false,
-				writethrough: false, initialReaderCount: 5, reduceFileCachePressure: false);
+				writethrough: false, initialReaderCount: TFChunkInitialReaderCountDefault, maxReaderCount: TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -7,11 +7,6 @@ using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog {
 	public static class TFChunkHelper {
-		public const int TFChunkInitialReaderCountDefault = Opts.ChunkInitialReaderCountDefault;
-		public const int TFChunkMaxReaderCountDefault = ESConsts.PTableMaxReaderCount
-		                                                + 2 /* for caching/uncaching, populating midpoints */
-		                                                + 1 /* for epoch manager usage of elections/replica service */
-		                                                + 1 /* for epoch manager usage of master replication service */;
 		public static TFChunkDbConfig CreateDbConfig(string pathName, long writerCheckpointPosition,
 			long chaserCheckpointPosition = 0,
 			long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000) {
@@ -23,9 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(chaserCheckpointPosition),
 				new InMemoryCheckpoint(epochCheckpointPosition),
 				new InMemoryCheckpoint(truncateCheckpoint),
-				new InMemoryCheckpoint(-1),
-				TFChunkInitialReaderCountDefault,
-				TFChunkMaxReaderCountDefault);
+				new InMemoryCheckpoint(-1), Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault);
 		}
 
 		public static TFChunkDbConfig CreateDbConfig(string pathName, ICheckpoint writerCheckpoint,
@@ -39,15 +32,13 @@ namespace EventStore.Core.Tests.TransactionLog {
 				chaserCheckpoint,
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
-				replicationCheckpoint,
-				TFChunkInitialReaderCountDefault,
-				TFChunkMaxReaderCountDefault);
+				replicationCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault);
 		}
 
 		public static TFChunk CreateNewChunk(string fileName, int chunkSize = 4096, bool isScavenged = false) {
 			return TFChunk.CreateNew(fileName, chunkSize, 0, 0,
 				isScavenged: isScavenged, inMem: false, unbuffered: false,
-				writethrough: false, initialReaderCount: TFChunkInitialReaderCountDefault, maxReaderCount: TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
+				writethrough: false, initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -5,7 +5,6 @@ using EventStore.Core.Index;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Services.Storage;
-using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -38,7 +37,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 				() => new HashListMemTable(PTableVersions.IndexV3, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				PTableVersions.IndexV3,
-				MaxEntriesInMemTable);
+				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,
 				TableIndex,

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -37,7 +37,9 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 				() => new HashListMemTable(PTableVersions.IndexV3, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				PTableVersions.IndexV3,
-				MaxEntriesInMemTable, Constants.PTableMaxReaderCountDefault);
+				int.MaxValue,
+				Constants.PTableMaxReaderCountDefault,
+				MaxEntriesInMemTable);
 			ReadIndex = new ReadIndex(new NoopPublisher(),
 				readers,
 				TableIndex,

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -15,8 +15,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk = TFChunkHelper.CreateNewChunk(Filename);
 			_chunk.Complete();
 			_testChunk = TFChunk.FromCompletedFile(Filename, true, false,
-				TFChunkHelper.TFChunkInitialReaderCountDefault,
-				TFChunkHelper.TFChunkMaxReaderCountDefault,
+				Constants.TFChunkInitialReaderCountDefault,
+				Constants.TFChunkMaxReaderCountDefault,
 				reduceFileCachePressure: false);
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -14,7 +14,10 @@ namespace EventStore.Core.Tests.TransactionLog {
 			base.TestFixtureSetUp();
 			_chunk = TFChunkHelper.CreateNewChunk(Filename);
 			_chunk.Complete();
-			_testChunk = TFChunk.FromCompletedFile(Filename, true, false, 5, reduceFileCachePressure: false);
+			_testChunk = TFChunk.FromCompletedFile(Filename, true, false,
+				TFChunkHelper.TFChunkInitialReaderCountDefault,
+				TFChunkHelper.TFChunkMaxReaderCountDefault,
+				reduceFileCachePressure: false);
 		}
 
 		[TearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void it_should_throw_a_file_not_found_exception() {
 			Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true,
-				unbufferedRead: false, initialReaderCount: 5, reduceFileCachePressure: false));
+				unbufferedRead: false, initialReaderCount: TFChunkHelper.TFChunkInitialReaderCountDefault, maxReaderCount: TFChunkHelper.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void it_should_throw_a_file_not_found_exception() {
 			Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true,
-				unbufferedRead: false, initialReaderCount: TFChunkHelper.TFChunkInitialReaderCountDefault, maxReaderCount: TFChunkHelper.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false));
+				unbufferedRead: false, initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Flush();
 			_chunk.Complete();
 			_cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
-				initialReaderCount: TFChunkHelper.TFChunkInitialReaderCountDefault, maxReaderCount: TFChunkHelper.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
+				initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
 			_cachedChunk.CacheInMemory();
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Flush();
 			_chunk.Complete();
 			_cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
-				initialReaderCount: 5, reduceFileCachePressure: false);
+				initialReaderCount: TFChunkHelper.TFChunkInitialReaderCountDefault, maxReaderCount: TFChunkHelper.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
 			_cachedChunk.CacheInMemory();
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Flush();
 			_chunk.Complete();
 			_uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
-				initialReaderCount: TFChunkHelper.TFChunkInitialReaderCountDefault, maxReaderCount: TFChunkHelper.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
+				initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
 			_uncachedChunk.CacheInMemory();
 			_uncachedChunk.UnCacheFromMemory();
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Flush();
 			_chunk.Complete();
 			_uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
-				initialReaderCount: 5, reduceFileCachePressure: false);
+				initialReaderCount: TFChunkHelper.TFChunkInitialReaderCountDefault, maxReaderCount: TFChunkHelper.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
 			_uncachedChunk.CacheInMemory();
 			_uncachedChunk.UnCacheFromMemory();
 		}

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -84,6 +84,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool StructuredLog;
 		public readonly bool ReadOnlyReplica;
 		public readonly Func<HttpMessageHandler> CreateHttpMessageHandler;
+		public int PTableMaxReaderCount;
 
 		public ClusterVNodeSettings(Guid instanceId, int debugIndex,
 			IPEndPoint internalTcpEndPoint,
@@ -133,6 +134,7 @@ namespace EventStore.Core.Cluster.Settings {
 			bool logHttpRequests,
 			int connectionPendingSendBytesThreshold,
 			int connectionQueueSizeThreshold,
+			int ptableMaxReaderCount,
 			string index = null, bool enableHistograms = false,
 			bool skipIndexVerify = false,
 			int indexCacheDepth = 16,
@@ -252,6 +254,7 @@ namespace EventStore.Core.Cluster.Settings {
 			StructuredLog = structuredLog;
 			ReadOnlyReplica = readOnlyReplica;
 			CreateHttpMessageHandler = createHttpMessageHandler;
+			PTableMaxReaderCount = ptableMaxReaderCount;
 		}
 
 		public override string ToString() =>

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -68,7 +68,6 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly int IndexCacheDepth;
 		public readonly byte IndexBitnessVersion;
 		public readonly bool OptimizeIndexMerge;
-		public readonly int ChunkInitialReaderCount;
 
 		public readonly bool BetterOrdering;
 		public readonly string Index;
@@ -134,7 +133,6 @@ namespace EventStore.Core.Cluster.Settings {
 			bool logHttpRequests,
 			int connectionPendingSendBytesThreshold,
 			int connectionQueueSizeThreshold,
-			int chunkInitialReaderCount,
 			string index = null, bool enableHistograms = false,
 			bool skipIndexVerify = false,
 			int indexCacheDepth = 16,
@@ -231,7 +229,6 @@ namespace EventStore.Core.Cluster.Settings {
 			ExtTcpHeartbeatInterval = extTcpHeartbeatInterval;
 			ConnectionPendingSendBytesThreshold = connectionPendingSendBytesThreshold;
 			ConnectionQueueSizeThreshold = connectionQueueSizeThreshold;
-			ChunkInitialReaderCount = chunkInitialReaderCount;
 
 			VerifyDbHash = verifyDbHash;
 			MaxMemtableEntryCount = maxMemtableEntryCount;
@@ -279,7 +276,6 @@ namespace EventStore.Core.Cluster.Settings {
 			$"HTTPCachingDisabled: {DisableHTTPCaching}\n" + $"IndexPath: {Index}\n" +
 			$"ScavengeHistoryMaxAge: {ScavengeHistoryMaxAge}\n" +
 			$"ConnectionPendingSendBytesThreshold: {ConnectionPendingSendBytesThreshold}\n" +
-			$"ChunkInitialReaderCount: {ChunkInitialReaderCount}\n" +
 			$"ReduceFileCachePressure: {ReduceFileCachePressure}\n" +
 			$"InitializationThreads: {InitializationThreads}\n" + $"StructuredLog: {StructuredLog}\n" +
 			$"DisableFirstLevelHttpAuthorization: {DisableFirstLevelHttpAuthorization}\n" +

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -258,9 +258,8 @@ namespace EventStore.Core {
 			// STORAGE SUBSYSTEM
 			db.Open(vNodeSettings.VerifyDbHash, threads: vNodeSettings.InitializationThreads);
 			var indexPath = vNodeSettings.Index ?? Path.Combine(db.Config.Path, "index");
-			var maxReaderCount = ESConsts.PTableMaxReaderCount + vNodeSettings.ReaderThreadsCount;
 			var readerPool = new ObjectPool<ITransactionFileReader>(
-				"ReadIndex readers pool", ESConsts.PTableInitialReaderCount, maxReaderCount,
+				"ReadIndex readers pool", ESConsts.PTableInitialReaderCount, vNodeSettings.PTableMaxReaderCount,
 				() => new TFChunkReader(db, db.Config.WriterCheckpoint,
 					optimizeReadSideCache: db.Config.OptimizeReadSideCache));
 			var tableIndex = new TableIndex(indexPath,
@@ -277,7 +276,8 @@ namespace EventStore.Core {
 				indexCacheDepth: vNodeSettings.IndexCacheDepth,
 				initializationThreads: vNodeSettings.InitializationThreads,
 				additionalReclaim: false,
-				maxAutoMergeIndexLevel: vNodeSettings.MaxAutoMergeIndexLevel);
+				maxAutoMergeIndexLevel: vNodeSettings.MaxAutoMergeIndexLevel,
+				pTableMaxReaderCount: vNodeSettings.PTableMaxReaderCount);
 			var readIndex = new ReadIndex(_mainQueue,
 				readerPool,
 				tableIndex,

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -80,8 +80,8 @@ namespace EventStore.Core.Index {
 
 		private PTable(string filename,
 			Guid id,
-			int initialReaders = ESConsts.PTableInitialReaderCount,
-			int maxReaders = ESConsts.PTableMaxReaderCount,
+			int initialReaders,
+			int maxReaders,
 			int depth = 16,
 			bool skipIndexVerify = false) {
 			Ensure.NotNullOrEmpty(filename, "filename");

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -11,11 +11,13 @@ using EventStore.Common.Utils;
 
 namespace EventStore.Core.Index {
 	public unsafe partial class PTable {
-		public static PTable FromFile(string filename, int cacheDepth, bool skipIndexVerify) {
-			return new PTable(filename, Guid.NewGuid(), depth: cacheDepth, skipIndexVerify: skipIndexVerify);
+		public static PTable FromFile(string filename, int initialReaders, int maxReaders, int cacheDepth,
+			bool skipIndexVerify) {
+			return new PTable(filename, Guid.NewGuid(), initialReaders, maxReaders, cacheDepth, skipIndexVerify);
 		}
 
-		public static PTable FromMemtable(IMemTable table, string filename, int cacheDepth = 16,
+		public static PTable FromMemtable(IMemTable table, string filename, int initialReaders, int maxReaders,
+			int cacheDepth = 16,
 			bool skipIndexVerify = false) {
 			Ensure.NotNull(table, "table");
 			Ensure.NotNullOrEmpty(filename, "filename");
@@ -84,11 +86,12 @@ namespace EventStore.Core.Index {
 			}
 
 			Log.Trace("Dumped MemTable [{id}, {table} entries] in {elapsed}.", table.Id, table.Count, sw.Elapsed);
-			return new PTable(filename, table.Id, depth: cacheDepth, skipIndexVerify: skipIndexVerify);
+			return new PTable(filename, table.Id, initialReaders, maxReaders, cacheDepth, skipIndexVerify);
 		}
 
 		public static PTable MergeTo(IList<PTable> tables, string outputFile, Func<string, ulong, ulong> upgradeHash,
 			Func<IndexEntry, bool> existsAt, Func<IndexEntry, Tuple<string, bool>> readRecord, byte version,
+			int initialReaders, int maxReaders,
 			int cacheDepth = 16, bool skipIndexVerify = false) {
 			Ensure.NotNull(tables, "tables");
 			Ensure.NotNullOrEmpty(outputFile, "outputFile");
@@ -103,7 +106,7 @@ namespace EventStore.Core.Index {
 			var fileSizeUpToIndexEntries = GetFileSizeUpToIndexEntries(numIndexEntries, version);
 			if (tables.Count == 2)
 				return MergeTo2(tables, numIndexEntries, indexEntrySize, outputFile, upgradeHash, existsAt, readRecord,
-					version, cacheDepth, skipIndexVerify); // special case
+					version, initialReaders, maxReaders, cacheDepth, skipIndexVerify); // special case
 
 			Log.Trace("PTables merge started.");
 			var watch = Stopwatch.StartNew();
@@ -187,7 +190,7 @@ namespace EventStore.Core.Index {
 				Log.Trace(
 					"PTables merge finished in {elapsed} ([{entryCount}] entries merged into {dumpedEntryCount}).",
 					watch.Elapsed, string.Join(", ", tables.Select(x => x.Count)), dumpedEntryCount);
-				return new PTable(outputFile, Guid.NewGuid(), depth: cacheDepth, skipIndexVerify: skipIndexVerify);
+				return new PTable(outputFile, Guid.NewGuid(), initialReaders, maxReaders, cacheDepth, skipIndexVerify);
 			} finally {
 				foreach (var enumerableTable in enumerators) {
 					enumerableTable.Dispose();
@@ -215,7 +218,8 @@ namespace EventStore.Core.Index {
 			string outputFile,
 			Func<string, ulong, ulong> upgradeHash, Func<IndexEntry, bool> existsAt,
 			Func<IndexEntry, Tuple<string, bool>> readRecord,
-			byte version, int cacheDepth, bool skipIndexVerify) {
+			byte version, int initialReaders, int maxReaders,
+			int cacheDepth, bool skipIndexVerify) {
 			Log.Trace("PTables merge started (specialized for <= 2 tables).");
 			var watch = Stopwatch.StartNew();
 
@@ -301,7 +305,7 @@ namespace EventStore.Core.Index {
 				Log.Trace(
 					"PTables merge finished in {elapsed} ([{entryCount}] entries merged into {dumpedEntryCount}).",
 					watch.Elapsed, string.Join(", ", tables.Select(x => x.Count)), dumpedEntryCount);
-				return new PTable(outputFile, Guid.NewGuid(), depth: cacheDepth, skipIndexVerify: skipIndexVerify);
+				return new PTable(outputFile, Guid.NewGuid(), initialReaders, maxReaders, cacheDepth, skipIndexVerify);
 			} finally {
 				foreach (var enumerator in enumerators) {
 					enumerator.Dispose();
@@ -312,7 +316,9 @@ namespace EventStore.Core.Index {
 		public static PTable Scavenged(PTable table, string outputFile, Func<string, ulong, ulong> upgradeHash,
 			Func<IndexEntry, bool> existsAt, Func<IndexEntry, Tuple<string, bool>> readRecord, byte version,
 			out long spaceSaved,
-			int cacheDepth = 16, bool skipIndexVerify = false, CancellationToken ct = default(CancellationToken)) {
+			int initialReaders, int maxReaders,
+			int cacheDepth = 16, bool skipIndexVerify = false,
+			CancellationToken ct = default(CancellationToken)) {
 			Ensure.NotNull(table, "table");
 			Ensure.NotNullOrEmpty(outputFile, "outputFile");
 			Ensure.Nonnegative(cacheDepth, "cacheDepth");
@@ -405,8 +411,7 @@ namespace EventStore.Core.Index {
 					"PTable scavenge finished in {elapsed} ({droppedCount} entries removed, {keptCount} remaining).",
 					watch.Elapsed,
 					droppedCount, keptCount);
-				var scavengedTable = new PTable(outputFile, Guid.NewGuid(), depth: cacheDepth,
-					skipIndexVerify: skipIndexVerify);
+				var scavengedTable = new PTable(outputFile, Guid.NewGuid(), initialReaders, maxReaders, cacheDepth, skipIndexVerify);
 				spaceSaved = table._size - scavengedTable._size;
 				return scavengedTable;
 			} catch (Exception) {

--- a/src/EventStore.Core/Settings/ESConsts.cs
+++ b/src/EventStore.Core/Settings/ESConsts.cs
@@ -3,18 +3,7 @@ using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Settings {
 	public static class ESConsts {
-		public const int StorageReaderThreadCount = 4;
-
 		public const int PTableInitialReaderCount = 5;
-
-		public const int PTableMaxReaderCount = 1 /* StorageWriter */
-		                                        + 1 /* StorageChaser */
-		                                        + 1 /* Projections */
-		                                        + TFChunkScavenger.MaxThreadCount /* Scavenging (1 per thread) */
-		                                        + 1 /* Subscription LinkTos resolving */
-		                                        + StorageReaderThreadCount
-		                                        + 5 /* just in case reserve :) */;
-
 		public const int MemTableEntryCount = 1000000;
 		public const int StreamInfoCacheCapacity = 100000;
 		public const int TransactionMetadataCacheCapacity = 50000;

--- a/src/EventStore.Core/Settings/ESConsts.cs
+++ b/src/EventStore.Core/Settings/ESConsts.cs
@@ -15,11 +15,6 @@ namespace EventStore.Core.Settings {
 		                                        + StorageReaderThreadCount
 		                                        + 5 /* just in case reserve :) */;
 
-		public const int TFChunkMaxReaderCount = PTableMaxReaderCount
-		                                         + 2 /* for caching/uncaching, populating midpoints */
-		                                         + 1 /* for epoch manager usage of elections/replica service */
-		                                         + 1 /* for epoch manager usage of master replication service */;
-
 		public const int MemTableEntryCount = 1000000;
 		public const int StreamInfoCacheCapacity = 100000;
 		public const int TransactionMetadataCacheCapacity = 50000;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -138,8 +138,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		}
 
 		public static TFChunk FromCompletedFile(string filename, bool verifyHash, bool unbufferedRead,
-			int initialReaderCount, bool optimizeReadSideCache = false, bool reduceFileCachePressure = false) {
-			var chunk = new TFChunk(filename, initialReaderCount, ESConsts.TFChunkMaxReaderCount,
+			int initialReaderCount, int maxReaderCount, bool optimizeReadSideCache = false, bool reduceFileCachePressure = false) {
+			var chunk = new TFChunk(filename, initialReaderCount, maxReaderCount,
 				TFConsts.MidpointsDepth, false, unbufferedRead, false, reduceFileCachePressure);
 			try {
 				chunk.InitCompleted(verifyHash, optimizeReadSideCache);
@@ -152,10 +152,10 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		}
 
 		public static TFChunk FromOngoingFile(string filename, int writePosition, bool checkSize, bool unbuffered,
-			bool writethrough, int initialReaderCount, bool reduceFileCachePressure) {
+			bool writethrough, int initialReaderCount, int maxReaderCount, bool reduceFileCachePressure) {
 			var chunk = new TFChunk(filename,
 				initialReaderCount,
-				ESConsts.TFChunkMaxReaderCount,
+				maxReaderCount,
 				TFConsts.MidpointsDepth,
 				false,
 				unbuffered,
@@ -179,11 +179,12 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			bool unbuffered,
 			bool writethrough,
 			int initialReaderCount,
+			int maxReaderCount,
 			bool reduceFileCachePressure) {
 			var size = GetAlignedSize(chunkSize + ChunkHeader.Size + ChunkFooter.Size);
 			var chunkHeader = new ChunkHeader(CurrentChunkVersion, chunkSize, chunkStartNumber, chunkEndNumber,
 				isScavenged, Guid.NewGuid());
-			return CreateWithHeader(filename, chunkHeader, size, inMem, unbuffered, writethrough, initialReaderCount,
+			return CreateWithHeader(filename, chunkHeader, size, inMem, unbuffered, writethrough, initialReaderCount, maxReaderCount,
 				reduceFileCachePressure);
 		}
 
@@ -194,10 +195,11 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			bool unbuffered,
 			bool writethrough,
 			int initialReaderCount,
+			int maxReaderCount,
 			bool reduceFileCachePressure) {
 			var chunk = new TFChunk(filename,
 				initialReaderCount,
-				ESConsts.TFChunkMaxReaderCount,
+				maxReaderCount,
 				TFConsts.MidpointsDepth,
 				inMem,
 				unbuffered,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -75,6 +75,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 								chunk = TFChunk.TFChunk.FromCompletedFile(chunkInfo.ChunkFileName, verifyHash: false,
 									unbufferedRead: Config.Unbuffered,
 									initialReaderCount: Config.InitialReaderCount,
+									maxReaderCount: Config.MaxReaderCount,
 									optimizeReadSideCache: Config.OptimizeReadSideCache,
 									reduceFileCachePressure: Config.ReduceFileCachePressure);
 							else {
@@ -82,6 +83,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 									checkSize: false,
 									unbuffered: Config.Unbuffered,
 									writethrough: Config.WriteThrough, initialReaderCount: Config.InitialReaderCount,
+									maxReaderCount: Config.MaxReaderCount,
 									reduceFileCachePressure: Config.ReduceFileCachePressure);
 								// chunk is full with data, we should complete it right here
 								if (!readOnly)
@@ -91,6 +93,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 							chunk = TFChunk.TFChunk.FromCompletedFile(chunkInfo.ChunkFileName, verifyHash: false,
 								unbufferedRead: Config.Unbuffered,
 								initialReaderCount: Config.InitialReaderCount,
+								maxReaderCount: Config.MaxReaderCount,
 								optimizeReadSideCache: Config.OptimizeReadSideCache,
 								reduceFileCachePressure: Config.ReduceFileCachePressure);
 						}
@@ -118,6 +121,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					var lastChunk = TFChunk.TFChunk.FromCompletedFile(chunkFileName, verifyHash: false,
 						unbufferedRead: Config.Unbuffered,
 						initialReaderCount: Config.InitialReaderCount,
+						maxReaderCount: Config.MaxReaderCount,
 						optimizeReadSideCache: Config.OptimizeReadSideCache,
 						reduceFileCachePressure: Config.ReduceFileCachePressure);
 					if (lastChunk.ChunkFooter.LogicalDataSize != chunkLocalPos) {
@@ -143,6 +147,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					var lastChunk = TFChunk.TFChunk.FromOngoingFile(chunkFileName, (int)chunkLocalPos, checkSize: false,
 						unbuffered: Config.Unbuffered,
 						writethrough: Config.WriteThrough, initialReaderCount: Config.InitialReaderCount,
+						maxReaderCount:Config.MaxReaderCount,
 						reduceFileCachePressure: Config.ReduceFileCachePressure);
 					Manager.AddChunk(lastChunk);
 				}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -17,6 +17,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly bool Unbuffered;
 		public readonly bool WriteThrough;
 		public readonly int InitialReaderCount;
+		public readonly int MaxReaderCount;
 		public readonly bool OptimizeReadSideCache;
 		public readonly bool ReduceFileCachePressure;
 
@@ -30,6 +31,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			ICheckpoint truncateCheckpoint,
 			ICheckpoint replicationCheckpoint,
 			int initialReaderCount,
+			int maxReaderCount,
 			bool inMemDb = false,
 			bool unbuffered = false,
 			bool writethrough = false,
@@ -45,6 +47,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			Ensure.NotNull(truncateCheckpoint, "truncateCheckpoint");
 			Ensure.NotNull(replicationCheckpoint, "replicationCheckpoint");
 			Ensure.Positive(initialReaderCount, "initialReaderCount");
+			Ensure.Positive(maxReaderCount, "maxReaderCount");
 
 			Path = path;
 			ChunkSize = chunkSize;
@@ -59,6 +62,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			Unbuffered = unbuffered;
 			WriteThrough = writethrough;
 			InitialReaderCount = initialReaderCount;
+			MaxReaderCount = maxReaderCount;
 			OptimizeReadSideCache = optimizeReadSideCache;
 			ReduceFileCachePressure = reduceFileCachePressure;
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -97,6 +97,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				_config.Unbuffered,
 				_config.WriteThrough,
 				_config.InitialReaderCount,
+				_config.MaxReaderCount,
 				_config.ReduceFileCachePressure);
 		}
 
@@ -113,6 +114,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					unbuffered: _config.Unbuffered,
 					writethrough: _config.WriteThrough,
 					initialReaderCount: _config.InitialReaderCount,
+					maxReaderCount: _config.MaxReaderCount,
 					reduceFileCachePressure: _config.ReduceFileCachePressure);
 				AddChunk(chunk);
 				return chunk;
@@ -137,6 +139,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					unbuffered: _config.Unbuffered,
 					writethrough: _config.WriteThrough,
 					initialReaderCount: _config.InitialReaderCount,
+					maxReaderCount: _config.MaxReaderCount,
 					reduceFileCachePressure: _config.ReduceFileCachePressure);
 				AddChunk(chunk);
 				return chunk;
@@ -194,7 +197,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				}
 
 				newChunk = TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered,
-					_config.InitialReaderCount, _config.OptimizeReadSideCache, _config.ReduceFileCachePressure);
+					_config.InitialReaderCount, _config.MaxReaderCount, _config.OptimizeReadSideCache, _config.ReduceFileCachePressure);
 			}
 
 			lock (_chunksLocker) {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -212,6 +212,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					unbuffered: _db.Config.Unbuffered,
 					writethrough: _db.Config.WriteThrough,
 					initialReaderCount: _db.Config.InitialReaderCount,
+					maxReaderCount: _db.Config.MaxReaderCount,
 					reduceFileCachePressure: _db.Config.ReduceFileCachePressure);
 			} catch (IOException exc) {
 				Log.ErrorException(exc,
@@ -378,6 +379,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					unbuffered: _db.Config.Unbuffered,
 					writethrough: _db.Config.WriteThrough,
 					initialReaderCount: _db.Config.InitialReaderCount,
+					maxReaderCount: _db.Config.MaxReaderCount,
 					reduceFileCachePressure: _db.Config.ReduceFileCachePressure);
 			} catch (IOException exc) {
 				Log.ErrorException(exc,

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -20,6 +20,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using EventStore.Core.Index;
 using Microsoft.AspNetCore.Hosting;
+using EventStore.Core.Settings;
 
 namespace EventStore.Core {
 	/// <summary>
@@ -1337,6 +1338,7 @@ namespace EventStore.Core {
 				_logHttpRequests,
 				_connectionPendingSendBytesThreshold,
 				_connectionQueueSizeThreshold,
+				ComputePTableMaxReaderCount(ESConsts.PTableInitialReaderCount, _readerThreadsCount),
 				_index,
 				_enableHistograms,
 				_skipIndexVerify,
@@ -1380,21 +1382,23 @@ namespace EventStore.Core {
 			return new ClusterVNode(_db, _vNodeSettings, GetGossipSource(), infoController, _subsystems.ToArray());
 		}
 
-		private int ComputeTFChunkMaxReaderCount(int tfChunkInitialReaderCount, int readerThreadsCount) {
-				var ptableMaxReaderCount = 1 /* StorageWriter */
-	                                        + 1 /* StorageChaser */
-	                                        + 1 /* Projections */
-	                                        + TFChunkScavenger.MaxThreadCount /* Scavenging (1 per thread) */
-	                                        + 1 /* Subscription LinkTos resolving */
-	                                        + readerThreadsCount
-	                                        + 5 /* just in case reserve :) */;
+		private int ComputePTableMaxReaderCount(int ptableInitialReaderCount, int readerThreadsCount) {
+			var ptableMaxReaderCount = 1 /* StorageWriter */
+			                           + 1 /* StorageChaser */
+			                           + 1 /* Projections */
+			                           + TFChunkScavenger.MaxThreadCount /* Scavenging (1 per thread) */
+			                           + 1 /* Subscription LinkTos resolving */
+			                           + readerThreadsCount
+			                           + 5 /* just in case reserve :) */;
+			return Math.Max(ptableMaxReaderCount, ptableInitialReaderCount);
+		}
 
-				var tfChunkMaxReaderCount = ptableMaxReaderCount
+		private int ComputeTFChunkMaxReaderCount(int tfChunkInitialReaderCount, int readerThreadsCount) {
+			var tfChunkMaxReaderCount = ComputePTableMaxReaderCount(ESConsts.PTableInitialReaderCount, readerThreadsCount)
                                             + 2 /* for caching/uncaching, populating midpoints */
                                             + 1 /* for epoch manager usage of elections/replica service */
                                             + 1 /* for epoch manager usage of master replication service */;
-
-				return Math.Max(tfChunkMaxReaderCount, tfChunkInitialReaderCount);
+			return Math.Max(tfChunkMaxReaderCount, tfChunkInitialReaderCount);
 		}
 
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1337,7 +1337,6 @@ namespace EventStore.Core {
 				_logHttpRequests,
 				_connectionPendingSendBytesThreshold,
 				_connectionQueueSizeThreshold,
-				_chunkInitialReaderCount,
 				_index,
 				_enableHistograms,
 				_skipIndexVerify,

--- a/src/EventStore.Grpc.Tests.Common/Constants.cs
+++ b/src/EventStore.Grpc.Tests.Common/Constants.cs
@@ -1,0 +1,24 @@
+using EventStore.Core.Settings;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.Util;
+
+namespace EventStore.Grpc.Tests.Common {
+	public class Constants {
+		public const int PTableInitialReaderCount = ESConsts.PTableInitialReaderCount;
+
+		public const int PTableMaxReaderCountDefault = 	1 /* StorageWriter */
+		                                                + 1 /* StorageChaser */
+		                                                + 1 /* Projections */
+		                                                + 4 /* Scavenging (1 per thread) */
+		                                                + 1 /* Subscription LinkTos resolving */
+		                                                + Opts.ReaderThreadsCountDefault
+		                                                + 5 /* just in case reserve :) */;
+
+		public const int TFChunkInitialReaderCountDefault = Opts.ChunkInitialReaderCountDefault;
+
+		public const int TFChunkMaxReaderCountDefault = PTableMaxReaderCountDefault
+		                                                + 2 /* for caching/uncaching, populating midpoints */
+		                                                + 1 /* for epoch manager usage of elections/replica service */
+		                                                + 1 /* for epoch manager usage of master replication service */;
+	}
+}

--- a/src/EventStore.Grpc.Tests.Common/StreamRevisionGreaterThanIntMaxValueFixture.cs
+++ b/src/EventStore.Grpc.Tests.Common/StreamRevisionGreaterThanIntMaxValueFixture.cs
@@ -14,6 +14,7 @@ using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Util;
+using EventStore.Grpc.Tests.Common;
 using Xunit;
 
 namespace EventStore.Grpc {
@@ -102,7 +103,9 @@ namespace EventStore.Grpc {
 				new InMemoryCheckpoint(epochCheckpointPosition),
 				new InMemoryCheckpoint(truncateCheckpoint),
 				new InMemoryCheckpoint(-1),
-				Opts.ChunkInitialReaderCountDefault);
+				Constants.TFChunkInitialReaderCountDefault,
+				Constants.TFChunkMaxReaderCountDefault
+				);
 		}
 
 		private static TFChunkDbConfig CreateDbConfig(string pathName, ICheckpoint writerCheckpoint,
@@ -117,13 +120,15 @@ namespace EventStore.Grpc {
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				replicationCheckpoint,
-				Opts.ChunkInitialReaderCountDefault);
+				Constants.TFChunkInitialReaderCountDefault,
+				Constants.TFChunkMaxReaderCountDefault
+			);
 		}
 
 		private static TFChunk CreateNewChunk(string fileName, int chunkSize = 4096, bool isScavenged = false) {
 			return TFChunk.CreateNew(fileName, chunkSize, 0, 0,
 				isScavenged: isScavenged, inMem: false, unbuffered: false,
-				writethrough: false, initialReaderCount: 5, reduceFileCachePressure: false);
+				writethrough: false, initialReaderCount: Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
 		}
 
 		protected new static IEnumerable<EventData> CreateTestEvents(int count)


### PR DESCRIPTION
This PR is a rebase of `fix-max-object-pool-size` onto `v6-master`. Previous v5 PR: #2058

Fixes #2044

*Reproduction steps:*

1. Apply following diff on the `master` branch to slow down returning the work item to make issue more easily reproducible:
```
diff --git a/src/EventStore.Core/Index/PTable.cs b/src/EventStore.Core/Index/PTable.cs
index 26ee7ff..afa8b69 100644
--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -708,6 +708,7 @@ namespace EventStore.Core.Index {
                }
 
                private void ReturnWorkItem(WorkItem workItem) {
+                       Thread.Sleep(10);
                        _workItems.Return(workItem);
                }
 
diff --git a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
index 3f49f6c..70e3420 100644
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -1035,6 +1035,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
                }
 
                private void ReturnReaderWorkItem(ReaderWorkItem item) {
+                       Thread.Sleep(10);
                        if (item.IsMemory) {
                                _memStreams.Enqueue(item);
                                if (_isCached == 0 || _selfdestructin54321)
```

2. Start eventstore with following parameters:
```
--db ../db --log ../log --structured-log=False --run-projections=All --reader-threads-count 26 --max-memtable-size 1000 --cached-chunks 0 --chunks-cache-size 0
```

3. Start test client and write a few events:
```
mono bin/Release/EventStore.TestClient/net471/EventStore.TestClient.exe
>> WRFL 1 3000
>> WRLT 1 1 1 1 stream
```
`WRFL` 3000 events will ensure that we create a PTable. Check your index directory to make sure it's been created.
`WRLT 1 1 1 1 stream` will ensure that we have a stream called `stream` because we're going to read events from it later.

4. Start the following project with `dotnet run`:
[multireader.zip](https://github.com/EventStore/EventStore/files/3868851/multireader.zip)

It will launch 30 threads to spam reads.

5. When the 30 threads have been launched and the reads start, the following errors should be visible in the logs. You should see two types of errors:
```
System.Exception: Unable to acquire reader work item. Max internal streams limit reached.
  at EventStore.Core.TransactionLog.Chunks.TFChunk.TFChunk.GetReaderWorkItem () [0x00068] in <437e25a373a84d3594ba358923fe3cb4>:0 
```
and
```
System.Exception: Unable to acquire work item.
  at EventStore.Core.Index.PTable.GetWorkItem () [0x00016] in <437e25a373a84d3594ba358923fe3cb4>:0 
```

6. Test EventStore with the branch `fix-max-object-pool-size` with the same steps, the errors do not occur.
