### PR TITLE
Fix socket leak in TCPConnection/TCPConnectionSsl

### DIFF
--- a/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionSslTests.cs
+++ b/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionSslTests.cs
@@ -33,6 +33,7 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 				bool dataReceivedAfterClose = false;
 				var listeningSocket = CreateListeningSocket();
 
+				var mre = new ManualResetEventSlim(false);
 				var clientTcpConnection = ClientAPI.Transport.Tcp.TcpConnectionSsl.CreateConnectingConnection(
 					new NoopLogger(),
 					Guid.NewGuid(),
@@ -41,8 +42,7 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 					false,
 					new ClientAPI.Transport.Tcp.TcpClientConnector(),
 					TimeSpan.FromSeconds(5),
-					(conn) => {
-					},
+					(conn) => mre.Set(),
 					(conn, error) => {
 						Assert.True(false, $"Connection failed: {error}");
 					},
@@ -54,6 +54,7 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 				var serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
 					(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, GetCertificate(), false);
 
+				mre.Wait(TimeSpan.FromSeconds(3));
 				try {
 					clientTcpConnection.ReceiveAsync((connection, data) => {
 						if (Volatile.Read(ref closed)) {

--- a/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionSslTests.cs
+++ b/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionSslTests.cs
@@ -85,6 +85,56 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 			}
 		}
 
+		[Fact]
+		public void when_connection_closed_quickly_socket_should_be_properly_disposed() {
+			for (int i = 0; i < 1000; i++) {
+				var listeningSocket = CreateListeningSocket();
+				ITcpConnection clientTcpConnection = null;
+				ITcpConnection serverTcpConnection = null;
+				Socket serverSocket = null;
+				try {
+					ManualResetEventSlim mre = new ManualResetEventSlim(false);
+
+					clientTcpConnection = TcpConnectionSsl.CreateConnectingConnection(
+						Guid.NewGuid(),
+						(IPEndPoint)listeningSocket.LocalEndPoint,
+						"localhost",
+						false,
+						new TcpClientConnector(),
+						TimeSpan.FromSeconds(5),
+						(conn) => {},
+						(conn, error) => {},
+						false);
+
+					clientTcpConnection.ConnectionClosed += (conn, error) => {
+						mre.Set();
+					};
+
+					serverSocket = listeningSocket.Accept();
+					clientTcpConnection.Close("Intentional close");
+					serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
+						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, GetCertificate(), false);
+
+					mre.Wait(TimeSpan.FromSeconds(10));
+					SpinWait.SpinUntil(() => serverTcpConnection.IsClosed, TimeSpan.FromSeconds(10));
+
+					var disposed = false;
+					try {
+						int x = serverSocket.Available;
+					} catch (ObjectDisposedException) {
+						disposed = true;
+					}
+
+					Assert.True(disposed);
+				} finally {
+					clientTcpConnection?.Close("Shut down");
+					serverTcpConnection?.Close("Shut down");
+					listeningSocket.Dispose();
+					serverSocket?.Dispose();
+				}
+			}
+		}
+
 		private X509Certificate GetCertificate() {
 			using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream(typeof(EventStoreClientAPIFixture), "server.p12");
 			using var mem = new MemoryStream();

--- a/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionTests.cs
+++ b/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionTests.cs
@@ -79,5 +79,53 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 				}
 			}
 		}
+
+		[Fact]
+		public void when_connection_closed_quickly_socket_should_be_properly_disposed() {
+			for (int i = 0; i < 1000; i++) {
+				var listeningSocket = CreateListeningSocket();
+				ITcpConnection clientTcpConnection = null;
+				ITcpConnection serverTcpConnection = null;
+				Socket serverSocket = null;
+				try {
+					ManualResetEventSlim mre = new ManualResetEventSlim(false);
+
+					clientTcpConnection = TcpConnection.CreateConnectingTcpConnection(
+						Guid.NewGuid(),
+						(IPEndPoint)listeningSocket.LocalEndPoint,
+						new TcpClientConnector(),
+						TimeSpan.FromSeconds(5),
+						(conn) => {},
+						(conn, error) => {},
+						false);
+
+					clientTcpConnection.ConnectionClosed += (conn, error) => {
+						mre.Set();
+					};
+
+					serverSocket = listeningSocket.Accept();
+					clientTcpConnection.Close("Intentional close");
+					serverTcpConnection = TcpConnection.CreateAcceptedTcpConnection(Guid.NewGuid(),
+						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, false);
+
+					mre.Wait(TimeSpan.FromSeconds(10));
+					SpinWait.SpinUntil(() => serverTcpConnection.IsClosed, TimeSpan.FromSeconds(10));
+
+					var disposed = false;
+					try {
+						int x = serverSocket.Available;
+					} catch (ObjectDisposedException) {
+						disposed = true;
+					}
+
+					Assert.True(disposed);
+				} finally {
+					clientTcpConnection?.Close("Shut down");
+					serverTcpConnection?.Close("Shut down");
+					listeningSocket.Dispose();
+					serverSocket?.Dispose();
+				}
+			}
+		}
 	}
 }

--- a/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionTests.cs
+++ b/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionTests.cs
@@ -30,13 +30,14 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 				bool dataReceivedAfterClose = false;
 				var listeningSocket = CreateListeningSocket();
 
+				var mre = new ManualResetEventSlim(false);
 				var clientTcpConnection = ClientAPI.Transport.Tcp.TcpConnection.CreateConnectingConnection(
 					new NoopLogger(),
 					Guid.NewGuid(),
 					(IPEndPoint)listeningSocket.LocalEndPoint,
 					new ClientAPI.Transport.Tcp.TcpClientConnector(),
 					TimeSpan.FromSeconds(5),
-					(conn) => {},
+					(conn) => mre.Set(),
 					(conn, error) => {
 						Assert.True(false, $"Connection failed: {error}");
 					},
@@ -48,6 +49,7 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 				var serverTcpConnection = TcpConnection.CreateAcceptedTcpConnection(Guid.NewGuid(),
 					(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, false);
 
+				mre.Wait(TimeSpan.FromSeconds(3));
 				try {
 					clientTcpConnection.ReceiveAsync((connection, data) => {
 						if (Volatile.Read(ref closed)) {

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpClientConnector.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpClientConnector.cs
@@ -53,12 +53,15 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		}
 
 		internal void InitConnect(IPEndPoint serverEndPoint,
+			Action<Socket> onSocketAssigned,
 			Action<IPEndPoint, Socket> onConnectionEstablished,
 			Action<IPEndPoint, SocketError> onConnectionFailed,
 			ITcpConnection connection,
 			TimeSpan connectionTimeout) {
 			if (serverEndPoint == null)
 				throw new ArgumentNullException("serverEndPoint");
+			if (onSocketAssigned == null)
+				throw new ArgumentNullException("onSocketAssigned");
 			if (onConnectionEstablished == null)
 				throw new ArgumentNullException("onConnectionEstablished");
 			if (onConnectionFailed == null)
@@ -66,6 +69,7 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 
 			var socketArgs = _connectSocketArgsPool.Get();
 			var connectingSocket = new Socket(serverEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+			onSocketAssigned(connectingSocket);
 			socketArgs.RemoteEndPoint = serverEndPoint;
 			socketArgs.AcceptSocket = connectingSocket;
 			var callbacks = (CallbacksStateToken)socketArgs.UserToken;

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -97,7 +97,6 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 					_socket.NoDelay = true;
 				} catch (ObjectDisposedException) {
 					CloseInternal(SocketError.Shutdown, "Socket disposed.");
-					_socket = null;
 					return;
 				}
 
@@ -304,7 +303,6 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 			if (_socket != null) {
 				Helper.EatException(() => _socket.Shutdown(SocketShutdown.Both));
 				Helper.EatException(() => _socket.Close());
-				_socket = null;
 			}
 
 			lock (_sendLock) {

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -98,6 +98,9 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 				} catch (ObjectDisposedException) {
 					CloseInternal(SocketError.Shutdown, "Socket disposed.");
 					return;
+				} catch (SocketException) {
+					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
+					return;
 				}
 
 				var receiveSocketArgs = SocketArgsPool.Get();

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
@@ -105,6 +105,9 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 				} catch (ObjectDisposedException) {
 					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
 					return;
+				} catch (SocketException) {
+					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
+					return;
 				}
 
 				try {

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
@@ -107,7 +107,15 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 					return;
 				}
 
-				_sslStream = new SslStream(new NetworkStream(_socket, true), false, ValidateServerCertificate, null);
+				try {
+					_sslStream = new SslStream(new NetworkStream(_socket, true), false, ValidateServerCertificate,
+						null);
+				} catch (IOException exc) {
+					_log.Debug(exc, "[S{0}, L{1}]: IOException on NetworkStream. The socket has already been disposed.", RemoteEndPoint,
+						LocalEndPoint);
+					return;
+				}
+
 				try {
 					_sslStream.BeginAuthenticateAsClient(targetHost, OnEndAuthenticateAsClient, _sslStream);
 				} catch (AuthenticationException exc) {

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
@@ -28,8 +28,11 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 			var connection = new TcpConnectionSsl(log, connectionId, remoteEndPoint, onConnectionClosed);
 			// ReSharper disable ImplicitlyCapturedClosure
 			connector.InitConnect(remoteEndPoint,
+				(socket) => {
+					connection.InitClientSocket(socket);
+				},
 				(_, socket) => {
-					connection.InitClientSocket(socket, targetHost, validateServer);
+					connection.InitSslStream(targetHost, validateServer);
 					if (onConnectionEstablished != null)
 						ThreadPool.QueueUserWorkItem(o => onConnectionEstablished(connection));
 				},
@@ -51,6 +54,7 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 
 		private readonly Guid _connectionId;
 		private readonly ILogger _log;
+		private Socket _socket;
 
 		private readonly ConcurrentQueueWrapper<ArraySegment<byte>> _sendQueue =
 			new ConcurrentQueueWrapper<ArraySegment<byte>>();
@@ -84,23 +88,26 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 			_onConnectionClosed = onConnectionClosed;
 		}
 
-		private void InitClientSocket(Socket socket, string targetHost, bool validateServer) {
-			Ensure.NotNull(targetHost, "targetHost");
+		private void InitClientSocket(Socket socket) {
+			_socket = socket;
+		}
 
-			InitConnectionBase(socket);
-			//_log.Info("TcpConnectionSsl::InitClientSocket({0}, L{1})", RemoteEndPoint, LocalEndPoint);
+		private void InitSslStream(string targetHost, bool validateServer) {
+			Ensure.NotNull(targetHost, "targetHost");
+			InitConnectionBase(_socket);
+			//_log.Info("TcpConnectionSsl::InitSslStream({0}, L{1})", RemoteEndPoint, LocalEndPoint);
 
 			_validateServer = validateServer;
 
 			lock (_streamLock) {
 				try {
-					socket.NoDelay = true;
+					_socket.NoDelay = true;
 				} catch (ObjectDisposedException) {
 					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
 					return;
 				}
 
-				_sslStream = new SslStream(new NetworkStream(socket, true), false, ValidateServerCertificate, null);
+				_sslStream = new SslStream(new NetworkStream(_socket, true), false, ValidateServerCertificate, null);
 				try {
 					_sslStream.BeginAuthenticateAsClient(targetHost, OnEndAuthenticateAsClient, _sslStream);
 				} catch (AuthenticationException exc) {
@@ -392,6 +399,9 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 
 			if (_sslStream != null)
 				Helper.EatException(() => _sslStream.Close());
+
+			if (_socket != null)
+				Helper.EatException(() => _socket.Dispose());
 
 			if (_onConnectionClosed != null)
 				_onConnectionClosed(this, socketError);

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
@@ -86,6 +86,56 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			}
 		}
 
+		[Test, Timeout(120000)]
+		public void when_connection_closed_quickly_socket_should_be_properly_disposed() {
+			for (int i = 0; i < 1000; i++) {
+				var listeningSocket = CreateListeningSocket();
+				ITcpConnection clientTcpConnection = null;
+				ITcpConnection serverTcpConnection = null;
+				Socket serverSocket = null;
+				try {
+					ManualResetEventSlim mre = new ManualResetEventSlim(false);
+
+					clientTcpConnection = TcpConnectionSsl.CreateConnectingConnection(
+						Guid.NewGuid(),
+						(IPEndPoint)listeningSocket.LocalEndPoint,
+						"localhost",
+						false,
+						new TcpClientConnector(),
+						TimeSpan.FromSeconds(5),
+						(conn) => {},
+						(conn, error) => {},
+						false);
+
+					clientTcpConnection.ConnectionClosed += (conn, error) => {
+						mre.Set();
+					};
+
+					serverSocket = listeningSocket.Accept();
+					clientTcpConnection.Close("Intentional close");
+					serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
+						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, GetCertificate(), false);
+
+					mre.Wait(TimeSpan.FromSeconds(10));
+					SpinWait.SpinUntil(() => serverTcpConnection.IsClosed, TimeSpan.FromSeconds(10));
+
+					var disposed = false;
+					try {
+						int x = serverSocket.Available;
+					} catch (ObjectDisposedException) {
+						disposed = true;
+					}
+
+					Assert.AreEqual(true, disposed);
+				} finally {
+					clientTcpConnection?.Close("Shut down");
+					serverTcpConnection?.Close("Shut down");
+					listeningSocket.Dispose();
+					serverSocket?.Dispose();
+				}
+			}
+		}
+
 		private X509Certificate GetCertificate() {
 			using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("EventStore.Core.Tests.server.p12");
 			using var mem = new MemoryStream();

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionTests.cs
@@ -80,5 +80,53 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				}
 			}
 		}
+
+		[Test, Timeout(120000)]
+		public void when_connection_closed_quickly_socket_should_be_properly_disposed() {
+			for (int i = 0; i < 1000; i++) {
+				var listeningSocket = CreateListeningSocket();
+				ITcpConnection clientTcpConnection = null;
+				ITcpConnection serverTcpConnection = null;
+				Socket serverSocket = null;
+				try {
+					ManualResetEventSlim mre = new ManualResetEventSlim(false);
+
+					clientTcpConnection = TcpConnection.CreateConnectingTcpConnection(
+					Guid.NewGuid(),
+					(IPEndPoint)listeningSocket.LocalEndPoint,
+					new TcpClientConnector(),
+					TimeSpan.FromSeconds(5),
+					(conn) => {},
+					(conn, error) => {},
+					false);
+
+					clientTcpConnection.ConnectionClosed += (conn, error) => {
+						mre.Set();
+					};
+
+					serverSocket = listeningSocket.Accept();
+					clientTcpConnection.Close("Intentional close");
+					serverTcpConnection = TcpConnection.CreateAcceptedTcpConnection(Guid.NewGuid(),
+						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, false);
+
+					mre.Wait(TimeSpan.FromSeconds(10));
+					SpinWait.SpinUntil(() => serverTcpConnection.IsClosed, TimeSpan.FromSeconds(10));
+
+					var disposed = false;
+					try {
+						int x = serverSocket.Available;
+					} catch (ObjectDisposedException) {
+						disposed = true;
+					}
+
+					Assert.AreEqual(true, disposed);
+				} finally {
+					clientTcpConnection?.Close("Shut down");
+					serverTcpConnection?.Close("Shut down");
+					listeningSocket.Dispose();
+					serverSocket?.Dispose();
+				}
+			}
+		}
 	}
 }

--- a/src/EventStore.Transport.Tcp/TcpClientConnector.cs
+++ b/src/EventStore.Transport.Tcp/TcpClientConnector.cs
@@ -57,12 +57,15 @@ namespace EventStore.Transport.Tcp {
 		}
 
 		internal void InitConnect(IPEndPoint serverEndPoint,
+			Action<Socket> onSocketAssigned,
 			Action<IPEndPoint, Socket> onConnectionEstablished,
 			Action<IPEndPoint, SocketError> onConnectionFailed,
 			ITcpConnection connection,
 			TimeSpan connectionTimeout) {
 			if (serverEndPoint == null)
 				throw new ArgumentNullException("serverEndPoint");
+			if (onSocketAssigned == null)
+				throw new ArgumentNullException("onSocketAssigned");
 			if (onConnectionEstablished == null)
 				throw new ArgumentNullException("onConnectionEstablished");
 			if (onConnectionFailed == null)
@@ -70,6 +73,7 @@ namespace EventStore.Transport.Tcp {
 
 			var socketArgs = _connectSocketArgsPool.Get();
 			var connectingSocket = new Socket(serverEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
+			onSocketAssigned(connectingSocket);
 			socketArgs.RemoteEndPoint = serverEndPoint;
 			socketArgs.AcceptSocket = connectingSocket;
 			var callbacks = (CallbacksStateToken)socketArgs.UserToken;

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -110,7 +110,6 @@ namespace EventStore.Transport.Tcp {
 					_socket.NoDelay = true;
 				} catch (ObjectDisposedException) {
 					CloseInternal(SocketError.Shutdown, "Socket disposed.");
-					_socket = null;
 					return;
 				}
 
@@ -351,7 +350,6 @@ namespace EventStore.Transport.Tcp {
 			if (_socket != null) {
 				Helper.EatException(() => _socket.Shutdown(SocketShutdown.Both));
 				Helper.EatException(() => _socket.Close());
-				_socket = null;
 			}
 
 			lock (_sendLock) {

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -111,6 +111,9 @@ namespace EventStore.Transport.Tcp {
 				} catch (ObjectDisposedException) {
 					CloseInternal(SocketError.Shutdown, "Socket disposed.");
 					return;
+				} catch (SocketException) {
+					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
+					return;
 				}
 
 				var receiveSocketArgs = SocketArgsPool.Get();

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -32,8 +32,11 @@ namespace EventStore.Transport.Tcp {
 			var connection = new TcpConnection(connectionId, remoteEndPoint, verbose);
 // ReSharper disable ImplicitlyCapturedClosure
 			connector.InitConnect(remoteEndPoint,
-				(_, socket) => {
+				(socket) => {
 					connection.InitSocket(socket);
+				},
+				(_, socket) => {
+					connection.InitSendReceive();
 					if (onConnectionEstablished != null)
 						onConnectionEstablished(connection);
 				},
@@ -49,6 +52,7 @@ namespace EventStore.Transport.Tcp {
 			Socket socket, bool verbose) {
 			var connection = new TcpConnection(connectionId, remoteEndPoint, verbose);
 			connection.InitSocket(socket);
+			connection.InitSendReceive();
 			return connection;
 		}
 
@@ -96,11 +100,14 @@ namespace EventStore.Transport.Tcp {
 		}
 
 		private void InitSocket(Socket socket) {
-			InitConnectionBase(socket);
+			_socket = socket;
+		}
+
+		private void InitSendReceive() {
+			InitConnectionBase(_socket);
 			lock (_sendLock) {
-				_socket = socket;
 				try {
-					socket.NoDelay = true;
+					_socket.NoDelay = true;
 				} catch (ObjectDisposedException) {
 					CloseInternal(SocketError.Shutdown, "Socket disposed.");
 					_socket = null;
@@ -109,12 +116,12 @@ namespace EventStore.Transport.Tcp {
 
 				var receiveSocketArgs = SocketArgsPool.Get();
 				_receiveSocketArgs = receiveSocketArgs;
-				_receiveSocketArgs.AcceptSocket = socket;
+				_receiveSocketArgs.AcceptSocket = _socket;
 				_receiveSocketArgs.Completed += OnReceiveAsyncCompleted;
 
 				var sendSocketArgs = SocketArgsPool.Get();
 				_sendSocketArgs = sendSocketArgs;
-				_sendSocketArgs.AcceptSocket = socket;
+				_sendSocketArgs.AcceptSocket = _socket;
 				_sendSocketArgs.Completed += OnSendAsyncCompleted;
 			}
 
@@ -138,7 +145,7 @@ namespace EventStore.Transport.Tcp {
 
 		private void TrySend() {
 			lock (_sendLock) {
-				if (_isSending || _sendQueue.IsEmpty || _socket == null) return;
+				if (_isSending || _sendQueue.IsEmpty || _sendSocketArgs == null) return;
 				if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
 				_isSending = true;
 			}

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -128,6 +128,9 @@ namespace EventStore.Transport.Tcp {
 				} catch (ObjectDisposedException) {
 					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
 					return;
+				} catch (SocketException) {
+					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
+					return;
 				}
 
 				try {
@@ -200,6 +203,9 @@ namespace EventStore.Transport.Tcp {
 				try {
 					_socket.NoDelay = true;
 				} catch (ObjectDisposedException) {
+					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
+					return;
+				} catch (SocketException) {
 					CloseInternal(SocketError.Shutdown, "Socket is disposed.");
 					return;
 				}

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -130,7 +130,14 @@ namespace EventStore.Transport.Tcp {
 					return;
 				}
 
-				_sslStream = new SslStream(new NetworkStream(socket, true), false);
+				try {
+					_sslStream = new SslStream(new NetworkStream(socket, true), false);
+				} catch (IOException exc) {
+					Log.DebugException(exc, "[S{remoteEndPoint}, L{localEndPoint}]: IOException on NetworkStream. The socket has already been disposed.", RemoteEndPoint,
+						LocalEndPoint);
+					return;
+				}
+
 				try {
 					var enabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls13;
 					_sslStream.BeginAuthenticateAsServer(certificate, false, enabledSslProtocols, true,
@@ -197,7 +204,14 @@ namespace EventStore.Transport.Tcp {
 					return;
 				}
 
-				_sslStream = new SslStream(new NetworkStream(_socket, true), false, ValidateServerCertificate, null);
+				try {
+					_sslStream = new SslStream(new NetworkStream(_socket, true), false, ValidateServerCertificate, null);
+				} catch (IOException exc) {
+					Log.DebugException(exc, "[S{remoteEndPoint}, L{localEndPoint}]: IOException on NetworkStream. The socket has already been disposed.", RemoteEndPoint,
+						LocalEndPoint);
+					return;
+				}
+
 				try {
 					_sslStream.BeginAuthenticateAsClient(targetHost, OnEndAuthenticateAsClient, _sslStream);
 				} catch (AuthenticationException exc) {


### PR DESCRIPTION
Fixes #2010 

## Description of race condition
It is possible for TcpConnection.Close() -> CloseInternal() to be called before the `onConnectionEstablished` callback is called. Thus `_socket`  will still be `null` (since `connection.InitSocket` has not been called yet) and the socket will not be closed due to the null check below, resulting in a socket leak:

Normal TCP connection / CloseInternal():
```
			if (_socket != null) {
				Helper.EatException(() => _socket.Shutdown(SocketShutdown.Both));
				Helper.EatException(() => _socket.Close());
				_socket = null;
			}
```

As mentioned on issue #2010, this results in connections staying in the `CLOSE_WAIT` state until the client holding the socket is stopped.

The same applies to SSL TCP connections, except that in this case, `_sslStream` will still be `null` and the stream will not be disposed:

SSL TCP connection / CloseInternal():
```
			if (_sslStream != null)
				Helper.EatException(() => _sslStream.Close());
```

## Reproduction steps
The following steps mirror what @Zetanova reported in #2010:
- Start a single node
- Run following application [socket_pile_up.zip](https://github.com/EventStore/EventStore/files/4126374/socket_pile_up.zip):
`dotnet run`
- Monitor number of sockets: `ss|grep 1113|grep "CLOSE-WAIT"|wc -l` . You will notice that the count keeps on increasing.

## Regression tests
4 regression tests have been added, one for each connection type: TcpConnection/TcpConnectionSsl (client & server). All of them fail when the fix is not present.

## Fix description
The fix adds a callback called `onSocketAssigned` which is triggered as soon as the socket is created and before it is used to connect using  `ConnectAsync()`. This ensures that `_socket` in `TcpConnection` will be properly assigned before the created `ITcpConnection` object is returned to the caller and thus if `Close()` is called on the `ITcpConnection` at any point after this, `_socket` is guaranteed to be not null which in turn implies that the socket will properly be disposed in `CloseInternal`.

The same applies to `TcpConnectionSsl` except that there was no `_socket` property (there is an `_sslStream` property instead). A `_socket` property has been added to ensure that the socket is disposed if the connection is closed before the `onConnectionEstablished` callback is called (in this case, `_sslStream` will still be null which would previously also result in a socket leak)

## Consequences of fixing the socket leak
Fixing the socket leak now implies that when `onConnectionEstablished` is called, the socket may have already been disposed. Thus, some new exceptions can now be thrown and these have been fixed in commits: e90c3b560530760df1e173c26a7928aaa4d4c65e,  e7e8eff4cb5358fe933dcb369f1602ebb4ed6eea and 3bc0187d8f7650916240540bbd72ac2f2da183a8.

As a consequence of the fix, `onConnectionFailed` callback can now also be triggered in `no_data_should_be_dispatched_after_tcp_connection_closed`. This has been fixed in commit: 032efe2e9096b05d770cbab67c920f9c6518d7da.