### PR TITLE
update gitignore for visual studio 16.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,7 @@ dependencies
 *.cache
 *.ncrunchsolution
 *.ncrunchproject
-src/.vs/
+**/.vs/
 
 .idea
 


### PR DESCRIPTION
Change `.gitignore` to detect .vs folders in multiple places