### PR TITLE
Dispose TokenRegistrations

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IReadIndex _readIndex;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private Position _nextPosition;
 			private ResolvedEvent _current;
 
@@ -47,11 +47,12 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_readIndex = readIndex;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IReadIndex _readIndex;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private Position _nextPosition;
 			private ResolvedEvent _current;
 
@@ -55,11 +55,12 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_readIndex = readIndex;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IPrincipal _user;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private Position _nextPosition;
 			private bool _isEnd;
 			private ResolvedEvent _current;
@@ -44,12 +44,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_user = user;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IPrincipal _user;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private Position _nextPosition;
 			private bool _isEnd;
 			private ResolvedEvent _current;
@@ -62,11 +62,12 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_user = user;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IPrincipal _user;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private Position _nextPosition;
 			private bool _isEnd;
 			private ResolvedEvent _current;
@@ -44,12 +44,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_user = user;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IPrincipal _user;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private Position _nextPosition;
 			private bool _isEnd;
 			private ResolvedEvent _current;
@@ -62,11 +62,12 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_user = user;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IPrincipal _user;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private StreamRevision _nextRevision;
 			private bool _isEnd;
 			private ResolvedEvent _current;
@@ -52,12 +52,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_user = user;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
@@ -20,6 +20,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IPrincipal _user;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private StreamRevision _nextRevision;
 			private bool _isEnd;
 			private ResolvedEvent _current;
@@ -50,11 +51,12 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_user = user;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IReadIndex _readIndex;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-
+			private readonly CancellationTokenRegistration _tokenRegistration;
 			private StreamRevision _nextRevision;
 			private ResolvedEvent _current;
 
@@ -52,12 +52,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_readIndex = readIndex;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				cancellationToken.Register(_disposedTokenSource.Dispose);
+				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
 
 			public ValueTask DisposeAsync() {
 				_disposedTokenSource.Dispose();
+				_tokenRegistration.Dispose();
 				return default;
 			}
 


### PR DESCRIPTION
Disposes the token registrations that are owned by the classes

Let me know if you want the blank line back between the readonly fields and the private fiels