### PR TITLE
Fix Off by One Errors in Subscriptions

### DIFF
--- a/src/EventStore.Grpc.Tests/Streams/subscribe_to_all.cs
+++ b/src/EventStore.Grpc.Tests/Streams/subscribe_to_all.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services;
+using Xunit;
+
+namespace EventStore.Grpc.Streams {
+	[Trait("Category", "LongRunning")]
+	public class subscribe_to_all : IAsyncLifetime {
+		private readonly Fixture _fixture;
+
+		/// <summary>
+		/// This class does not implement IClassFixture because it checks $all, and we want a fresh Node for each test.
+		/// </summary>
+		public subscribe_to_all() {
+			_fixture = new Fixture();
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_disposed() {
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = _fixture.Client.SubscribeToAll(EventAppeared, false, SubscriptionDropped);
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) => Task.CompletedTask;
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_error_processing_event() {
+			var stream = _fixture.GetStreamName();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var expectedException = new Exception("Error");
+
+			using var subscription = _fixture.Client.SubscribeToAll(EventAppeared, false, SubscriptionDropped);
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents());
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.SubscriberError, reason);
+			Assert.Same(expectedException, ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) =>
+				Task.FromException(expectedException);
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task subscribe_to_empty_database() {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = _fixture.Client.SubscribeToAll(EventAppeared, false, SubscriptionDropped);
+
+			await Task.Delay(200);
+
+			Assert.False(appeared.Task.IsCompleted);
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (!SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task reads_all_existing_events_and_keep_listening_to_new_ones() {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var appearedEvents = new List<EventRecord>();
+			var beforeEvents = _fixture.CreateTestEvents(10).ToArray();
+			var afterEvents = _fixture.CreateTestEvents(10).ToArray();
+
+			foreach (var @event in beforeEvents) {
+				await _fixture.Client.AppendToStreamAsync($"stream-{@event.EventId:n}", AnyStreamRevision.NoStream,
+					new[] {@event});
+			}
+
+			using var subscription = _fixture.Client.SubscribeToAll(EventAppeared, false, SubscriptionDropped);
+
+			foreach (var @event in afterEvents) {
+				await _fixture.Client.AppendToStreamAsync($"stream-{@event.EventId:n}", AnyStreamRevision.NoStream,
+					new[] {@event});
+			}
+
+			await appeared.Task.WithTimeout();
+
+			Assert.True(EventDataComparer.Equal(beforeEvents.Concat(afterEvents).ToArray(), appearedEvents.ToArray()));
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (!SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					appearedEvents.Add(e.Event);
+
+					if (appearedEvents.Count >= beforeEvents.Length + afterEvents.Length) {
+						appeared.TrySetResult(true);
+					}
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			protected override Task Given() =>
+				Client.SetStreamMetadataAsync("$all", AnyStreamRevision.NoStream,
+					new StreamMetadata(acl: new StreamAcl(SystemRoles.All)), TestCredentials.Root);
+
+			protected override Task When() => Task.CompletedTask;
+		}
+
+		public Task InitializeAsync() => _fixture.InitializeAsync();
+		public Task DisposeAsync() => _fixture.DisposeAsync();
+	}
+}

--- a/src/EventStore.Grpc.Tests/Streams/subscribe_to_all_filtered_live.cs
+++ b/src/EventStore.Grpc.Tests/Streams/subscribe_to_all_filtered_live.cs
@@ -8,10 +8,10 @@ using EventStore.Core.Services;
 using Xunit;
 
 namespace EventStore.Grpc.Streams {
-	public class subscribe_to_all_from_filtered : IClassFixture<subscribe_to_all_from_filtered.Fixture> {
+	public class subscribe_to_all_filtered_live : IClassFixture<subscribe_to_all_filtered_live.Fixture> {
 		private readonly Fixture _fixture;
 
-		public subscribe_to_all_from_filtered(Fixture fixture) {
+		public subscribe_to_all_filtered_live(Fixture fixture) {
 			_fixture = fixture;
 		}
 

--- a/src/EventStore.Grpc.Tests/Streams/subscribe_to_all_with_position.cs
+++ b/src/EventStore.Grpc.Tests/Streams/subscribe_to_all_with_position.cs
@@ -1,0 +1,165 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services;
+using Xunit;
+
+namespace EventStore.Grpc.Streams {
+	[Trait("Category", "LongRunning")]
+	public class subscribe_to_all_with_position : IAsyncLifetime {
+		private readonly Fixture _fixture;
+
+		/// <summary>
+		/// This class does not implement IClassFixture because it checks $all, and we want a fresh Node for each test.
+		/// </summary>
+		public subscribe_to_all_with_position() {
+			_fixture = new Fixture();
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_disposed() {
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription =
+				_fixture.Client.SubscribeToAll(new Position(169, 169), EventAppeared, false, SubscriptionDropped);
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) => Task.CompletedTask;
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_error_processing_event() {
+			var stream = _fixture.GetStreamName();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var expectedException = new Exception("Error");
+
+			using var subscription =
+				_fixture.Client.SubscribeToAll(new Position(169, 169), EventAppeared, false, SubscriptionDropped);
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents());
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.SubscriberError, reason);
+			Assert.Same(expectedException, ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) =>
+				Task.FromException(expectedException);
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task subscribe_to_empty_database() {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription =
+				_fixture.Client.SubscribeToAll(new Position(169, 169), EventAppeared, false, SubscriptionDropped);
+
+			await Task.Delay(200);
+
+			Assert.False(appeared.Task.IsCompleted);
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (!SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task reads_all_existing_events_after_position_and_keep_listening_to_new_ones() {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var appearedEvents = new List<EventRecord>();
+			var beforeEvents = _fixture.CreateTestEvents(10).ToArray();
+			var afterEvents = _fixture.CreateTestEvents(10).ToArray();
+
+			var position = await _fixture.Client.ReadAllForwardsAsync(Position.Start, 1)
+				.Select(x => x.OriginalEvent.Position)
+				.FirstAsync();
+
+			foreach (var @event in beforeEvents) {
+				await _fixture.Client.AppendToStreamAsync($"stream-{@event.EventId:n}", AnyStreamRevision.NoStream,
+					new[] {@event});
+			}
+
+			using var subscription = _fixture.Client.SubscribeToAll(position, EventAppeared, false, SubscriptionDropped);
+
+			foreach (var @event in afterEvents) {
+				await _fixture.Client.AppendToStreamAsync($"stream-{@event.EventId:n}", AnyStreamRevision.NoStream,
+					new[] {@event});
+			}
+
+			await appeared.Task.WithTimeout();
+
+			Assert.True(EventDataComparer.Equal(beforeEvents.Concat(afterEvents).ToArray(), appearedEvents.ToArray()));
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (position <= e.OriginalEvent.Position) {
+					appeared.TrySetException(new Exception());
+				}
+				if (!SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					appearedEvents.Add(e.Event);
+
+					if (appearedEvents.Count >= beforeEvents.Length + afterEvents.Length) {
+						appeared.TrySetResult(true);
+					}
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			protected override Task Given() =>
+				Client.SetStreamMetadataAsync("$all", AnyStreamRevision.NoStream,
+					new StreamMetadata(acl: new StreamAcl(SystemRoles.All)), TestCredentials.Root);
+
+			protected override Task When() => Task.CompletedTask;
+		}
+
+		public Task InitializeAsync() => _fixture.InitializeAsync();
+		public Task DisposeAsync() => _fixture.DisposeAsync();
+	}
+}

--- a/src/EventStore.Grpc.Tests/Streams/subscribe_to_stream.cs
+++ b/src/EventStore.Grpc.Tests/Streams/subscribe_to_stream.cs
@@ -7,10 +7,10 @@ using Xunit;
 
 namespace EventStore.Grpc.Streams {
 	[Trait("Category", "LongRunning")]
-	public class stream_catch_up_subscription : IClassFixture<stream_catch_up_subscription.Fixture> {
+	public class subscribe_to_stream : IClassFixture<subscribe_to_stream.Fixture> {
 		private readonly Fixture _fixture;
 
-		public stream_catch_up_subscription(Fixture fixture) {
+		public subscribe_to_stream(Fixture fixture) {
 			_fixture = fixture;
 		}
 

--- a/src/EventStore.Grpc.Tests/Streams/subscribe_to_stream_live.cs
+++ b/src/EventStore.Grpc.Tests/Streams/subscribe_to_stream_live.cs
@@ -5,10 +5,10 @@ using Xunit;
 
 namespace EventStore.Grpc.Streams {
 	[Trait("Category", "LongRunning")]
-	public class stream_subscription : IClassFixture<stream_subscription.Fixture> {
+	public class subscribe_to_stream_live : IClassFixture<subscribe_to_stream_live.Fixture> {
 		private readonly Fixture _fixture;
 
-		public stream_subscription(Fixture fixture) {
+		public subscribe_to_stream_live(Fixture fixture) {
 			_fixture = fixture;
 		}
 

--- a/src/EventStore.Grpc.Tests/Streams/subscribe_to_stream_with_revision.cs
+++ b/src/EventStore.Grpc.Tests/Streams/subscribe_to_stream_with_revision.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Grpc.Streams {
+	[Trait("Category", "LongRunning")]
+	public class subscribe_to_stream_with_revision : IClassFixture<subscribe_to_stream_with_revision.Fixture> {
+		private readonly Fixture _fixture;
+
+		public subscribe_to_stream_with_revision(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task subscribe_to_non_existing_stream() {
+			var stream = _fixture.GetStreamName();
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = _fixture.Client.SubscribeToStream(stream, StreamRevision.Start, EventAppeared,
+				false, SubscriptionDropped);
+
+			await Task.Delay(200);
+
+			Assert.False(appeared.Task.IsCompleted);
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				appeared.TrySetResult(true);
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex)
+				=> dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task subscribe_to_non_existing_stream_then_get_event() {
+			var stream = _fixture.GetStreamName();
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = _fixture.Client.SubscribeToStream(stream, StreamRevision.Start, EventAppeared,
+				false, SubscriptionDropped);
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents(2));
+
+			Assert.True(await appeared.Task.WithTimeout());
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (e.OriginalEvent.EventNumber == StreamRevision.Start) {
+					appeared.TrySetException(new Exception());
+				} else {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex)
+				=> dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task allow_multiple_subscriptions_to_same_stream() {
+			var stream = _fixture.GetStreamName();
+
+			var appeared = new TaskCompletionSource<bool>();
+
+			int appearedCount = 0;
+
+			using var s1 = _fixture.Client.SubscribeToStream(stream, StreamRevision.Start, EventAppeared);
+			using var s2 = _fixture.Client.SubscribeToStream(stream, StreamRevision.Start, EventAppeared);
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents());
+
+			Assert.True(await appeared.Task.WithTimeout());
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (e.OriginalEvent.EventNumber == StreamRevision.Start) {
+					appeared.TrySetException(new Exception());
+					return Task.CompletedTask;
+				}
+
+				if (++appearedCount == 2) {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_disposed() {
+			var stream = _fixture.GetStreamName();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = _fixture.Client.SubscribeToStream(stream, StreamRevision.Start, EventAppeared,
+				false, SubscriptionDropped);
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) => Task.CompletedTask;
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_error_processing_event() {
+			var stream = _fixture.GetStreamName();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var expectedException = new Exception("Error");
+
+			using var subscription = _fixture.Client.SubscribeToStream(stream, StreamRevision.Start, EventAppeared,
+				false, SubscriptionDropped);
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents());
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.SubscriberError, reason);
+			Assert.Same(expectedException, ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) =>
+				Task.FromException(expectedException);
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task reads_all_existing_events_and_keep_listening_to_new_ones() {
+			var stream = _fixture.GetStreamName();
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var appearedEvents = new List<EventRecord>();
+			var beforeEvents = _fixture.CreateTestEvents(10).ToArray();
+			var afterEvents = _fixture.CreateTestEvents(10).ToArray();
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents());
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, beforeEvents);
+
+			using var subscription =
+				_fixture.Client.SubscribeToStream(stream, EventAppeared, false, SubscriptionDropped);
+
+			var writeResult = await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, afterEvents);
+
+			await appeared.Task.WithTimeout(TimeSpan.FromMinutes(10));
+
+			Assert.True(EventDataComparer.Equal(beforeEvents.Concat(afterEvents).ToArray(), appearedEvents.ToArray()));
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (e.OriginalEvent.EventNumber == StreamRevision.Start) {
+					appeared.TrySetException(new Exception());
+					return Task.CompletedTask;
+				}
+
+				appearedEvents.Add(e.Event);
+
+				if (appearedEvents.Count >= beforeEvents.Length + afterEvents.Length) {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) {
+				dropped.SetResult((reason, ex));
+			}
+		}
+
+
+		public class Fixture : EventStoreGrpcFixture {
+			public EventData[] Events { get; }
+
+			public Fixture() {
+				Events = CreateTestEvents(10).ToArray();
+			}
+
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}


### PR DESCRIPTION
When sending a position / revision in a subscription it should be exclusive of. However, currently you can receive a message you did not want.