### PR TITLE
Remove Task.Run from IO bound path

### DIFF
--- a/src/EventStore.ClientAPI/Projections/QueryManager.cs
+++ b/src/EventStore.ClientAPI/Projections/QueryManager.cs
@@ -45,12 +45,14 @@ namespace EventStore.ClientAPI.Projections {
 		/// <returns>String of JSON containing query result.</returns>
 		public async Task<string> ExecuteAsync(string name, string query, TimeSpan initialPollingDelay,
 			TimeSpan maximumPollingDelay, UserCredentials userCredentials = null) {
-			return await Task.Run(async () => {
+			return await ExecuteAsyncInternal().WithTimeout(_queryTimeout).ConfigureAwait(false);
+
+			async Task<string> ExecuteAsyncInternal() {
 				await _projectionsManager.CreateTransientAsync(name, query, userCredentials).ConfigureAwait(false);
 				await WaitForCompletedAsync(name, initialPollingDelay, maximumPollingDelay, userCredentials)
 					.ConfigureAwait(false);
 				return await _projectionsManager.GetStateAsync(name, userCredentials).ConfigureAwait(false);
-			}).WithTimeout(_queryTimeout).ConfigureAwait(false);
+			}
 		}
 
 		private async Task WaitForCompletedAsync(string name, TimeSpan initialPollingDelay,

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -40,7 +40,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			string subscriptionId = default;
 			await using var _ = context.CancellationToken.Register(source.SetCanceled).ConfigureAwait(false);
 
-			_ = requestStream.ForEachAsync(HandleAckNack);
+#pragma warning disable 4014
+			requestStream.ForEachAsync(HandleAckNack);
+#pragma warning restore 4014
 
 			await using var enumerator = new PersistentStreamSubscriptionEnumerator(correlationId, connectionName,
 				_queue, options.StreamName, options.GroupName, options.BufferSize, user, context.CancellationToken);

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -40,9 +40,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			string subscriptionId = default;
 			await using var _ = context.CancellationToken.Register(source.SetCanceled).ConfigureAwait(false);
 
-#pragma warning disable 4014
-			Task.Run(() => requestStream.ForEachAsync(HandleAckNack));
-#pragma warning restore 4014
+			_ = requestStream.ForEachAsync(HandleAckNack);
 
 			await using var enumerator = new PersistentStreamSubscriptionEnumerator(correlationId, connectionName,
 				_queue, options.StreamName, options.GroupName, options.BufferSize, user, context.CancellationToken);

--- a/src/EventStore.Grpc/PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Grpc/PersistentSubscriptions/PersistentSubscription.cs
@@ -58,9 +58,7 @@ namespace EventStore.Grpc.PersistentSubscriptions {
 				_started.SetResult(true);
 			}
 
-#pragma warning disable 4014
-			Task.Run(Subscribe);
-#pragma warning restore 4014
+			_ = Subscribe();
 		}
 
 		public Task Ack(params Uuid[] eventIds) {


### PR DESCRIPTION
I'm reasonably certain the `Task.Run` remove here are not necessary because the underlying path is IO-bound anyway and there is no need to explicitely offload to the worker thread pool

I deliberately left the `StreamSubscription` and `PersistenceSubscription` `Task.Run` in the constructor for now because haven't figured out yet how the GRPC Read behaves and the async enumerable in `StreamSubscription` could in theory yield synchronously