### PR TITLE
Provide the ability to specify DnsEndpoint as Gossip Seeds.

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -399,10 +399,10 @@ namespace EventStore.ClientAPI {
 		/// If the server requires a specific Host header to be sent as part of the gossip
 		/// request, use the overload of this method taking <see cref="GossipSeed" /> instead.
 		/// </summary>
-		/// <param name="gossipSeeds"><see cref="IPEndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
+		/// <param name="gossipSeeds"><see cref="EndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
 		/// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
 		/// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
-		public ConnectionSettingsBuilder SetGossipSeedEndPoints(params IPEndPoint[] gossipSeeds) {
+		public ConnectionSettingsBuilder SetGossipSeedEndPoints(params EndPoint[] gossipSeeds) {
 			return SetGossipSeedEndPoints(true, gossipSeeds);
 		}
 
@@ -418,10 +418,10 @@ namespace EventStore.ClientAPI {
 		/// request, use the overload of this method taking <see cref="GossipSeed" /> instead.
 		/// </summary>
 		/// <param name="seedOverTls">Specifies that eventstore should use https when connecting to gossip</param>
-		/// <param name="gossipSeeds"><see cref="IPEndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
+		/// <param name="gossipSeeds"><see cref="EndPoint" />s representing the endpoints of nodes from which to seed gossip.</param>
 		/// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
 		/// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
-		public ConnectionSettingsBuilder SetGossipSeedEndPoints(bool seedOverTls, params IPEndPoint[] gossipSeeds) {
+		public ConnectionSettingsBuilder SetGossipSeedEndPoints(bool seedOverTls, params EndPoint[] gossipSeeds) {
 			if (gossipSeeds == null || gossipSeeds.Length == 0)
 				throw new ArgumentException("Empty FakeDnsEntries collection.");
 

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -403,7 +403,7 @@ namespace EventStore.ClientAPI {
 		/// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
 		/// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
 		public ConnectionSettingsBuilder SetGossipSeedEndPoints(params IPEndPoint[] gossipSeeds) {
-			return SetGossipSeedEndPoints(false, gossipSeeds);
+			return SetGossipSeedEndPoints(true, gossipSeeds);
 		}
 
 		/// <summary>

--- a/src/EventStore.ClientAPI/GossipSeed.cs
+++ b/src/EventStore.ClientAPI/GossipSeed.cs
@@ -30,7 +30,7 @@ namespace EventStore.ClientAPI {
 		/// <param name="endPoint">The <see cref="IPEndPoint"/> for the External HTTP endpoint of the gossip seed. The standard port is 2113.</param>
 		/// <param name="hostHeader">The host header to be sent when requesting gossip. Defaults to String.Empty</param>
 		/// <param name="seedOverTls">Specifies that eventstore should use https when connecting to gossip</param>
-		public GossipSeed(IPEndPoint endPoint, string hostHeader = "", bool seedOverTls = false) {
+		public GossipSeed(IPEndPoint endPoint, string hostHeader = "", bool seedOverTls = true) {
 			EndPoint = endPoint;
 			HostHeader = hostHeader;
 			SeedOverTls = seedOverTls;

--- a/src/EventStore.ClientAPI/GossipSeed.cs
+++ b/src/EventStore.ClientAPI/GossipSeed.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 
 namespace EventStore.ClientAPI {
 	/// <summary>
@@ -6,16 +7,16 @@ namespace EventStore.ClientAPI {
 	/// </summary>
 	public class GossipSeed {
 		/// <summary>
-		/// The <see cref="IPEndPoint"/> for the External HTTP endpoint of the gossip seed.
+		/// The <see cref="EndPoint"/> for the External HTTP endpoint of the gossip seed.
 		///
 		/// The HTTP endpoint is used rather than the TCP endpoint because it is required
 		/// for the client to exchange gossip with the server. The standard port which should be
 		/// used here is 2113.
 		/// </summary>
-		public readonly IPEndPoint EndPoint;
+		public readonly EndPoint EndPoint;
 
 		/// <summary>
-		/// If Gossip should be requested
+		/// If Gossip should be requested over Tls
 		/// </summary>
 		public readonly bool SeedOverTls;
 
@@ -27,10 +28,10 @@ namespace EventStore.ClientAPI {
 		/// <summary>
 		/// Creates a new <see cref="GossipSeed" />.
 		/// </summary>
-		/// <param name="endPoint">The <see cref="IPEndPoint"/> for the External HTTP endpoint of the gossip seed. The standard port is 2113.</param>
+		/// <param name="endPoint">The <see cref="EndPoint"/> for the External HTTP endpoint of the gossip seed. The standard port is 2113.</param>
 		/// <param name="hostHeader">The host header to be sent when requesting gossip. Defaults to String.Empty</param>
 		/// <param name="seedOverTls">Specifies that eventstore should use https when connecting to gossip</param>
-		public GossipSeed(IPEndPoint endPoint, string hostHeader = "", bool seedOverTls = true) {
+		public GossipSeed(EndPoint endPoint, string hostHeader = "", bool seedOverTls = true) {
 			EndPoint = endPoint;
 			HostHeader = hostHeader;
 			SeedOverTls = seedOverTls;

--- a/src/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/GossipSeedClusterSettingsBuilder.cs
@@ -27,7 +27,7 @@ namespace EventStore.ClientAPI {
 		/// <returns>A <see cref="ClusterSettingsBuilder"/> for further configuration.</returns>
 		/// <exception cref="ArgumentException">If no gossip seeds are specified.</exception>
 		public GossipSeedClusterSettingsBuilder SetGossipSeedEndPoints(params IPEndPoint[] gossipSeeds) {
-			return SetGossipSeedEndPoints(false, gossipSeeds);
+			return SetGossipSeedEndPoints(true, gossipSeeds);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Fixes #2093

- This changes the default gossiping from the Client API to happen via HTTPs instead of HTTP.
- It also provides the ability to specify `DnsEndpoint`s as Gossip Seeds.


e.g.
```
var settings = ConnectionSettings.Create()
    .SetGossipTimeout(TimeSpan.FromMilliseconds(5000))
    .SetGossipSeedEndPoints(
        new DnsEndPoint("localhost", 1114),
        new DnsEndPoint("localhost", 2114),
        new DnsEndPoint("localhost", 3114))
    .Build();

var connection = EventStoreConnection.Create(settings);
```

The above will work for example with the development certificate from Kestrel. Changing the above to the following example would surface the issue described in the note below.
```
var settings = ConnectionSettings.Create()
    .SetGossipTimeout(TimeSpan.FromMilliseconds(5000))
    .SetGossipSeedEndPoints(
        new IPEndPoint(IPAddress.Loopback, 1114),
        new IPEndPoint(IPAddress.Loopback, 2114),
        new IPEndPoint(IPAddress.Loopback, 3114))
    .Build();
```

**Note**
- This change should easily be portable to v5 clients to allow them the ability to also use `DnsEndpoint`s
