### PR TITLE
Introduce Cluster Connectivity for the gRPC Client

### DIFF
--- a/src/EventStore.Client.Common/Constants.cs
+++ b/src/EventStore.Client.Common/Constants.cs
@@ -10,6 +10,7 @@ namespace EventStore.Client {
 			public const string StreamNotFound = "stream-not-found";
 			public const string MaximumAppendSizeExceeded = "maximum-append-size-exceeded";
 			public const string MissingRequiredMetadataProperty = "missing-required-metadata-property";
+			public const string NotLeader = "not-leader";
 
 			public const string PersistentSubscriptionFailed = "persistent-subscription-failed";
 			public const string PersistentSubscriptionDoesNotExist = "persistent-subscription-does-not-exist";
@@ -30,6 +31,7 @@ namespace EventStore.Client {
 			public const string MaximumAppendSize = "maximum-append-size";
 			public const string RequiredMetadataProperties = "required-metadata-properties";
 			public const string ScavengeId = "scavenge-id";
+			public const string LeaderEndpoint = "leader-endpoint";
 
 			public const string LoginName = "login-name";
 		}

--- a/src/EventStore.Client.Common/Constants.cs
+++ b/src/EventStore.Client.Common/Constants.cs
@@ -46,6 +46,7 @@ namespace EventStore.Client {
 			public const string BasicScheme = "Basic";
 
 			public const string ConnectionName = "connection-name";
+			public const string RequiresLeader = "requires-leader";
 		}
 	}
 }

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/StandaloneKestrelServerFixture.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/StandaloneKestrelServerFixture.cs
@@ -51,13 +51,10 @@ namespace EventStore.Client {
 			Client = new EventStoreClient(new UriBuilder {
 				Port = port,
 				Scheme = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? Uri.UriSchemeHttp : Uri.UriSchemeHttps
-			}.Uri, () => new HttpClient(new SocketsHttpHandler {
+			}.Uri, () => new SocketsHttpHandler {
 				SslOptions = new SslClientAuthenticationOptions {
 					RemoteCertificateValidationCallback = delegate { return true; }
 				}
-			}) {
-				DefaultRequestVersion = new Version(2, 0),
-				Timeout = Timeout.InfiniteTimeSpan
 			});
 		}
 

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/StandaloneKestrelServerFixture.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/StandaloneKestrelServerFixture.cs
@@ -48,12 +48,19 @@ namespace EventStore.Client {
 				.UseStartup(_node.Startup)
 				.Build();
 
-			Client = new EventStoreClient(new UriBuilder {
-				Port = port,
-				Scheme = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? Uri.UriSchemeHttp : Uri.UriSchemeHttps
-			}.Uri, () => new SocketsHttpHandler {
-				SslOptions = new SslClientAuthenticationOptions {
-					RemoteCertificateValidationCallback = delegate { return true; }
+			Client = new EventStoreClient(new EventStoreClientSettings {
+				CreateHttpMessageHandler = () => new SocketsHttpHandler {
+					SslOptions = new SslClientAuthenticationOptions {
+						RemoteCertificateValidationCallback = delegate { return true; }
+					}
+				},
+				ConnectivitySettings = new EventStoreClientConnectivitySettings {
+					Address = new UriBuilder {
+						Port = port,
+						Scheme = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
+							? Uri.UriSchemeHttp
+							: Uri.UriSchemeHttps
+					}.Uri,
 				}
 			});
 		}

--- a/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
+++ b/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
@@ -42,11 +42,9 @@ namespace EventStore.Client {
 				webHostBuilder
 					.UseStartup(new TestClusterVNodeStartup(Node)));
 
-			var settings = clientSettings ?? new EventStoreClientSettings(new UriBuilder().Uri) {
-				CreateHttpClient = () => new HttpClient(new ResponseVersionHandler {
+			var settings = clientSettings ?? new EventStoreClientSettings() {
+				CreateHttpMessageHandler = () => new ResponseVersionHandler {
 					InnerHandler = TestServer.CreateHandler()
-				}) {
-					Timeout = Timeout.InfiniteTimeSpan
 				}
 			};
 

--- a/src/EventStore.Client.Tests/ClusterAwareHttpHandlerTests.cs
+++ b/src/EventStore.Client.Tests/ClusterAwareHttpHandlerTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Xunit;
 
 namespace EventStore.Client {
-	public class NodeBasedClientHandlerTests {
+	public class ClusterAwareHttpHandlerTests {
 		[Theory, InlineData(true), InlineData(false)]
 		public async Task should_set_requires_leader_header(bool requiresLeader) {
 			var sut = new ClusterAwareHttpHandler(
@@ -66,6 +66,25 @@ namespace EventStore.Client {
 				client.SendAsync(new HttpRequestMessage(HttpMethod.Get, new UriBuilder().Uri)));
 
 			Assert.Equal(2, discoveryAttempts);
+		}
+
+		[Fact]
+		public async Task should_set_endpoint_to_leader_endpoint_on_exception() {
+			var sut = new ClusterAwareHttpHandler(
+				true, new FakeEndpointDiscoverer(() => new IPEndPoint(IPAddress.Parse("0.0.0.0"), 2113))) {
+				InnerHandler = new TestMessageHandler()
+			};
+
+			var client = new HttpClient(sut);
+
+			var request = new HttpRequestMessage(HttpMethod.Get, new UriBuilder().Uri);
+
+			var newLeaderEndpoint = new IPEndPoint(IPAddress.Loopback, 1115);
+			sut.ExceptionOccurred(new NotLeaderException(newLeaderEndpoint));
+			await client.SendAsync(request);
+			
+			Assert.Equal(newLeaderEndpoint.Address.ToString(), request.RequestUri.Host);
+			Assert.Equal(newLeaderEndpoint.Port, request.RequestUri.Port);
 		}
 	}
 

--- a/src/EventStore.Client.Tests/GossipBasedEndpointDiscovererTests.cs
+++ b/src/EventStore.Client.Tests/GossipBasedEndpointDiscovererTests.cs
@@ -1,0 +1,272 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client {
+	public class GossipBasedEndpointDiscovererTests {
+		[Fact]
+		public async Task should_issue_gossip_to_gossip_seed() {
+			HttpRequestMessage request = null;
+			var gossip = new ClusterMessages.ClusterInfo {
+				Members = new[] {
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Leader,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 4444,
+						IsAlive = true,
+					},
+				}
+			};
+
+			var handler = new FakeMessageHandler(req => {
+				request = req;
+				return ResponseFromGossip(gossip);
+			});
+
+			var gossipSeed = new DnsEndPoint("gossip_seed_endpoint", 1114);
+
+			var sut = new ClusterEndpointDiscoverer(1, new[] {
+				gossipSeed,
+			}, Timeout.InfiniteTimeSpan, TimeSpan.Zero, NodePreference.Leader, handler);
+
+			await sut.DiscoverAsync();
+
+			Assert.Equal(Uri.UriSchemeHttps, request?.RequestUri.Scheme);
+			Assert.Equal(gossipSeed.Host, request?.RequestUri.Host);
+			Assert.Equal(gossipSeed.Port, request?.RequestUri.Port);
+		}
+		
+		[Fact]
+		public async Task should_be_able_to_discover_twice() {
+			bool isFirstGossip = true;
+			var firstGossip = new ClusterMessages.ClusterInfo {
+				Members = new[] {
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Leader,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 1111,
+						IsAlive = true,
+					},
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Follower,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 2222,
+						IsAlive = true,
+					},
+				}
+			};
+			var secondGossip = new ClusterMessages.ClusterInfo {
+				Members = new[] {
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Leader,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 1111,
+						IsAlive = false,
+					},
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Leader,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 2222,
+						IsAlive = true,
+					},
+				}
+			};
+
+			var handler = new FakeMessageHandler(req => {
+				if (isFirstGossip) {
+					isFirstGossip = false;
+					return ResponseFromGossip(firstGossip);
+				} else {
+					return ResponseFromGossip(secondGossip);
+				}
+			});
+
+			var gossipSeed = new DnsEndPoint("gossip_seed_endpoint", 1114);
+
+			var sut = new ClusterEndpointDiscoverer(5, new[] {
+				gossipSeed,
+			}, Timeout.InfiniteTimeSpan, TimeSpan.Zero, NodePreference.Leader, handler);
+
+			var result = await sut.DiscoverAsync();
+
+			var expected = firstGossip.Members.First(x => x.ExternalHttpPort == 1111);
+			
+			Assert.Equal(expected.ExternalHttpIp, result.Address.ToString());
+			Assert.Equal(expected.ExternalHttpPort, result.Port);
+			
+			result = await sut.DiscoverAsync();
+
+			expected = secondGossip.Members.First(x => x.ExternalHttpPort == 2222);
+			
+			Assert.Equal(expected.ExternalHttpIp, result.Address.ToString());
+			Assert.Equal(expected.ExternalHttpPort, result.Port);
+		}
+
+		[Fact]
+		public async Task should_not_exceed_max_discovery_attempts() {
+			int maxDiscoveryAttempts = 5;
+			int discoveryAttempts = 0;
+
+			var handler = new FakeMessageHandler(request => {
+				discoveryAttempts++;
+				throw new Exception();
+			});
+
+			var sut = new ClusterEndpointDiscoverer(maxDiscoveryAttempts, new[] {
+				new DnsEndPoint("localhost", 1114),
+			}, Timeout.InfiniteTimeSpan, TimeSpan.Zero, NodePreference.Leader, handler);
+
+			await Assert.ThrowsAsync<DiscoveryException>(() => sut.DiscoverAsync());
+
+			Assert.Equal(maxDiscoveryAttempts, discoveryAttempts);
+		}
+
+		[Theory,
+		 InlineData(ClusterMessages.VNodeState.Manager),
+		 InlineData(ClusterMessages.VNodeState.Shutdown),
+		 InlineData(ClusterMessages.VNodeState.Unknown),
+		 InlineData(ClusterMessages.VNodeState.Initializing),
+		 InlineData(ClusterMessages.VNodeState.CatchingUp),
+		 InlineData(ClusterMessages.VNodeState.ResigningLeader),
+		 InlineData(ClusterMessages.VNodeState.ShuttingDown),
+		 InlineData(ClusterMessages.VNodeState.PreLeader),
+		 InlineData(ClusterMessages.VNodeState.PreReplica),
+		 InlineData(ClusterMessages.VNodeState.PreReadOnlyReplica)]
+		public async Task should_not_be_able_to_pick_invalid_node(ClusterMessages.VNodeState invalidState) {
+			var gossip = new ClusterMessages.ClusterInfo {
+				Members = new[] {
+					new ClusterMessages.MemberInfo {
+						State = invalidState,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 4444,
+						IsAlive = true,
+					},
+				}
+			};
+
+			var handler = new FakeMessageHandler(req => ResponseFromGossip(gossip));
+
+			var sut = new ClusterEndpointDiscoverer(1, new[] { new DnsEndPoint("localhost", 1113),
+			}, Timeout.InfiniteTimeSpan, TimeSpan.Zero, NodePreference.Leader, handler);
+
+			await Assert.ThrowsAsync<DiscoveryException>(() => sut.DiscoverAsync());
+		}
+
+		[Theory,
+		 InlineData(NodePreference.Leader, ClusterMessages.VNodeState.Leader),
+		 InlineData(NodePreference.Follower, ClusterMessages.VNodeState.Follower),
+		 InlineData(NodePreference.ReadOnlyReplica, ClusterMessages.VNodeState.ReadOnlyReplica),
+		 InlineData(NodePreference.ReadOnlyReplica, ClusterMessages.VNodeState.ReadOnlyLeaderless)]
+		public async Task should_pick_node_based_on_preference(NodePreference preference,
+			ClusterMessages.VNodeState expectedState) {
+			var gossip = new ClusterMessages.ClusterInfo {
+				Members = new[] {
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Leader,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 1111,
+						IsAlive = true,
+					},
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Follower,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 2222,
+						IsAlive = true,
+					},
+					new ClusterMessages.MemberInfo {
+						State = expectedState == ClusterMessages.VNodeState.ReadOnlyLeaderless
+							? expectedState
+							: ClusterMessages.VNodeState.ReadOnlyReplica,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 3333,
+						IsAlive = true,
+					},
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Manager,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 4444,
+						IsAlive = true,
+					},
+				}
+			};
+			var handler = new FakeMessageHandler(req => ResponseFromGossip(gossip));
+
+			var sut = new ClusterEndpointDiscoverer(1, new[] {
+				new DnsEndPoint("localhost", 1113)
+			}, Timeout.InfiniteTimeSpan, TimeSpan.Zero, preference, handler);
+
+			var result = await sut.DiscoverAsync();
+			Assert.Equal(result.Port,
+				gossip.Members.Last(x => x.State == expectedState).ExternalHttpPort);
+		}
+
+		[Fact]
+		public async Task falls_back_to_first_alive_node_if_a_preferred_node_is_not_found() {
+			var gossip = new ClusterMessages.ClusterInfo {
+				Members = new[] {
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Leader,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 1111,
+						IsAlive = false,
+					},
+					new ClusterMessages.MemberInfo {
+						State = ClusterMessages.VNodeState.Follower,
+						InstanceId = Guid.NewGuid(),
+						ExternalHttpIp = IPAddress.Any.ToString(),
+						ExternalHttpPort = 2222,
+						IsAlive = true,
+					},
+				}
+			};
+			var handler = new FakeMessageHandler(req => ResponseFromGossip(gossip));
+
+			var sut = new ClusterEndpointDiscoverer(1, new[] {
+				new DnsEndPoint("localhost", 1113)
+			}, Timeout.InfiniteTimeSpan, TimeSpan.Zero, NodePreference.Leader, handler);
+
+			var result = await sut.DiscoverAsync();
+			Assert.Equal(result.Port,
+				gossip.Members.Last(x => x.State == ClusterMessages.VNodeState.Follower).ExternalHttpPort);
+		}
+
+		private HttpResponseMessage ResponseFromGossip(ClusterMessages.ClusterInfo gossip) =>
+			new HttpResponseMessage(HttpStatusCode.OK) {
+				Content = new StringContent(JsonSerializer.Serialize(gossip, new JsonSerializerOptions {
+					PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+					PropertyNameCaseInsensitive = true,
+					Converters = {new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)}
+				}))
+			};
+
+		private class FakeMessageHandler : HttpMessageHandler {
+			private readonly Func<HttpRequestMessage, HttpResponseMessage> _handle;
+
+			public FakeMessageHandler(Func<HttpRequestMessage, HttpResponseMessage> handle) {
+				_handle = handle;
+			}
+
+			protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+				CancellationToken cancellationToken) {
+				return Task.FromResult(_handle(request));
+			}
+		}
+	}
+}

--- a/src/EventStore.Client.Tests/NodeBasedClientHandlerTests.cs
+++ b/src/EventStore.Client.Tests/NodeBasedClientHandlerTests.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace EventStore.Client {
+	public class NodeBasedClientHandlerTests {
+		[Theory, InlineData(true), InlineData(false)]
+		public async Task should_set_requires_leader_header(bool requiresLeader) {
+			var sut = new ClusterAwareHttpHandler(
+				requiresLeader, new FakeEndpointDiscoverer(() => new IPEndPoint(IPAddress.Parse("0.0.0.0"), 2113))) {
+				InnerHandler = new TestMessageHandler()
+			};
+
+			var client = new HttpClient(sut);
+
+			var request = new HttpRequestMessage(HttpMethod.Get, new UriBuilder().Uri);
+
+			await client.SendAsync(request);
+
+			request.Headers.TryGetValues(Constants.Headers.RequiresLeader, out var value);
+			Assert.True(request.Headers.Contains(Constants.Headers.RequiresLeader));
+			Assert.True(bool.Parse(value.First()) == requiresLeader);
+		}
+
+		[Fact]
+		public async Task should_issue_request_to_discovered_endpoint() {
+			var discoveredEndpoint = new IPEndPoint(IPAddress.Parse("0.0.0.0"), 2113);
+
+			var sut = new ClusterAwareHttpHandler(
+				true, new FakeEndpointDiscoverer(() => discoveredEndpoint)) {
+				InnerHandler = new TestMessageHandler()
+			};
+
+			var client = new HttpClient(sut);
+
+			await client.SendAsync(new HttpRequestMessage(HttpMethod.Get, new UriBuilder().Uri));
+
+			var request = new HttpRequestMessage(HttpMethod.Get, new UriBuilder().Uri);
+			await client.SendAsync(request);
+
+			Assert.Equal(discoveredEndpoint.Address.ToString(), request.RequestUri.Host);
+			Assert.Equal(discoveredEndpoint.Port, request.RequestUri.Port);
+		}
+
+		[Fact]
+		public async Task should_attempt_endpoint_discovery_on_next_request_when_request_fails() {
+			int discoveryAttempts = 0;
+
+			var sut = new ClusterAwareHttpHandler(
+				true, new FakeEndpointDiscoverer(() => {
+					discoveryAttempts++;
+					throw new Exception();
+				})) {
+				InnerHandler = new TestMessageHandler()
+			};
+
+			var client = new HttpClient(sut);
+
+			await Assert.ThrowsAsync<Exception>(() =>
+				client.SendAsync(new HttpRequestMessage(HttpMethod.Get, new UriBuilder().Uri)));
+			await Assert.ThrowsAsync<Exception>(() =>
+				client.SendAsync(new HttpRequestMessage(HttpMethod.Get, new UriBuilder().Uri)));
+
+			Assert.Equal(2, discoveryAttempts);
+		}
+	}
+
+	internal class FakeEndpointDiscoverer : IEndpointDiscoverer {
+		private readonly Func<IPEndPoint> _function;
+
+		public FakeEndpointDiscoverer(Func<IPEndPoint> function) {
+			_function = function;
+		}
+
+		public Task<IPEndPoint> DiscoverAsync() {
+			return Task.FromResult(_function());
+		}
+	}
+
+	internal class TestMessageHandler : HttpMessageHandler {
+		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+			CancellationToken cancellationToken) {
+			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+		}
+	}
+}

--- a/src/EventStore.Client.Tests/Streams/append_to_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/append_to_stream_with_timeout.cs
@@ -36,9 +36,9 @@ namespace EventStore.Client.Streams {
 		}
 
 		public class Fixture : EventStoreGrpcFixture {
-			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
-				CreateHttpClient = () =>
-					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			public Fixture() : base(clientSettings: new EventStoreClientSettings {
+				CreateHttpMessageHandler = () =>
+					new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)}
 			}) {
 			}
 

--- a/src/EventStore.Client.Tests/Streams/delete_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/delete_stream_with_timeout.cs
@@ -56,9 +56,9 @@ namespace EventStore.Client.Streams {
 		}
 
 		public class Fixture : EventStoreGrpcFixture {
-			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
-				CreateHttpClient = () =>
-					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			public Fixture() : base(clientSettings: new EventStoreClientSettings {
+				CreateHttpMessageHandler = () =>
+					new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)}
 			}) {
 			}
 

--- a/src/EventStore.Client.Tests/Streams/read_all_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_with_timeout.cs
@@ -25,9 +25,9 @@ namespace EventStore.Client.Streams {
 		}
 
 		public class Fixture : EventStoreGrpcFixture {
-			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
-				CreateHttpClient = () =>
-					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			public Fixture() : base(clientSettings: new EventStoreClientSettings {
+				CreateHttpMessageHandler = () =>
+					new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)}
 			}) {
 			}
 

--- a/src/EventStore.Client.Tests/Streams/read_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_with_timeout.cs
@@ -27,9 +27,9 @@ namespace EventStore.Client.Streams {
 		}
 
 		public class Fixture : EventStoreGrpcFixture {
-			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
-				CreateHttpClient = () =>
-					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			public Fixture() : base(clientSettings: new EventStoreClientSettings {
+				CreateHttpMessageHandler = () =>
+					new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)}
 			}) {
 			}
 			protected override Task Given() => Task.CompletedTask;

--- a/src/EventStore.Client.Tests/Streams/stream_metadata_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/stream_metadata_with_timeout.cs
@@ -45,9 +45,9 @@ namespace EventStore.Client.Streams {
 		}
 
 		public class Fixture : EventStoreGrpcFixture {
-			public Fixture() : base(clientSettings: new EventStoreClientSettings(new UriBuilder().Uri) {
-				CreateHttpClient = () =>
-					new HttpClient(new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)})
+			public Fixture() : base(clientSettings: new EventStoreClientSettings {
+				CreateHttpMessageHandler = () =>
+					new ResponseVersionHandler {InnerHandler = new DelayedHandler(200)}
 			}) {
 			}
 			protected override Task Given() => Task.CompletedTask;

--- a/src/EventStore.Client/ClusterAwareHttpHandler.cs
+++ b/src/EventStore.Client/ClusterAwareHttpHandler.cs
@@ -37,8 +37,8 @@ namespace EventStore.Client {
 		}
 
 		public void ExceptionOccurred(Exception exception) {
-			if (exception is NotLeaderException) {
-				_endpoint = new Lazy<Task<IPEndPoint>>(Task.FromResult(((NotLeaderException)exception).LeaderEndpoint));
+			if (exception is NotLeaderException ex) {
+				_endpoint = new Lazy<Task<IPEndPoint>>(Task.FromResult(ex.LeaderEndpoint));
 			}
 		}
 	}

--- a/src/EventStore.Client/ClusterAwareHttpHandler.cs
+++ b/src/EventStore.Client/ClusterAwareHttpHandler.cs
@@ -9,20 +9,20 @@ namespace EventStore.Client {
 		private readonly bool _requiresLeader;
 		private readonly IEndpointDiscoverer _endpointDiscoverer;
 		private Lazy<Task<IPEndPoint>> _endpoint;
-	
+
 		public ClusterAwareHttpHandler(bool requiresLeader, IEndpointDiscoverer endpointDiscoverer) {
 			_requiresLeader = requiresLeader;
 			_endpointDiscoverer = endpointDiscoverer;
 			_endpoint = new Lazy<Task<IPEndPoint>>(endpointDiscoverer.DiscoverAsync,
 				LazyThreadSafetyMode.ExecutionAndPublication);
 		}
-	
+
 		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
 			CancellationToken cancellationToken) {
 			var endpointResolver = _endpoint;
 			try {
 				var endpoint = await endpointResolver.Value;
-				
+
 				request.RequestUri = new UriBuilder(Uri.UriSchemeHttps, endpoint.Address.ToString(), endpoint.Port,
 					request.RequestUri.PathAndQuery).Uri;
 				request.Headers.Add(Constants.Headers.RequiresLeader, _requiresLeader.ToString());
@@ -31,8 +31,14 @@ namespace EventStore.Client {
 				Interlocked.CompareExchange(ref _endpoint,
 					new Lazy<Task<IPEndPoint>>(() => _endpointDiscoverer.DiscoverAsync(),
 						LazyThreadSafetyMode.ExecutionAndPublication), endpointResolver);
-	
+
 				throw;
+			}
+		}
+
+		public void ExceptionOccurred(Exception exception) {
+			if (exception is NotLeaderException) {
+				_endpoint = new Lazy<Task<IPEndPoint>>(Task.FromResult(((NotLeaderException)exception).LeaderEndpoint));
 			}
 		}
 	}

--- a/src/EventStore.Client/ClusterAwareHttpHandler.cs
+++ b/src/EventStore.Client/ClusterAwareHttpHandler.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Client {
+	public class ClusterAwareHttpHandler : DelegatingHandler {
+		private readonly bool _requiresLeader;
+		private readonly IEndpointDiscoverer _endpointDiscoverer;
+		private Lazy<Task<IPEndPoint>> _endpoint;
+	
+		public ClusterAwareHttpHandler(bool requiresLeader, IEndpointDiscoverer endpointDiscoverer) {
+			_requiresLeader = requiresLeader;
+			_endpointDiscoverer = endpointDiscoverer;
+			_endpoint = new Lazy<Task<IPEndPoint>>(endpointDiscoverer.DiscoverAsync,
+				LazyThreadSafetyMode.ExecutionAndPublication);
+		}
+	
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+			CancellationToken cancellationToken) {
+			var endpointResolver = _endpoint;
+			try {
+				var endpoint = await endpointResolver.Value;
+				
+				request.RequestUri = new UriBuilder(Uri.UriSchemeHttps, endpoint.Address.ToString(), endpoint.Port,
+					request.RequestUri.PathAndQuery).Uri;
+				request.Headers.Add(Constants.Headers.RequiresLeader, _requiresLeader.ToString());
+				return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+			} catch (Exception) {
+				Interlocked.CompareExchange(ref _endpoint,
+					new Lazy<Task<IPEndPoint>>(() => _endpointDiscoverer.DiscoverAsync(),
+						LazyThreadSafetyMode.ExecutionAndPublication), endpointResolver);
+	
+				throw;
+			}
+		}
+	}
+}

--- a/src/EventStore.Client/ClusterMessage.cs
+++ b/src/EventStore.Client/ClusterMessage.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace EventStore.Client {
+	public class ClusterMessages {
+		public class ClusterInfo {
+			public MemberInfo[] Members { get; set; }
+		}
+
+		public class MemberInfo {
+			public Guid InstanceId { get; set; }
+
+			public VNodeState State { get; set; }
+			public bool IsAlive { get; set; }
+			public string ExternalHttpIp { get; set; }
+			public int ExternalHttpPort { get; set; }
+		}
+
+		public enum VNodeState {
+			Initializing,
+			Unknown,
+			PreReplica,
+			CatchingUp,
+			Clone,
+			Follower,
+			PreLeader,
+			Leader,
+			Manager,
+			ShuttingDown,
+			Shutdown,
+			ReadOnlyLeaderless,
+			PreReadOnlyReplica,
+			ReadOnlyReplica,
+			ResigningLeader
+		}
+	}
+}

--- a/src/EventStore.Client/DiscoveryException.cs
+++ b/src/EventStore.Client/DiscoveryException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace EventStore.Client {
+	public class DiscoveryException : Exception {
+		public DiscoveryException(string message)
+			: base(message) {
+		}
+
+		public DiscoveryException(string message, Exception innerException)
+			: base(message, innerException) {
+		}
+	}
+}

--- a/src/EventStore.Client/EndpointExtensions.cs
+++ b/src/EventStore.Client/EndpointExtensions.cs
@@ -1,0 +1,45 @@
+﻿using System.Net;
+
+namespace EventStore.Client {
+	public static class EndpointExtensions {
+		public static string ToHttpUrl(this EndPoint endPoint, string schema, string rawUrl = null) {
+			if (endPoint is IPEndPoint) {
+				var ipEndPoint = endPoint as IPEndPoint;
+				return CreateHttpUrl(schema, ipEndPoint.ToString(),
+					rawUrl != null ? rawUrl.TrimStart('/') : string.Empty);
+			}
+
+			if (endPoint is DnsEndPoint) {
+				var dnsEndpoint = endPoint as DnsEndPoint;
+				return CreateHttpUrl(schema, dnsEndpoint.Host, dnsEndpoint.Port,
+					rawUrl != null ? rawUrl.TrimStart('/') : string.Empty);
+			}
+
+			return null;
+		}
+
+		public static string ToHttpUrl(this EndPoint endPoint, string schema, string formatString,
+			params object[] args) {
+			if (endPoint is IPEndPoint) {
+				var ipEndPoint = endPoint as IPEndPoint;
+				return CreateHttpUrl(schema, ipEndPoint.ToString(), string.Format(formatString.TrimStart('/'), args));
+			}
+
+			if (endPoint is DnsEndPoint) {
+				var dnsEndpoint = endPoint as DnsEndPoint;
+				return CreateHttpUrl(schema, dnsEndpoint.Host, dnsEndpoint.Port,
+					string.Format(formatString.TrimStart('/'), args));
+			}
+
+			return null;
+		}
+
+		private static string CreateHttpUrl(string schema, string host, int port, string path) {
+			return $"{schema}://{host}:{port}/{path}";
+		}
+
+		private static string CreateHttpUrl(string schema, string address, string path) {
+			return $"{schema}://{address}/{path}";
+		}
+	}
+}

--- a/src/EventStore.Client/EventStoreClientConnectivitySettings.cs
+++ b/src/EventStore.Client/EventStoreClientConnectivitySettings.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Net;
+
+namespace EventStore.Client {
+	public class EventStoreClientConnectivitySettings {
+		public int MaxDiscoverAttempts { get; set; }
+		public EndPoint[] GossipSeeds { get; set; } = Array.Empty<EndPoint>();
+		public TimeSpan GossipTimeout { get; set; }
+		public TimeSpan DiscoveryInterval { get; set; }
+		public NodePreference NodePreference { get; set; }
+
+		public static EventStoreClientConnectivitySettings Default => new EventStoreClientConnectivitySettings {
+			MaxDiscoverAttempts = 10,
+			GossipTimeout = TimeSpan.FromSeconds(5),
+			DiscoveryInterval = TimeSpan.FromMilliseconds(100),
+			NodePreference = NodePreference.Leader,
+		};
+	}
+}

--- a/src/EventStore.Client/EventStoreClientConnectivitySettings.cs
+++ b/src/EventStore.Client/EventStoreClientConnectivitySettings.cs
@@ -3,8 +3,25 @@ using System.Net;
 
 namespace EventStore.Client {
 	public class EventStoreClientConnectivitySettings {
+		public Uri Address { get; set; } = new UriBuilder {
+			Scheme = Uri.UriSchemeHttps,
+			Port = 2113
+		}.Uri;
 		public int MaxDiscoverAttempts { get; set; }
-		public EndPoint[] GossipSeeds { get; set; } = Array.Empty<EndPoint>();
+
+		public EndPoint[] GossipSeeds {
+			get {
+				object endpoints = (object)DnsGossipSeeds ?? IpGossipSeeds;
+				return endpoints switch {
+					DnsEndPoint[] dns => Array.ConvertAll<DnsEndPoint, EndPoint>(dns, x => x),
+					IPEndPoint[] ip => Array.ConvertAll<IPEndPoint, EndPoint>(ip, x => x),
+					_ => Array.Empty<EndPoint>()
+				};
+			}
+		}
+
+		public DnsEndPoint[] DnsGossipSeeds { get; set; }
+		public IPEndPoint[] IpGossipSeeds { get; set; }
 		public TimeSpan GossipTimeout { get; set; }
 		public TimeSpan DiscoveryInterval { get; set; }
 		public NodePreference NodePreference { get; set; }

--- a/src/EventStore.Client/EventStoreClientSettings.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.cs
@@ -4,16 +4,19 @@ using Grpc.Core.Interceptors;
 
 namespace EventStore.Client {
 	public class EventStoreClientSettings {
-		public Uri Address { get; set; }
+		public Uri Address { get; set; } = new UriBuilder {
+			Scheme = Uri.UriSchemeHttps,
+			Port = 2113
+		}.Uri;
+
 		public Interceptor[] Interceptors { get; set; } = Array.Empty<Interceptor>();
 		public string ConnectionName { get; set; }
-		public Func<HttpClient> CreateHttpClient { get; set; }
+		public Func<HttpMessageHandler> CreateHttpMessageHandler { get; set; }
 
-		public EventStoreClientOperationOptions OperationOptions { get; set; } = EventStoreClientOperationOptions.Default;
+		public EventStoreClientOperationOptions OperationOptions { get; set; } =
+			EventStoreClientOperationOptions.Default;
 
-		public EventStoreClientSettings(Uri address) {
-			if (address == null) throw new ArgumentNullException(nameof(address));
-			Address = address;
-		}
+		public EventStoreClientConnectivitySettings ConnectivitySettings { get; set; } =
+			EventStoreClientConnectivitySettings.Default;
 	}
 }

--- a/src/EventStore.Client/EventStoreClientSettings.cs
+++ b/src/EventStore.Client/EventStoreClientSettings.cs
@@ -4,11 +4,6 @@ using Grpc.Core.Interceptors;
 
 namespace EventStore.Client {
 	public class EventStoreClientSettings {
-		public Uri Address { get; set; } = new UriBuilder {
-			Scheme = Uri.UriSchemeHttps,
-			Port = 2113
-		}.Uri;
-
 		public Interceptor[] Interceptors { get; set; } = Array.Empty<Interceptor>();
 		public string ConnectionName { get; set; }
 		public Func<HttpMessageHandler> CreateHttpMessageHandler { get; set; }

--- a/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
+++ b/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
@@ -184,7 +184,6 @@ namespace EventStore.Client {
 
 		private bool IsReadOnlyReplicaState(ClusterMessages.VNodeState state) {
 			return state == ClusterMessages.VNodeState.ReadOnlyLeaderless
-			       || state == ClusterMessages.VNodeState.PreReadOnlyReplica
 			       || state == ClusterMessages.VNodeState.ReadOnlyReplica;
 		}
 	}

--- a/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
+++ b/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Client {
+	internal class ClusterEndpointDiscoverer : IEndpointDiscoverer {
+		private readonly int _maxDiscoverAttempts;
+		private readonly EndPoint[] _gossipSeeds;
+		private readonly TimeSpan _discoveryInterval;
+
+		private readonly HttpClient _client;
+		private ClusterMessages.MemberInfo[] _oldGossip;
+
+		private readonly NodePreference _nodePreference;
+
+		private readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions {
+			PropertyNameCaseInsensitive = true,
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+			Converters = {new JsonStringEnumConverter(JsonNamingPolicy.CamelCase)}
+		};
+
+		public ClusterEndpointDiscoverer(
+			int maxDiscoverAttempts,
+			EndPoint[] gossipSeeds,
+			TimeSpan gossipTimeout,
+			TimeSpan discoveryInterval,
+			NodePreference nodePreference,
+			HttpMessageHandler httpMessageHandler = null) {
+			_maxDiscoverAttempts = maxDiscoverAttempts;
+			_gossipSeeds = gossipSeeds;
+			_discoveryInterval = discoveryInterval;
+			_client = new HttpClient(httpMessageHandler ?? new HttpClientHandler()) {Timeout = gossipTimeout};
+			_nodePreference = nodePreference;
+		}
+
+		public async Task<IPEndPoint> DiscoverAsync() {
+			for (int attempt = 1; attempt <= _maxDiscoverAttempts; ++attempt) {
+				try {
+					var endpoint = await DiscoverEndpointAsync().ConfigureAwait(false);
+					if (endpoint != null) {
+						return endpoint;
+					}
+				} catch (Exception exc) {
+				}
+
+				await Task.Delay(_discoveryInterval).ConfigureAwait(false);
+			}
+
+			throw new DiscoveryException($"Failed to discover candidate in {_maxDiscoverAttempts} attempts.");
+		}
+
+		private async Task<IPEndPoint> DiscoverEndpointAsync() {
+			var oldGossip = Interlocked.Exchange(ref _oldGossip, null);
+			var gossipCandidates = oldGossip != null
+				? ArrangeGossipCandidates(oldGossip.ToArray())
+				: GetGossipCandidates();
+			foreach (var candidate in gossipCandidates) {
+				var gossip = await TryGetGossipFrom(candidate).ConfigureAwait(false);
+				if (gossip?.Members == null || gossip.Members.Length == 0)
+					continue;
+
+				var bestNode = TryDetermineBestNode(gossip.Members, _nodePreference);
+				if (bestNode == null) continue;
+				_oldGossip = gossip.Members;
+				return bestNode;
+			}
+
+			return null;
+		}
+
+		private EndPoint[] GetGossipCandidates() {
+			EndPoint[] endpoints = _gossipSeeds;
+			RandomShuffle(endpoints, 0, endpoints.Length - 1);
+			return endpoints;
+		}
+
+		private EndPoint[] ArrangeGossipCandidates(ClusterMessages.MemberInfo[] members) {
+			var result = new EndPoint[members.Length];
+			int i = -1;
+			int j = members.Length;
+			for (int k = 0; k < members.Length; ++k) {
+				if (members[k].State == ClusterMessages.VNodeState.Manager)
+					result[--j] = new IPEndPoint(IPAddress.Parse(members[k].ExternalHttpIp),
+						members[k].ExternalHttpPort);
+				else
+					result[++i] = new IPEndPoint(IPAddress.Parse(members[k].ExternalHttpIp),
+						members[k].ExternalHttpPort);
+			}
+
+			RandomShuffle(result, 0, i);
+			RandomShuffle(result, j, members.Length - 1);
+
+			return result;
+		}
+
+		private void RandomShuffle<T>(T[] arr, int i, int j) {
+			if (i >= j)
+				return;
+			var rnd = new Random(Guid.NewGuid().GetHashCode());
+			for (int k = i; k <= j; ++k) {
+				var index = rnd.Next(k, j + 1);
+				var tmp = arr[index];
+				arr[index] = arr[k];
+				arr[k] = tmp;
+			}
+		}
+
+		private async Task<ClusterMessages.ClusterInfo> TryGetGossipFrom(EndPoint gossipSeed) {
+			string url = string.Empty;
+			switch (gossipSeed) {
+				case DnsEndPoint dnsEndPoint:
+					url = $"{Uri.UriSchemeHttps}://{dnsEndPoint.Host}:{dnsEndPoint.Port}/gossip?format=json";
+					break;
+				case IPEndPoint ipEndPoint:
+					url = $"{Uri.UriSchemeHttps}://{ipEndPoint.Address}:{ipEndPoint.Port}/gossip?format=json";
+					break;
+			}
+
+			var response = await _client.GetStringAsync(url).ConfigureAwait(false);
+			var result = JsonSerializer.Deserialize<ClusterMessages.ClusterInfo>(response, _jsonSerializerOptions);
+			return result;
+		}
+
+		private IPEndPoint TryDetermineBestNode(IEnumerable<ClusterMessages.MemberInfo> members,
+			NodePreference nodePreference) {
+			var notAllowedStates = new[] {
+				ClusterMessages.VNodeState.Manager,
+				ClusterMessages.VNodeState.ShuttingDown,
+				ClusterMessages.VNodeState.Manager,
+				ClusterMessages.VNodeState.Shutdown,
+				ClusterMessages.VNodeState.Unknown,
+				ClusterMessages.VNodeState.Initializing,
+				ClusterMessages.VNodeState.CatchingUp,
+				ClusterMessages.VNodeState.ResigningLeader,
+				ClusterMessages.VNodeState.ShuttingDown,
+				ClusterMessages.VNodeState.PreLeader,
+				ClusterMessages.VNodeState.PreReplica,
+				ClusterMessages.VNodeState.PreReadOnlyReplica,
+			};
+
+			var nodes = members.Where(x => x.IsAlive)
+				.Where(x => !notAllowedStates.Contains(x.State))
+				.OrderByDescending(x => x.State)
+				.ToArray();
+
+			switch (nodePreference) {
+				case NodePreference.Random:
+					RandomShuffle(nodes, 0, nodes.Length - 1);
+					break;
+				case NodePreference.Leader:
+					nodes = nodes.OrderBy(nodeEntry => nodeEntry.State != ClusterMessages.VNodeState.Leader)
+						.ToArray();
+					RandomShuffle(nodes, 0,
+						nodes.Count(nodeEntry => nodeEntry.State == ClusterMessages.VNodeState.Leader) - 1);
+					break;
+				case NodePreference.Follower:
+					nodes = nodes.OrderBy(nodeEntry => nodeEntry.State != ClusterMessages.VNodeState.Follower)
+						.ToArray();
+					RandomShuffle(nodes, 0,
+						nodes.Count(nodeEntry => nodeEntry.State == ClusterMessages.VNodeState.Follower) - 1);
+					break;
+				case NodePreference.ReadOnlyReplica:
+					nodes = nodes.OrderBy(nodeEntry => !IsReadOnlyReplicaState(nodeEntry.State))
+						.ToArray();
+					RandomShuffle(nodes, 0,
+						nodes.Count(nodeEntry => IsReadOnlyReplicaState(nodeEntry.State)) - 1);
+					break;
+			}
+
+			var node = nodes.FirstOrDefault();
+
+			if (node == default(ClusterMessages.MemberInfo)) {
+				return null;
+			}
+
+			return new IPEndPoint(IPAddress.Parse(node.ExternalHttpIp), node.ExternalHttpPort);
+		}
+
+		private bool IsReadOnlyReplicaState(ClusterMessages.VNodeState state) {
+			return state == ClusterMessages.VNodeState.ReadOnlyLeaderless
+			       || state == ClusterMessages.VNodeState.PreReadOnlyReplica
+			       || state == ClusterMessages.VNodeState.ReadOnlyReplica;
+		}
+	}
+}

--- a/src/EventStore.Client/IEndpointDiscoverer.cs
+++ b/src/EventStore.Client/IEndpointDiscoverer.cs
@@ -1,0 +1,8 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+
+namespace EventStore.Client {
+	public interface IEndpointDiscoverer {
+		Task<IPEndPoint> DiscoverAsync();
+	}
+}

--- a/src/EventStore.Client/NodePreference.cs
+++ b/src/EventStore.Client/NodePreference.cs
@@ -1,0 +1,8 @@
+﻿namespace EventStore.Client {
+	public enum NodePreference {
+		Leader,
+		Follower,
+		Random,
+		ReadOnlyReplica
+	}
+}

--- a/src/EventStore.Client/NotLeaderException.cs
+++ b/src/EventStore.Client/NotLeaderException.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Net;
+
+namespace EventStore.Client {
+	public class NotLeaderException : Exception {
+		public IPEndPoint LeaderEndpoint { get; }
+
+		public NotLeaderException(IPEndPoint newLeaderEndpoint, Exception exception = default) : base(
+			$"Not leader. New leader at {newLeaderEndpoint}.", exception) {
+			LeaderEndpoint = newLeaderEndpoint;
+		}
+	}
+}

--- a/src/EventStore.Client/TypedExceptionInterceptor.cs
+++ b/src/EventStore.Client/TypedExceptionInterceptor.cs
@@ -7,6 +7,7 @@ using Grpc.Core.Interceptors;
 
 namespace EventStore.Client {
 	public class TypedExceptionInterceptor : Interceptor {
+		
 		public override AsyncServerStreamingCall<TResponse> AsyncServerStreamingCall<TRequest, TResponse>(
 			TRequest request,
 			ClientInterceptorContext<TRequest, TResponse> context,
@@ -107,7 +108,7 @@ namespace EventStore.Client {
 				},
 				false => ex.StatusCode switch {
 					StatusCode.DeadlineExceeded => ex,
-					_ => new InvalidOperationException()
+					_ => new InvalidOperationException(ex.Message, ex)
 				}
 			};
 

--- a/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
@@ -76,9 +76,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		}
 
 		public static bool GetRequiresLeader(Metadata requestHeaders) {
-			var requiresLeader =
+			var requiresLeaderHeaderValue =
 				requestHeaders.FirstOrDefault(x => x.Key == Constants.Headers.RequiresLeader)?.Value;
-			return !string.IsNullOrEmpty(requiresLeader) && bool.Parse(requiresLeader);
+			if (string.IsNullOrEmpty(requiresLeaderHeaderValue)) return false;
+			bool.TryParse(requiresLeaderHeaderValue, out var requiresLeader);
+			return requiresLeader;
 		}
 
 		private class GrpcBasicAuthenticationRequest : AuthenticationRequest {

--- a/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
@@ -72,6 +72,12 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				return true;
 			}
 		}
+		
+		public static bool GetRequiresLeader(Metadata requestHeaders) {
+			var requiresLeader =
+				requestHeaders.FirstOrDefault(x => x.Key == Constants.Headers.RequiresLeader)?.Value;
+			return !string.IsNullOrEmpty(requiresLeader) && bool.Parse(requiresLeader);
+		}
 
 		private class GrpcBasicAuthenticationRequest : AuthenticationRequest {
 			private readonly TaskCompletionSource<IPrincipal> _principalSource;

--- a/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Security.Principal;
 using System.Text;
@@ -42,7 +43,8 @@ namespace EventStore.Client.Operations {
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public class ServiceBase {
-		public static Task<IPrincipal> GetUser(IAuthenticationProvider authenticationProvider, Metadata requestHeaders) {
+		public static Task<IPrincipal> GetUser(IAuthenticationProvider authenticationProvider,
+			Metadata requestHeaders) {
 			var principalSource = new TaskCompletionSource<IPrincipal>();
 
 			if (AuthenticationHeaderValue.TryParse(
@@ -72,7 +74,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				return true;
 			}
 		}
-		
+
 		public static bool GetRequiresLeader(Metadata requestHeaders) {
 			var requiresLeader =
 				requestHeaders.FirstOrDefault(x => x.Key == Constants.Headers.RequiresLeader)?.Value;

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -32,6 +32,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			};
 
 			var user = await GetUser(_authenticationProvider, context.RequestHeaders).ConfigureAwait(false);
+			var requiresLeader = GetRequiresLeader(context.RequestHeaders);
 
 			var correlationId = Guid.NewGuid(); // TODO: JPB use request id?
 
@@ -74,7 +75,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				correlationId,
 				correlationId,
 				envelope,
-				true,
+				requiresLeader,
 				streamName,
 				expectedVersion,
 				events.ToArray(),

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -75,7 +75,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				correlationId,
 				correlationId,
 				envelope,
-				requiresLeader,
+				true,
 				streamName,
 				expectedVersion,
 				events.ToArray(),

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -25,8 +25,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			};
 
 			var user = await GetUser(_authenticationProvider, context.RequestHeaders).ConfigureAwait(false);
+			var requiresLeader = GetRequiresLeader(context.RequestHeaders);
 
-			var position = await DeleteInternal(streamName, expectedVersion, user, false).ConfigureAwait(false);
+			var position = await DeleteInternal(streamName, expectedVersion, user, false, requiresLeader).ConfigureAwait(false);
 
 			return position.HasValue
 				? new DeleteResp {
@@ -56,8 +57,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			};
 
 			var user = await GetUser(_authenticationProvider, context.RequestHeaders).ConfigureAwait(false);
+			var requiresLeader = GetRequiresLeader(context.RequestHeaders);
 
-			var position = await DeleteInternal(streamName, expectedVersion, user, true).ConfigureAwait(false);
+			var position = await DeleteInternal(streamName, expectedVersion, user, true, requiresLeader).ConfigureAwait(false);
 
 			return position.HasValue
 				? new TombstoneResp {
@@ -72,7 +74,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		}
 
 		private async Task<Position?> DeleteInternal(string streamName, long expectedVersion,
-			IPrincipal user, bool hardDelete) {
+			IPrincipal user, bool hardDelete, bool requiresLeader) {
 			var correlationId = Guid.NewGuid(); // TODO: JPB use request id?
 			var deleteResponseSource = new TaskCompletionSource<Position?>();
 
@@ -82,7 +84,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				correlationId,
 				correlationId,
 				envelope,
-				true,
+				requiresLeader,
 				streamName,
 				expectedVersion,
 				hardDelete,


### PR DESCRIPTION
Repurposed the [endpoint discoverer](https://github.com/EventStore/EventStore/blob/master/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs) from the TCP Client API for node discovery.

Here is an example configuration for connecting to a cluster of nodes with a provided set of gossip seeds.
```
var client = new EventStoreClient(new EventStoreClientSettings
{
    ConnectivitySettings =
    {
        GossipSeeds = new[]
        {
            new DnsEndpoint("localhost", 1114),
            new DnsEndpoint("localhost", 2114),
            new DnsEndpoint("localhost", 3114),
        },
        NodePreference = NodePreference.Leader,
        MaxDiscoverAttempts = 5,
    }
};
```