### PR TITLE
Handle GRPC Client Cancellations Better

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -66,6 +66,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			public async ValueTask<bool> MoveNextAsync() {
 				ReadLoop:
+				if (_disposedTokenSource.IsCancellationRequested) {
+					return false;
+				}
+
 				if (_buffer.TryDequeue(out var current)) {
 					_current = current;
 					return true;
@@ -90,7 +94,15 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					return true;
 				}
 
-				await Task.Delay(100, _disposedTokenSource.Token).ConfigureAwait(false);
+				if (_disposedTokenSource.IsCancellationRequested) {
+					return false;
+				}
+
+				try {
+					await Task.Delay(100, _disposedTokenSource.Token).ConfigureAwait(false);
+				} catch (ObjectDisposedException) {
+					return false;
+				}
 
 				goto ReadLoop;
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
@@ -55,6 +55,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
+				if (_disposedTokenSource.IsCancellationRequested) {
+					return false;
+				}
+
 				if (_buffer.TryDequeue(out var current)) {
 					_current = current;
 					return true;
@@ -76,6 +80,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_resolveLinks, false, default, _user));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
+					return false;
+				}
+
+				if (_disposedTokenSource.IsCancellationRequested) {
 					return false;
 				}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
@@ -72,6 +72,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
+				if (_disposedTokenSource.IsCancellationRequested) {
+					return false;
+				}
+
 				if (_buffer.TryDequeue(out var current)) {
 					_current = current;
 					return true;
@@ -93,6 +97,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_resolveLinks, false, _maxSearchWindow, default, _eventFilter, _user));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
+					return false;
+				}
+
+				if (_disposedTokenSource.IsCancellationRequested) {
 					return false;
 				}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
@@ -55,6 +55,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
+				if (_disposedTokenSource.IsCancellationRequested) {
+					return false;
+				}
+
 				if (_buffer.TryDequeue(out var current)) {
 					_current = current;
 					return true;
@@ -74,6 +78,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					correlationId, correlationId, new CallbackEnvelope(OnMessage),
 					commitPosition, preparePosition, Math.Min(_maxCount, 32),
 					_resolveLinks, false, default, _user));
+
+				if (_disposedTokenSource.IsCancellationRequested) {
+					return false;
+				}
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
 					return false;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
@@ -72,6 +72,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
+				if (_disposedTokenSource.IsCancellationRequested) {
+					return false;
+				}
+
 				if (_buffer.TryDequeue(out var current)) {
 					_current = current;
 					return true;
@@ -93,6 +97,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_resolveLinks, false, _maxSearchWindow, default, _eventFilter, _user));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
+					return false;
+				}
+
+				if (_disposedTokenSource.IsCancellationRequested) {
 					return false;
 				}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				if (_readCount >= _maxCount) {
+				if (_readCount >= _maxCount || _disposedTokenSource.IsCancellationRequested) {
 					return false;
 				}
 
@@ -87,6 +87,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_resolveLinks, false, default, _user));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
+					return false;
+				}
+
+				if (_disposedTokenSource.IsCancellationRequested) {
 					return false;
 				}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
@@ -61,7 +61,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				if (_readCount >= _maxCount) {
+				if (_readCount >= _maxCount || _disposedTokenSource.IsCancellationRequested) {
 					return false;
 				}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -218,7 +218,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				(ResolvedEvent, int, Exception) _;
 
 				while (!_sendQueue.TryDequeue(out _)) {
-					await Task.Delay(1, _disposedTokenSource.Token).ConfigureAwait(false);
+					try {
+						await Task.Delay(1, _disposedTokenSource.Token).ConfigureAwait(false);
+					} catch (ObjectDisposedException) {
+						return false;
+					}
 				}
 
 				var (resolvedEvent, retryCount, exception) = _;


### PR DESCRIPTION
If the grpc client cancels an in-flight request, a message can appear in the log e.g.
```
[08399,11,11:13:48.595] Error when executing service method 'Read'.
EXCEPTION OCCURRED
The CancellationTokenSource has been disposed.
```
We don't want this especially if people have monitoring around errors in the logs.