### PR TITLE
Potential Fix for Random Cancellations

### DIFF
--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -6,9 +6,9 @@
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Protobuf" Version="3.10.0" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.24.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.24.0">
+		<PackageReference Include="Google.Protobuf" Version="3.11.1" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.25.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.25.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -8,7 +8,6 @@
 	<ItemGroup>
 		<PackageReference Include="Google.Protobuf" Version="3.10.0" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.24.0" />
-		<PackageReference Include="Grpc.Core" Version="2.24.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.24.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -37,7 +37,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			context.CancellationToken.Register(source.SetCanceled);
 
 #pragma warning disable 4014
-			Task.Run(() => requestStream.ForEachAsync(HandleAckNack));
+			Task.Run(async () => {
+				while (await requestStream.MoveNext()) {
+					await HandleAckNack(requestStream.Current);
+				}
+			});
 #pragma warning restore 4014
 
 			await using var enumerator = new PersistentStreamSubscriptionEnumerator(correlationId, _queue,

--- a/src/EventStore.Grpc/EventStore.Grpc.csproj
+++ b/src/EventStore.Grpc/EventStore.Grpc.csproj
@@ -8,8 +8,8 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Google.Protobuf" Version="3.10.0" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.24.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.24.0">
+		<PackageReference Include="Grpc.Net.Client" Version="2.25.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.25.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -5,7 +5,7 @@
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-		<PackageReference Include="Grpc.Tools" Version="2.24.0">
+		<PackageReference Include="Grpc.Tools" Version="2.25.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
`write_stream_meta_security.writing_meta_to_no_acl_stream_is_not_authenticated_when_not_existing_credentials_are_passed` is failing randomly.

It is possible that this behavior has been fixed in grpc/grpc-dotnet#637