### PR TITLE
Allow projections to subscribe from the end of the transaction log

### DIFF
--- a/src/EventStore.Client.Projections.Tests/Projections/create.cs
+++ b/src/EventStore.Client.Projections.Tests/Projections/create.cs
@@ -15,11 +15,11 @@ namespace EventStore.Client.Projections {
 				"fromAll().when({$init: function (state, ev) {return {};}});", TestCredentials.Root);
 		}
 
-		[Theory, InlineData(true), InlineData(false)]
-		public async Task continuous(bool trackEmittedStreams) {
+		[Theory, InlineData(true, true), InlineData(false, false)]
+		public async Task continuous(bool trackEmittedStreams, bool subscribeFromEnd) {
 			await _fixture.Client.ProjectionsManager.CreateContinuousAsync(
 				$"{nameof(continuous)}_{trackEmittedStreams}",
-				"fromAll().when({$init: function (state, ev) {return {};}});", trackEmittedStreams,
+				"fromAll().when({$init: function (state, ev) {return {};}});", trackEmittedStreams, subscribeFromEnd,
 				TestCredentials.Root);
 		}
 

--- a/src/EventStore.Client/Projections/EventStoreProjectionManagerGrpcClient.Create.cs
+++ b/src/EventStore.Client/Projections/EventStoreProjectionManagerGrpcClient.Create.cs
@@ -16,12 +16,14 @@ namespace EventStore.Client.Projections {
 		}
 
 		public async Task CreateContinuousAsync(string name, string query, bool trackEmittedStreams = false,
-			UserCredentials userCredentials = default, CancellationToken cancellationToken = default) {
+			bool subscribeFromEnd = false, UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
 			using var call = _client.CreateAsync(new CreateReq {
 				Options = new CreateReq.Types.Options {
 					Continuous = new CreateReq.Types.Options.Types.Continuous {
 						Name = name,
-						TrackEmittedStreams = trackEmittedStreams
+						TrackEmittedStreams = trackEmittedStreams,
+						SubscribeFromEnd = subscribeFromEnd,
 					},
 					Query = query
 				}

--- a/src/EventStore.ClientAPI/Projections/ProjectionConfig.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionConfig.cs
@@ -37,6 +37,10 @@ namespace EventStore.ClientAPI.Projections {
 		/// Maximum number of concurrent writes to allow for a projection.
 		/// </summary>
 		public readonly int MaxAllowedWritesInFlight = 0;
+		/// <summary>
+		/// Whether to start the projection from the end of the transaction log.
+		/// </summary>
+		public readonly bool SubscribeFromEnd = false;
 
 		/// <summary>
 		/// create a new <see cref="ProjectionConfig"/> class.
@@ -49,6 +53,7 @@ namespace EventStore.ClientAPI.Projections {
 		/// <param name="pendingEventsThreshold">Number of events that can be pending before the projection is temporarily paused. Default: 5000</param>
 		/// <param name="maxWriteBatchLength">Maximum number of events the projection can write in a batch at a time. Default: 500</param>
 		/// <param name="maxAllowedWritesInFlight">Maximum number of concurrent writes to allow for a projection. Default: 0 (Unbounded)</param>
+		/// <param name="subscribeFromEnd">Whether to subscribe the projection from the end of the transaction log. Default: false</param>
 		public ProjectionConfig(
 			bool emitEnabled,
 			bool trackEmittedStreams,
@@ -57,7 +62,8 @@ namespace EventStore.ClientAPI.Projections {
 			int checkpointUnhandledBytesThreshold,
 			int pendingEventsThreshold,
 			int maxWriteBatchLength,
-			int maxAllowedWritesInFlight
+			int maxAllowedWritesInFlight,
+			bool subscribeFromEnd
 			) {
 			EmitEnabled = emitEnabled;
 			TrackEmittedStreams = trackEmittedStreams;
@@ -67,6 +73,7 @@ namespace EventStore.ClientAPI.Projections {
 			PendingEventsThreshold = pendingEventsThreshold;
 			MaxWriteBatchLength = maxWriteBatchLength;
 			MaxAllowedWritesInFlight = maxAllowedWritesInFlight;
+			SubscribeFromEnd = subscribeFromEnd;
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsClient.cs
@@ -54,10 +54,11 @@ namespace EventStore.ClientAPI.Projections {
 		}
 
 		public Task CreateContinuous(EndPoint endPoint, string name, string query, bool trackEmitted,
-			UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			bool subscribeFromEnd, UserCredentials userCredentials = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
 			return SendPost(
 				endPoint.ToHttpUrl(httpSchema,
-					"/projections/continuous?name={0}&type=JS&emit=1&trackemittedstreams={1}", name, trackEmitted),
+					"/projections/continuous?name={0}&type=JS&emit=1&trackemittedstreams={1}&subscribefromend={2}",
+					name, trackEmitted, subscribeFromEnd),
 				query, userCredentials, HttpStatusCode.Created);
 		}
 

--- a/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
@@ -109,12 +109,26 @@ namespace EventStore.ClientAPI.Projections {
 		/// <param name="userCredentials">Credentials for a user with permission to create a query.</param>
 		public Task CreateContinuousAsync(string name, string query, bool trackEmittedStreams,
 			UserCredentials userCredentials = null) {
+			return CreateContinuousAsync(name, query, trackEmittedStreams, false, userCredentials);
+		}
+		
+		/// <summary>
+		/// Asynchronously creates a continuous projection.
+		/// </summary>
+		/// <param name="name">The name of the projection.</param>
+		/// <param name="query">The JavaScript source code for the query.</param>
+		/// <param name="trackEmittedStreams">Whether the streams emitted by this projection should be tracked.</param>
+		/// <param name="subscribeFromEnd">Whether to start the projection from the end of the transaction log.</param>
+		/// <param name="userCredentials">Credentials for a user with permission to create a query.</param>
+		public Task CreateContinuousAsync(string name, string query, bool trackEmittedStreams, bool subscribeFromEnd,
+			UserCredentials userCredentials = null) {
 			Ensure.NotNullOrEmpty(name, "name");
 			Ensure.NotNullOrEmpty(query, "query");
 
-			return _client.CreateContinuous(_httpEndPoint, name, query, trackEmittedStreams, userCredentials,
-				_httpSchema);
+			return _client.CreateContinuous(_httpEndPoint, name, query, trackEmittedStreams, subscribeFromEnd,
+				userCredentials, _httpSchema);
 		}
+
 
 		/// <summary>
 		/// Asynchronously lists this status of all projections.

--- a/src/EventStore.Projections.Core.Tests/Integration/projections_starting_from_end/from_all_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/projections_starting_from_end/from_all_projection.cs
@@ -1,0 +1,174 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EventStore.Core.Messaging;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Integration.projections_starting_from_end {
+	public class from_all_projection {
+		[TestFixture]
+		public class when_subscribing_from_end: specification_with_a_v8_projection_posted {
+			private readonly string _projectedStream = "projected-stream";
+			private readonly ProjectionNamesBuilder _namesBuilder;
+
+			public when_subscribing_from_end() {
+				_namesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
+			}
+
+			protected override void GivenEvents() {
+				ExistingEvent("before-stream", "test", "", "{\"a\":1}");
+				ExistingEvent("before-stream", "test", "", "{\"a\":2}");
+				ExistingEvent("before-stream", "test", "", "{\"a\":3}");
+			}
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				// Write some more events
+				yield return CreateWriteEvent("after-stream", "test", "{\"b\":1}");
+				yield return CreateWriteEvent("after-stream", "test", "{\"b\":2}");
+				yield return CreateWriteEvent("after-stream", "test", "{\"b\":3}");
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+						_projectionName,
+						"fromAll().when({$any: function(s,e) { linkTo(\"" + _projectedStream + "\", e) }})",
+						subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_handle_new_events() {
+				AssertStreamContains(_projectedStream, "0@after-stream", "1@after-stream", "2@after-stream");
+			}
+
+			[Test]
+			public void should_not_handle_old_events() {
+				AssertStreamDoesNotContain(_projectedStream, "0@before-stream", "1@before-stream", "2@before-stream");
+			}
+
+			[Test]
+			public void should_write_checkpoint_on_first_handled_event() {
+				var checkpointEvents = _streams[_namesBuilder.MakeCheckpointStreamName()];
+				Assert.AreEqual(1, checkpointEvents.Count);
+				var checkpointMetadata = Encoding.UTF8.GetString(checkpointEvents[0].Metadata);
+
+				var expectedPosition = _streams["after-stream"][0].LogPosition;
+				Assert.True(checkpointMetadata.Contains(expectedPosition.ToString()),
+					$"Expected checkpoint to contain position {expectedPosition}, but was '{checkpointMetadata}'");
+			}
+		}
+
+		[TestFixture]
+		public class when_subscribing_from_end_and_restarted : specification_with_a_v8_projection_posted {
+			private readonly string _projectedStream = "projected-stream";
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				// Write an event to force a checkpoint
+				yield return CreateWriteEvent("input-stream", "test", "{\"b\":1}");
+
+				yield return new ProjectionManagementMessage.Command.Disable(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+
+				// Write events between stopping and starting the projection
+				yield return CreateWriteEvent("input-stream", "test", "{\"b\":2}");
+				yield return CreateWriteEvent("input-stream", "test", "{\"b\":3}");
+
+				// Start the projection up again
+				yield return new ProjectionManagementMessage.Command.Enable(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+					_projectionName,
+					"fromAll().when({$any: function(s,e) { linkTo(\"" + _projectedStream + "\", e) }})",
+					subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_handle_original_event() {
+				AssertStreamContains(_projectedStream, "0@input-stream");
+			}
+
+			[Test]
+			public void should_handle_events_posted_while_disabled() {
+				AssertStreamContains(_projectedStream, "1@input-stream", "2@input-stream");
+			}
+		}
+
+		[TestFixture]
+		public class when_subscribing_from_end_and_reset : specification_with_a_v8_projection_posted {
+			private readonly string _inputStream = "input-stream";
+			private readonly string _projectedStream = "projected-stream";
+			private readonly ProjectionNamesBuilder _namesBuilder;
+
+			public when_subscribing_from_end_and_reset() {
+				_namesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
+			}
+
+			protected override void GivenEvents() {
+			}
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":1}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":2}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":3}");
+
+				yield return new ProjectionManagementMessage.Command.Reset(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":4}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":5}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":6}");
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+					_projectionName,
+					"fromAll().when({$any: function(s,e) { linkTo(\"" + _projectedStream + "\", e) }})",
+					subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_have_truncated_output_stream() {
+				AssertStreamMetadata(_projectedStream, "\"$tb\":4");
+			}
+
+			[Test]
+			public void should_not_handle_original_events_again() {
+				var eventsData = GetStreamEventData(_projectedStream);
+
+				var notExpected = new[] {"0@input-stream", "1@input-stream", "2@input-stream"};
+				var duplicates = notExpected.Where(v => eventsData.Count(x => x == v) > 1).ToArray();
+
+				Assert.That(duplicates.Length == 0,
+					$"{_projectedStream} contains duplicates : {duplicates.Aggregate("", (a, v) => a + " " + v)}");
+			}
+
+			[Test]
+			public void should_handle_new_events() {
+				AssertStreamContains(_projectedStream, "3@input-stream", "4@input-stream", "5@input-stream");
+			}
+
+			[Test]
+			public void should_write_checkpoint_on_first_handled_event_after_reset() {
+				var checkpointEvents = _streams[_namesBuilder.MakeCheckpointStreamName()];
+
+				// Projection checkpoints when it is reset
+				Assert.AreEqual(3, checkpointEvents.Count);
+				var checkpointMetadata = Encoding.UTF8.GetString(checkpointEvents.Last().Metadata);
+
+				var expectedPosition = _streams[_inputStream][3].LogPosition;
+				Assert.True(checkpointMetadata.Contains(expectedPosition.ToString()),
+					$"Expected checkpoint to contain position {expectedPosition}, but was '{checkpointMetadata}'");
+			}
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Integration/projections_starting_from_end/from_multi_stream_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/projections_starting_from_end/from_multi_stream_projection.cs
@@ -1,0 +1,168 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EventStore.Core.Messaging;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Integration.projections_starting_from_end {
+	public class multi_stream_projection {
+		[TestFixture]
+		public class when_subscribing_from_end : specification_with_a_v8_projection_posted {
+			private readonly string _projectedStream = "projected-stream";
+			private readonly ProjectionNamesBuilder _namesBuilder;
+
+			public when_subscribing_from_end() {
+				_namesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
+			}
+
+			protected override void GivenEvents() {
+				ExistingEvent("stream-1", "test", "", "{\"a\":1}");
+				ExistingEvent("stream-2", "test", "", "{\"a\":2}");
+				ExistingEvent("stream-3", "test", "", "{\"a\":3}");
+			}
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				// Write some more events
+				yield return CreateWriteEvent("stream-1", "test", "{\"b\":1}");
+				yield return CreateWriteEvent("stream-2", "test", "{\"b\":2}");
+				yield return CreateWriteEvent("stream-3", "test", "{\"b\":3}");
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+					_projectionName,
+					"fromStreams(\"stream-1\", \"stream-2\", \"stream-3\").when({$any: function(s,e) { linkTo(\"" +
+					_projectedStream + "\", e) }})",
+					subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_handle_new_events() {
+				AssertStreamContains(_projectedStream, "1@stream-1", "1@stream-2", "1@stream-3");
+			}
+
+			[Test]
+			public void should_not_handle_old_events() {
+				AssertStreamDoesNotContain(_projectedStream, "0@stream-1", "0@stream-2", "0@stream-3");
+			}
+
+			[Test]
+			public void should_write_checkpoint_on_first_handled_event() {
+				var checkpointEvents = _streams[_namesBuilder.MakeCheckpointStreamName()];
+				Assert.AreEqual(1, checkpointEvents.Count);
+				var checkpointMetadata = Encoding.UTF8.GetString(checkpointEvents[0].Metadata);
+
+				var expectedCheckpoint = "\"stream-1\":1,\"stream-2\":-1,\"stream-3\":-1";
+				Assert.True(checkpointMetadata.Contains(expectedCheckpoint),
+					$"Expected checkpoint to contain '{expectedCheckpoint}', but was: '{checkpointMetadata}'");
+			}
+		}
+
+		[TestFixture]
+		public class when_subscribing_from_end_and_restarted : specification_with_a_v8_projection_posted {
+			private readonly string _projectedStream = "projected-stream";
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				// Write an event to force a checkpoint
+				yield return CreateWriteEvent("stream-1", "test", "{\"b\":1}");
+
+				yield return new ProjectionManagementMessage.Command.Disable(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+
+				// Write events between stopping and starting the projection
+				yield return CreateWriteEvent("stream-2", "test", "{\"b\":2}");
+				yield return CreateWriteEvent("stream-3", "test", "{\"b\":3}");
+
+				// Start the projection up again
+				yield return new ProjectionManagementMessage.Command.Enable(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+					_projectionName,
+					"fromStreams(\"stream-1\", \"stream-2\", \"stream-3\").when({$any: function(s,e) { linkTo(\"" +
+					_projectedStream + "\", e) }})",
+					subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_handle_original_event() {
+				AssertStreamContains(_projectedStream, "0@stream-1");
+			}
+
+			[Test]
+			public void should_handle_events_posted_while_disabled() {
+				AssertStreamContains(_projectedStream, "0@stream-2", "0@stream-3");
+			}
+		}
+
+		[TestFixture]
+		public class when_subscribing_from_end_and_reset : specification_with_a_v8_projection_posted {
+			private readonly string _projectedStream = "projected-stream";
+			private readonly ProjectionNamesBuilder _namesBuilder;
+
+			public when_subscribing_from_end_and_reset() {
+				_namesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
+			}
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				yield return CreateWriteEvent("stream-1", "test", "{\"b\":1}");
+				yield return CreateWriteEvent("stream-2", "test", "{\"b\":2}");
+				yield return CreateWriteEvent("stream-3", "test", "{\"b\":3}");
+
+				yield return new ProjectionManagementMessage.Command.Reset(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+
+				yield return CreateWriteEvent("stream-1", "test", "{\"b\":1}");
+				yield return CreateWriteEvent("stream-2", "test", "{\"b\":2}");
+				yield return CreateWriteEvent("stream-3", "test", "{\"b\":3}");
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+					_projectionName,
+					"fromStreams(\"stream-1\", \"stream-2\", \"stream-3\").when({$any: function(s,e) { linkTo(\"" +
+					_projectedStream + "\", e) }})",
+					subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_not_handle_original_events_again() {
+				var eventsData = GetStreamEventData(_projectedStream);
+
+				var notExpected = new[] {"0@stream-1", "0@stream-2", "0@stream-3"};
+				var duplicates = notExpected.Where(v => eventsData.Count(x => x == v) > 1).ToArray();
+
+				Assert.That(duplicates.Length == 0,
+					$"{_projectedStream} contains duplicates : {duplicates.Aggregate("", (a, v) => a + " " + v)}");
+			}
+
+			[Test]
+			public void should_handle_new_events() {
+				AssertStreamContains(_projectedStream, "1@stream-1", "1@stream-2", "1@stream-3");
+			}
+
+			[Test]
+			public void should_write_checkpoint_on_first_handled_event() {
+				var checkpointEvents = _streams[_namesBuilder.MakeCheckpointStreamName()];
+
+				// Projection checkpoints when it is reset
+				Assert.AreEqual(3, checkpointEvents.Count);
+				var checkpointMetadata = Encoding.UTF8.GetString(checkpointEvents[0].Metadata);
+
+				var expectedCheckpoint = "\"stream-1\":0,\"stream-2\":-1,\"stream-3\":-1";
+				Assert.True(checkpointMetadata.Contains(expectedCheckpoint),
+					$"Expected checkpoint to contain '{expectedCheckpoint}', but was: '{checkpointMetadata}'");
+			}
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Integration/projections_starting_from_end/from_stream_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/projections_starting_from_end/from_stream_projection.cs
@@ -1,0 +1,175 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using EventStore.Core.Messaging;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Integration.projections_starting_from_end {
+	public class from_stream_projection {
+		[TestFixture]
+		public class when_subscribing_from_end : specification_with_a_v8_projection_posted {
+			private readonly string _inputStream = "input-stream";
+			private readonly string _projectedStream = "projected-stream";
+			private readonly ProjectionNamesBuilder _namesBuilder;
+
+			public when_subscribing_from_end() {
+				_namesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
+			}
+
+			protected override void GivenEvents() {
+				ExistingEvent(_inputStream, "test", "", "{\"a\":1}");
+				ExistingEvent(_inputStream, "test", "", "{\"a\":2}");
+				ExistingEvent(_inputStream, "test", "", "{\"a\":3}");
+			}
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				// Write some more events
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":1}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":2}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":3}");
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+					_projectionName,
+					"fromStream(\"" + _inputStream + "\").when({$any: function(s,e) { linkTo(\"" +
+					_projectedStream + "\", e) }})",
+					subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_handle_new_events() {
+				AssertStreamContains(_projectedStream, "3@input-stream", "4@input-stream", "5@input-stream");
+			}
+
+			[Test]
+			public void should_not_handle_old_events() {
+				AssertStreamDoesNotContain(_projectedStream, "0@input-stream", "1@input-stream", "2@input-stream");
+			}
+
+			[Test]
+			public void should_write_checkpoint_on_first_handled_event() {
+				var checkpointEvents = _streams[_namesBuilder.MakeCheckpointStreamName()];
+				Assert.AreEqual(1, checkpointEvents.Count);
+				var checkpointMetadata = Encoding.UTF8.GetString(checkpointEvents[0].Metadata);
+
+				Assert.True(checkpointMetadata.Contains("\"" + _inputStream + "\":3"),
+					$"Expected checkpoint to contain '{_inputStream}:3', but was: '{checkpointMetadata}'");
+			}
+		}
+
+		[TestFixture]
+		public class when_subscribing_from_end_and_reset : specification_with_a_v8_projection_posted {
+			private readonly string _inputStream = "input-stream";
+			private readonly string _projectedStream = "projected-stream";
+			private readonly ProjectionNamesBuilder _namesBuilder;
+
+			public when_subscribing_from_end_and_reset() {
+				_namesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
+			}
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				// Write some more events
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":1}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":2}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":3}");
+
+				yield return new ProjectionManagementMessage.Command.Reset(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":4}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":5}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":6}");
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+					_projectionName,
+					"fromStream(\"" + _inputStream + "\").when({$any: function(s,e) { linkTo(\"" +
+					_projectedStream + "\", e) }})",
+					subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_have_truncated_output_stream() {
+				AssertStreamMetadata(_projectedStream, "\"$tb\":3");
+			}
+
+			[Test]
+			public void should_not_handle_original_events_again() {
+				var eventsData = GetStreamEventData(_projectedStream);
+
+				var notExpected = new[] {"0@input-stream", "1@input-stream", "2@input-stream"};
+				var duplicates = notExpected.Where(v => eventsData.Count(x => x == v) > 1).ToArray();
+
+				Assert.That(duplicates.Length == 0,
+					$"{_projectedStream} contains duplicates : {duplicates.Aggregate("", (a, v) => a + " " + v)}");
+			}
+
+			[Test]
+			public void should_handle_new_events() {
+				AssertStreamContains(_projectedStream, "3@input-stream", "4@input-stream", "5@input-stream");
+			}
+
+			[Test]
+			public void should_write_checkpoint_on_first_handled_event_after_reset() {
+				var checkpointEvents = _streams[_namesBuilder.MakeCheckpointStreamName()];
+
+				// Projection checkpoints when it is reset
+				Assert.AreEqual(3, checkpointEvents.Count);
+				var checkpointMetadata = Encoding.UTF8.GetString(checkpointEvents.Last().Metadata);
+
+				Assert.True(checkpointMetadata.Contains("\"" + _inputStream + "\":3"),
+					$"Expected checkpoint to contain '{_inputStream}:3', but was: '{checkpointMetadata}'");
+			}
+		}
+
+		[TestFixture]
+		public class when_subscribing_from_end_and_restarted : specification_with_a_v8_projection_posted {
+			private readonly string _inputStream = "input-stream";
+			private readonly string _projectedStream = "projected-stream";
+
+			protected override IEnumerable<WhenStep> When() {
+				foreach (var e in base.When()) yield return e;
+
+				// Write an event to force the checkpoint
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":1}");
+
+				yield return new ProjectionManagementMessage.Command.Disable(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+
+				// Write events between stopping and starting the projection
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":2}");
+				yield return CreateWriteEvent(_inputStream, "test", "{\"b\":3}");
+
+				// Start the projection up again
+				yield return new ProjectionManagementMessage.Command.Enable(new NoopEnvelope(), _projectionName,
+					ProjectionManagementMessage.RunAs.System);
+			}
+
+			protected override ProjectionManagementMessage.Command.Post GivenProjection() {
+				return CreateNewProjectionMessage(
+					_projectionName,
+					"fromStream(\"" + _inputStream + "\").when({$any: function(s,e) { linkTo(\"" +
+					_projectedStream + "\", e) }})",
+					subscribeFromEnd: true);
+			}
+
+			[Test]
+			public void should_handle_original_event() {
+				AssertStreamContains(_projectedStream, "0@input-stream");
+			}
+
+			[Test]
+			public void should_handle_events_posted_while_disabled() {
+				AssertStreamContains(_projectedStream, "1@input-stream", "2@input-stream");
+			}
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_projection_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_projection_posted.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using EventStore.Core.Bus;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Projections.Core.Tests.Services.projections_manager;
+
+namespace EventStore.Projections.Core.Tests.Integration {
+	public abstract class specification_with_a_v8_projection_posted
+		: TestFixtureWithProjectionCoreAndManagementServices {
+		protected string _projectionName = "test-projection";
+
+		protected override void Given() {
+			base.Given();
+			AllWritesSucceed();
+			NoOtherStreams();
+			GivenEvents();
+			EnableReadAll();
+		}
+
+		protected override Tuple<IBus, IPublisher, InMemoryBus, TimeoutScheduler, Guid>[] GivenProcessingQueues() {
+			var buses = new IBus[] {new InMemoryBus("1"), new InMemoryBus("2")};
+			var outBuses = new[] {new InMemoryBus("o1"), new InMemoryBus("o2")};
+			_otherQueues = new ManualQueue[]
+				{new ManualQueue(buses[0], _timeProvider), new ManualQueue(buses[1], _timeProvider)};
+			return new[] {
+				Tuple.Create(
+					buses[0],
+					(IPublisher)_otherQueues[0],
+					outBuses[0],
+					default(TimeoutScheduler),
+					Guid.NewGuid()),
+				Tuple.Create(
+					buses[1],
+					(IPublisher)_otherQueues[1],
+					outBuses[1],
+					default(TimeoutScheduler),
+					Guid.NewGuid())
+			};
+		}
+
+		protected virtual void GivenEvents() {}
+
+		protected abstract ProjectionManagementMessage.Command.Post GivenProjection();
+
+		protected ProjectionManagementMessage.Command.Post CreateNewProjectionMessage
+			(string name, string source, bool subscribeFromEnd = false) {
+			return new ProjectionManagementMessage.Command.Post(
+				new PublishEnvelope(_bus), ProjectionMode.Continuous, name, ProjectionManagementMessage.RunAs.System,
+				"JS", source, enabled: true, checkpointsEnabled: true, trackEmittedStreams: true, emitEnabled: true,
+				subscribeFromEnd: subscribeFromEnd);
+		}
+
+		protected override IEnumerable<WhenStep> When() {
+			yield return (new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid()));
+
+			yield return GivenProjection();
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/specification_with_a_v8_query_posted.cs
@@ -68,13 +68,14 @@ namespace EventStore.Projections.Core.Tests.Integration {
 				new PublishEnvelope(_bus), ProjectionMode.Transient, name,
 				ProjectionManagementMessage.RunAs.System, "JS", source, enabled: true, checkpointsEnabled: false,
 				trackEmittedStreams: false,
-				emitEnabled: false);
+				emitEnabled: false, subscribeFromEnd: false);
 		}
 
 		protected Message CreateNewProjectionMessage(string name, string source) {
 			return new ProjectionManagementMessage.Command.Post(
 				new PublishEnvelope(_bus), ProjectionMode.Continuous, name, ProjectionManagementMessage.RunAs.System,
-				"JS", source, enabled: true, checkpointsEnabled: true, trackEmittedStreams: true, emitEnabled: true);
+				"JS", source, enabled: true, checkpointsEnabled: true, trackEmittedStreams: true, emitEnabled: true,
+				subscribeFromEnd: false);
 		}
 
 		protected override IEnumerable<WhenStep> When() {
@@ -106,7 +107,7 @@ namespace EventStore.Projections.Core.Tests.Integration {
 						new PublishEnvelope(_bus), ProjectionMode.Continuous, "other_" + index,
 						ProjectionManagementMessage.RunAs.System, "JS", source, enabled: true, checkpointsEnabled: true,
 						trackEmittedStreams: true,
-						emitEnabled: true));
+						emitEnabled: true, subscribeFromEnd: false));
 				index++;
 			}
 
@@ -116,7 +117,7 @@ namespace EventStore.Projections.Core.Tests.Integration {
 						new PublishEnvelope(_bus), _projectionMode, _projectionName,
 						ProjectionManagementMessage.RunAs.System, "JS", _projectionSource, enabled: true,
 						checkpointsEnabled: _checkpointsEnabled, emitEnabled: _emitEnabled,
-						trackEmittedStreams: _trackEmittedStreams));
+						trackEmittedStreams: _trackEmittedStreams, subscribeFromEnd: false));
 			}
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services {
 			_projectionNamesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
 			_emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher,
 				new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false,
-					_trackEmittedStreams, 10000, 1), _projectionNamesBuilder);
+					_trackEmittedStreams, 10000, 1, false), _projectionNamesBuilder);
 			_emittedStreamsDeleter = new EmittedStreamsDeleter(_ioDispatcher,
 				_projectionNamesBuilder.GetEmittedStreamsName(),
 				_projectionNamesBuilder.GetEmittedStreamsCheckpointName());

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
@@ -93,7 +93,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold, GivenPendingEventsThreshold(),
 				GivenMaxWriteBatchLength(), GivenEmitEventEnabled(), GivenCheckpointsEnabled(), _createTempStreams,
 				GivenStopOnEof(), GivenTrackEmittedStreams(), GivenCheckpointAfterMs(),
-				GivenMaximumAllowedWritesInFlight());
+				GivenMaximumAllowedWritesInFlight(), GivenSubscribeFromEnd());
 		}
 
 		protected virtual int GivenMaxWriteBatchLength() {
@@ -128,6 +128,10 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 			return 1;
 		}
 
+		protected virtual bool GivenSubscribeFromEnd() {
+			return false;
+		}
+		
 		protected virtual FakeProjectionStateHandler GivenProjectionStateHandler() {
 			return new FakeProjectionStateHandler(configureBuilder: _configureBuilderByQuerySource);
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/TestFixtureWithCoreProjectionCheckpointManager.cs
@@ -29,6 +29,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
 		protected CoreProjectionCheckpointReader _checkpointReader;
 		protected string _projectionName;
 		protected ProjectionVersion _projectionVersion;
+		protected bool _subscribeFromEnd;
 
 		[SetUp]
 		public void setup() {
@@ -37,7 +38,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
 			_config = new ProjectionConfig(null, _checkpointHandledThreshold, _checkpointUnhandledBytesThreshold,
 				_pendingEventsThreshold, _maxWriteBatchLength, _emitEventEnabled,
 				_checkpointsEnabled, _createTempStreams, _stopOnEof, _trackEmittedStreams, _checkpointAfterMs,
-				_maximumAllowedWritesInFlight);
+				_maximumAllowedWritesInFlight, _subscribeFromEnd);
 			When();
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/with_multi_stream_checkpoint_manager.cs
@@ -35,7 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
 			_projectionVersion = new ProjectionVersion(3, 1, 2);
 			_projectionConfig = new ProjectionConfig(SystemAccount.Principal, 10, 1000, 1000, 10, true, true, true,
 				false,
-				false, 5000, 10);
+				false, 5000, 10, false);
 			_positionTagger = new MultiStreamPositionTagger(3, _streams);
 			_positionTagger.AdjustTag(CheckpointTag.FromStreamPositions(3,
 				new Dictionary<string, long> {{"a", 0}, {"b", 0}, {"c", 0}}));

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
@@ -21,7 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 		}
 
 		private readonly ProjectionConfig _defaultProjectionConfig = new ProjectionConfig(
-			null, 5, 10, 1000, 250, true, true, true, true, true, 10000, 1);
+			null, 5, 10, 1000, 250, true, true, true, true, true, 10000, 1, false);
 
 		private IODispatcher _ioDispatcher;
 
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, 10, 5, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, false);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,
@@ -63,7 +63,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, -1, 10, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, false);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,
@@ -255,7 +255,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 				var version = new ProjectionVersion(1, 0, 0);
 				var projectionConfig = new ProjectionConfig(null, 0, 10, 1000, 250, true, true, false, false,
-					true, 10000, 1);
+					true, 10000, 1, false);
 				new ContinuousProjectionProcessingStrategy(
 					"projection",
 					version,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 			_bus.Subscribe(_ioDispatcher);
 			IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 			_projectionConfig =
-				new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, true, 10000, 1);
+				new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, true, 10000, 1, false);
 			var version = new ProjectionVersion(1, 0, 0);
 			var projectionProcessingStrategy = new ContinuousProjectionProcessingStrategy(
 				"projection", version, projectionStateHandler, _projectionConfig,

--- a/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_service {
 			_readerService.Handle(
 				new ReaderSubscriptionManagement.Subscribe(
 					projectionCorrelationId, CheckpointTag.FromPosition(0, 0, 0), readerStrategy,
-					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
+					new ReaderSubscriptionOptions(1000, 2000, 10000, false,  null, false)));
 			_readerService.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					readerStrategy.EventReaderId, new TFPos(20, 10), "throws", 10, false, Guid.NewGuid(),

--- a/src/EventStore.Projections.Core.Tests/Services/core_service/when_unsubscribing_a_subscribed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_service/when_unsubscribing_a_subscribed_projection.cs
@@ -21,11 +21,13 @@ namespace EventStore.Projections.Core.Tests.Services.core_service {
 			_readerService.Handle(
 				new ReaderSubscriptionManagement.Subscribe(
 					_projectionCorrelationId, CheckpointTag.FromPosition(0, 0, 0), CreateReaderStrategy(),
-					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
+					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null,
+						subscribeFromEnd: false)));
 			_readerService.Handle(
 				new ReaderSubscriptionManagement.Subscribe(
 					_projectionCorrelationId2, CheckpointTag.FromPosition(0, 0, 0), CreateReaderStrategy(),
-					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
+					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null,
+						subscribeFromEnd: false)));
 			// when
 			_readerService.Handle(new ReaderSubscriptionManagement.Unsubscribe(_projectionCorrelationId));
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/TestFixtureWithEventReaderService.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/TestFixtureWithEventReaderService.cs
@@ -34,7 +34,6 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader {
 			_subscriptionDispatcher =
 				new ReaderSubscriptionDispatcher(GetInputQueue());
 
-
 			_bus.Subscribe(
 				_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.CheckpointSuggested>());
 			_bus.Subscribe(
@@ -48,7 +47,6 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader {
 			_bus.Subscribe(_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.NotAuthorized>());
 			_bus.Subscribe(
 				_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.ReaderAssignedReader>());
-
 
 			_bus.Subscribe<ReaderCoreServiceMessage.StartReader>(_readerService);
 			_bus.Subscribe<ReaderCoreServiceMessage.StopReader>(_readerService);
@@ -79,10 +77,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader {
 		}
 
 		protected Guid GetReaderId() {
-			var readerAssignedMessage =
-				_consumer.HandledMessages.OfType<EventReaderSubscriptionMessage.ReaderAssignedReader>().LastOrDefault();
-			Assert.IsNotNull(readerAssignedMessage);
-			var reader = readerAssignedMessage.ReaderId;
+			var readerStartingMessage =
+				_consumer.HandledMessages.OfType<ReaderSubscriptionMessage.EventReaderIdle>().LastOrDefault();
+			Assert.IsNotNull(readerStartingMessage);
+			var reader = readerStartingMessage.CorrelationId;
 			return reader;
 		}
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_including_links.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_including_links.cs
@@ -49,7 +49,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.all_streams_wi
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: true,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null, subscribeFromEnd: false);
 			}
 
 			protected override IEnumerable<WhenStep> When() {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_not_including_links.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_not_including_links.cs
@@ -49,7 +49,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.all_streams_wi
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: true,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null, subscribeFromEnd: false);
 			}
 
 			protected override IEnumerable<WhenStep> When() {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
@@ -48,7 +48,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: false,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null, subscribeFromEnd: false);
 			}
 
 			protected abstract void GivenInitialIndexState();

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_one_event_type_has_been_never_emitted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_one_event_type_has_been_never_emitted.cs
@@ -54,7 +54,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: false,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null, subscribeFromEnd: false);
 			}
 
 			protected abstract void GivenInitialIndexState();

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_reordering_happens_in_event_by_type_index.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_reordering_happens_in_event_by_type_index.cs
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: false,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null, subscribeFromEnd: false);
 			}
 
 			protected abstract void GivenInitialIndexState();

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_reader_core_service/when_starting_reader_from_end_with_existing_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_reader_core_service/when_starting_reader_from_end_with_existing_checkpoint.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.event_reader.heading_event_reader;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.event_reader_core_service {
+	[TestFixture]
+	public class when_starting_reader_from_end_with_existing_checkpoint : TestFixtureWithEventReaderService {
+		private FakeReaderSubscription _subscription;
+		private Guid _headingEventReaderId;
+
+		protected override bool GivenHeadingReaderRunning() {
+			return true;
+		}
+		
+		[SetUp]
+		public new void When() {
+			_headingEventReaderId = GetReaderId();
+
+			var firstEvent =
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					_headingEventReaderId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]);
+			_readerService.Handle(firstEvent);
+			_readerService.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					_headingEventReaderId, new TFPos(40, 30), "stream", 11, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+			_readerService.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					_headingEventReaderId, new TFPos(60, 50), "stream", 12, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+        		
+			_subscription = new FakeReaderSubscription();
+			var readerStrategy = new FakeReaderStrategy(_subscription);
+			var zeroTag = readerStrategy.PositionTagger.MakeZeroCheckpointTag();
+			var readerSubscriptionOptions = new ReaderSubscriptionOptions
+				(10000, 4000, 10000, false, null, subscribeFromEnd: true);
+			
+			// Create a checkpoint for the first event
+			var checkpoint = readerStrategy.PositionTagger.MakeCheckpointTag(zeroTag, firstEvent);
+
+			var subscribeMessage = new ReaderSubscriptionManagement.Subscribe
+				(Guid.NewGuid(), checkpoint, readerStrategy, readerSubscriptionOptions);
+			
+			_readerService.Handle(subscribeMessage);
+			var readerId = _subscription.EventReader.EventReaderId;
+			
+			// Send committed event distributed to the reader with a safe join position.
+			// This will switch the projection over to the heading event reader and catch up missed events
+			_readerService.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					readerId, new TFPos(60, 50), new TFPos(60, 50), "stream", 12, "stream", 12, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0], 30, 100f));
+			
+			// Send a new event to the heading event reader
+			_readerService.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					_headingEventReaderId, new TFPos(80, 70), "stream", 13, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+		}
+
+		[Test]
+		public void it_does_not_get_the_event_before_the_checkpoint() {
+			Assert.AreEqual(false, _subscription.ReceivedEvents
+				.Any(v => v.Data.Position.PreparePosition <= 10));
+		}
+		
+		[Test]
+		public void it_gets_the_event_after_the_checkpoint_and_before_subscribing_to_the_heading_event_reader() {
+			Assert.AreEqual(true, _subscription.ReceivedEvents
+				.Any(v => v.Data.Position.PreparePosition == 30));
+		}
+
+		[Test]
+		public void it_gets_the_events_after_subscribing() {
+			Assert.AreEqual(true, _subscription.ReceivedEvents
+				.Any(v => v.Data.Position.PreparePosition == 50 
+				          || v.Data.Position.PreparePosition == 70));
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_reader_core_service/when_starting_reader_from_end_without_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_reader_core_service/when_starting_reader_from_end_without_checkpoint.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.event_reader.heading_event_reader;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.event_reader_core_service {
+	[TestFixture]
+	public class when_starting_reader_from_end_without_checkpoint : TestFixtureWithEventReaderService {
+		private FakeReaderSubscription _subscription;
+
+		protected override bool GivenHeadingReaderRunning() {
+			return true;
+		}
+		
+		[SetUp]
+		public new void When() {
+			var headingEventReaderId = GetReaderId();
+			
+			_readerService.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					headingEventReaderId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+			_readerService.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					headingEventReaderId, new TFPos(40, 30), "stream", 11, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+			
+			_subscription = new FakeReaderSubscription();
+			var readerStrategy = new FakeReaderStrategy(_subscription);
+			var zeroTag = readerStrategy.PositionTagger.MakeZeroCheckpointTag();
+			var readerSubscriptionOptions = new ReaderSubscriptionOptions
+				(10000, 4000, 10000, false, null, subscribeFromEnd: true);
+			
+			var subscribeMessage = new ReaderSubscriptionManagement.Subscribe
+				(Guid.NewGuid(), zeroTag, readerStrategy, readerSubscriptionOptions);
+			
+			_readerService.Handle(subscribeMessage);
+			
+			_readerService.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					headingEventReaderId, new TFPos(60, 50), "stream", 12, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+		}
+
+		[Test]
+		public void it_does_not_get_events_before_subscribing() {
+			Assert.AreEqual(false, _subscription.ReceivedEvents
+				.Any(v => v.Data.Position.PreparePosition <= 30));
+		}
+
+		[Test]
+		public void it_gets_events_after_subscribing() {
+			Assert.AreEqual(true, _subscription.ReceivedEvents
+				.Any(v => v.Data.Position.PreparePosition == 50));
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/FakeReaderSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/FakeReaderSubscription.cs
@@ -137,7 +137,11 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
 	public class FakeReaderStrategy : IReaderStrategy {
 		public EventFilter EventFilter { get; set; }
 		public bool IsReadingOrderRepeatable { get; set; }
-		public PositionTagger PositionTagger { get; set; }
+
+		public PositionTagger PositionTagger {
+			get { return new TransactionFilePositionTagger(0); }
+		}
+
 		private FakeReaderSubscription _subscription;
 
 		public Guid EventReaderId {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/FakeReaderSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/FakeReaderSubscription.cs
@@ -148,6 +148,13 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
 			get { return _subscription.EventReader.EventReaderId; }
 		}
 
+		public FakeReaderStrategy() {
+		}
+
+		public FakeReaderStrategy(FakeReaderSubscription subscription) {
+			_subscription = subscription;
+		}
+
 		public IEventReader CreatePausedEventReader(Guid eventReaderId, IPublisher publisher, IODispatcher ioDispatcher,
 			CheckpointTag checkpointTag, bool stopOnEof, int? stopAfterNEvents) {
 			throw new NotImplementedException();
@@ -155,7 +162,9 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
 
 		public IReaderSubscription CreateReaderSubscription(IPublisher publisher, CheckpointTag fromCheckpointTag,
 			Guid subscriptionId, ReaderSubscriptionOptions readerSubscriptionOptions) {
-			_subscription = new FakeReaderSubscription();
+			if (_subscription is null) {
+				_subscription = new FakeReaderSubscription();
+			}
 			return _subscription;
 		}
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_subscribes_a_projection_to_the_end.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/when_the_heading_event_reader_subscribes_a_projection_to_the_end.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_reader {
+	[TestFixture]
+	public class when_the_heading_event_reader_subscribes_a_projection_to_the_end : TestFixtureWithReadWriteDispatchers {
+		private HeadingEventReader _point;
+		private Exception _exception;
+		private Guid _distributionPointCorrelationId;
+		private FakeReaderSubscription _subscription;
+		private Guid _projectionSubscriptionId;
+
+		[SetUp]
+		public void setup() {
+			_exception = null;
+			try {
+				_point = new HeadingEventReader(10, _bus);
+			} catch (Exception ex) {
+				_exception = ex;
+			}
+
+			Assume.That(_exception == null);
+
+			_distributionPointCorrelationId = Guid.NewGuid();
+			_point.Start(
+				_distributionPointCorrelationId,
+				new TransactionFileEventReader(_bus, _distributionPointCorrelationId, null, new TFPos(0, -1),
+					new RealTimeProvider()));
+			_point.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					_distributionPointCorrelationId, new TFPos(20, 10), "stream", 10, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+			_point.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					_distributionPointCorrelationId, new TFPos(40, 30), "stream", 11, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+			_subscription = new FakeReaderSubscription();
+			_projectionSubscriptionId = Guid.NewGuid();
+			_point.TrySubscribeFromEnd(_projectionSubscriptionId, _subscription);
+			_point.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					_distributionPointCorrelationId, new TFPos(60, 50), "stream", 12, false, Guid.NewGuid(),
+					"type", false, new byte[0], new byte[0]));
+		}
+
+
+		[Test]
+		public void projection_should_not_receive_cached_events() {
+			Assert.AreEqual(false, _subscription.ReceivedEvents.Any(v => v.Data.Position.PreparePosition <= 30));
+		}
+
+		[Test]
+		public void projection_should_receive_event_committed_after_subscribing() {
+			Assert.AreEqual(true, _subscription.ReceivedEvents.Any(v => v.Data.Position.PreparePosition == 50));
+		}
+
+		[Test]
+		public void it_can_be_unsubscribed() {
+			_point.Unsubscribe(_projectionSubscriptionId);
+		}
+
+		[Test]
+		public void no_other_projection_can_subscribe_with_the_same_projection_id() {
+			Assert.Throws<InvalidOperationException>(() => {
+				_point.TrySubscribe(_projectionSubscriptionId, _subscription, 30);
+			});
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/reordering.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/reordering.cs
@@ -45,7 +45,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: false,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null, subscribeFromEnd: false);
 			}
 
 			protected abstract void GivenOtherEvents();

--- a/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/TestFixtureWithEventReorderingProjectionSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/TestFixtureWithEventReorderingProjectionSubscription.cs
@@ -10,6 +10,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 	public abstract class TestFixtureWithEventReorderingProjectionSubscription : TestFixtureWithProjectionSubscription {
 		protected int _timeBetweenEvents;
 		protected int _processingLagMs;
+		protected bool _subscribeFromEnd;
 
 		protected override void Given() {
 			_timeBetweenEvents = 1100;
@@ -32,7 +33,7 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 				_readerStrategy,
 				_timeProvider,
 				_checkpointUnhandledBytesThreshold, _checkpointProcessedEventsThreshold, _checkpointAfterMs,
-				_processingLagMs);
+				_processingLagMs, _subscribeFromEnd);
 		}
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/when_creating_projection_subscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/when_creating_projection_subscription.cs
@@ -19,7 +19,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 				1000,
 				2000,
 				10000,
-				500);
+				500,
+				false);
 		}
 
 		[Test]
@@ -34,7 +35,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 					1000,
 					2000,
 					10000,
-					500);
+					500,
+					false);
 			});
 		}
 
@@ -50,7 +52,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 					1000,
 					2000,
 					10000,
-					500);
+					500,
+					false);
 			});
 		}
 
@@ -66,7 +69,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 					1000,
 					2000,
 					10000,
-					500);
+					500,
+					false);
 			});
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
@@ -26,6 +26,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 		protected int _checkpointUnhandledBytesThreshold;
 		protected int _checkpointProcessedEventsThreshold;
 		protected int _checkpointAfterMs;
+		protected bool _checkpointFirstEvent;
 		protected IReaderStrategy _readerStrategy;
 
 		[SetUp]
@@ -33,6 +34,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 			_checkpointUnhandledBytesThreshold = 1000;
 			_checkpointProcessedEventsThreshold = 2000;
 			_checkpointAfterMs = 10000;
+			_checkpointFirstEvent = false;
 			_timeProvider = new RealTimeProvider();
 			Given();
 			_bus = new InMemoryBus("bus");
@@ -68,7 +70,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 				_timeProvider,
 				_checkpointUnhandledBytesThreshold,
 				_checkpointProcessedEventsThreshold,
-				_checkpointAfterMs);
+				_checkpointAfterMs,
+				_checkpointFirstEvent);
 		}
 
 		protected virtual void Given() {

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_creating_projection_subscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_creating_projection_subscription.cs
@@ -19,7 +19,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 				new FakeTimeProvider(),
 				1000,
 				2000,
-				10000);
+				10000,
+				false);
 		}
 
 		[Test]
@@ -34,7 +35,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					new FakeTimeProvider(),
 					1000,
 					2000,
-					10000);
+					10000,
+					false);
 			});
 		}
 
@@ -50,7 +52,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					new FakeTimeProvider(),
 					1000,
 					2000,
-					10000);
+					10000,
+					false);
 			});
 		}
 
@@ -66,7 +69,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					null,
 					1000,
 					2000,
-					10000);
+					10000,
+					false);
 			});
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_event_with_checkpoint_first_event_enabled.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_event_with_checkpoint_first_event_enabled.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
+	[TestFixture]
+	public class when_handling_event_with_checkpoint_first_event_enabled : TestFixtureWithProjectionSubscription {
+		protected override void Given() {
+			_checkpointFirstEvent = true;
+		}
+
+		protected override void When() {
+			_subscription.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+					"bad-event-type", false, new byte[0], new byte[0]));
+		}
+
+		[Test]
+		public void checkpoint_is_suggested() {
+			Assert.AreEqual(1, _checkpointHandler.HandledMessages.Count);
+		}
+	}
+	
+	[TestFixture]
+	public class when_handling_event_that_does_not_pass_filter_with_checkpoint_first_event_enabled
+		: TestFixtureWithProjectionSubscription {
+		protected override void Given() {
+			_checkpointFirstEvent = true;
+			_source = source => {
+				source.FromAll();
+				source.IncludeEvent("specific-event");
+			};
+		}
+
+		protected override void When() {
+			_subscription.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+					"bad-event-type", false, new byte[0], new byte[0]));
+		}
+
+		[Test]
+		public void checkpoint_is_suggested() {
+			Assert.AreEqual(1, _checkpointHandler.HandledMessages.Count);
+		}
+	}
+	
+	[TestFixture]
+	public class when_handling_event_that_does_not_belong_to_stream_with_checkpoint_first_event_enabled
+		: TestFixtureWithProjectionSubscription {
+		protected override void Given() {
+			_checkpointFirstEvent = true;
+			_source = source => {
+				source.FromStream("test-stream");
+				source.IncludeEvent("specific-event");
+			};
+		}
+
+		protected override void When() {
+			_subscription.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					Guid.NewGuid(), new TFPos(200, 200), "bad-stream", 1, false, Guid.NewGuid(),
+					"bad-event-type", false, new byte[0], new byte[0]));
+		}
+
+		[Test]
+		public void checkpoint_is_not_suggested() {
+			Assert.IsEmpty(_checkpointHandler.HandledMessages);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -125,7 +125,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			InMemoryBus output_,
 			ISingletonTimeoutScheduler timeoutScheduler) {
 			var output = (output_ ?? inputQueue);
-			ICheckpoint writerCheckpoint = new InMemoryCheckpoint(1000);
+			ICheckpoint writerCheckpoint = new InMemoryCheckpoint(0);
 			var readerService = new EventReaderCoreService(
 				output,
 				_ioDispatcher,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/bi_state/a_new_posted_projection.cs
@@ -21,6 +21,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
 			protected bool _checkpointsEnabled;
 			protected bool _trackEmittedStreams;
 			protected bool _emitEnabled;
+			protected bool _subscribeFromEnd;
 
 			protected override void Given() {
 				base.Given();
@@ -34,6 +35,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
 				_checkpointsEnabled = true;
 				_trackEmittedStreams = true;
 				_emitEnabled = false;
+				_subscribeFromEnd = false;
 			}
 
 			protected override IEnumerable<WhenStep> When() {
@@ -44,7 +46,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.bi_stat
 						ProjectionManagementMessage.RunAs.System, "native:" + _fakeProjectionType.AssemblyQualifiedName,
 						_projectionSource, enabled: true, checkpointsEnabled: _checkpointsEnabled,
 						trackEmittedStreams: _trackEmittedStreams,
-						emitEnabled: _emitEnabled));
+						emitEnabled: _emitEnabled, subscribeFromEnd: _subscribeFromEnd));
 			}
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/continuous/a_new_posted_projection.cs
@@ -49,7 +49,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.continu
 						"native:" + _fakeProjectionType.AssemblyQualifiedName, _projectionSource,
 						enabled: _projectionEnabled,
 						checkpointsEnabled: _checkpointsEnabled, trackEmittedStreams: _trackEmittedStreams,
-						emitEnabled: _emitEnabled));
+						emitEnabled: _emitEnabled, subscribeFromEnd: false));
 			}
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_a_managed_projection_state.cs
@@ -51,7 +51,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 				ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
 					new NoopEnvelope(), ProjectionMode.OneTime, "name", ProjectionManagementMessage.RunAs.Anonymous,
 					(string)null, @"log(1);", enabled: true, checkpointsEnabled: false, emitEnabled: false,
-					trackEmittedStreams: false);
+					trackEmittedStreams: false, subscribeFromEnd: false);
 				_mp.InitializeNew(
 					new ManagedProjection.PersistedState {
 						Enabled = message.Enabled,
@@ -74,7 +74,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 				ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
 					new NoopEnvelope(), ProjectionMode.OneTime, "name", ProjectionManagementMessage.RunAs.Anonymous, "",
 					@"log(1);", enabled: true, checkpointsEnabled: false, emitEnabled: false,
-					trackEmittedStreams: false);
+					trackEmittedStreams: false, subscribeFromEnd: false);
 				_mp.InitializeNew(
 					new ManagedProjection.PersistedState {
 						Enabled = message.Enabled,
@@ -97,7 +97,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 				ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
 					new NoopEnvelope(), ProjectionMode.OneTime, "name", ProjectionManagementMessage.RunAs.Anonymous,
 					"JS", query: null, enabled: true, checkpointsEnabled: false, emitEnabled: false,
-					trackEmittedStreams: false);
+					trackEmittedStreams: false, subscribeFromEnd: false);
 				_mp.InitializeNew(
 					new ManagedProjection.PersistedState {
 						Enabled = message.Enabled,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_persisted_state_write_fails.cs
@@ -83,7 +83,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 		protected override IEnumerable<WhenStep> When() {
 			ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
 				Envelope, ProjectionMode.OneTime, _projectionName, ProjectionManagementMessage.RunAs.System,
-				typeof(FakeForeachStreamProjection), "", true, false, false, false);
+				typeof(FakeForeachStreamProjection), "", true, false, false, false, false);
 			_managedProjection.InitializeNew(
 				new ManagedProjection.PersistedState {
 					Enabled = message.Enabled,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_follower_projections.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_starting_a_managed_projection_without_follower_projections.cs
@@ -64,7 +64,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 		protected override IEnumerable<WhenStep> When() {
 			ProjectionManagementMessage.Command.Post message = new ProjectionManagementMessage.Command.Post(
 				Envelope, ProjectionMode.Transient, _projectionName, ProjectionManagementMessage.RunAs.System,
-				typeof(FakeForeachStreamProjection), "", true, false, false, false);
+				typeof(FakeForeachStreamProjection), "", true, false, false, false, false);
 			_mp.InitializeNew(
 				new ManagedProjection.PersistedState {
 					Enabled = message.Enabled,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_updating_projection_config.cs
@@ -34,7 +34,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 			CheckpointUnhandledBytesThreshold = 3,
 			PendingEventsThreshold = 4,
 			MaxWriteBatchLength = 5,
-			MaxAllowedWritesInFlight = 6
+			MaxAllowedWritesInFlight = 6,
+			SubscribeFromEnd = true,
 		};
 
 		public when_getting_config() {
@@ -70,6 +71,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 			Assert.AreEqual(_persistedState.MaxWriteBatchLength, _config.MaxWriteBatchLength, "MaxWriteBatchLength");
 			Assert.AreEqual(_persistedState.MaxAllowedWritesInFlight, _config.MaxAllowedWritesInFlight,
 				"MaxAllowedWritesInFlight");
+			Assert.AreEqual(_persistedState.SubscribeFromEnd, _config.SubscribeFromEnd,
+				"SubscribeFromEnd");
 		}
 	}
 
@@ -143,6 +146,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 			Assert.AreEqual(_updateConfig.PendingEventsThreshold, getConfigResult.PendingEventsThreshold);
 			Assert.AreEqual(_updateConfig.MaxWriteBatchLength, getConfigResult.MaxWriteBatchLength);
 			Assert.AreEqual(_updateConfig.MaxAllowedWritesInFlight, getConfigResult.MaxAllowedWritesInFlight);
+			Assert.AreEqual(_updateConfig.SubscribeFromEnd, getConfigResult.SubscribeFromEnd);
 		}
 	}
 
@@ -219,6 +223,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 				"MaxWriteBatchLength");
 			Assert.AreEqual(_persistedState.MaxAllowedWritesInFlight, getConfigResult.MaxAllowedWritesInFlight,
 				"MaxAllowedWritesInFlight");
+			Assert.AreEqual(_persistedState.SubscribeFromEnd, getConfigResult.SubscribeFromEnd,
+				"SubscribeFromEnd");
 		}
 	}
 
@@ -252,7 +258,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed
 
 		protected ProjectionManagementMessage.Command.UpdateConfig CreateConfig() {
 			return new ProjectionManagementMessage.Command.UpdateConfig(
-				new NoopEnvelope(), "name", true, false, 100, 200, 300, 400, 500, 600,
+				new NoopEnvelope(), "name", true, false, 100, 200, 300, 400, 500, 600, true,
 				ProjectionManagementMessage.RunAs.Anonymous);
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_new_posted_projection.cs
@@ -18,6 +18,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query {
 			protected bool _checkpointsEnabled;
 			protected bool _trackEmittedStreams;
 			protected bool _emitEnabled;
+			protected bool _subscribeFromEnd;
 
 			protected override void Given() {
 				base.Given();
@@ -29,6 +30,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query {
 				_checkpointsEnabled = false;
 				_trackEmittedStreams = false;
 				_emitEnabled = false;
+				_subscribeFromEnd = false;
 				NoOtherStreams();
 			}
 
@@ -39,7 +41,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query {
 						new PublishEnvelope(_bus), _projectionMode, _projectionName,
 						ProjectionManagementMessage.RunAs.System, "native:" + _fakeProjectionType.AssemblyQualifiedName,
 						_projectionSource, enabled: true, checkpointsEnabled: _checkpointsEnabled,
-						emitEnabled: _emitEnabled, trackEmittedStreams: _trackEmittedStreams));
+						emitEnabled: _emitEnabled, trackEmittedStreams: _trackEmittedStreams, 
+						subscribeFromEnd: _subscribeFromEnd));
 			}
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
@@ -33,7 +33,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 					new ProjectionManagementMessage.Command.Post(
 						new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
 						new ProjectionManagementMessage.RunAs(_testUserPrincipal), "JS", _projectionBody, enabled: true,
-						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
+						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, subscribeFromEnd: false,
+						enableRunAs: true);
 			}
 
 			[Test, Ignore("Persistent projections are admin only")]
@@ -81,7 +82,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 					new ProjectionManagementMessage.Command.Post(
 						new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
 						ProjectionManagementMessage.RunAs.Anonymous, "JS", _projectionBody, enabled: true,
-						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
+						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, subscribeFromEnd: false,
+						enableRunAs: true);
 			}
 
 			[Test]
@@ -117,7 +119,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 					new ProjectionManagementMessage.Command.Post(
 						new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
 						new ProjectionManagementMessage.RunAs(_testUserPrincipal), "JS", _projectionBody, enabled: true,
-						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
+						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, subscribeFromEnd: false,
+						enableRunAs: true);
 			}
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -33,7 +33,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 					new ProjectionManagementMessage.Command.Post(
 						new PublishEnvelope(GetInputQueue()), ProjectionMode.Transient, _projectionName,
 						new ProjectionManagementMessage.RunAs(_testUserPrincipal), "JS", _projectionBody, enabled: true,
-						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
+						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, subscribeFromEnd: false,
+						enableRunAs: true);
 			}
 
 			[Test, Ignore("ignored")]
@@ -81,7 +82,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 					new ProjectionManagementMessage.Command.Post(
 						new PublishEnvelope(GetInputQueue()), ProjectionMode.Continuous, _projectionName,
 						ProjectionManagementMessage.RunAs.Anonymous, "JS", _projectionBody, enabled: true,
-						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, enableRunAs: true);
+						checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, subscribeFromEnd: false,
+						enableRunAs: true);
 			}
 
 			[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_faulted_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_faulted_persistent_projection.cs
@@ -27,7 +27,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"faulted_projection",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 			yield return
 				new ProjectionManagementMessage.Command.Delete(
 					new PublishEnvelope(_bus), _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection.cs
@@ -27,7 +27,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 			yield return
 				new ProjectionManagementMessage.Command.Disable(
 					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_checkpoint_stream.cs
@@ -29,7 +29,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 			yield return
 				new ProjectionManagementMessage.Command.Disable(
 					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_emitted_streams_stream.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_keep_emitted_streams_stream.cs
@@ -28,7 +28,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 			yield return
 				new ProjectionManagementMessage.Command.Disable(
 					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_not_authorised.cs
@@ -27,7 +27,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: false, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: false, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 			yield return
 				new ProjectionManagementMessage.Command.Disable(
 					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_running_persistent_projection.cs
@@ -25,7 +25,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 			yield return
 				new ProjectionManagementMessage.Command.Delete(
 					new PublishEnvelope(_bus), _projectionName,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection.cs
@@ -26,7 +26,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 			OneWriteCompletes();
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_registration_write_fails.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_registration_write_fails.cs
@@ -46,7 +46,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 		}
 
 		[Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_posting_a_persistent_projection_and_writes_succeed.cs
@@ -29,7 +29,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false);
 		}
 
 		[Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_recreating_a_deleted_projection.cs
@@ -25,7 +25,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, subscribeFromEnd: false);
 			yield return
 				new ProjectionManagementMessage.Command.Disable(
 					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true);
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true, subscribeFromEnd: false);
 		}
 
 		[Test, Category("v8")]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_disabled_projection_query_text.cs
@@ -29,7 +29,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				(new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll(); on_any(function(){});log(1);",
-					enabled: false, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true));
+					enabled: false, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false));
 			// when
 			_newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
 			yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
@@ -30,7 +30,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				(new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll(); on_any(function(){});log(1****);",
-					enabled: false, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true));
+					enabled: false, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false));
 			// when
 			_newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
 			yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
@@ -30,7 +30,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				(new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", _source, enabled: true, checkpointsEnabled: true,
-					emitEnabled: true, trackEmittedStreams: true));
+					emitEnabled: true, trackEmittedStreams: true, subscribeFromEnd: false));
 			// when
 			yield return
 				(new ProjectionManagementMessage.Command.UpdateQuery(

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
@@ -30,7 +30,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS",
 					@"fromAll(); on_any(function(){return {};});log(1);",
-					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true));
+					enabled: true, checkpointsEnabled: true, emitEnabled: true, trackEmittedStreams: true,
+					subscribeFromEnd: false));
 			// when
 			_newProjectionSource = @"fromAll().when({a:function(){return {};}});log(2);";
 			yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
@@ -70,7 +70,8 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				(new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Transient, _projectionName,
 					ProjectionManagementMessage.RunAs.Anonymous, "JS", @"fromAll(); on_any(function(){});log(1);",
-					enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: true));
+					enabled: true, checkpointsEnabled: false, emitEnabled: false, trackEmittedStreams: true,
+					subscribeFromEnd: false));
 			// when
 			_newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
 			yield return

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/updating_projections/updating_projection_sources.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/updating_projections/updating_projection_sources.cs
@@ -31,7 +31,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system.updating
 					new ProjectionManagementMessage.Command.Post(
 						Envelope, ProjectionMode.Continuous, _projectionName,
 						ProjectionManagementMessage.RunAs.System, "js", GivenOriginalSource(), true,
-						_checkpointsEnabled, _emitEnabled, _trackEmittedStreams);
+						_checkpointsEnabled, _emitEnabled, _trackEmittedStreams, _subscribeFromEnd);
 				yield return CreateWriteEvent("stream1", "type2", "{\"Data\": 2}");
 				yield return CreateWriteEvent("stream2", "type2", "{\"Data\": 3}");
 				yield return CreateWriteEvent("stream3", "type3", "{\"Data\": 4}");

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/when_requesting_state_from_a_faulted_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/when_requesting_state_from_a_faulted_projection.cs
@@ -24,7 +24,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system {
 					Envelope, ProjectionMode.Continuous, _projectionName, ProjectionManagementMessage.RunAs.System,
 					"js",
 					_projectionSource, enabled: true, checkpointsEnabled: true, emitEnabled: true,
-					trackEmittedStreams: true);
+					trackEmittedStreams: true, subscribeFromEnd: false);
 			yield return Yield;
 			yield return new ProjectionManagementMessage.Command.GetState(Envelope, _projectionName, "");
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projection_config.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/with_projection_config.cs
@@ -7,6 +7,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system {
 		protected bool _checkpointsEnabled;
 		protected bool _trackEmittedStreams;
 		protected bool _emitEnabled;
+		protected bool _subscribeFromEnd;
 
 		protected override void Given() {
 			base.Given();
@@ -16,6 +17,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system {
 			_checkpointsEnabled = true;
 			_trackEmittedStreams = true;
 			_emitEnabled = true;
+			_subscribeFromEnd = false;
 
 			NoStream(ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName + "-checkpoint");
 			NoStream(ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName + "-order");

--- a/src/EventStore.Projections.Core/EventReaders/Feeds/FeedReader.cs
+++ b/src/EventStore.Projections.Core/EventReaders/Feeds/FeedReader.cs
@@ -85,7 +85,8 @@ namespace EventStore.Projections.Core.EventReaders.Feeds {
 				checkpointAfterMs: 10000,
 				checkpointProcessedEventsThreshold: null,
 				stopOnEof: true,
-				stopAfterNEvents: _maxEvents);
+				stopAfterNEvents: _maxEvents,
+				subscribeFromEnd: false);
 
 			_subscriptionId =
 				_subscriptionDispatcher.PublishSubscribe(

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -826,6 +826,7 @@ namespace EventStore.Projections.Core.Messages {
 			private readonly string _projectionType;
 			private readonly bool? _trackEmittedStreams;
 			private readonly bool? _checkpointsEnabled;
+			private readonly bool? _subscribeFromEnd;
 
 			public ProjectionQuery(
 				string name,
@@ -834,6 +835,7 @@ namespace EventStore.Projections.Core.Messages {
 				string projectionType,
 				bool? trackEmittedStreams,
 				bool? checkpointsEnabled,
+				bool? subscribeFromEnd,
 				ProjectionSourceDefinition definition,
 				ProjectionOutputConfig outputConfig) {
 				_name = name;
@@ -842,6 +844,7 @@ namespace EventStore.Projections.Core.Messages {
 				_projectionType = projectionType;
 				_trackEmittedStreams = trackEmittedStreams;
 				_checkpointsEnabled = checkpointsEnabled;
+				_subscribeFromEnd = subscribeFromEnd;
 				_definition = definition;
 				_outputConfig = outputConfig;
 			}
@@ -864,6 +867,10 @@ namespace EventStore.Projections.Core.Messages {
 			
 			public bool? CheckpointsEnabled {
 				get { return _checkpointsEnabled; }
+			}
+
+			public bool? SubscribeFromEnd {
+				get { return _subscribeFromEnd; }
 			}
 
 			public string Type {

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -58,11 +58,12 @@ namespace EventStore.Projections.Core.Messages {
 					public bool EmitEnabled { get; }
 					public bool EnableRunAs { get; }
 					public bool TrackEmittedStreams { get; }
+					public bool SubscribeFromEnd { get; }
 
 					public ProjectionPost(
 						ProjectionMode mode, RunAs runAs, string name, string handlerType, string query,
 						bool enabled, bool checkpointsEnabled, bool emitEnabled, bool enableRunAs,
-						bool trackEmittedStreams)
+						bool trackEmittedStreams, bool subscribeFromEnd)
 					{
 						Mode = mode;
 						RunAs = runAs;
@@ -74,6 +75,7 @@ namespace EventStore.Projections.Core.Messages {
 						EmitEnabled = emitEnabled;
 						EnableRunAs = enableRunAs;
 						TrackEmittedStreams = trackEmittedStreams;
+						SubscribeFromEnd = subscribeFromEnd;
 					}
 				}
 			}
@@ -94,11 +96,12 @@ namespace EventStore.Projections.Core.Messages {
 				private readonly bool _emitEnabled;
 				private readonly bool _enableRunAs;
 				private readonly bool _trackEmittedStreams;
+				private readonly bool _subscribeFromEnd;
 
 				public Post(
 					IEnvelope envelope, ProjectionMode mode, string name, RunAs runAs, string handlerType, string query,
 					bool enabled, bool checkpointsEnabled, bool emitEnabled, bool trackEmittedStreams,
-					bool enableRunAs = false)
+					bool subscribeFromEnd, bool enableRunAs=false)
 					: base(envelope, runAs) {
 					_name = name;
 					_handlerType = handlerType;
@@ -109,12 +112,13 @@ namespace EventStore.Projections.Core.Messages {
 					_emitEnabled = emitEnabled;
 					_trackEmittedStreams = trackEmittedStreams;
 					_enableRunAs = enableRunAs;
+					_subscribeFromEnd = subscribeFromEnd;
 				}
 
 				public Post(
 					IEnvelope envelope, ProjectionMode mode, string name, RunAs runAs, Type handlerType, string query,
 					bool enabled, bool checkpointsEnabled, bool emitEnabled, bool trackEmittedStreams,
-					bool enableRunAs = false)
+					bool subscribeFromEnd, bool enableRunAs=false)
 					: base(envelope, runAs) {
 					_name = name;
 					_handlerType = "native:" + handlerType.Namespace + "." + handlerType.Name;
@@ -125,6 +129,7 @@ namespace EventStore.Projections.Core.Messages {
 					_emitEnabled = emitEnabled;
 					_trackEmittedStreams = trackEmittedStreams;
 					_enableRunAs = enableRunAs;
+					_subscribeFromEnd = subscribeFromEnd;
 				}
 
 				// shortcut for posting ad-hoc JS queries
@@ -174,6 +179,10 @@ namespace EventStore.Projections.Core.Messages {
 
 				public bool TrackEmittedStreams {
 					get { return _trackEmittedStreams; }
+				}
+
+				public bool SubscribeFromEnd {
+					get { return _subscribeFromEnd; }
 				}
 			}
 
@@ -414,11 +423,12 @@ namespace EventStore.Projections.Core.Messages {
 				private readonly int _pendingEventsThreshold;
 				private readonly int _maxWriteBatchLength;
 				private readonly int _maxAllowedWritesInFlight;
+				private readonly bool _subscribeFromEnd;
 
 				public UpdateConfig(IEnvelope envelope, string name, bool emitEnabled, bool trackEmittedStreams,
 					int checkpointAfterMs,
 					int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold, int pendingEventsThreshold,
-					int maxWriteBatchLength, int maxAllowedWritesInFlight, RunAs runAs) :
+					int maxWriteBatchLength, int maxAllowedWritesInFlight, bool subscribeFromEnd, RunAs runAs) :
 					base(envelope, runAs) {
 					_name = name;
 					_emitEnabled = emitEnabled;
@@ -429,6 +439,7 @@ namespace EventStore.Projections.Core.Messages {
 					_pendingEventsThreshold = pendingEventsThreshold;
 					_maxWriteBatchLength = maxWriteBatchLength;
 					_maxAllowedWritesInFlight = maxAllowedWritesInFlight;
+					_subscribeFromEnd = subscribeFromEnd;
 				}
 
 				public string Name {
@@ -465,6 +476,10 @@ namespace EventStore.Projections.Core.Messages {
 
 				public int MaxAllowedWritesInFlight {
 					get { return _maxAllowedWritesInFlight; }
+				}
+
+				public bool SubscribeFromEnd {
+					get { return _subscribeFromEnd; }
 				}
 			}
 
@@ -955,11 +970,12 @@ namespace EventStore.Projections.Core.Messages {
 			private readonly int _pendingEventsThreshold;
 			private readonly int _maxWriteBatchLength;
 			private readonly int _maxAllowedWritesInFlight;
+			private readonly bool _subscribeFromEnd;
 
 			public ProjectionConfig(bool emitEnabled, bool trackEmittedStreams, int checkpointAfterMs,
 				int checkpointHandledThreshold,
 				int checkpointUnhandledBytesThreshold, int pendingEventsThreshold, int maxWriteBatchLength,
-				int maxAllowedWritesInFlight) {
+				int maxAllowedWritesInFlight, bool subscribeFromEnd) {
 				_emitEnabled = emitEnabled;
 				_trackEmittedStreams = trackEmittedStreams;
 				_checkpointAfterMs = checkpointAfterMs;
@@ -968,6 +984,7 @@ namespace EventStore.Projections.Core.Messages {
 				_pendingEventsThreshold = pendingEventsThreshold;
 				_maxWriteBatchLength = maxWriteBatchLength;
 				_maxAllowedWritesInFlight = maxAllowedWritesInFlight;
+				_subscribeFromEnd = subscribeFromEnd;
 			}
 
 			public bool EmitEnabled {
@@ -1000,6 +1017,10 @@ namespace EventStore.Projections.Core.Messages {
 
 			public int MaxAllowedWritesInFlight {
 				get { return _maxAllowedWritesInFlight; }
+			}
+
+			public bool SubscribeFromEnd {
+				get { return _subscribeFromEnd; }
 			}
 		}
 	}

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
@@ -27,6 +27,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				ModeOneofCase.OneTime => ProjectionMode.OneTime,
 				_ => throw new InvalidOperationException()
 			};
+			// TODO: Verify that this is doing what we want
 			var emitEnabled = options.ModeCase switch {
 				ModeOneofCase.Continuous => options.Continuous.TrackEmittedStreams,
 				_ => false
@@ -42,12 +43,15 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				(ModeOneofCase.Continuous, false) => true,
 				_ => false
 			};
+			// TODO: Implement subscribeFromEnd for grpc
+			var subscribeFromEnd = false;
 			var runAs = new ProjectionManagementMessage.RunAs(user);
 
 			var envelope = new CallbackEnvelope(OnMessage);
 
 			_queue.Publish(new ProjectionManagementMessage.Command.Post(envelope, projectionMode, name, runAs,
-				handlerType, options.Query, enabled, checkpointsEnables, emitEnabled, trackEmittedStreams, true));
+				handlerType, options.Query, enabled, checkpointsEnables, emitEnabled, trackEmittedStreams,
+				subscribeFromEnd, true));
 
 			await createdSource.Task.ConfigureAwait(false);
 

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -50,6 +50,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			public int PendingEventsThreshold { get; set; }
 			public int MaxWriteBatchLength { get; set; }
 			public int MaxAllowedWritesInFlight { get; set; }
+			public bool SubscribeFromEnd { get; set; }
 
 			public PersistedState() {
 				CheckpointHandledThreshold = ProjectionConsts.CheckpointHandledThreshold;
@@ -58,6 +59,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				PendingEventsThreshold = ProjectionConsts.PendingEventsThreshold;
 				MaxWriteBatchLength = ProjectionConsts.MaxWriteBatchLength;
 				MaxAllowedWritesInFlight = ProjectionConsts.MaxAllowedWritesInFlight;
+				SubscribeFromEnd = false;
 			}
 		}
 
@@ -448,7 +450,8 @@ namespace EventStore.Projections.Core.Services.Management {
 					PersistedProjectionState.CheckpointHandledThreshold,
 					PersistedProjectionState.CheckpointUnhandledBytesThreshold,
 					PersistedProjectionState.PendingEventsThreshold, PersistedProjectionState.MaxWriteBatchLength,
-					PersistedProjectionState.MaxAllowedWritesInFlight));
+					PersistedProjectionState.MaxAllowedWritesInFlight,
+					PersistedProjectionState.SubscribeFromEnd));
 		}
 
 		public void Handle(ProjectionManagementMessage.Command.UpdateConfig message) {
@@ -466,6 +469,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			PersistedProjectionState.PendingEventsThreshold = message.PendingEventsThreshold;
 			PersistedProjectionState.MaxWriteBatchLength = message.MaxWriteBatchLength;
 			PersistedProjectionState.MaxAllowedWritesInFlight = message.MaxAllowedWritesInFlight;
+			PersistedProjectionState.SubscribeFromEnd = message.SubscribeFromEnd;
 
 			UpdateProjectionVersion();
 			_pendingWritePersistedState = true;
@@ -937,6 +941,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			var emitEventEnabled = PersistedProjectionState.EmitEnabled == true;
 			var createTempStreams = PersistedProjectionState.CreateTempStreams == true;
 			var stopOnEof = PersistedProjectionState.Mode <= ProjectionMode.OneTime;
+			var subscribeFromEnd = PersistedProjectionState.SubscribeFromEnd;
 
 			var projectionConfig = new ProjectionConfig(
 				_runAs,
@@ -950,7 +955,8 @@ namespace EventStore.Projections.Core.Services.Management {
 				stopOnEof,
 				trackEmittedStreams,
 				checkpointAfterMs,
-				maximumAllowedWritesInFlight);
+				maximumAllowedWritesInFlight,
+				subscribeFromEnd);
 			return projectionConfig;
 		}
 

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -348,6 +348,7 @@ namespace EventStore.Projections.Core.Services.Management {
 					PersistedProjectionState.Mode.ToString(),
 					PersistedProjectionState.TrackEmittedStreams,
 					!PersistedProjectionState.CheckpointsDisabled,
+					PersistedProjectionState.SubscribeFromEnd,
 					PersistedProjectionState.SourceDefinition,
 					projectionOutputConfig));
 		}

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -889,7 +889,8 @@ namespace EventStore.Projections.Core.Services.Management {
 				checkpointsEnabled: true,
 				emitEnabled: true,
 				trackEmittedStreams: false,
-				enableRunAs: true);
+				enableRunAs: true,
+				subscribeFromEnd: false);
 		}
 
 		private void PostNewTransientProjection(PendingProjection projection, IEnvelope replyEnvelope) {
@@ -1114,6 +1115,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			private readonly bool _emitEnabled;
 			private readonly bool _checkpointsEnabled;
 			private readonly bool _trackEmittedStreams;
+			private readonly bool _subscribeFromEnd;
 			private readonly bool _enableRunAs;
 			private readonly ProjectionManagementMessage.RunAs _runAs;
 			private readonly IEnvelope _replyEnvelope;
@@ -1130,6 +1132,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				bool checkpointsEnabled,
 				bool enableRunAs,
 				bool trackEmittedStreams,
+				bool subscribeFromEnd,
 				ProjectionManagementMessage.RunAs runAs,
 				IEnvelope replyEnvelope) {
 				if (projectionMode >= ProjectionMode.Continuous && !checkpointsEnabled)
@@ -1146,6 +1149,7 @@ namespace EventStore.Projections.Core.Services.Management {
 				_emitEnabled = emitEnabled;
 				_checkpointsEnabled = checkpointsEnabled;
 				_trackEmittedStreams = trackEmittedStreams;
+				_subscribeFromEnd = subscribeFromEnd;
 				_enableRunAs = enableRunAs;
 				_runAs = runAs;
 				_replyEnvelope = replyEnvelope;
@@ -1171,6 +1175,7 @@ namespace EventStore.Projections.Core.Services.Management {
 						EmitEnabled = _emitEnabled,
 						CheckpointsDisabled = !_checkpointsEnabled,
 						TrackEmittedStreams = _trackEmittedStreams,
+						SubscribeFromEnd = _subscribeFromEnd,
 						CheckpointHandledThreshold = ProjectionConsts.CheckpointHandledThreshold,
 						CheckpointAfterMs = (int)ProjectionConsts.CheckpointAfterMs.TotalMilliseconds,
 						MaxAllowedWritesInFlight = ProjectionConsts.MaxAllowedWritesInFlight,
@@ -1233,11 +1238,12 @@ namespace EventStore.Projections.Core.Services.Management {
 			public bool EnableRunAs { get; }
 			public bool TrackEmittedStreams { get; }
 			public long ProjectionId { get; }
+			public bool SubscribeFromEnd { get; }
 
 			public PendingProjection(
 				long projectionId, ProjectionMode mode, SerializedRunAs runAs, string name, string handlerType, string query,
 				bool enabled, bool checkpointsEnabled, bool emitEnabled, bool enableRunAs,
-				bool trackEmittedStreams) {
+				bool trackEmittedStreams, bool subscribeFromEnd) {
 				ProjectionId = projectionId;
 				Mode = mode;
 				RunAs = runAs;
@@ -1249,17 +1255,18 @@ namespace EventStore.Projections.Core.Services.Management {
 				EmitEnabled = emitEnabled;
 				EnableRunAs = enableRunAs;
 				TrackEmittedStreams = trackEmittedStreams;
+				SubscribeFromEnd = subscribeFromEnd;
 			}
 
 			public PendingProjection(long projectionId, ProjectionManagementMessage.Command.PostBatch.ProjectionPost projection)
 				: this(projectionId, projection.Mode, projection.RunAs, projection.Name, projection.HandlerType,
 					projection.Query, projection.Enabled, projection.CheckpointsEnabled,
-					projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams) { }
+					projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams, projection.SubscribeFromEnd) { }
 
 			public PendingProjection(long projectionId, ProjectionManagementMessage.Command.Post projection)
 				: this(projectionId, projection.Mode, projection.RunAs, projection.Name, projection.HandlerType,
 					projection.Query, projection.Enabled, projection.CheckpointsEnabled,
-					projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams) { }
+					projection.EmitEnabled, projection.EnableRunAs, projection.TrackEmittedStreams, projection.SubscribeFromEnd) { }
 
 			public NewProjectionInitializer CreateInitializer(IEnvelope replyEnvelope) {
 				return new NewProjectionInitializer(
@@ -1273,6 +1280,7 @@ namespace EventStore.Projections.Core.Services.Management {
 					CheckpointsEnabled,
 					EnableRunAs,
 					TrackEmittedStreams,
+					SubscribeFromEnd,
 					RunAs,
 					replyEnvelope);
 			}

--- a/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReaderCoreService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using EventStore.Common.Log;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
@@ -110,7 +109,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				_subscriptionEventReaders[subscriptionId] = Guid.Empty;
 				_publisher.Publish(
 					new EventReaderSubscriptionMessage.ReaderAssignedReader(
-						subscriptionId, distributionPointCorrelationId));
+						subscriptionId, Guid.Empty));
 				return;
 			}
 
@@ -119,7 +118,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			_eventReaders.Add(distributionPointCorrelationId, eventReader);
 			_subscriptionEventReaders.Add(subscriptionId, distributionPointCorrelationId);
 			_eventReaderSubscriptions.Add(distributionPointCorrelationId, subscriptionId);
-						_publisher.Publish(
+			_publisher.Publish(
 				new EventReaderSubscriptionMessage.ReaderAssignedReader(
 					subscriptionId, distributionPointCorrelationId));
 			eventReader.Resume();

--- a/src/EventStore.Projections.Core/Services/Processing/EventReorderingReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReorderingReaderSubscription.cs
@@ -22,6 +22,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			int? checkpointProcessedEventsThreshold,
 			int checkpointAfterMs,
 			int processingLagMs,
+			bool checkpointFirstEvent,
 			bool stopOnEof = false,
 			int? stopAfterNEvents = null)
 			: base(
@@ -33,6 +34,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				checkpointUnhandledBytesThreshold,
 				checkpointProcessedEventsThreshold,
 				checkpointAfterMs,
+				checkpointFirstEvent,
 				stopOnEof,
 				stopAfterNEvents) {
 			_processingLagMs = processingLagMs;

--- a/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
@@ -272,12 +272,11 @@ namespace EventStore.Projections.Core.Services.Processing {
 		}
 
 		public ReaderSubscriptionOptions GetSubscriptionOptions() {
-			// TODO: Get subscribeFromEnd from projection options
 			return new ReaderSubscriptionOptions(
 				_projectionConfig.CheckpointUnhandledBytesThreshold, _projectionConfig.CheckpointHandledThreshold,
 				_projectionConfig.CheckpointAfterMs,
 				_stopOnEof, stopAfterNEvents: null,
-				subscribeFromEnd: true);
+				subscribeFromEnd: _projectionConfig.SubscribeFromEnd);
 		}
 
 		protected void SubscribeReaders(CheckpointTag checkpointTag) {

--- a/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
@@ -272,10 +272,12 @@ namespace EventStore.Projections.Core.Services.Processing {
 		}
 
 		public ReaderSubscriptionOptions GetSubscriptionOptions() {
+			// TODO: Get subscribeFromEnd from projection options
 			return new ReaderSubscriptionOptions(
 				_projectionConfig.CheckpointUnhandledBytesThreshold, _projectionConfig.CheckpointHandledThreshold,
 				_projectionConfig.CheckpointAfterMs,
-				_stopOnEof, stopAfterNEvents: null);
+				_stopOnEof, stopAfterNEvents: null,
+				subscribeFromEnd: true);
 		}
 
 		protected void SubscribeReaders(CheckpointTag checkpointTag) {

--- a/src/EventStore.Projections.Core/Services/Processing/HeadingEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/HeadingEventReader.cs
@@ -163,6 +163,14 @@ namespace EventStore.Projections.Core.Services.Processing {
 			return false;
 		}
 
+		public void TrySubscribeFromEnd(Guid projectionId, IReaderSubscription readerSubscription) {
+			EnsureStarted();
+			if (_headSubscribers.ContainsKey(projectionId))
+				throw new InvalidOperationException(
+					string.Format("Projection '{0}' has been already subscribed", projectionId));
+			AddSubscriber(projectionId, readerSubscription);
+		}
+
 		public void Unsubscribe(Guid projectionId) {
 			EnsureStarted();
 			if (!_headSubscribers.ContainsKey(projectionId))

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderStrategy.cs
@@ -147,6 +147,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					readerSubscriptionOptions.CheckpointProcessedEventsThreshold,
 					readerSubscriptionOptions.CheckpointAfterMs,
 					_processingLag,
+					readerSubscriptionOptions.SubscribeFromEnd,
 					readerSubscriptionOptions.StopOnEof,
 					readerSubscriptionOptions.StopAfterNEvents);
 			else
@@ -160,6 +161,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					readerSubscriptionOptions.CheckpointUnhandledBytesThreshold,
 					readerSubscriptionOptions.CheckpointProcessedEventsThreshold,
 					readerSubscriptionOptions.CheckpointAfterMs,
+					readerSubscriptionOptions.SubscribeFromEnd,
 					readerSubscriptionOptions.StopOnEof,
 					readerSubscriptionOptions.StopAfterNEvents);
 		}

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
@@ -15,6 +15,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			long? checkpointUnhandledBytesThreshold,
 			int? checkpointProcessedEventsThreshold,
 			int checkpointAfterMs,
+			bool checkpointFirstEvent,
 			bool stopOnEof = false,
 			int? stopAfterNEvents = null)
 			: base(
@@ -26,6 +27,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				checkpointUnhandledBytesThreshold,
 				checkpointProcessedEventsThreshold,
 				checkpointAfterMs,
+				checkpointFirstEvent,
 				stopOnEof,
 				stopAfterNEvents) {
 			_tag = tag;

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
@@ -26,8 +26,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		private DateTime _lastProgressPublished;
 		private TimeSpan _checkpointAfter;
 		private DateTime _lastCheckpointTime = DateTime.MinValue;
-		// TODO: Get this from settings
-		private readonly bool _checkpointFirstEvent = true;
+		private readonly bool _checkpointFirstEvent;
 
 		protected ReaderSubscriptionBase(
 			IPublisher publisher,
@@ -38,6 +37,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			long? checkpointUnhandledBytesThreshold,
 			int? checkpointProcessedEventsThreshold,
 			int checkpointAfterMs,
+			bool checkpointFirstEvent,
 			bool stopOnEof,
 			int? stopAfterNEvents) {
 			if (publisher == null) throw new ArgumentNullException("publisher");
@@ -56,6 +56,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			_stopAfterNEvents = stopAfterNEvents;
 			_subscriptionId = subscriptionId;
 			_lastPassedOrCheckpointedEventPosition = null;
+			_checkpointFirstEvent = checkpointFirstEvent;
 
 			_eventFilter = readerStrategy.EventFilter;
 

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionOptions.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionOptions.cs
@@ -5,15 +5,17 @@ namespace EventStore.Projections.Core.Services.Processing {
 		private readonly int _checkpointAfterMs;
 		private readonly bool _stopOnEof;
 		private readonly int? _stopAfterNEvents;
+		private readonly bool _subscribeFromEnd;
 
 		public ReaderSubscriptionOptions(
 			long checkpointUnhandledBytesThreshold, int? checkpointProcessedEventsThreshold, int checkpointAfterMs,
-			bool stopOnEof, int? stopAfterNEvents) {
+			bool stopOnEof, int? stopAfterNEvents, bool subscribeFromEnd = false) {
 			_checkpointUnhandledBytesThreshold = checkpointUnhandledBytesThreshold;
 			_checkpointProcessedEventsThreshold = checkpointProcessedEventsThreshold;
 			_checkpointAfterMs = checkpointAfterMs;
 			_stopOnEof = stopOnEof;
 			_stopAfterNEvents = stopAfterNEvents;
+			_subscribeFromEnd = subscribeFromEnd;
 		}
 
 		public long CheckpointUnhandledBytesThreshold {
@@ -34,6 +36,10 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		public int? StopAfterNEvents {
 			get { return _stopAfterNEvents; }
+		}
+
+		public bool SubscribeFromEnd {
+			get { return _subscribeFromEnd; }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionOptions.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionOptions.cs
@@ -9,7 +9,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		public ReaderSubscriptionOptions(
 			long checkpointUnhandledBytesThreshold, int? checkpointProcessedEventsThreshold, int checkpointAfterMs,
-			bool stopOnEof, int? stopAfterNEvents, bool subscribeFromEnd = false) {
+			bool stopOnEof, int? stopAfterNEvents, bool subscribeFromEnd) {
 			_checkpointUnhandledBytesThreshold = checkpointUnhandledBytesThreshold;
 			_checkpointProcessedEventsThreshold = checkpointProcessedEventsThreshold;
 			_checkpointAfterMs = checkpointAfterMs;

--- a/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
+++ b/src/EventStore.Projections.Core/Services/ProjectionConfig.cs
@@ -16,11 +16,12 @@ namespace EventStore.Projections.Core.Services {
 		private readonly bool _trackEmittedStreams;
 		private readonly int _checkpointAfterMs;
 		private readonly int _maximumAllowedWritesInFlight;
+		private readonly bool _subscribeFromEnd;
 
 		public ProjectionConfig(IPrincipal runAs, int checkpointHandledThreshold, int checkpointUnhandledBytesThreshold,
 			int pendingEventsThreshold, int maxWriteBatchLength, bool emitEventEnabled, bool checkpointsEnabled,
 			bool createTempStreams, bool stopOnEof, bool trackEmittedStreams,
-			int checkpointAfterMs, int maximumAllowedWritesInFlight) {
+			int checkpointAfterMs, int maximumAllowedWritesInFlight, bool subscribeFromEnd) {
 			if (checkpointsEnabled) {
 				if (checkpointHandledThreshold <= 0)
 					throw new ArgumentOutOfRangeException("checkpointHandledThreshold");
@@ -51,6 +52,7 @@ namespace EventStore.Projections.Core.Services {
 			_trackEmittedStreams = trackEmittedStreams;
 			_checkpointAfterMs = checkpointAfterMs;
 			_maximumAllowedWritesInFlight = maximumAllowedWritesInFlight;
+			_subscribeFromEnd = subscribeFromEnd;
 		}
 
 		public int CheckpointHandledThreshold {
@@ -101,9 +103,13 @@ namespace EventStore.Projections.Core.Services {
 			get { return _maximumAllowedWritesInFlight; }
 		}
 
+		public bool SubscribeFromEnd {
+			get { return _subscribeFromEnd; }
+		}
+
 		public static ProjectionConfig GetTest() {
 			return new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false, true, 10000,
-				1);
+				1, false);
 		}
 	}
 }

--- a/src/Protos/Grpc/projections.proto
+++ b/src/Protos/Grpc/projections.proto
@@ -33,6 +33,7 @@ message CreateReq {
 		message Continuous {
 			string name = 1;
 			bool track_emitted_streams = 2;
+			bool subscribe_from_end = 3;
 		}
 	}
 	message Empty {


### PR DESCRIPTION
Fixes #1911
Related UI change https://github.com/EventStore/EventStore.UI/pull/234

Add a `subscribeFromEnd` option to projection creation.
This option has been added to the HTTP, TCP and gRPC API's.

When this is set, the projection will not start an `EventReader`, but will rather immediately subscribe to the `HeadingEventReader`.
This subscription will start from whatever position the `HeadingEventReader` is at at the time of the projection's start.

It will also cause the projection to write a checkpoint on the first event it processes.
At the moment, it will need to receive an event that passes the filter in order for it to write the checkpoint.

Once a checkpoint has been written, restarting the projection will continue it from the checkpointed position rather than from the end of the stream.
If the projection is reset, it will start again from the end of the transaction log.

**Note:**
The proto for the gRPC projections client has changed.