### PR TITLE
Fix stream position overflow bug in checkpoint tag

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/checkpoint_tag/checkpoint_tag_to_from_json.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/checkpoint_tag/checkpoint_tag_to_from_json.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.IO;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Processing;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.checkpoint_tag {
+	[TestFixture]
+	public class checkpoint_tag_to_from_json {
+		[Test]
+		public void stream_position_should_not_overflow() {
+			var checkpointTag = CheckpointTag.FromStreamPosition(1, "test", 9876543210L);
+			var json = checkpointTag.ToJsonString();
+
+			var jsonReader = new JsonTextReader(new StringReader(json));
+			var checkpointTagFromJson = CheckpointTag.FromJson(jsonReader, new ProjectionVersion(0, 0, 0));
+			Assert.AreEqual(9876543210L, checkpointTagFromJson.Tag.Streams["test"]);
+		}
+
+		[Test]
+		public void data_and_catalog_position_should_not_overflow() {
+			var checkpointTag =
+				CheckpointTag.FromByStreamPosition(1, "catalog", 9876543210L, "data", 9876543211L, 9876543212L);
+			var json = checkpointTag.ToJsonString();
+
+			var jsonReader = new JsonTextReader(new StringReader(json));
+			var checkpointTagFromJson = CheckpointTag.FromJson(jsonReader, new ProjectionVersion(0, 0, 0));
+			Assert.AreEqual(9876543210L, checkpointTagFromJson.Tag.CatalogPosition);
+			Assert.AreEqual(9876543211L, checkpointTagFromJson.Tag.DataPosition);
+		}
+
+		[Test]
+		public void prepare_and_commit_positions_should_not_overflow() {
+			var checkpointTag =
+				CheckpointTag.FromPosition(1, 9876543210L, 9876543211L);
+			var json = checkpointTag.ToJsonString();
+
+			var jsonReader = new JsonTextReader(new StringReader(json));
+			var checkpointTagFromJson = CheckpointTag.FromJson(jsonReader, new ProjectionVersion(0, 0, 0));
+			Assert.AreEqual(9876543210L, checkpointTagFromJson.Tag.CommitPosition);
+			Assert.AreEqual(9876543211L, checkpointTagFromJson.Tag.PreparePosition);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Processing/CheckpointTag.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CheckpointTag.cs
@@ -628,16 +628,16 @@ namespace EventStore.Projections.Core.Services.Processing {
 			long? preparePosition = null;
 			string catalogStream = null;
 			string dataStream = null;
-			int? catalogPosition = null;
-			int? dataPosition = null;
+			long? catalogPosition = null;
+			long? dataPosition = null;
 			bool byStreamMode = false;
 			Dictionary<string, long> streams = null;
 			Dictionary<string, JToken> extra = null;
 			var projectionId = current.ProjectionId;
 			var projectionEpoch = 0;
-			var projectionVersion = 0;
+			int projectionVersion = 0;
 			var projectionSystemVersion = 0;
-			var projectionPhase = 0;
+			int projectionPhase = 0;
 			while (true) {
 				Check(reader.Read(), reader);
 				if (reader.TokenType == JsonToken.EndObject)
@@ -697,7 +697,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 							Check(JsonToken.PropertyName, reader);
 							catalogStream = (string)reader.Value;
 							Check(reader.Read(), reader);
-							catalogPosition = (int)(long)reader.Value;
+							catalogPosition = (long)reader.Value;
 							Check(reader.Read(), reader);
 							Check(JsonToken.EndObject, reader);
 
@@ -707,7 +707,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 								Check(JsonToken.PropertyName, reader);
 								dataStream = (string)reader.Value;
 								Check(reader.Read(), reader);
-								dataPosition = (int)(long)reader.Value;
+								dataPosition = (long)reader.Value;
 								Check(reader.Read(), reader);
 								Check(JsonToken.EndObject, reader);
 								Check(reader.Read(), reader);
@@ -724,7 +724,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 								Check(JsonToken.PropertyName, reader);
 								var streamName = (string)reader.Value;
 								Check(reader.Read(), reader);
-								var position = (int)(long)reader.Value;
+								long position = (long)reader.Value;
 								streams.Add(streamName, position);
 							}
 						}


### PR DESCRIPTION
Stream positions, dataPosition and catalogPosition may overflow due to the (int)(long) typecasts which were already present in the code before we introduced 64-bit event numbers.

We have seen at least one such case in practice so far where an assertion for non-negative sequence number was failing when creating the checkpoint tag.

Co-Authored-By: Lokhesh Ujhoodha <iamyog@hotmail.co.uk>