### PR TITLE
Fix hanging during shutdown if node shut down when not yet ready

### DIFF
--- a/src/EventStore.ClientAPIAcceptanceTests/EventStoreClientAPIFixture.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/EventStoreClientAPIFixture.cs
@@ -34,7 +34,7 @@ namespace EventStore.ClientAPI.Tests {
 		}
 
 		public async Task InitializeAsync() {
-			await _node.StartAndWaitUntilReady();
+			await _node.StartAsync(true);
 			await Connections[true].ConnectAsync();
 			await Connections[false].ConnectAsync();
 		}

--- a/src/EventStore.ClientAPIAcceptanceTests/EventStoreClientAPIFixture.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/EventStoreClientAPIFixture.cs
@@ -42,7 +42,7 @@ namespace EventStore.ClientAPI.Tests {
 		public Task DisposeAsync() {
 			Connections[true].Dispose();
 			Connections[false].Dispose();
-			return _node.Stop().WithTimeout();
+			return _node.StopAsync().WithTimeout();
 		}
 
 		ValueTask IAsyncDisposable.DisposeAsync() => new ValueTask(DisposeAsync());

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -479,7 +479,7 @@ namespace EventStore.ClusterNode {
 		}
 
 		public override Task Stop() {
-			return Task.WhenAll(_node.Stop(), _host.StopAsync());
+			return Task.WhenAll(_node.StopAsync(), _host.StopAsync());
 		}
 
 		protected override void OnProgramExit() {

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -475,7 +475,7 @@ namespace EventStore.ClusterNode {
 		}
 
 		protected override Task Start() {
-			return Task.WhenAll(_node.StartAndWaitUntilReady(), _host.StartAsync());
+			return Task.WhenAll(_node.StartAsync(false), _host.StartAsync());
 		}
 
 		public override Task Stop() {

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 
 		[OneTimeTearDown]
 		public virtual async Task TestFixtureTearDown() {
-			await _node.Stop();
+			await _node.StopAsync();
 		}
 
 		public abstract void Given();
@@ -54,7 +54,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 
 		[OneTimeTearDown]
 		public virtual async Task TestFixtureTearDown() {
-			await _node.Stop();
+			await _node.StopAsync();
 		}
 
 		public abstract void Given();

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -173,7 +173,7 @@ VNodeState.ReadOnlyMasterless : VNodeState.Unknown;
 
 		public async Task Shutdown(bool keepDb = false) {
 			StoppingTime.Start();
-			await Node.Stop().WithTimeout(TimeSpan.FromSeconds(20));
+			await Node.StopAsync().WithTimeout(TimeSpan.FromSeconds(20));
 			_host?.Dispose();
 			if (!keepDb)
 				TryDeleteDirectory(_dbPath);

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -166,7 +166,7 @@ namespace EventStore.Core.Tests.Helpers {
 		public async Task Start() {
 			StartingTime.Start();
 
-			await Node.StartAndWaitUntilReady().WithTimeout(TimeSpan.FromSeconds(60))
+			await Node.StartAsync(true).WithTimeout(TimeSpan.FromSeconds(60))
 				.ConfigureAwait(false); //starts the node
 
 			StartingTime.Stop();
@@ -176,7 +176,7 @@ namespace EventStore.Core.Tests.Helpers {
 		private async Task StartMiniNode(Task monitorFailuresTask) {
 			StartingTime.Start();
 
-			var startNodeTask = Node.StartAndWaitUntilReady(); //starts the node
+			var startNodeTask = Node.StartAsync(true); //starts the node
 
 			await Task.WhenAny(
 				monitorFailuresTask,

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -222,7 +222,7 @@ namespace EventStore.Core.Tests.Helpers {
 			_kestrelTestServer.Dispose();
 			HttpMessageHandler.Dispose();
 			HttpClient.Dispose();
-			await Node.Stop().WithTimeout(TimeSpan.FromSeconds(20)).ConfigureAwait(false);
+			await Node.StopAsync().WithTimeout(TimeSpan.FromSeconds(20)).ConfigureAwait(false);
 
 			if (!keepDb)
 				TryDeleteDirectory(DbPath);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -730,7 +730,7 @@ namespace EventStore.Core {
 			_mainQueue.Publish(new SystemMessage.SystemInit());
 		}
 
-		public async Task Stop() {
+		public async Task StopAsync() {
 			_mainQueue.Publish(new ClientMessage.RequestShutdown(false, true));
 
 			if (_subsystems != null) {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -786,11 +786,15 @@ namespace EventStore.Core {
 #endif
 		}
 
-		public async Task<ClusterVNode> StartAndWaitUntilReady() {
+		public async Task<ClusterVNode> StartAsync(bool waitUntilReady) {
 			var tcs = new TaskCompletionSource<ClusterVNode>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-			_mainBus.Subscribe(new AdHocHandler<SystemMessage.SystemReady>(
-				_ => tcs.TrySetResult(this)));
+			if (waitUntilReady) {
+				_mainBus.Subscribe(new AdHocHandler<SystemMessage.SystemReady>(
+					_ => tcs.TrySetResult(this)));
+			} else {
+				tcs.TrySetResult(this);
+			}
 
 			Start();
 

--- a/src/EventStore.Grpc.PersistentSubscriptions.Tests/StandaloneKestrelServerFixture.cs
+++ b/src/EventStore.Grpc.PersistentSubscriptions.Tests/StandaloneKestrelServerFixture.cs
@@ -67,7 +67,7 @@ namespace EventStore.Grpc {
 		}
 
 		public virtual async Task DisposeAsync() {
-			await _node.Stop();
+			await _node.StopAsync();
 			_db.Dispose();
 			await _host.StopAsync();
 			_host.Dispose();

--- a/src/EventStore.Grpc.PersistentSubscriptions.Tests/StandaloneKestrelServerFixture.cs
+++ b/src/EventStore.Grpc.PersistentSubscriptions.Tests/StandaloneKestrelServerFixture.cs
@@ -62,7 +62,7 @@ namespace EventStore.Grpc {
 		}
 
 		public virtual async Task InitializeAsync() {
-			await _node.StartAndWaitUntilReady();
+			await _node.StartAsync(true);
 			await _host.StartAsync();
 		}
 

--- a/src/EventStore.Grpc.Projections.Tests/Projections/EventStoreProjectionManagerGrpcFixture.cs
+++ b/src/EventStore.Grpc.Projections.Tests/Projections/EventStoreProjectionManagerGrpcFixture.cs
@@ -15,7 +15,7 @@ namespace EventStore.Grpc.Projections {
 
 		public override async Task InitializeAsync() {
 			var projectionsStarted = StandardProjections.Created(Projections.MasterMainBus);
-			await Node.StartAndWaitUntilReady();
+			await Node.StartAsync(true);
 
 			await projectionsStarted.WithTimeout(TimeSpan.FromMinutes(5));
 

--- a/src/EventStore.Grpc.Tests.Common/EventStoreGrpcFixture.cs
+++ b/src/EventStore.Grpc.Tests.Common/EventStoreGrpcFixture.cs
@@ -62,7 +62,7 @@ namespace EventStore.Grpc {
 			=> new EventData(Uuid.NewUuid(), type, Encoding.UTF8.GetBytes($@"{{""x"":{index}}}"));
 
 		public virtual async Task InitializeAsync() {
-			await Node.StartAndWaitUntilReady();
+			await Node.StartAsync(true);
 			await Given().WithTimeout(TimeSpan.FromMinutes(5));
 			await When().WithTimeout(TimeSpan.FromMinutes(5));
 		}

--- a/src/EventStore.Grpc.Tests.Common/EventStoreGrpcFixture.cs
+++ b/src/EventStore.Grpc.Tests.Common/EventStoreGrpcFixture.cs
@@ -68,7 +68,7 @@ namespace EventStore.Grpc {
 		}
 
 		public virtual async Task DisposeAsync() {
-			await Node.Stop();
+			await Node.StopAsync();
 			_db.Dispose();
 			_testServer.Dispose();
 			Client?.Dispose();

--- a/src/EventStore.Grpc.Tests/Streams/stream_with_hash_collision.cs
+++ b/src/EventStore.Grpc.Tests/Streams/stream_with_hash_collision.cs
@@ -63,7 +63,7 @@ namespace EventStore.Grpc.Streams {
 			public async Task throws_not_found() {
 				await using var fixture = new Fixture { DeleteDirectory = true };
 
-				await fixture.Node.StartAndWaitUntilReady();
+				await fixture.Node.StartAsync(true);
 
 				await Assert.ThrowsAsync<StreamNotFoundException>(
 					() => fixture.Client.ReadStreamForwardsAsync(Stream1, StreamRevision.Start, 1, true)
@@ -85,7 +85,7 @@ namespace EventStore.Grpc.Streams {
 			public async Task throws_not_found() {
 				await using var fixture = new Fixture { DeleteDirectory = true };
 
-				await fixture.Node.StartAndWaitUntilReady();
+				await fixture.Node.StartAsync(true);
 
 				await Assert.ThrowsAsync<StreamNotFoundException>(
 					() => fixture.Client.ReadStreamBackwardsAsync(Stream1, StreamRevision.End, 1, true)


### PR DESCRIPTION
Fixes #2168

In the current code, `StartAndWaitUntilReady()` waits for the `SystemReady` message to be received before marking the task as complete. The `SystemReady` message is received only after a node has been able to join a cluster as a slave or master. Waiting for this message is useful for tests to determine that the node has successfully joined a cluster but when running a real node, there are some situations where you want to shut down the node but the node was not yet ready, for example:
- When a node is trying to join a cluster but it needs to go offline for truncation
- When a node has not even joined a cluster but you still want to stop it from the UI

In the above scenarios, the node will hang here: https://github.com/EventStore/EventStore/blob/master/src/EventStore.Core/ProgramBase.cs#L92 since the task completion source in `StartAndWaitUntilReady()` was never set. Even if you trigger a shutdown, it will hang there.

*Reproduction steps*
1. Start one node out of a 3 node cluster
2. Try to shut down the node from the UI
3. It will hang after shutting down

*Resolution*
The fix simply adds a boolean parameter called `waitUntilReady` to the start function and calls it with false when a real node is starting up.
Start and stop functions have also been renamed for consistency with async-await pattern.