### PR TITLE
Introduce ability to set deadlines (timeouts) in the gRPC Client

### DIFF
--- a/src/EventStore.Client.Tests/EventStoreClientOperationOptionsTests.cs
+++ b/src/EventStore.Client.Tests/EventStoreClientOperationOptionsTests.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Xunit;
+
+namespace EventStore.Client {
+	public class EventStoreClientOperationOptionsTests {
+		[Fact]
+		public void setting_options_on_clone_should_not_modify_original() {
+			EventStoreClientOperationOptions options = new EventStoreClientOperationOptions {
+				TimeoutAfter = TimeSpan.FromDays(5),
+			};
+			
+			var clonedOptions = options.Clone();
+			clonedOptions.TimeoutAfter = TimeSpan.FromSeconds(1);
+			
+			Assert.Equal(options.TimeoutAfter, TimeSpan.FromDays(5));
+			Assert.Equal(clonedOptions.TimeoutAfter, TimeSpan.FromSeconds(1));
+		}
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/append_to_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/append_to_stream_with_timeout.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Xunit;
+
+namespace EventStore.Client.Streams {
+	[Trait("Category", "Network")]
+	public class append_to_stream_with_timeout : IClassFixture<append_to_stream_with_timeout.Fixture> {
+		private readonly Fixture _fixture;
+
+		public append_to_stream_with_timeout(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task any_stream_revision_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents(),
+					options => options.TimeoutAfter = TimeSpan.Zero));
+
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		[Fact]
+		public async Task stream_revision_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.AppendToStreamAsync(stream, new StreamRevision(0), _fixture.CreateTestEvents(),
+					options => options.TimeoutAfter = TimeSpan.Zero));
+
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
+				CreateHttpClient = () =>
+					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			}) {
+			}
+
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/delete_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/delete_stream_with_timeout.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Xunit;
+
+namespace EventStore.Client.Streams {
+	[Trait("Category", "Network")]
+	public class deleting_stream_with_timeout : IClassFixture<deleting_stream_with_timeout.Fixture> {
+		private readonly Fixture _fixture;
+
+		public deleting_stream_with_timeout(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task any_stream_revision_soft_delete_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.SoftDeleteAsync(stream, AnyStreamRevision.Any,
+					options => options.TimeoutAfter = TimeSpan.Zero));
+
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		[Fact]
+		public async Task stream_revision_soft_delete_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.SoftDeleteAsync(stream, new StreamRevision(0),
+					options => options.TimeoutAfter = TimeSpan.Zero));
+
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		[Fact]
+		public async Task any_stream_revision_tombstoning_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.TombstoneAsync(stream, AnyStreamRevision.Any,
+					options => options.TimeoutAfter = TimeSpan.Zero));
+
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		[Fact]
+		public async Task stream_revision_tombstoning_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.TombstoneAsync(stream, new StreamRevision(0),
+					options => options.TimeoutAfter = TimeSpan.Zero));
+
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
+				CreateHttpClient = () =>
+					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			}) {
+			}
+
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/read_all_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_with_timeout.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Xunit;
+
+namespace EventStore.Client.Streams {
+	[Trait("Category", "Network")]
+	public class read_all_with_timeout : IClassFixture<read_all_with_timeout.Fixture> {
+		private readonly Fixture _fixture;
+
+		public read_all_with_timeout(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task fails_when_operation_expired() {
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() => _fixture.Client
+				.ReadAllAsync(Direction.Backwards, Position.Start, 1,
+					options => options.TimeoutAfter = TimeSpan.Zero)
+				.ToArrayAsync().AsTask());
+
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
+				CreateHttpClient = () =>
+					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			}) {
+			}
+
+			protected override Task Given() => Task.CompletedTask;
+
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/read_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_with_timeout.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Xunit;
+
+namespace EventStore.Client.Streams {
+	[Trait("Category", "Network")]
+	public class read_stream_with_timeout : IClassFixture<read_stream_with_timeout.Fixture> {
+		private readonly Fixture _fixture;
+
+		public read_stream_with_timeout(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() => _fixture.Client
+				.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, 1,
+					options => options.TimeoutAfter = TimeSpan.Zero)
+				.ToArrayAsync().AsTask());
+			
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
+				CreateHttpClient = () =>
+					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			}) {
+			}
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/stream_metadata_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/stream_metadata_with_timeout.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Grpc.Core;
+using Xunit;
+
+namespace EventStore.Client.Streams {
+	[Trait("Category", "Network")]
+	public class stream_metadata_with_timeout : IClassFixture<stream_metadata_with_timeout.Fixture> {
+		private readonly Fixture _fixture;
+
+		public stream_metadata_with_timeout(Fixture fixture) {
+			_fixture = fixture;
+		}
+
+		[Fact]
+		public async Task set_with_any_stream_revision_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.SetStreamMetadataAsync(stream, AnyStreamRevision.Any, new StreamMetadata(),
+					options => options.TimeoutAfter = TimeSpan.Zero));
+			
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		[Fact]
+		public async Task set_with_stream_revision_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.SetStreamMetadataAsync(stream, new StreamRevision(0), new StreamMetadata(),
+					options => options.TimeoutAfter = TimeSpan.Zero));
+			
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		[Fact]
+		public async Task get_fails_when_operation_expired() {
+			var stream = _fixture.GetStreamName();
+			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+				_fixture.Client.GetStreamMetadataAsync(stream,
+					options => options.TimeoutAfter = TimeSpan.Zero));
+			
+			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
+		}
+
+		public class Fixture : EventStoreGrpcFixture {
+			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
+				CreateHttpClient = () =>
+					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			}) {
+			}
+			protected override Task Given() => Task.CompletedTask;
+			protected override Task When() => Task.CompletedTask;
+		}
+	}
+}

--- a/src/EventStore.Client/DeadLine.cs
+++ b/src/EventStore.Client/DeadLine.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace EventStore.Client {
+	internal static class DeadLine {
+		public static DateTime? After(TimeSpan? timeoutAfter) =>
+			timeoutAfter.HasValue ? DateTime.UtcNow.Add(timeoutAfter.Value) : (DateTime?)null;
+
+		public static TimeSpan? None = null;
+	}
+}

--- a/src/EventStore.Client/EventStoreClient.cs
+++ b/src/EventStore.Client/EventStoreClient.cs
@@ -17,6 +17,7 @@ namespace EventStore.Client {
 			},
 		};
 
+		private readonly EventStoreClientSettings _settings;
 		private readonly GrpcChannel _channel;
 		private readonly Streams.Streams.StreamsClient _client;
 		public EventStorePersistentSubscriptionsClient PersistentSubscriptions { get; }
@@ -24,7 +25,7 @@ namespace EventStore.Client {
 		public EventStoreUserManagerClient UsersManager { get; }
 
 		public EventStoreClient(EventStoreClientSettings settings = null) {
-			settings ??= new EventStoreClientSettings(new UriBuilder {
+			_settings = settings ??= new EventStoreClientSettings(new UriBuilder {
 				Scheme = Uri.UriSchemeHttps,
 				Port = 2113
 			}.Uri);

--- a/src/EventStore.Client/EventStoreClientOperationOptions.cs
+++ b/src/EventStore.Client/EventStoreClientOperationOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace EventStore.Client {
+	public class EventStoreClientOperationOptions {
+		public TimeSpan? TimeoutAfter { get; set; }
+		public static EventStoreClientOperationOptions Default => new EventStoreClientOperationOptions {
+			TimeoutAfter = TimeSpan.FromSeconds(5),
+		};
+
+		public EventStoreClientOperationOptions Clone() =>
+			new EventStoreClientOperationOptions {
+				TimeoutAfter = TimeoutAfter,
+			};
+	}
+}

--- a/src/EventStore.Client/EventStoreClientSettings.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.cs
@@ -9,6 +9,8 @@ namespace EventStore.Client {
 		public string ConnectionName { get; set; }
 		public Func<HttpClient> CreateHttpClient { get; set; }
 
+		public EventStoreClientOperationOptions OperationOptions { get; set; } = EventStoreClientOperationOptions.Default;
+
 		public EventStoreClientSettings(Uri address) {
 			if (address == null) throw new ArgumentNullException(nameof(address));
 			Address = address;

--- a/src/EventStore.Client/EventStoreGrpcClient.Append.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Append.cs
@@ -21,6 +21,15 @@ namespace EventStore.Client {
 				}
 			}, eventData, operationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Appends events asynchronously to a stream.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to append events to.</param>
+		/// <param name="expectedRevision">The expected <see cref="StreamRevision"/> of the stream to append to.</param>
+		/// <param name="eventData">An <see cref="IEnumerable{EventData}"/> to append to the stream.</param>
+		/// <param name="userCredentials">The <see cref="UserCredentials"/> for the operation.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<WriteResult> AppendToStreamAsync(
 			string streamName,
 			StreamRevision expectedRevision,
@@ -30,6 +39,16 @@ namespace EventStore.Client {
 			AppendToStreamAsync(streamName, expectedRevision, eventData, _settings.OperationOptions,
 				userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Appends events asynchronously to a stream.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to append events to.</param>
+		/// <param name="expectedRevision">The expected <see cref="StreamRevision"/> of the stream to append to.</param>
+		/// <param name="eventData">An <see cref="IEnumerable{EventData}"/> to append to the stream.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The <see cref="UserCredentials"/> for the operation.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<WriteResult> AppendToStreamAsync(
 			string streamName,
 			StreamRevision expectedRevision,
@@ -58,6 +77,16 @@ namespace EventStore.Client {
 				}
 			}.WithAnyStreamRevision(expectedRevision), eventData, operationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Appends events asynchronously to a stream.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to append events to.</param>
+		/// <param name="expectedRevision">The expected <see cref="AnyStreamRevision"/> of the stream to append to.</param>
+		/// <param name="eventData">An <see cref="IEnumerable{EventData}"/> to append to the stream.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The <see cref="UserCredentials"/> for the operation.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<WriteResult> AppendToStreamAsync(
 			string streamName,
 			AnyStreamRevision expectedRevision,
@@ -73,6 +102,15 @@ namespace EventStore.Client {
 				cancellationToken);
 		}
 
+		/// <summary>
+		/// Appends events asynchronously to a stream.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to append events to.</param>
+		/// <param name="expectedRevision">The expected <see cref="AnyStreamRevision"/> of the stream to append to.</param>
+		/// <param name="eventData">An <see cref="IEnumerable{EventData}"/> to append to the stream.</param>
+		/// <param name="userCredentials">The <see cref="UserCredentials"/> for the operation.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<WriteResult> AppendToStreamAsync(
 			string streamName,
 			AnyStreamRevision expectedRevision,

--- a/src/EventStore.Client/EventStoreGrpcClient.Append.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Append.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -6,10 +7,11 @@ using Google.Protobuf;
 
 namespace EventStore.Client {
 	public partial class EventStoreClient {
-		public Task<WriteResult> AppendToStreamAsync(
+		private Task<WriteResult> AppendToStreamAsync(
 			string streamName,
 			StreamRevision expectedRevision,
 			IEnumerable<EventData> eventData,
+			EventStoreClientOperationOptions operationOptions,
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) =>
 			AppendToStreamInternal(new AppendReq {
@@ -17,7 +19,59 @@ namespace EventStore.Client {
 					StreamName = streamName,
 					Revision = expectedRevision
 				}
-			}, eventData, userCredentials, cancellationToken);
+			}, eventData, operationOptions, userCredentials, cancellationToken);
+
+		public Task<WriteResult> AppendToStreamAsync(
+			string streamName,
+			StreamRevision expectedRevision,
+			IEnumerable<EventData> eventData,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) =>
+			AppendToStreamAsync(streamName, expectedRevision, eventData, _settings.OperationOptions,
+				userCredentials, cancellationToken);
+
+		public Task<WriteResult> AppendToStreamAsync(
+			string streamName,
+			StreamRevision expectedRevision,
+			IEnumerable<EventData> eventData,
+			Action<EventStoreClientOperationOptions> configureOperationOptions,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			
+			var options = _settings.OperationOptions.Clone();
+			configureOperationOptions(options);
+			
+			return AppendToStreamAsync(streamName, expectedRevision, eventData, options, userCredentials,
+				cancellationToken);
+		}
+
+		private Task<WriteResult> AppendToStreamAsync(
+			string streamName,
+			AnyStreamRevision expectedRevision,
+			IEnumerable<EventData> eventData,
+			EventStoreClientOperationOptions operationOptions,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) =>
+			AppendToStreamInternal(new AppendReq {
+				Options = new AppendReq.Types.Options {
+					StreamName = streamName
+				}
+			}.WithAnyStreamRevision(expectedRevision), eventData, operationOptions, userCredentials, cancellationToken);
+
+		public Task<WriteResult> AppendToStreamAsync(
+			string streamName,
+			AnyStreamRevision expectedRevision,
+			IEnumerable<EventData> eventData,
+			Action<EventStoreClientOperationOptions> configureOperationOptions,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			
+			var operationOptions = _settings.OperationOptions.Clone();
+			configureOperationOptions(operationOptions);
+			
+			return AppendToStreamAsync(streamName, expectedRevision, eventData, operationOptions, userCredentials,
+				cancellationToken);
+		}
 
 		public Task<WriteResult> AppendToStreamAsync(
 			string streamName,
@@ -25,19 +79,17 @@ namespace EventStore.Client {
 			IEnumerable<EventData> eventData,
 			UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) =>
-			AppendToStreamInternal(new AppendReq {
-				Options = new AppendReq.Types.Options {
-					StreamName = streamName
-				}
-			}.WithAnyStreamRevision(expectedRevision), eventData, userCredentials, cancellationToken);
+			AppendToStreamAsync(streamName, expectedRevision, eventData, _settings.OperationOptions,
+				userCredentials, cancellationToken);
 
 		private async Task<WriteResult> AppendToStreamInternal(
 			AppendReq header,
 			IEnumerable<EventData> eventData,
+			EventStoreClientOperationOptions operationOptions,
 			UserCredentials userCredentials,
 			CancellationToken cancellationToken) {
 			using var call = _client.Append(RequestMetadata.Create(userCredentials),
-				cancellationToken: cancellationToken);
+				deadline: DeadLine.After(operationOptions.TimeoutAfter), cancellationToken: cancellationToken);
 
 			await call.RequestStream.WriteAsync(header).ConfigureAwait(false);
 

--- a/src/EventStore.Client/EventStoreGrpcClient.Delete.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Delete.cs
@@ -18,6 +18,14 @@ namespace EventStore.Client {
 				}
 			}, operationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Soft Deletes a stream asynchronously.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to delete.</param>
+		/// <param name="expectedRevision">The expected <see cref="StreamRevision"/> of the stream being deleted.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<DeleteResult> SoftDeleteAsync(
 			string streamName,
 			StreamRevision expectedRevision,
@@ -25,6 +33,15 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) => SoftDeleteAsync(streamName, expectedRevision,
 			_settings.OperationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Soft Deletes a stream asynchronously.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to delete.</param>
+		/// <param name="expectedRevision">The expected <see cref="StreamRevision"/> of the stream being deleted.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<DeleteResult> SoftDeleteAsync(
 			string streamName,
 			StreamRevision expectedRevision,
@@ -50,6 +67,14 @@ namespace EventStore.Client {
 				}
 			}.WithAnyStreamRevision(expectedRevision), operationOptions, userCredentials, cancellationToken);
 		
+		/// <summary>
+		/// Soft Deletes a stream asynchronously.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to delete.</param>
+		/// <param name="expectedRevision">The expected <see cref="AnyStreamRevision"/> of the stream being deleted.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<DeleteResult> SoftDeleteAsync(
 			string streamName,
 			AnyStreamRevision expectedRevision,
@@ -57,6 +82,15 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) => SoftDeleteAsync(streamName, expectedRevision,
 			_settings.OperationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Soft Deletes a stream asynchronously.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to delete.</param>
+		/// <param name="expectedRevision">The expected <see cref="AnyStreamRevision"/> of the stream being deleted.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<DeleteResult> SoftDeleteAsync(
 			string streamName,
 			AnyStreamRevision expectedRevision,

--- a/src/EventStore.Client/EventStoreGrpcClient.Metadata.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Metadata.cs
@@ -30,10 +30,25 @@ namespace EventStore.Client {
 					JsonSerializer.Deserialize<StreamMetadata>(metadata.Event.Data, StreamMetadataJsonSerializerOptions));
 		}
 
+		/// <summary>
+		/// Asynchronously reads the metadata for a stream
+		/// </summary>
+		/// <param name="streamName">The name of the stream to read the metadata for.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<StreamMetadataResult> GetStreamMetadataAsync(string streamName,
 			UserCredentials userCredentials = default, CancellationToken cancellationToken = default)
 			=> GetStreamMetadataAsync(streamName, _settings.OperationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Asynchronously reads the metadata for a stream
+		/// </summary>
+		/// <param name="streamName">The name of the stream to read the metadata for.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<StreamMetadataResult> GetStreamMetadataAsync(string streamName,
 			Action<EventStoreClientOperationOptions> configureOperationOptions,
 			UserCredentials userCredentials = default, CancellationToken cancellationToken = default) {
@@ -51,12 +66,31 @@ namespace EventStore.Client {
 				}
 			}.WithAnyStreamRevision(expectedRevision), operationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Asynchronously sets the metadata for a stream.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to set metadata for.</param>
+		/// <param name="expectedRevision">The <see cref="AnyStreamRevision"/> of the stream to append to.</param>
+		/// <param name="metadata">A <see cref="StreamMetadata"/> representing the new metadata.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<WriteResult> SetStreamMetadataAsync(string streamName, AnyStreamRevision expectedRevision,
 			StreamMetadata metadata, UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default)
 			=> SetStreamMetadataAsync(streamName, expectedRevision, metadata, _settings.OperationOptions,
 				userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Asynchronously sets the metadata for a stream.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to set metadata for.</param>
+		/// <param name="expectedRevision">The <see cref="AnyStreamRevision"/> of the stream to append to.</param>
+		/// <param name="metadata">A <see cref="StreamMetadata"/> representing the new metadata.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<WriteResult> SetStreamMetadataAsync(string streamName, AnyStreamRevision expectedRevision,
 			StreamMetadata metadata, Action<EventStoreClientOperationOptions> configureOperationOptions,
 			UserCredentials userCredentials = default,
@@ -77,12 +111,31 @@ namespace EventStore.Client {
 				}
 			}, operationOptions, userCredentials, cancellationToken);
 		
+		/// <summary>
+		/// Asynchronously sets the metadata for a stream.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to set metadata for.</param>
+		/// <param name="expectedRevision">The <see cref="StreamRevision"/> of the stream to append to.</param>
+		/// <param name="metadata">A <see cref="StreamMetadata"/> representing the new metadata.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<WriteResult> SetStreamMetadataAsync(string streamName, StreamRevision expectedRevision,
 			StreamMetadata metadata, UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default)
 			=> SetStreamMetadataAsync(streamName, expectedRevision, metadata, _settings.OperationOptions,
 				userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Asynchronously sets the metadata for a stream.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to set metadata for.</param>
+		/// <param name="expectedRevision">The <see cref="StreamRevision"/> of the stream to append to.</param>
+		/// <param name="metadata">A <see cref="StreamMetadata"/> representing the new metadata.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<WriteResult> SetStreamMetadataAsync(string streamName, StreamRevision expectedRevision,
 			StreamMetadata metadata, Action<EventStoreClientOperationOptions> configureOperationOptions,
 			UserCredentials userCredentials = default,

--- a/src/EventStore.Client/EventStoreGrpcClient.Metadata.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Metadata.cs
@@ -4,17 +4,18 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Client.Streams;
-using Google.Protobuf;
 
 namespace EventStore.Client {
 	public partial class EventStoreClient {
-		public async Task<StreamMetadataResult> GetStreamMetadataAsync(string streamName,
-			UserCredentials userCredentials = default, CancellationToken cancellationToken = default) {
+		private async Task<StreamMetadataResult> GetStreamMetadataAsync(string streamName,
+			EventStoreClientOperationOptions operationOptions, UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
 			ResolvedEvent metadata = default;
 
 			try {
 				metadata = await ReadStreamAsync(Direction.Backwards, SystemStreams.MetastreamOf(streamName), StreamRevision.End, 1,
-					false,
+					operationOptions,
+					resolveLinkTos: false,
 					userCredentials: userCredentials,
 					cancellationToken: cancellationToken).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 			} catch (StreamNotFoundException) {
@@ -29,33 +30,77 @@ namespace EventStore.Client {
 					JsonSerializer.Deserialize<StreamMetadata>(metadata.Event.Data, StreamMetadataJsonSerializerOptions));
 		}
 
-		public Task<WriteResult> SetStreamMetadataAsync(string streamName, AnyStreamRevision expectedRevision,
-			StreamMetadata metadata, UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default)
+		public Task<StreamMetadataResult> GetStreamMetadataAsync(string streamName,
+			UserCredentials userCredentials = default, CancellationToken cancellationToken = default)
+			=> GetStreamMetadataAsync(streamName, _settings.OperationOptions, userCredentials, cancellationToken);
+
+		public Task<StreamMetadataResult> GetStreamMetadataAsync(string streamName,
+			Action<EventStoreClientOperationOptions> configureOperationOptions,
+			UserCredentials userCredentials = default, CancellationToken cancellationToken = default) {
+			var options = _settings.OperationOptions.Clone();
+			configureOperationOptions(options);
+			return GetStreamMetadataAsync(streamName, options, userCredentials, cancellationToken);
+		}
+
+		private Task<WriteResult> SetStreamMetadataAsync(string streamName, AnyStreamRevision expectedRevision,
+			StreamMetadata metadata, EventStoreClientOperationOptions operationOptions,
+			UserCredentials userCredentials = default, CancellationToken cancellationToken = default)
 			=> SetStreamMetadataInternal(metadata, new AppendReq {
 				Options = new AppendReq.Types.Options {
 					StreamName = SystemStreams.MetastreamOf(streamName)
 				}
-			}.WithAnyStreamRevision(expectedRevision), userCredentials, cancellationToken);
+			}.WithAnyStreamRevision(expectedRevision), operationOptions, userCredentials, cancellationToken);
 
-		public Task<WriteResult> SetStreamMetadataAsync(string streamName, StreamRevision expectedRevision,
+		public Task<WriteResult> SetStreamMetadataAsync(string streamName, AnyStreamRevision expectedRevision,
 			StreamMetadata metadata, UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default)
+			=> SetStreamMetadataAsync(streamName, expectedRevision, metadata, _settings.OperationOptions,
+				userCredentials, cancellationToken);
+
+		public Task<WriteResult> SetStreamMetadataAsync(string streamName, AnyStreamRevision expectedRevision,
+			StreamMetadata metadata, Action<EventStoreClientOperationOptions> configureOperationOptions,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			var options = _settings.OperationOptions.Clone();
+			configureOperationOptions(options);
+			return SetStreamMetadataAsync(streamName, expectedRevision, metadata, options,
+				userCredentials, cancellationToken);
+		}
+
+		private Task<WriteResult> SetStreamMetadataAsync(string streamName, StreamRevision expectedRevision,
+			StreamMetadata metadata, EventStoreClientOperationOptions operationOptions,
+			UserCredentials userCredentials = default, CancellationToken cancellationToken = default)
 			=> SetStreamMetadataInternal(metadata, new AppendReq {
 				Options = new AppendReq.Types.Options {
 					StreamName = SystemStreams.MetastreamOf(streamName),
 					Revision = expectedRevision
 				}
-			}, userCredentials,
-				cancellationToken);
+			}, operationOptions, userCredentials, cancellationToken);
+		
+		public Task<WriteResult> SetStreamMetadataAsync(string streamName, StreamRevision expectedRevision,
+			StreamMetadata metadata, UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default)
+			=> SetStreamMetadataAsync(streamName, expectedRevision, metadata, _settings.OperationOptions,
+				userCredentials, cancellationToken);
+
+		public Task<WriteResult> SetStreamMetadataAsync(string streamName, StreamRevision expectedRevision,
+			StreamMetadata metadata, Action<EventStoreClientOperationOptions> configureOperationOptions,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			var options = _settings.OperationOptions.Clone();
+			configureOperationOptions(options);
+			return SetStreamMetadataAsync(streamName, expectedRevision, metadata, options,
+				userCredentials, cancellationToken);
+		}
 
 		private Task<WriteResult> SetStreamMetadataInternal(StreamMetadata metadata,
 			AppendReq appendReq,
+			EventStoreClientOperationOptions operationOptions,
 			UserCredentials userCredentials,
 			CancellationToken cancellationToken) =>
 			AppendToStreamInternal(appendReq, new[] {
 				new EventData(Uuid.NewUuid(), SystemEventTypes.StreamMetadata,
 					JsonSerializer.SerializeToUtf8Bytes(metadata, StreamMetadataJsonSerializerOptions)),
-			}, userCredentials, cancellationToken);
+			}, operationOptions, userCredentials, cancellationToken);
 	}
 }

--- a/src/EventStore.Client/EventStoreGrpcClient.Read.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Read.cs
@@ -9,18 +9,6 @@ using Grpc.Core;
 
 namespace EventStore.Client {
 	public partial class EventStoreClient {
-		/// <summary>
-		/// Asynchronously reads all events in the node forward (e.g. beginning to end).
-		/// </summary>
-		/// <param name="direction">The direction in which to read. <see cref="Direction"/></param>
-		/// <param name="position">The position to start reading from.</param>
-		/// <param name="maxCount">The maximum count to read.</param>
-		/// <param name="operationOptions"><see cref="EventStoreClientOperationOptions" /> to perform the operation with.</param>
-		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
-		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
-		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
-		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
-		/// <returns></returns>
 		private IAsyncEnumerable<ResolvedEvent> ReadAllAsync(
 			Direction direction,
 			Position position,
@@ -46,6 +34,17 @@ namespace EventStore.Client {
 			userCredentials,
 			cancellationToken);
 		
+		/// <summary>
+		/// Asynchronously reads all events.
+		/// </summary>
+		/// <param name="direction">The <see cref="Direction"/> in which to read.</param>
+		/// <param name="position">The <see cref="Position"/> to start reading from.</param>
+		/// <param name="maxCount">The maximum count to read.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public IAsyncEnumerable<ResolvedEvent> ReadAllAsync(
 			Direction direction,
 			Position position,
@@ -56,6 +55,18 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) => ReadAllAsync(direction, position, maxCount,
 			_settings.OperationOptions, resolveLinkTos, filter, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Asynchronously reads all events.
+		/// </summary>
+		/// <param name="direction">The <see cref="Direction"/> in which to read.</param>
+		/// <param name="position">The <see cref="Position"/> to start reading from.</param>
+		/// <param name="maxCount">The maximum count to read.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public IAsyncEnumerable<ResolvedEvent> ReadAllAsync(
 			Direction direction,
 			Position position,
@@ -97,7 +108,17 @@ namespace EventStore.Client {
 			userCredentials,
 			cancellationToken);
 			
-		
+		/// <summary>
+		/// Asynchronously reads all events from a stream.
+		/// </summary>
+		/// <param name="direction">The <see cref="Direction"/> in which to read.</param>
+		/// <param name="streamName">The name of the stream to read.</param>
+		/// <param name="revision">The <see cref="StreamRevision"/> to start reading from.</param>
+		/// <param name="count">The number of events to read from the stream.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public IAsyncEnumerable<ResolvedEvent> ReadStreamAsync(
 			Direction direction,
 			string streamName,
@@ -108,6 +129,18 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) => ReadStreamAsync(direction, streamName, revision, count,
 			_settings.OperationOptions, resolveLinkTos, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Asynchronously reads all the events from a stream.
+		/// </summary>
+		/// <param name="direction">The <see cref="Direction"/> in which to read.</param>
+		/// <param name="streamName">The name of the stream to read.</param>
+		/// <param name="revision">The <see cref="StreamRevision"/> to start reading from.</param>
+		/// <param name="count">The number of events to read from the stream.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public IAsyncEnumerable<ResolvedEvent> ReadStreamAsync(
 			Direction direction,
 			string streamName,

--- a/src/EventStore.Client/EventStoreGrpcClient.Subscriptions.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Subscriptions.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Client.Streams;
@@ -10,74 +9,193 @@ namespace EventStore.Client {
 		/// Subscribes to all events. Use this when you have no checkpoint.
 		/// </summary>
 		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="operationOptions"><see cref="EventStoreClientOperationOptions" /> to perform the operation with.</param>
 		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
 		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
 		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
+		private StreamSubscription SubscribeToAll(
+			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+			EventStoreClientOperationOptions operationOptions,
+			bool resolveLinkTos = false,
+			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
+			IEventFilter filter = null,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			operationOptions.TimeoutAfter = DeadLine.None;
+
+			var subscription = new StreamSubscription(ReadInternal(new ReadReq {
+					Options = new ReadReq.Types.Options {
+						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+						ResolveLinks = resolveLinkTos,
+						All = ReadReq.Types.Options.Types.AllOptions.FromPosition(Position.Start),
+						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions(),
+						Filter = GetFilterOptions(filter)
+					}
+				}, operationOptions, userCredentials, cancellationToken), eventAppeared,
+				subscriptionDropped);
+			return subscription;
+		}
+
 		public StreamSubscription SubscribeToAll(
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			IEventFilter filter = null,
 			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => new StreamSubscription(ReadInternal(new ReadReq {
-				Options = new ReadReq.Types.Options {
-					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
-					ResolveLinks = resolveLinkTos,
-					All = ReadReq.Types.Options.Types.AllOptions.FromPosition(Position.Start),
-					Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions(),
-					Filter = GetFilterOptions(filter)
-				}
-			}, userCredentials,
-			cancellationToken), eventAppeared, subscriptionDropped);
+			CancellationToken cancellationToken = default) => SubscribeToAll(eventAppeared,
+			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped, filter, userCredentials,
+			cancellationToken);
+
+		public StreamSubscription SubscribeToAll(
+			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+			Action<EventStoreClientOperationOptions> configureOperationOptions,
+			bool resolveLinkTos = false,
+			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
+			IEventFilter filter = null,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			var operationOptions = _settings.OperationOptions.Clone();
+			configureOperationOptions(operationOptions);
+
+			return SubscribeToAll(eventAppeared, operationOptions, resolveLinkTos, subscriptionDropped, filter,
+				userCredentials,
+				cancellationToken);
+		}
 
 		/// <summary>
 		/// Subscribes to all events from a checkpoint. This is exclusive of.
 		/// </summary>
 		/// <param name="start">A position (exclusive of) to start the subscription from.</param>
 		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="operationOptions"><see cref="EventStoreClientOperationOptions" /> to perform the operation with.</param>
 		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
 		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
 		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
 		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
 		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
 		/// <returns></returns>
+		private StreamSubscription SubscribeToAll(Position start,
+			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+			EventStoreClientOperationOptions operationOptions,
+			bool resolveLinkTos = false,
+			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
+			IEventFilter filter = null,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			operationOptions.TimeoutAfter = DeadLine.None;
+
+			var subscription = new StreamSubscription(ReadInternal(new ReadReq {
+					Options = new ReadReq.Types.Options {
+						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+						ResolveLinks = resolveLinkTos,
+						All = ReadReq.Types.Options.Types.AllOptions.FromPosition(start),
+						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions(),
+						Filter = GetFilterOptions(filter)
+					}
+				}, operationOptions, userCredentials, cancellationToken), eventAppeared,
+				subscriptionDropped);
+			return subscription;
+		}
+
 		public StreamSubscription SubscribeToAll(Position start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			IEventFilter filter = null,
 			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => new StreamSubscription(ReadInternal(new ReadReq {
-				Options = new ReadReq.Types.Options {
-					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
-					ResolveLinks = resolveLinkTos,
-					All = ReadReq.Types.Options.Types.AllOptions.FromPosition(start),
-					Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions(),
-					Filter = GetFilterOptions(filter)
-				}
-			}, userCredentials,
-			cancellationToken), eventAppeared, subscriptionDropped);
+			CancellationToken cancellationToken = default) => SubscribeToAll(start, eventAppeared,
+			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped, filter, userCredentials,
+			cancellationToken);
+
+		public StreamSubscription SubscribeToAll(Position start,
+			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+			Action<EventStoreClientOperationOptions> configureOperationOptions,
+			bool resolveLinkTos = false,
+			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
+			IEventFilter filter = null,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			var operationOptions = _settings.OperationOptions.Clone();
+			configureOperationOptions(operationOptions);
+
+			return SubscribeToAll(start, eventAppeared, operationOptions, resolveLinkTos, subscriptionDropped, filter,
+				userCredentials, cancellationToken);
+		}
+
+		private StreamSubscription SubscribeToStream(string streamName,
+			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+			EventStoreClientOperationOptions operationOptions,
+			bool resolveLinkTos = false,
+			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			operationOptions.TimeoutAfter = DeadLine.None;
+
+			var subscription = new StreamSubscription(ReadInternal(new ReadReq {
+					Options = new ReadReq.Types.Options {
+						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+						ResolveLinks = resolveLinkTos,
+						Stream = ReadReq.Types.Options.Types.StreamOptions.FromStreamNameAndRevision(
+							streamName,
+							StreamRevision.Start),
+						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
+					}
+				}, operationOptions, userCredentials, cancellationToken), eventAppeared,
+				subscriptionDropped);
+			return subscription;
+		}
 
 		public StreamSubscription SubscribeToStream(string streamName,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => new StreamSubscription(ReadInternal(new ReadReq {
-				Options = new ReadReq.Types.Options {
-					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
-					ResolveLinks = resolveLinkTos,
-					Stream = ReadReq.Types.Options.Types.StreamOptions.FromStreamNameAndRevision(
-						streamName,
-						StreamRevision.Start),
-					Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
-				}
-			},
-			userCredentials,
-			cancellationToken), eventAppeared, subscriptionDropped);
+			CancellationToken cancellationToken = default) => SubscribeToStream(streamName, eventAppeared,
+			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped,
+			userCredentials, cancellationToken);
+
+		public StreamSubscription SubscribeToStream(string streamName,
+			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+			Action<EventStoreClientOperationOptions> configureOperationOptions,
+			bool resolveLinkTos = false,
+			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			
+			var operationOptions = _settings.OperationOptions.Clone();
+			configureOperationOptions(operationOptions);
+			
+			return SubscribeToStream(streamName, eventAppeared, operationOptions, resolveLinkTos, subscriptionDropped,
+				userCredentials, cancellationToken);
+		}
+
+		private StreamSubscription SubscribeToStream(string streamName,
+			StreamRevision start,
+			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+			EventStoreClientOperationOptions operationOptions,
+			bool resolveLinkTos = false,
+			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			
+			operationOptions.TimeoutAfter = DeadLine.None;
+
+			var subscription = new StreamSubscription(ReadInternal(new ReadReq {
+						Options = new ReadReq.Types.Options {
+							ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+							ResolveLinks = resolveLinkTos,
+							Stream = ReadReq.Types.Options.Types.StreamOptions.FromStreamNameAndRevision(streamName,
+								start),
+							Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
+						}
+					},
+					operationOptions, userCredentials, cancellationToken), eventAppeared,
+				subscriptionDropped);
+			return subscription;
+		}
 
 		public StreamSubscription SubscribeToStream(string streamName,
 			StreamRevision start,
@@ -85,15 +203,25 @@ namespace EventStore.Client {
 			bool resolveLinkTos = false,
 			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
 			UserCredentials userCredentials = default,
-			CancellationToken cancellationToken = default) => new StreamSubscription(ReadInternal(new ReadReq {
-				Options = new ReadReq.Types.Options {
-					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
-					ResolveLinks = resolveLinkTos,
-					Stream = ReadReq.Types.Options.Types.StreamOptions.FromStreamNameAndRevision(streamName, start),
-					Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
-				}
-			},
-			userCredentials,
-			cancellationToken), eventAppeared, subscriptionDropped);
+			CancellationToken cancellationToken = default) => SubscribeToStream(streamName, start, eventAppeared,
+			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped,
+			userCredentials, cancellationToken);
+
+		public StreamSubscription SubscribeToStream(string streamName,
+			StreamRevision start,
+			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
+			Action<EventStoreClientOperationOptions> configureOperationOptions,
+			bool resolveLinkTos = false,
+			Action<StreamSubscription, SubscriptionDroppedReason, Exception> subscriptionDropped = default,
+			UserCredentials userCredentials = default,
+			CancellationToken cancellationToken = default) {
+			
+			var operationOptions = _settings.OperationOptions.Clone();
+			configureOperationOptions(operationOptions);
+			
+			return SubscribeToStream(streamName, start, eventAppeared, operationOptions, resolveLinkTos,
+				subscriptionDropped,
+				userCredentials, cancellationToken);
+		}
 	}
 }

--- a/src/EventStore.Client/EventStoreGrpcClient.Subscriptions.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Subscriptions.cs
@@ -5,17 +5,6 @@ using EventStore.Client.Streams;
 
 namespace EventStore.Client {
 	public partial class EventStoreClient {
-		/// <summary>
-		/// Subscribes to all events. Use this when you have no checkpoint.
-		/// </summary>
-		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
-		/// <param name="operationOptions"><see cref="EventStoreClientOperationOptions" /> to perform the operation with.</param>
-		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
-		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
-		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
-		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
-		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
-		/// <returns></returns>
 		private StreamSubscription SubscribeToAll(
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			EventStoreClientOperationOptions operationOptions,
@@ -39,6 +28,16 @@ namespace EventStore.Client {
 			return subscription;
 		}
 
+		/// <summary>
+		/// Subscribes to all events. Use this when you have no checkpoint.
+		/// </summary>
+		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
+		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
+		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public StreamSubscription SubscribeToAll(
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
@@ -49,6 +48,17 @@ namespace EventStore.Client {
 			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped, filter, userCredentials,
 			cancellationToken);
 
+		/// <summary>
+		/// Subscribes to all events. Use this when you have no checkpoint.
+		/// </summary>
+		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
+		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
+		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public StreamSubscription SubscribeToAll(
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<EventStoreClientOperationOptions> configureOperationOptions,
@@ -65,18 +75,6 @@ namespace EventStore.Client {
 				cancellationToken);
 		}
 
-		/// <summary>
-		/// Subscribes to all events from a checkpoint. This is exclusive of.
-		/// </summary>
-		/// <param name="start">A position (exclusive of) to start the subscription from.</param>
-		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
-		/// <param name="operationOptions"><see cref="EventStoreClientOperationOptions" /> to perform the operation with.</param>
-		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
-		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
-		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
-		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
-		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
-		/// <returns></returns>
 		private StreamSubscription SubscribeToAll(Position start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			EventStoreClientOperationOptions operationOptions,
@@ -100,6 +98,17 @@ namespace EventStore.Client {
 			return subscription;
 		}
 
+		/// <summary>
+		/// Subscribes to all events from a checkpoint. This is exclusive of.
+		/// </summary>
+		/// <param name="start">A position (exclusive of) to start the subscription from.</param>
+		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
+		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
+		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public StreamSubscription SubscribeToAll(Position start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
@@ -110,6 +119,18 @@ namespace EventStore.Client {
 			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped, filter, userCredentials,
 			cancellationToken);
 
+		/// <summary>
+		/// Subscribes to all events from a checkpoint. This is exclusive of.
+		/// </summary>
+		/// <param name="start">A <see cref="Position"/> (exclusive of) to start the subscription from.</param>
+		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
+		/// <param name="filter">The optional <see cref="IEventFilter"/> to apply.</param>
+		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public StreamSubscription SubscribeToAll(Position start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<EventStoreClientOperationOptions> configureOperationOptions,
@@ -148,6 +169,16 @@ namespace EventStore.Client {
 			return subscription;
 		}
 
+		/// <summary>
+		/// Subscribes to a stream from a checkpoint. This is exclusive of.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to read events from.</param>
+		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
+		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public StreamSubscription SubscribeToStream(string streamName,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			bool resolveLinkTos = false,
@@ -157,6 +188,17 @@ namespace EventStore.Client {
 			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped,
 			userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Subscribes to a stream from a checkpoint. This is exclusive of.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to read events from.</param>
+		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
+		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public StreamSubscription SubscribeToStream(string streamName,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
 			Action<EventStoreClientOperationOptions> configureOperationOptions,
@@ -197,6 +239,17 @@ namespace EventStore.Client {
 			return subscription;
 		}
 
+		/// <summary>
+		/// Subscribes to a stream from a checkpoint. This is exclusive of.
+		/// </summary>
+		/// <param name="start">A <see cref="Position"/> (exclusive of) to start the subscription from.</param>
+		/// <param name="streamName">The name of the stream to read events from.</param>
+		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
+		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public StreamSubscription SubscribeToStream(string streamName,
 			StreamRevision start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,
@@ -207,6 +260,18 @@ namespace EventStore.Client {
 			_settings.OperationOptions.Clone(), resolveLinkTos, subscriptionDropped,
 			userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Subscribes to a stream from a checkpoint. This is exclusive of.
+		/// </summary>
+		/// <param name="start">A <see cref="Position"/> (exclusive of) to start the subscription from.</param>
+		/// <param name="streamName">The name of the stream to read events from.</param>
+		/// <param name="eventAppeared">A Task invoked and awaited when a new event is received over the subscription.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="resolveLinkTos">Whether to resolve LinkTo events automatically.</param>
+		/// <param name="subscriptionDropped">An action invoked if the subscription is dropped.</param>
+		/// <param name="userCredentials">The optional user credentials to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public StreamSubscription SubscribeToStream(string streamName,
 			StreamRevision start,
 			Func<StreamSubscription, ResolvedEvent, CancellationToken, Task> eventAppeared,

--- a/src/EventStore.Client/EventStoreGrpcClient.Tombstone.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Tombstone.cs
@@ -18,6 +18,14 @@ namespace EventStore.Client {
 				}
 			}, operationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Tombstones a stream asynchronously. Note: Tombstoned streams can never be recreated.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to tombstone.</param>
+		/// <param name="expectedRevision">The expected <see cref="StreamRevision"/> of the stream being deleted.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<DeleteResult> TombstoneAsync(
 			string streamName,
 			StreamRevision expectedRevision,
@@ -25,6 +33,15 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) => TombstoneAsync(streamName, expectedRevision,
 			_settings.OperationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Tombstones a stream asynchronously. Note: Tombstoned streams can never be recreated.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to tombstone.</param>
+		/// <param name="expectedRevision">The expected <see cref="StreamRevision"/> of the stream being deleted.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<DeleteResult> TombstoneAsync(
 			string streamName,
 			StreamRevision expectedRevision,
@@ -50,6 +67,14 @@ namespace EventStore.Client {
 				}
 			}.WithAnyStreamRevision(expectedRevision), operationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Tombstones a stream asynchronously. Note: Tombstoned streams can never be recreated.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to tombstone.</param>
+		/// <param name="expectedRevision">The expected <see cref="AnyStreamRevision"/> of the stream being deleted.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<DeleteResult> TombstoneAsync(
 			string streamName,
 			AnyStreamRevision expectedRevision,
@@ -57,6 +82,15 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken = default) => TombstoneAsync(streamName, expectedRevision,
 			_settings.OperationOptions, userCredentials, cancellationToken);
 
+		/// <summary>
+		/// Tombstones a stream asynchronously. Note: Tombstoned streams can never be recreated.
+		/// </summary>
+		/// <param name="streamName">The name of the stream to tombstone.</param>
+		/// <param name="expectedRevision">The expected <see cref="AnyStreamRevision"/> of the stream being deleted.</param>
+		/// <param name="configureOperationOptions">An <see cref="Action{EventStoreClientOperationOptions}"/> to configure the operation's options.</param>
+		/// <param name="userCredentials">The optional <see cref="UserCredentials"/> to perform operation with.</param>
+		/// <param name="cancellationToken">The optional <see cref="System.Threading.CancellationToken"/>.</param>
+		/// <returns></returns>
 		public Task<DeleteResult> TombstoneAsync(
 			string streamName,
 			AnyStreamRevision expectedRevision,

--- a/src/EventStore.Client/TypedExceptionInterceptor.cs
+++ b/src/EventStore.Client/TypedExceptionInterceptor.cs
@@ -105,7 +105,10 @@ namespace EventStore.Client {
 						.FirstOrDefault(x => x.Key == Constants.Exceptions.ScavengeId)?.Value),
 					_ => (Exception)new InvalidOperationException(ex.Message, ex)
 				},
-				false => new InvalidOperationException(ex.Message, ex)
+				false => ex.StatusCode switch {
+					StatusCode.DeadlineExceeded => ex,
+					_ => new InvalidOperationException()
+				}
 			};
 
 		class AsyncStreamReader<TResponse> : IAsyncStreamReader<TResponse> {


### PR DESCRIPTION
Introduces the ability to specify a deadline on the gRPC operations.

In addition to the ability to set deadlines, we introduced the notion of operation options which can be configured per operation.

**Note**
- There are no tests for the subscriptions client operations. They only set the timeout to never timeout.