### PR TITLE
Throw when a required metadata property is missing

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -77,6 +77,14 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					{Constants.Exceptions.MaximumAppendSize, maxAppendSize.ToString()}
 				});
 
+		public static Exception RequiredMetadataPropertyMissing(string missingMetadataProperty) =>
+			new RpcException(
+				new Status(StatusCode.InvalidArgument, $"Required Metadata Property '{missingMetadataProperty}' is missing"),
+				new Metadata {
+					{Constants.Exceptions.ExceptionKey, Constants.Exceptions.MissingRequiredMetadataProperty},
+					{Constants.Exceptions.RequiredMetadataProperties, string.Join(",", Constants.Metadata.RequiredMetadata)}
+				});
+
 		public static bool TryHandleNotHandled(ClientMessage.NotHandled notHandled, out Exception exception) {
 			exception = null;
 			switch (notHandled.Reason) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -50,10 +50,18 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw RpcExceptions.MaxAppendSizeExceeded(_maxAppendSize);
 				}
 
+				if (!proposedMessage.Metadata.TryGetValue(Constants.Metadata.Type, out var eventType)) {
+					throw RpcExceptions.RequiredMetadataPropertyMissing(Constants.Metadata.Type);
+				}
+
+				if (!proposedMessage.Metadata.TryGetValue(Constants.Metadata.IsJson, out var isJson)) {
+					throw RpcExceptions.RequiredMetadataPropertyMissing(Constants.Metadata.IsJson);
+				}
+
 				events.Add(new Event(
 					Uuid.FromDto(proposedMessage.Id).ToGuid(),
-					proposedMessage.Metadata[Constants.Metadata.Type],
-					bool.Parse(proposedMessage.Metadata[Constants.Metadata.IsJson]),
+					eventType,
+					bool.Parse(isJson),
 					data,
 					proposedMessage.CustomMetadata.ToByteArray()));
 			}

--- a/src/EventStore.Grpc.Common/Constants.cs
+++ b/src/EventStore.Grpc.Common/Constants.cs
@@ -9,6 +9,7 @@ namespace EventStore.Grpc {
 			public const string WrongExpectedVersion = "wrong-expected-version";
 			public const string StreamNotFound = "stream-not-found";
 			public const string MaximumAppendSizeExceeded = "maximum-append-size-exceeded";
+			public const string MissingRequiredMetadataProperty = "missing-required-metadata-property";
 
 			public const string PersistentSubscriptionFailed = "persistent-subscription-failed";
 			public const string PersistentSubscriptionDoesNotExist = "persistent-subscription-does-not-exist";
@@ -25,6 +26,7 @@ namespace EventStore.Grpc {
 			public const string GroupName = "group-name";
 			public const string Reason = "reason";
 			public const string MaximumAppendSize = "maximum-append-size";
+			public const string RequiredMetadataProperties = "required-metadata-properties";
 
 			public const string LoginName = "login-name";
 		}
@@ -33,6 +35,7 @@ namespace EventStore.Grpc {
 			public const string IsJson = "is-json";
 			public const string Type = "type";
 			public const string Created = "created";
+			public static readonly string[] RequiredMetadata = {Type, IsJson};
 		}
 
 		public static class Headers {

--- a/src/EventStore.Grpc/RequiredMetadataPropertyMissingException.cs
+++ b/src/EventStore.Grpc/RequiredMetadataPropertyMissingException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace EventStore.Grpc {
+	/// <summary>
+	/// Exception thrown when a required metadata property is missing.
+	/// </summary>
+	public class RequiredMetadataPropertyMissingException : Exception {
+		public RequiredMetadataPropertyMissingException(string missingMetadataProperty, Exception innerException) :
+			base($"Required metadata property {missingMetadataProperty} is missing", innerException) {
+		}
+	}
+}

--- a/src/EventStore.Grpc/TypedExceptionInterceptor.cs
+++ b/src/EventStore.Grpc/TypedExceptionInterceptor.cs
@@ -97,6 +97,10 @@ namespace EventStore.Grpc {
 							ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.GroupName)?.Value, ex),
 					Constants.Exceptions.UserNotFound => new UserNotFoundException(
 						ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.LoginName)?.Value),
+					Constants.Exceptions.MissingRequiredMetadataProperty => new
+						RequiredMetadataPropertyMissingException(
+							ex.Trailers.FirstOrDefault(x => x.Key == Constants.Exceptions.MissingRequiredMetadataProperty)
+								?.Value, ex),
 					_ => (Exception)new InvalidOperationException(ex.Message, ex)
 				},
 				false => new InvalidOperationException(ex.Message, ex)


### PR DESCRIPTION
Fixes #2172
Currently we require `is-json` as well as `type` to be included in the metadata for appending messages.

The downsides to this approach is that if both metadata properties are missing, you will only observe the first exception which should include the information about the required metadata properties.

Once the ecosystem of Client APIs are established clients, shouldn't really hit this exception very often and it's likely only useful in the initial development phase.

e.g.
From a sample client in development seeing this exception now which helps.
```
Unexpected failure rpc error: code = InvalidArgument desc = Required Metadata Property 'type' is missing
```