### PR TITLE
Set the default to false for WriteStatsToDb

### DIFF
--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -428,6 +428,6 @@ namespace EventStore.Core.Util {
 		public static readonly int MaxAutoMergeIndexLevelDefault = int.MaxValue;
 
 		public const string WriteStatsToDbDescr = "Set this option to write statistics to the database.";
-		public const bool WriteStatsToDbDefault = true;
+		public const bool WriteStatsToDbDefault = false;
 	}
 }


### PR DESCRIPTION
For Event Store V6, we will no longer by default write stats to the database. Writing stats to the database can be enabled by setting `WriteStatsToDb` to `true`.