### PR TITLE
Use Internal Subscriptions Model in GRPC Subscriptions

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -18,13 +19,21 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly bool _resolveLinks;
 			private readonly IPrincipal _user;
 			private readonly IReadIndex _readIndex;
-			private readonly CancellationTokenSource _disposedTokenSource;
-			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-			private readonly CancellationTokenRegistration _tokenRegistration;
-			private Position _nextPosition;
-			private ResolvedEvent _current;
+			private readonly CancellationToken _cancellationToken;
+			private IAsyncEnumerator<ResolvedEvent> _inner;
+			private readonly Guid _connectionId;
 
-			public ResolvedEvent Current => _current;
+			private bool _catchUpRestarted;
+
+			public ResolvedEvent Current => _inner.Current;
+
+			private Position CurrentPosition {
+				get {
+					var position = _inner.Current.OriginalPosition.Value;
+
+					return Position.FromInt64(position.CommitPosition, position.PreparePosition);
+				}
+			}
 
 			public AllSubscription(IPublisher bus,
 				Position position,
@@ -41,93 +50,341 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				}
 
 				_bus = bus;
-				_nextPosition = position;
 				_resolveLinks = resolveLinks;
 				_user = user;
 				_readIndex = readIndex;
-				_disposedTokenSource = new CancellationTokenSource();
-				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
-			}
+				_cancellationToken = cancellationToken;
+				_connectionId = Guid.NewGuid();
 
-			public ValueTask DisposeAsync() {
-				_disposedTokenSource.Dispose();
-				_tokenRegistration.Dispose();
-				return default;
+				_inner = new CatchupAllSubscription(bus, position, resolveLinks, user, readIndex, cancellationToken);
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				ReadLoop:
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
-				}
-
-				if (_buffer.TryDequeue(out var current)) {
-					_current = current;
+				var result = await _inner.MoveNextAsync().ConfigureAwait(false);
+				if (result) {
 					return true;
 				}
 
-				var correlationId = Guid.NewGuid();
-
-				var readNextSource = new TaskCompletionSource<bool>();
-
-				var (commitPosition, preparePosition) = _nextPosition == Position.End
-					? (_readIndex.LastCommitPosition, _readIndex.LastReplicatedPosition)
-					: _nextPosition.ToInt64();
-
-				_bus.Publish(new ClientMessage.ReadAllEventsForward(
-					correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition, 32,
-					_resolveLinks, false, default, _user));
-
-				await readNextSource.Task.ConfigureAwait(false);
-
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
+				if (!_catchUpRestarted) {
+					await _inner.DisposeAsync().ConfigureAwait(false);
+					_inner = new LiveStreamSubscription(_bus, OnLiveSubscriptionDropped, _connectionId, CurrentPosition,
+						_resolveLinks, _user, _cancellationToken);
+				} else {
+					_catchUpRestarted = true;
 				}
 
-				if (_buffer.TryDequeue(out current)) {
-					_current = current;
+				return await _inner.MoveNextAsync().ConfigureAwait(false);
+			}
+
+			public ValueTask DisposeAsync() => _inner.DisposeAsync();
+
+			private async ValueTask OnLiveSubscriptionDropped(Position caughtUpPosition) {
+				await _inner.DisposeAsync().ConfigureAwait(false);
+
+				_inner = new CatchupAllSubscription(_bus, caughtUpPosition, _resolveLinks, _user, _readIndex,
+					_cancellationToken);
+			}
+
+			private class CatchupAllSubscription : IAsyncEnumerator<ResolvedEvent> {
+				private readonly IPublisher _bus;
+				private readonly bool _resolveLinks;
+				private readonly IPrincipal _user;
+				private readonly IReadIndex _readIndex;
+				private readonly CancellationTokenSource _disposedTokenSource;
+				private readonly ConcurrentQueue<ResolvedEvent> _buffer;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private Position _nextPosition;
+				private ResolvedEvent _current;
+
+				public ResolvedEvent Current => _current;
+
+				public CatchupAllSubscription(IPublisher bus,
+					Position position,
+					bool resolveLinks,
+					IPrincipal user,
+					IReadIndex readIndex,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
+
+					if (readIndex == null) {
+						throw new ArgumentNullException(nameof(readIndex));
+					}
+
+					_bus = bus;
+					_nextPosition = position;
+					_resolveLinks = resolveLinks;
+					_user = user;
+					_readIndex = readIndex;
+					_disposedTokenSource = new CancellationTokenSource();
+					_buffer = new ConcurrentQueue<ResolvedEvent>();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+				}
+
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					ReadLoop:
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					if (_buffer.TryDequeue(out var current)) {
+						_current = current;
+						return true;
+					}
+
+					var correlationId = Guid.NewGuid();
+
+					var readNextSource = new TaskCompletionSource<bool>();
+
+					var (commitPosition, preparePosition) = _nextPosition == Position.End
+						? (_readIndex.LastCommitPosition, _readIndex.LastReplicatedPosition)
+						: _nextPosition.ToInt64();
+
+					_bus.Publish(new ClientMessage.ReadAllEventsForward(
+						correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition,
+						32, _resolveLinks, false, default, _user));
+
+					var isEnd = await readNextSource.Task.ConfigureAwait(false);
+
+					if (_buffer.TryDequeue(out current)) {
+						_current = current;
+						return true;
+					}
+
+					if (isEnd) {
+						return false;
+					}
+
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					goto ReadLoop;
+
+					void OnMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							readNextSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.ReadAllEventsForwardCompleted completed)) {
+							readNextSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.ReadAllEventsForwardCompleted>(message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case ReadAllResult.Success:
+								foreach (var @event in completed.Events) {
+									_buffer.Enqueue(@event);
+								}
+
+								_nextPosition = Position.FromInt64(
+									completed.NextPos.CommitPosition,
+									completed.NextPos.PreparePosition);
+								readNextSource.TrySetResult(completed.IsEndOfStream);
+								return;
+							case ReadAllResult.AccessDenied:
+								readNextSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+				}
+			}
+
+			private class LiveStreamSubscription : IAsyncEnumerator<ResolvedEvent> {
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_historicalEventBuffer;
+
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)> _liveEventBuffer;
+				private readonly Func<Position, ValueTask> _onDropped;
+				private readonly Position _position;
+				private readonly TaskCompletionSource<bool> _subscriptionStartedSource;
+				private readonly TaskCompletionSource<bool> _readHistoricalStartedSource;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly CancellationTokenSource _disposedTokenSource;
+
+				private ResolvedEvent _current;
+				private bool _historicalEventsRead;
+
+				public LiveStreamSubscription(IPublisher bus,
+					Func<Position, ValueTask> onDropped,
+					Guid connectionId,
+					Position position,
+					bool resolveLinks,
+					IPrincipal user,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
+
+					if (onDropped == null) {
+						throw new ArgumentNullException(nameof(onDropped));
+					}
+
+					_liveEventBuffer = new ConcurrentQueueWrapper<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_historicalEventBuffer =
+						new ConcurrentQueueWrapper<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_onDropped = onDropped;
+					_position = position;
+					_subscriptionStartedSource = new TaskCompletionSource<bool>();
+					_readHistoricalStartedSource = new TaskCompletionSource<bool>();
+					_disposedTokenSource = new CancellationTokenSource();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+
+					var correlationId = Guid.NewGuid();
+
+					bus.Publish(new ClientMessage.SubscribeToStream(correlationId, correlationId,
+						new CallbackEnvelope(OnSubscriptionMessage), connectionId, string.Empty, resolveLinks, user));
+
+					ReadHistoricalEvents(position);
+
+					void OnSubscriptionMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_subscriptionStartedSource.TrySetException(ex);
+							return;
+						}
+
+						switch (message) {
+							case ClientMessage.SubscriptionConfirmation _:
+								_subscriptionStartedSource.TrySetResult(true);
+								return;
+							case ClientMessage.SubscriptionDropped dropped:
+								switch (dropped.Reason) {
+									case SubscriptionDropReason.AccessDenied:
+										Fail(RpcExceptions.AccessDenied());
+										return;
+									default:
+										Fail(RpcExceptions.UnknownError(dropped.Reason));
+										return;
+								}
+							case ClientMessage.StreamEventAppeared appeared:
+								_liveEventBuffer.Enqueue((appeared.Event, null));
+								return;
+							default:
+								_subscriptionStartedSource.TrySetException(
+									RpcExceptions.UnknownMessage<ClientMessage.SubscriptionConfirmation>(message));
+								return;
+						}
+
+						void Fail(Exception ex) {
+							_liveEventBuffer.Enqueue((default, ex));
+							_subscriptionStartedSource.TrySetException(ex);
+						}
+					}
+
+					void OnHistoricalEventsMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_readHistoricalStartedSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.ReadAllEventsForwardCompleted completed)) {
+							_readHistoricalStartedSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.ReadStreamEventsForwardCompleted>(message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case ReadAllResult.Success:
+								foreach (var @event in completed.Events) {
+									_historicalEventBuffer.Enqueue((@event, null));
+								}
+
+								_readHistoricalStartedSource.TrySetResult(true);
+								var tfPos = completed.Events[^1].OriginalPosition.Value;
+								var position = Position.FromInt64(
+									tfPos.CommitPosition,
+									tfPos.PreparePosition);
+								ReadHistoricalEvents(position);
+								return;
+							case ReadAllResult.AccessDenied:
+								_readHistoricalStartedSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								_readHistoricalStartedSource.TrySetException(
+									RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+
+					void ReadHistoricalEvents(Position position) {
+						var correlationId = Guid.NewGuid();
+						var (commitPosition, preparePosition) = position.ToInt64();
+						bus.Publish(new ClientMessage.ReadAllEventsForward(correlationId, correlationId,
+							new CallbackEnvelope(OnHistoricalEventsMessage), commitPosition, preparePosition, 32,
+							resolveLinks, false, null, user));
+					}
+				}
+
+				public ResolvedEvent Current => _current;
+
+				public async ValueTask<bool> MoveNextAsync() {
+					(ResolvedEvent, Exception) _;
+
+					await Task.WhenAll(_subscriptionStartedSource.Task, _readHistoricalStartedSource.Task)
+						.ConfigureAwait(false);
+
+					if (!_historicalEventsRead) {
+						while (!_historicalEventBuffer.TryDequeue(out _)) {
+							await Task.Delay(1, _disposedTokenSource.Token).ConfigureAwait(false);
+						}
+
+						var (historicalEvent, historicalException) = _;
+
+						if (historicalException != null) {
+							throw historicalException;
+						}
+
+						var position = Position.FromInt64(historicalEvent.OriginalPosition.Value.CommitPosition,
+							historicalEvent.OriginalPosition.Value.PreparePosition);
+
+						if (_liveEventBuffer.Count > MaxLiveEventBufferCount) {
+							_liveEventBuffer.Clear();
+							await _onDropped(position).ConfigureAwait(false);
+							return false;
+						}
+
+						if (position < _position) {
+							_current = historicalEvent;
+							return true;
+						}
+
+						_historicalEventBuffer.Clear();
+						_historicalEventsRead = true;
+					}
+
+					while (!_liveEventBuffer.TryDequeue(out _)) {
+						await Task.Delay(1, _disposedTokenSource.Token).ConfigureAwait(false);
+					}
+
+					var (resolvedEvent, exception) = _;
+
+					if (exception != null) {
+						throw exception;
+					}
+
+					_current = resolvedEvent;
 					return true;
 				}
 
-				try {
-					await Task.Delay(100, _disposedTokenSource.Token).ConfigureAwait(false);
-				} catch (ObjectDisposedException) {
-					return false;
-				}
-
-				goto ReadLoop;
-
-				void OnMessage(Message message) {
-					if (message is ClientMessage.NotHandled notHandled &&
-					    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-						readNextSource.TrySetException(ex);
-						return;
-					}
-
-					if (!(message is ClientMessage.ReadAllEventsForwardCompleted completed)) {
-						readNextSource.TrySetException(RpcExceptions.UnknownMessage<ClientMessage.ReadAllEventsForwardCompleted>(message));
-						return;
-					}
-
-					switch (completed.Result) {
-						case ReadAllResult.Success:
-							foreach (var @event in completed.Events) {
-								_buffer.Enqueue(@event);
-							}
-
-							_nextPosition = Position.FromInt64(
-								completed.NextPos.CommitPosition,
-								completed.NextPos.PreparePosition);
-							readNextSource.TrySetResult(true);
-							return;
-						case ReadAllResult.AccessDenied:
-							readNextSource.TrySetException(RpcExceptions.AccessDenied());
-							return;
-						default:
-							readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
-							return;
-					}
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -20,13 +21,21 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly IEventFilter _eventFilter;
 			private readonly IPrincipal _user;
 			private readonly IReadIndex _readIndex;
-			private readonly CancellationTokenSource _disposedTokenSource;
-			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-			private readonly CancellationTokenRegistration _tokenRegistration;
-			private Position _nextPosition;
-			private ResolvedEvent _current;
+			private readonly CancellationToken _cancellationToken;
+			private IAsyncEnumerator<ResolvedEvent> _inner;
+			private readonly Guid _connectionId;
 
-			public ResolvedEvent Current => _current;
+			private bool _catchUpRestarted;
+
+			public ResolvedEvent Current => _inner.Current;
+
+			private Position CurrentPosition {
+				get {
+					var position = _inner.Current.OriginalPosition.Value;
+
+					return Position.FromInt64(position.CommitPosition, position.PreparePosition);
+				}
+			}
 
 			public AllSubscriptionFiltered(IPublisher bus,
 				Position position,
@@ -39,104 +48,367 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw new ArgumentNullException(nameof(bus));
 				}
 
-				if (readIndex == null) {
-					throw new ArgumentNullException(nameof(readIndex));
-				}
-
 				if (eventFilter == null) {
 					throw new ArgumentNullException(nameof(eventFilter));
 				}
 
+				if (readIndex == null) {
+					throw new ArgumentNullException(nameof(readIndex));
+				}
+
 				_bus = bus;
-				_nextPosition = position;
 				_resolveLinks = resolveLinks;
 				_eventFilter = eventFilter;
 				_user = user;
 				_readIndex = readIndex;
-				_disposedTokenSource = new CancellationTokenSource();
-				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
-			}
+				_cancellationToken = cancellationToken;
+				_connectionId = Guid.NewGuid();
 
-			public ValueTask DisposeAsync() {
-				_disposedTokenSource.Dispose();
-				_tokenRegistration.Dispose();
-				return default;
+				_inner = new CatchupAllSubscription(bus, position, resolveLinks, eventFilter, user, readIndex,
+					cancellationToken);
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				ReadLoop:
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
-				}
-
-				if (_buffer.TryDequeue(out var current)) {
-					_current = current;
+				var result = await _inner.MoveNextAsync().ConfigureAwait(false);
+				if (result) {
 					return true;
 				}
 
-				var correlationId = Guid.NewGuid();
+				if (!_catchUpRestarted) {
+					await _inner.DisposeAsync().ConfigureAwait(false);
+					_inner = new LiveStreamSubscription(_bus, OnLiveSubscriptionDropped, _connectionId, CurrentPosition,
+						_resolveLinks, _eventFilter, _user, _cancellationToken);
+				} else {
+					_catchUpRestarted = true;
+				}
 
-				var readNextSource = new TaskCompletionSource<bool>();
+				return await _inner.MoveNextAsync().ConfigureAwait(false);
+			}
 
-				var (commitPosition, preparePosition) = _nextPosition == Position.End
-					? (_readIndex.LastCommitPosition, _readIndex.LastReplicatedPosition)
-					: _nextPosition.ToInt64();
+			public ValueTask DisposeAsync() => _inner.DisposeAsync();
 
-				_bus.Publish(new ClientMessage.FilteredReadAllEventsForward(
-					correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition, 32,
-					_resolveLinks, false, 32, default, _eventFilter, _user));
+			private async ValueTask OnLiveSubscriptionDropped(Position caughtUpPosition) {
+				await _inner.DisposeAsync().ConfigureAwait(false);
 
-				await readNextSource.Task.ConfigureAwait(false);
+				_inner = new CatchupAllSubscription(_bus, caughtUpPosition, _resolveLinks, _eventFilter, _user,
+					_readIndex, _cancellationToken);
+			}
 
-				if (_buffer.TryDequeue(out current)) {
-					_current = current;
+			private class CatchupAllSubscription : IAsyncEnumerator<ResolvedEvent> {
+				private readonly IPublisher _bus;
+				private readonly bool _resolveLinks;
+				private readonly IEventFilter _eventFilter;
+				private readonly IPrincipal _user;
+				private readonly IReadIndex _readIndex;
+				private readonly CancellationTokenSource _disposedTokenSource;
+				private readonly ConcurrentQueue<ResolvedEvent> _buffer;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private Position _nextPosition;
+				private ResolvedEvent _current;
+
+				public ResolvedEvent Current => _current;
+
+				public CatchupAllSubscription(IPublisher bus,
+					Position position,
+					bool resolveLinks,
+					IEventFilter eventFilter,
+					IPrincipal user,
+					IReadIndex readIndex,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
+
+					if (eventFilter == null) {
+						throw new ArgumentNullException(nameof(eventFilter));
+					}
+
+					if (readIndex == null) {
+						throw new ArgumentNullException(nameof(readIndex));
+					}
+
+					_bus = bus;
+					_nextPosition = position;
+					_resolveLinks = resolveLinks;
+					_eventFilter = eventFilter;
+					_user = user;
+					_readIndex = readIndex;
+					_disposedTokenSource = new CancellationTokenSource();
+					_buffer = new ConcurrentQueue<ResolvedEvent>();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+				}
+
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					ReadLoop:
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					if (_buffer.TryDequeue(out var current)) {
+						_current = current;
+						return true;
+					}
+
+					var correlationId = Guid.NewGuid();
+
+					var readNextSource = new TaskCompletionSource<bool>();
+
+					var (commitPosition, preparePosition) = _nextPosition == Position.End
+						? (_readIndex.LastCommitPosition, _readIndex.LastReplicatedPosition)
+						: _nextPosition.ToInt64();
+
+					_bus.Publish(new ClientMessage.FilteredReadAllEventsForward(
+						correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition,
+						32, _resolveLinks, false, 32, default, _eventFilter, _user));
+
+					var isEnd = await readNextSource.Task.ConfigureAwait(false);
+
+					if (_buffer.TryDequeue(out current)) {
+						_current = current;
+						return true;
+					}
+
+					if (isEnd) {
+						return false;
+					}
+
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					goto ReadLoop;
+
+					void OnMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							readNextSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.FilteredReadAllEventsForwardCompleted completed)) {
+							readNextSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.FilteredReadAllEventsForwardCompleted>(
+									message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case FilteredReadAllResult.Success:
+								foreach (var @event in completed.Events) {
+									_buffer.Enqueue(@event);
+								}
+
+								_nextPosition = Position.FromInt64(
+									completed.NextPos.CommitPosition,
+									completed.NextPos.PreparePosition);
+								readNextSource.TrySetResult(completed.IsEndOfStream);
+								return;
+							case FilteredReadAllResult.AccessDenied:
+								readNextSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+				}
+			}
+
+			private class LiveStreamSubscription : IAsyncEnumerator<ResolvedEvent> {
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_historicalEventBuffer;
+
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)> _liveEventBuffer;
+				private readonly Func<Position, ValueTask> _onDropped;
+				private readonly Position _position;
+				private readonly TaskCompletionSource<bool> _subscriptionStartedSource;
+				private readonly TaskCompletionSource<bool> _readHistoricalStartedSource;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly CancellationTokenSource _disposedTokenSource;
+
+				private ResolvedEvent _current;
+				private bool _historicalEventsRead;
+
+				public LiveStreamSubscription(IPublisher bus,
+					Func<Position, ValueTask> onDropped,
+					Guid connectionId,
+					Position position,
+					bool resolveLinks,
+					IEventFilter eventFilter,
+					IPrincipal user,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
+
+					if (onDropped == null) {
+						throw new ArgumentNullException(nameof(onDropped));
+					}
+
+					if (eventFilter == null) {
+						throw new ArgumentNullException(nameof(eventFilter));
+					}
+
+					_liveEventBuffer = new ConcurrentQueueWrapper<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_historicalEventBuffer =
+						new ConcurrentQueueWrapper<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_onDropped = onDropped;
+					_position = position;
+					_subscriptionStartedSource = new TaskCompletionSource<bool>();
+					_readHistoricalStartedSource = new TaskCompletionSource<bool>();
+					_disposedTokenSource = new CancellationTokenSource();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+
+					var correlationId = Guid.NewGuid();
+
+					bus.Publish(new ClientMessage.FilteredSubscribeToStream(correlationId, correlationId,
+						new CallbackEnvelope(OnSubscriptionMessage), connectionId, string.Empty, resolveLinks, user,
+						eventFilter, 32));
+
+					ReadHistoricalEvents(position);
+
+					void OnSubscriptionMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_subscriptionStartedSource.TrySetException(ex);
+							return;
+						}
+
+						switch (message) {
+							case ClientMessage.SubscriptionConfirmation _:
+								_subscriptionStartedSource.TrySetResult(true);
+								return;
+							case ClientMessage.SubscriptionDropped dropped:
+								switch (dropped.Reason) {
+									case SubscriptionDropReason.AccessDenied:
+										Fail(RpcExceptions.AccessDenied());
+										return;
+									default:
+										Fail(RpcExceptions.UnknownError(dropped.Reason));
+										return;
+								}
+							case ClientMessage.StreamEventAppeared appeared:
+								_liveEventBuffer.Enqueue((appeared.Event, null));
+								return;
+							default:
+								_subscriptionStartedSource.TrySetException(
+									RpcExceptions.UnknownMessage<ClientMessage.SubscriptionConfirmation>(message));
+								return;
+						}
+
+						void Fail(Exception ex) {
+							_liveEventBuffer.Enqueue((default, ex));
+							_subscriptionStartedSource.TrySetException(ex);
+						}
+					}
+
+					void OnHistoricalEventsMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_readHistoricalStartedSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.FilteredReadAllEventsForwardCompleted completed)) {
+							_readHistoricalStartedSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.FilteredReadAllEventsForwardCompleted>(
+									message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case FilteredReadAllResult.Success:
+								foreach (var @event in completed.Events) {
+									_historicalEventBuffer.Enqueue((@event, null));
+								}
+
+								_readHistoricalStartedSource.TrySetResult(true);
+								var tfPos = completed.Events[^1].OriginalPosition.Value;
+								var position = Position.FromInt64(
+									tfPos.CommitPosition,
+									tfPos.PreparePosition);
+								ReadHistoricalEvents(position);
+								return;
+							case FilteredReadAllResult.AccessDenied:
+								_readHistoricalStartedSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								_readHistoricalStartedSource.TrySetException(
+									RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+
+					void ReadHistoricalEvents(Position position) {
+						var correlationId = Guid.NewGuid();
+						var (commitPosition, preparePosition) = position.ToInt64();
+						bus.Publish(new ClientMessage.FilteredReadAllEventsForward(correlationId, correlationId,
+							new CallbackEnvelope(OnHistoricalEventsMessage), commitPosition, preparePosition, 32,
+							resolveLinks, false, 32, null, eventFilter, user));
+					}
+				}
+
+				public ResolvedEvent Current => _current;
+
+				public async ValueTask<bool> MoveNextAsync() {
+					(ResolvedEvent, Exception) _;
+
+					await Task.WhenAll(_subscriptionStartedSource.Task, _readHistoricalStartedSource.Task)
+						.ConfigureAwait(false);
+
+					if (!_historicalEventsRead) {
+						while (!_historicalEventBuffer.TryDequeue(out _)) {
+							await Task.Delay(1, _disposedTokenSource.Token).ConfigureAwait(false);
+						}
+
+						var (historicalEvent, historicalException) = _;
+
+						if (historicalException != null) {
+							throw historicalException;
+						}
+
+						var position = Position.FromInt64(historicalEvent.OriginalPosition.Value.CommitPosition,
+							historicalEvent.OriginalPosition.Value.PreparePosition);
+
+						if (_liveEventBuffer.Count > MaxLiveEventBufferCount) {
+							_liveEventBuffer.Clear();
+							await _onDropped(position).ConfigureAwait(false);
+							return false;
+						}
+
+						if (position < _position) {
+							_current = historicalEvent;
+							return true;
+						}
+
+						_historicalEventBuffer.Clear();
+						_historicalEventsRead = true;
+					}
+
+					while (!_liveEventBuffer.TryDequeue(out _)) {
+						await Task.Delay(1, _disposedTokenSource.Token).ConfigureAwait(false);
+					}
+
+					var (resolvedEvent, exception) = _;
+
+					if (exception != null) {
+						throw exception;
+					}
+
+					_current = resolvedEvent;
 					return true;
 				}
 
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
-				}
-
-				try {
-					await Task.Delay(100, _disposedTokenSource.Token).ConfigureAwait(false);
-				} catch (ObjectDisposedException) {
-					return false;
-				}
-
-				goto ReadLoop;
-
-				void OnMessage(Message message) {
-					if (message is ClientMessage.NotHandled notHandled && 
-					    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-						readNextSource.TrySetException(ex);
-						return;
-					}
-
-					if (!(message is ClientMessage.FilteredReadAllEventsForwardCompleted completed)) {
-						readNextSource.TrySetException(
-							RpcExceptions.UnknownMessage<ClientMessage.FilteredReadAllEventsForwardCompleted>(message));
-						return;
-					}
-
-					switch (completed.Result) {
-						case FilteredReadAllResult.Success:
-							foreach (var @event in completed.Events) {
-								_buffer.Enqueue(@event);
-							}
-
-							_nextPosition = Position.FromInt64(
-								completed.NextPos.CommitPosition,
-								completed.NextPos.PreparePosition);
-							readNextSource.TrySetResult(true);
-							return;
-						case FilteredReadAllResult.AccessDenied:
-							readNextSource.TrySetException(RpcExceptions.AccessDenied());
-							return;
-						default:
-							readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
-							return;
-					}
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -18,16 +19,14 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly string _streamName;
 			private readonly bool _resolveLinks;
 			private readonly IPrincipal _user;
-			private readonly IReadIndex _readIndex;
-			private readonly CancellationTokenSource _disposedTokenSource;
-			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-			private readonly CancellationTokenRegistration _tokenRegistration;
-			private StreamRevision _nextRevision;
-			private ResolvedEvent _current;
+			private readonly CancellationToken _cancellationToken;
+			private IAsyncEnumerator<ResolvedEvent> _inner;
+			private readonly Guid _connectionId;
 
-			public ResolvedEvent Current => _current;
+			public ResolvedEvent Current => _inner.Current;
 
-			public StreamSubscription(IPublisher bus,
+			public StreamSubscription(
+				IPublisher bus,
 				string streamName,
 				StreamRevision startRevision,
 				bool resolveLinks,
@@ -42,105 +41,341 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw new ArgumentNullException(nameof(streamName));
 				}
 
-				if (readIndex == null) throw new ArgumentNullException(nameof(readIndex));
+				if (readIndex == null) {
+					throw new ArgumentNullException(nameof(readIndex));
+				}
 
 				_bus = bus;
 				_streamName = streamName;
-				_nextRevision = startRevision;
-				_resolveLinks = resolveLinks;
 				_user = user;
-				_readIndex = readIndex;
-				_disposedTokenSource = new CancellationTokenSource();
-				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
-			}
+				_cancellationToken = cancellationToken;
+				_resolveLinks = resolveLinks;
+				_connectionId = Guid.NewGuid();
 
-
-			public ValueTask DisposeAsync() {
-				_disposedTokenSource.Dispose();
-				_tokenRegistration.Dispose();
-				return default;
+				_inner = new CatchupStreamSubscription(bus, streamName, startRevision, resolveLinks, user, readIndex,
+					cancellationToken);
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				ReadLoop:
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
-				}
-
-				if (_buffer.TryDequeue(out var current)) {
-					_current = current;
+				var result = await _inner.MoveNextAsync().ConfigureAwait(false);
+				if (result) {
 					return true;
 				}
 
-				var correlationId = Guid.NewGuid();
+				_inner = new LiveStreamSubscription(_bus, _connectionId, _streamName, Current.OriginalEvent.EventNumber,
+					_resolveLinks, _user, _cancellationToken);
+				return await _inner.MoveNextAsync().ConfigureAwait(false);
+			}
 
-				var readNextSource = new TaskCompletionSource<bool>();
+			public ValueTask DisposeAsync() => _inner.DisposeAsync();
 
-				var nextRevision = _nextRevision == StreamRevision.End
-					? Math.Max(_readIndex.GetStreamLastEventNumber(_streamName), 0L)
-					: _nextRevision.ToInt64();
+			private class CatchupStreamSubscription : IAsyncEnumerator<ResolvedEvent> {
+				private readonly IPublisher _bus;
+				private readonly string _streamName;
+				private readonly bool _resolveLinks;
+				private readonly IPrincipal _user;
+				private readonly IReadIndex _readIndex;
+				private readonly CancellationTokenSource _disposedTokenSource;
+				private readonly ConcurrentQueue<ResolvedEvent> _buffer;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private StreamRevision _nextRevision;
+				private ResolvedEvent _current;
 
-				_bus.Publish(new ClientMessage.ReadStreamEventsForward(
-					correlationId, correlationId, new CallbackEnvelope(OnMessage), _streamName,
-					nextRevision, 32,
-					_resolveLinks, false, default, _user));
+				public ResolvedEvent Current => _current;
 
-				await readNextSource.Task.ConfigureAwait(false);
+				public CatchupStreamSubscription(
+					IPublisher bus,
+					string streamName,
+					StreamRevision startRevision,
+					bool resolveLinks,
+					IPrincipal user,
+					IReadIndex readIndex,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
 
-				if (_buffer.TryDequeue(out current)) {
-					_current = current;
+					if (streamName == null) {
+						throw new ArgumentNullException(nameof(streamName));
+					}
+
+					if (readIndex == null) {
+						throw new ArgumentNullException(nameof(readIndex));
+					}
+
+					_bus = bus;
+					_streamName = streamName;
+					_nextRevision = startRevision;
+					_resolveLinks = resolveLinks;
+					_user = user;
+					_readIndex = readIndex;
+					_disposedTokenSource = new CancellationTokenSource();
+					_buffer = new ConcurrentQueue<ResolvedEvent>();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+				}
+
+
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					ReadLoop:
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					if (_buffer.TryDequeue(out var current)) {
+						_current = current;
+						return true;
+					}
+
+					var correlationId = Guid.NewGuid();
+
+					var readNextSource = new TaskCompletionSource<bool>();
+
+					var nextRevision = _nextRevision == StreamRevision.End
+						? Math.Max(_readIndex.GetStreamLastEventNumber(_streamName), 0L)
+						: _nextRevision.ToInt64();
+
+					_bus.Publish(new ClientMessage.ReadStreamEventsForward(
+						correlationId, correlationId, new CallbackEnvelope(OnMessage), _streamName, nextRevision, 32,
+						_resolveLinks, false, default, _user));
+
+					var isEnd = await readNextSource.Task.ConfigureAwait(false);
+
+					if (_buffer.TryDequeue(out current)) {
+						_current = current;
+						return true;
+					}
+
+					if (isEnd) {
+						return false;
+					}
+
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					goto ReadLoop;
+
+					void OnMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							readNextSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.ReadStreamEventsForwardCompleted completed)) {
+							readNextSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.ReadStreamEventsForwardCompleted>(message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case ReadStreamResult.Success:
+								foreach (var @event in completed.Events) {
+									_buffer.Enqueue(@event);
+								}
+
+								_nextRevision = StreamRevision.FromInt64(completed.NextEventNumber);
+								readNextSource.TrySetResult(completed.IsEndOfStream);
+								return;
+							case ReadStreamResult.NoStream:
+								readNextSource.TrySetException(RpcExceptions.StreamNotFound(_streamName));
+								return;
+							case ReadStreamResult.StreamDeleted:
+								readNextSource.TrySetException(RpcExceptions.StreamDeleted(_streamName));
+								return;
+							case ReadStreamResult.AccessDenied:
+								readNextSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+				}
+			}
+
+			private class LiveStreamSubscription : IAsyncEnumerator<ResolvedEvent> {
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_historicalEventBuffer;
+
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)> _liveEventBuffer;
+				private readonly long _currentRevision;
+				private readonly TaskCompletionSource<bool> _subscriptionStartedSource;
+				private readonly TaskCompletionSource<bool> _readHistoricalStartedSource;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly CancellationTokenSource _disposedTokenSource;
+
+				private ResolvedEvent _current;
+				private bool _historicalEventsRead;
+
+				public LiveStreamSubscription(IPublisher bus,
+					Guid connectionId,
+					string streamName,
+					long currentRevision,
+					bool resolveLinks,
+					IPrincipal user,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
+
+					if (streamName == null) {
+						throw new ArgumentNullException(nameof(streamName));
+					}
+
+					_liveEventBuffer = new ConcurrentQueueWrapper<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_historicalEventBuffer =
+						new ConcurrentQueueWrapper<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_currentRevision = currentRevision;
+					_subscriptionStartedSource = new TaskCompletionSource<bool>();
+					_readHistoricalStartedSource = new TaskCompletionSource<bool>();
+					_disposedTokenSource = new CancellationTokenSource();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+
+					var correlationId = Guid.NewGuid();
+
+					bus.Publish(new ClientMessage.SubscribeToStream(correlationId, correlationId,
+						new CallbackEnvelope(OnSubscriptionMessage), connectionId, streamName, resolveLinks, user));
+
+					ReadHistoricalEvents(currentRevision);
+
+					void OnSubscriptionMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_subscriptionStartedSource.TrySetException(ex);
+							return;
+						}
+
+						switch (message) {
+							case ClientMessage.SubscriptionConfirmation _:
+								_subscriptionStartedSource.TrySetResult(true);
+								return;
+							case ClientMessage.SubscriptionDropped dropped:
+								switch (dropped.Reason) {
+									case SubscriptionDropReason.AccessDenied:
+										Fail(RpcExceptions.AccessDenied());
+										return;
+									case SubscriptionDropReason.NotFound:
+										Fail(RpcExceptions.StreamNotFound(streamName));
+										return;
+									default:
+										Fail(RpcExceptions.UnknownError(dropped.Reason));
+										return;
+								}
+							case ClientMessage.StreamEventAppeared appeared:
+								_liveEventBuffer.Enqueue((appeared.Event, null));
+								return;
+							default:
+								_subscriptionStartedSource.TrySetException(
+									RpcExceptions.UnknownMessage<ClientMessage.SubscriptionConfirmation>(message));
+								return;
+						}
+
+						void Fail(Exception ex) {
+							_liveEventBuffer.Enqueue((default, ex));
+							_subscriptionStartedSource.TrySetException(ex);
+						}
+					}
+
+					void OnHistoricalEventsMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_readHistoricalStartedSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.ReadStreamEventsForwardCompleted completed)) {
+							_readHistoricalStartedSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.ReadStreamEventsForwardCompleted>(message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case ReadStreamResult.Success:
+								foreach (var @event in completed.Events) {
+									_historicalEventBuffer.Enqueue((@event, null));
+								}
+
+								_readHistoricalStartedSource.TrySetResult(completed.IsEndOfStream);
+								ReadHistoricalEvents(completed.Events[^1].OriginalEvent.EventNumber);
+								return;
+							case ReadStreamResult.NoStream:
+								_readHistoricalStartedSource.TrySetException(RpcExceptions.StreamNotFound(streamName));
+								return;
+							case ReadStreamResult.StreamDeleted:
+								_readHistoricalStartedSource.TrySetException(RpcExceptions.StreamDeleted(streamName));
+								return;
+							case ReadStreamResult.AccessDenied:
+								_readHistoricalStartedSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								_readHistoricalStartedSource.TrySetException(
+									RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+
+					void ReadHistoricalEvents(long fromStreamRevision) {
+						var correlationId = Guid.NewGuid();
+						bus.Publish(new ClientMessage.ReadStreamEventsForward(correlationId, correlationId,
+							new CallbackEnvelope(OnHistoricalEventsMessage), streamName, fromStreamRevision, 32,
+							resolveLinks, false, null,
+							user));
+					}
+				}
+
+				public ResolvedEvent Current => _current;
+
+				public async ValueTask<bool> MoveNextAsync() {
+					(ResolvedEvent, Exception) _;
+
+					await Task.WhenAll(_subscriptionStartedSource.Task, _readHistoricalStartedSource.Task)
+						.ConfigureAwait(false);
+
+					if (!_historicalEventsRead) {
+						while (!_historicalEventBuffer.TryDequeue(out _)) {
+							await Task.Delay(1, _disposedTokenSource.Token).ConfigureAwait(false);
+						}
+
+						var (historicalEvent, historicalException) = _;
+
+						if (historicalException != null) {
+							throw historicalException;
+						}
+
+						if (historicalEvent.OriginalEvent.EventNumber < _currentRevision) {
+							_current = historicalEvent;
+							return true;
+						}
+
+						_historicalEventBuffer.Clear();
+						_historicalEventsRead = true;
+					}
+
+					while (!_liveEventBuffer.TryDequeue(out _)) {
+						await Task.Delay(1, _disposedTokenSource.Token).ConfigureAwait(false);
+					}
+
+					var (resolvedEvent, exception) = _;
+
+					if (exception != null) {
+						throw exception;
+					}
+
+					_current = resolvedEvent;
 					return true;
 				}
 
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
-				}
-
-				try {
-					await Task.Delay(100, _disposedTokenSource.Token).ConfigureAwait(false);
-				} catch (ObjectDisposedException) {
-					return false;
-				}
-
-
-				goto ReadLoop;
-
-				void OnMessage(Message message) {
-					if (message is ClientMessage.NotHandled notHandled &&
-					    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-						readNextSource.TrySetException(ex);
-						return;
-					}
-
-					if (!(message is ClientMessage.ReadStreamEventsForwardCompleted completed)) {
-						readNextSource.TrySetException(
-							RpcExceptions.UnknownMessage<ClientMessage.ReadStreamEventsForwardCompleted>(message));
-						return;
-					}
-
-					switch (completed.Result) {
-						case ReadStreamResult.Success:
-							foreach (var @event in completed.Events) {
-								_buffer.Enqueue(@event);
-							}
-
-							_nextRevision = StreamRevision.FromInt64(completed.NextEventNumber);
-							readNextSource.TrySetResult(true);
-							return;
-						case ReadStreamResult.NoStream:
-							readNextSource.TrySetException(RpcExceptions.StreamNotFound(_streamName));
-							return;
-						case ReadStreamResult.StreamDeleted:
-							readNextSource.TrySetException(RpcExceptions.StreamDeleted(_streamName));
-							return;
-						case ReadStreamResult.AccessDenied:
-							readNextSource.TrySetException(RpcExceptions.AccessDenied());
-							return;
-						default:
-							readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
-							return;
-					}
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
@@ -379,7 +379,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 						var streamRevision = StreamRevision.FromInt64(historicalEvent.OriginalEvent.EventNumber);
 
-						if (_liveEventBuffer.Count > 512) {
+						if (_liveEventBuffer.Count > MaxLiveEventBufferCount) {
 							_liveEventBuffer.Clear();
 							await _onDropped(streamRevision).ConfigureAwait(false);
 							return false;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.cs
@@ -1,4 +1,5 @@
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal static partial class Enumerators {
+		private const int MaxLiveEventBufferCount = 512;
 	}
 }

--- a/src/EventStore.Grpc.Tests/EventStore.Grpc.Tests.csproj
+++ b/src/EventStore.Grpc.Tests/EventStore.Grpc.Tests.csproj
@@ -5,6 +5,7 @@
 				<RootNamespace>EventStore.Grpc</RootNamespace>
 		</PropertyGroup>
 		<ItemGroup>
+				<PackageReference Include="CompareNETObjects" Version="4.65.0" />
 				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.0" />
 				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
 				<PackageReference Include="xunit" Version="2.4.1" />

--- a/src/EventStore.Grpc.Tests/Streams/AssertEx.cs
+++ b/src/EventStore.Grpc.Tests/Streams/AssertEx.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using KellermanSoftware.CompareNetObjects;
+using Xunit;
+
+namespace EventStore.Grpc.Streams {
+	internal static class AssertEx {
+		public static void EventsEqual(EventData[] expected, EventRecord[] actual) {
+			if (expected == null) throw new ArgumentNullException(nameof(expected));
+			if (actual == null) throw new ArgumentNullException(nameof(actual));
+			var logic = new CompareLogic {
+				Config = {
+					MaxDifferences = 16
+				}
+			};
+
+			var expectedObject = Array.ConvertAll(expected, e => new {
+				e.EventId,
+				e.Type,
+				e.IsJson,
+				e.Data,
+				e.Metadata
+			});
+			var actualObject = Array.ConvertAll(actual, e => new {
+				e.EventId,
+				Type = e.EventType,
+				e.IsJson,
+				e.Data,
+				e.Metadata
+			});
+			var result = logic.Compare(
+				expectedObject,
+				actualObject);
+
+			Assert.True(result.AreEqual, result.DifferencesString);
+		}
+	}
+}

--- a/src/EventStore.Grpc.Tests/Streams/EventDataComparer.cs
+++ b/src/EventStore.Grpc.Tests/Streams/EventDataComparer.cs
@@ -1,8 +1,9 @@
+using System;
 using EventStore.Common.Utils;
 
-namespace EventStore.Grpc.Streams
-{
+namespace EventStore.Grpc.Streams {
 	internal static class EventDataComparer {
+		[Obsolete]
 		public static bool Equal(EventData expected, EventRecord actual) {
 			if (expected.EventId != actual.EventId)
 				return false;
@@ -10,22 +11,24 @@ namespace EventStore.Grpc.Streams
 			if (expected.Type != actual.EventType)
 				return false;
 
-			var expectedDataString = Helper.UTF8NoBom.GetString(expected.Data ?? new byte[0]);
-			var expectedMetadataString = Helper.UTF8NoBom.GetString(expected.Metadata ?? new byte[0]);
+			var expectedDataString = Helper.UTF8NoBom.GetString(expected.Data ?? Array.Empty<byte>());
+			var expectedMetadataString = Helper.UTF8NoBom.GetString(expected.Metadata ?? Array.Empty<byte>());
 
-			var actualDataString = Helper.UTF8NoBom.GetString(actual.Data ?? new byte[0]);
-			var actualMetadataDataString = Helper.UTF8NoBom.GetString(actual.Metadata ?? new byte[0]);
+			var actualDataString = Helper.UTF8NoBom.GetString(actual.Data ?? Array.Empty<byte>());
+			var actualMetadataDataString = Helper.UTF8NoBom.GetString(actual.Metadata ?? Array.Empty<byte>());
 
 			return expectedDataString == actualDataString && expectedMetadataString == actualMetadataDataString;
 		}
 
+		[Obsolete]
 		public static bool Equal(EventData[] expected, EventRecord[] actual) {
 			if (expected.Length != actual.Length)
 				return false;
 
 			for (var i = 0; i < expected.Length; i++) {
-				if (!Equal(expected[i], actual[i]))
+				if (!Equal(expected[i], actual[i])) {
 					return false;
+				}
 			}
 
 			return true;

--- a/src/EventStore.Grpc.Tests/Streams/all_stream_catch_up_subscription.cs
+++ b/src/EventStore.Grpc.Tests/Streams/all_stream_catch_up_subscription.cs
@@ -114,7 +114,7 @@ namespace EventStore.Grpc.Streams {
 
 			await appeared.Task.WithTimeout();
 
-			Assert.True(EventDataComparer.Equal(beforeEvents.Concat(afterEvents).ToArray(), appearedEvents.ToArray()));
+			AssertEx.EventsEqual(beforeEvents.Concat(afterEvents).ToArray(), appearedEvents.ToArray());
 
 			Assert.False(dropped.Task.IsCompleted);
 

--- a/src/EventStore.Grpc.Tests/Streams/stream_catch_up_subscription.cs
+++ b/src/EventStore.Grpc.Tests/Streams/stream_catch_up_subscription.cs
@@ -72,7 +72,7 @@ namespace EventStore.Grpc.Streams {
 			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex)
 				=> dropped.SetResult((reason, ex));
 		}
-		
+
 		[Fact]
 		public async Task allow_multiple_subscriptions_to_same_stream() {
 			var stream = _fixture.GetStreamName();
@@ -101,7 +101,8 @@ namespace EventStore.Grpc.Streams {
 			var stream = _fixture.GetStreamName();
 			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
 
-			using var subscription = _fixture.Client.SubscribeToStream(stream, EventAppeared, false, SubscriptionDropped);
+			using var subscription =
+				_fixture.Client.SubscribeToStream(stream, EventAppeared, false, SubscriptionDropped);
 
 			Assert.False(dropped.Task.IsCompleted);
 
@@ -161,7 +162,7 @@ namespace EventStore.Grpc.Streams {
 
 			await appeared.Task.WithTimeout(TimeSpan.FromMinutes(10));
 
-			Assert.True(EventDataComparer.Equal(beforeEvents.Concat(afterEvents).ToArray(), appearedEvents.ToArray()));
+			AssertEx.EventsEqual(beforeEvents.Concat(afterEvents).ToArray(), appearedEvents.ToArray());
 
 			Assert.False(dropped.Task.IsCompleted);
 
@@ -173,7 +174,7 @@ namespace EventStore.Grpc.Streams {
 			Assert.Null(ex);
 
 			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
-				appearedEvents.Add(e.Event);
+				appearedEvents.Add(e.OriginalEvent);
 
 				if (appearedEvents.Count >= beforeEvents.Length + afterEvents.Length) {
 					appeared.TrySetResult(true);
@@ -186,7 +187,6 @@ namespace EventStore.Grpc.Streams {
 				dropped.SetResult((reason, ex));
 			}
 		}
-
 
 		public class Fixture : EventStoreGrpcFixture {
 			public EventData[] Events { get; }


### PR DESCRIPTION
Currently the GRPC subscriptions model uses reads internally even when the subscription is caught up. This may result in lowered performance and/or an unacceptable delay to receive a message in a subscription.