### PR TITLE
Allow Persistent Subscription to be created with Timeout of 0 from HTTP

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -175,12 +175,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				message.LiveBufferSize,
 				message.BufferSize,
 				message.ReadBatchSize,
-				ToTimeout(message.CheckPointAfterMilliseconds),
+				ToCheckPointAfterTimeout(message.CheckPointAfterMilliseconds),
 				message.MinCheckPointCount,
 				message.MaxCheckPointCount,
 				message.MaxSubscriberCount,
 				message.NamedConsumerStrategy,
-				ToTimeout(message.MessageTimeoutMilliseconds)
+				ToMessageTimeout(message.MessageTimeoutMilliseconds)
 			);
 
 			Log.Debug("New persistent subscription {subscriptionKey}", key);
@@ -248,12 +248,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				message.LiveBufferSize,
 				message.BufferSize,
 				message.ReadBatchSize,
-				ToTimeout(message.CheckPointAfterMilliseconds),
+				ToCheckPointAfterTimeout(message.CheckPointAfterMilliseconds),
 				message.MinCheckPointCount,
 				message.MaxCheckPointCount,
 				message.MaxSubscriberCount,
 				message.NamedConsumerStrategy,
-				ToTimeout(message.MessageTimeoutMilliseconds)
+				ToMessageTimeout(message.MessageTimeoutMilliseconds)
 			);
 			_config.Updated = DateTime.Now;
 			_config.UpdatedBy = message.User.Identity.Name;
@@ -634,12 +634,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 								entry.LiveBufferSize,
 								entry.HistoryBufferSize,
 								entry.ReadBatchSize,
-								ToTimeout(entry.CheckPointAfter),
+								ToCheckPointAfterTimeout(entry.CheckPointAfter),
 								entry.MinCheckPointCount,
 								entry.MaxCheckPointCount,
 								entry.MaxSubscriberCount,
 								entry.NamedConsumerStrategy,
-								ToTimeout(entry.MessageTimeout));
+								ToMessageTimeout(entry.MessageTimeout));
 						}
 
 						continueWith();
@@ -773,8 +773,13 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			}
 		}
 
-		private TimeSpan ToTimeout(int milliseconds) {
+		
+		private TimeSpan ToCheckPointAfterTimeout(int milliseconds) {
 			return milliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(milliseconds);
+		}
+
+		private TimeSpan ToMessageTimeout(int milliseconds) {
+			return milliseconds == 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(milliseconds);
 		}
 	}
 }

--- a/src/EventStore.Transport.Http/Codecs/JsonCodec.cs
+++ b/src/EventStore.Transport.Http/Codecs/JsonCodec.cs
@@ -16,7 +16,7 @@ namespace EventStore.Transport.Http.Codecs {
 			ContractResolver = new CamelCasePropertyNamesContractResolver(),
 			DateParseHandling = DateParseHandling.None,
 			NullValueHandling = NullValueHandling.Ignore,
-			DefaultValueHandling = DefaultValueHandling.Ignore,
+			DefaultValueHandling = DefaultValueHandling.Include,
 			MissingMemberHandling = MissingMemberHandling.Ignore,
 			TypeNameHandling = TypeNameHandling.None,
 			MetadataPropertyHandling = MetadataPropertyHandling.Ignore,


### PR DESCRIPTION
- Change `DefaultValueHandling` to `Include` so the serializer does not ignore `MessageTimeoutMilliseconds` when set to 0

- Added `ToMessageTimeout()` & `ToCheckPointAfterTimeout()` for respective handling of conversion from `int` to `TimeSpan` when set to 0

Resolves #1479