### PR TITLE
Expose Read Direction in Client API

### DIFF
--- a/src/EventStore.Client.Tests/Streams/SecurityFixture.cs
+++ b/src/EventStore.Client.Tests/Streams/SecurityFixture.cs
@@ -124,17 +124,17 @@ namespace EventStore.Client.Streams {
 		}
 
 		public Task ReadEvent(string streamId, UserCredentials userCredentials = default) =>
-			Client.ReadStreamForwardsAsync(streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
+			Client.ReadStreamAsync(ReadDirection.Forwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 
 		public Task ReadStreamForward(string streamId, UserCredentials userCredentials = default) =>
-			Client.ReadStreamForwardsAsync(streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
+			Client.ReadStreamAsync(ReadDirection.Forwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 
 		public Task ReadStreamBackward(string streamId, UserCredentials userCredentials = default) =>
-			Client.ReadStreamBackwardsAsync(streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
+			Client.ReadStreamAsync(ReadDirection.Backwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 
@@ -142,12 +142,12 @@ namespace EventStore.Client.Streams {
 			Client.AppendToStreamAsync(streamId, AnyStreamRevision.Any, CreateTestEvents(3), userCredentials);
 
 		public Task ReadAllForward(UserCredentials userCredentials = default) =>
-			Client.ReadAllForwardsAsync(Position.Start, 1, false, userCredentials: userCredentials)
+			Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 
 		public Task ReadAllBackward(UserCredentials userCredentials = default) =>
-			Client.ReadAllBackwardsAsync(Position.End, 1, false, userCredentials: userCredentials)
+			Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 

--- a/src/EventStore.Client.Tests/Streams/SecurityFixture.cs
+++ b/src/EventStore.Client.Tests/Streams/SecurityFixture.cs
@@ -124,17 +124,17 @@ namespace EventStore.Client.Streams {
 		}
 
 		public Task ReadEvent(string streamId, UserCredentials userCredentials = default) =>
-			Client.ReadStreamAsync(ReadDirection.Forwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
+			Client.ReadStreamAsync(Direction.Forwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 
 		public Task ReadStreamForward(string streamId, UserCredentials userCredentials = default) =>
-			Client.ReadStreamAsync(ReadDirection.Forwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
+			Client.ReadStreamAsync(Direction.Forwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 
 		public Task ReadStreamBackward(string streamId, UserCredentials userCredentials = default) =>
-			Client.ReadStreamAsync(ReadDirection.Backwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
+			Client.ReadStreamAsync(Direction.Backwards, streamId, StreamRevision.Start, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 
@@ -142,12 +142,12 @@ namespace EventStore.Client.Streams {
 			Client.AppendToStreamAsync(streamId, AnyStreamRevision.Any, CreateTestEvents(3), userCredentials);
 
 		public Task ReadAllForward(UserCredentials userCredentials = default) =>
-			Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 1, false, userCredentials: userCredentials)
+			Client.ReadAllAsync(Direction.Forwards, Position.Start, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 
 		public Task ReadAllBackward(UserCredentials userCredentials = default) =>
-			Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 1, false, userCredentials: userCredentials)
+			Client.ReadAllAsync(Direction.Backwards, Position.End, 1, false, userCredentials: userCredentials)
 				.ToArrayAsync()
 				.AsTask();
 

--- a/src/EventStore.Client.Tests/Streams/append_to_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/append_to_stream.cs
@@ -30,7 +30,7 @@ namespace EventStore.Client.Streams {
 
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() =>
 				_fixture.Client
-					.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, iterations, false)
+					.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, iterations, false)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -49,7 +49,7 @@ namespace EventStore.Client.Streams {
 
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() =>
 				_fixture.Client
-					.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, iterations, false)
+					.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, iterations, false)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -68,7 +68,7 @@ namespace EventStore.Client.Streams {
 
 			Assert.Equal(0, writeResult.NextExpectedVersion);
 
-			var count = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 2, false)
+			var count = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, 2, false)
 				.CountAsync();
 			Assert.Equal(1, count);
 		}

--- a/src/EventStore.Client.Tests/Streams/append_to_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/append_to_stream.cs
@@ -30,7 +30,7 @@ namespace EventStore.Client.Streams {
 
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() =>
 				_fixture.Client
-					.ReadStreamForwardsAsync(stream, StreamRevision.Start, iterations, false)
+					.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, iterations, false)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -49,7 +49,7 @@ namespace EventStore.Client.Streams {
 
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() =>
 				_fixture.Client
-					.ReadStreamForwardsAsync(stream, StreamRevision.Start, iterations, false)
+					.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, iterations, false)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -68,7 +68,7 @@ namespace EventStore.Client.Streams {
 
 			Assert.Equal(0, writeResult.NextExpectedVersion);
 
-			var count = await _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, 2, false)
+			var count = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 2, false)
 				.CountAsync();
 			Assert.Equal(1, count);
 		}

--- a/src/EventStore.Client.Tests/Streams/append_to_stream_with_event_numbers_greater_than_int32_max_value.cs
+++ b/src/EventStore.Client.Tests/Streams/append_to_stream_with_event_numbers_greater_than_int32_max_value.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.Streams {
 				new StreamRevision(int.MaxValue + 5L), expected);
 			Assert.Equal(int.MaxValue + 6L, writeResult.NextExpectedVersion);
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream,
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards, Stream,
 					new StreamRevision(int.MaxValue + 6L), 1, false, userCredentials: TestCredentials.Root)
 				.SingleAsync();
 			Assert.Equal(expected.Single().EventId, actual.Event.EventId);

--- a/src/EventStore.Client.Tests/Streams/append_to_stream_with_event_numbers_greater_than_int32_max_value.cs
+++ b/src/EventStore.Client.Tests/Streams/append_to_stream_with_event_numbers_greater_than_int32_max_value.cs
@@ -20,7 +20,7 @@ namespace EventStore.Client.Streams {
 				new StreamRevision(int.MaxValue + 5L), expected);
 			Assert.Equal(int.MaxValue + 6L, writeResult.NextExpectedVersion);
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(Stream,
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream,
 					new StreamRevision(int.MaxValue + 6L), 1, false, userCredentials: TestCredentials.Root)
 				.SingleAsync();
 			Assert.Equal(expected.Single().EventId, actual.Event.EventId);

--- a/src/EventStore.Client.Tests/Streams/appending_to_implicitly_created_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/appending_to_implicitly_created_stream.cs
@@ -22,7 +22,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -37,7 +37,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -52,7 +52,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, new StreamRevision(5), events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 2).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 2).CountAsync();
 
 			Assert.Equal(events.Length + 1, count);
 		}
@@ -91,7 +91,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, StreamRevision.Start, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 2).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 2).CountAsync();
 
 			Assert.Equal(events.Length + 1, count);
 		}
@@ -106,7 +106,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -121,7 +121,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -137,7 +137,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Skip(1).Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -152,7 +152,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -167,7 +167,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -183,7 +183,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, StreamRevision.Start, events.Skip(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -198,7 +198,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Skip(1).Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}

--- a/src/EventStore.Client.Tests/Streams/appending_to_implicitly_created_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/appending_to_implicitly_created_stream.cs
@@ -22,7 +22,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -37,7 +37,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -52,7 +52,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, new StreamRevision(5), events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 2).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 2).CountAsync();
 
 			Assert.Equal(events.Length + 1, count);
 		}
@@ -91,7 +91,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, StreamRevision.Start, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 2).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 2).CountAsync();
 
 			Assert.Equal(events.Length + 1, count);
 		}
@@ -106,7 +106,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -121,7 +121,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -137,7 +137,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Skip(1).Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -152,7 +152,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -167,7 +167,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -183,7 +183,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, StreamRevision.Start, events.Skip(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}
@@ -198,7 +198,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, events.Skip(1).Take(1));
 
 			var count = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)events.Length + 1).CountAsync();
 
 			Assert.Equal(events.Length, count);
 		}

--- a/src/EventStore.Client.Tests/Streams/is_json.cs
+++ b/src/EventStore.Client.Tests/Streams/is_json.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, new[] {eventData});
 
-			var @event = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 1, true).FirstOrDefaultAsync();
+			var @event = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, 1, true).FirstOrDefaultAsync();
 
 			Assert.Equal(isJson, @event.Event.IsJson);
 			Assert.Equal(data, encoding.GetString(@event.Event.Data));

--- a/src/EventStore.Client.Tests/Streams/is_json.cs
+++ b/src/EventStore.Client.Tests/Streams/is_json.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.Any, new[] {eventData});
 
-			var @event = await _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, 1, true).FirstOrDefaultAsync();
+			var @event = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 1, true).FirstOrDefaultAsync();
 
 			Assert.Equal(isJson, @event.Event.IsJson);
 			Assert.Equal(data, encoding.GetString(@event.Event.Data));

--- a/src/EventStore.Client.Tests/Streams/read_all_events_backward.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_backward.cs
@@ -15,13 +15,13 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task return_empty_if_reading_from_start() {
-			var count = await _fixture.Client.ReadAllBackwardsAsync(Position.Start, 1).CountAsync();
+			var count = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.Start, 1).CountAsync();
 			Assert.Equal(0, count);
 		}
 
 		[Fact]
 		public async Task return_partial_slice_if_not_enough_events() {
-			var events = await _fixture.Client.ReadAllBackwardsAsync(Position.End, (ulong)(_fixture.Events.Length * 2))
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, (ulong)(_fixture.Events.Length * 2))
 				.ToArrayAsync();
 
 			Assert.True(events.Length < _fixture.Events.Length * 2);
@@ -29,7 +29,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task return_events_in_reversed_order_compared_to_written() {
-			var events = await _fixture.Client.ReadAllBackwardsAsync(Position.End, (ulong)_fixture.Events.Length)
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, (ulong)_fixture.Events.Length)
 				.ToArrayAsync();
 
 			Assert.True(EventDataComparer.Equal(
@@ -55,7 +55,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task max_count_is_respected() {
 			var maxCount = (ulong)_fixture.Events.Length / 2;
-			var events = await _fixture.Client.ReadAllBackwardsAsync(Position.End, maxCount)
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, maxCount)
 				.Take(_fixture.Events.Length)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_all_events_backward.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_backward.cs
@@ -15,13 +15,13 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task return_empty_if_reading_from_start() {
-			var count = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.Start, 1).CountAsync();
+			var count = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.Start, 1).CountAsync();
 			Assert.Equal(0, count);
 		}
 
 		[Fact]
 		public async Task return_partial_slice_if_not_enough_events() {
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, (ulong)(_fixture.Events.Length * 2))
+			var events = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, (ulong)(_fixture.Events.Length * 2))
 				.ToArrayAsync();
 
 			Assert.True(events.Length < _fixture.Events.Length * 2);
@@ -29,7 +29,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task return_events_in_reversed_order_compared_to_written() {
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, (ulong)_fixture.Events.Length)
+			var events = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, (ulong)_fixture.Events.Length)
 				.ToArrayAsync();
 
 			Assert.True(EventDataComparer.Equal(
@@ -55,7 +55,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task max_count_is_respected() {
 			var maxCount = (ulong)_fixture.Events.Length / 2;
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, maxCount)
+			var events = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, maxCount)
 				.Take(_fixture.Events.Length)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_all_events_backward_filtered.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_backward_filtered.cs
@@ -24,7 +24,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 20,
+			var result = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, 20,
 					filter: new StreamFilter(new RegularFilterExpression(new Regex($"^{streamPrefix}"))))
 				.ToArrayAsync();
 
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 20,
+			var result = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, 20,
 					filter: new StreamFilter(new PrefixFilterExpression(streamPrefix)))
 				.ToArrayAsync();
 
@@ -62,7 +62,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 20,
+			var result = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, 20,
 					filter: new EventTypeFilter(new RegularFilterExpression(new Regex($"^{eventTypePrefix}"))))
 				.ToArrayAsync();
 
@@ -83,7 +83,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 20,
+			var result = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, 20,
 					filter: new EventTypeFilter(new PrefixFilterExpression(eventTypePrefix)))
 				.ToArrayAsync();
 
@@ -99,7 +99,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.NoStream,
 				_fixture.CreateTestEvents(count));
 
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, maxCount,
+			var events = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, maxCount,
 					filter: new StreamFilter(RegularFilterExpression.ExcludeSystemEvents))
 				.Take(count)
 				.ToArrayAsync();

--- a/src/EventStore.Client.Tests/Streams/read_all_events_backward_filtered.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_backward_filtered.cs
@@ -24,7 +24,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllBackwardsAsync(Position.End, 20,
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 20,
 					filter: new StreamFilter(new RegularFilterExpression(new Regex($"^{streamPrefix}"))))
 				.ToArrayAsync();
 
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllBackwardsAsync(Position.End, 20,
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 20,
 					filter: new StreamFilter(new PrefixFilterExpression(streamPrefix)))
 				.ToArrayAsync();
 
@@ -62,7 +62,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllBackwardsAsync(Position.End, 20,
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 20,
 					filter: new EventTypeFilter(new RegularFilterExpression(new Regex($"^{eventTypePrefix}"))))
 				.ToArrayAsync();
 
@@ -83,7 +83,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllBackwardsAsync(Position.End, 20,
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 20,
 					filter: new EventTypeFilter(new PrefixFilterExpression(eventTypePrefix)))
 				.ToArrayAsync();
 
@@ -99,7 +99,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.NoStream,
 				_fixture.CreateTestEvents(count));
 
-			var events = await _fixture.Client.ReadAllBackwardsAsync(Position.End, maxCount,
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, maxCount,
 					filter: new StreamFilter(RegularFilterExpression.ExcludeSystemEvents))
 				.Take(count)
 				.ToArrayAsync();

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward.cs
@@ -15,13 +15,13 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task return_empty_if_reading_from_end() {
-			var count = await _fixture.Client.ReadAllForwardsAsync(Position.End, 1, false).CountAsync();
+			var count = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.End, 1, false).CountAsync();
 			Assert.Equal(0, count);
 		}
 
 		[Fact]
 		public async Task return_partial_slice_if_not_enough_events() {
-			var events = await _fixture.Client.ReadAllForwardsAsync(Position.Start, (ulong)_fixture.Events.Length * 2)
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
 				.ToArrayAsync();
 
 			Assert.True(events.Length < _fixture.Events.Length * 2);
@@ -29,7 +29,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task return_events_in_correct_order_compared_to_written() {
-			var events = await _fixture.Client.ReadAllForwardsAsync(Position.Start, (ulong)_fixture.Events.Length * 2)
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
 				.ToArrayAsync();
 
 			Assert.True(EventDataComparer.Equal(_fixture.Events, events.AsResolvedTestEvents().ToArray()));
@@ -53,7 +53,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task max_count_is_respected() {
 			var maxCount = (ulong)_fixture.Events.Length / 2;
-			var events = await _fixture.Client.ReadAllForwardsAsync(Position.Start, maxCount)
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, maxCount)
 				.Take(_fixture.Events.Length)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward.cs
@@ -15,13 +15,13 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task return_empty_if_reading_from_end() {
-			var count = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.End, 1, false).CountAsync();
+			var count = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.End, 1, false).CountAsync();
 			Assert.Equal(0, count);
 		}
 
 		[Fact]
 		public async Task return_partial_slice_if_not_enough_events() {
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
+			var events = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
 				.ToArrayAsync();
 
 			Assert.True(events.Length < _fixture.Events.Length * 2);
@@ -29,7 +29,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task return_events_in_correct_order_compared_to_written() {
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
+			var events = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
 				.ToArrayAsync();
 
 			Assert.True(EventDataComparer.Equal(_fixture.Events, events.AsResolvedTestEvents().ToArray()));
@@ -53,7 +53,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task max_count_is_respected() {
 			var maxCount = (ulong)_fixture.Events.Length / 2;
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, maxCount)
+			var events = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, maxCount)
 				.Take(_fixture.Events.Length)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_hard_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_hard_deleted_stream.cs
@@ -17,13 +17,13 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task reading_hard_deleted_stream_throws_stream_deleted() {
 			var ex = await Assert.ThrowsAsync<StreamDeletedException>(() =>
-				_fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream, StreamRevision.Start, 1).CountAsync().AsTask());
+				_fixture.Client.ReadStreamAsync(Direction.Forwards, Stream, StreamRevision.Start, 1).CountAsync().AsTask());
 			Assert.Equal(Stream, ex.Stream);
 		}
 
 		[Fact]
 		public async Task returns_all_events_including_tombstone() {
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
+			var events = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
 				.ToArrayAsync();
 
 			var tombstone = events.Last();

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_hard_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_hard_deleted_stream.cs
@@ -17,13 +17,13 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task reading_hard_deleted_stream_throws_stream_deleted() {
 			var ex = await Assert.ThrowsAsync<StreamDeletedException>(() =>
-				_fixture.Client.ReadStreamForwardsAsync(Stream, StreamRevision.Start, 1).CountAsync().AsTask());
+				_fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream, StreamRevision.Start, 1).CountAsync().AsTask());
 			Assert.Equal(Stream, ex.Stream);
 		}
 
 		[Fact]
 		public async Task returns_all_events_including_tombstone() {
-			var events = await _fixture.Client.ReadAllForwardsAsync(Position.Start, (ulong)_fixture.Events.Length * 2)
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
 				.ToArrayAsync();
 
 			var tombstone = events.Last();

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_linkto_passed_max_count.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_linkto_passed_max_count.cs
@@ -40,7 +40,7 @@ namespace EventStore.Client.Streams {
 			}
 
 			protected override async Task When() {
-				Events = await Client.ReadStreamAsync(ReadDirection.Forwards, LinkedStream, StreamRevision.Start, int.MaxValue, true)
+				Events = await Client.ReadStreamAsync(Direction.Forwards, LinkedStream, StreamRevision.Start, int.MaxValue, true)
 					.ToArrayAsync();
 			}
 		}

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_linkto_passed_max_count.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_linkto_passed_max_count.cs
@@ -40,7 +40,7 @@ namespace EventStore.Client.Streams {
 			}
 
 			protected override async Task When() {
-				Events = await Client.ReadStreamForwardsAsync(LinkedStream, StreamRevision.Start, int.MaxValue, true)
+				Events = await Client.ReadStreamAsync(ReadDirection.Forwards, LinkedStream, StreamRevision.Start, int.MaxValue, true)
 					.ToArrayAsync();
 			}
 		}

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_soft_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_soft_deleted_stream.cs
@@ -18,13 +18,13 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task reading_soft_deleted_stream_throws_stream_not_found() {
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() =>
-				_fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream, StreamRevision.Start, 1).CountAsync().AsTask());
+				_fixture.Client.ReadStreamAsync(Direction.Forwards, Stream, StreamRevision.Start, 1).CountAsync().AsTask());
 			Assert.Equal(Stream, ex.Stream);
 		}
 
 		[Fact]
 		public async Task returns_all_events_including_tombstone() {
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
+			var events = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
 				.ToArrayAsync();
 
 			var tombstone = events.Last();

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_soft_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_soft_deleted_stream.cs
@@ -18,13 +18,13 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task reading_soft_deleted_stream_throws_stream_not_found() {
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() =>
-				_fixture.Client.ReadStreamForwardsAsync(Stream, StreamRevision.Start, 1).CountAsync().AsTask());
+				_fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream, StreamRevision.Start, 1).CountAsync().AsTask());
 			Assert.Equal(Stream, ex.Stream);
 		}
 
 		[Fact]
 		public async Task returns_all_events_including_tombstone() {
-			var events = await _fixture.Client.ReadAllForwardsAsync(Position.Start, (ulong)_fixture.Events.Length * 2)
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, (ulong)_fixture.Events.Length * 2)
 				.ToArrayAsync();
 
 			var tombstone = events.Last();

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forwards_filtered.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forwards_filtered.cs
@@ -24,7 +24,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100,
+			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100,
 					filter: new StreamFilter(new RegularFilterExpression(new Regex($"^{streamPrefix}"))))
 				.ToArrayAsync();
 
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100,
+			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100,
 					filter: new StreamFilter(new PrefixFilterExpression(streamPrefix)))
 				.ToArrayAsync();
 
@@ -62,7 +62,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100,
+			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100,
 					filter: new EventTypeFilter(new RegularFilterExpression(new Regex($"^{eventTypePrefix}"))))
 				.ToArrayAsync();
 
@@ -83,7 +83,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100,
+			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100,
 					filter: new EventTypeFilter(new PrefixFilterExpression(eventTypePrefix)))
 				.ToArrayAsync();
 
@@ -99,7 +99,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.NoStream,
 				_fixture.CreateTestEvents(count));
 
-			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, maxCount,
+			var events = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, maxCount,
 					filter: new StreamFilter(RegularFilterExpression.ExcludeSystemEvents))
 				.Take(count)
 				.ToArrayAsync();

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forwards_filtered.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forwards_filtered.cs
@@ -24,7 +24,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllForwardsAsync(Position.Start, 100,
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100,
 					filter: new StreamFilter(new RegularFilterExpression(new Regex($"^{streamPrefix}"))))
 				.ToArrayAsync();
 
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllForwardsAsync(Position.Start, 100,
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100,
 					filter: new StreamFilter(new PrefixFilterExpression(streamPrefix)))
 				.ToArrayAsync();
 
@@ -62,7 +62,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllForwardsAsync(Position.Start, 100,
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100,
 					filter: new EventTypeFilter(new RegularFilterExpression(new Regex($"^{eventTypePrefix}"))))
 				.ToArrayAsync();
 
@@ -83,7 +83,7 @@ namespace EventStore.Client.Streams {
 					AnyStreamRevision.NoStream, new[] {e});
 			}
 
-			var result = await _fixture.Client.ReadAllForwardsAsync(Position.Start, 100,
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100,
 					filter: new EventTypeFilter(new PrefixFilterExpression(eventTypePrefix)))
 				.ToArrayAsync();
 
@@ -99,7 +99,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.NoStream,
 				_fixture.CreateTestEvents(count));
 
-			var events = await _fixture.Client.ReadAllForwardsAsync(Position.Start, maxCount,
+			var events = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, maxCount,
 					filter: new StreamFilter(RegularFilterExpression.ExcludeSystemEvents))
 				.Take(count)
 				.ToArrayAsync();

--- a/src/EventStore.Client.Tests/Streams/read_events_linked_to_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/read_events_linked_to_deleted_stream.cs
@@ -62,7 +62,7 @@ namespace EventStore.Client.Streams {
 
 			public new class Fixture : read_events_linked_to_deleted_stream.Fixture {
 				protected override ValueTask<ResolvedEvent[]> Read()
-					=> Client.ReadStreamForwardsAsync(LinkedStream, StreamRevision.Start, 1, true).ToArrayAsync();
+					=> Client.ReadStreamAsync(ReadDirection.Forwards, LinkedStream, StreamRevision.Start, 1, true).ToArrayAsync();
 			}
 		}
 
@@ -72,7 +72,7 @@ namespace EventStore.Client.Streams {
 
 			public new class Fixture : read_events_linked_to_deleted_stream.Fixture {
 				protected override ValueTask<ResolvedEvent[]> Read()
-					=> Client.ReadStreamBackwardsAsync(LinkedStream, StreamRevision.Start, 1, true).ToArrayAsync();
+					=> Client.ReadStreamAsync(ReadDirection.Backwards, LinkedStream, StreamRevision.Start, 1, true).ToArrayAsync();
 			}
 		}
 	}

--- a/src/EventStore.Client.Tests/Streams/read_events_linked_to_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/read_events_linked_to_deleted_stream.cs
@@ -62,7 +62,7 @@ namespace EventStore.Client.Streams {
 
 			public new class Fixture : read_events_linked_to_deleted_stream.Fixture {
 				protected override ValueTask<ResolvedEvent[]> Read()
-					=> Client.ReadStreamAsync(ReadDirection.Forwards, LinkedStream, StreamRevision.Start, 1, true).ToArrayAsync();
+					=> Client.ReadStreamAsync(Direction.Forwards, LinkedStream, StreamRevision.Start, 1, true).ToArrayAsync();
 			}
 		}
 
@@ -72,7 +72,7 @@ namespace EventStore.Client.Streams {
 
 			public new class Fixture : read_events_linked_to_deleted_stream.Fixture {
 				protected override ValueTask<ResolvedEvent[]> Read()
-					=> Client.ReadStreamAsync(ReadDirection.Backwards, LinkedStream, StreamRevision.Start, 1, true).ToArrayAsync();
+					=> Client.ReadStreamAsync(Direction.Backwards, LinkedStream, StreamRevision.Start, 1, true).ToArrayAsync();
 			}
 		}
 	}

--- a/src/EventStore.Client.Tests/Streams/read_stream_backward.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_backward.cs
@@ -17,7 +17,7 @@ namespace EventStore.Client.Streams {
 			var stream = _fixture.GetStreamName();
 
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-				_fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.Start, count)
+				_fixture.Client.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.Start, count)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(nameof(count), ex.ParamName);
@@ -28,7 +28,7 @@ namespace EventStore.Client.Streams {
 			var stream = _fixture.GetStreamName();
 
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.Client
-				.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 1)
+				.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, 1)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.TombstoneAsync(stream, AnyStreamRevision.NoStream);
 
 			var ex = await Assert.ThrowsAsync<StreamDeletedException>(() => _fixture.Client
-				.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 1)
+				.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, 1)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -56,7 +56,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, expected);
 
 			var actual = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, (ulong)expected.Length)
+				.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, (ulong)expected.Length)
 				.Select(x => x.Event).ToArrayAsync();
 
 			Assert.True(EventDataComparer.Equal(expected.Reverse().ToArray(),
@@ -73,7 +73,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events);
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, new StreamRevision(7), 1)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Backwards, stream, new StreamRevision(7), 1)
 				.Select(x => x.Event)
 				.SingleAsync();
 
@@ -88,7 +88,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events);
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, new StreamRevision(3), 2)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Backwards, stream, new StreamRevision(3), 2)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -103,7 +103,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, testEvents);
 
-			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.Start, 1)
+			var events = await _fixture.Client.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.Start, 1)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -119,7 +119,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, testEvents);
 
-			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 1)
+			var events = await _fixture.Client.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, 1)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -136,7 +136,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.NoStream,
 				_fixture.CreateTestEvents(count));
 
-			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, streamName, StreamRevision.End, maxCount)
+			var events = await _fixture.Client.ReadStreamAsync(Direction.Backwards, streamName, StreamRevision.End, maxCount)
 				.Take(count)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_stream_backward.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_backward.cs
@@ -17,7 +17,7 @@ namespace EventStore.Client.Streams {
 			var stream = _fixture.GetStreamName();
 
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-				_fixture.Client.ReadStreamBackwardsAsync(stream, StreamRevision.Start, count)
+				_fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.Start, count)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(nameof(count), ex.ParamName);
@@ -28,7 +28,7 @@ namespace EventStore.Client.Streams {
 			var stream = _fixture.GetStreamName();
 
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.Client
-				.ReadStreamBackwardsAsync(stream, StreamRevision.End, 1)
+				.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 1)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.TombstoneAsync(stream, AnyStreamRevision.NoStream);
 
 			var ex = await Assert.ThrowsAsync<StreamDeletedException>(() => _fixture.Client
-				.ReadStreamBackwardsAsync(stream, StreamRevision.End, 1)
+				.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 1)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -56,7 +56,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, expected);
 
 			var actual = await _fixture.Client
-				.ReadStreamBackwardsAsync(stream, StreamRevision.End, (ulong)expected.Length)
+				.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, (ulong)expected.Length)
 				.Select(x => x.Event).ToArrayAsync();
 
 			Assert.True(EventDataComparer.Equal(expected.Reverse().ToArray(),
@@ -73,7 +73,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events);
 
-			var actual = await _fixture.Client.ReadStreamBackwardsAsync(stream, new StreamRevision(7), 1)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, new StreamRevision(7), 1)
 				.Select(x => x.Event)
 				.SingleAsync();
 
@@ -88,7 +88,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events);
 
-			var actual = await _fixture.Client.ReadStreamBackwardsAsync(stream, new StreamRevision(3), 2)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, new StreamRevision(3), 2)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -103,7 +103,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, testEvents);
 
-			var events = await _fixture.Client.ReadStreamBackwardsAsync(stream, StreamRevision.Start, 1)
+			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.Start, 1)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -119,7 +119,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, testEvents);
 
-			var events = await _fixture.Client.ReadStreamBackwardsAsync(stream, StreamRevision.End, 1)
+			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 1)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -136,7 +136,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.NoStream,
 				_fixture.CreateTestEvents(count));
 
-			var events = await _fixture.Client.ReadStreamBackwardsAsync(streamName, StreamRevision.End, maxCount)
+			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, streamName, StreamRevision.End, maxCount)
 				.Take(count)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_stream_forward.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_forward.cs
@@ -17,7 +17,7 @@ namespace EventStore.Client.Streams {
 			var stream = _fixture.GetStreamName();
 
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-				_fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, count)
+				_fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, count)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(nameof(count), ex.ParamName);
@@ -28,7 +28,7 @@ namespace EventStore.Client.Streams {
 			var stream = _fixture.GetStreamName();
 
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 1)
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, 1)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.TombstoneAsync(stream, AnyStreamRevision.NoStream);
 
 			var ex = await Assert.ThrowsAsync<StreamDeletedException>(() => _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 1)
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, 1)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -56,7 +56,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, expected);
 
 			var actual = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)expected.Length)
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, (ulong)expected.Length)
 				.Select(x => x.Event).ToArrayAsync();
 
 			Assert.True(EventDataComparer.Equal(expected, actual));
@@ -72,7 +72,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events);
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, new StreamRevision(7), 1)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, new StreamRevision(7), 1)
 				.Select(x => x.Event)
 				.SingleAsync();
 
@@ -87,7 +87,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events);
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, new StreamRevision(3), 2)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, new StreamRevision(3), 2)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -102,7 +102,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, testEvents);
 
-			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 1)
+			var events = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, 1)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -119,7 +119,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.NoStream,
 				_fixture.CreateTestEvents(count));
 
-			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, streamName, StreamRevision.Start, maxCount)
+			var events = await _fixture.Client.ReadStreamAsync(Direction.Forwards, streamName, StreamRevision.Start, maxCount)
 				.Take(count)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_stream_forward.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_forward.cs
@@ -17,7 +17,7 @@ namespace EventStore.Client.Streams {
 			var stream = _fixture.GetStreamName();
 
 			var ex = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-				_fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, count)
+				_fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, count)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(nameof(count), ex.ParamName);
@@ -28,7 +28,7 @@ namespace EventStore.Client.Streams {
 			var stream = _fixture.GetStreamName();
 
 			var ex = await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, 1)
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 1)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.TombstoneAsync(stream, AnyStreamRevision.NoStream);
 
 			var ex = await Assert.ThrowsAsync<StreamDeletedException>(() => _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, 1)
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 1)
 				.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -56,7 +56,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, expected);
 
 			var actual = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, (ulong)expected.Length)
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, (ulong)expected.Length)
 				.Select(x => x.Event).ToArrayAsync();
 
 			Assert.True(EventDataComparer.Equal(expected, actual));
@@ -72,7 +72,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events);
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(stream, new StreamRevision(7), 1)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, new StreamRevision(7), 1)
 				.Select(x => x.Event)
 				.SingleAsync();
 
@@ -87,7 +87,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, events);
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(stream, new StreamRevision(3), 2)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, new StreamRevision(3), 2)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -102,7 +102,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, testEvents);
 
-			var events = await _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, 1)
+			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 1)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -119,7 +119,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.NoStream,
 				_fixture.CreateTestEvents(count));
 
-			var events = await _fixture.Client.ReadStreamForwardsAsync(streamName, StreamRevision.Start, maxCount)
+			var events = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, streamName, StreamRevision.Start, maxCount)
 				.Take(count)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_stream_with_event_numbers_greater_than_int32_max_value.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_with_event_numbers_greater_than_int32_max_value.cs
@@ -15,14 +15,14 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task read_forward_from_zero() {
-			var result = await _fixture.Client.ReadStreamForwardsAsync(Stream, StreamRevision.Start, 100)
+			var result = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream, StreamRevision.Start, 100)
 				.ToArrayAsync();
 			Assert.Empty(result);
 		}
 
 		[Fact]
 		public async Task should_be_able_to_read_stream_forward() {
-			var result = await _fixture.Client.ReadStreamForwardsAsync(Stream, new StreamRevision(int.MaxValue), 100)
+			var result = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream, new StreamRevision(int.MaxValue), 100)
 				.ToArrayAsync();
 			Assert.Equal(5, result.Length);
 			Assert.Equal(Fixture.Events.Select(x => x.EventId), result.Select(x => x.Event.EventId));
@@ -31,7 +31,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task should_be_able_to_read_stream_backward() {
 			var result =
-				await _fixture.Client.ReadStreamBackwardsAsync(Stream, new StreamRevision(int.MaxValue + 6L), 100)
+				await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, Stream, new StreamRevision(int.MaxValue + 6L), 100)
 					.Reverse()
 					.ToArrayAsync();
 			Assert.Equal(5, result.Length);
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task should_be_able_to_read_all_forward() {
-			var result = await _fixture.Client.ReadAllForwardsAsync(Position.Start, 100, false, userCredentials: TestCredentials.Root)
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100, false, userCredentials: TestCredentials.Root)
 				.Where(x => x.OriginalStreamId == Stream)
 				.ToArrayAsync();
 			Assert.Equal(5, result.Length);
@@ -50,7 +50,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task should_be_able_to_read_all_backward() {
-			var result = await _fixture.Client.ReadAllBackwardsAsync(Position.End, 100, false, userCredentials: TestCredentials.Root)
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 100, false, userCredentials: TestCredentials.Root)
 				.Where(x => x.OriginalStreamId == Stream)
 				.Reverse()
 				.ToArrayAsync();

--- a/src/EventStore.Client.Tests/Streams/read_stream_with_event_numbers_greater_than_int32_max_value.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_with_event_numbers_greater_than_int32_max_value.cs
@@ -15,14 +15,14 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task read_forward_from_zero() {
-			var result = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream, StreamRevision.Start, 100)
+			var result = await _fixture.Client.ReadStreamAsync(Direction.Forwards, Stream, StreamRevision.Start, 100)
 				.ToArrayAsync();
 			Assert.Empty(result);
 		}
 
 		[Fact]
 		public async Task should_be_able_to_read_stream_forward() {
-			var result = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream, new StreamRevision(int.MaxValue), 100)
+			var result = await _fixture.Client.ReadStreamAsync(Direction.Forwards, Stream, new StreamRevision(int.MaxValue), 100)
 				.ToArrayAsync();
 			Assert.Equal(5, result.Length);
 			Assert.Equal(Fixture.Events.Select(x => x.EventId), result.Select(x => x.Event.EventId));
@@ -31,7 +31,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task should_be_able_to_read_stream_backward() {
 			var result =
-				await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, Stream, new StreamRevision(int.MaxValue + 6L), 100)
+				await _fixture.Client.ReadStreamAsync(Direction.Backwards, Stream, new StreamRevision(int.MaxValue + 6L), 100)
 					.Reverse()
 					.ToArrayAsync();
 			Assert.Equal(5, result.Length);
@@ -41,7 +41,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task should_be_able_to_read_all_forward() {
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100, false, userCredentials: TestCredentials.Root)
+			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100, false, userCredentials: TestCredentials.Root)
 				.Where(x => x.OriginalStreamId == Stream)
 				.ToArrayAsync();
 			Assert.Equal(5, result.Length);
@@ -50,7 +50,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task should_be_able_to_read_all_backward() {
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 100, false, userCredentials: TestCredentials.Root)
+			var result = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, 100, false, userCredentials: TestCredentials.Root)
 				.Where(x => x.OriginalStreamId == Stream)
 				.Reverse()
 				.ToArrayAsync();

--- a/src/EventStore.Client.Tests/Streams/read_stream_with_event_numbers_greater_than_int32_max_value_resolve_links.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_with_event_numbers_greater_than_int32_max_value_resolve_links.cs
@@ -18,7 +18,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task should_be_able_to_read_linked_stream_forward() {
 			var result = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, LinkedStream, StreamRevision.Start, 100, true)
+				.ReadStreamAsync(Direction.Forwards, LinkedStream, StreamRevision.Start, 100, true)
 				.ToArrayAsync();
 
 			Assert.Equal(2, result.Length);
@@ -31,7 +31,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task should_be_able_to_read_stream_backward() {
 			var result = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Backwards, LinkedStream, new StreamRevision(10), 100, true)
+				.ReadStreamAsync(Direction.Backwards, LinkedStream, new StreamRevision(10), 100, true)
 				.Reverse()
 				.ToArrayAsync();
 
@@ -45,7 +45,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task should_be_able_to_read_all_forward() {
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100, true, userCredentials: TestCredentials.Root)
+			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100, true, userCredentials: TestCredentials.Root)
 				.Where(x => x.OriginalStreamId == LinkedStream)
 				.ToArrayAsync();
 
@@ -58,7 +58,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task should_be_able_to_read_all_backward() {
-			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 100, true, userCredentials: TestCredentials.Root)
+			var result = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, 100, true, userCredentials: TestCredentials.Root)
 				.Where(x => x.OriginalStreamId == LinkedStream)
 				.Reverse()
 				.ToArrayAsync();

--- a/src/EventStore.Client.Tests/Streams/read_stream_with_event_numbers_greater_than_int32_max_value_resolve_links.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_with_event_numbers_greater_than_int32_max_value_resolve_links.cs
@@ -18,7 +18,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task should_be_able_to_read_linked_stream_forward() {
 			var result = await _fixture.Client
-				.ReadStreamForwardsAsync(LinkedStream, StreamRevision.Start, 100, true)
+				.ReadStreamAsync(ReadDirection.Forwards, LinkedStream, StreamRevision.Start, 100, true)
 				.ToArrayAsync();
 
 			Assert.Equal(2, result.Length);
@@ -31,7 +31,7 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task should_be_able_to_read_stream_backward() {
 			var result = await _fixture.Client
-				.ReadStreamBackwardsAsync(LinkedStream, new StreamRevision(10), 100, true)
+				.ReadStreamAsync(ReadDirection.Backwards, LinkedStream, new StreamRevision(10), 100, true)
 				.Reverse()
 				.ToArrayAsync();
 
@@ -45,7 +45,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task should_be_able_to_read_all_forward() {
-			var result = await _fixture.Client.ReadAllForwardsAsync(Position.Start, 100, true, userCredentials: TestCredentials.Root)
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Forwards, Position.Start, 100, true, userCredentials: TestCredentials.Root)
 				.Where(x => x.OriginalStreamId == LinkedStream)
 				.ToArrayAsync();
 
@@ -58,7 +58,7 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task should_be_able_to_read_all_backward() {
-			var result = await _fixture.Client.ReadAllBackwardsAsync(Position.End, 100, true, userCredentials: TestCredentials.Root)
+			var result = await _fixture.Client.ReadAllAsync(ReadDirection.Backwards, Position.End, 100, true, userCredentials: TestCredentials.Root)
 				.Where(x => x.OriginalStreamId == LinkedStream)
 				.Reverse()
 				.ToArrayAsync();

--- a/src/EventStore.Client.Tests/Streams/soft_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/soft_deleted_stream.cs
@@ -36,7 +36,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.SoftDeleteAsync(stream, StreamRevision.FromInt64(writeResult.NextExpectedVersion));
 
 			await Assert.ThrowsAsync<StreamNotFoundException>(
-				() => _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, int.MaxValue)
+				() => _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
 					.ToArrayAsync().AsTask());
 		}
 
@@ -67,7 +67,7 @@ namespace EventStore.Client.Streams {
 
 			await Task.Delay(50); //TODO: This is a workaround until github issue #1744 is fixed
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards,
 					stream, StreamRevision.Start, int.MaxValue)
 				.Select(x => x.Event)
 				.ToArrayAsync();
@@ -105,7 +105,7 @@ namespace EventStore.Client.Streams {
 
 			await Task.Delay(50); //TODO: This is a workaround until github issue #1744 is fixed
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards,
 					stream, StreamRevision.Start, int.MaxValue)
 				.Select(x => x.Event)
 				.ToArrayAsync();
@@ -148,7 +148,7 @@ namespace EventStore.Client.Streams {
 
 			await Task.Delay(500); //TODO: This is a workaround until github issue #1744 is fixed
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, int.MaxValue)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -180,7 +180,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.TombstoneAsync(stream, AnyStreamRevision.Any);
 
 			var ex = await Assert.ThrowsAsync<StreamDeletedException>(
-				() => _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, int.MaxValue)
+				() => _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -239,7 +239,7 @@ namespace EventStore.Client.Streams {
 
 			Assert.Equal(6, writeResult.NextExpectedVersion);
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, int.MaxValue)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -274,7 +274,7 @@ namespace EventStore.Client.Streams {
 			Assert.Equal(1, writeResult.NextExpectedVersion);
 
 			await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, int.MaxValue)
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
 				.ToArrayAsync().AsTask());
 
 			var expected = new StreamMetadata(streamMetadata.MaxCount, streamMetadata.MaxAge, StreamRevision.Start,
@@ -310,7 +310,7 @@ namespace EventStore.Client.Streams {
 			Assert.Equal(1, writeResult.NextExpectedVersion);
 
 			var actual = await _fixture.Client
-				.ReadStreamForwardsAsync(stream, StreamRevision.Start, int.MaxValue)
+				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
 				.ToArrayAsync();
 
 			Assert.Empty(actual);

--- a/src/EventStore.Client.Tests/Streams/soft_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/soft_deleted_stream.cs
@@ -36,7 +36,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.SoftDeleteAsync(stream, StreamRevision.FromInt64(writeResult.NextExpectedVersion));
 
 			await Assert.ThrowsAsync<StreamNotFoundException>(
-				() => _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
+				() => _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, int.MaxValue)
 					.ToArrayAsync().AsTask());
 		}
 
@@ -67,7 +67,7 @@ namespace EventStore.Client.Streams {
 
 			await Task.Delay(50); //TODO: This is a workaround until github issue #1744 is fixed
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards,
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards,
 					stream, StreamRevision.Start, int.MaxValue)
 				.Select(x => x.Event)
 				.ToArrayAsync();
@@ -105,7 +105,7 @@ namespace EventStore.Client.Streams {
 
 			await Task.Delay(50); //TODO: This is a workaround until github issue #1744 is fixed
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards,
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards,
 					stream, StreamRevision.Start, int.MaxValue)
 				.Select(x => x.Event)
 				.ToArrayAsync();
@@ -148,7 +148,7 @@ namespace EventStore.Client.Streams {
 
 			await Task.Delay(500); //TODO: This is a workaround until github issue #1744 is fixed
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, int.MaxValue)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -180,7 +180,7 @@ namespace EventStore.Client.Streams {
 			await _fixture.Client.TombstoneAsync(stream, AnyStreamRevision.Any);
 
 			var ex = await Assert.ThrowsAsync<StreamDeletedException>(
-				() => _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
+				() => _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, int.MaxValue)
 					.ToArrayAsync().AsTask());
 
 			Assert.Equal(stream, ex.Stream);
@@ -239,7 +239,7 @@ namespace EventStore.Client.Streams {
 
 			Assert.Equal(6, writeResult.NextExpectedVersion);
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, int.MaxValue)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -274,7 +274,7 @@ namespace EventStore.Client.Streams {
 			Assert.Equal(1, writeResult.NextExpectedVersion);
 
 			await Assert.ThrowsAsync<StreamNotFoundException>(() => _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, int.MaxValue)
 				.ToArrayAsync().AsTask());
 
 			var expected = new StreamMetadata(streamMetadata.MaxCount, streamMetadata.MaxAge, StreamRevision.Start,
@@ -310,7 +310,7 @@ namespace EventStore.Client.Streams {
 			Assert.Equal(1, writeResult.NextExpectedVersion);
 
 			var actual = await _fixture.Client
-				.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, int.MaxValue)
+				.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, int.MaxValue)
 				.ToArrayAsync();
 
 			Assert.Empty(actual);

--- a/src/EventStore.Client.Tests/Streams/stream_with_hash_collision.cs
+++ b/src/EventStore.Client.Tests/Streams/stream_with_hash_collision.cs
@@ -66,7 +66,7 @@ namespace EventStore.Client.Streams {
 				await fixture.Node.StartAsync(true);
 
 				await Assert.ThrowsAsync<StreamNotFoundException>(
-					() => fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream1, StreamRevision.Start, 1, true)
+					() => fixture.Client.ReadStreamAsync(Direction.Forwards, Stream1, StreamRevision.Start, 1, true)
 						.ToArrayAsync().AsTask());
 			}
 
@@ -88,7 +88,7 @@ namespace EventStore.Client.Streams {
 				await fixture.Node.StartAsync(true);
 
 				await Assert.ThrowsAsync<StreamNotFoundException>(
-					() => fixture.Client.ReadStreamAsync(ReadDirection.Backwards, Stream1, StreamRevision.End, 1, true)
+					() => fixture.Client.ReadStreamAsync(Direction.Backwards, Stream1, StreamRevision.End, 1, true)
 						.ToArrayAsync().AsTask());
 			}
 

--- a/src/EventStore.Client.Tests/Streams/stream_with_hash_collision.cs
+++ b/src/EventStore.Client.Tests/Streams/stream_with_hash_collision.cs
@@ -66,7 +66,7 @@ namespace EventStore.Client.Streams {
 				await fixture.Node.StartAsync(true);
 
 				await Assert.ThrowsAsync<StreamNotFoundException>(
-					() => fixture.Client.ReadStreamForwardsAsync(Stream1, StreamRevision.Start, 1, true)
+					() => fixture.Client.ReadStreamAsync(ReadDirection.Forwards, Stream1, StreamRevision.Start, 1, true)
 						.ToArrayAsync().AsTask());
 			}
 
@@ -88,7 +88,7 @@ namespace EventStore.Client.Streams {
 				await fixture.Node.StartAsync(true);
 
 				await Assert.ThrowsAsync<StreamNotFoundException>(
-					() => fixture.Client.ReadStreamBackwardsAsync(Stream1, StreamRevision.End, 1, true)
+					() => fixture.Client.ReadStreamAsync(ReadDirection.Backwards, Stream1, StreamRevision.End, 1, true)
 						.ToArrayAsync().AsTask());
 			}
 

--- a/src/EventStore.Client.Tests/Streams/when_having_max_count_set_for_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/when_having_max_count_set_for_stream.cs
@@ -21,7 +21,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, expected);
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -39,7 +39,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, expected);
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -59,7 +59,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.SetStreamMetadataAsync(stream, StreamRevision.Start, new StreamMetadata(4));
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -79,7 +79,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.SetStreamMetadataAsync(stream, StreamRevision.Start, new StreamMetadata(2));
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Forwards, stream, StreamRevision.Start, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -99,7 +99,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.SetStreamMetadataAsync(stream, StreamRevision.Start, new StreamMetadata(4));
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -119,7 +119,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.SetStreamMetadataAsync(stream, StreamRevision.Start, new StreamMetadata(2));
 
-			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/when_having_max_count_set_for_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/when_having_max_count_set_for_stream.cs
@@ -21,7 +21,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, expected);
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -39,7 +39,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, expected);
 
-			var actual = await _fixture.Client.ReadStreamBackwardsAsync(stream, StreamRevision.End, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -59,7 +59,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.SetStreamMetadataAsync(stream, StreamRevision.Start, new StreamMetadata(4));
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -79,7 +79,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.SetStreamMetadataAsync(stream, StreamRevision.Start, new StreamMetadata(2));
 
-			var actual = await _fixture.Client.ReadStreamForwardsAsync(stream, StreamRevision.Start, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Forwards, stream, StreamRevision.Start, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -99,7 +99,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.SetStreamMetadataAsync(stream, StreamRevision.Start, new StreamMetadata(4));
 
-			var actual = await _fixture.Client.ReadStreamBackwardsAsync(stream, StreamRevision.End, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 
@@ -119,7 +119,7 @@ namespace EventStore.Client.Streams {
 
 			await _fixture.Client.SetStreamMetadataAsync(stream, StreamRevision.Start, new StreamMetadata(2));
 
-			var actual = await _fixture.Client.ReadStreamBackwardsAsync(stream, StreamRevision.End, 100)
+			var actual = await _fixture.Client.ReadStreamAsync(ReadDirection.Backwards, stream, StreamRevision.End, 100)
 				.Select(x => x.Event)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client/Direction.cs
+++ b/src/EventStore.Client/Direction.cs
@@ -1,5 +1,5 @@
 ﻿namespace EventStore.Client {
-	public enum ReadDirection {
+	public enum Direction {
 		Backwards,
 		Forwards
 	}

--- a/src/EventStore.Client/EventStore.Client.csproj
+++ b/src/EventStore.Client/EventStore.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/EventStore.Client/EventStoreGrpcClient.Metadata.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Metadata.cs
@@ -13,7 +13,7 @@ namespace EventStore.Client {
 			ResolvedEvent metadata = default;
 
 			try {
-				metadata = await ReadStreamAsync(ReadDirection.Backwards, SystemStreams.MetastreamOf(streamName), StreamRevision.End, 1,
+				metadata = await ReadStreamAsync(Direction.Backwards, SystemStreams.MetastreamOf(streamName), StreamRevision.End, 1,
 					false,
 					userCredentials: userCredentials,
 					cancellationToken: cancellationToken).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EventStore.Client/EventStoreGrpcClient.Metadata.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Metadata.cs
@@ -13,7 +13,7 @@ namespace EventStore.Client {
 			ResolvedEvent metadata = default;
 
 			try {
-				metadata = await ReadStreamBackwardsAsync(SystemStreams.MetastreamOf(streamName), StreamRevision.End, 1,
+				metadata = await ReadStreamAsync(ReadDirection.Backwards, SystemStreams.MetastreamOf(streamName), StreamRevision.End, 1,
 					false,
 					userCredentials: userCredentials,
 					cancellationToken: cancellationToken).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);

--- a/src/EventStore.Client/EventStoreGrpcClient.Read.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Read.cs
@@ -20,7 +20,8 @@ namespace EventStore.Client {
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
-		public IAsyncEnumerable<ResolvedEvent> ReadAllForwardsAsync(
+		public IAsyncEnumerable<ResolvedEvent> ReadAllAsync(
+			ReadDirection readDirection,
 			Position position,
 			ulong maxCount,
 			bool resolveLinkTos = false,
@@ -28,7 +29,11 @@ namespace EventStore.Client {
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) => ReadInternal(new ReadReq {
 				Options = new ReadReq.Types.Options {
-					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+					ReadDirection = readDirection switch {
+						ReadDirection.Backwards => ReadReq.Types.Options.Types.ReadDirection.Backwards,
+						ReadDirection.Forwards => ReadReq.Types.Options.Types.ReadDirection.Forwards,
+						_ => throw new InvalidOperationException()
+					},
 					ResolveLinks = resolveLinkTos,
 					All = ReadReq.Types.Options.Types.AllOptions.FromPosition(position),
 					Count = maxCount,
@@ -38,35 +43,8 @@ namespace EventStore.Client {
 			userCredentials,
 			cancellationToken);
 
-		/// <summary>
-		/// Asynchronously reads all events in the node backwards (e.g. end to beginning).
-		/// </summary>
-		/// <param name="position">The position to start reading from.</param>
-		/// <param name="maxCount">The maximum count to read.</param>
-		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
-		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
-		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
-		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
-		/// <returns></returns>
-		public IAsyncEnumerable<ResolvedEvent> ReadAllBackwardsAsync(
-			Position position,
-			ulong maxCount,
-			bool resolveLinkTos = false,
-			IEventFilter filter = null,
-			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => ReadInternal(new ReadReq {
-				Options = new ReadReq.Types.Options {
-					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Backwards,
-					ResolveLinks = resolveLinkTos,
-					All = ReadReq.Types.Options.Types.AllOptions.FromPosition(position),
-					Count = maxCount,
-					Filter = GetFilterOptions(filter)
-				}
-			},
-			userCredentials,
-			cancellationToken);
-
-		public IAsyncEnumerable<ResolvedEvent> ReadStreamForwardsAsync(
+		public IAsyncEnumerable<ResolvedEvent> ReadStreamAsync(
+			ReadDirection readDirection,
 			string streamName,
 			StreamRevision revision,
 			ulong count,
@@ -74,29 +52,17 @@ namespace EventStore.Client {
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) => ReadInternal(new ReadReq {
 				Options = new ReadReq.Types.Options {
-					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+					ReadDirection = readDirection switch {
+						ReadDirection.Backwards => ReadReq.Types.Options.Types.ReadDirection.Backwards,
+						ReadDirection.Forwards => ReadReq.Types.Options.Types.ReadDirection.Forwards,
+						_ => throw new InvalidOperationException()
+					},
 					ResolveLinks = resolveLinkTos,
 					Stream = ReadReq.Types.Options.Types.StreamOptions.FromStreamNameAndRevision(streamName, revision),
 					Count = count
 				}
 			},
 			userCredentials,
-			cancellationToken);
-
-		public IAsyncEnumerable<ResolvedEvent> ReadStreamBackwardsAsync(
-			string streamName,
-			StreamRevision revision,
-			ulong count,
-			bool resolveLinkTos = false,
-			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => ReadInternal(new ReadReq {
-				Options = new ReadReq.Types.Options {
-					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Backwards,
-					ResolveLinks = resolveLinkTos,
-					Stream = ReadReq.Types.Options.Types.StreamOptions.FromStreamNameAndRevision(streamName, revision),
-					Count = count
-				}
-			}, userCredentials,
 			cancellationToken);
 
 		private async IAsyncEnumerable<ResolvedEvent> ReadInternal(

--- a/src/EventStore.Client/EventStoreGrpcClient.Read.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Read.cs
@@ -13,6 +13,7 @@ namespace EventStore.Client {
 		/// <summary>
 		/// Asynchronously reads all events in the node forward (e.g. beginning to end).
 		/// </summary>
+		/// <param name="direction">The direction in which to read. <see cref="Direction"/></param>
 		/// <param name="position">The position to start reading from.</param>
 		/// <param name="maxCount">The maximum count to read.</param>
 		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
@@ -21,7 +22,7 @@ namespace EventStore.Client {
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
 		public IAsyncEnumerable<ResolvedEvent> ReadAllAsync(
-			ReadDirection readDirection,
+			Direction direction,
 			Position position,
 			ulong maxCount,
 			bool resolveLinkTos = false,
@@ -29,9 +30,9 @@ namespace EventStore.Client {
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) => ReadInternal(new ReadReq {
 				Options = new ReadReq.Types.Options {
-					ReadDirection = readDirection switch {
-						ReadDirection.Backwards => ReadReq.Types.Options.Types.ReadDirection.Backwards,
-						ReadDirection.Forwards => ReadReq.Types.Options.Types.ReadDirection.Forwards,
+					ReadDirection = direction switch {
+						Direction.Backwards => ReadReq.Types.Options.Types.ReadDirection.Backwards,
+						Direction.Forwards => ReadReq.Types.Options.Types.ReadDirection.Forwards,
 						_ => throw new InvalidOperationException()
 					},
 					ResolveLinks = resolveLinkTos,
@@ -44,7 +45,7 @@ namespace EventStore.Client {
 			cancellationToken);
 
 		public IAsyncEnumerable<ResolvedEvent> ReadStreamAsync(
-			ReadDirection readDirection,
+			Direction direction,
 			string streamName,
 			StreamRevision revision,
 			ulong count,
@@ -52,9 +53,9 @@ namespace EventStore.Client {
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) => ReadInternal(new ReadReq {
 				Options = new ReadReq.Types.Options {
-					ReadDirection = readDirection switch {
-						ReadDirection.Backwards => ReadReq.Types.Options.Types.ReadDirection.Backwards,
-						ReadDirection.Forwards => ReadReq.Types.Options.Types.ReadDirection.Forwards,
+					ReadDirection = direction switch {
+						Direction.Backwards => ReadReq.Types.Options.Types.ReadDirection.Backwards,
+						Direction.Forwards => ReadReq.Types.Options.Types.ReadDirection.Forwards,
 						_ => throw new InvalidOperationException()
 					},
 					ResolveLinks = resolveLinkTos,

--- a/src/EventStore.Client/ReadDirection.cs
+++ b/src/EventStore.Client/ReadDirection.cs
@@ -1,0 +1,6 @@
+﻿namespace EventStore.Client {
+	public enum ReadDirection {
+		Backwards,
+		Forwards
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/EventStore/EventStore/issues/2231

Remove ReadDirection specific methods from the Client API