### PR TITLE
Performance counters

### DIFF
--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -24,6 +24,8 @@
 		<PackageReference Include="SimpleSyndicate.UriTemplate" Version="1.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
 		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
+		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
+		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.48" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />
@@ -34,12 +36,7 @@
 		<ProjectReference Include="..\EventStore.Transport.Tcp\EventStore.Transport.Tcp.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<Protobuf
-						Include="../Protos/Grpc/*.proto"
-						Exclude="../Protos/Grpc/projections.proto"
-						GrpcServices="Server"
-						LinkBase="Services/Transport/Grpc"
-						ProtoRoot="../Protos/Grpc"/>
+		<Protobuf Include="../Protos/Grpc/*.proto" Exclude="../Protos/Grpc/projections.proto" GrpcServices="Server" LinkBase="Services/Transport/Grpc" ProtoRoot="../Protos/Grpc" />
 		<Compile Include="../EventStore.Grpc.Common/*.cs" LinkBase="Services/Transport/Grpc" />
 	</ItemGroup>
 	<ItemGroup>

--- a/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
+++ b/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
@@ -61,6 +61,7 @@ namespace EventStore.Core.Services.Monitoring {
 		private DateTime _lastTcpConnectionsRequestTime;
 		private IPEndPoint _tcpEndpoint;
 		private IPEndPoint _tcpSecureEndpoint;
+		private bool _started = false;
 
 		public MonitoringService(IQueuedHandler monitoringQueue,
 			IPublisher statsCollectionBus,
@@ -97,11 +98,15 @@ namespace EventStore.Core.Services.Monitoring {
 		}
 
 		public void Handle(SystemMessage.SystemInit message) {
-			_systemStats.Start();
 			_timer.Change(_statsCollectionPeriodMs, Timeout.Infinite);
 		}
 
 		public void OnTimerTick(object state) {
+			if (!_started) {
+				_started = true;
+				_systemStats.Start();
+			}
+
 			CollectRegularStats();
 			_timer.Change(_statsCollectionPeriodMs, Timeout.Infinite);
 		}

--- a/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
+++ b/src/EventStore.Core/Services/Monitoring/MonitoringService.cs
@@ -93,10 +93,11 @@ namespace EventStore.Core.Services.Monitoring {
 			_tcpEndpoint = tcpEndpoint;
 			_tcpSecureEndpoint = tcpSecureEndpoint;
 			_timer = new Timer(OnTimerTick, null, Timeout.Infinite, Timeout.Infinite);
-			_systemStats = new SystemStatsHelper(Log, _writerCheckpoint, _dbPath);
+			_systemStats = new SystemStatsHelper(Log, _writerCheckpoint, _dbPath, _statsCollectionPeriodMs);
 		}
 
 		public void Handle(SystemMessage.SystemInit message) {
+			_systemStats.Start();
 			_timer.Change(_statsCollectionPeriodMs, Timeout.Infinite);
 		}
 

--- a/src/EventStore.Core/Services/Monitoring/SystemStatsHelper.cs
+++ b/src/EventStore.Core/Services/Monitoring/SystemStatsHelper.cs
@@ -111,8 +111,6 @@ namespace EventStore.Core.Services.Monitoring {
 				return;
 			var process = Process.GetCurrentProcess();
 			try {
-				_perfCounter.RefreshInstanceName();
-
 				var procCpuUsage = _perfCounter.GetProcCpuUsage();
 
 				stats["proc-startTime"] = process.StartTime.ToUniversalTime().ToString("O");

--- a/src/EventStore.Core/Services/Monitoring/Utils/EventCountersHelper.cs
+++ b/src/EventStore.Core/Services/Monitoring/Utils/EventCountersHelper.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Tracing;
+using System.Threading.Tasks;
+using EventStore.Common.Log;
+using EventStore.Core.Services.Monitoring.Stats;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Analysis;
+using Microsoft.Diagnostics.Tracing.Parsers;
+
+namespace EventStore.Core.Services.Monitoring.Utils {
+	internal class EventCountersHelper : IDisposable {
+		private static readonly ILogger Log = LogManager.GetLoggerFor<EventCountersHelper>();
+		private const int InvalidCounterResult = -1;
+
+		private readonly List<EventPipeProvider> _providers;
+		private DiagnosticsClient _client;
+		private EventPipeSession _session;
+		private readonly IDictionary<string, double> _collectedStats = new Dictionary<string, double>();
+
+		private readonly int _pid;
+
+		public EventCountersHelper(long collectIntervalInMs) {
+			var currentProcess = Process.GetCurrentProcess();
+			_pid = currentProcess.Id;
+
+			_providers = new List<EventPipeProvider> {
+				new EventPipeProvider("System.Runtime", EventLevel.Informational,
+					(long)(ClrTraceEventParser.Keywords.GC | ClrTraceEventParser.Keywords.Threading | ClrTraceEventParser.Keywords.Exception | ClrTraceEventParser.Keywords.Contention), new Dictionary<string, string> {
+						{"EventCounterIntervalSec", $"{collectIntervalInMs / 1000}"}
+					}),
+				new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational,
+					(long)ClrTraceEventParser.Keywords.GC, new Dictionary<string, string>())
+			};
+		}
+
+		public void Start() {
+			Task.Run(() => {
+				_client = new DiagnosticsClient(_pid);
+				_session = _client.StartEventPipeSession(_providers, false);
+				var source = new EventPipeEventSource(_session.EventStream);
+				
+				source.NeedLoadedDotNetRuntimes();
+				source.AddCallbackOnProcessStart(proc =>
+				{
+					if (proc.ProcessID != _pid)
+						return;
+
+					proc.AddCallbackOnDotNetRuntimeLoad(runtime =>
+					{
+						runtime.GCEnd += (process, gc) => {
+							var key = $"gen-{gc.Generation}-gc-collection-count";
+							_collectedStats.TryGetValue(key, out var collected);
+							_collectedStats[key] = ++collected;
+						};
+					});
+				});
+
+				source.Dynamic.All += obj => {
+					if (obj.EventName.Equals("EventCounters")) {
+						var payload = (IDictionary<string, object>)obj.PayloadValue(0);
+						var pairs = (IDictionary<string, object>)(payload["Payload"]);
+
+						var name = string.Intern(pairs["Name"].ToString());
+
+						var counterType = pairs["CounterType"];
+						if (counterType.Equals("Sum")) {
+							_collectedStats[name] = double.Parse(pairs["Increment"].ToString());
+						}
+
+						if (counterType.Equals("Mean")) {
+							_collectedStats[name] = double.Parse(pairs["Mean"].ToString());
+						}
+					}
+				};
+			
+				try {
+					source.Process();
+				} catch (Exception exception) {
+					Log.WarnException(exception, "Error encountered while processing events");
+				}
+			});
+		}
+
+		///<summary>
+		///Total process CPU usage
+		///</summary>
+		public float GetProcCpuUsage() {
+			return (float)GetCounterValue("cpu-usage");
+		}
+
+		///<summary>
+		///Current thread count
+		///</summary>
+		public int GetProcThreadsCount() {
+			return (int)GetCounterValue("threadpool-thread-count");
+		}
+
+		///<summary>
+		///Number of exceptions thrown per second
+		///</summary>
+		public float GetThrownExceptionsRate() {
+			return (float)GetCounterValue("exception-count");
+		}
+
+		///<summary>
+		///The rate at which threads in the runtime attempt to acquire a managed lock unsuccessfully
+		///</summary>
+		public float GetContentionsRateCount() {
+			return (float)GetCounterValue("monitor-lock-contention-count");
+		}
+
+		private double GetCounterValue(string name) {
+			if (!_collectedStats.TryGetValue(name, out var value)) return InvalidCounterResult;
+			return value;
+		}
+
+		public GcStats GetGcStats() {
+			return new GcStats(
+				gcAllocationSpeed: (float)GetCounterValue("alloc-rate"),
+				gcGen0Items: (long)GetCounterValue("gen-0-gc-collection-count"),
+				gcGen0Size: (long)GetCounterValue("gen-0-size"),
+				gcGen1Items: (long)GetCounterValue("gen-1-gc-collection-count"),
+				gcGen1Size: (long)GetCounterValue("gen-1-size"),
+				gcGen2Items: (long)GetCounterValue("gen-2-gc-collection-count"),
+				gcGen2Size: (long)GetCounterValue("gen-2-size"),
+				gcLargeHeapSize: (long)GetCounterValue("loh-size"),
+				gcTimeInGc: (long)GetCounterValue("time-in-gc"),
+				gcTotalBytesInHeaps: (long)GetCounterValue("gc-heap-size") * 1024 * 1024);
+		}
+
+		public void Dispose() {
+			_session?.Stop();
+			_session?.Dispose();
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Monitoring/Utils/PerfCounterHelper.cs
+++ b/src/EventStore.Core/Services/Monitoring/Utils/PerfCounterHelper.cs
@@ -1,95 +1,21 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.Tracing;
-using System.Threading.Tasks;
 using EventStore.Common.Log;
-using EventStore.Common.Utils;
-using EventStore.Core.Services.Monitoring.Stats;
-using Microsoft.Diagnostics.NETCore.Client;
-using Microsoft.Diagnostics.Tracing;
-using Microsoft.Diagnostics.Tracing.Analysis;
-using Microsoft.Diagnostics.Tracing.Parsers;
 
 namespace EventStore.Core.Services.Monitoring.Utils {
 	internal class PerfCounterHelper : IDisposable {
-		private static readonly ILogger Log = LogManager.GetLoggerFor<PerfCounterHelper>();
 		private const int InvalidCounterResult = -1;
-
-		private readonly List<EventPipeProvider> _providers;
-		private DiagnosticsClient _client;
-		private EventPipeSession _session;
-		private readonly IDictionary<string, double> _collectedStats = new Dictionary<string, double>();
 
 		private readonly ILogger _log;
 
 		private readonly PerformanceCounter _totalCpuCounter;
 		private readonly PerformanceCounter _totalMemCounter; //doesn't work on mono
-		private readonly int _pid;
 
-		public PerfCounterHelper(ILogger log, long collectIntervalInMs) {
+		public PerfCounterHelper(ILogger log) {
 			_log = log;
-
-			var currentProcess = Process.GetCurrentProcess();
-			_pid = currentProcess.Id;
-
-			_providers = new List<EventPipeProvider> {
-				new EventPipeProvider("System.Runtime", EventLevel.Informational,
-					(long)ClrTraceEventParser.Keywords.All, new Dictionary<string, string> {
-						{"EventCounterIntervalSec", $"{collectIntervalInMs / 1000}"}
-					}),
-				new EventPipeProvider("Microsoft-Windows-DotNETRuntime", EventLevel.Informational,
-					(long)ClrTraceEventParser.Keywords.All, new Dictionary<string, string>())
-			};
 
 			_totalCpuCounter = CreatePerfCounter("Processor", "% Processor Time", "_Total");
 			_totalMemCounter = CreatePerfCounter("Memory", "Available Bytes");
-		}
-
-		public void Start() {
-			Task.Run(() => {
-				_client = new DiagnosticsClient(_pid);
-				_session = _client.StartEventPipeSession(_providers, false);
-				using var source = new EventPipeEventSource(_session.EventStream);
-				
-				source.NeedLoadedDotNetRuntimes();
-				source.AddCallbackOnProcessStart(proc =>
-				{
-					if (proc.ProcessID != _pid)
-						return;
-
-					proc.AddCallbackOnDotNetRuntimeLoad(runtime =>
-					{
-						runtime.GCEnd += (process, gc) =>
-						{
-							_collectedStats[$"gen-{gc.Generation}-gc-collection-count"] = gc.Number;
-						};
-					});
-				});
-
-				source.Dynamic.All += obj => {
-					if (obj.EventName.Equals("EventCounters")) {
-						var payload = (IDictionary<string, object>)obj.PayloadValue(0);
-						var pairs = (IDictionary<string, object>)(payload["Payload"]);
-
-						var name = string.Intern(pairs["Name"].ToString());
-
-						var counterType = pairs["CounterType"];
-						if (counterType.Equals("Sum")) {
-							_collectedStats[name] = double.Parse(pairs["Increment"].ToString());
-						}
-
-						if (counterType.Equals("Mean")) {
-							_collectedStats[name] = double.Parse(pairs["Mean"].ToString());
-						}
-					}
-				};
-				try {
-					source.Process();
-				} catch (Exception exception) {
-					Log.WarnException(exception, "Error encountered while processing events");
-				}
-			});
 		}
 
 		private PerformanceCounter CreatePerfCounter(string category, string counter, string instance = null) {
@@ -103,37 +29,6 @@ namespace EventStore.Core.Services.Monitoring.Utils {
 					category, counter, instance ?? string.Empty, ex.Message);
 				return null;
 			}
-		}
-
-		private string GetProcessInstanceName(string categoryName, string counterName) {
-			// On Unix or MacOS, use the PID as the instance name
-			if (Runtime.IsUnixOrMac) {
-				return _pid.ToString();
-			}
-
-			// On Windows use the Performance Counter to get the name
-			try {
-				if (PerformanceCounterCategory.Exists(categoryName)) {
-					var category = new PerformanceCounterCategory(categoryName).ReadCategory();
-
-					if (category.Contains(counterName)) {
-						var instanceDataCollection = category[counterName];
-
-						if (instanceDataCollection.Values != null) {
-							foreach (InstanceData item in instanceDataCollection.Values) {
-								var instancePid = (int)item.RawValue;
-								if (_pid.Equals(instancePid)) {
-									return item.InstanceName;
-								}
-							}
-						}
-					}
-				}
-			} catch (InvalidOperationException) {
-				_log.Trace("Unable to get performance counter category '{category}' instances.", categoryName);
-			}
-
-			return null;
 		}
 
 		///<summary>
@@ -150,55 +45,7 @@ namespace EventStore.Core.Services.Monitoring.Utils {
 			return _totalMemCounter?.NextSample().RawValue ?? InvalidCounterResult;
 		}
 
-		///<summary>
-		///Total process CPU usage
-		///</summary>
-		public float GetProcCpuUsage() {
-			return (float)GetCounterValue("cpu-usage");
-		}
-
-		///<summary>
-		///Current thread count
-		///</summary>
-		public int GetProcThreadsCount() {
-			return (int)GetCounterValue("threadpool-thread-count");
-		}
-
-		///<summary>
-		///Number of exceptions thrown per second
-		///</summary>
-		public float GetThrownExceptionsRate() {
-			return (float)GetCounterValue("exception-count");
-		}
-
-		///<summary>
-		///The rate at which threads in the runtime attempt to acquire a managed lock unsuccessfully
-		///</summary>
-		public float GetContentionsRateCount() {
-			return (float)GetCounterValue("monitor-lock-contention-count");
-		}
-
-		private double GetCounterValue(string name) {
-			if (!_collectedStats.TryGetValue(name, out var value)) return InvalidCounterResult;
-			return value;
-		}
-
-		public GcStats GetGcStats() {
-			return new GcStats(
-				gcAllocationSpeed: (float)GetCounterValue("alloc-rate"),
-				gcGen0Items: (long)GetCounterValue("gen-0-gc-collection-count"),
-				gcGen0Size: (long)GetCounterValue("gen-0-size"),
-				gcGen1Items: (long)GetCounterValue("gen-1-gc-collection-count"),
-				gcGen1Size: (long)GetCounterValue("gen-1-size"),
-				gcGen2Items: (long)GetCounterValue("gen-2-gc-collection-count"),
-				gcGen2Size: (long)GetCounterValue("gen-2-size"),
-				gcLargeHeapSize: (long)GetCounterValue("loh-size"),
-				gcTimeInGc: (long)GetCounterValue("time-in-gc"),
-				gcTotalBytesInHeaps: (long)GetCounterValue("gc-heap-size") * 1024 * 1024);
-		}
-
 		public void Dispose() {
-			_session?.Dispose();
 			_totalCpuCounter?.Dispose();
 			_totalMemCounter?.Dispose();
 		}


### PR DESCRIPTION
Fixes #2020

This PR leverages the EventCounters based performance monitoring capabilities with the help of [Microsoft.Diagnostics.NETCore.Client](https://www.nuget.org/packages/Microsoft.Diagnostics.NETCore.Client/).

We use 2 providers namely `System.Runtime` and `Microsoft-Windows-DotNETRuntime`.

The `System.Runtime` provides basic information about the the garbage collector in addition to items such as allocation rate, contention count, exception count and thread pool thread count.

The `Microsoft-Windows-DotNETRuntime` provides detailed information about the garbage collector such as number of allocations per generation (which is captured on a `GCEnd`) since the application started for example which is a replacement for `# Gen 0 Collections` that we used to gather from the performance counters.

### Note
Our xunit tests were failing because of a deadlock that occurred because of `DiagnosticsClient.StartEventPipeSession`. As a workaround, we will only start the event counters once the stats period interval is reached which means that we don't start the event counters for any of our tests. This feels like a very ugly workaround and will likely require further investigation.

### Todo
- [ ] Find a reliable replacement for getting total system cpu usage cross platform. #2208