### PR TITLE
The host header needs to contain the port for forwarding

### DIFF
--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -195,7 +195,7 @@ namespace EventStore.Core.Services {
 						case "expect":
 							break;
 						case "host":
-							request.Headers.Host = forwardUri.Host;
+							request.Headers.Host = $"{forwardUri.Host}:{forwardUri.Port}";
 							break;
 						case "if-modified-since":
 							request.Headers.IfModifiedSince = DateTime.Parse(srcReq.GetHeaderValues(headerKey).ToString());


### PR DESCRIPTION
We need to include the port in the host header. The [following bit](https://github.com/EventStore/EventStore/blob/v6-master/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs#L101) in the `KestrelHttpService` checks it