### PR TITLE
Replay *some* parked messages

### DIFF
--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/parked.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/parked.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Net;
 using System.Text.RegularExpressions;
 using EventStore.Core.Tests.Http.Users.users;
@@ -41,10 +42,10 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 			var parkedStreamId = String.Format("$persistentsubscription-{0}::{1}-parked", TestStreamName, GroupName);
 
 			await _connection.SubscribeToStreamAsync(parkedStreamId, true, (x, y) => {
-				_parkedEventId = y.Event.EventId;
-				_eventParked.TrySetResult(true);
-				return Task.CompletedTask;
-			},
+					_parkedEventId = y.Event.EventId;
+					_eventParked.TrySetResult(true);
+					return Task.CompletedTask;
+				},
 				(x, y, z) => { },
 				DefaultData.AdminCredentials);
 
@@ -59,7 +60,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 		}
 	}
 
-	class when_replaying_parked_message : with_subscription_having_events {
+	class when_replaying_one_all_parked_message : with_subscription_having_events {
 		private string _nackLink;
 		private Guid _eventIdToPark;
 		private Guid _receivedEventId;
@@ -137,6 +138,200 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 		[Test]
 		public void should_receive_the_replayed_event() {
 			Assert.AreEqual(_eventIdToPark, _receivedEventId);
+		}
+	}
+
+
+	class when_replaying_multiple_all_parked_messages : with_subscription_having_events {
+		private List<Guid> _parkedEventIds = new List<Guid>();
+		private List<Guid> _receivedEventId = new List<Guid>();
+
+		private string _subscriptionParkedStream;
+		private ConcurrentDictionary<Guid, bool> _writeCorrelationId = new ConcurrentDictionary<Guid, bool>();
+		private TaskCompletionSource<bool> _eventParked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+		private long _stopAt = 2;
+
+		protected override async Task Given() {
+			_connection.Close();
+			_connection.Dispose();
+			NumberOfEventsToCreate = 3;
+			await base.Given();
+
+			_subscriptionParkedStream =
+				"$persistentsubscription-" + TestStream.Substring(9) + "::" + GroupName + "-parked";
+
+			// Subscribe to the writes to ensure the parked message has been written
+			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.WritePrepares>(Handle));
+			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.CommitReplicated>(Handle));
+
+			// park 3 events
+			for (int i = 0; i < NumberOfEventsToCreate; i++) {
+				for (var attempt = 0; attempt < 10; attempt++) {
+					var json = await GetJson2<JObject>(
+						SubscriptionPath + "/1", "embed=rich",
+						ContentType.CompetingJson,
+						_admin);
+
+					Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+
+					var entries = json != null ? json["entries"].ToList() : new List<JToken>();
+					if (entries.Count == 1) {
+						//Park the message
+						_parkedEventIds.Add(Guid.Parse(entries[0]["eventId"].ToString()));
+						var nackLink = entries[0]["links"][3]["uri"] + "?action=park";
+						var response = await MakePost(nackLink, _admin);
+						Assert.AreEqual(HttpStatusCode.Accepted, response.StatusCode);
+						break;
+					}
+
+					Console.WriteLine("Received no entries. Attempt {0} of 10", attempt + 1);
+					await Task.Delay(TimeSpan.FromSeconds(1));
+				}
+			}
+		}
+
+		private void Handle(StorageMessage.WritePrepares msg) {
+			if (msg.EventStreamId == _subscriptionParkedStream) {
+				_writeCorrelationId.TryAdd(msg.CorrelationId, true);
+			}
+		}
+
+		private void Handle(StorageMessage.CommitReplicated msg) {
+			if (_writeCorrelationId.TryUpdate(msg.CorrelationId, false, true) && _writeCorrelationId.Count(kvp => !kvp.Value) == NumberOfEventsToCreate) {
+				_eventParked.TrySetResult(true);
+			}
+		}
+
+		protected override async Task When() {
+			await _eventParked.Task.WithTimeout(10000);
+
+			// replay all
+			var response = await MakePost(SubscriptionPath + "/replayParked", _admin);
+			Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+			for (int i = 0; i < NumberOfEventsToCreate; i++) {
+				for (var attempt = 0; attempt < 10; attempt++) {
+					var json = await GetJson2<JObject>(
+						SubscriptionPath + "/1", "embed=rich",
+						ContentType.CompetingJson,
+						_admin);
+
+					Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+
+					var entries = json != null ? json["entries"].ToList() : new List<JToken>();
+					if (entries.Count == 1) {
+						_receivedEventId.Add(Guid.Parse(entries[0]["eventId"].ToString()));
+						break;
+					}
+
+					Console.WriteLine("Received no entries. Attempt {0} of 10", attempt + 1);
+					await Task.Delay(TimeSpan.FromSeconds(1));
+				}
+			}
+		}
+
+		[Test]
+		public void should_receive_the_replayed_event() {
+			Assert.AreEqual(_parkedEventIds[0], _receivedEventId[0]);
+			Assert.AreEqual(_parkedEventIds[1], _receivedEventId[1]);
+			Assert.AreEqual(_parkedEventIds[2], _receivedEventId[2]);
+		}
+	}
+	
+	
+	class when_replaying_multiple_some_parked_messages : with_subscription_having_events {
+		private List<Guid> _parkedEventIds = new List<Guid>();
+		private List<Guid> _receivedEventId = new List<Guid>();
+
+		private string _subscriptionParkedStream;
+		private ConcurrentDictionary<Guid, bool> _writeCorrelationId = new ConcurrentDictionary<Guid, bool>();
+		private TaskCompletionSource<bool> _eventParked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		protected override async Task Given() {
+			_connection.Close();
+			_connection.Dispose();
+			NumberOfEventsToCreate = 3;
+			await base.Given();
+
+			_subscriptionParkedStream =
+				"$persistentsubscription-" + TestStream.Substring(9) + "::" + GroupName + "-parked";
+
+			// Subscribe to the writes to ensure the parked message has been written
+			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.WritePrepares>(Handle));
+			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.CommitReplicated>(Handle));
+
+			// park 3 events
+			for (int i = 0; i < NumberOfEventsToCreate; i++) {
+				for (var attempt = 0; attempt < 10; attempt++) {
+					var json = await GetJson2<JObject>(
+						SubscriptionPath + "/1", "embed=rich",
+						ContentType.CompetingJson,
+						_admin);
+
+					Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+
+					var entries = json != null ? json["entries"].ToList() : new List<JToken>();
+					if (entries.Count == 1) {
+						//Park the message
+						_parkedEventIds.Add(Guid.Parse(entries[0]["eventId"].ToString()));
+						var nackLink = entries[0]["links"][3]["uri"] + "?action=park";
+						var response = await MakePost(nackLink, _admin);
+						Assert.AreEqual(HttpStatusCode.Accepted, response.StatusCode);
+						break;
+					}
+
+					Console.WriteLine("Received no entries. Attempt {0} of 10", attempt + 1);
+					await Task.Delay(TimeSpan.FromSeconds(1));
+				}
+			}
+		}
+
+		private void Handle(StorageMessage.WritePrepares msg) {
+			if (msg.EventStreamId == _subscriptionParkedStream) {
+				_writeCorrelationId.TryAdd(msg.CorrelationId, true);
+			}
+		}
+
+		private void Handle(StorageMessage.CommitReplicated msg) {
+			if (_writeCorrelationId.TryUpdate(msg.CorrelationId, false, true) && _writeCorrelationId.Count(kvp => !kvp.Value) == NumberOfEventsToCreate) {
+				_eventParked.TrySetResult(true);
+			}
+		}
+
+		protected override async Task When() {
+			await _eventParked.Task.WithTimeout(10000);
+
+			// only replay 2 of the 3 messages
+			var response = await MakePost(SubscriptionPath + "/replayParked", _admin, "stopAt=2");
+			Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+			for (int i = 0; i < 2; i++) {
+				for (var attempt = 0; attempt < 10; attempt++) {
+					var json = await GetJson2<JObject>(
+						SubscriptionPath + "/1", "embed=rich",
+						ContentType.CompetingJson,
+						_admin);
+
+					Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+
+					var entries = json != null ? json["entries"].ToList() : new List<JToken>();
+					if (entries.Count == 1) {
+						_receivedEventId.Add(Guid.Parse(entries[0]["eventId"].ToString()));
+						break;
+					}
+
+					Console.WriteLine("Received no entries. Attempt {0} of 10", attempt + 1);
+					await Task.Delay(TimeSpan.FromSeconds(1));
+				}
+			}
+		}
+
+		[Test]
+		public void should_receive_the_replayed_event() {
+			Assert.AreEqual(2, _receivedEventId.Count);
+			Assert.AreEqual(3, _parkedEventIds.Count);
+			Assert.AreEqual(_parkedEventIds[0], _receivedEventId[0]);
+			Assert.AreEqual(_parkedEventIds[1], _receivedEventId[1]);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/parked.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/parked.cs
@@ -149,8 +149,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 		private string _subscriptionParkedStream;
 		private ConcurrentDictionary<Guid, bool> _writeCorrelationId = new ConcurrentDictionary<Guid, bool>();
 		private TaskCompletionSource<bool> _eventParked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-		private long _stopAt = 2;
-
+		
 		protected override async Task Given() {
 			_connection.Close();
 			_connection.Dispose();
@@ -162,7 +161,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 
 			// Subscribe to the writes to ensure the parked message has been written
 			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.WritePrepares>(Handle));
-			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.CommitReplicated>(Handle));
+			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.CommitIndexed>(Handle));
 
 			// park 3 events
 			for (int i = 0; i < NumberOfEventsToCreate; i++) {
@@ -196,7 +195,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 			}
 		}
 
-		private void Handle(StorageMessage.CommitReplicated msg) {
+		private void Handle(StorageMessage.CommitIndexed msg) {
 			if (_writeCorrelationId.TryUpdate(msg.CorrelationId, false, true) && _writeCorrelationId.Count(kvp => !kvp.Value) == NumberOfEventsToCreate) {
 				_eventParked.TrySetResult(true);
 			}
@@ -258,7 +257,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 
 			// Subscribe to the writes to ensure the parked message has been written
 			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.WritePrepares>(Handle));
-			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.CommitReplicated>(Handle));
+			_node.Node.MainBus.Subscribe(new AdHocHandler<StorageMessage.CommitIndexed>(Handle));
 
 			// park 3 events
 			for (int i = 0; i < NumberOfEventsToCreate; i++) {
@@ -292,7 +291,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 			}
 		}
 
-		private void Handle(StorageMessage.CommitReplicated msg) {
+		private void Handle(StorageMessage.CommitIndexed msg) {
 			if (_writeCorrelationId.TryUpdate(msg.CorrelationId, false, true) && _writeCorrelationId.Count(kvp => !kvp.Value) == NumberOfEventsToCreate) {
 				_eventParked.TrySetResult(true);
 			}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -569,7 +569,7 @@ namespace EventStore.Core {
 			_mainBus.Subscribe(perSubscrQueue.WidenFrom<ClientMessage.UnsubscribeFromStream, Message>());
 			_mainBus.Subscribe(perSubscrQueue.WidenFrom<ClientMessage.PersistentSubscriptionAckEvents, Message>());
 			_mainBus.Subscribe(perSubscrQueue.WidenFrom<ClientMessage.PersistentSubscriptionNackEvents, Message>());
-			_mainBus.Subscribe(perSubscrQueue.WidenFrom<ClientMessage.ReplayAllParkedMessages, Message>());
+			_mainBus.Subscribe(perSubscrQueue.WidenFrom<ClientMessage.ReplayParkedMessages, Message>());
 			_mainBus.Subscribe(perSubscrQueue.WidenFrom<ClientMessage.ReplayParkedMessage, Message>());
 			_mainBus.Subscribe(perSubscrQueue.WidenFrom<ClientMessage.ReadNextNPersistentMessages, Message>());
 			_mainBus.Subscribe(perSubscrQueue.WidenFrom<StorageMessage.EventCommitted, Message>());
@@ -599,7 +599,7 @@ namespace EventStore.Core {
 			perSubscrBus.Subscribe<ClientMessage.DeletePersistentSubscription>(persistentSubscription);
 			perSubscrBus.Subscribe<ClientMessage.CreatePersistentSubscription>(persistentSubscription);
 			perSubscrBus.Subscribe<ClientMessage.UpdatePersistentSubscription>(persistentSubscription);
-			perSubscrBus.Subscribe<ClientMessage.ReplayAllParkedMessages>(persistentSubscription);
+			perSubscrBus.Subscribe<ClientMessage.ReplayParkedMessages>(persistentSubscription);
 			perSubscrBus.Subscribe<ClientMessage.ReplayParkedMessage>(persistentSubscription);
 			perSubscrBus.Subscribe<ClientMessage.ReadNextNPersistentMessages>(persistentSubscription);
 			perSubscrBus.Subscribe<MonitoringMessage.GetAllPersistentSubscriptionStats>(persistentSubscription);

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1424,8 +1424,8 @@ namespace EventStore.Core.Messages {
 				SubscriptionId = subscriptionId;
 			}
 		}
-
-		public class ReplayAllParkedMessages : ReadRequestMessage {
+		
+		public class ReplayParkedMessages : ReadRequestMessage {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 
 			public override int MsgTypeId {
@@ -1434,12 +1434,14 @@ namespace EventStore.Core.Messages {
 
 			public readonly string EventStreamId;
 			public readonly string GroupName;
+			public readonly long? StopAt;
 
-			public ReplayAllParkedMessages(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
-				string eventStreamId, string groupName, IPrincipal user)
+			public ReplayParkedMessages(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
+				string eventStreamId, string groupName, long? stopAt, IPrincipal user)
 				: base(internalCorrId, correlationId, envelope, user) {
 				EventStreamId = eventStreamId;
 				GroupName = groupName;
+				StopAt = stopAt;
 			}
 		}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -560,9 +560,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		public void Handle(ClientMessage.ReplayParkedMessages message) {
 			PersistentSubscription subscription;
 			var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} (To: '{stopAt}')", 
+			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey}", 
 				key,
-				message.StopAt.HasValue ? message.StopAt.ToString() : "<null>");
+				message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
 
 			if (message.StopAt.HasValue && message.StopAt.Value < 0) {
 				message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		IHandle<TcpMessage.ConnectionClosed>,
 		IHandle<SystemMessage.BecomeMaster>,
 		IHandle<SubscriptionMessage.PersistentSubscriptionTimerTick>,
-		IHandle<ClientMessage.ReplayAllParkedMessages>,
+		IHandle<ClientMessage.ReplayParkedMessages>,
 		IHandle<ClientMessage.ReplayParkedMessage>,
 		IHandle<SystemMessage.StateChangeMessage>,
 		IHandle<ClientMessage.ConnectToPersistentSubscription>,
@@ -557,11 +557,20 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					messages));
 		}
 
-		public void Handle(ClientMessage.ReplayAllParkedMessages message) {
+		public void Handle(ClientMessage.ReplayParkedMessages message) {
 			PersistentSubscription subscription;
 			var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey}", key);
+			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} (To: '{stopAt}')", 
+				key,
+				message.StopAt.HasValue ? message.StopAt.ToString() : "<null>");
 
+			if (message.StopAt.HasValue && message.StopAt.Value < 0) {
+				message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
+					ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Fail,
+					"Cannot stop replaying parked message at a negative version."));
+				return;
+			}
+				
 			if (!IsUserOpsOrAdmin(message.User)) {
 				message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
 					ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied,
@@ -576,7 +585,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				return;
 			}
 
-			subscription.RetryAllParkedMessages();
+			subscription.RetryParkedMessages(message.StopAt);
 			message.Envelope.ReplyWith(new ClientMessage.ReplayMessagesReceived(message.CorrelationId,
 				ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success, ""));
 		}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -560,7 +560,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		public void Handle(ClientMessage.ReplayParkedMessages message) {
 			PersistentSubscription subscription;
 			var key = BuildSubscriptionGroupKey(message.EventStreamId, message.GroupName);
-			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey}", 
+			Log.Debug("Replaying parked messages for persistent subscription {subscriptionKey} {to}", 
 				key,
 				message.StopAt.HasValue ? $" (To: '{message.StopAt.ToString()}')" : " (All)");
 


### PR DESCRIPTION
Currently there is the ability to replay all parked messages in a particular persistent subscription.  Unfortunately, the way it does this is to load *all* of those parked messages into memory and push them onto a replay buffer in preparation for dispatch ahead of the on-going stream subscription.

The issue with this is that when a parked message stream gets beyond a certain size, it becomes impossible to replay.  We have had numerous examples of this in our production environment whereby the parked streams are gathering messages overnight and by the time a support person was aware, it was too late to replay them; upon replay, the persistent subscription subsystem crashes and a master failover is necessary.  Unfortunately, at this point, the truncate `$metadata` has already been written to the parked stream but without the parked messages being dispatched meaning when we failover, we lose the entire parked message stream.  We have a custom tool to fix this but it is far from ideal.

This PR enables an optional `stopAt` version to be passed into the replay command so chunked parked message replays are possible.  We envision that we will use it for times when we have more than, for example, 5,000 or so parked messages outstanding so we can reduce the instant load & memory pressure on the persistent subscription subsystem.