### PR TITLE
Use gossip to determine node liveness after tcp connection drops

### DIFF
--- a/src/EventStore.Core.Tests/AssertEx.cs
+++ b/src/EventStore.Core.Tests/AssertEx.cs
@@ -1,9 +1,33 @@
 using System;
+using System.Globalization;
+using System.Linq;
 using System.Threading.Tasks;
+using KellermanSoftware.CompareNetObjects;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests {
 	public static class AssertEx {
+		private static ComparisonConfig Configuration = new ComparisonConfig {
+			IgnoreCollectionOrder = false,
+			MaxDifferences = 10,
+		};
+		public static void AssertUsingDeepCompare(object actual, object expected) {
+			var compareLogic = new CompareLogic(Configuration);
+			var result = compareLogic.Compare(actual, expected);
+			Assert.IsTrue(result.AreEqual, string.Join(Environment.NewLine, result.Differences.Select(x =>
+				$"{x.GetWhatIsCompared()}, Values ({FormatString(x.Object1)},{FormatString(x.Object2)})")));
+		}
+
+		private static string FormatString(object o) {
+			if (o == null) return string.Empty;
+			if (o is DateTime time) {
+				return time.ToString("MM/dd/yyyy HH:mm:ss.fff",
+					CultureInfo.InvariantCulture);
+			}
+
+			return o.ToString();
+		}
+		
 		public static async Task<TException> ThrowsAsync<TException>(Func<Task> code)
 			where TException : Exception {
 			var expected = default(TException);

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -11,6 +11,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+		<PackageReference Include="CompareNETObjects" Version="4.65.0" />
 	</ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.ClientAPI.Embedded\EventStore.ClientAPI.Embedded.csproj" />    

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -187,7 +187,9 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			bool? isAlive = null,
 			long? writerCheckpoint = null,
 			long? chaserCheckpoint = null) {
-			ClusterInfo.Members[nodeIndex] = ClusterInfo.Members[nodeIndex].Updated(state: role,
+			ClusterInfo.Members[nodeIndex] = ClusterInfo.Members[nodeIndex].Updated(
+				DateTime.UtcNow,
+				state: role,
 				isAlive: isAlive,
 				writerCheckpoint: writerCheckpoint,
 				chaserCheckpoint: chaserCheckpoint);

--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -82,7 +82,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				_nodes.Add(endPoint, inputBus);
 
 				var gossip = new NodeGossipService(outputBus, seedSource, nodeInfo, writerCheckpoint, readerCheckpoint,
-					epochManager, lastCommitPosition, 0, TimeSpan.FromMilliseconds(500), TimeSpan.FromDays(1));
+					epochManager, lastCommitPosition, 0, TimeSpan.FromMilliseconds(500), TimeSpan.FromDays(1),
+					_fakeTimeProvider);
 				inputBus.Subscribe<SystemMessage.SystemInit>(gossip);
 				inputBus.Subscribe<GossipMessage.RetrieveGossipSeedSources>(gossip);
 				inputBus.Subscribe<GossipMessage.GotGossipSeedSources>(gossip);

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -1,0 +1,845 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using EventStore.Core.Cluster;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Gossip;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.Tests.Services.ElectionsService;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.TransactionLog.Checkpoint;
+using NUnit.Framework;
+using MemberInfo = EventStore.Core.Cluster.MemberInfo;
+
+namespace EventStore.Core.Tests.Services.GossipService {
+	public abstract class NodeGossipServiceTestFixture {
+		protected NodeGossipService SUT;
+		protected FakePublisher _bus;
+		protected VNodeInfo _currentNode;
+		protected VNodeInfo _nodeTwo;
+		protected VNodeInfo _nodeThree;
+		protected ITimeProvider _timeProvider;
+		protected Func<MemberInfo[], MemberInfo> _getNodeToGossipTo;
+		protected IGossipSeedSource _gossipSeedSource;
+		protected TimeSpan _gossipInterval = TimeSpan.FromMilliseconds(1000);
+		private readonly TimeSpan _allowedTimeDifference = TimeSpan.FromMilliseconds(1000);
+
+		public NodeGossipServiceTestFixture() {
+			_bus = new FakePublisher();
+			_timeProvider = new FakeTimeProvider();
+
+			_currentNode = new VNodeInfo(
+				Guid.Parse("00000000-0000-0000-0000-000000000001"), 1,
+				new IPEndPoint(IPAddress.Loopback, 1111),
+				new IPEndPoint(IPAddress.Loopback, 1111),
+				new IPEndPoint(IPAddress.Loopback, 1111),
+				new IPEndPoint(IPAddress.Loopback, 1111),
+				new IPEndPoint(IPAddress.Loopback, 1111),
+				new IPEndPoint(IPAddress.Loopback, 1111), false);
+			_nodeTwo = new VNodeInfo(
+				Guid.Parse("00000000-0000-0000-0000-000000000002"), 2,
+				new IPEndPoint(IPAddress.Loopback, 2222),
+				new IPEndPoint(IPAddress.Loopback, 2222),
+				new IPEndPoint(IPAddress.Loopback, 2222),
+				new IPEndPoint(IPAddress.Loopback, 2222),
+				new IPEndPoint(IPAddress.Loopback, 2222),
+				new IPEndPoint(IPAddress.Loopback, 2222), false);
+			_nodeThree = new VNodeInfo(
+				Guid.Parse("00000000-0000-0000-0000-000000000003"), 3,
+				new IPEndPoint(IPAddress.Loopback, 3333),
+				new IPEndPoint(IPAddress.Loopback, 3333),
+				new IPEndPoint(IPAddress.Loopback, 3333),
+				new IPEndPoint(IPAddress.Loopback, 3333),
+				new IPEndPoint(IPAddress.Loopback, 3333),
+				new IPEndPoint(IPAddress.Loopback, 3333), false);
+
+			_getNodeToGossipTo = infos => infos.First(x => Equals(x.InternalHttpEndPoint, _nodeTwo.InternalHttp));
+			_gossipSeedSource = new KnownEndpointGossipSeedSource(new[]
+				{_currentNode.InternalHttp, _nodeTwo.InternalHttp, _nodeThree.InternalHttp});
+		}
+
+		[SetUp]
+		public void Setup() {
+			SUT = new NodeGossipService(_bus, _gossipSeedSource, _currentNode,
+				new InMemoryCheckpoint(0), new InMemoryCheckpoint(0), new FakeEpochManager(), () => 0L, 0,
+				_gossipInterval, _allowedTimeDifference, _timeProvider, _getNodeToGossipTo);
+
+			foreach (var message in Given()) {
+				SUT.Handle((dynamic)message);
+			}
+
+			_bus.Messages.Clear();
+
+			var when = When();
+			if (when != null) {
+				SUT.Handle((dynamic)when);
+			}
+		}
+
+		protected virtual Message[] Given() => Array.Empty<Message>();
+
+		protected virtual Message When() => null;
+
+		protected void ExpectMessages(params Message[] expected) =>
+			AssertEx.AssertUsingDeepCompare(_bus.Messages.ToArray(), expected);
+
+		protected void ExpectNoMessages() =>
+			Assert.IsEmpty(_bus.Messages);
+
+		protected Message[] GivenSystemInitializedWithKnownGossipSeedSources(params Message[] additionalGivens) {
+			return new Message[] {
+				new SystemMessage.SystemInit(),
+				new GossipMessage.GotGossipSeedSources(new[]
+					{_currentNode.InternalHttp, _nodeTwo.InternalHttp, _nodeThree.InternalHttp})
+			}.Concat(additionalGivens).ToArray();
+		}
+
+		protected static MemberInfo MemberInfoForVNode(VNodeInfo nodeInfo, DateTime utcNow,
+			int? nodePriority = null, int? epochNumber = null, long? writerCheckpoint = null,
+			VNodeState nodeState = VNodeState.Initializing) {
+			return MemberInfo.ForVNode(nodeInfo.InstanceId, utcNow, nodeState, true,
+				nodeInfo.InternalTcp, nodeInfo.InternalSecureTcp, nodeInfo.ExternalTcp,
+				nodeInfo.ExternalSecureTcp, nodeInfo.InternalHttp, nodeInfo.ExternalHttp,
+				0, writerCheckpoint ?? 0, 0, -1, epochNumber ?? -1, Guid.Empty, nodePriority ?? 0, false);
+		}
+
+		/// <summary>
+		/// The initial state for a node currently is represented as a Manager
+		/// </summary>
+		protected static MemberInfo InitialStateForVNode(VNodeInfo nodeInfo, DateTime utcNow, bool isAlive = true) {
+			return MemberInfo.ForManager(Guid.Empty, utcNow, isAlive, nodeInfo.InternalHttp,
+				nodeInfo.InternalHttp);
+		}
+	}
+
+	public class when_system_initializes : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			Array.Empty<Message>();
+
+		protected override Message When() =>
+			new SystemMessage.SystemInit();
+
+		[Test]
+		public void should_get_gossip_sources() {
+			ExpectMessages(
+				new GossipMessage.GotGossipSeedSources(new[]
+					{_currentNode.InternalHttp, _nodeTwo.InternalHttp, _nodeThree.InternalHttp}));
+		}
+	}
+
+	public class when_system_initializes_twice : NodeGossipServiceTestFixture {
+		protected override Message[] Given() => new Message[] {
+			new SystemMessage.SystemInit()
+		};
+
+		protected override Message When() =>
+			new SystemMessage.SystemInit();
+
+		[Test]
+		public void should_ignore_system_init() {
+			ExpectNoMessages();
+		}
+	}
+
+	public class when_retrieving_gossip_seed_sources : NodeGossipServiceTestFixture {
+		protected override Message[] Given() => new Message[] {
+			new SystemMessage.SystemInit()
+		};
+
+		protected override Message When() =>
+			new GossipMessage.RetrieveGossipSeedSources();
+
+		[Test]
+		public void should_get_gossip_seeds() {
+			ExpectMessages(
+				new GossipMessage.GotGossipSeedSources(new[]
+					{_currentNode.InternalHttp, _nodeTwo.InternalHttp, _nodeThree.InternalHttp}));
+		}
+	}
+
+	public class when_retrieving_gossip_seed_sources_and_gossip_seed_source_throws : NodeGossipServiceTestFixture {
+		class ThrowingGossipSeedSource : IGossipSeedSource {
+			public IAsyncResult BeginGetHostEndpoints(AsyncCallback requestCallback, object state) {
+				throw new NotImplementedException();
+			}
+
+			public IPEndPoint[] EndGetHostEndpoints(IAsyncResult asyncResult) {
+				throw new NotImplementedException();
+			}
+		}
+
+		public when_retrieving_gossip_seed_sources_and_gossip_seed_source_throws() {
+			_gossipSeedSource = new ThrowingGossipSeedSource();
+		}
+
+		protected override Message[] Given() => new Message[] {
+			new SystemMessage.SystemInit()
+		};
+
+		protected override Message When() =>
+			new GossipMessage.RetrieveGossipSeedSources();
+
+		[Test]
+		public void should_schedule_retry_retrieve_gossip_seed_sources() {
+			ExpectMessages(
+				TimerMessage.Schedule.Create(GossipServiceBase.DnsRetryTimeout, new PublishEnvelope(_bus),
+					new GossipMessage.RetrieveGossipSeedSources()));
+		}
+	}
+
+	public class when_got_gossip_seed_sources : NodeGossipServiceTestFixture {
+		protected override Message[] Given() => new Message[] {
+			new SystemMessage.SystemInit()
+		};
+
+		protected override Message When() =>
+			new GossipMessage.GotGossipSeedSources(new[]
+				{_currentNode.InternalHttp, _nodeTwo.InternalHttp, _nodeThree.InternalHttp});
+
+		[Test]
+		public void should_start_gossiping_and_schedule_another_gossip() {
+			ExpectMessages(
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp, new GossipMessage.SendGossip(new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_currentNode.InternalHttp), _timeProvider.LocalTime.Add(_gossipInterval)),
+				TimerMessage.Schedule.Create(GossipServiceBase.GossipStartupInterval, new PublishEnvelope(_bus),
+					new GossipMessage.Gossip(1)));
+		}
+	}
+
+	public class when_gossip : NodeGossipServiceTestFixture {
+		private int _gossipRound = GossipServiceBase.GossipRoundStartupThreshold + 1;
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources();
+
+		protected override Message When() =>
+			new GossipMessage.Gossip(_gossipRound);
+
+		[Test]
+		public void should_send_the_gossip_over_http_and_schedule_the_next_gossip() {
+			ExpectMessages(
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp, new GossipMessage.SendGossip(new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_currentNode.InternalHttp), _timeProvider.LocalTime.Add(_gossipInterval)),
+				TimerMessage.Schedule.Create(_gossipInterval, new PublishEnvelope(_bus),
+					new GossipMessage.Gossip(++_gossipRound)));
+		}
+	}
+
+	public class when_gossip_and_no_node_is_selected_to_gossip_to : NodeGossipServiceTestFixture {
+		private int _gossipRound = GossipServiceBase.GossipRoundStartupThreshold + 1;
+
+		public when_gossip_and_no_node_is_selected_to_gossip_to() {
+			_getNodeToGossipTo = infos => null;
+		}
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources();
+
+		protected override Message When() =>
+			new GossipMessage.Gossip(_gossipRound);
+
+		[Test]
+		public void should_just_schedule_next_gossip() {
+			ExpectMessages(TimerMessage.Schedule.Create(_gossipInterval, new PublishEnvelope(_bus),
+				new GossipMessage.Gossip(_gossipRound)));
+		}
+	}
+
+	public class when_gossip_and_gossip_service_is_not_in_working_state : NodeGossipServiceTestFixture {
+		protected override Message[] Given() => Array.Empty<Message>();
+
+		protected override Message When() =>
+			new GossipMessage.Gossip(1);
+
+		[Test]
+		public void should_ignore_message() {
+			ExpectNoMessages();
+		}
+	}
+
+	public class when_gossip_and_gossip_round_less_than_startup_gossip_threshold : NodeGossipServiceTestFixture {
+		private int _gossipRound = new Random().Next(0, GossipServiceBase.GossipRoundStartupThreshold);
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources();
+
+		protected override Message When() =>
+			new GossipMessage.Gossip(_gossipRound);
+
+		[Test]
+		public void should_use_startup_gossip_interval() {
+			ExpectMessages(
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp, new GossipMessage.SendGossip(new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_currentNode.InternalHttp), _timeProvider.LocalTime.Add(_gossipInterval)),
+				TimerMessage.Schedule.Create(GossipServiceBase.GossipStartupInterval, new PublishEnvelope(_bus),
+					new GossipMessage.Gossip(++_gossipRound)));
+		}
+	}
+
+	public class when_gossip_and_gossip_round_larger_than_startup_gossip_threshold : NodeGossipServiceTestFixture {
+		private int _gossipRound = new Random().Next(GossipServiceBase.GossipRoundStartupThreshold, int.MaxValue);
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources();
+
+		protected override Message When() =>
+			new GossipMessage.Gossip(_gossipRound);
+
+		[Test]
+		public void should_use_provided_gossip_interval_for_next_gossip() {
+			ExpectMessages(
+				new HttpMessage.SendOverHttp(_nodeTwo.InternalHttp, new GossipMessage.SendGossip(new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_currentNode.InternalHttp), _timeProvider.LocalTime.Add(_gossipInterval)),
+				TimerMessage.Schedule.Create(_gossipInterval, new PublishEnvelope(_bus),
+					new GossipMessage.Gossip(++_gossipRound)));
+		}
+	}
+
+	public class when_gossip_received_with_older_timestamp_about_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly DateTime _timestamp = DateTime.Now;
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timestamp),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timestamp.AddMilliseconds(-1)),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow)),
+				_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_about_the_node_even_if_outdated() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timestamp.AddMilliseconds(-1)),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow))));
+		}
+	}
+
+	public class when_gossip_received_with_lower_epoch_number_about_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly int _epochNumber = new Random().Next();
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, epochNumber: _epochNumber),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, epochNumber: _epochNumber - 1),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow)),
+				_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_about_the_node_even_if_outdated() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, epochNumber: _epochNumber - 1),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow))));
+		}
+	}
+
+	public class when_gossip_received_with_lower_writer_checkpoint_about_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly int _writerCheckpoint = new Random().Next();
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, writerCheckpoint: _writerCheckpoint),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, writerCheckpoint: _writerCheckpoint - 1),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow)),
+				_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_about_the_node_even_if_outdated() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, writerCheckpoint: _writerCheckpoint - 1),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow))));
+		}
+	}
+
+	public class when_gossip_received_with_more_recent_timestamp_about_non_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly DateTime _timestamp = DateTime.Now;
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeThree, _timestamp)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timestamp.AddMilliseconds(1))),
+				_nodeThree.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_if_its_more_recent() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timestamp.AddMilliseconds(1)))));
+		}
+	}
+
+	public class when_gossip_received_with_higher_epoch_number_about_non_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly int _epochNumber = new Random().Next();
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, epochNumber: _epochNumber)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, epochNumber: _epochNumber + 1)),
+				_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_if_its_more_recent() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, epochNumber: _epochNumber + 1))));
+		}
+	}
+
+	public class when_gossip_received_with_higher_writer_checkpoint_about_non_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly int _writerCheckpoint = new Random().Next();
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, writerCheckpoint: _writerCheckpoint)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, writerCheckpoint: _writerCheckpoint + 1)),
+				_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_if_its_more_recent() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, writerCheckpoint: _writerCheckpoint + 1))));
+		}
+	}
+
+	public class when_state_changed_to_master : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow, nodeState: VNodeState.Initializing),
+						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new SystemMessage.BecomeMaster(Guid.NewGuid());
+
+		[Test]
+		public void should_update_gossip() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow, nodeState: VNodeState.Master),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow))));
+		}
+	}
+
+	public class when_state_changed_to_non_master : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow, nodeState: VNodeState.Initializing),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)), _nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new SystemMessage.BecomeSlave(Guid.NewGuid(), _nodeTwo);
+
+		[Test]
+		public void should_update_gossip() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow, nodeState: VNodeState.Slave),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow))));
+		}
+	}
+
+	public class when_gossip_send_failed : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources();
+
+		protected override Message When() =>
+			new GossipMessage.GossipSendFailed("failed", _nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_mark_the_node_as_dead() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow, isAlive: false),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow))));
+		}
+	}
+
+	public class when_gossip_send_failed_to_a_dead_node : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow, isAlive: false),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)), _nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() => new GossipMessage.GossipSendFailed("failed",
+			_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_ignore_message() {
+			ExpectNoMessages();
+		}
+	}
+
+	public class when_gossip_send_failed_to_the_current_master_node : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, nodeState: VNodeState.Master)),
+					_nodeTwo.InternalHttp),
+				new SystemMessage.BecomeSlave(Guid.NewGuid(), _nodeTwo)
+			);
+
+		protected override Message When() => new GossipMessage.GossipSendFailed("failed",
+			_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_ignore_message_and_wait_for_tcp_to_decide() {
+			ExpectNoMessages();
+		}
+	}
+
+	public class when_vnode_connection_lost : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)), _nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new SystemMessage.VNodeConnectionLost(_currentNode.InternalHttp, Guid.NewGuid());
+
+		[Test]
+		public void should_issue_get_gossip() {
+			ExpectMessages(
+				new HttpMessage.SendOverHttp(_currentNode.InternalHttp, new GossipMessage.GetGossip(),
+					_timeProvider.LocalTime.Add(GossipServiceBase.GossipTimeout)));
+		}
+	}
+
+	public class when_vnode_connection_lost_to_dead_node : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow, isAlive: false),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)), _nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new SystemMessage.VNodeConnectionLost(_nodeTwo.InternalHttp, Guid.NewGuid());
+
+		[Test]
+		public void should_ignore_message() {
+			ExpectNoMessages();
+		}
+	}
+
+	public class when_get_gossip_received_with_more_recent_timestamp_about_non_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly DateTime _timestamp = DateTime.Now;
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeThree, _timestamp)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GetGossipReceived(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timestamp.AddMilliseconds(1))),
+				_nodeThree.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_if_its_more_recent() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timestamp.AddMilliseconds(1)))));
+		}
+	}
+
+	public class when_get_gossip_received_with_higher_epoch_number_about_non_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly int _epochNumber = new Random().Next();
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, epochNumber: _epochNumber)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GetGossipReceived(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, epochNumber: _epochNumber + 1)),
+				_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_if_its_more_recent() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, epochNumber: _epochNumber + 1))));
+		}
+	}
+
+	public class when_get_gossip_received_with_higher_writer_checkpoint_about_non_peer_node :
+		NodeGossipServiceTestFixture {
+		private readonly int _writerCheckpoint = new Random().Next();
+
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow,
+							writerCheckpoint: _writerCheckpoint)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GetGossipReceived(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow,
+						writerCheckpoint: _writerCheckpoint + 1)),
+				_nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_accept_the_information_if_its_more_recent() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow,
+						writerCheckpoint: _writerCheckpoint + 1))));
+		}
+	}
+
+	public class
+		when_get_gossip_received_and_gossip_service_is_not_in_working_state : NodeGossipServiceTestFixture {
+		protected override Message[] Given() => Array.Empty<Message>();
+
+		protected override Message When() =>
+			new GossipMessage.GetGossipReceived(new ClusterInfo(), _nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_ignore_message() {
+			ExpectNoMessages();
+		}
+	}
+
+	public class
+		when_get_gossip_failed_and_gossip_service_is_not_in_working_state : NodeGossipServiceTestFixture {
+		protected override Message[] Given() => Array.Empty<Message>();
+
+		protected override Message When() =>
+			new GossipMessage.GetGossipFailed("failed", _nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_ignore_message() {
+			ExpectNoMessages();
+		}
+	}
+
+	public class when_get_gossip_failed : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow, isAlive: true),
+						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_currentNode.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new GossipMessage.GetGossipFailed("failed", _nodeTwo.InternalHttp);
+
+		[Test]
+		public void should_mark_node_as_dead() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow, isAlive: false),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow))));
+		}
+	}
+
+	public class when_vnode_connection_established : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow, isAlive: false),
+						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
+					_currentNode.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new SystemMessage.VNodeConnectionEstablished(_nodeTwo.InternalHttp, Guid.NewGuid());
+
+		[Test]
+		public void should_mark_node_as_alive() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+					InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow, isAlive: true),
+					InitialStateForVNode(_nodeThree, _timeProvider.UtcNow))
+				));
+		}
+	}
+
+	public class when_elections_are_done : NodeGossipServiceTestFixture {
+		protected override Message[] Given() =>
+			GivenSystemInitializedWithKnownGossipSeedSources(
+				new GossipMessage.GossipReceived(new NoopEnvelope(), new ClusterInfo(
+						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow,
+							nodeState: VNodeState.Initializing),
+						MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Initializing),
+						MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow,
+							nodeState: VNodeState.Initializing)),
+					_nodeTwo.InternalHttp)
+			);
+
+		protected override Message When() =>
+			new ElectionMessage.ElectionsDone(0,
+				MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Master));
+
+		[Test]
+		public void should_set_master_node_and_other_nodes_to_unknown() {
+			ExpectMessages(
+				new GossipMessage.GossipUpdated(new ClusterInfo(
+					MemberInfoForVNode(_currentNode, _timeProvider.UtcNow, nodeState: VNodeState.Unknown),
+					MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Master),
+					MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow, nodeState: VNodeState.Unknown))));
+		}
+	}
+
+	public class when_updating_node_priority : NodeGossipServiceTestFixture {
+		private readonly int _nodePriority = new Random().Next();
+		protected override Message[] Given() => GivenSystemInitializedWithKnownGossipSeedSources();
+
+		protected override Message When() {
+			return new GossipMessage.UpdateNodePriority(_nodePriority);
+		}
+
+		[Test]
+		public void should_set_node_priority() {
+			var clusterInfo = new ClusterInfo(
+				MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
+				MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow),
+				MemberInfoForVNode(_nodeThree, _timeProvider.UtcNow));
+
+			SUT.Handle(new GossipMessage.GossipReceived(new NoopEnvelope(), clusterInfo,
+				_nodeTwo.InternalHttp));
+			var memberInfo = _bus.Messages.OfType<GossipMessage.GossipUpdated>().First().ClusterInfo.Members
+				.First(x => x.InstanceId == _currentNode.InstanceId);
+			Assert.AreEqual(memberInfo.NodePriority, _nodePriority);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -842,4 +842,51 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			Assert.AreEqual(memberInfo.NodePriority, _nodePriority);
 		}
 	}
+
+	public class when_updating_cluster {
+		private static MemberInfo TestNodeFor(int identifier, bool isAlive, DateTime timeStamp) {
+			var ipEndpoint = new IPEndPoint(IPAddress.Loopback, identifier);
+			return MemberInfo.ForVNode(Guid.NewGuid(), timeStamp, VNodeState.Initializing, isAlive,
+				ipEndpoint, ipEndpoint, ipEndpoint, ipEndpoint, ipEndpoint, ipEndpoint,
+				0, 0, 0, -1, -1, Guid.Empty, 0, false);
+		}
+
+		[Test]
+		public void
+			should_remove_dead_members_which_have_timestamps_older_than_the_allowed_dead_member_removal_timeout() {
+			var timeProvider = new FakeTimeProvider();
+			var deadMemberRemovalTimeout = TimeSpan.FromSeconds(1);
+
+			var nodeToBeRemoved =
+				TestNodeFor(2, isAlive: false, timeProvider.UtcNow.Subtract(deadMemberRemovalTimeout));
+			
+			var updatedCluster = GossipServiceBase.UpdateCluster(new ClusterInfo(
+					TestNodeFor(1, isAlive: false, timeProvider.UtcNow),
+					nodeToBeRemoved,
+					TestNodeFor(3, isAlive: false, timeProvider.UtcNow)), info => info,
+				timeProvider, deadMemberRemovalTimeout);
+
+			Assert.That(updatedCluster.Members, Has.Length.EqualTo(2));
+			Assert.IsFalse(updatedCluster.Members.Any(x => x.Is(nodeToBeRemoved.InternalHttpEndPoint)));
+		}
+		
+		[Test]
+		public void
+			should_not_remove_alive_members_which_have_timestamps_older_than_the_allowed_dead_member_removal_timeout() {
+			var timeProvider = new FakeTimeProvider();
+			var deadMemberRemovalTimeout = TimeSpan.FromSeconds(1);
+
+			var nodeToNotBeRemoved =
+				TestNodeFor(2, isAlive: true, timeProvider.UtcNow.Subtract(deadMemberRemovalTimeout));
+			
+			var updatedCluster = GossipServiceBase.UpdateCluster(new ClusterInfo(
+					TestNodeFor(1, isAlive: false, timeProvider.UtcNow),
+					nodeToNotBeRemoved,
+					TestNodeFor(3, isAlive: false, timeProvider.UtcNow)), info => info,
+				timeProvider, deadMemberRemovalTimeout);
+
+			Assert.That(updatedCluster.Members, Has.Length.EqualTo(3));
+			Assert.IsTrue(updatedCluster.Members.Any(x => x.Is(nodeToNotBeRemoved.InternalHttpEndPoint)));
+		}
+	}
 }

--- a/src/EventStore.Core/Cluster/MemberInfo.cs
+++ b/src/EventStore.Core/Cluster/MemberInfo.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Cluster {
 
 		public static MemberInfo ForManager(Guid instanceId, DateTime timeStamp, bool isAlive,
 			IPEndPoint internalHttpEndPoint, IPEndPoint externalHttpEndPoint) {
-			return new MemberInfo(instanceId, timeStamp, VNodeState.Manager, true,
+			return new MemberInfo(instanceId, timeStamp, VNodeState.Manager, isAlive,
 				internalHttpEndPoint, null, externalHttpEndPoint, null,
 				internalHttpEndPoint, externalHttpEndPoint,
 				-1, -1, -1, -1, -1, Guid.Empty, 0, false);
@@ -139,7 +139,8 @@ namespace EventStore.Core.Cluster {
 			           || (ExternalSecureTcpEndPoint != null && ExternalSecureTcpEndPoint.Equals(endPoint)));
 		}
 
-		public MemberInfo Updated(VNodeState? state = null,
+		public MemberInfo Updated(DateTime utcNow,
+			VNodeState? state = null,
 			bool? isAlive = null,
 			long? lastCommitPosition = null,
 			long? writerCheckpoint = null,
@@ -147,7 +148,7 @@ namespace EventStore.Core.Cluster {
 			EpochRecord epoch = null,
 			int? nodePriority = null) {
 			return new MemberInfo(InstanceId,
-				DateTime.UtcNow,
+				utcNow,
 				state ?? State,
 				isAlive ?? IsAlive,
 				InternalTcpEndPoint,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -700,6 +700,8 @@ namespace EventStore.Core {
 				_mainBus.Subscribe<GossipMessage.UpdateNodePriority>(gossip);
 				_mainBus.Subscribe<SystemMessage.VNodeConnectionEstablished>(gossip);
 				_mainBus.Subscribe<SystemMessage.VNodeConnectionLost>(gossip);
+				_mainBus.Subscribe<GossipMessage.GetGossipFailed>(gossip);
+				_mainBus.Subscribe<GossipMessage.GetGossipReceived>(gossip);
 				_mainBus.Subscribe<ElectionMessage.ElectionsDone>(gossip);
 			}
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -689,7 +689,8 @@ namespace EventStore.Core {
 				var gossip = new NodeGossipService(_mainQueue, gossipSeedSource, gossipInfo, db.Config.WriterCheckpoint,
 					db.Config.ChaserCheckpoint, epochManager, () => readIndex.LastCommitPosition,
 					vNodeSettings.NodePriority, vNodeSettings.GossipInterval,
-					vNodeSettings.GossipAllowedTimeDifference);
+					vNodeSettings.GossipAllowedTimeDifference,
+					_timeProvider);
 				_mainBus.Subscribe<SystemMessage.SystemInit>(gossip);
 				_mainBus.Subscribe<GossipMessage.RetrieveGossipSeedSources>(gossip);
 				_mainBus.Subscribe<GossipMessage.GotGossipSeedSources>(gossip);

--- a/src/EventStore.Core/Messages/GossipMessage.cs
+++ b/src/EventStore.Core/Messages/GossipMessage.cs
@@ -75,7 +75,7 @@ namespace EventStore.Core.Messages {
 				ServerEndPoint = serverEndPoint;
 			}
 		}
-
+		
 		public class GossipUpdated : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 
@@ -107,6 +107,52 @@ namespace EventStore.Core.Messages {
 
 			public override string ToString() {
 				return String.Format("Reason: {0}, Recipient: {1}", Reason, Recipient);
+			}
+		}
+		
+		public class GetGossip : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public GetGossip() { }
+		}
+		
+		public class GetGossipFailed : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public readonly string Reason;
+			public readonly IPEndPoint Recipient;
+
+			public GetGossipFailed(string reason, IPEndPoint recipient) {
+				Reason = reason;
+				Recipient = recipient;
+			}
+
+			public override string ToString() {
+				return String.Format("Reason: {0}, Recipient: {1}", Reason, Recipient);
+			}
+		}
+		
+		public class GetGossipReceived : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public readonly ClusterInfo ClusterInfo;
+			public readonly IPEndPoint Server;
+
+			public GetGossipReceived(ClusterInfo clusterInfo, IPEndPoint server) {
+				ClusterInfo = clusterInfo;
+				Server = server;
 			}
 		}
 

--- a/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
@@ -131,7 +131,7 @@ namespace EventStore.Core.Services.Gossip {
 			}
 
 			var interval = message.GossipRound < GossipRoundStartupThreshold ? GossipStartupInterval : GossipInterval;
-			var gossipRound = Math.Min(int.MaxValue, node == null ? message.GossipRound : message.GossipRound + 1);
+			var gossipRound = Math.Min(int.MaxValue - 1, node == null ? message.GossipRound : message.GossipRound + 1);
 			_bus.Publish(
 				TimerMessage.Schedule.Create(interval, _publishEnvelope, new GossipMessage.Gossip(gossipRound)));
 		}

--- a/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using System.Text;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
@@ -25,16 +24,17 @@ namespace EventStore.Core.Services.Gossip {
 		IHandle<GossipMessage.GetGossipReceived>,
 		IHandle<GossipMessage.GetGossipFailed>,
 		IHandle<ElectionMessage.ElectionsDone> {
-		private static readonly TimeSpan DnsRetryTimeout = TimeSpan.FromMilliseconds(1000);
-		private static readonly TimeSpan GossipTimeout = TimeSpan.FromMilliseconds(1000);
-		private static readonly TimeSpan GossipStartupInterval = TimeSpan.FromMilliseconds(100);
+		public const int GossipRoundStartupThreshold = 20;
+		public static readonly TimeSpan DnsRetryTimeout = TimeSpan.FromMilliseconds(1000);
+		public static readonly TimeSpan GossipTimeout = TimeSpan.FromMilliseconds(1000);
+		public static readonly TimeSpan GossipStartupInterval = TimeSpan.FromMilliseconds(100);
 		private static readonly TimeSpan DeadMemberRemovalTimeout = TimeSpan.FromMinutes(30);
 
 		private static readonly ILogger Log = LogManager.GetLoggerFor<GossipServiceBase>();
 
 		protected readonly VNodeInfo NodeInfo;
 		protected VNodeState CurrentRole = VNodeState.Initializing;
-		protected VNodeInfo CurrentMaster;
+		private VNodeInfo CurrentMaster;
 		private readonly TimeSpan GossipInterval = TimeSpan.FromMilliseconds(1000);
 		private readonly TimeSpan AllowedTimeDifference = TimeSpan.FromMinutes(30);
 
@@ -45,15 +45,20 @@ namespace EventStore.Core.Services.Gossip {
 		private GossipState _state;
 		private ClusterInfo _cluster;
 		private readonly Random _rnd = new Random(Math.Abs(Environment.TickCount));
+		private ITimeProvider _timeProvider;
+		private Func<MemberInfo[], MemberInfo> _getNodeToGossipTo;
 
 		protected GossipServiceBase(IPublisher bus,
 			IGossipSeedSource gossipSeedSource,
 			VNodeInfo nodeInfo,
 			TimeSpan gossipInterval,
-			TimeSpan allowedTimeDifference) {
+			TimeSpan allowedTimeDifference,
+			ITimeProvider timeProvider,
+			Func<MemberInfo[], MemberInfo> getNodeToGossipTo = null) {
 			Ensure.NotNull(bus, "bus");
 			Ensure.NotNull(gossipSeedSource, "gossipSeedSource");
 			Ensure.NotNull(nodeInfo, "nodeInfo");
+			Ensure.NotNull(timeProvider, nameof(timeProvider));
 
 			_bus = bus;
 			_publishEnvelope = new PublishEnvelope(bus);
@@ -62,6 +67,8 @@ namespace EventStore.Core.Services.Gossip {
 			GossipInterval = gossipInterval;
 			AllowedTimeDifference = allowedTimeDifference;
 			_state = GossipState.Startup;
+			_timeProvider = timeProvider;
+			_getNodeToGossipTo = getNodeToGossipTo ?? GetNodeToGossipTo;
 		}
 
 		protected abstract MemberInfo GetInitialMe();
@@ -97,7 +104,7 @@ namespace EventStore.Core.Services.Gossip {
 		}
 
 		public void Handle(GossipMessage.GotGossipSeedSources message) {
-			var now = DateTime.UtcNow;
+			var now = _timeProvider.UtcNow;
 			var dnsCluster = new ClusterInfo(
 				message.GossipSeeds.Select(x => MemberInfo.ForManager(Guid.Empty, now, true, x, x)).ToArray());
 
@@ -106,22 +113,24 @@ namespace EventStore.Core.Services.Gossip {
 			LogClusterChange(oldCluster, _cluster, null);
 
 			_state = GossipState.Working;
-			Handle(new GossipMessage.Gossip(0)); // start gossiping
+			Handle(new GossipMessage.Gossip(0));
 		}
 
 		public void Handle(GossipMessage.Gossip message) {
 			if (_state != GossipState.Working)
 				return;
 
-			var node = GetNodeToGossipTo(_cluster.Members);
+			var node = _getNodeToGossipTo(_cluster.Members);
 			if (node != null) {
-				_cluster = UpdateCluster(_cluster, x => x.InstanceId == NodeInfo.InstanceId ? GetUpdatedMe(x) : x);
+				_cluster = UpdateCluster(_cluster, x => x.InstanceId == NodeInfo.InstanceId ? GetUpdatedMe(x) : x,
+					_timeProvider);
 				_bus.Publish(new HttpMessage.SendOverHttp(node.InternalHttpEndPoint,
-					new GossipMessage.SendGossip(_cluster, NodeInfo.InternalHttp), DateTime.Now.Add(GossipInterval)));
+					new GossipMessage.SendGossip(_cluster, NodeInfo.InternalHttp),
+					_timeProvider.LocalTime.Add(GossipInterval)));
 			}
 
-			var interval = message.GossipRound < 20 ? GossipStartupInterval : GossipInterval;
-			var gossipRound = Math.Min(2000000000, node == null ? message.GossipRound : message.GossipRound + 1);
+			var interval = message.GossipRound < GossipRoundStartupThreshold ? GossipStartupInterval : GossipInterval;
+			var gossipRound = Math.Min(int.MaxValue, node == null ? message.GossipRound : message.GossipRound + 1);
 			_bus.Publish(
 				TimerMessage.Schedule.Create(interval, _publishEnvelope, new GossipMessage.Gossip(gossipRound)));
 		}
@@ -159,10 +168,9 @@ namespace EventStore.Core.Services.Gossip {
 			CurrentRole = message.State;
 			var replicaState = message as SystemMessage.ReplicaStateMessage;
 			CurrentMaster = replicaState == null ? null : replicaState.Master;
-			_cluster = UpdateCluster(_cluster, x => x.InstanceId == NodeInfo.InstanceId ? GetUpdatedMe(x) : x);
+			_cluster = UpdateCluster(_cluster, x => x.InstanceId == NodeInfo.InstanceId ? GetUpdatedMe(x) : x,
+				_timeProvider);
 
-			//if (_cluster.HasChangedSince(oldCluster))
-			//LogClusterChange(oldCluster, _cluster, _nodeInfo.InternalHttp);
 			_bus.Publish(new GossipMessage.GossipUpdated(_cluster));
 		}
 
@@ -181,7 +189,9 @@ namespace EventStore.Core.Services.Gossip {
 			Log.Trace("Looks like node [{nodeEndPoint}] is DEAD (Gossip send failed).", message.Recipient);
 
 			var oldCluster = _cluster;
-			_cluster = UpdateCluster(_cluster, x => x.Is(message.Recipient) ? x.Updated(isAlive: false) : x);
+			_cluster = UpdateCluster(_cluster, x => x.Is(message.Recipient)
+					? x.Updated(_timeProvider.UtcNow, isAlive: false) : x,
+				_timeProvider);
 			if (_cluster.HasChangedSince(oldCluster))
 				LogClusterChange(oldCluster, _cluster, string.Format("gossip send failed to [{0}]", message.Recipient));
 			_bus.Publish(new GossipMessage.GossipUpdated(_cluster));
@@ -195,7 +205,7 @@ namespace EventStore.Core.Services.Gossip {
 			Log.Trace("Looks like node [{nodeEndPoint}] is DEAD (TCP connection lost). Issuing a gossip to confirm.",
 				message.VNodeEndPoint);
 			_bus.Publish(new HttpMessage.SendOverHttp(node.InternalHttpEndPoint,
-				new GossipMessage.GetGossip(), DateTime.Now.Add(GossipTimeout)));
+				new GossipMessage.GetGossip(), _timeProvider.LocalTime.Add(GossipTimeout)));
 		}
 
 		public void Handle(GossipMessage.GetGossipReceived message) {
@@ -218,12 +228,16 @@ namespace EventStore.Core.Services.Gossip {
 		public void Handle(GossipMessage.GetGossipFailed message) {
 			if (_state != GossipState.Working)
 				return;
-			
+
 			Log.Trace("Gossip Failed, The node [{nodeEndpoint}] is being marked as DEAD.",
 				message.Recipient);
 
 			var oldCluster = _cluster;
-			_cluster = UpdateCluster(_cluster, x => x.Is(message.Recipient) ? x.Updated(isAlive: false) : x);
+			_cluster = UpdateCluster(_cluster, x => x.Is(message.Recipient)
+					? x.Updated(
+						_timeProvider.UtcNow, isAlive: false)
+					: x,
+				_timeProvider);
 			if (_cluster.HasChangedSince(oldCluster))
 				LogClusterChange(oldCluster, _cluster,
 					string.Format("TCP connection lost to [{0}]", message.Recipient));
@@ -232,7 +246,11 @@ namespace EventStore.Core.Services.Gossip {
 
 		public void Handle(SystemMessage.VNodeConnectionEstablished message) {
 			var oldCluster = _cluster;
-			_cluster = UpdateCluster(_cluster, x => x.Is(message.VNodeEndPoint) ? x.Updated(isAlive: true) : x);
+			_cluster = UpdateCluster(_cluster, x => x.Is(message.VNodeEndPoint)
+					? x.Updated(
+						_timeProvider.UtcNow, isAlive: true)
+					: x,
+				_timeProvider);
 			if (_cluster.HasChangedSince(oldCluster))
 				LogClusterChange(oldCluster, _cluster,
 					string.Format("TCP connection established to [{0}]", message.VNodeEndPoint));
@@ -243,8 +261,9 @@ namespace EventStore.Core.Services.Gossip {
 			var oldCluster = _cluster;
 			_cluster = UpdateCluster(_cluster,
 				x => x.InstanceId == message.Master.InstanceId
-					? x.Updated(VNodeState.Master)
-					: x.Updated(VNodeState.Unknown));
+					? x.Updated(_timeProvider.UtcNow, VNodeState.Master)
+					: x.Updated(_timeProvider.UtcNow, VNodeState.Unknown),
+				_timeProvider);
 			if (_cluster.HasChangedSince(oldCluster))
 				LogClusterChange(oldCluster, _cluster, "Elections Done");
 			_bus.Publish(new GossipMessage.GossipUpdated(_cluster));
@@ -252,39 +271,40 @@ namespace EventStore.Core.Services.Gossip {
 
 		private ClusterInfo MergeClusters(ClusterInfo myCluster, ClusterInfo othersCluster,
 			IPEndPoint peerEndPoint, Func<MemberInfo, MemberInfo> update) {
-			var mems = myCluster.Members.ToDictionary(member => member.InternalHttpEndPoint);
+			var members = myCluster.Members.ToDictionary(member => member.InternalHttpEndPoint);
 			foreach (var member in othersCluster.Members) {
 				if (member.InstanceId == NodeInfo.InstanceId || member.Is(NodeInfo.InternalHttp)
 				) // we know about ourselves better
 					continue;
 				if (peerEndPoint != null && member.Is(peerEndPoint)) // peer knows about itself better
 				{
-					if ((DateTime.UtcNow - member.TimeStamp).Duration() > AllowedTimeDifference) {
+					if ((_timeProvider.UtcNow - member.TimeStamp).Duration() > AllowedTimeDifference) {
 						Log.Error("Time difference between us and [{peerEndPoint}] is too great! "
 						          + "UTC now: {dateTime:yyyy-MM-dd HH:mm:ss.fff}, peer's time stamp: {peerTimestamp:yyyy-MM-dd HH:mm:ss.fff}.",
-							peerEndPoint, DateTime.UtcNow, member.TimeStamp);
+							peerEndPoint, _timeProvider.UtcNow, member.TimeStamp);
 					}
 
-					mems[member.InternalHttpEndPoint] = member;
+					members[member.InternalHttpEndPoint] = member;
 				} else {
 					MemberInfo existingMem;
 					// if there is no data about this member or data is stale -- update
-					if (!mems.TryGetValue(member.InternalHttpEndPoint, out existingMem) ||
+					if (!members.TryGetValue(member.InternalHttpEndPoint, out existingMem) ||
 					    IsMoreUpToDate(member, existingMem)) {
 						// we do not trust master's alive status and state to come from outside
 						if (CurrentMaster != null && existingMem != null &&
 						    member.InstanceId == CurrentMaster.InstanceId)
-							mems[member.InternalHttpEndPoint] =
-								member.Updated(isAlive: existingMem.IsAlive, state: existingMem.State);
+							members[member.InternalHttpEndPoint] =
+								member.Updated(utcNow: _timeProvider.UtcNow, isAlive: existingMem.IsAlive,
+									state: existingMem.State);
 						else
-							mems[member.InternalHttpEndPoint] = member;
+							members[member.InternalHttpEndPoint] = member;
 					}
 				}
 			}
 
 			// update members and remove dead timed-out members, if there are any
-			var newMembers = mems.Values.Select(update)
-				.Where(x => x.IsAlive || DateTime.UtcNow - x.TimeStamp < DeadMemberRemovalTimeout);
+			var newMembers = members.Values.Select(update)
+				.Where(x => x.IsAlive || _timeProvider.UtcNow - x.TimeStamp < DeadMemberRemovalTimeout);
 			return new ClusterInfo(newMembers);
 		}
 
@@ -296,10 +316,11 @@ namespace EventStore.Core.Services.Gossip {
 			return member.TimeStamp > existingMem.TimeStamp;
 		}
 
-		private static ClusterInfo UpdateCluster(ClusterInfo cluster, Func<MemberInfo, MemberInfo> update) {
+		private static ClusterInfo UpdateCluster(ClusterInfo cluster, Func<MemberInfo, MemberInfo> update,
+			ITimeProvider timeProvider) {
 			// update members and remove dead timed-out members, if there are any
 			var newMembers = cluster.Members.Select(update)
-				.Where(x => x.IsAlive || DateTime.UtcNow - x.TimeStamp < DeadMemberRemovalTimeout);
+				.Where(x => x.IsAlive || timeProvider.UtcNow - x.TimeStamp < DeadMemberRemovalTimeout);
 			return new ClusterInfo(newMembers);
 		}
 


### PR DESCRIPTION
When elections occur and a new master node is elected, we drop the TCP Connection and reconnect to the new master. We however mark the previous node as dead during this time which isn't entirely accurate.

This work introduces a double check on the liveness of a node by issuing a new `GetGossip` (The name could be better) when the subscription TCP Connection is dropped (`VNodeConnectionLost`) instead of assuming the node is dead immediately.

We then mark the node as **dead** if the `GetGossip` fails or mark the node as **alive** if the `GetGossip` succeeds.

This will provide a little more stability for example during elections, specifically in cases where a master resignation has been performed and a new master gets elected.

Ref: #1917