### PR TITLE
Add option to enable or disable ATOM Controller

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -313,7 +313,10 @@ namespace EventStore.ClusterNode {
 		
 		[ArgDescription(Opts.DevDescr, Opts.AppGroup)]
 		public bool Dev { get; set; }
-
+		
+		[ArgDescription(Opts.EnableHTTPInterfaceDescr, Opts.InterfacesGroup)]
+		public bool EnableHTTPInterface { get; set; }
+		
 		public ClusterNodeOptions() {
 			Config = "";
 			Help = Opts.ShowHelpDefault;
@@ -364,6 +367,8 @@ namespace EventStore.ClusterNode {
 			BetterOrdering = Opts.BetterOrderingDefault;
 
 			EnableTrustedAuth = Opts.EnableTrustedAuthDefault;
+			
+			EnableHTTPInterface = Opts.EnableHTTPInterfaceDefault;
 
 			ExtTcpHeartbeatTimeout = Opts.ExtTcpHeartbeatTimeoutDefault;
 			IntTcpHeartbeatTimeout = Opts.IntTcpHeartbeatTimeoutDefault;

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -314,8 +314,8 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.DevDescr, Opts.AppGroup)]
 		public bool Dev { get; set; }
 		
-		[ArgDescription(Opts.EnableHTTPInterfaceDescr, Opts.InterfacesGroup)]
-		public bool EnableHTTPInterface { get; set; }
+		[ArgDescription(Opts.EnableAtomPubOverHTTPDescr, Opts.InterfacesGroup)]
+		public bool EnableAtomPubOverHTTP { get; set; }
 		
 		public ClusterNodeOptions() {
 			Config = "";
@@ -367,8 +367,8 @@ namespace EventStore.ClusterNode {
 			BetterOrdering = Opts.BetterOrderingDefault;
 
 			EnableTrustedAuth = Opts.EnableTrustedAuthDefault;
-			
-			EnableHTTPInterface = Opts.EnableHTTPInterfaceDefault;
+
+			EnableAtomPubOverHTTP = Opts.EnableAtomPubOverHTTPDefault;
 
 			ExtTcpHeartbeatTimeout = Opts.ExtTcpHeartbeatTimeoutDefault;
 			IntTcpHeartbeatTimeout = Opts.IntTcpHeartbeatTimeoutDefault;

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -263,7 +263,7 @@ namespace EventStore.ClusterNode {
 				.WithInitializationThreads(options.InitializationThreads)
 				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel)
 				.WithMaxAppendSize(options.MaxAppendSize)
-				.EnableAtomPubOverHTTP();
+				.WithEnableAtomPubOverHTTP(options.EnableAtomPubOverHTTP);
 
 			if (options.GossipSeed.Length > 0)
 				builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -97,7 +97,7 @@ namespace EventStore.ClusterNode {
 					"========================================================================================================\n");
 			}
 
-			if (opts.EnableHTTPInterface) {
+			if (opts.EnableAtomPubOverHTTP) {
 				Log.Warning("\n DEPRECATION WARNING: AtomPub over HTTP Interface has been deprecated in version 20.02. It is recommended to use GRPC instead.\n");
 			}
 
@@ -263,7 +263,7 @@ namespace EventStore.ClusterNode {
 				.WithInitializationThreads(options.InitializationThreads)
 				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel)
 				.WithMaxAppendSize(options.MaxAppendSize)
-				.WithEnableHTTPInterface(options.EnableHTTPInterface);
+				.WithEnableAtomPubOverHTTP(options.EnableAtomPubOverHTTP);
 
 			if (options.GossipSeed.Length > 0)
 				builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -263,7 +263,7 @@ namespace EventStore.ClusterNode {
 				.WithInitializationThreads(options.InitializationThreads)
 				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel)
 				.WithMaxAppendSize(options.MaxAppendSize)
-				.WithEnableAtomPubOverHTTP(options.EnableAtomPubOverHTTP);
+				.EnableAtomPubOverHTTP();
 
 			if (options.GossipSeed.Length > 0)
 				builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -97,6 +97,10 @@ namespace EventStore.ClusterNode {
 					"========================================================================================================\n");
 			}
 
+			if (opts.EnableHTTPInterface) {
+				Log.Warning("\n DEPRECATION WARNING: AtomPub over HTTP Interface has been deprecated in version 20.02. It is recommended to use GRPC instead.\n");
+			}
+
 			if (!opts.MemDb) {
 				var absolutePath = Path.GetFullPath(dbPath);
 				if (Runtime.IsWindows)
@@ -258,7 +262,8 @@ namespace EventStore.ClusterNode {
 				.WithChunkInitialReaderCount(options.ChunkInitialReaderCount)
 				.WithInitializationThreads(options.InitializationThreads)
 				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel)
-				.WithMaxAppendSize(options.MaxAppendSize);
+				.WithMaxAppendSize(options.MaxAppendSize)
+				.WithEnableHTTPInterface(options.EnableHTTPInterface);
 
 			if (options.GossipSeed.Length > 0)
 				builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -19,6 +19,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly X509Certificate2 Certificate;
 		public readonly int WorkerThreads;
 		public readonly bool StartStandardProjections;
+		public readonly bool EnableHTTPInterface;
 		public readonly bool DisableHTTPCaching;
 		public readonly bool LogHttpRequests;
 		public readonly bool LogFailedAuthenticationAttempts;
@@ -158,7 +159,9 @@ namespace EventStore.Core.Cluster.Settings {
 			bool readOnlyReplica = false,
 			int maxAppendSize = 1024 * 1024,
 			Func<HttpMessageHandler> createHttpMessageHandler = null,
-			bool unsafeAllowSurplusNodes = false) {
+			bool unsafeAllowSurplusNodes = false,
+			bool enableHTTPInterface = true
+			) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
@@ -195,6 +198,7 @@ namespace EventStore.Core.Cluster.Settings {
 			Certificate = certificate;
 			WorkerThreads = workerThreads;
 			StartStandardProjections = startStandardProjections;
+			EnableHTTPInterface = enableHTTPInterface;
 			DisableHTTPCaching = disableHTTPCaching;
 			LogHttpRequests = logHttpRequests;
 			LogFailedAuthenticationAttempts = logFailedAuthenticationAttempts;

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly X509Certificate2 Certificate;
 		public readonly int WorkerThreads;
 		public readonly bool StartStandardProjections;
-		public readonly bool EnableHTTPInterface;
+		public readonly bool EnableAtomPubOverHTTP;
 		public readonly bool DisableHTTPCaching;
 		public readonly bool LogHttpRequests;
 		public readonly bool LogFailedAuthenticationAttempts;
@@ -160,7 +160,7 @@ namespace EventStore.Core.Cluster.Settings {
 			int maxAppendSize = 1024 * 1024,
 			Func<HttpMessageHandler> createHttpMessageHandler = null,
 			bool unsafeAllowSurplusNodes = false,
-			bool enableHTTPInterface = true
+			bool enableAtomPubOverHTTP = true
 			) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
@@ -198,7 +198,7 @@ namespace EventStore.Core.Cluster.Settings {
 			Certificate = certificate;
 			WorkerThreads = workerThreads;
 			StartStandardProjections = startStandardProjections;
-			EnableHTTPInterface = enableHTTPInterface;
+			EnableAtomPubOverHTTP = enableAtomPubOverHTTP;
 			DisableHTTPCaching = disableHTTPCaching;
 			LogHttpRequests = logHttpRequests;
 			LogFailedAuthenticationAttempts = logFailedAuthenticationAttempts;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -447,7 +447,7 @@ namespace EventStore.Core {
 			_externalHttpService.SetupController(infoController);
 			if (vNodeSettings.StatsOnPublic)
 				_externalHttpService.SetupController(statController);
-			if (vNodeSettings.EnableHTTPInterface) 
+			if (vNodeSettings.EnableAtomPubOverHTTP) 
 				_externalHttpService.SetupController(atomController);
 			if (vNodeSettings.GossipOnPublic)
 				_externalHttpService.SetupController(gossipController);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -447,7 +447,8 @@ namespace EventStore.Core {
 			_externalHttpService.SetupController(infoController);
 			if (vNodeSettings.StatsOnPublic)
 				_externalHttpService.SetupController(statController);
-			_externalHttpService.SetupController(atomController);
+			if (vNodeSettings.EnableHTTPInterface) 
+				_externalHttpService.SetupController(atomController);
 			if (vNodeSettings.GossipOnPublic)
 				_externalHttpService.SetupController(gossipController);
 			_externalHttpService.SetupController(histogramController);

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -14,7 +14,6 @@ namespace EventStore.Core.Services.Transport.Http {
 	public static class Configure {
 		private const int MaxPossibleAge = 31536000;
 		public static bool DisableHTTPCaching = false;
-		public static bool EnableHTTPInterface = true;
 
 		public static ResponseConfiguration Ok(string contentType) {
 			return new ResponseConfiguration(HttpStatusCode.OK, "OK", contentType, Helper.UTF8NoBom);

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -14,6 +14,7 @@ namespace EventStore.Core.Services.Transport.Http {
 	public static class Configure {
 		private const int MaxPossibleAge = 31536000;
 		public static bool DisableHTTPCaching = false;
+		public static bool EnableHTTPInterface = true;
 
 		public static ResponseConfiguration Ok(string contentType) {
 			return new ResponseConfiguration(HttpStatusCode.OK, "OK", contentType, Helper.UTF8NoBom);

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -219,6 +219,11 @@ namespace EventStore.Core.Util {
 
 		public const string CertificateThumbprintDescr = "The certificate fingerprint/thumbprint.";
 		public static readonly string CertificateThumbprintDefault = string.Empty;
+		
+		public const string EnableHTTPInterfaceDescr =
+			"Client requests using the HTTP API.";
+
+		public static readonly bool EnableHTTPInterfaceDefault = true;
 
 		/*
 		 *  SINGLE NODE OPTIONS

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -220,10 +220,10 @@ namespace EventStore.Core.Util {
 		public const string CertificateThumbprintDescr = "The certificate fingerprint/thumbprint.";
 		public static readonly string CertificateThumbprintDefault = string.Empty;
 		
-		public const string EnableHTTPInterfaceDescr =
-			"Enable the HTTP Interface.";
+		public const string EnableAtomPubOverHTTPDescr =
+			"Enable Atom over HTTP Interface.";
 
-		public static readonly bool EnableHTTPInterfaceDefault = true;
+		public static readonly bool EnableAtomPubOverHTTPDefault = true;
 
 		/*
 		 *  SINGLE NODE OPTIONS

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -221,7 +221,7 @@ namespace EventStore.Core.Util {
 		public static readonly string CertificateThumbprintDefault = string.Empty;
 		
 		public const string EnableHTTPInterfaceDescr =
-			"Client requests using the HTTP API.";
+			"Enable the HTTP Interface.";
 
 		public static readonly bool EnableHTTPInterfaceDefault = true;
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -223,7 +223,7 @@ namespace EventStore.Core.Util {
 		public const string EnableAtomPubOverHTTPDescr =
 			"Enable AtomPub over HTTP Interface.";
 
-		public static readonly bool EnableAtomPubOverHTTPDefault = false;
+		public static readonly bool EnableAtomPubOverHTTPDefault = true;
 
 		/*
 		 *  SINGLE NODE OPTIONS

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -221,9 +221,9 @@ namespace EventStore.Core.Util {
 		public static readonly string CertificateThumbprintDefault = string.Empty;
 		
 		public const string EnableAtomPubOverHTTPDescr =
-			"Enable Atom over HTTP Interface.";
+			"Enable AtomPub over HTTP Interface.";
 
-		public static readonly bool EnableAtomPubOverHTTPDefault = true;
+		public static readonly bool EnableAtomPubOverHTTPDefault = false;
 
 		/*
 		 *  SINGLE NODE OPTIONS

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -256,7 +256,7 @@ namespace EventStore.Core {
 		/// <summary>
 		/// Enable HTTP API Interface
 		/// </summary>
-		/// <param name="EnableHTTPInterface">Enable structured logging</param>
+		/// <param name="EnableHTTPInterface">Enable HTTP Interface</param>
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
 		public VNodeBuilder WithEnableHTTPInterface(bool enableHTTPInterface) {
 			_enableHTTPInterface = enableHTTPInterface;

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core {
 		protected bool _disableHTTPCaching;
 		protected bool _logHttpRequests;
 		protected bool _enableHistograms;
-		protected bool _enableHTTPInterface;
+		protected bool _enableAtomPubOverHTTP;
 		protected IPEndPoint _internalTcp;
 		protected IPEndPoint _internalSecureTcp;
 		protected IPEndPoint _externalTcp;
@@ -155,7 +155,7 @@ namespace EventStore.Core {
 			_inMemoryDb = true;
 			_projectionType = ProjectionType.None;
 
-			_enableHTTPInterface = Opts.EnableHTTPInterfaceDefault;
+			_enableAtomPubOverHTTP = Opts.EnableAtomPubOverHTTPDefault;
 			_externalTcp = new IPEndPoint(Opts.ExternalIpDefault, Opts.ExternalTcpPortDefault);
 			_externalSecureTcp = null;
 			_internalTcp = new IPEndPoint(Opts.InternalIpDefault, Opts.InternalTcpPortDefault);
@@ -256,10 +256,10 @@ namespace EventStore.Core {
 		/// <summary>
 		/// Enable HTTP API Interface
 		/// </summary>
-		/// <param name="EnableHTTPInterface">Enable HTTP Interface</param>
+		/// <param name="EnableAtomPubOverHTTP">Enable AtomPub over HTTP</param>
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-		public VNodeBuilder WithEnableHTTPInterface(bool enableHTTPInterface) {
-			_enableHTTPInterface = enableHTTPInterface;
+		public VNodeBuilder WithEnableAtomPubOverHTTP(bool EnableAtomPubOverHTTP) {
+			_enableAtomPubOverHTTP = EnableAtomPubOverHTTP;
 			return this;
 		}
 
@@ -1388,7 +1388,7 @@ namespace EventStore.Core {
 				_maxAppendSize,
 				_createHttpMessageHandler,
 				_unsafeAllowSurplusNodes,
-				_enableHTTPInterface);
+				_enableAtomPubOverHTTP);
 
 			var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -18,7 +18,6 @@ using EventStore.Core.Services.Transport.Http.Controllers;
 using EventStore.Core.Data;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using EventStore.Core.Index;
-using Microsoft.AspNetCore.Hosting;
 using EventStore.Core.Settings;
 using ILogger = Serilog.ILogger;
 
@@ -29,7 +28,7 @@ namespace EventStore.Core {
 	/// </summary>
 	public abstract class VNodeBuilder {
 		// ReSharper disable FieldCanBeMadeReadOnly.Local - as more options are added
-		protected Serilog.ILogger _log;
+		protected ILogger _log;
 
 		protected int _chunkSize;
 		protected string _dbPath;
@@ -40,6 +39,7 @@ namespace EventStore.Core {
 		protected bool _disableHTTPCaching;
 		protected bool _logHttpRequests;
 		protected bool _enableHistograms;
+		protected bool _enableHTTPInterface;
 		protected IPEndPoint _internalTcp;
 		protected IPEndPoint _internalSecureTcp;
 		protected IPEndPoint _externalTcp;
@@ -155,6 +155,7 @@ namespace EventStore.Core {
 			_inMemoryDb = true;
 			_projectionType = ProjectionType.None;
 
+			_enableHTTPInterface = Opts.EnableHTTPInterfaceDefault;
 			_externalTcp = new IPEndPoint(Opts.ExternalIpDefault, Opts.ExternalTcpPortDefault);
 			_externalSecureTcp = null;
 			_internalTcp = new IPEndPoint(Opts.InternalIpDefault, Opts.InternalTcpPortDefault);
@@ -249,6 +250,16 @@ namespace EventStore.Core {
 			_clusterNodeCount = clusterNodeCount;
 			_prepareAckCount = quorumSize;
 			_commitAckCount = quorumSize;
+			return this;
+		}
+
+		/// <summary>
+		/// Enable HTTP API Interface
+		/// </summary>
+		/// <param name="EnableHTTPInterface">Enable structured logging</param>
+		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+		public VNodeBuilder WithEnableHTTPInterface(bool enableHTTPInterface) {
+			_enableHTTPInterface = enableHTTPInterface;
 			return this;
 		}
 
@@ -1376,7 +1387,8 @@ namespace EventStore.Core {
 				_readOnlyReplica,
 				_maxAppendSize,
 				_createHttpMessageHandler,
-				_unsafeAllowSurplusNodes);
+				_unsafeAllowSurplusNodes,
+				_enableHTTPInterface);
 
 			var infoController = new InfoController(options, _projectionType);
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -258,8 +258,8 @@ namespace EventStore.Core {
 		/// </summary>
 		/// <param name="EnableAtomPubOverHTTP">Enable AtomPub over HTTP</param>
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-		public VNodeBuilder WithEnableAtomPubOverHTTP(bool EnableAtomPubOverHTTP) {
-			_enableAtomPubOverHTTP = EnableAtomPubOverHTTP;
+		public VNodeBuilder EnableAtomPubOverHTTP() {
+			_enableAtomPubOverHTTP = true;
 			return this;
 		}
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -256,10 +256,10 @@ namespace EventStore.Core {
 		/// <summary>
 		/// Enable HTTP API Interface
 		/// </summary>
-		/// <param name="EnableAtomPubOverHTTP">Enable AtomPub over HTTP</param>
+		/// <param name="WithEnableAtomPubOverHTTP">Enable AtomPub over HTTP</param>
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-		public VNodeBuilder EnableAtomPubOverHTTP() {
-			_enableAtomPubOverHTTP = true;
+		public VNodeBuilder WithEnableAtomPubOverHTTP(bool enableAtomPubOverHTTP) {
+			_enableAtomPubOverHTTP = enableAtomPubOverHTTP;
 			return this;
 		}
 


### PR DESCRIPTION
PR adds option to Enable/Disable Atom Controller and shows a deprecation message if Atom controller interface is enabled. Atom Controller is enabled by default, for now.
Flag is --enable-atom-pub-over-http

Breaks UI
This breaks stream browser page and every url /streams/* i.e. viewing streams, events and adding new events. Admin UI is partly broken, scavenges are not shown although scavenge button will still trigger scavenging.

Related to issue https://github.com/EventStore/EventStore/issues/2268
Enable external tcp interface moved to another pr
