### PR TITLE
Drop surplus of nodes in a cluster

### DIFF
--- a/src/EventStore.ClientAPI/SystemData/TcpCommand.cs
+++ b/src/EventStore.ClientAPI/SystemData/TcpCommand.cs
@@ -11,6 +11,7 @@ namespace EventStore.ClientAPI.SystemData {
 
 		SlaveAssignment = 0x07,
 		CloneAssignment = 0x08,
+		DropSubscription = 0x09,
 
 		SubscribeReplica = 0x10,
 		ReplicaLogPositionAck = 0x11,

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -253,6 +253,7 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.UnsafeDisableFlushToDiskDescr, Opts.DbGroup)]
 		public bool UnsafeDisableFlushToDisk { get; set; }
 
+
 		[ArgDescription(Opts.BetterOrderingDescr, Opts.DbGroup)]
 		public bool BetterOrdering { get; set; }
 
@@ -279,6 +280,9 @@ namespace EventStore.ClusterNode {
 
 		[ArgDescription(Opts.ReadOnlyReplicaDescr, Opts.ClusterGroup)]
 		public bool ReadOnlyReplica { get; set; }
+
+		[ArgDescription(Opts.UnsafeAllowSurplusNodesDescr, Opts.ClusterGroup)]
+		public bool UnsafeAllowSurplusNodes { get; set; }
 
 		[ArgDescription(Opts.HistogramDescr, Opts.AppGroup)]
 		public bool EnableHistograms { get; set; }
@@ -350,6 +354,7 @@ namespace EventStore.ClusterNode {
 			ClusterGossipPort = Opts.ClusterGossipPortDefault;
 			GossipSeed = Opts.GossipSeedDefault;
 			ReadOnlyReplica = Opts.ReadOnlyReplicaDefault;
+			UnsafeAllowSurplusNodes = Opts.UnsafeAllowSurplusNodesDefault;
 
 			StatsPeriodSec = Opts.StatsPeriodDefault;
 

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -367,6 +367,8 @@ namespace EventStore.ClusterNode {
 				builder.WithStructuredLogging(options.StructuredLog);
 			if (options.DisableFirstLevelHttpAuthorization)
 				builder.DisableFirstLevelHttpAuthorization();
+			if(options.UnsafeAllowSurplusNodes)
+				builder.WithUnsafeAllowSurplusNodes();
 
 			if (!string.IsNullOrWhiteSpace(options.CertificateStoreLocation)) {
 				var location = GetCertificateStoreLocation(options.CertificateStoreLocation);

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -87,6 +87,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool ReadOnlyReplica;
 		public readonly Func<HttpMessageHandler> CreateHttpMessageHandler;
 		public int PTableMaxReaderCount;
+		public readonly bool UnsafeAllowSurplusNodes;
 
 		public ClusterVNodeSettings(Guid instanceId, int debugIndex,
 			IPEndPoint internalTcpEndPoint,
@@ -158,7 +159,8 @@ namespace EventStore.Core.Cluster.Settings {
 			bool logFailedAuthenticationAttempts = false,
 			bool readOnlyReplica = false,
 			int maxAppendSize = 1024 * 1024,
-			Func<HttpMessageHandler> createHttpMessageHandler = null) {
+			Func<HttpMessageHandler> createHttpMessageHandler = null,
+			bool unsafeAllowSurplusNodes = false) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
@@ -264,6 +266,7 @@ namespace EventStore.Core.Cluster.Settings {
 			MaxAppendSize = maxAppendSize;
 			CreateHttpMessageHandler = createHttpMessageHandler;
 			PTableMaxReaderCount = ptableMaxReaderCount;
+			UnsafeAllowSurplusNodes = unsafeAllowSurplusNodes;
 		}
 
 		public override string ToString() =>
@@ -291,6 +294,7 @@ namespace EventStore.Core.Cluster.Settings {
 			$"ReduceFileCachePressure: {ReduceFileCachePressure}\n" +
 			$"InitializationThreads: {InitializationThreads}\n" + $"StructuredLog: {StructuredLog}\n" +
 			$"DisableFirstLevelHttpAuthorization: {DisableFirstLevelHttpAuthorization}\n" +
-			$"ReadOnlyReplica: {ReadOnlyReplica}\n";
+			$"ReadOnlyReplica: {ReadOnlyReplica}\n" +
+			$"UnsafeAllowSurplusNodes: {UnsafeAllowSurplusNodes}\n";
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -654,6 +654,7 @@ namespace EventStore.Core {
 				var masterReplicationService = new MasterReplicationService(_mainQueue, gossipInfo.InstanceId, db,
 					_workersHandler,
 					epochManager, vNodeSettings.ClusterNodeCount,
+					vNodeSettings.UnsafeAllowSurplusNodes,
 					_queueStatsManager);
 				AddTask(masterReplicationService.Task);
 				_mainBus.Subscribe<SystemMessage.SystemStart>(masterReplicationService);

--- a/src/EventStore.Core/Messages/ReplicationMessage.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessage.cs
@@ -453,6 +453,32 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class DropSubscription : Message, IReplicationMessage {
+			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			Guid IReplicationMessage.MasterId {
+				get { return MasterId; }
+			}
+
+			Guid IReplicationMessage.SubscriptionId {
+				get { return SubscriptionId; }
+			}
+
+			public readonly Guid MasterId;
+			public readonly Guid SubscriptionId;
+
+			public DropSubscription(Guid masterId, Guid subscriptionId) {
+				Ensure.NotEmptyGuid(masterId, "masterId");
+				Ensure.NotEmptyGuid(subscriptionId, "subscriptionId");
+				MasterId = masterId;
+				SubscriptionId = subscriptionId;
+			}
+		}
+
 		public class GetReplicationStats : Message {
 			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Messages/ReplicationMessageDto.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessageDto.cs
@@ -288,5 +288,20 @@ namespace EventStore.Core.Messages {
 				SubscriptionId = subscriptionId;
 			}
 		}
+
+		[ProtoContract]
+		public class DropSubscription {
+			[ProtoMember(1)] public byte[] MasterId { get; set; }
+
+			[ProtoMember(2)] public byte[] SubscriptionId { get; set; }
+
+			public DropSubscription() {
+			}
+
+			public DropSubscription(byte[] masterId, byte[] subscriptionId) {
+				MasterId = masterId;
+				SubscriptionId = subscriptionId;
+			}
+		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
@@ -36,6 +36,8 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			AddWrapper<ReplicationMessage.SlaveAssignment>(WrapSlaveAssignment, ClientVersion.V2);
 			AddUnwrapper(TcpCommand.CloneAssignment, UnwrapCloneAssignment, ClientVersion.V2);
 			AddWrapper<ReplicationMessage.CloneAssignment>(WrapCloneAssignment, ClientVersion.V2);
+			AddUnwrapper(TcpCommand.DropSubscription, UnwrapDropSubscription, ClientVersion.V2);
+			AddWrapper<ReplicationMessage.DropSubscription>(WrapDropSubscription, ClientVersion.V2);
 		}
 
 		private TcpPackage WrapPrepareAck(StorageMessage.PrepareAck msg) {
@@ -221,6 +223,17 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			var dto = new ReplicationMessageDto.CloneAssignment(msg.MasterId.ToByteArray(),
 				msg.SubscriptionId.ToByteArray());
 			return new TcpPackage(TcpCommand.CloneAssignment, Guid.NewGuid(), dto.Serialize());
+		}
+
+		private ReplicationMessage.DropSubscription UnwrapDropSubscription(TcpPackage package, IEnvelope envelope) {
+			var dto = package.Data.Deserialize<ReplicationMessageDto.CloneAssignment>();
+			return new ReplicationMessage.DropSubscription(new Guid(dto.MasterId), new Guid(dto.SubscriptionId));
+		}
+
+		private TcpPackage WrapDropSubscription(ReplicationMessage.DropSubscription msg) {
+			var dto = new ReplicationMessageDto.DropSubscription(msg.MasterId.ToByteArray(),
+				msg.SubscriptionId.ToByteArray());
+			return new TcpPackage(TcpCommand.DropSubscription, Guid.NewGuid(), dto.Serialize());
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpCommand.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpCommand.cs
@@ -11,6 +11,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 
 		SlaveAssignment = 0x07,
 		CloneAssignment = 0x08,
+		DropSubscription = 0x09,
 
 		SubscribeReplica = 0x10,
 		ReplicaLogPositionAck = 0x11,

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -366,6 +366,9 @@ namespace EventStore.Core.Util {
 			"Sets this node as a read only replica that is not allowed to participate in elections or accept writes from clients.";
 		public static readonly bool ReadOnlyReplicaDefault = false;
 
+		public const string UnsafeAllowSurplusNodesDescr = "Allow more nodes than the cluster size to join the cluster as clones. (UNSAFE: can cause data loss if a clone is promoted as master)";
+		public static readonly bool UnsafeAllowSurplusNodesDefault = false;
+
 		/*
 		 *  MANAGER OPTIONS
 		 */

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -139,6 +139,7 @@ namespace EventStore.Core {
 		private bool _gossipOnSingleNode;
 
 		private bool _readOnlyReplica;
+		private bool _unsafeAllowSurplusNodes;
 		private Func<HttpMessageHandler> _createHttpMessageHandler;
 
 		// ReSharper restore FieldCanBeMadeReadOnly.Local
@@ -234,6 +235,7 @@ namespace EventStore.Core {
 			_initializationThreads = Opts.InitializationThreadsDefault;
 
 			_readOnlyReplica = Opts.ReadOnlyReplicaDefault;
+			_unsafeAllowSurplusNodes = Opts.UnsafeAllowSurplusNodesDefault;
 			_maxAppendSize = Opts.MaxAppendSizeDefault;
 		}
 
@@ -1386,7 +1388,8 @@ namespace EventStore.Core {
 				_logFailedAuthenticationAttempts,
 				_readOnlyReplica,
 				_maxAppendSize,
-				_createHttpMessageHandler);
+				_createHttpMessageHandler,
+				_unsafeAllowSurplusNodes);
 
 			var infoController = new InfoController(options, _projectionType);
 
@@ -1530,6 +1533,10 @@ namespace EventStore.Core {
 				reduceFileCachePressure);
 
 			return nodeConfig;
+		}
+
+		public void WithUnsafeAllowSurplusNodes() {
+			_unsafeAllowSurplusNodes = true;
 		}
 	}
 }


### PR DESCRIPTION
Fixes: #2167
With the current code, if more nodes are added than the cluster size, the extra nodes will remain as Clones. Clones were useful to maintain asynchronous replicas but they have now been superseded by read-only replicas which have been designed specifically for this purpose: #1976

This PR drops extra nodes from a cluster by introducing a new `DropSubscription` message. After the required number of clones have been assigned as slaves and after all slaves that are lagging behind have been downgraded to clones & clones upgraded to slaves, we drop the remaining clones from the cluster.

Edit: A configuration option called `--unsafe-allow-surplus-nodes` has been added to allow the previous behaviour.