### PR TITLE
Ignore the $type property when parsing the Event(s) from the HTTP API.

### DIFF
--- a/src/EventStore.Transport.Http/Codecs/JsonCodec.cs
+++ b/src/EventStore.Transport.Http/Codecs/JsonCodec.cs
@@ -19,6 +19,7 @@ namespace EventStore.Transport.Http.Codecs {
 			DefaultValueHandling = DefaultValueHandling.Ignore,
 			MissingMemberHandling = MissingMemberHandling.Ignore,
 			TypeNameHandling = TypeNameHandling.None,
+			MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
 			Converters = new JsonConverter[] {
 				new StringEnumConverter()
 			}


### PR DESCRIPTION
Fixes #1792

Customers are using `$type` as a means to encode some information in their
messages persisted in Event Store. They don't and should not care about
what we use internally and therefor we should do as little as possible
to mess with the data they provide us.

Setting the [`MetadataPropertyHandling`](https://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_MetadataPropertyHandling.htm) to Ignore will tell Newtonsoft Json
to ignore these metadata properties when deserializing.