### PR TITLE
Socket.Close() fixes & re-enable all macOS tests

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -67,17 +67,7 @@ jobs:
       version: '3.1.100'
   - bash: dotnet build -c $(Configuration) src/EventStore.sln
     displayName: Compile
-  - bash: |
-      EXIT_CODE=0
-      dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings src/EventStore.Rags.Tests || EXIT_CODE=$?
-      dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings src/EventStore.ClientAPI.Tests || EXIT_CODE=$?
-      dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings src/EventStore.ClientAPI.Embedded.Tests || EXIT_CODE=$?
-      dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings src/EventStore.Grpc.Tests || EXIT_CODE=$?
-      dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings src/EventStore.Grpc.PersistentSubscriptions.Tests || EXIT_CODE=$?
-      dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings src/EventStore.Grpc.Projections.Tests || EXIT_CODE=$?
-      dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings src/EventStore.Grpc.UserManagement.Tests || EXIT_CODE=$?
-      exit $EXIT_CODE
-    condition: succeededOrFailed()
+  - bash: find ./src -maxdepth 1 -type d -name "*.Tests" -print0| xargs -0 -n1 dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings
     displayName: Run Tests
   - task: PublishTestResults@2
     displayName: Publish Test Results

--- a/ci.yml
+++ b/ci.yml
@@ -81,7 +81,7 @@ jobs:
     condition: eq(variables['System.PullRequest.IsFork'], 'False')
     displayName: Publish Artifacts
     inputs:
-      artifactName: macos-netcoreapp3-{{ variables['Configuration'] }}
+      artifactName: macos-netcoreapp3-$(Configuration)
       pathToPublish: '$(Build.SourcesDirectory)/bin/'
 
 - job: ubuntu_x64
@@ -116,5 +116,5 @@ jobs:
     condition: eq(variables['System.PullRequest.IsFork'], 'False')
     displayName: Publish Artifacts
     inputs:
-      artifactName: ubuntu1604-netcoreapp3-${{ variables['Configuration'] }}
+      artifactName: ubuntu1604-netcoreapp3-$(Configuration)
       pathToPublish: '$(Build.SourcesDirectory)/bin/'

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpClientConnector.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpClientConnector.cs
@@ -104,7 +104,7 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 			var onConnectionFailed = callbacks.OnConnectionFailed;
 			var pendingConnection = callbacks.PendingConnection;
 
-			Helper.EatException(() => socketArgs.AcceptSocket.Close(TcpConfiguration.SocketCloseTimeoutSecs));
+			Helper.EatException(() => socketArgs.AcceptSocket.Close());
 			socketArgs.AcceptSocket = null;
 			callbacks.Reset();
 			_connectSocketArgsPool.Return(socketArgs);

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -283,7 +283,7 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 
 			if (_socket != null) {
 				Helper.EatException(() => _socket.Shutdown(SocketShutdown.Both));
-				Helper.EatException(() => _socket.Close(TcpConfiguration.SocketCloseTimeoutSecs));
+				Helper.EatException(() => _socket.Close());
 				_socket = null;
 			}
 

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionLockless.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionLockless.cs
@@ -286,7 +286,7 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 			var socket = Interlocked.Exchange(ref _socket, null);
 			if (socket != null) {
 				Helper.EatException(() => socket.Shutdown(SocketShutdown.Both));
-				Helper.EatException(() => socket.Close(TcpConfiguration.SocketCloseTimeoutSecs));
+				Helper.EatException(() => socket.Close());
 			}
 		}
 

--- a/src/EventStore.Transport.Tcp/TcpClientConnector.cs
+++ b/src/EventStore.Transport.Tcp/TcpClientConnector.cs
@@ -106,7 +106,7 @@ namespace EventStore.Transport.Tcp {
 			var onConnectionFailed = callbacks.OnConnectionFailed;
 			var pendingConnection = callbacks.PendingConnection;
 
-			Helper.EatException(() => socketArgs.AcceptSocket.Close(TcpConfiguration.SocketCloseTimeoutSecs));
+			Helper.EatException(() => socketArgs.AcceptSocket.Close());
 			socketArgs.AcceptSocket = null;
 			callbacks.Reset();
 			_connectSocketArgsPool.Return(socketArgs);

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -329,7 +329,7 @@ namespace EventStore.Transport.Tcp {
 
 			if (_socket != null) {
 				Helper.EatException(() => _socket.Shutdown(SocketShutdown.Both));
-				Helper.EatException(() => _socket.Close(TcpConfiguration.SocketCloseTimeoutSecs));
+				Helper.EatException(() => _socket.Close());
 				_socket = null;
 			}
 

--- a/src/EventStore.Transport.Tcp/TcpConnectionLockless.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionLockless.cs
@@ -335,7 +335,7 @@ namespace EventStore.Transport.Tcp {
 			var socket = Interlocked.Exchange(ref _socket, null);
 			if (socket != null) {
 				Helper.EatException(() => socket.Shutdown(SocketShutdown.Both));
-				Helper.EatException(() => socket.Close(TcpConfiguration.SocketCloseTimeoutSecs));
+				Helper.EatException(() => socket.Close());
 			}
 		}
 


### PR DESCRIPTION
Due to this bug: https://github.com/dotnet/corefx/issues/42718, a deadlock can occur on macOS. This was preventing us from running all tests on macOS after the move to .NET Core 3 since they would very often hang on CI.

The pattern causing this has now been [identified](https://github.com/dotnet/corefx/issues/42718#issuecomment-569046141): calling, socket.Shutdown(SocketShutdown.Both) followed by socket.Close() with a timeout + doing a Receive in parallel

This PR does the following:
- Call socket.Close() without timeout
- Re-enable all tests on macOS

Unrelated fix:
- Fix $Configuration variable