### PR TITLE
Fix Off by One Errors in Subscriptions

### DIFF
--- a/src/EventStore.Client.Common/Position.cs
+++ b/src/EventStore.Client.Common/Position.cs
@@ -151,7 +151,7 @@ namespace EventStore.Client {
 		/// A <see cref="T:System.String"/> containing a fully qualified type name.
 		/// </returns>
 		/// <filterpriority>2</filterpriority>
-		public override string ToString() => $"{CommitPosition}/{PreparePosition}";
+		public override string ToString() => $"C:{CommitPosition}/P:{PreparePosition}";
 
 		internal readonly (long commitPosition, long preparePosition) ToInt64() => Equals(End)
 			? (-1, -1)

--- a/src/EventStore.Client.Common/StreamRevision.cs
+++ b/src/EventStore.Client.Common/StreamRevision.cs
@@ -30,11 +30,17 @@ namespace EventStore.Client {
 		public static bool operator ==(StreamRevision left, StreamRevision right) => left.Equals(right);
 		public static bool operator !=(StreamRevision left, StreamRevision right) => !left.Equals(right);
 
-		public static StreamRevision operator +(StreamRevision left, uint right) =>
-			new StreamRevision(left._value + right);
+		public static StreamRevision operator +(StreamRevision left, ulong right) {
+			checked {
+				return new StreamRevision(left._value + right);
+			}
+		}
 
-		public static StreamRevision operator +(uint left, StreamRevision right) =>
-			new StreamRevision(left + right._value);
+		public static StreamRevision operator +(ulong left, StreamRevision right) {
+			checked {
+				return new StreamRevision(left + right._value);
+			}
+		}
 
 		public static bool operator >(StreamRevision left, StreamRevision right) => left._value > right._value;
 		public static bool operator <(StreamRevision left, StreamRevision right) => left._value < right._value;

--- a/src/EventStore.Client.Operations.Tests/EventStore.Client.Operations.Tests.csproj
+++ b/src/EventStore.Client.Operations.Tests/EventStore.Client.Operations.Tests.csproj
@@ -6,6 +6,10 @@
 		<ItemGroup>
 				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1" />
 				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="System.Reactive" Version="4.3.1" />
 				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/EventStore.Client.PersistentSubscriptions.Tests.csproj
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/EventStore.Client.PersistentSubscriptions.Tests.csproj
@@ -7,6 +7,10 @@
 		<ItemGroup>
 				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1" />
 				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="System.Reactive" Version="4.3.2" />
 				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.Client.Projections.Tests/EventStore.Client.Projections.Tests.csproj
+++ b/src/EventStore.Client.Projections.Tests/EventStore.Client.Projections.Tests.csproj
@@ -7,6 +7,10 @@
 		<ItemGroup>
 				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1" />
 				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="System.Reactive" Version="4.3.2" />
 				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
+++ b/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
@@ -8,7 +8,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Client.Operations;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;

--- a/src/EventStore.Client.Tests.Common/LoggingHelper.cs
+++ b/src/EventStore.Client.Tests.Common/LoggingHelper.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.IO;
 using System.Reactive.Linq;
 using System.Threading;
-using EventStore.Grpc.Logging;
+using EventStore.Client.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using NLog;
 using Serilog;
@@ -11,7 +11,7 @@ using Serilog.Events;
 using Serilog.Formatting.Display;
 using Xunit.Abstractions;
 
-namespace EventStore.Grpc {
+namespace EventStore.Client {
 	public static class LoggingHelper {
 		private const string CaptureCorrelationId = nameof(CaptureCorrelationId);
 		private static readonly Subject<LogEvent> s_logEventSubject = new Subject<LogEvent>();

--- a/src/EventStore.Client.Tests.Common/SerilogTarget.cs
+++ b/src/EventStore.Client.Tests.Common/SerilogTarget.cs
@@ -4,7 +4,7 @@ using NLog;
 using NLog.Targets;
 using Serilog;
 
-namespace EventStore.Grpc {
+namespace EventStore.Client {
 	public sealed class SerilogTarget : TargetWithLayout {
 		protected override void Write(LogEventInfo logEvent) {
 			var log = Log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, logEvent.LoggerName);

--- a/src/EventStore.Client.Tests/EventStore.Client.Tests.csproj
+++ b/src/EventStore.Client.Tests/EventStore.Client.Tests.csproj
@@ -7,6 +7,10 @@
 		<ItemGroup>
 				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1" />
 				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="System.Reactive" Version="4.3.2" />
 				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.Client.Tests/StreamRevisionTests.cs
+++ b/src/EventStore.Client.Tests/StreamRevisionTests.cs
@@ -28,6 +28,22 @@ namespace EventStore.Client {
 			Assert.True(new StreamRevision(2) != sut);
 		}
 
+		[Fact]
+		public void AdditionOperator() {
+			var sut = StreamRevision.Start;
+			Assert.Equal(new StreamRevision(1), sut + 1);
+		}
+
+		public static IEnumerable<object[]> AdditionOutOfBoundsCases() {
+			yield return new object[] {StreamRevision.End, 1};
+			yield return new object[] {new StreamRevision(long.MaxValue), long.MaxValue + 2UL};
+		}
+
+		[Theory, MemberData(nameof(AdditionOutOfBoundsCases))]
+		public void AdditionOutOfBoundsThrows(StreamRevision left, ulong right) {
+			Assert.Throws<OverflowException>(() => left + right);
+		}
+
 		public static IEnumerable<object[]> ArgumentOutOfRangeTestCases() {
 			yield return new object[] { long.MaxValue + 1UL };
 			yield return new object[] { ulong.MaxValue - 1UL };

--- a/src/EventStore.Client.Tests/Streams/SecurityFixture.cs
+++ b/src/EventStore.Client.Tests/Streams/SecurityFixture.cs
@@ -166,28 +166,28 @@ namespace EventStore.Client.Streams {
 
 		public async Task SubscribeToStream(string streamId, UserCredentials userCredentials = default) {
 			var source = new TaskCompletionSource<bool>();
-			using (Client.SubscribeToStream(streamId, (x, y, ct) => {
+			using (await Client.SubscribeToStreamAsync(streamId, (x, y, ct) => {
 					source.TrySetResult(true);
 					return Task.CompletedTask;
 				},
 				subscriptionDropped: (x, y, ex) => {
 					if (ex == null) source.TrySetResult(true);
 					else source.TrySetException(ex);
-				}, userCredentials: userCredentials)) {
+				}, userCredentials: userCredentials).WithTimeout()) {
 				await source.Task.WithTimeout();
 			}
 		}
 
 		public async Task SubscribeToAll(UserCredentials userCredentials = default) {
 			var source = new TaskCompletionSource<bool>();
-			using (Client.SubscribeToAll((x, y, ct) => {
+			using (await Client.SubscribeToAllAsync((x, y, ct) => {
 					source.TrySetResult(true);
 					return Task.CompletedTask;
 				},
 				subscriptionDropped: (x, y, ex) => {
 					if (ex == null) source.TrySetResult(true);
 					else source.TrySetException(ex);
-				}, userCredentials: userCredentials)) {
+				}, userCredentials: userCredentials).WithTimeout()) {
 				await source.Task.WithTimeout();
 			}
 		}

--- a/src/EventStore.Client.Tests/Streams/subscribe_to_all.cs
+++ b/src/EventStore.Client.Tests/Streams/subscribe_to_all.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Client.Streams {
+	[Trait("Category", "LongRunning")]
+	public class subscribe_to_all : IAsyncLifetime, IDisposable {
+		private readonly Fixture _fixture;
+		private readonly IDisposable _loggingContext;
+
+		/// <summary>
+		/// This class does not implement IClassFixture because it checks $all, and we want a fresh Node for each test.
+		/// </summary>
+		public subscribe_to_all(ITestOutputHelper outputHelper) {
+			_fixture = new Fixture();
+			_loggingContext = LoggingHelper.Capture(outputHelper);
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_disposed() {
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription =
+				await _fixture.Client.SubscribeToAllAsync(EventAppeared, false, SubscriptionDropped);
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) => Task.CompletedTask;
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_error_processing_event() {
+			var stream = _fixture.GetStreamName();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var expectedException = new Exception("Error");
+
+			using var subscription =
+				await _fixture.Client.SubscribeToAllAsync(EventAppeared, false, SubscriptionDropped).WithTimeout();
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents());
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.SubscriberError, reason);
+			Assert.Same(expectedException, ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) =>
+				Task.FromException(expectedException);
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task subscribe_to_empty_database() {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = await _fixture.Client.SubscribeToAllAsync(EventAppeared, false, SubscriptionDropped);
+
+			Assert.False(appeared.Task.IsCompleted);
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (!Core.Services.SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task reads_all_existing_events_and_keep_listening_to_new_ones() {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var appearedEvents = new List<EventRecord>();
+			var beforeEvents = _fixture.CreateTestEvents(10).ToArray();
+			var afterEvents = _fixture.CreateTestEvents(10).ToArray();
+
+			foreach (var @event in beforeEvents) {
+				await _fixture.Client.AppendToStreamAsync($"stream-{@event.EventId:n}", AnyStreamRevision.NoStream,
+					new[] {@event});
+			}
+
+			using var subscription = await _fixture.Client.SubscribeToAllAsync(EventAppeared, false, SubscriptionDropped);
+
+			foreach (var @event in afterEvents) {
+				await _fixture.Client.AppendToStreamAsync($"stream-{@event.EventId:n}", AnyStreamRevision.NoStream,
+					new[] {@event});
+			}
+
+			await appeared.Task.WithTimeout();
+
+			Assert.Equal(beforeEvents.Concat(afterEvents).Select(x => x.EventId),
+				appearedEvents.Select(x => x.EventId));
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (!Core.Services.SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					appearedEvents.Add(e.Event);
+
+					if (appearedEvents.Count >= beforeEvents.Length + afterEvents.Length) {
+						appeared.TrySetResult(true);
+					}
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			protected override Task Given() =>
+				Client.SetStreamMetadataAsync("$all", AnyStreamRevision.NoStream,
+					new StreamMetadata(acl: new StreamAcl(SystemRoles.All)), TestCredentials.Root);
+
+			protected override Task When() => Task.CompletedTask;
+		}
+
+		public Task InitializeAsync() => _fixture.InitializeAsync();
+		public Task DisposeAsync() => _fixture.DisposeAsync();
+		public void Dispose() => _loggingContext.Dispose();
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/subscribe_to_all_filtered_with_position.cs
+++ b/src/EventStore.Client.Tests/Streams/subscribe_to_all_filtered_with_position.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Client.Streams {
+	public class subscribe_to_all_filtered_with_position : IAsyncLifetime, IDisposable {
+		private readonly Fixture _fixture;
+		private readonly IDisposable _loggingContext;
+
+		public subscribe_to_all_filtered_with_position(ITestOutputHelper outputHelper) {
+			_fixture = new Fixture();
+			_loggingContext = LoggingHelper.Capture(outputHelper);
+		}
+
+		private async Task TestFilter(string streamPrefix, EventData[] events, IEventFilter filter) {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var enumerator = events.AsEnumerable().GetEnumerator();
+			enumerator.MoveNext();
+
+			var writeResult = await _fixture.Client.AppendToStreamAsync($"{streamPrefix}_{Guid.NewGuid():n}",
+				AnyStreamRevision.NoStream, _fixture.CreateTestEvents(type: $"{streamPrefix}_{Guid.NewGuid():n}"));
+
+			using var subscription = await _fixture.Client.SubscribeToAllAsync(writeResult.LogPosition, EventAppeared,
+				false, SubscriptionDropped, filter);
+
+			foreach (var e in events) {
+				await _fixture.Client.AppendToStreamAsync($"{streamPrefix}_{e.EventId:n}",
+					AnyStreamRevision.NoStream, new[] {e});
+			}
+
+			await appeared.Task.WithTimeout();
+
+			Assert.False(dropped.Task.IsCompleted);
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				Serilog.Log.Verbose("EventAppeared received {eventId} {position}", e.OriginalEvent.EventId,
+					e.OriginalPosition);
+				if (writeResult.LogPosition >= e.OriginalEvent.Position) {
+					appeared.TrySetException(new Exception(
+						$"Expected to see events greater than {writeResult.LogPosition} but saw {e.OriginalEvent.Position}"));
+					return Task.CompletedTask;
+				}
+
+				if (!SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					try {
+						Assert.Equal(enumerator.Current.EventId, e.OriginalEvent.EventId);
+						if (!enumerator.MoveNext()) {
+							appeared.TrySetResult(true);
+						}
+					} catch (Exception ex) {
+						appeared.TrySetException(ex);
+						throw;
+					}
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task regular_expression_stream_name() {
+			var streamPrefix = _fixture.GetStreamName();
+			var filter = new StreamFilter(new RegularFilterExpression(new Regex($"^{streamPrefix}")));
+			var events = _fixture.CreateTestEvents(10).ToArray();
+
+			await TestFilter(streamPrefix, events, filter);
+		}
+
+		[Fact]
+		public async Task prefix_stream_name() {
+			var streamPrefix = _fixture.GetStreamName();
+			var filter = new StreamFilter(new PrefixFilterExpression(streamPrefix));
+			var events = _fixture.CreateTestEvents(10).ToArray();
+
+			await TestFilter(streamPrefix, events, filter);
+		}
+
+		[Fact]
+		public async Task regular_expression_event_type() {
+			const string eventTypePrefix = nameof(regular_expression_event_type);
+			var streamPrefix = _fixture.GetStreamName();
+			var events = _fixture.CreateTestEvents(10)
+				.Select(e =>
+					new EventData(e.EventId, $"{eventTypePrefix}-{e.EventId:n}", e.Data, e.Metadata, e.IsJson))
+				.ToArray();
+			var filter = new EventTypeFilter(new RegularFilterExpression(new Regex($"^{eventTypePrefix}")));
+
+			await TestFilter(streamPrefix, events, filter);
+		}
+
+		[Fact]
+		public async Task prefix_event_type() {
+			const string eventTypePrefix = nameof(prefix_event_type);
+			var streamPrefix = _fixture.GetStreamName();
+			var events = _fixture.CreateTestEvents(10)
+				.Select(e =>
+					new EventData(e.EventId, $"{eventTypePrefix}-{e.EventId:n}", e.Data, e.Metadata, e.IsJson))
+				.ToArray();
+			var filter = new EventTypeFilter(new PrefixFilterExpression(eventTypePrefix));
+
+			await TestFilter(streamPrefix, events, filter);
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			public const string FilteredOutStream = nameof(FilteredOutStream);
+
+			protected override Task Given() => Client.SetStreamMetadataAsync("$all", AnyStreamRevision.Any,
+				new StreamMetadata(acl: new StreamAcl(SystemRoles.All)), TestCredentials.Root);
+
+			protected override Task When() =>
+				Client.AppendToStreamAsync(FilteredOutStream, AnyStreamRevision.NoStream, CreateTestEvents(10));
+		}
+
+		public Task InitializeAsync() => _fixture.InitializeAsync();
+
+		public Task DisposeAsync() => _fixture.DisposeAsync();
+		public void Dispose() => _loggingContext.Dispose();
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/subscribe_to_all_live.cs
+++ b/src/EventStore.Client.Tests/Streams/subscribe_to_all_live.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Client.Streams {
+	[Trait("Category", "LongRunning")]
+	public class subscribe_to_all_live : IAsyncLifetime, IDisposable {
+		private readonly Fixture _fixture;
+		private readonly IDisposable _loggingContext;
+
+		/// <summary>
+		/// This class does not implement IClassFixture because it checks $all, and we want a fresh Node for each test.
+		/// </summary>
+		public subscribe_to_all_live(ITestOutputHelper outputHelper) {
+			_fixture = new Fixture();
+			_loggingContext = LoggingHelper.Capture(outputHelper);
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_disposed() {
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription =
+				await _fixture.Client.SubscribeToAllAsync(Position.End, EventAppeared, false, SubscriptionDropped);
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) => Task.CompletedTask;
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_error_processing_event() {
+			var stream = _fixture.GetStreamName();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var expectedException = new Exception("Error");
+
+			using var subscription =
+				_fixture.Client.SubscribeToAllAsync(Position.End, EventAppeared, false, SubscriptionDropped);
+
+			await Task.Delay(100);
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents());
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.SubscriberError, reason);
+			Assert.Same(expectedException, ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) =>
+				Task.FromException(expectedException);
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task subscribe_to_empty_database() {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription =
+				await _fixture.Client.SubscribeToAllAsync(Position.End, EventAppeared, false, SubscriptionDropped);
+
+			Assert.False(appeared.Task.IsCompleted);
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (!Core.Services.SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task does_not_read_existing_events_but_keep_listening_to_new_ones() {
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var appearedEvents = new List<EventRecord>();
+			var afterEvents = _fixture.CreateTestEvents(10).ToArray();
+
+			using var subscription =
+				await _fixture.Client.SubscribeToAllAsync(Position.End, EventAppeared, false, SubscriptionDropped);
+
+			foreach (var @event in afterEvents) {
+				await _fixture.Client.AppendToStreamAsync($"stream-{@event.EventId:n}", AnyStreamRevision.NoStream,
+					new[] {@event});
+			}
+
+			await appeared.Task.WithTimeout();
+
+			Assert.Equal(afterEvents.Select(x => x.EventId), appearedEvents.Select(x => x.EventId));
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (!Core.Services.SystemStreams.IsSystemStream(e.OriginalStreamId)) {
+					appearedEvents.Add(e.Event);
+
+					if (appearedEvents.Count >= afterEvents.Length) {
+						appeared.TrySetResult(true);
+					}
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			protected override Task Given() =>
+				Client.SetStreamMetadataAsync("$all", AnyStreamRevision.NoStream,
+					new StreamMetadata(acl: new StreamAcl(SystemRoles.All)), TestCredentials.Root);
+
+			protected override Task When() => Task.CompletedTask;
+		}
+
+		public Task InitializeAsync() => _fixture.InitializeAsync();
+		public Task DisposeAsync() => _fixture.DisposeAsync();
+		public void Dispose() => _loggingContext.Dispose();
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/subscribe_to_all_with_event_numbers_greater_than_int32_max_value.cs
+++ b/src/EventStore.Client.Tests/Streams/subscribe_to_all_with_event_numbers_greater_than_int32_max_value.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.Streams {
 			var source = new TaskCompletionSource<bool>();
 			var @event = new EventData(Uuid.NewUuid(), "-", Array.Empty<byte>(), isJson: false);
 			var received = new List<Uuid>(3);
-			using var _ = _fixture.Client.SubscribeToAll(
+			using var _ = await _fixture.Client.SubscribeToAllAsync(
 				Position.Start, EventAppeared, false, SubscriptionDropped, userCredentials: TestCredentials.Root);
 
 			await _fixture.Client.AppendToStreamAsync(Stream, AnyStreamRevision.Any, new[] {@event});

--- a/src/EventStore.Client.Tests/Streams/subscribe_to_stream_with_event_numbers_greater_than_int32_max_value_resolve_links.cs
+++ b/src/EventStore.Client.Tests/Streams/subscribe_to_stream_with_event_numbers_greater_than_int32_max_value_resolve_links.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task should_subscribe() {
 			var source = new TaskCompletionSource<ResolvedEvent>();
-			using var _ = _fixture.Client.SubscribeToStream(
+			using var _ = await _fixture.Client.SubscribeToStreamAsync(
 				Stream, StreamRevision.Start, EventAppeared, true, SubscriptionDropped);
 
 			var result = await source.Task.WithTimeout();

--- a/src/EventStore.Client.Tests/Streams/subscribe_to_stream_with_revision.cs
+++ b/src/EventStore.Client.Tests/Streams/subscribe_to_stream_with_revision.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace EventStore.Client.Streams {
+	[Trait("Category", "LongRunning")]
+	public class subscribe_to_stream_with_revision : IAsyncLifetime, IDisposable {
+		private readonly Fixture _fixture;
+		private readonly IDisposable _loggingContext;
+		public subscribe_to_stream_with_revision(ITestOutputHelper outputHelper) {
+			_fixture = new Fixture();
+			_loggingContext = LoggingHelper.Capture(outputHelper);
+		}
+
+		[Fact]
+		public async Task subscribe_to_non_existing_stream() {
+			var stream = _fixture.GetStreamName();
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = await _fixture.Client.SubscribeToStreamAsync(stream, StreamRevision.Start, EventAppeared,
+				false, SubscriptionDropped);
+
+			Assert.False(appeared.Task.IsCompleted);
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				appeared.TrySetResult(true);
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex)
+				=> dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task subscribe_to_non_existing_stream_then_get_event() {
+			var stream = _fixture.GetStreamName();
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = await _fixture.Client.SubscribeToStreamAsync(stream, StreamRevision.Start, EventAppeared,
+				false, SubscriptionDropped);
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream,
+				_fixture.CreateTestEvents(2));
+
+			Assert.True(await appeared.Task.WithTimeout());
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (e.OriginalEvent.EventNumber == StreamRevision.Start) {
+					appeared.TrySetException(new Exception());
+				} else {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex)
+				=> dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task allow_multiple_subscriptions_to_same_stream() {
+			var stream = _fixture.GetStreamName();
+
+			var appeared = new TaskCompletionSource<bool>();
+
+			int appearedCount = 0;
+
+			using var s1 = await _fixture.Client.SubscribeToStreamAsync(stream, StreamRevision.Start, EventAppeared);
+			using var s2 = await _fixture.Client.SubscribeToStreamAsync(stream, StreamRevision.Start, EventAppeared);
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents(2));
+
+			Assert.True(await appeared.Task.WithTimeout());
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				if (e.OriginalEvent.EventNumber == StreamRevision.Start) {
+					appeared.TrySetException(new Exception());
+					return Task.CompletedTask;
+				}
+
+				if (++appearedCount == 2) {
+					appeared.TrySetResult(true);
+				}
+
+				return Task.CompletedTask;
+			}
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_disposed() {
+			var stream = _fixture.GetStreamName();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			using var subscription = await _fixture.Client.SubscribeToStreamAsync(stream, StreamRevision.Start, EventAppeared,
+				false, SubscriptionDropped);
+
+			if (dropped.Task.IsCompleted) {
+				Assert.False(dropped.Task.IsCompleted, dropped.Task.Result.ToString());
+			}
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) => Task.CompletedTask;
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task calls_subscription_dropped_when_error_processing_event() {
+			var stream = _fixture.GetStreamName();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+			var expectedException = new Exception("Error");
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents(2));
+
+			using var subscription = await _fixture.Client.SubscribeToStreamAsync(stream, StreamRevision.Start, EventAppeared,
+				false, SubscriptionDropped);
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.SubscriberError, reason);
+			Assert.Same(expectedException, ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) =>
+				Task.FromException(expectedException);
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) =>
+				dropped.SetResult((reason, ex));
+		}
+
+		[Fact]
+		public async Task reads_all_existing_events_and_keep_listening_to_new_ones() {
+			var stream = _fixture.GetStreamName();
+
+			var events = _fixture.CreateTestEvents(20).ToArray();
+
+			var appeared = new TaskCompletionSource<bool>();
+			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
+
+			var beforeEvents = events.Take(10);
+			var afterEvents = events.Skip(10);
+
+			using var enumerator = events.AsEnumerable().GetEnumerator();
+
+			enumerator.MoveNext();
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents());
+
+			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, beforeEvents);
+
+			using var subscription =
+				await _fixture.Client.SubscribeToStreamAsync(stream, StreamRevision.Start, EventAppeared, false,
+					SubscriptionDropped);
+
+			var writeResult = await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, afterEvents);
+
+			await appeared.Task.WithTimeout();
+
+			subscription.Dispose();
+
+			var (reason, ex) = await dropped.Task.WithTimeout();
+
+			Assert.Equal(SubscriptionDroppedReason.Disposed, reason);
+			Assert.Null(ex);
+
+			Task EventAppeared(StreamSubscription s, ResolvedEvent e, CancellationToken ct) {
+				try {
+					Assert.Equal(enumerator.Current.EventId, e.OriginalEvent.EventId);
+					if (!enumerator.MoveNext()) {
+						appeared.TrySetResult(true);
+					}
+				} catch (Exception ex) {
+					appeared.TrySetException(ex);
+					throw;
+				}
+
+				return Task.CompletedTask;
+			}
+
+			void SubscriptionDropped(StreamSubscription s, SubscriptionDroppedReason reason, Exception ex) {
+				dropped.SetResult((reason, ex));
+			}
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+
+		public Task InitializeAsync() => _fixture.InitializeAsync();
+
+		public Task DisposeAsync() => _fixture.DisposeAsync();
+
+		public void Dispose() => _loggingContext.Dispose();
+	}
+}

--- a/src/EventStore.Client.UserManagement.Tests/EventStore.Client.UserManagement.Tests.csproj
+++ b/src/EventStore.Client.UserManagement.Tests/EventStore.Client.UserManagement.Tests.csproj
@@ -6,6 +6,10 @@
 		<ItemGroup>
 				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1" />
 				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="System.Reactive" Version="4.3.1" />
 				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.Client/EventStore.Client.csproj
+++ b/src/EventStore.Client/EventStore.Client.csproj
@@ -28,9 +28,10 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
 		<PackageReference Include="System.Text.Json" Version="4.7.0" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 	<ItemGroup>
 		<Protobuf Include="../Protos/Grpc/*.proto" Exclude="../Protos/Grpc/operations.proto" Access="internal" GrpcServices="Client" ProtoRoot="../Protos/Grpc" />

--- a/src/EventStore.Client/EventStoreClient.cs
+++ b/src/EventStore.Client/EventStoreClient.cs
@@ -2,11 +2,13 @@ using System;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
+using EventStore.Client.Logging;
 using EventStore.Client.PersistentSubscriptions;
 using EventStore.Client.Projections;
 using EventStore.Client.Users;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
+using Microsoft.Extensions.Logging;
 using ReadReq = EventStore.Client.Streams.ReadReq;
 
 namespace EventStore.Client {
@@ -16,6 +18,8 @@ namespace EventStore.Client {
 				StreamMetadataJsonConverter.Instance
 			},
 		};
+
+		private static readonly ILogger Log = LogProvider.CreateLogger<EventStoreClient>();
 
 		private readonly EventStoreClientSettings _settings;
 		private readonly GrpcChannel _channel;
@@ -30,7 +34,8 @@ namespace EventStore.Client {
 				Port = 2113
 			}.Uri);
 			_channel = GrpcChannel.ForAddress(settings.Address, new GrpcChannelOptions {
-				HttpClient = settings.CreateHttpClient?.Invoke()
+				HttpClient = settings.CreateHttpClient?.Invoke(),
+				LoggerFactory = LogProvider.LoggerFactory
 			});
 			var connectionName = settings.ConnectionName ?? $"ES-{Guid.NewGuid()}";
 

--- a/src/EventStore.Client/EventStoreGrpcClient.Subscriptions.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Subscriptions.cs
@@ -5,7 +5,7 @@ using EventStore.Client.Streams;
 
 namespace EventStore.Client {
 	public partial class EventStoreClient {
-		private StreamSubscription SubscribeToAll(
+		private Task<StreamSubscription> SubscribeToAllAsync(
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			EventStoreClientOperationOptions operationOptions,
 			bool resolveLinkTos = false,
@@ -15,17 +15,18 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) {
 			operationOptions.TimeoutAfter = DeadLine.None;
 
-			var subscription = new StreamSubscription(ReadInternal(new ReadReq {
+			return StreamSubscription.Confirm(ReadInternal(new ReadReq {
 					Options = new ReadReq.Types.Options {
 						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
 						ResolveLinks = resolveLinkTos,
-						All = ReadReq.Types.Options.Types.AllOptions.FromPosition(Position.Start),
+						All = new ReadReq.Types.Options.Types.AllOptions {
+							Start = new ReadReq.Types.Empty()
+						},
 						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions(),
 						Filter = GetFilterOptions(filter)
 					}
 				}, operationOptions, userCredentials, cancellationToken), eventAppeared,
-				subscriptionDropped);
-			return subscription;
+				subscriptionDropped, cancellationToken);
 		}
 
 		/// <summary>
@@ -38,13 +39,13 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public StreamSubscription SubscribeToAll(
+		public Task<StreamSubscription> SubscribeToAllAsync(
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			IEventFilter filter = null,
 			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => SubscribeToAll(eventAppeared,
+			CancellationToken cancellationToken = default) => SubscribeToAllAsync(eventAppeared,
 			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped, filter, userCredentials,
 			cancellationToken);
 
@@ -59,7 +60,7 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public StreamSubscription SubscribeToAll(
+		public Task<StreamSubscription> SubscribeToAllAsync(
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<EventStoreClientOperationOptions> configureOperationOptions,
 			bool resolveLinkTos = false,
@@ -70,12 +71,12 @@ namespace EventStore.Client {
 			var operationOptions = _settings.OperationOptions.Clone();
 			configureOperationOptions(operationOptions);
 
-			return SubscribeToAll(eventAppeared, operationOptions, resolveLinkTos, subscriptionDropped, filter,
+			return SubscribeToAllAsync(eventAppeared, operationOptions, resolveLinkTos, subscriptionDropped, filter,
 				userCredentials,
 				cancellationToken);
 		}
 
-		private StreamSubscription SubscribeToAll(Position start,
+		private Task<StreamSubscription> SubscribeToAllAsync(Position start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			EventStoreClientOperationOptions operationOptions,
 			bool resolveLinkTos = false,
@@ -85,7 +86,7 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) {
 			operationOptions.TimeoutAfter = DeadLine.None;
 
-			var subscription = new StreamSubscription(ReadInternal(new ReadReq {
+			return StreamSubscription.Confirm(ReadInternal(new ReadReq {
 					Options = new ReadReq.Types.Options {
 						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
 						ResolveLinks = resolveLinkTos,
@@ -94,8 +95,7 @@ namespace EventStore.Client {
 						Filter = GetFilterOptions(filter)
 					}
 				}, operationOptions, userCredentials, cancellationToken), eventAppeared,
-				subscriptionDropped);
-			return subscription;
+				subscriptionDropped, cancellationToken);
 		}
 
 		/// <summary>
@@ -109,13 +109,13 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public StreamSubscription SubscribeToAll(Position start,
+		public Task<StreamSubscription> SubscribeToAllAsync(Position start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			IEventFilter filter = null,
 			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => SubscribeToAll(start, eventAppeared,
+			CancellationToken cancellationToken = default) => SubscribeToAllAsync(start, eventAppeared,
 			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped, filter, userCredentials,
 			cancellationToken);
 
@@ -131,7 +131,7 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public StreamSubscription SubscribeToAll(Position start,
+		public Task<StreamSubscription> SubscribeToAllAsync(Position start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<EventStoreClientOperationOptions> configureOperationOptions,
 			bool resolveLinkTos = false,
@@ -142,11 +142,11 @@ namespace EventStore.Client {
 			var operationOptions = _settings.OperationOptions.Clone();
 			configureOperationOptions(operationOptions);
 
-			return SubscribeToAll(start, eventAppeared, operationOptions, resolveLinkTos, subscriptionDropped, filter,
+			return SubscribeToAllAsync(start, eventAppeared, operationOptions, resolveLinkTos, subscriptionDropped, filter,
 				userCredentials, cancellationToken);
 		}
 
-		private StreamSubscription SubscribeToStream(string streamName,
+		private Task<StreamSubscription> SubscribeToStreamAsync(string streamName,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			EventStoreClientOperationOptions operationOptions,
 			bool resolveLinkTos = false,
@@ -155,18 +155,18 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) {
 			operationOptions.TimeoutAfter = DeadLine.None;
 
-			var subscription = new StreamSubscription(ReadInternal(new ReadReq {
+			return StreamSubscription.Confirm(ReadInternal(new ReadReq {
 					Options = new ReadReq.Types.Options {
 						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
 						ResolveLinks = resolveLinkTos,
-						Stream = ReadReq.Types.Options.Types.StreamOptions.FromStreamNameAndRevision(
-							streamName,
-							StreamRevision.Start),
+						Stream = new ReadReq.Types.Options.Types.StreamOptions {
+							Start = new ReadReq.Types.Empty(),
+							StreamName = streamName
+						},
 						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
 					}
 				}, operationOptions, userCredentials, cancellationToken), eventAppeared,
-				subscriptionDropped);
-			return subscription;
+				subscriptionDropped, cancellationToken);
 		}
 
 		/// <summary>
@@ -179,12 +179,12 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public StreamSubscription SubscribeToStream(string streamName,
+		public Task<StreamSubscription> SubscribeToStreamAsync(string streamName,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => SubscribeToStream(streamName, eventAppeared,
+			CancellationToken cancellationToken = default) => SubscribeToStreamAsync(streamName, eventAppeared,
 			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped,
 			userCredentials, cancellationToken);
 
@@ -199,22 +199,22 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public StreamSubscription SubscribeToStream(string streamName,
+		public Task<StreamSubscription> SubscribeToStreamAsync(string streamName,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<EventStoreClientOperationOptions> configureOperationOptions,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) {
-			
 			var operationOptions = _settings.OperationOptions.Clone();
 			configureOperationOptions(operationOptions);
-			
-			return SubscribeToStream(streamName, eventAppeared, operationOptions, resolveLinkTos, subscriptionDropped,
+
+			return SubscribeToStreamAsync(streamName, eventAppeared, operationOptions, resolveLinkTos,
+				subscriptionDropped,
 				userCredentials, cancellationToken);
 		}
 
-		private StreamSubscription SubscribeToStream(string streamName,
+		private Task<StreamSubscription> SubscribeToStreamAsync(string streamName,
 			StreamRevision start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			EventStoreClientOperationOptions operationOptions,
@@ -222,21 +222,26 @@ namespace EventStore.Client {
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) {
-			
 			operationOptions.TimeoutAfter = DeadLine.None;
 
-			var subscription = new StreamSubscription(ReadInternal(new ReadReq {
+			return StreamSubscription.Confirm(ReadInternal(new ReadReq {
 						Options = new ReadReq.Types.Options {
 							ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
 							ResolveLinks = resolveLinkTos,
-							Stream = ReadReq.Types.Options.Types.StreamOptions.FromStreamNameAndRevision(streamName,
-								start),
+							Stream = start == StreamRevision.End
+								? new ReadReq.Types.Options.Types.StreamOptions {
+									End = new ReadReq.Types.Empty(),
+									StreamName = streamName
+								}
+								: new ReadReq.Types.Options.Types.StreamOptions {
+									Revision = start,
+									StreamName = streamName
+								},
 							Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
 						}
 					},
 					operationOptions, userCredentials, cancellationToken), eventAppeared,
-				subscriptionDropped);
-			return subscription;
+				subscriptionDropped, cancellationToken);
 		}
 
 		/// <summary>
@@ -250,13 +255,13 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public StreamSubscription SubscribeToStream(string streamName,
+		public Task<StreamSubscription> SubscribeToStreamAsync(string streamName,
 			StreamRevision start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => SubscribeToStream(streamName, start, eventAppeared,
+			CancellationToken cancellationToken = default) => SubscribeToStreamAsync(streamName, start, eventAppeared,
 			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped,
 			userCredentials, cancellationToken);
 
@@ -272,7 +277,7 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public StreamSubscription SubscribeToStream(string streamName,
+		public Task<StreamSubscription> SubscribeToStreamAsync(string streamName,
 			StreamRevision start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<EventStoreClientOperationOptions> configureOperationOptions,
@@ -280,11 +285,10 @@ namespace EventStore.Client {
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) {
-			
 			var operationOptions = _settings.OperationOptions.Clone();
 			configureOperationOptions(operationOptions);
-			
-			return SubscribeToStream(streamName, start, eventAppeared, operationOptions, resolveLinkTos,
+
+			return SubscribeToStreamAsync(streamName, start, eventAppeared, operationOptions, resolveLinkTos,
 				subscriptionDropped,
 				userCredentials, cancellationToken);
 		}

--- a/src/EventStore.Client/Logging/LogProvider.cs
+++ b/src/EventStore.Client/Logging/LogProvider.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace EventStore.Client.Logging {
+	public static class LogProvider {
+		/// <summary>
+		///
+		/// </summary>
+		public static Action<IServiceCollection> Configure;
+
+		private static readonly Lazy<ILoggerFactory> s_LoggerFactoryFactory = new Lazy<ILoggerFactory>(
+			() => {
+				var services = new ServiceCollection()
+					.AddLogging();
+				Configure?.Invoke(services);
+
+				return services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+			});
+
+		public static ILoggerFactory LoggerFactory => s_LoggerFactoryFactory.Value;
+
+		internal static ILogger CreateLogger(string categoryName) => LoggerFactory.CreateLogger(categoryName);
+		internal static ILogger CreateLogger(Type type) => LoggerFactory.CreateLogger(type);
+		internal static ILogger<T> CreateLogger<T>() => LoggerFactory.CreateLogger<T>();
+	}
+}

--- a/src/EventStore.Client/SubscriptionConfirmation.cs
+++ b/src/EventStore.Client/SubscriptionConfirmation.cs
@@ -1,0 +1,28 @@
+using System;
+
+namespace EventStore.Client {
+	internal struct SubscriptionConfirmation : IEquatable<SubscriptionConfirmation> {
+		public static readonly SubscriptionConfirmation None = default;
+		public string SubscriptionId { get; }
+
+		public SubscriptionConfirmation(string subscriptionId) {
+			if (subscriptionId == null) {
+				throw new ArgumentNullException(nameof(subscriptionId));
+			}
+
+			SubscriptionId = subscriptionId;
+		}
+
+		public bool Equals(SubscriptionConfirmation other) => SubscriptionId == other.SubscriptionId;
+		public override bool Equals(object obj) => obj is SubscriptionConfirmation other && Equals(other);
+		public override int GetHashCode() => SubscriptionId?.GetHashCode() ?? 0;
+
+		public static bool operator ==(SubscriptionConfirmation left, SubscriptionConfirmation right) =>
+			left.Equals(right);
+
+		public static bool operator !=(SubscriptionConfirmation left, SubscriptionConfirmation right) =>
+			!left.Equals(right);
+
+		public override string ToString() => SubscriptionId;
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
@@ -1,9 +1,12 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Log;
+using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -13,21 +16,24 @@ using EventStore.Client;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	partial class Enumerators {
-		public class AllSubscription : IAsyncEnumerator<ResolvedEvent> {
+		public class AllSubscription : ISubscriptionEnumerator {
+			private static readonly ILogger Log = LogManager.GetLoggerFor<StreamSubscription>();
+
+			private readonly Guid _subscriptionId;
 			private readonly IPublisher _bus;
 			private readonly bool _resolveLinks;
 			private readonly IPrincipal _user;
 			private readonly IReadIndex _readIndex;
-			private readonly CancellationTokenSource _disposedTokenSource;
-			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-			private readonly CancellationTokenRegistration _tokenRegistration;
-			private Position _nextPosition;
-			private ResolvedEvent _current;
+			private readonly CancellationToken _cancellationToken;
+			private readonly TaskCompletionSource<bool> _subscriptionStarted;
+			private IStreamSubscription _inner;
 
-			public ResolvedEvent Current => _current;
+			public ResolvedEvent Current => _inner.Current;
+			public Task Started => _subscriptionStarted.Task;
+			public string SubscriptionId => _subscriptionId.ToString();
 
 			public AllSubscription(IPublisher bus,
-				Position position,
+				Position? startPosition,
 				bool resolveLinks,
 				IPrincipal user,
 				IReadIndex readIndex,
@@ -40,94 +46,430 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw new ArgumentNullException(nameof(readIndex));
 				}
 
+				_subscriptionId = Guid.NewGuid();
 				_bus = bus;
-				_nextPosition = position;
 				_resolveLinks = resolveLinks;
 				_user = user;
 				_readIndex = readIndex;
-				_disposedTokenSource = new CancellationTokenSource();
-				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
-			}
+				_cancellationToken = cancellationToken;
+				_subscriptionStarted = new TaskCompletionSource<bool>();
+				_subscriptionStarted.SetResult(true);
 
-			public ValueTask DisposeAsync() {
-				_disposedTokenSource.Dispose();
-				_tokenRegistration.Dispose();
-				return default;
+				_inner = startPosition == Position.End
+					? (IStreamSubscription)new LiveStreamSubscription(_subscriptionId, _bus,
+						Position.FromInt64(_readIndex.LastIndexedPosition, _readIndex.LastIndexedPosition),
+						_resolveLinks, _user, _cancellationToken)
+					: new CatchupAllSubscription(_subscriptionId, bus, startPosition ?? Position.Start, resolveLinks,
+						user, readIndex, cancellationToken);
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
 				ReadLoop:
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
-				}
-
-				if (_buffer.TryDequeue(out var current)) {
-					_current = current;
+				if (await _inner.MoveNextAsync().ConfigureAwait(false)) {
 					return true;
 				}
 
-				var correlationId = Guid.NewGuid();
-
-				var readNextSource = new TaskCompletionSource<bool>();
-
-				var (commitPosition, preparePosition) = _nextPosition == Position.End
-					? (_readIndex.LastIndexedPosition, _readIndex.LastIndexedPosition)
-					: _nextPosition.ToInt64();
-
-				_bus.Publish(new ClientMessage.ReadAllEventsForward(
-					correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition, 32,
-					_resolveLinks, false, default, _user));
-
-				await readNextSource.Task.ConfigureAwait(false);
-
-				if (_disposedTokenSource.IsCancellationRequested) {
+				if (_cancellationToken.IsCancellationRequested) {
 					return false;
 				}
 
-				if (_buffer.TryDequeue(out current)) {
-					_current = current;
-					return true;
-				}
+				var currentPosition = _inner.CurrentPosition;
+				await _inner.DisposeAsync().ConfigureAwait(false);
+				Log.Trace("Subscription {subscriptionId} to $all reached the end, switching...",
+					_subscriptionId);
 
-				try {
-					await Task.Delay(100, _disposedTokenSource.Token).ConfigureAwait(false);
-				} catch (ObjectDisposedException) {
-					return false;
-				}
+				if (_inner is LiveStreamSubscription)
+					_inner = new CatchupAllSubscription(_subscriptionId, _bus, currentPosition, _resolveLinks,
+						_user, _readIndex, _cancellationToken);
+				else
+					_inner = new LiveStreamSubscription(_subscriptionId, _bus, currentPosition, _resolveLinks,
+						_user, _cancellationToken);
 
 				goto ReadLoop;
+			}
 
-				void OnMessage(Message message) {
-					if (message is ClientMessage.NotHandled notHandled &&
-					    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-						readNextSource.TrySetException(ex);
-						return;
+			public ValueTask DisposeAsync() => _inner.DisposeAsync();
+
+			private interface IStreamSubscription : IAsyncEnumerator<ResolvedEvent> {
+				Position CurrentPosition { get; }
+			}
+
+			private class CatchupAllSubscription : IStreamSubscription {
+				private readonly Guid _subscriptionId;
+				private readonly IPublisher _bus;
+				private readonly bool _resolveLinks;
+				private readonly IPrincipal _user;
+				private readonly CancellationTokenSource _disposedTokenSource;
+				private readonly ConcurrentQueue<ResolvedEvent> _buffer;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly Position _startPosition;
+
+				private Position _nextPosition;
+				private ResolvedEvent _current;
+				private Position _currentPosition;
+
+				public ResolvedEvent Current => _current;
+				public Position CurrentPosition => _currentPosition;
+
+				public CatchupAllSubscription(Guid subscriptionId,
+					IPublisher bus,
+					Position position,
+					bool resolveLinks,
+					IPrincipal user,
+					IReadIndex readIndex,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
 					}
 
-					if (!(message is ClientMessage.ReadAllEventsForwardCompleted completed)) {
-						readNextSource.TrySetException(RpcExceptions.UnknownMessage<ClientMessage.ReadAllEventsForwardCompleted>(message));
-						return;
+					if (readIndex == null) {
+						throw new ArgumentNullException(nameof(readIndex));
 					}
 
-					switch (completed.Result) {
-						case ReadAllResult.Success:
-							foreach (var @event in completed.Events) {
-								_buffer.Enqueue(@event);
+					_subscriptionId = subscriptionId;
+					_bus = bus;
+					_nextPosition = position == Position.End
+						? Position.FromInt64(readIndex.LastIndexedPosition, readIndex.LastIndexedPosition)
+						: position;
+					_startPosition = position == Position.End ? Position.Start : position;
+					_resolveLinks = resolveLinks;
+					_user = user;
+					_disposedTokenSource = new CancellationTokenSource();
+					_buffer = new ConcurrentQueue<ResolvedEvent>();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+					_currentPosition = _startPosition;
+					Log.Info("Catch-up subscription {subscriptionId} to $all running...", _subscriptionId);
+				}
+
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					ReadLoop:
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					if (_buffer.TryDequeue(out var current)) {
+						_current = current;
+						_currentPosition = Position.FromInt64(current.OriginalPosition.Value.CommitPosition,
+							current.OriginalPosition.Value.PreparePosition);
+						return true;
+					}
+
+					var correlationId = Guid.NewGuid();
+
+					var readNextSource = new TaskCompletionSource<bool>();
+
+					var (commitPosition, preparePosition) = _nextPosition.ToInt64();
+
+					Log.Trace(
+						"Catch-up subscription {subscriptionId} to $all reading next page starting from {nextPosition}.",
+						_subscriptionId, _nextPosition);
+
+					_bus.Publish(new ClientMessage.ReadAllEventsForward(
+						correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition,
+						ReadBatchSize, _resolveLinks, false, default, _user));
+
+					var isEnd = await readNextSource.Task.ConfigureAwait(false);
+
+					if (_buffer.TryDequeue(out current)) {
+						_current = current;
+						_currentPosition = Position.FromInt64(current.OriginalPosition.Value.CommitPosition,
+							current.OriginalPosition.Value.PreparePosition);
+						return true;
+					}
+
+					if (isEnd) {
+						return false;
+					}
+
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					goto ReadLoop;
+
+					void OnMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							readNextSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.ReadAllEventsForwardCompleted completed)) {
+							readNextSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.ReadAllEventsForwardCompleted>(message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case ReadAllResult.Success:
+								foreach (var @event in completed.Events) {
+									var position = Position.FromInt64(
+										@event.OriginalPosition.Value.CommitPosition,
+										@event.OriginalPosition.Value.PreparePosition);
+									if (position <= _startPosition) {
+										Log.Trace(
+											"Catch-up subscription {subscriptionId} to $all skipped event {position}.",
+											_subscriptionId, position);
+										continue;
+									}
+
+									Log.Trace(
+										"Catch-up subscription {subscriptionId} to $all received event {position}.",
+										_subscriptionId, position);
+
+									_buffer.Enqueue(@event);
+								}
+
+								_nextPosition = Position.FromInt64(
+									completed.NextPos.CommitPosition,
+									completed.NextPos.PreparePosition);
+								readNextSource.TrySetResult(completed.IsEndOfStream);
+								return;
+							case ReadAllResult.AccessDenied:
+								readNextSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+				}
+			}
+
+			private class LiveStreamSubscription : IStreamSubscription {
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_liveEventBuffer;
+
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_historicalEventBuffer;
+
+				private readonly Guid _subscriptionId;
+				private readonly IPublisher _bus;
+				private readonly IPrincipal _user;
+				private readonly TaskCompletionSource<Position> _subscriptionConfirmed;
+				private readonly TaskCompletionSource<bool> _readHistoricalEventsCompleted;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly CancellationTokenSource _disposedTokenSource;
+
+				private ResolvedEvent _current;
+				private Position _currentPosition;
+
+				public ResolvedEvent Current => _current;
+				public Position CurrentPosition => _currentPosition;
+
+				public LiveStreamSubscription(Guid subscriptionId,
+					IPublisher bus,
+					Position currentPosition,
+					bool resolveLinks,
+					IPrincipal user,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
+
+					_liveEventBuffer = new ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_historicalEventBuffer = new ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_subscriptionId = subscriptionId;
+					_bus = bus;
+					_user = user;
+					_subscriptionConfirmed = new TaskCompletionSource<Position>();
+					_readHistoricalEventsCompleted = new TaskCompletionSource<bool>();
+					_disposedTokenSource = new CancellationTokenSource();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+					_currentPosition = currentPosition;
+
+					Log.Info("Live subscription {subscriptionId} to $all running...", subscriptionId);
+
+					bus.Publish(new ClientMessage.SubscribeToStream(Guid.NewGuid(), _subscriptionId,
+						new CallbackEnvelope(OnSubscriptionMessage), subscriptionId, string.Empty, resolveLinks, user));
+
+					void OnSubscriptionMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_subscriptionConfirmed.TrySetException(ex);
+							return;
+						}
+
+						switch (message) {
+							case ClientMessage.SubscriptionConfirmation confirmed:
+								var caughtUp = Position.FromInt64(confirmed.LastIndexedPosition,
+									confirmed.LastIndexedPosition);
+								Log.Trace(
+									"Live subscription {subscriptionId} to $all confirmed at {position}.",
+									_subscriptionId, caughtUp);
+								_subscriptionConfirmed.TrySetResult(caughtUp);
+								ReadHistoricalEvents(currentPosition);
+
+								return;
+							case ClientMessage.SubscriptionDropped dropped:
+								switch (dropped.Reason) {
+									case SubscriptionDropReason.AccessDenied:
+										Fail(RpcExceptions.AccessDenied());
+										return;
+									default:
+										Fail(RpcExceptions.UnknownError(dropped.Reason));
+										return;
+								}
+							case ClientMessage.StreamEventAppeared appeared:
+								_liveEventBuffer.Enqueue((appeared.Event, null));
+								return;
+							default:
+								Fail(RpcExceptions.UnknownMessage<ClientMessage.SubscriptionConfirmation>(message));
+								return;
+						}
+
+						void Fail(Exception ex) {
+							_liveEventBuffer.Enqueue((default, ex));
+							_subscriptionConfirmed.TrySetException(ex);
+						}
+
+						void OnHistoricalEventsMessage(Message message) {
+							if (message is ClientMessage.NotHandled notHandled &&
+							    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+								_readHistoricalEventsCompleted.TrySetException(ex);
+								return;
 							}
 
-							_nextPosition = Position.FromInt64(
-								completed.NextPos.CommitPosition,
-								completed.NextPos.PreparePosition);
-							readNextSource.TrySetResult(true);
-							return;
-						case ReadAllResult.AccessDenied:
-							readNextSource.TrySetException(RpcExceptions.AccessDenied());
-							return;
-						default:
-							readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
-							return;
+							if (!(message is ClientMessage.ReadAllEventsForwardCompleted completed)) {
+								_readHistoricalEventsCompleted.TrySetException(
+									RpcExceptions
+										.UnknownMessage<ClientMessage.ReadAllEventsForwardCompleted>(message));
+								return;
+							}
+
+							switch (completed.Result) {
+								case ReadAllResult.Success:
+									foreach (var @event in completed.Events) {
+										var position = Position.FromInt64(
+											@event.OriginalPosition.Value.CommitPosition,
+											@event.OriginalPosition.Value.PreparePosition);
+										if (currentPosition >= position) {
+											Log.Trace(
+												"Live subscription {subscriptionId} to $all skipping missed event at {position}.",
+												_subscriptionId, position);
+											continue;
+										}
+
+										if (position <= _subscriptionConfirmed.Task.Result) {
+											Log.Trace(
+												"Live subscription {subscriptionId} to $all enqueueing missed event at {position}.",
+												_subscriptionId, position);
+											_historicalEventBuffer.Enqueue((@event, null));
+										} else {
+											Log.Trace(
+												"Live subscription {subscriptionId} to $all caught up at {position}.",
+												_subscriptionId, position);
+											_readHistoricalEventsCompleted.TrySetResult(true);
+											return;
+										}
+									}
+
+									var fromPosition = Position.FromInt64(
+										completed.NextPos.CommitPosition,
+										completed.NextPos.PreparePosition);
+									if (completed.IsEndOfStream) {
+										Log.Trace(
+											"Live subscription {subscriptionId} to $all caught up at {position}.",
+											_subscriptionId, fromPosition);
+										_readHistoricalEventsCompleted.TrySetResult(true);
+										return;
+									}
+
+									ReadHistoricalEvents(fromPosition);
+									return;
+								case ReadAllResult.AccessDenied:
+									_readHistoricalEventsCompleted.TrySetException(RpcExceptions.AccessDenied());
+									return;
+								default:
+									_readHistoricalEventsCompleted.TrySetException(
+										RpcExceptions.UnknownError(completed.Result));
+									return;
+							}
+						}
+
+						void ReadHistoricalEvents(Position fromPosition) {
+							Log.Trace(
+								"Live subscription {subscriptionId} to $all loading any missed events starting from {position}.",
+								subscriptionId, fromPosition);
+
+							var correlationId = Guid.NewGuid();
+							var (commitPosition, preparePosition) = fromPosition.ToInt64();
+							bus.Publish(new ClientMessage.ReadAllEventsForward(correlationId, correlationId,
+								new CallbackEnvelope(OnHistoricalEventsMessage), commitPosition, preparePosition,
+								ReadBatchSize, resolveLinks, false, null, user));
+						}
 					}
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					(ResolvedEvent, Exception) _;
+
+					await Task.WhenAll(_subscriptionConfirmed.Task, _readHistoricalEventsCompleted.Task)
+						.ConfigureAwait(false);
+
+					if (_historicalEventBuffer.TryDequeue(out _)) {
+						var (historicalEvent, historicalException) = _;
+
+						if (historicalException != null) {
+							throw historicalException;
+						}
+
+						var position = Position.FromInt64(
+							historicalEvent.OriginalPosition.Value.CommitPosition,
+							historicalEvent.OriginalPosition.Value.PreparePosition);
+
+						if (_liveEventBuffer.Count > MaxLiveEventBufferCount) {
+							Log.Warn("Live subscription {subscriptionId} to $all buffer is full.",
+								_subscriptionId);
+
+							_liveEventBuffer.Clear();
+							_historicalEventBuffer.Clear();
+
+							return false;
+						}
+
+						_current = historicalEvent;
+						_currentPosition = position;
+						Log.Trace(
+							"Live subscription {subscriptionId} to $all received event {position} historically.",
+							_subscriptionId, position);
+						return true;
+					}
+
+					var delay = 1;
+
+					while (!_liveEventBuffer.TryDequeue(out _)) {
+						await Task.Delay(Math.Max(delay *= 2, 50), _disposedTokenSource.Token)
+							.ConfigureAwait(false);
+					}
+
+					var (resolvedEvent, exception) = _;
+
+					if (exception != null) {
+						throw exception;
+					}
+
+					Log.Trace("Live subscription {subscriptionId} to $all received event {position} live.",
+						_subscriptionId, resolvedEvent.OriginalPosition);
+					_current = resolvedEvent;
+					_currentPosition = Position.FromInt64(resolvedEvent.OriginalPosition.Value.CommitPosition,
+						resolvedEvent.OriginalPosition.Value.PreparePosition);
+					return true;
+				}
+
+				public ValueTask DisposeAsync() {
+					Log.Info("Live subscription {subscriptionId} to $all disposed.", _subscriptionId);
+					_bus.Publish(new ClientMessage.UnsubscribeFromStream(Guid.NewGuid(), _subscriptionId,
+						new NoopEnvelope(), _user));
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -4,32 +4,37 @@ using System.Collections.Generic;
 using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client;
+using EventStore.Common.Log;
 using IEventFilter = EventStore.Core.Util.IEventFilter;
 using IReadIndex = EventStore.Core.Services.Storage.ReaderIndex.IReadIndex;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal static partial class Enumerators {
-		public class AllSubscriptionFiltered : IAsyncEnumerator<ResolvedEvent> {
+		public class AllSubscriptionFiltered : ISubscriptionEnumerator {
+			private static readonly ILogger Log = LogManager.GetLoggerFor<StreamSubscription>();
+
+			private readonly Guid _subscriptionId;
 			private readonly IPublisher _bus;
 			private readonly bool _resolveLinks;
 			private readonly IEventFilter _eventFilter;
 			private readonly IPrincipal _user;
 			private readonly IReadIndex _readIndex;
-			private readonly CancellationTokenSource _disposedTokenSource;
-			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-			private readonly CancellationTokenRegistration _tokenRegistration;
-			private Position _nextPosition;
-			private ResolvedEvent _current;
+			private readonly TaskCompletionSource<bool> _subscriptionStarted;
+			private readonly CancellationToken _cancellationToken;
+			private IStreamSubscription _inner;
 
-			public ResolvedEvent Current => _current;
+			public ResolvedEvent Current => _inner.Current;
+			public Task Started => _subscriptionStarted.Task;
+			public string SubscriptionId => _subscriptionId.ToString();
 
 			public AllSubscriptionFiltered(IPublisher bus,
-				Position position,
+				Position? startPosition,
 				bool resolveLinks,
 				IEventFilter eventFilter,
 				IPrincipal user,
@@ -39,104 +44,460 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw new ArgumentNullException(nameof(bus));
 				}
 
-				if (readIndex == null) {
-					throw new ArgumentNullException(nameof(readIndex));
-				}
-
 				if (eventFilter == null) {
 					throw new ArgumentNullException(nameof(eventFilter));
 				}
 
+				if (readIndex == null) {
+					throw new ArgumentNullException(nameof(readIndex));
+				}
+
+				_subscriptionId = Guid.NewGuid();
 				_bus = bus;
-				_nextPosition = position;
 				_resolveLinks = resolveLinks;
 				_eventFilter = eventFilter;
 				_user = user;
 				_readIndex = readIndex;
-				_disposedTokenSource = new CancellationTokenSource();
-				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
-			}
+				_cancellationToken = cancellationToken;
+				_subscriptionStarted = new TaskCompletionSource<bool>();
+				_subscriptionStarted.SetResult(true);
 
-			public ValueTask DisposeAsync() {
-				_disposedTokenSource.Dispose();
-				_tokenRegistration.Dispose();
-				return default;
+				_inner = startPosition == Position.End
+					? (IStreamSubscription)new LiveStreamSubscription(_subscriptionId, _bus,
+						Position.FromInt64(_readIndex.LastIndexedPosition, _readIndex.LastIndexedPosition),
+						_resolveLinks, _eventFilter, _user, _cancellationToken)
+					: new CatchupAllSubscription(_subscriptionId, bus, startPosition ?? Position.Start, resolveLinks,
+						_eventFilter, user, readIndex, cancellationToken);
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
 				ReadLoop:
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
-				}
-
-				if (_buffer.TryDequeue(out var current)) {
-					_current = current;
+				if (await _inner.MoveNextAsync().ConfigureAwait(false)) {
 					return true;
 				}
 
-				var correlationId = Guid.NewGuid();
-
-				var readNextSource = new TaskCompletionSource<bool>();
-
-				var (commitPosition, preparePosition) = _nextPosition == Position.End
-					? (_readIndex.LastIndexedPosition, _readIndex.LastIndexedPosition)
-					: _nextPosition.ToInt64();
-
-				_bus.Publish(new ClientMessage.FilteredReadAllEventsForward(
-					correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition, 32,
-					_resolveLinks, false, 32, default, _eventFilter, _user));
-
-				await readNextSource.Task.ConfigureAwait(false);
-
-				if (_buffer.TryDequeue(out current)) {
-					_current = current;
-					return true;
-				}
-
-				if (_disposedTokenSource.IsCancellationRequested) {
+				if (_cancellationToken.IsCancellationRequested) {
 					return false;
 				}
 
-				try {
-					await Task.Delay(100, _disposedTokenSource.Token).ConfigureAwait(false);
-				} catch (ObjectDisposedException) {
-					return false;
-				}
+				var currentPosition = _inner.CurrentPosition;
+				await _inner.DisposeAsync().ConfigureAwait(false);
+				Log.Trace("Subscription {subscriptionId} to $all:{eventFilter} reached the end, switching...",
+					_subscriptionId, _eventFilter);
+
+				if (_inner is LiveStreamSubscription)
+					_inner = new CatchupAllSubscription(_subscriptionId, _bus, currentPosition, _resolveLinks,
+						_eventFilter, _user, _readIndex, _cancellationToken);
+				else
+					_inner = new LiveStreamSubscription(_subscriptionId, _bus, currentPosition, _resolveLinks,
+						_eventFilter, _user, _cancellationToken);
 
 				goto ReadLoop;
+			}
 
-				void OnMessage(Message message) {
-					if (message is ClientMessage.NotHandled notHandled && 
-					    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-						readNextSource.TrySetException(ex);
-						return;
+			public ValueTask DisposeAsync() => _inner.DisposeAsync();
+
+			private interface IStreamSubscription : IAsyncEnumerator<ResolvedEvent> {
+				Position CurrentPosition { get; }
+			}
+
+			private class CatchupAllSubscription : IStreamSubscription {
+				private readonly Guid _subscriptionId;
+				private readonly IPublisher _bus;
+				private readonly bool _resolveLinks;
+				private readonly IEventFilter _eventFilter;
+				private readonly IPrincipal _user;
+				private readonly CancellationTokenSource _disposedTokenSource;
+				private readonly ConcurrentQueueWrapper<ResolvedEvent> _buffer;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly Position _startPosition;
+
+				private Position _nextPosition;
+				private ResolvedEvent _current;
+				private Position _currentPosition;
+
+				public ResolvedEvent Current => _current;
+				public Position CurrentPosition => _currentPosition;
+
+				public CatchupAllSubscription(Guid subscriptionId,
+					IPublisher bus,
+					Position position,
+					bool resolveLinks,
+					IEventFilter eventFilter,
+					IPrincipal user,
+					IReadIndex readIndex,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
 					}
 
-					if (!(message is ClientMessage.FilteredReadAllEventsForwardCompleted completed)) {
-						readNextSource.TrySetException(
-							RpcExceptions.UnknownMessage<ClientMessage.FilteredReadAllEventsForwardCompleted>(message));
-						return;
+					if (eventFilter == null) {
+						throw new ArgumentNullException(nameof(eventFilter));
 					}
 
-					switch (completed.Result) {
-						case FilteredReadAllResult.Success:
-							foreach (var @event in completed.Events) {
-								_buffer.Enqueue(@event);
-							}
-
-							_nextPosition = Position.FromInt64(
-								completed.NextPos.CommitPosition,
-								completed.NextPos.PreparePosition);
-							readNextSource.TrySetResult(true);
-							return;
-						case FilteredReadAllResult.AccessDenied:
-							readNextSource.TrySetException(RpcExceptions.AccessDenied());
-							return;
-						default:
-							readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
-							return;
+					if (readIndex == null) {
+						throw new ArgumentNullException(nameof(readIndex));
 					}
+
+					_subscriptionId = subscriptionId;
+					_bus = bus;
+					_nextPosition = position == Position.End
+						? Position.FromInt64(readIndex.LastIndexedPosition, readIndex.LastIndexedPosition)
+						: position;
+					_startPosition = position == Position.End ? Position.Start : position;
+					_resolveLinks = resolveLinks;
+					_eventFilter = eventFilter;
+					_user = user;
+					_disposedTokenSource = new CancellationTokenSource();
+					_buffer = new ConcurrentQueueWrapper<ResolvedEvent>();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+					_currentPosition = _startPosition;
+					Log.Info("Catch-up subscription {subscriptionId} to $all:{eventFilter} running...",
+						_subscriptionId, _eventFilter);
+				}
+
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					ReadLoop:
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					if (_buffer.TryDequeue(out var current)) {
+						_current = current;
+						_currentPosition = Position.FromInt64(current.OriginalPosition.Value.CommitPosition,
+							current.OriginalPosition.Value.PreparePosition);
+						return true;
+					}
+
+					var correlationId = Guid.NewGuid();
+
+					var readNextSource = new TaskCompletionSource<bool>();
+
+					var (commitPosition, preparePosition) = _nextPosition.ToInt64();
+
+					Log.Trace(
+						"Catch-up subscription {subscriptionId} to $all:{eventFilter} reading next page starting from {nextPosition}.",
+						_subscriptionId, _eventFilter, _nextPosition);
+
+					_bus.Publish(new ClientMessage.FilteredReadAllEventsForward(
+						correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition,
+						ReadBatchSize, _resolveLinks, false, 32, default, _eventFilter, _user));
+
+					var isEnd = await readNextSource.Task.ConfigureAwait(false);
+
+					if (_buffer.TryDequeue(out current)) {
+						_current = current;
+						_currentPosition = Position.FromInt64(current.OriginalPosition.Value.CommitPosition,
+							current.OriginalPosition.Value.PreparePosition);
+						return true;
+					}
+
+					if (isEnd) {
+						return false;
+					}
+
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					goto ReadLoop;
+
+					void OnMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							readNextSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.FilteredReadAllEventsForwardCompleted completed)) {
+							readNextSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.FilteredReadAllEventsForwardCompleted>(
+									message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case FilteredReadAllResult.Success:
+								foreach (var @event in completed.Events) {
+									var position = Position.FromInt64(
+										@event.OriginalPosition.Value.CommitPosition,
+										@event.OriginalPosition.Value.PreparePosition);
+									if (position <= _startPosition) {
+										Log.Trace(
+											"Catch-up subscription {subscriptionId} to $all:{eventFilter} skipped event {position}.",
+											_subscriptionId, _eventFilter, position);
+										continue;
+									}
+
+									Log.Trace(
+										"Catch-up subscription {subscriptionId} to $all:{eventFilter} received event {position}.",
+										_subscriptionId, _eventFilter, position);
+
+									_buffer.Enqueue(@event);
+								}
+
+								_nextPosition = Position.FromInt64(
+									completed.NextPos.CommitPosition,
+									completed.NextPos.PreparePosition);
+								readNextSource.TrySetResult(completed.IsEndOfStream);
+								return;
+							case FilteredReadAllResult.AccessDenied:
+								readNextSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+				}
+			}
+
+			private class LiveStreamSubscription : IStreamSubscription {
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_liveEventBuffer;
+
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_historicalEventBuffer;
+
+				private readonly Guid _subscriptionId;
+				private readonly IPublisher _bus;
+				private readonly IEventFilter _eventFilter;
+				private readonly IPrincipal _user;
+				private readonly TaskCompletionSource<Position> _subscriptionConfirmed;
+				private readonly TaskCompletionSource<bool> _readHistoricalEventsCompleted;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly CancellationTokenSource _disposedTokenSource;
+
+				private ResolvedEvent _current;
+				private Position _currentPosition;
+
+				public ResolvedEvent Current => _current;
+				public Position CurrentPosition => _currentPosition;
+
+				public LiveStreamSubscription(Guid subscriptionId,
+					IPublisher bus,
+					Position currentPosition,
+					bool resolveLinks,
+					IEventFilter eventFilter,
+					IPrincipal user,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
+
+					if (eventFilter == null) {
+						throw new ArgumentNullException(nameof(eventFilter));
+					}
+
+					_liveEventBuffer = new ConcurrentQueueWrapper<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_historicalEventBuffer = new ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_subscriptionId = subscriptionId;
+					_bus = bus;
+					_eventFilter = eventFilter;
+					_user = user;
+					_subscriptionConfirmed = new TaskCompletionSource<Position>();
+					_readHistoricalEventsCompleted = new TaskCompletionSource<bool>();
+					_disposedTokenSource = new CancellationTokenSource();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+					_currentPosition = currentPosition;
+
+					Log.Info("Live subscription {subscriptionId} to $all:{eventFilter} running...",
+						_subscriptionId, eventFilter);
+
+					bus.Publish(new ClientMessage.FilteredSubscribeToStream(Guid.NewGuid(), _subscriptionId,
+						new CallbackEnvelope(OnSubscriptionMessage), subscriptionId, string.Empty, resolveLinks, user,
+						eventFilter, 32));
+
+					void OnSubscriptionMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_subscriptionConfirmed.TrySetException(ex);
+							return;
+						}
+
+						switch (message) {
+							case ClientMessage.SubscriptionConfirmation confirmed:
+								var caughtUp = Position.FromInt64(confirmed.LastIndexedPosition,
+									confirmed.LastIndexedPosition);
+								Log.Trace(
+									"Live subscription {subscriptionId} to $all:{eventFilter} confirmed at {position}.",
+									_subscriptionId, _eventFilter, caughtUp);
+								_subscriptionConfirmed.TrySetResult(caughtUp);
+								ReadHistoricalEvents(currentPosition);
+
+								return;
+							case ClientMessage.SubscriptionDropped dropped:
+								switch (dropped.Reason) {
+									case SubscriptionDropReason.AccessDenied:
+										Fail(RpcExceptions.AccessDenied());
+										return;
+									default:
+										Fail(RpcExceptions.UnknownError(dropped.Reason));
+										return;
+								}
+							case ClientMessage.StreamEventAppeared appeared:
+								_liveEventBuffer.Enqueue((appeared.Event, null));
+								return;
+							default:
+								Fail(RpcExceptions.UnknownMessage<ClientMessage.SubscriptionConfirmation>(message));
+								return;
+						}
+
+						void Fail(Exception ex) {
+							_liveEventBuffer.Enqueue((default, ex));
+							_subscriptionConfirmed.TrySetException(ex);
+						}
+					}
+
+					void OnHistoricalEventsMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_readHistoricalEventsCompleted.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.FilteredReadAllEventsForwardCompleted completed)) {
+							_readHistoricalEventsCompleted.TrySetException(
+								RpcExceptions
+									.UnknownMessage<ClientMessage.FilteredReadAllEventsForwardCompleted>(message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case FilteredReadAllResult.Success:
+								foreach (var @event in completed.Events) {
+									var position = Position.FromInt64(
+										@event.OriginalPosition.Value.CommitPosition,
+										@event.OriginalPosition.Value.PreparePosition);
+									if (currentPosition >= position) {
+										Log.Trace(
+											"Live subscription {subscriptionId} to $all:{eventFilter} skipping missed event at {position}.",
+											_subscriptionId, eventFilter, position);
+										continue;
+									}
+
+									if (position <= _subscriptionConfirmed.Task.Result) {
+										Log.Trace(
+											"Live subscription {subscriptionId} to $all:{eventFilter} enqueueing missed event at {position}.",
+											_subscriptionId, eventFilter, position);
+										_historicalEventBuffer.Enqueue((@event, null));
+									} else {
+										Log.Trace(
+											"Live subscription {subscriptionId} to $all:{eventFilter} caught up at {position}.",
+											_subscriptionId, eventFilter, position);
+										_readHistoricalEventsCompleted.TrySetResult(true);
+										return;
+									}
+								}
+
+								var fromPosition = Position.FromInt64(
+									completed.NextPos.CommitPosition,
+									completed.NextPos.PreparePosition);
+								if (completed.IsEndOfStream) {
+									Log.Trace(
+										"Live subscription {subscriptionId} to $all:{eventFilter} caught up at {position}.",
+										_subscriptionId, eventFilter, fromPosition);
+									_readHistoricalEventsCompleted.TrySetResult(true);
+									return;
+								}
+
+								ReadHistoricalEvents(fromPosition);
+								return;
+							case FilteredReadAllResult.AccessDenied:
+								_readHistoricalEventsCompleted.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								_readHistoricalEventsCompleted.TrySetException(
+									RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+
+					void ReadHistoricalEvents(Position fromPosition) {
+						Log.Trace(
+							"Live subscription {subscriptionId} to $all:{eventFilter} loading any missed events ending with {fromPosition}.",
+							_subscriptionId, eventFilter, fromPosition);
+
+						var correlationId = Guid.NewGuid();
+						var (commitPosition, preparePosition) = fromPosition.ToInt64();
+						bus.Publish(new ClientMessage.FilteredReadAllEventsForward(correlationId, correlationId,
+							new CallbackEnvelope(OnHistoricalEventsMessage), commitPosition, preparePosition,
+							ReadBatchSize, resolveLinks, false, 32, null, eventFilter, user));
+					}
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					(ResolvedEvent, Exception) _;
+
+					await Task.WhenAll(_subscriptionConfirmed.Task, _readHistoricalEventsCompleted.Task)
+						.ConfigureAwait(false);
+
+					if (_historicalEventBuffer.TryDequeue(out _)) {
+						var (historicalEvent, historicalException) = _;
+
+						if (historicalException != null) {
+							throw historicalException;
+						}
+
+						var position = Position.FromInt64(
+							historicalEvent.OriginalPosition.Value.CommitPosition,
+							historicalEvent.OriginalPosition.Value.PreparePosition);
+
+						if (_liveEventBuffer.Count > MaxLiveEventBufferCount) {
+							Log.Warn("Live subscription {subscriptionId} to $all:{eventFilter} buffer is full.",
+								_subscriptionId, _eventFilter);
+
+							_liveEventBuffer.Clear();
+							_historicalEventBuffer.Clear();
+
+							return false;
+						}
+
+						_current = historicalEvent;
+						_currentPosition = position;
+						Log.Trace(
+							"Live subscription {subscriptionId} to $all:{eventFilter} received event {position} historically.",
+							_subscriptionId, _eventFilter, position);
+						return true;
+					}
+
+					var delay = 1;
+
+					while (!_liveEventBuffer.TryDequeue(out _)) {
+						await Task.Delay(Math.Max(delay *= 2, 50), _disposedTokenSource.Token)
+							.ConfigureAwait(false);
+					}
+
+					var (resolvedEvent, exception) = _;
+
+					if (exception != null) {
+						throw exception;
+					}
+
+					Log.Trace(
+						"Live subscription {subscriptionId} to $all:{eventFilter} received event {position} live.",
+						_subscriptionId, _eventFilter, resolvedEvent.OriginalPosition);
+					_current = resolvedEvent;
+					_currentPosition = Position.FromInt64(resolvedEvent.OriginalPosition.Value.CommitPosition,
+						resolvedEvent.OriginalPosition.Value.PreparePosition);
+					return true;
+				}
+
+				public ValueTask DisposeAsync() {
+					Log.Info("Live subscription {subscriptionId} to $all:{eventFilter} disposed.",
+						_subscriptionId,
+						_eventFilter);
+					_bus.Publish(new ClientMessage.UnsubscribeFromStream(Guid.NewGuid(), _subscriptionId,
+						new NoopEnvelope(), _user));
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -276,6 +276,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				private ResolvedEvent _current;
 				private Position _currentPosition;
+				private int _maxBufferSizeExceeded;
+
+				private bool MaxBufferSizeExceeded => _maxBufferSizeExceeded > 0;
 
 				public ResolvedEvent Current => _current;
 				public Position CurrentPosition => _currentPosition;
@@ -306,6 +309,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_disposedTokenSource = new CancellationTokenSource();
 					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 					_currentPosition = currentPosition;
+					_maxBufferSizeExceeded = 0;
 
 					Log.Info("Live subscription {subscriptionId} to $all:{eventFilter} running...",
 						_subscriptionId, eventFilter);
@@ -342,6 +346,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 										return;
 								}
 							case ClientMessage.StreamEventAppeared appeared:
+								if (MaxBufferSizeExceeded) {
+									return;
+								}
+								if (_liveEventBuffer.Count > MaxLiveEventBufferCount) {
+									MaximumBufferSizeExceeded();
+									return;
+								}
 								_liveEventBuffer.Enqueue((appeared.Event, null));
 								return;
 							default:
@@ -396,6 +407,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 									}
 								}
 
+								if (_historicalEventBuffer.Count > MaxLiveEventBufferCount) {
+									MaximumBufferSizeExceeded();
+									return;
+								}
+
 								var fromPosition = Position.FromInt64(
 									completed.NextPos.CommitPosition,
 									completed.NextPos.PreparePosition);
@@ -438,6 +454,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					await Task.WhenAll(_subscriptionConfirmed.Task, _readHistoricalEventsCompleted.Task)
 						.ConfigureAwait(false);
 
+					if (MaxBufferSizeExceeded) {
+						return false;
+					}
+
 					if (_historicalEventBuffer.TryDequeue(out _)) {
 						var (historicalEvent, historicalException) = _;
 
@@ -448,16 +468,6 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						var position = Position.FromInt64(
 							historicalEvent.OriginalPosition.Value.CommitPosition,
 							historicalEvent.OriginalPosition.Value.PreparePosition);
-
-						if (_liveEventBuffer.Count > MaxLiveEventBufferCount) {
-							Log.Warn("Live subscription {subscriptionId} to $all:{eventFilter} buffer is full.",
-								_subscriptionId, _eventFilter);
-
-							_liveEventBuffer.Clear();
-							_historicalEventBuffer.Clear();
-
-							return false;
-						}
 
 						_current = historicalEvent;
 						_currentPosition = position;
@@ -470,6 +480,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					var delay = 1;
 
 					while (!_liveEventBuffer.TryDequeue(out _)) {
+						if (MaxBufferSizeExceeded) {
+							return false;
+						}
 						await Task.Delay(Math.Max(delay *= 2, 50), _disposedTokenSource.Token)
 							.ConfigureAwait(false);
 					}
@@ -487,6 +500,15 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_currentPosition = Position.FromInt64(resolvedEvent.OriginalPosition.Value.CommitPosition,
 						resolvedEvent.OriginalPosition.Value.PreparePosition);
 					return true;
+				}
+
+				private void MaximumBufferSizeExceeded() {
+					Interlocked.Exchange(ref _maxBufferSizeExceeded, 1);
+					Log.Warn("Live subscription {subscriptionId} to $all:{eventFilter} buffer is full.",
+						_subscriptionId, _eventFilter);
+
+					_liveEventBuffer.Clear();
+					_historicalEventBuffer.Clear();
 				}
 
 				public ValueTask DisposeAsync() {

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
@@ -9,27 +9,33 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client;
+using EventStore.Common.Log;
 using IReadIndex = EventStore.Core.Services.Storage.ReaderIndex.IReadIndex;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal static partial class Enumerators {
-		public class StreamSubscription : IAsyncEnumerator<ResolvedEvent> {
+		public class StreamSubscription : ISubscriptionEnumerator {
+			private static readonly ILogger Log = LogManager.GetLoggerFor<StreamSubscription>();
+
+			private readonly Guid _subscriptionId;
 			private readonly IPublisher _bus;
 			private readonly string _streamName;
 			private readonly bool _resolveLinks;
 			private readonly IPrincipal _user;
 			private readonly IReadIndex _readIndex;
-			private readonly CancellationTokenSource _disposedTokenSource;
-			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
-			private readonly CancellationTokenRegistration _tokenRegistration;
-			private StreamRevision _nextRevision;
-			private ResolvedEvent _current;
+			private readonly CancellationToken _cancellationToken;
+			private readonly TaskCompletionSource<bool> _subscriptionStarted;
+			private readonly StreamRevision _startRevision;
+			private IStreamEnumerator _inner;
 
-			public ResolvedEvent Current => _current;
+			public ResolvedEvent Current => _inner.Current;
+			public Task Started => _subscriptionStarted.Task;
+			public string SubscriptionId => _subscriptionId.ToString();
 
-			public StreamSubscription(IPublisher bus,
+			public StreamSubscription(
+				IPublisher bus,
 				string streamName,
-				StreamRevision startRevision,
+				StreamRevision? startRevision,
 				bool resolveLinks,
 				IPrincipal user,
 				IReadIndex readIndex,
@@ -42,105 +48,509 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw new ArgumentNullException(nameof(streamName));
 				}
 
-				if (readIndex == null) throw new ArgumentNullException(nameof(readIndex));
+				if (readIndex == null) {
+					throw new ArgumentNullException(nameof(readIndex));
+				}
 
+				_subscriptionId = Guid.NewGuid();
 				_bus = bus;
 				_streamName = streamName;
-				_nextRevision = startRevision;
 				_resolveLinks = resolveLinks;
 				_user = user;
 				_readIndex = readIndex;
-				_disposedTokenSource = new CancellationTokenSource();
-				_buffer = new ConcurrentQueue<ResolvedEvent>();
-				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
-			}
+				_cancellationToken = cancellationToken;
+				_subscriptionStarted = new TaskCompletionSource<bool>();
 
+				_startRevision = startRevision == StreamRevision.End
+					? StreamRevision.FromInt64(readIndex.GetStreamLastEventNumber(_streamName) + 1)
+					: startRevision + 1 ?? StreamRevision.Start;
 
-			public ValueTask DisposeAsync() {
-				_disposedTokenSource.Dispose();
-				_tokenRegistration.Dispose();
-				return default;
+				_inner = startRevision == StreamRevision.End
+					? (IStreamEnumerator)new LiveStreamSubscription(_subscriptionId, _bus, _streamName,
+						StreamRevision.FromInt64(readIndex.GetStreamLastEventNumber(_streamName) + 1), _resolveLinks,
+						_user, _subscriptionStarted, _cancellationToken)
+					: new CatchupStreamSubscription(_subscriptionId, bus, streamName,
+						startRevision + 1 ?? StreamRevision.Start, resolveLinks, user, readIndex, _subscriptionStarted,
+						cancellationToken);
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
 				ReadLoop:
-				if (_disposedTokenSource.IsCancellationRequested) {
+				if (await _inner.MoveNextAsync().ConfigureAwait(false)) {
+					if (_inner.CurrentStreamRevision >= _startRevision)
+						return true;
+					goto ReadLoop;
+				}
+
+				if (_cancellationToken.IsCancellationRequested) {
 					return false;
 				}
 
-				if (_buffer.TryDequeue(out var current)) {
-					_current = current;
-					return true;
-				}
+				await _inner.DisposeAsync().ConfigureAwait(false);
+				var currentStreamRevision = _inner.CurrentStreamRevision;
+				Log.Trace("Subscription {subscriptionId} to {streamName} reached the end at {streamRevision}, switching...",
+					_subscriptionId, _streamName, currentStreamRevision);
 
-				var correlationId = Guid.NewGuid();
-
-				var readNextSource = new TaskCompletionSource<bool>();
-
-				var nextRevision = _nextRevision == StreamRevision.End
-					? Math.Max(_readIndex.GetStreamLastEventNumber(_streamName), 0L)
-					: _nextRevision.ToInt64();
-
-				_bus.Publish(new ClientMessage.ReadStreamEventsForward(
-					correlationId, correlationId, new CallbackEnvelope(OnMessage), _streamName,
-					nextRevision, 32,
-					_resolveLinks, false, default, _user));
-
-				await readNextSource.Task.ConfigureAwait(false);
-
-				if (_buffer.TryDequeue(out current)) {
-					_current = current;
-					return true;
-				}
-
-				if (_disposedTokenSource.IsCancellationRequested) {
-					return false;
-				}
-
-				try {
-					await Task.Delay(100, _disposedTokenSource.Token).ConfigureAwait(false);
-				} catch (ObjectDisposedException) {
-					return false;
-				}
-
+				if (_inner is LiveStreamSubscription)
+					_inner = new CatchupStreamSubscription(_subscriptionId, _bus, _streamName,
+						currentStreamRevision, _resolveLinks, _user, _readIndex, _subscriptionStarted,
+						_cancellationToken);
+				else
+					_inner = new LiveStreamSubscription(_subscriptionId, _bus, _streamName, currentStreamRevision,
+						_resolveLinks, _user, _subscriptionStarted, _cancellationToken);
 
 				goto ReadLoop;
+			}
 
-				void OnMessage(Message message) {
-					if (message is ClientMessage.NotHandled notHandled &&
-					    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-						readNextSource.TrySetException(ex);
-						return;
+
+			public ValueTask DisposeAsync() => _inner.DisposeAsync();
+
+			private interface IStreamEnumerator : IAsyncEnumerator<ResolvedEvent> {
+				StreamRevision CurrentStreamRevision { get; }
+			}
+
+			private class CatchupStreamSubscription : IStreamEnumerator {
+				private readonly Guid _subscriptionId;
+				private readonly IPublisher _bus;
+				private readonly string _streamName;
+				private readonly bool _resolveLinks;
+				private readonly IPrincipal _user;
+				private readonly CancellationTokenSource _disposedTokenSource;
+				private readonly ConcurrentQueue<ResolvedEvent> _buffer;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly StreamRevision _startRevision;
+
+				private StreamRevision _nextRevision;
+				private ResolvedEvent _current;
+				private StreamRevision _currentStreamRevision;
+
+				public ResolvedEvent Current => _current;
+				public StreamRevision CurrentStreamRevision => _currentStreamRevision;
+
+				public CatchupStreamSubscription(Guid subscriptionId,
+					IPublisher bus,
+					string streamName,
+					StreamRevision startRevision,
+					bool resolveLinks,
+					IPrincipal user,
+					IReadIndex readIndex,
+					TaskCompletionSource<bool> subscriptionStarted,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
 					}
 
-					if (!(message is ClientMessage.ReadStreamEventsForwardCompleted completed)) {
-						readNextSource.TrySetException(
-							RpcExceptions.UnknownMessage<ClientMessage.ReadStreamEventsForwardCompleted>(message));
-						return;
+					if (streamName == null) {
+						throw new ArgumentNullException(nameof(streamName));
 					}
 
-					switch (completed.Result) {
-						case ReadStreamResult.Success:
-							foreach (var @event in completed.Events) {
-								_buffer.Enqueue(@event);
-							}
-
-							_nextRevision = StreamRevision.FromInt64(completed.NextEventNumber);
-							readNextSource.TrySetResult(true);
-							return;
-						case ReadStreamResult.NoStream:
-							readNextSource.TrySetException(RpcExceptions.StreamNotFound(_streamName));
-							return;
-						case ReadStreamResult.StreamDeleted:
-							readNextSource.TrySetException(RpcExceptions.StreamDeleted(_streamName));
-							return;
-						case ReadStreamResult.AccessDenied:
-							readNextSource.TrySetException(RpcExceptions.AccessDenied());
-							return;
-						default:
-							readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
-							return;
+					if (readIndex == null) {
+						throw new ArgumentNullException(nameof(readIndex));
 					}
+
+					if (subscriptionStarted == null) {
+						throw new ArgumentNullException(nameof(subscriptionStarted));
+					}
+
+					_subscriptionId = subscriptionId;
+					_bus = bus;
+					_streamName = streamName;
+					_nextRevision = startRevision == StreamRevision.End
+						? StreamRevision.FromInt64(readIndex.GetStreamLastEventNumber(_streamName) + 1)
+						: startRevision;
+					_startRevision = startRevision == StreamRevision.End ? StreamRevision.Start : startRevision;
+					_resolveLinks = resolveLinks;
+					_user = user;
+					var subscriptionStarted1 = subscriptionStarted;
+					_disposedTokenSource = new CancellationTokenSource();
+					_buffer = new ConcurrentQueue<ResolvedEvent>();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+
+					if (!subscriptionStarted1.Task.IsCompleted) {
+						subscriptionStarted1.SetResult(true);
+					}
+
+					Log.Info(
+						"Catch-up subscription {subscriptionId} to {streamName}@{streamRevision} running...",
+						_subscriptionId, streamName, _nextRevision);
+				}
+
+				public ValueTask DisposeAsync() {
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					ReadLoop:
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					if (_buffer.TryDequeue(out var current)) {
+						_current = current;
+						_currentStreamRevision = StreamRevision.FromInt64(current.OriginalEventNumber);
+						return true;
+					}
+
+					var readNextSource = new TaskCompletionSource<bool>();
+
+					Guid correlationId = Guid.NewGuid();
+					Log.Trace(
+						"Catch-up subscription {subscriptionId} to {streamName} reading next page starting from {nextRevision}.",
+						_subscriptionId, _streamName, _nextRevision);
+
+					_bus.Publish(new ClientMessage.ReadStreamEventsForward(
+						correlationId, correlationId, new CallbackEnvelope(OnMessage), _streamName,
+						_nextRevision.ToInt64(), ReadBatchSize, _resolveLinks, false, default, _user));
+
+					var isEnd = await readNextSource.Task.ConfigureAwait(false);
+
+					if (_buffer.TryDequeue(out current)) {
+						_current = current;
+						_currentStreamRevision = StreamRevision.FromInt64(current.OriginalEvent.EventNumber);
+						return true;
+					}
+
+					if (isEnd) {
+						return false;
+					}
+
+					if (_disposedTokenSource.IsCancellationRequested) {
+						return false;
+					}
+
+					goto ReadLoop;
+
+					void OnMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							readNextSource.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.ReadStreamEventsForwardCompleted completed)) {
+							readNextSource.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.ReadStreamEventsForwardCompleted>(message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case ReadStreamResult.Success:
+								foreach (var @event in completed.Events) {
+									var streamRevision = StreamRevision.FromInt64(@event.OriginalEvent.EventNumber);
+									if (streamRevision < _startRevision) {
+										Log.Trace(
+											"Catch-up subscription {subscriptionId} to {streamName} skipped event {streamRevision}.",
+											_subscriptionId, _streamName, streamRevision);
+										continue;
+									}
+
+									Log.Trace(
+										"Catch-up subscription {subscriptionId} to {streamName} received event {streamRevision}.",
+										_subscriptionId, _streamName, streamRevision);
+
+									_buffer.Enqueue(@event);
+								}
+
+								_nextRevision = StreamRevision.FromInt64(completed.NextEventNumber);
+								readNextSource.TrySetResult(completed.IsEndOfStream);
+								return;
+							case ReadStreamResult.NoStream:
+								readNextSource.TrySetResult(true);
+								return;
+							case ReadStreamResult.StreamDeleted:
+								readNextSource.TrySetException(RpcExceptions.StreamDeleted(_streamName));
+								return;
+							case ReadStreamResult.AccessDenied:
+								readNextSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								readNextSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+				}
+			}
+
+			private class LiveStreamSubscription : IStreamEnumerator {
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_liveEventBuffer;
+
+				private readonly ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>
+					_historicalEventBuffer;
+
+				private readonly Guid _subscriptionId;
+				private readonly IPublisher _bus;
+				private readonly string _streamName;
+				private readonly IPrincipal _user;
+				private readonly TaskCompletionSource<StreamRevision> _subscriptionConfirmed;
+				private readonly TaskCompletionSource<bool> _readHistoricalEventsCompleted;
+				private readonly CancellationTokenRegistration _tokenRegistration;
+				private readonly CancellationTokenSource _disposedTokenSource;
+
+				private ResolvedEvent _current;
+				private StreamRevision _currentStreamRevision;
+
+				public ResolvedEvent Current => _current;
+
+				public StreamRevision CurrentStreamRevision => _currentStreamRevision;
+
+				public LiveStreamSubscription(Guid subscriptionId,
+					IPublisher bus,
+					string streamName,
+					StreamRevision currentStreamRevision,
+					bool resolveLinks,
+					IPrincipal user,
+					TaskCompletionSource<bool> subscriptionStarted,
+					CancellationToken cancellationToken) {
+					if (bus == null) {
+						throw new ArgumentNullException(nameof(bus));
+					}
+
+					if (streamName == null) {
+						throw new ArgumentNullException(nameof(streamName));
+					}
+
+					if (subscriptionStarted == null) {
+						throw new ArgumentNullException(nameof(subscriptionStarted));
+					}
+
+					if (currentStreamRevision == StreamRevision.End) {
+						throw new ArgumentOutOfRangeException(nameof(currentStreamRevision));
+					}
+
+					_liveEventBuffer = new ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_historicalEventBuffer = new ConcurrentQueue<(ResolvedEvent resolvedEvent, Exception exception)>();
+					_subscriptionId = subscriptionId;
+					_bus = bus;
+					_streamName = streamName;
+					_user = user;
+					_subscriptionConfirmed = new TaskCompletionSource<StreamRevision>();
+					_readHistoricalEventsCompleted = new TaskCompletionSource<bool>();
+					_disposedTokenSource = new CancellationTokenSource();
+					_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
+					_currentStreamRevision = currentStreamRevision;
+
+					Log.Info(
+						"Live subscription {subscriptionId} to {streamName} running from {streamRevision}...",
+						subscriptionId, streamName, currentStreamRevision);
+
+					bus.Publish(new ClientMessage.SubscribeToStream(Guid.NewGuid(), _subscriptionId,
+						new CallbackEnvelope(OnSubscriptionMessage), subscriptionId, streamName, resolveLinks, user));
+
+					void OnSubscriptionMessage(Message message) {
+						if (!subscriptionStarted.Task.IsCompleted) {
+							subscriptionStarted.SetResult(true);
+						}
+
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_subscriptionConfirmed.TrySetException(ex);
+							return;
+						}
+
+						switch (message) {
+							case ClientMessage.SubscriptionConfirmation confirmed:
+								var caughtUp = StreamRevision.FromInt64(Math.Max(confirmed.LastEventNumber.Value + 1,
+									currentStreamRevision.ToInt64()));
+								Log.Trace(
+									"Live subscription {subscriptionId} to {streamName} confirmed at {streamRevision}.",
+									_subscriptionId, _streamName, caughtUp);
+								_subscriptionConfirmed.TrySetResult(caughtUp);
+								subscriptionStarted.TrySetResult(true);
+								ReadHistoricalEvents(currentStreamRevision);
+
+								return;
+							case ClientMessage.SubscriptionDropped dropped:
+								Log.Debug(
+									"Live subscription {subscriptionId} to {streamName} dropped: {droppedReason}",
+									_subscriptionId, _streamName, dropped.Reason);
+								switch (dropped.Reason) {
+									case SubscriptionDropReason.AccessDenied:
+										Fail(RpcExceptions.AccessDenied());
+										return;
+									case SubscriptionDropReason.NotFound:
+										Fail(RpcExceptions.StreamNotFound(streamName));
+										return;
+									default:
+										Fail(RpcExceptions.UnknownError(dropped.Reason));
+										return;
+								}
+							case ClientMessage.StreamEventAppeared appeared:
+								if (appeared.Event.OriginalEvent.EventType == SystemEventTypes.StreamDeleted) {
+									_liveEventBuffer.Enqueue((default, RpcExceptions.StreamDeleted(_streamName)));
+									return;
+								}
+
+								var streamRevision = StreamRevision.FromInt64(appeared.Event.OriginalEventNumber);
+								if (currentStreamRevision > streamRevision) {
+									Log.Trace(
+										"Live subscription {subscriptionId} to {streamName} skipped event {streamRevision}.",
+										_subscriptionId, _streamName, streamRevision);
+									return;
+								}
+
+								_liveEventBuffer.Enqueue((appeared.Event, null));
+								return;
+							default:
+								Fail(RpcExceptions.UnknownMessage<ClientMessage.SubscriptionConfirmation>(message));
+								return;
+						}
+
+						void Fail(Exception ex) {
+							_liveEventBuffer.Enqueue((default, ex));
+							_subscriptionConfirmed.TrySetException(ex);
+						}
+					}
+
+					void OnHistoricalEventsMessage(Message message) {
+						if (message is ClientMessage.NotHandled notHandled &&
+						    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+							_readHistoricalEventsCompleted.TrySetException(ex);
+							return;
+						}
+
+						if (!(message is ClientMessage.ReadStreamEventsForwardCompleted completed)) {
+							_readHistoricalEventsCompleted.TrySetException(
+								RpcExceptions.UnknownMessage<ClientMessage.ReadStreamEventsForwardCompleted>(message));
+							return;
+						}
+
+						switch (completed.Result) {
+							case ReadStreamResult.Success:
+								foreach (var @event in completed.Events) {
+									var streamRevision = StreamRevision.FromInt64(@event.OriginalEvent.EventNumber);
+									if (streamRevision < currentStreamRevision) {
+										Log.Trace(
+											"Live subscription {subscriptionId} to {streamName} skipping missed event at {streamRevision}.",
+											_subscriptionId, streamName, streamRevision);
+										continue;
+									}
+
+									if (streamRevision < _subscriptionConfirmed.Task.Result && streamRevision > currentStreamRevision) {
+										Log.Trace(
+											"Live subscription {subscriptionId} to {streamName} enqueueing missed event at {streamRevision}.",
+											_subscriptionId, streamName, streamRevision);
+										_historicalEventBuffer.Enqueue((@event, null));
+									} else {
+										Log.Trace(
+											"Live subscription {subscriptionId} to {streamName} caught up at {streamRevision}.",
+											_subscriptionId, streamName, streamRevision);
+										_readHistoricalEventsCompleted.TrySetResult(true);
+										return;
+									}
+								}
+
+								var fromStreamRevision = StreamRevision.FromInt64(completed.NextEventNumber);
+								if (completed.IsEndOfStream) {
+									Log.Trace(
+										"Live subscription {subscriptionId} to {streamName} caught up at {streamRevision}.",
+										_subscriptionId, streamName, fromStreamRevision);
+									_readHistoricalEventsCompleted.TrySetResult(true);
+									return;
+								}
+
+								ReadHistoricalEvents(fromStreamRevision);
+								return;
+							case ReadStreamResult.NoStream:
+								Log.Trace("Live subscription {subscriptionId} to {streamName} stream not found.",
+									_subscriptionId, _streamName);
+								_readHistoricalEventsCompleted.TrySetResult(true);
+								return;
+							case ReadStreamResult.StreamDeleted:
+								Log.Trace("Live subscription {subscriptionId} to {streamName} stream deleted.",
+									_subscriptionId, _streamName);
+								_readHistoricalEventsCompleted.TrySetException(RpcExceptions.StreamDeleted(streamName));
+								return;
+							case ReadStreamResult.AccessDenied:
+								_readHistoricalEventsCompleted.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							default:
+								_readHistoricalEventsCompleted.TrySetException(
+									RpcExceptions.UnknownError(completed.Result));
+								return;
+						}
+					}
+
+					void ReadHistoricalEvents(StreamRevision fromStreamRevision) {
+						if (fromStreamRevision == StreamRevision.End) {
+							throw new ArgumentOutOfRangeException(nameof(fromStreamRevision));
+						}
+
+						Log.Trace(
+							"Live subscription {subscriptionId} to {streamName} loading any missed events starting from {streamRevision}",
+							subscriptionId, streamName, fromStreamRevision);
+
+						var correlationId = Guid.NewGuid();
+						bus.Publish(new ClientMessage.ReadStreamEventsForward(correlationId, correlationId,
+							new CallbackEnvelope(OnHistoricalEventsMessage), streamName, fromStreamRevision.ToInt64(),
+							ReadBatchSize, resolveLinks, false, null, user));
+					}
+				}
+
+				public async ValueTask<bool> MoveNextAsync() {
+					(ResolvedEvent, Exception) _;
+
+					await Task.WhenAll(_subscriptionConfirmed.Task, _readHistoricalEventsCompleted.Task)
+						.ConfigureAwait(false);
+
+					if (_historicalEventBuffer.TryDequeue(out _)) {
+						var (historicalEvent, historicalException) = _;
+
+						if (historicalException != null) {
+							throw historicalException;
+						}
+
+						var streamRevision = StreamRevision.FromInt64(historicalEvent.OriginalEventNumber);
+
+						if (_liveEventBuffer.Count > MaxLiveEventBufferCount) {
+							Log.Warn("Live subscription {subscriptionId} to {streamName} buffer is full.",
+								_subscriptionId, _streamName);
+
+							_liveEventBuffer.Clear();
+							_historicalEventBuffer.Clear();
+
+							return false;
+						}
+
+						_current = historicalEvent;
+						_currentStreamRevision = streamRevision;
+						Log.Trace(
+							"Live subscription {subscriptionId} to {streamName} received event {streamRevision} historically.",
+							_subscriptionId, _streamName, streamRevision);
+						return true;
+					}
+
+					var delay = 1;
+
+					while (!_liveEventBuffer.TryDequeue(out _)) {
+						await Task.Delay(Math.Max(delay *= 2, 50), _disposedTokenSource.Token)
+							.ConfigureAwait(false);
+					}
+
+					var (resolvedEvent, exception) = _;
+
+					if (exception != null) {
+						throw exception;
+					}
+
+					_currentStreamRevision = StreamRevision.FromInt64(resolvedEvent.OriginalEventNumber);
+					Log.Trace(
+						"Live subscription {subscriptionId} to {streamName} received event {streamRevision} live.",
+						_subscriptionId, _streamName, _currentStreamRevision);
+					_current = resolvedEvent;
+					return true;
+				}
+
+				public ValueTask DisposeAsync() {
+					Log.Info("Live subscription {subscriptionId} to {streamName} disposed.", _subscriptionId,
+						_streamName);
+					_bus.Publish(new ClientMessage.UnsubscribeFromStream(Guid.NewGuid(), _subscriptionId,
+						new NoopEnvelope(), _user));
+					_disposedTokenSource.Dispose();
+					_tokenRegistration.Dispose();
+					return default;
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.cs
@@ -1,4 +1,14 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EventStore.Core.Data;
+
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal static partial class Enumerators {
+		private const int MaxLiveEventBufferCount = 16;
+		private const int ReadBatchSize = 32; // TODO  JPB make this configurable
+		public interface ISubscriptionEnumerator : IAsyncEnumerator<ResolvedEvent> {
+			Task Started { get; }
+			string SubscriptionId { get; }
+		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/ReadReq.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/ReadReq.cs
@@ -15,12 +15,27 @@ namespace EventStore.Client.Streams {
 							RevisionOptionOneofCase.Revision => new StreamRevision(Revision),
 							_ => throw new InvalidOperationException()
 						};
+
+						internal StreamRevision? ToSubscriptionStreamRevision() => RevisionOptionCase switch {
+							RevisionOptionOneofCase.End => StreamRevision.End,
+							RevisionOptionOneofCase.Start => null,
+							RevisionOptionOneofCase.Revision => new StreamRevision(Revision),
+							_ => throw new InvalidOperationException()
+						};
 					}
 
 					public partial class AllOptions {
 						internal Client.Position ToPosition() => AllOptionCase switch {
 							AllOptionOneofCase.End => Client.Position.End,
 							AllOptionOneofCase.Start => Client.Position.Start,
+							AllOptionOneofCase.Position => new Client.Position(Position.CommitPosition,
+								Position.PreparePosition),
+							_ => throw new InvalidOperationException()
+						};
+
+						internal Client.Position? ToSubscriptionPosition() => AllOptionCase switch {
+							AllOptionOneofCase.End => Client.Position.End,
+							AllOptionOneofCase.Start => null,
 							AllOptionOneofCase.Position => new Client.Position(Position.CommitPosition,
 								Position.PreparePosition),
 							_ => throw new InvalidOperationException()

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		private readonly IQueuedHandler _queue;
 		private readonly IReadIndex _readIndex;
 		private readonly IAuthenticationProvider _authenticationProvider;
-		private int _maxAppendSize;
+		private readonly int _maxAppendSize;
 
 		public Streams(IQueuedHandler queue, IAuthenticationProvider authenticationProvider, IReadIndex readIndex,
 			int maxAppendSize) {

--- a/src/EventStore.Core/Util/EventFilter.cs
+++ b/src/EventStore.Core/Util/EventFilter.cs
@@ -50,6 +50,8 @@ namespace EventStore.Core.Util {
 			public bool IsEventAllowed(EventRecord eventRecord) {
 				return true;
 			}
+
+			public override string ToString() => nameof(AlwaysAllowStrategy);
 		}
 
 		private class StreamIdPrefixStrategy : IEventFilter {
@@ -60,6 +62,9 @@ namespace EventStore.Core.Util {
 
 			public bool IsEventAllowed(EventRecord eventRecord) =>
 				_expectedPrefixes.Any(expectedPrefix => eventRecord.EventStreamId.StartsWith(expectedPrefix));
+
+			public override string ToString() =>
+				$"{nameof(StreamIdPrefixStrategy)}: ({string.Join(", ", _expectedPrefixes)})";
 		}
 
 		private class EventTypePrefixStrategy : IEventFilter {
@@ -70,6 +75,9 @@ namespace EventStore.Core.Util {
 
 			public bool IsEventAllowed(EventRecord eventRecord) =>
 				_expectedPrefixes.Any(expectedPrefix => eventRecord.EventType.StartsWith(expectedPrefix));
+
+			public override string ToString() =>
+				$"{nameof(EventTypePrefixStrategy)}: ({string.Join(", ", _expectedPrefixes)})";
 		}
 
 		private class EventTypeRegexStrategy : IEventFilter {
@@ -80,6 +88,9 @@ namespace EventStore.Core.Util {
 
 			public bool IsEventAllowed(EventRecord eventRecord) =>
 				_expectedRegex.Match(eventRecord.EventType).Success;
+
+			public override string ToString() =>
+				$"{nameof(EventTypeRegexStrategy)}: ({string.Join(", ", _expectedRegex)})";
 		}
 
 		private class StreamIdRegexStrategy : IEventFilter {
@@ -90,6 +101,9 @@ namespace EventStore.Core.Util {
 
 			public bool IsEventAllowed(EventRecord eventRecord) =>
 				_expectedRegex.Match(eventRecord.EventStreamId).Success;
+
+			public override string ToString() =>
+				$"{nameof(StreamIdRegexStrategy)}: ({string.Join(", ", _expectedRegex)})";
 		}
 
 		public static (bool Success, string Reason) TryParse(string context, string type, string data,

--- a/src/EventStore.Grpc.Tests.Common/LoggingHelper.cs
+++ b/src/EventStore.Grpc.Tests.Common/LoggingHelper.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reactive.Linq;
+using System.Threading;
+using EventStore.Grpc.Logging;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting.Display;
+using Xunit.Abstractions;
+
+namespace EventStore.Grpc {
+	public static class LoggingHelper {
+		private const string CaptureCorrelationId = nameof(CaptureCorrelationId);
+		private static readonly Subject<LogEvent> s_logEventSubject = new Subject<LogEvent>();
+
+		private static readonly MessageTemplateTextFormatter s_formatter = new MessageTemplateTextFormatter(
+			"{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}");
+
+		private static readonly MessageTemplateTextFormatter s_formatterWithException =
+			new MessageTemplateTextFormatter(
+				"{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level}] {Message}{NewLine}{Exception}");
+
+		static LoggingHelper() {
+			if (!Enum.TryParse<LogEventLevel>(Environment.GetEnvironmentVariable("LOGLEVEL"), out var logLevel)) {
+				logLevel = LogEventLevel.Fatal;
+			}
+
+			Log.Logger = new LoggerConfiguration()
+				.WriteTo
+				.Observers(observable => observable.Subscribe(s_logEventSubject.OnNext))
+				.Enrich.FromLogContext()
+				.MinimumLevel.Is(logLevel)
+				.CreateLogger();
+
+			ForwardNLogToSerilog();
+
+			LogProvider.Configure = services => services.AddLogging(l => l.AddSerilog());
+		}
+
+		private static void ForwardNLogToSerilog() {
+			// sic: blindly overwrite the forwarding rules every time
+			var target = new SerilogTarget();
+			var cfg = new NLog.Config.LoggingConfiguration();
+			cfg.AddTarget(nameof(SerilogTarget), target);
+			cfg.LoggingRules.Add(new NLog.Config.LoggingRule("*", LogLevel.Trace, target));
+			// NB assignment must happen last; rules get ingested upon assignment
+			LogManager.Configuration = cfg;
+		}
+
+		public static IDisposable Capture(ITestOutputHelper testOutputHelper) {
+			var captureId = Guid.NewGuid();
+
+			var callContextData = new AsyncLocal<Tuple<string, Guid>> {
+				Value = Tuple.Create(CaptureCorrelationId, captureId)
+			};
+
+			bool Filter(LogEvent logEvent) {
+				return callContextData.Value.Item2.Equals(captureId);
+			}
+
+			var subscription = s_logEventSubject.Subscribe(logEvent => {
+				using var writer = new StringWriter();
+				if (logEvent.Exception != null) {
+					s_formatterWithException.Format(logEvent, writer);
+				} else {
+					s_formatter.Format(logEvent, writer);
+				}
+
+				testOutputHelper.WriteLine(writer.ToString());
+			});
+
+			return new DisposableAction(() => {
+				subscription.Dispose();
+				callContextData.Value = default;
+			});
+		}
+
+		private class DisposableAction : IDisposable {
+			private readonly Action _action;
+
+			public DisposableAction(Action action) {
+				_action = action;
+			}
+
+			public void Dispose() {
+				_action();
+			}
+		}
+
+		private class Subject<T> : IObserver<T>, IObservable<T> {
+			private readonly ConcurrentDictionary<Guid, IObserver<T>> _observers =
+				new ConcurrentDictionary<Guid, IObserver<T>>();
+
+			public void OnCompleted() {
+				foreach (var observer in _observers.Values) {
+					observer.OnCompleted();
+				}
+			}
+
+			public void OnError(Exception error) {
+				foreach (var observer in _observers.Values) {
+					observer.OnError(error);
+				}
+			}
+
+			public void OnNext(T value) {
+				foreach (var observer in _observers.Values) {
+					observer.OnNext(value);
+				}
+			}
+
+			public IDisposable Subscribe(IObserver<T> observer) {
+				var guid = Guid.NewGuid();
+				_observers.TryAdd(guid, observer);
+
+				return new DisposableAction(() => _observers.TryRemove(guid, out _));
+			}
+		}
+	}
+}

--- a/src/EventStore.Grpc.Tests.Common/SerilogTarget.cs
+++ b/src/EventStore.Grpc.Tests.Common/SerilogTarget.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using NLog;
+using NLog.Targets;
+using Serilog;
+
+namespace EventStore.Grpc {
+	public sealed class SerilogTarget : TargetWithLayout {
+		protected override void Write(LogEventInfo logEvent) {
+			var log = Log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, logEvent.LoggerName);
+			var logEventLevel = ConvertLevel(logEvent.Level);
+			if ((logEvent.Parameters?.Length ?? 0) == 0) {
+				// NLog treats a single string as a verbatim string; Serilog treats it as a String.Format format and hence collapses doubled braces
+				// This is the most direct way to emit this without it being re-processed by Serilog (via @nblumhardt)
+				var template = new Serilog.Events.MessageTemplate(new[]
+					{new Serilog.Parsing.TextToken(logEvent.FormattedMessage)});
+				log.Write(new Serilog.Events.LogEvent(DateTimeOffset.Now, logEventLevel, logEvent.Exception, template,
+					Enumerable.Empty<Serilog.Events.LogEventProperty>()));
+			} else
+				// Risk: tunneling an NLog format and assuming it will Just Work as a Serilog format
+#pragma warning disable Serilog004 // Constant MessageTemplate verifier
+				log.Write(logEventLevel, logEvent.Exception, logEvent.Message, logEvent.Parameters);
+#pragma warning restore Serilog004
+		}
+
+		static Serilog.Events.LogEventLevel ConvertLevel(LogLevel logEventLevel) {
+			if (logEventLevel == LogLevel.Info)
+				return Serilog.Events.LogEventLevel.Information;
+			else if (logEventLevel == LogLevel.Trace)
+				return Serilog.Events.LogEventLevel.Verbose;
+			else if (logEventLevel == LogLevel.Debug)
+				return Serilog.Events.LogEventLevel.Debug;
+			else if (logEventLevel == LogLevel.Error)
+				return Serilog.Events.LogEventLevel.Error;
+			return Serilog.Events.LogEventLevel.Fatal;
+		}
+	}
+}

--- a/src/Protos/Grpc/streams.proto
+++ b/src/Protos/Grpc/streams.proto
@@ -74,6 +74,7 @@ message ReadReq {
 				Empty structured = 1;
 				Empty string = 2;
 			}
+
 		}
 	}
 	message Empty {
@@ -81,7 +82,10 @@ message ReadReq {
 }
 
 message ReadResp {
-	ReadEvent event = 1;
+	oneof content {
+		ReadEvent event = 1;
+		SubscriptionConfirmation confirmation = 2;
+	}
 
 	message ReadEvent {
 		RecordedEvent event = 1;
@@ -101,6 +105,9 @@ message ReadResp {
 			bytes custom_metadata = 7;
 			bytes data = 8;
 		}
+	}
+	message SubscriptionConfirmation {
+		string subscription_id = 1;
 	}
 	message Empty {
 	}


### PR DESCRIPTION
When sending a position / revision in a subscription it should be exclusive of. However, currently you can receive a message you did not want.