### PR TITLE
Add flag to enable external TCP interface

### DIFF
--- a/src/EventStore.ClientAPIAcceptanceTests/EventStoreClientAPIFixture.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/EventStoreClientAPIFixture.cs
@@ -24,7 +24,8 @@ namespace EventStore.ClientAPI.Tests {
 				.WithExternalTcpOn(new IPEndPoint(IPAddress.Loopback, ExternalPort))
 				.WithExternalSecureTcpOn(new IPEndPoint(IPAddress.Loopback, ExternalSecurePort))
 				.WithServerCertificate(new X509Certificate2(mem.ToArray(), "1111"))
-				.RunInMemory();
+				.RunInMemory()
+				.EnableExternalTCP();
 
 			_node = vNodeBuilder.Build();
 			Connections = new Dictionary<bool, IEventStoreConnection> {

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -42,6 +42,9 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.ExternalHttpPortDescr, Opts.InterfacesGroup)]
 		public int ExtHttpPort { get; set; }
 
+		[ArgDescription(Opts.EnableExternalTCPDescr, Opts.InterfacesGroup)]
+		public bool EnableExternalTCP { get; set; }
+		
 		[ArgDescription(Opts.InternalTcpPortDescr, Opts.InterfacesGroup)]
 		public int IntTcpPort { get; set; }
 
@@ -329,6 +332,7 @@ namespace EventStore.ClusterNode {
 			ExtIp = Opts.ExternalIpDefault;
 			IntHttpPort = Opts.InternalHttpPortDefault;
 			ExtHttpPort = Opts.ExternalHttpPortDefault;
+			EnableExternalTCP = Opts.EnableExternalTCPDefault;
 			IntTcpPort = Opts.InternalTcpPortDefault;
 			IntSecureTcpPort = Opts.InternalSecureTcpPortDefault;
 			ExtTcpPort = Opts.ExternalTcpPortDefault;

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -301,6 +301,8 @@ namespace EventStore.ClusterNode {
 				builder.ValidateSslServer();
 			if (options.UseInternalSsl)
 				builder.EnableSsl();
+			if (options.EnableExternalTCP)
+				builder.EnableExternalTCP();
 			if (options.DisableInsecureTCP)
 				builder.DisableInsecureTCP();
 			if (!options.AdminOnExt)

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -116,7 +116,8 @@ namespace EventStore.Core.Tests.Helpers {
 				connectionPendingSendBytesThreshold: Opts.ConnectionPendingSendBytesThresholdDefault,
 				connectionQueueSizeThreshold: Opts.ConnectionQueueSizeThresholdDefault,
 				readOnlyReplica: readOnlyReplica,
-				ptableMaxReaderCount: Constants.PTableMaxReaderCountDefault);
+				ptableMaxReaderCount: Constants.PTableMaxReaderCountDefault,
+				enableExternalTCP: true);
 			_isReadOnlyReplica = readOnlyReplica;
 
 			Log.Information(

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -115,7 +115,8 @@ namespace EventStore.Core.Tests.Helpers {
 				.AdvertiseExternalHttpPortAs(advertisedExtHttpPort)
 				.WithHashCollisionReadLimitOf(hashCollisionReadLimit)
 				.WithIndexBitnessVersion(indexBitnessVersion)
-				.WithHttpMessageHandlerFactory(() => HttpMessageHandler);
+				.WithHttpMessageHandlerFactory(() => HttpMessageHandler)
+				.EnableExternalTCP();
 
 			if (enableTrustedAuth)
 				builder.EnableTrustedAuth();

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -40,6 +38,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly int NodePriority;
 
 		public readonly bool UseSsl;
+		public readonly bool EnableExternalTCP;
 		public readonly bool DisableInsecureTCP;
 		public readonly string SslTargetHost;
 		public readonly bool SslValidateServer;
@@ -160,8 +159,8 @@ namespace EventStore.Core.Cluster.Settings {
 			int maxAppendSize = 1024 * 1024,
 			Func<HttpMessageHandler> createHttpMessageHandler = null,
 			bool unsafeAllowSurplusNodes = false,
-			bool enableAtomPubOverHTTP = true
-			) {
+			bool enableExternalTCP = false,
+			bool enableAtomPubOverHTTP = true) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
@@ -218,6 +217,7 @@ namespace EventStore.Core.Cluster.Settings {
 			CommitTimeout = commitTimeout;
 
 			UseSsl = useSsl;
+			EnableExternalTCP = enableExternalTCP;
 			DisableInsecureTCP = disableInsecureTCP;
 			SslTargetHost = sslTargetHost;
 			SslValidateServer = sslValidateServer;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -336,7 +336,7 @@ namespace EventStore.Core {
 
 			{
 				// EXTERNAL TCP
-				if (!vNodeSettings.DisableInsecureTCP) {
+				if (!vNodeSettings.DisableInsecureTCP && vNodeSettings.EnableExternalTCP) {
 					var extTcpService = new TcpService(_mainQueue, _nodeInfo.ExternalTcp, _workersHandler,
 						TcpServiceType.External, TcpSecurityType.Normal, new ClientTcpDispatcher(),
 						vNodeSettings.ExtTcpHeartbeatInterval, vNodeSettings.ExtTcpHeartbeatTimeout,
@@ -348,7 +348,7 @@ namespace EventStore.Core {
 				}
 
 				// EXTERNAL SECURE TCP
-				if (_nodeInfo.ExternalSecureTcp != null) {
+				if (_nodeInfo.ExternalSecureTcp != null && vNodeSettings.EnableExternalTCP) {
 					var extSecTcpService = new TcpService(_mainQueue, _nodeInfo.ExternalSecureTcp, _workersHandler,
 						TcpServiceType.External, TcpSecurityType.Secure, new ClientTcpDispatcher(),
 						vNodeSettings.ExtTcpHeartbeatInterval, vNodeSettings.ExtTcpHeartbeatTimeout,

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -339,6 +339,11 @@ namespace EventStore.Core.Util {
 		public const string UseInternalSslDescr = "Whether to use secure internal communication.";
 		public const bool UseInternalSslDefault = false;
 
+		
+		public const string EnableExternalTCPDescr = "Whether to enable external TCP communication";
+		public const bool EnableExternalTCPDefault = false;
+
+		
 		public const string DisableInsecureTCPDescr = "Whether to disable insecure TCP communication";
 		public const bool DisableInsecureTCPDefault = false;
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -66,6 +66,7 @@ namespace EventStore.Core {
 		protected int _nodePriority;
 
 		protected bool _useSsl;
+		protected bool _enableExternalTCP;
 		protected bool _disableInsecureTCP;
 		protected string _sslTargetHost;
 		protected bool _sslValidateServer;
@@ -183,6 +184,7 @@ namespace EventStore.Core {
 			_nodePriority = Opts.NodePriorityDefault;
 
 			_useSsl = Opts.UseInternalSslDefault;
+			_enableExternalTCP = Opts.EnableExternalTCPDefault;
 			_disableInsecureTCP = Opts.DisableInsecureTCPDefault;
 			_sslTargetHost = Opts.SslTargetHostDefault;
 			_sslValidateServer = Opts.SslValidateServerDefault;
@@ -521,6 +523,15 @@ namespace EventStore.Core {
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
 		public VNodeBuilder EnableSsl() {
 			_useSsl = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Enable External TCP Communication
+		/// </summary>
+		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+		public VNodeBuilder EnableExternalTCP() {
+			_enableExternalTCP = true;
 			return this;
 		}
 
@@ -1388,6 +1399,7 @@ namespace EventStore.Core {
 				_maxAppendSize,
 				_createHttpMessageHandler,
 				_unsafeAllowSurplusNodes,
+				_enableExternalTCP,
 				_enableAtomPubOverHTTP);
 
 			var infoController = new InfoController(options, _projectionType);


### PR DESCRIPTION
Flag to enable external tcp interface. External TCP Interface is disabled by default.
--enable-external-tcp
Related to issue https://github.com/EventStore/EventStore/issues/2268