### PR TITLE
Start Adding Client Operations Tests

### DIFF
--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Tests.ClientOperations {
+	public abstract class specification_with_bare_vnode : IPublisher, ISubscriber, IDisposable {
+		private ClusterVNode _node;
+		private readonly List<IDisposable> _disposables = new List<IDisposable>();
+		public void CreateTestNode() {
+			var builder = IntegrationVNodeBuilder
+			.AsSingleNode()
+			.RunInMemory();
+
+			_node = builder.Build();
+			_node.StartAsync(true).Wait();
+		}
+		public void Publish(Message message) {
+			_node.MainQueue.Handle(message);
+		}
+
+		public void Subscribe<T>(IHandle<T> handler) where T : Message {
+			_node.MainBus.Subscribe(handler);
+		}
+
+		public void Unsubscribe<T>(IHandle<T> handler) where T : Message {
+			_node.MainBus.Unsubscribe(handler);
+		}
+		public Task<T> WaitForNext<T>() where T : Message {			
+			var handler = new TaskHandler<T>(_node.MainBus);
+			_disposables.Add(handler);
+			return handler.Message;
+		}
+		private sealed class TaskHandler<T> : IHandle<T>, IDisposable where T : Message {
+			private readonly ISubscriber _source;
+			private readonly TaskCompletionSource<T> _tcs = new TaskCompletionSource<T>();
+			public Task<T> Message => _tcs.Task;
+			public void Handle(T message) {
+				_tcs.SetResult(message);
+				Dispose();
+			}
+			public TaskHandler(ISubscriber source) {
+				_source = source;
+				_source.Subscribe(this);
+			}
+			private bool _disposed;
+			public void Dispose() {
+				if (_disposed) { return; }
+				_disposed = true;
+				try {
+					_source.Unsubscribe(this);
+				} catch (Exception) { /* ignore*/}
+			}
+		}
+		#region IDisposable Support
+		private bool _disposed;
+		protected virtual void Dispose(bool disposing) {
+			if (!_disposed) {
+				if (disposing) {					
+					_disposables?.ForEach(d => d?.Dispose());
+					_disposables?.Clear();
+					_node?.StopAsync().Wait();
+				}				
+				_disposed = true;
+			}
+		}
+
+		public void Dispose() {
+			Dispose(true);
+		}
+		#endregion
+	}
+	internal class IntegrationVNodeBuilder : VNodeBuilder {
+		protected IntegrationVNodeBuilder() {
+
+		}
+		public static IntegrationVNodeBuilder AsSingleNode() {
+			var ret = new IntegrationVNodeBuilder().WithSingleNodeSettings();
+			return (IntegrationVNodeBuilder)ret;
+		}
+		protected override void SetUpProjectionsIfNeeded() {}
+	}
+}

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_request_manager_integration.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_request_manager_integration.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Services.Replication;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientOperations {
+	public abstract class specification_with_request_manager_integration : specification_with_bare_vnode {
+		
+		protected long CompletionMessageCount;
+		protected StorageMessage.RequestCompleted CompletionMessage;
+
+		protected Guid InternalCorrId = Guid.NewGuid();
+		protected Guid ClientCorrId = Guid.NewGuid();
+		protected FakeEnvelope Envelope;
+
+		protected abstract IEnumerable<Message> WithInitialMessages();
+		protected abstract Message When();
+
+		[SetUp]
+		public void Setup() {
+			CreateTestNode();
+			Envelope = new FakeEnvelope();
+
+			foreach (var m in WithInitialMessages()) {
+				Publish(m);
+			}
+			Subscribe(new AdHocHandler<StorageMessage.RequestCompleted>(msg => {
+				Interlocked.Exchange(ref CompletionMessage, msg);
+				Interlocked.Increment(ref CompletionMessageCount);
+			}));
+			Publish(When());
+		}
+
+	}
+}

--- a/src/EventStore.Core.Tests/ClientOperations/when_committing_a_transaction_with_data.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/when_committing_a_transaction_with_data.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.ClientAPI.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientOperations {
+	public class when_committing_a_transaction_with_data : specification_with_request_manager_integration {
+		readonly string _streamId = $"new_test_stream_{Guid.NewGuid()}";
+		readonly Event _evt = new Event(Guid.NewGuid(), "SomethingHappened", true, Helper.UTF8NoBom.GetBytes("{Value:42}"), null);
+		long _transactionId;
+
+		protected override IEnumerable<Message> WithInitialMessages() {
+			var requestComplete = WaitForNext<StorageMessage.RequestCompleted>();
+			yield return new ClientMessage.TransactionStart(Guid.NewGuid(), Guid.NewGuid(), Envelope, true, _streamId, ExpectedVersion.Any, null);
+			requestComplete.Wait();
+			var resp = Envelope.Replies[0] as ClientMessage.TransactionStartCompleted;
+			_transactionId = resp?.TransactionId ?? 0;
+			requestComplete = WaitForNext<StorageMessage.RequestCompleted>();
+			yield return new ClientMessage.TransactionWrite(Guid.NewGuid(), Guid.NewGuid(), Envelope, true, _transactionId, new[] { _evt }, null);
+			requestComplete.Wait();
+			Interlocked.Exchange(ref CompletionMessage, null);
+			Interlocked.Exchange(ref CompletionMessageCount, 0);
+			Envelope.Replies.Clear();
+		}
+
+		protected override Message When() {
+			return new ClientMessage.TransactionCommit(InternalCorrId, ClientCorrId, Envelope, true, _transactionId, null);
+		}
+
+		[Test]
+		public void successful_request_message_is_published() {
+			AssertEx.IsOrBecomesTrue(()=> Interlocked.Read(ref CompletionMessageCount) == 1);
+			Assert.AreEqual(InternalCorrId, CompletionMessage.CorrelationId);
+			Assert.True(CompletionMessage.Success);
+		}
+
+		[Test]
+		public void the_envelope_is_replied_to_with_success() {
+			AssertEx.IsOrBecomesTrue(() => Envelope.Replies.Count > 0);
+			Assert.That(Envelope.Replies.ContainsSingle<ClientMessage.TransactionCommitCompleted>(
+				x => x.CorrelationId == ClientCorrId && x.Result == OperationResult.Success), () => $"Does not contain single successful TransactionCommitCompleted with id {ClientCorrId}");
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/ClientOperations/when_starting_a_transaction_expecting_no_stream.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/when_starting_a_transaction_expecting_no_stream.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientOperations {
+	public class when_starting_a_transaction_expecting_no_stream : specification_with_request_manager_integration {
+		readonly string _streamId = $"new_test_stream_{Guid.NewGuid()}";
+
+		protected override IEnumerable<Message> WithInitialMessages() {
+			yield break;
+		}
+
+		protected override Message When() {
+			return new ClientMessage.TransactionStart(InternalCorrId, ClientCorrId, Envelope, true, _streamId, ExpectedVersion.NoStream, null);
+		}
+
+		[Test]
+		public void successful_request_message_is_published() {
+			AssertEx.IsOrBecomesTrue(()=> Interlocked.Read(ref CompletionMessageCount) == 1);
+			Assert.AreEqual(InternalCorrId, CompletionMessage.CorrelationId);
+			Assert.True(CompletionMessage.Success);
+		}
+
+		[Test]
+		public void the_envelope_is_replied_to_with_success() {
+			AssertEx.IsOrBecomesTrue(() => Envelope.Replies.Count > 0);
+			Assert.That(Envelope.Replies.ContainsSingle<ClientMessage.TransactionStartCompleted>(
+				x => x.CorrelationId == ClientCorrId && x.Result == OperationResult.Success));
+		}
+
+	}
+}

--- a/src/EventStore.Core.Tests/ClientOperations/when_starting_a_transaction_expecting_version_any.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/when_starting_a_transaction_expecting_version_any.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Helpers;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.ClientOperations {
+	public class when_starting_a_transaction_expecting_version_any : specification_with_request_manager_integration {
+		readonly string _streamId = $"new_test_stream_{Guid.NewGuid()}";
+
+		protected override IEnumerable<Message> WithInitialMessages() {
+			yield break;
+		}
+
+		protected override Message When() {
+			return new ClientMessage.TransactionStart(InternalCorrId, ClientCorrId, Envelope, true, _streamId, ExpectedVersion.Any, null);
+		}
+
+		[Test]
+		public void successful_request_message_is_published() {
+			AssertEx.IsOrBecomesTrue(()=> Interlocked.Read(ref CompletionMessageCount) == 1);
+			Assert.AreEqual(InternalCorrId, CompletionMessage.CorrelationId);
+			Assert.True(CompletionMessage.Success);
+		}
+
+		[Test]
+		public void the_envelope_is_replied_to_with_success() {
+			AssertEx.IsOrBecomesTrue(() => Envelope.Replies.Count > 0);
+			Assert.That(Envelope.Replies.ContainsSingle<ClientMessage.TransactionStartCompleted>(
+				x => x.CorrelationId == ClientCorrId && x.Result == OperationResult.Success));
+		}
+	}
+}


### PR DESCRIPTION
Start adding tests for client operations directly against the vNode using the ClientMessages and without using any of the client connections.

This will allow testing and confirmation of behavior in the vNode with conflating it with behaviors in the various clients. This will also simply debugging greatly.
replaces #2194 