### PR TITLE
Skip running if --help or --version specified

### DIFF
--- a/src/EventStore.Core/ProgramBase.cs
+++ b/src/EventStore.Core/ProgramBase.cs
@@ -28,6 +28,7 @@ namespace EventStore.Core {
 		protected abstract void Create(TOptions options);
 		protected abstract Task Start();
 		public abstract Task Stop();
+		private bool _skipRun;
 
 		protected ProgramBase(string[] args) {
 			Application.RegisterExitAction(Exit);
@@ -37,9 +38,11 @@ namespace EventStore.Core {
 				if (options.Help) {
 					Console.WriteLine("Options:");
 					Console.WriteLine(EventStoreOptions.GetUsage<TOptions>());
+					_skipRun = true;
 				} else if (options.Version) {
 					Console.WriteLine("EventStore version {0} ({1}/{2}, {3})",
 						VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp);
+					_skipRun = true;
 				} else {
 					PreInit(options);
 					Init(options);
@@ -77,6 +80,8 @@ namespace EventStore.Core {
 		}
 
 		public async Task<int> Run() {
+			if (_skipRun)
+				return 0;
 			try {
 				await _startupSource.Task;
 				await Start();


### PR DESCRIPTION
`--version` or `--help` waits for the startup source: `_startupSource` task to complete in ProgramBase.Run() which never happens.