### PR TITLE
Provide ability to specify runtime and framework

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -12,8 +12,8 @@ exit /B %errorlevel%
 :help
 
 echo Usage:
-echo build.cmd ^[-Version=0.0.0.0^] ^[-Configuration=Debug^|Release^] ^[-BuildUI=yes^|no^]
+echo build.cmd ^[-Version=0.0.0.0^] ^[-Configuration=Debug^|Release^] ^[-Runtime=win10-x64] ^[-BuildUI=yes^|no^]
 echo.
 echo Prerequisites:
-echo Building EventStore database requires .NET Core SDK 2.1.402+ and .NET Framework 4.7.1+ (Developer Pack)
+echo Building EventStore database requires .NET Core SDK 3.1.100
 echo Building the UI requires Node.js (v8.11.4+)

--- a/build.ps1
+++ b/build.ps1
@@ -5,6 +5,8 @@ Param(
     [Parameter(HelpMessage="Configuration (Debug, Release)")]
     [ValidateSet("Debug","Release")]
     [string]$Configuration = "Release",
+    [Parameter(HelpMessage="The runtime identifier")]
+    [string]$Runtime = "win10-x64",
     [Parameter(HelpMessage="Build UI (yes,no)")]
     [ValidateSet("yes","no")]
     [string]$BuildUI = "no",
@@ -12,6 +14,8 @@ Param(
     [ValidateSet("yes","no")]
     [string]$RunTests = "no"
 )
+
+$NetFramework = "netcoreapp3.1"
 
 Function Write-Info {
     Param([string]$message)
@@ -120,6 +124,7 @@ Function Start-Build{
     Write-Info "Version: $Version"
     Write-Info "Platform: $platform"
     Write-Info "Configuration: $Configuration"    
+    Write-Info "Runtime: $Runtime"    
     Write-Info "Build UI: $BuildUI"
     Write-Info "Run Tests: $RunTests"
 
@@ -154,7 +159,7 @@ Function Start-Build{
         Write-Info "Patching $versionInfoFile with product information."
         Patch-VersionInfo -versionInfoFilePath $versionInfoFile -version $Version -commitHash $commitHash -timestamp $timestamp -branch $branchName
 
-        Exec { dotnet build -c $configuration /p:Version=$Version $eventStoreSolution }
+        Exec { dotnet build -c $configuration --runtime=$Runtime --framework=$NetFramework /p:Version=$Version $eventStoreSolution }
     } finally {
         Write-Info "Reverting $versionInfoFile to original state."
         & { git checkout --quiet $versionInfoFile }

--- a/build.sh
+++ b/build.sh
@@ -9,16 +9,20 @@ COPYRIGHT="Copyright 2019 Event Store Ltd. All rights reserved."
 # ------------ End of configuration -------------
 
 CONFIGURATION="Release"
+RUNTIME="linux-x64"
 BUILD_UI="no"
+NET_FRAMEWORK="netcoreapp3.1"
 
 function usage() {    
 cat <<EOF
 Usage:
-  $0 [<version=0.0.0.0>] [<configuration=Debug|Release>] [<build_ui=yes|no>]
+  $0 [<version=0.0.0.0>] [<configuration=Debug|Release>] [<runtime=linux-x64>] [<build_ui=yes|no>]
 
 version: EventStore build version. Versions must be complete four part identifiers valid for use on a .NET assembly.
 
 configuration: Build configuration. Valid configurations are: Debug, Release
+
+runtime: Runtime Identifier (linux-x64, ubuntu.18.04-x64, etc)
 
 build_ui: Whether or not to build the EventStore UI. Building the UI requires an installation of Node.js (v8.11.4+)
 
@@ -48,7 +52,8 @@ function checkParams() {
 
     version=$1
     configuration=$2
-    build_ui=$3
+    runtime=$3
+    build_ui=$4
 
     [[ $# -gt 4 ]] && usage
 
@@ -71,6 +76,13 @@ function checkParams() {
             echo "Invalid configuration: $configuration"
             usage
         fi
+    fi
+
+    if [[ "$runtime" == "" ]]; then
+        RUNTIME="linux-x64"
+        echo "Runtime defaulted to linux-64: $RUNTIME"
+    else
+        RUNTIME=$runtime
     fi
 
     if [[ "$build_ui" == "" ]]; then
@@ -159,7 +171,7 @@ function buildUI {
 function buildEventStore {
     patchVersionInfo
     rm -rf bin/
-    dotnet build -c $CONFIGURATION /p:Version=$VERSIONSTRING src/EventStore.sln || err
+    dotnet build -c $CONFIGURATION /p:Version=$VERSIONSTRING --runtime=$RUNTIME --framework=$NET_FRAMEWORK src/EventStore.sln || err
     revertVersionInfo
 }
 
@@ -169,7 +181,7 @@ function exitWithError {
 }
 
 detectOS
-checkParams "$1" "$2" "$3"
+checkParams "$1" "$2" "$3" "$4"
 
 echo "Running from base directory: $BASE_DIR"
 buildUI


### PR DESCRIPTION
When building we want to specify the runtime identifier and the framework so that we can package without having to build again (We want to retain the compiled VersionInfo).

The compiled `VersionInfo` provides the necessary information to print out the sha as well as the version information when starting Event Store.