### PR TITLE
Include projection dependencies in output

### DIFF
--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -32,10 +32,23 @@
     <IsMac>false</IsMac>
     <IsMac Condition="('$(OS)' == 'Unix') And (Exists ('/Library/Frameworks'))">true</IsMac>
   </PropertyGroup>
-  <Target Name="CopyJs1" BeforeTargets="BeforeBuild">
-    <Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\linux\libjs1.so" DestinationFolder="$(OutDir)" Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'false'" />
-    <Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\mac\libjs1.dylib" DestinationFolder="$(OutDir)" Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'true'" />
-    <Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\win\js1.dll" DestinationFolder="$(OutDir)" Condition=" '$(OS)' == 'Windows_NT' " />
-    <Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\win\js1.pdb" DestinationFolder="$(OutDir)" Condition=" '$(OS)' == 'Windows_NT' " />
-  </Target>
+	<ItemGroup>
+		<Content Include="..\EventStore.Projections.Core\Prelude\**\*">
+			<PackagePath>Prelude</PackagePath>
+			<Link>Prelude/%(RecursiveDir)%(Filename)%(Extension)</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\libs\x64\win\js1.dll;..\libs\x64\win\js1.pdb" Condition=" '$(OS)' == 'Windows_NT' ">
+			<PackagePath>runtimes/win-x64/native/js1.dll</PackagePath>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\libs\x64\linux\libjs1.so" Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'false'">
+			<PackagePath>runtimes/linux-x64/native/libjs1.so</PackagePath>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+		<Content Include="..\libs\x64\mac\libjs1.dylib" Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'true'">
+			<PackagePath>runtimes/osx-x64/native/libjs1.dylib</PackagePath>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
js1.dll, libjs1.so and libjs1.dylib (dependent on operating system) are required for projections to
function. We need to include them when publishing via dotnet publish