### PR TITLE
Consolidate Protos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ CMD ["/build/test.sh"]
 FROM build as publish
 ARG RUNTIME=linux-x64
 
-RUN dotnet publish --configuration=Release --no-build --runtime=${RUNTIME} --self-contained \
+RUN dotnet publish --configuration=Release --runtime=${RUNTIME} --self-contained \
      --framework=netcoreapp3.1 --output /publish /p:PublishTrimmed=true EventStore.ClusterNode
 
 FROM mcr.microsoft.com/dotnet/core/runtime-deps:3.1-${CONTAINER_RUNTIME} AS runtime

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,6 @@
 		<DebugType Condition=" '$(Configuration)' == 'Debug' ">full</DebugType>
 		<DebugType Condition=" '$(Configuration)' == 'Release' ">pdbonly</DebugType>
 		<OutputPath>$(MSBuildThisFileDirectory)..\bin\$(Configuration)\$(MSBuildProjectName)\</OutputPath>
-		<IntermediateOutputPath>$(MSBuildThisFileDirectory)\..\obj\$(Configuration)\$(MSBuildProjectName)\</IntermediateOutputPath>
 		<Authors>Event Store Ltd</Authors>
 		<PackageLicenseUrl>https://github.com/EventStore/EventStore/blob/master/LICENSE.md</PackageLicenseUrl>
 		<PackageProjectUrl>https://eventstore.com</PackageProjectUrl>

--- a/src/EventStore.Client.Common/Uuid.cs
+++ b/src/EventStore.Client.Common/Uuid.cs
@@ -17,27 +17,15 @@ namespace EventStore.Client {
 		public static Uuid Parse(string value) => new Uuid(value);
 		public static Uuid FromInt64(long msb, long lsb) => new Uuid(msb, lsb);
 
-		internal static Uuid FromDto(Streams.UUID dto) {
+		internal static Uuid FromDto(Shared.UUID dto) {
 			if (dto == null) throw new ArgumentNullException(nameof(dto));
 			return dto.ValueCase switch {
-				Streams.UUID.ValueOneofCase.String => new Uuid(dto.String),
-				Streams.UUID.ValueOneofCase.Structured => new Uuid(dto.Structured.MostSignificantBits,
+				Shared.UUID.ValueOneofCase.String => new Uuid(dto.String),
+				Shared.UUID.ValueOneofCase.Structured => new Uuid(dto.Structured.MostSignificantBits,
 					dto.Structured.LeastSignificantBits),
 				_ => throw new ArgumentException($"Invalid argument: {dto.ValueCase}", nameof(dto))
 			};
 		}
-
-		internal static Uuid FromDto(PersistentSubscriptions.UUID dto) {
-			if (dto == null) throw new ArgumentNullException(nameof(dto));
-			return dto.ValueCase switch {
-				PersistentSubscriptions.UUID.ValueOneofCase.String => new Uuid(dto.String),
-				PersistentSubscriptions.UUID.ValueOneofCase.Structured => new Uuid(
-					dto.Structured.MostSignificantBits,
-					dto.Structured.LeastSignificantBits),
-				_ => throw new ArgumentException($"Invalid argument: {dto.ValueCase}", nameof(dto))
-			};
-		}
-
 		private Uuid(Guid value) {
 			if (!BitConverter.IsLittleEndian) {
 				throw new NotSupportedException();
@@ -69,17 +57,9 @@ namespace EventStore.Client {
 			_lsb = lsb;
 		}
 
-		internal readonly PersistentSubscriptions.UUID ToPersistentSubscriptionsDto() =>
-			new PersistentSubscriptions.UUID {
-				Structured = new PersistentSubscriptions.UUID.Types.Structured {
-					LeastSignificantBits = _lsb,
-					MostSignificantBits = _msb,
-				}
-			};
-
-		internal readonly Streams.UUID ToStreamsDto() =>
-			new Streams.UUID {
-				Structured = new Streams.UUID.Types.Structured {
+		internal readonly Shared.UUID ToDto() =>
+			new Shared.UUID {
+				Structured = new Shared.UUID.Types.Structured {
 					LeastSignificantBits = _lsb,
 					MostSignificantBits = _msb
 				}

--- a/src/EventStore.Client.Tests/UuidTests.cs
+++ b/src/EventStore.Client.Tests/UuidTests.cs
@@ -56,28 +56,15 @@ namespace EventStore.Client {
 			Assert.Equal(sut.ToGuid().ToString("n"),sut.ToString("n"));
 		}
 
+
 		[Fact]
-		public void ToPersistentSubscriptionDtoReturnsExpectedResult() {
+		public void ToDtoReturnsExpectedResult() {
 			var msb = GetRandomInt64();
 			var lsb = GetRandomInt64();
 
 			var sut = Uuid.FromInt64(msb, lsb);
 
-			var result = sut.ToPersistentSubscriptionsDto();
-
-			Assert.NotNull(result.Structured);
-			Assert.Equal(lsb, result.Structured.LeastSignificantBits);
-			Assert.Equal(msb, result.Structured.MostSignificantBits);
-		}
-
-		[Fact]
-		public void ToStreamsDtoReturnsExpectedResult() {
-			var msb = GetRandomInt64();
-			var lsb = GetRandomInt64();
-
-			var sut = Uuid.FromInt64(msb, lsb);
-
-			var result = sut.ToStreamsDto();
+			var result = sut.ToDto();
 
 			Assert.NotNull(result.Structured);
 			Assert.Equal(lsb, result.Structured.LeastSignificantBits);

--- a/src/EventStore.Client/EventStoreClient.cs
+++ b/src/EventStore.Client/EventStoreClient.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using EventStore.Client.Logging;
 using EventStore.Client.PersistentSubscriptions;
 using EventStore.Client.Projections;
+using EventStore.Client.Shared;
 using EventStore.Client.Users;
 using Grpc.Core.Interceptors;
 using Grpc.Net.Client;
@@ -126,7 +127,7 @@ namespace EventStore.Client {
 			if (filter.MaxSearchWindow.HasValue) {
 				options.Max = filter.MaxSearchWindow.Value;
 			} else {
-				options.Count = new ReadReq.Types.Empty();
+				options.Count = new Empty();
 			}
 
 			options.CheckpointIntervalMultiplier = filterOptions.CheckpointInterval;

--- a/src/EventStore.Client/EventStoreGrpcClient.Append.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Append.cs
@@ -98,7 +98,7 @@ namespace EventStore.Client {
 			foreach (var e in eventData)
 				await call.RequestStream.WriteAsync(new AppendReq {
 					ProposedMessage = new AppendReq.Types.ProposedMessage {
-						Id = e.EventId.ToStreamsDto(),
+						Id = e.EventId.ToDto(),
 						Data = ByteString.CopyFrom(e.Data),
 						CustomMetadata = ByteString.CopyFrom(e.Metadata),
 						Metadata = {

--- a/src/EventStore.Client/EventStoreGrpcClient.Read.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Read.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client.Shared;
 using EventStore.Client.Streams;
 using Grpc.Core;
 
@@ -130,11 +131,11 @@ namespace EventStore.Client {
 			}
 
 			if (request.Options.Filter == null) {
-				request.Options.NoFilter = new ReadReq.Types.Empty();
+				request.Options.NoFilter = new Empty();
 			}
 
 			request.Options.UuidOption = new ReadReq.Types.Options.Types.UUIDOption
-				{Structured = new ReadReq.Types.Empty()};
+				{Structured = new Empty()};
 
 			using var call = _client.Read(
 				request, RequestMetadata.Create(userCredentials),

--- a/src/EventStore.Client/EventStoreGrpcClient.Subscriptions.cs
+++ b/src/EventStore.Client/EventStoreGrpcClient.Subscriptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client.Shared;
 using EventStore.Client.Streams;
 
 namespace EventStore.Client {
@@ -20,7 +21,7 @@ namespace EventStore.Client {
 						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
 						ResolveLinks = resolveLinkTos,
 						All = new ReadReq.Types.Options.Types.AllOptions {
-							Start = new ReadReq.Types.Empty()
+							Start = new Empty()
 						},
 						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions(),
 						Filter = GetFilterOptions(filterOptions)
@@ -119,7 +120,7 @@ namespace EventStore.Client {
 						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
 						ResolveLinks = resolveLinkTos,
 						Stream = new ReadReq.Types.Options.Types.StreamOptions {
-							Start = new ReadReq.Types.Empty(),
+							Start = new Empty(),
 							StreamName = streamName
 						},
 						Subscription = new ReadReq.Types.Options.Types.SubscriptionOptions()
@@ -170,7 +171,7 @@ namespace EventStore.Client {
 							ResolveLinks = resolveLinkTos,
 							Stream = start == StreamRevision.End
 								? new ReadReq.Types.Options.Types.StreamOptions {
-									End = new ReadReq.Types.Empty(),
+									End = new Empty(),
 									StreamName = streamName
 								}
 								: new ReadReq.Types.Options.Types.StreamOptions {

--- a/src/EventStore.Client/PersistentSubscriptions/EventStorePersistentSubscriptionsGrpcClient.Read.cs
+++ b/src/EventStore.Client/PersistentSubscriptions/EventStorePersistentSubscriptionsGrpcClient.Read.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client.Shared;
 
 namespace EventStore.Client.PersistentSubscriptions {
 	partial class EventStorePersistentSubscriptionsClient {
@@ -36,7 +37,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 				BufferSize = bufferSize,
 				GroupName = groupName,
 				StreamName = streamName,
-				UuidOption = new ReadReq.Types.Options.Types.UUIDOption {Structured = new ReadReq.Types.Empty()}
+				UuidOption = new ReadReq.Types.Options.Types.UUIDOption {Structured = new Empty()}
 			};
 
 

--- a/src/EventStore.Client/PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Client/PersistentSubscriptions/PersistentSubscription.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client.Shared;
 using Google.Protobuf;
 using Grpc.Core;
 
@@ -179,7 +180,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 			_call.RequestStream.WriteAsync(new ReadReq {
 				Ack = new ReadReq.Types.Ack {
 					Ids = {
-						Array.ConvertAll(ids, id => id.ToPersistentSubscriptionsDto())
+						Array.ConvertAll(ids, id => id.ToDto())
 					}
 				}
 			});
@@ -188,7 +189,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 			_call.RequestStream.WriteAsync(new ReadReq {
 				Nack = new ReadReq.Types.Nack {
 					Ids = {
-						Array.ConvertAll(ids, id => id.ToPersistentSubscriptionsDto())
+						Array.ConvertAll(ids, id => id.ToDto())
 					},
 					Action = action switch {
 						PersistentSubscriptionNakEventAction.Park => ReadReq.Types.Nack.Types.Action.Park,

--- a/src/EventStore.Client/PersistentSubscriptions/PersistentSubscription.cs
+++ b/src/EventStore.Client/PersistentSubscriptions/PersistentSubscription.cs
@@ -48,8 +48,8 @@ namespace EventStore.Client.PersistentSubscriptions {
 					Options = _options
 				}).ConfigureAwait(false);
 
-				if (!await _call.ResponseStream.MoveNext(_disposed.Token)
-.ConfigureAwait(false) || _call.ResponseStream.Current.ContentCase != ReadResp.ContentOneofCase.Empty) {
+				if (!await _call.ResponseStream.MoveNext(_disposed.Token).ConfigureAwait(false) ||
+				    _call.ResponseStream.Current.ContentCase != ReadResp.ContentOneofCase.SubscriptionConfirmation) {
 					throw new InvalidOperationException();
 				}
 			} catch (Exception ex) {

--- a/src/EventStore.Client/Projections/EventStoreProjectionManagerGrpcClient.Create.cs
+++ b/src/EventStore.Client/Projections/EventStoreProjectionManagerGrpcClient.Create.cs
@@ -1,6 +1,6 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client.Shared;
 
 namespace EventStore.Client.Projections {
 	public partial class EventStoreProjectionManagerClient {
@@ -8,7 +8,7 @@ namespace EventStore.Client.Projections {
 			CancellationToken cancellationToken = default) {
 			using var call = _client.CreateAsync(new CreateReq {
 				Options = new CreateReq.Types.Options {
-					OneTime = new CreateReq.Types.Empty(),
+					OneTime = new Empty(),
 					Query = query
 				}
 			}, RequestMetadata.Create(userCredentials), cancellationToken: cancellationToken);

--- a/src/EventStore.Client/Projections/EventStoreProjectionManagerGrpcClient.Statistics.cs
+++ b/src/EventStore.Client/Projections/EventStoreProjectionManagerGrpcClient.Statistics.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client.Shared;
 using Grpc.Core;
 
 namespace EventStore.Client.Projections {
@@ -10,13 +11,13 @@ namespace EventStore.Client.Projections {
 		public IAsyncEnumerable<ProjectionDetails> ListOneTimeAsync(UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) =>
 			ListInternalAsync(new StatisticsReq.Types.Options {
-				OneTime = new StatisticsReq.Types.Empty()
+				OneTime = new Empty()
 			}, userCredentials, cancellationToken);
 
 		public IAsyncEnumerable<ProjectionDetails> ListContinuousAsync(UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) =>
 			ListInternalAsync(new StatisticsReq.Types.Options {
-				Continuous = new StatisticsReq.Types.Empty()
+				Continuous = new Empty()
 			}, userCredentials, cancellationToken);
 
 		public Task<ProjectionDetails> GetStatusAsync(string name, UserCredentials userCredentials = default,
@@ -55,7 +56,7 @@ namespace EventStore.Client.Projections {
 		public IAsyncEnumerable<ProjectionDetails> ListAllAsync(UserCredentials userCredentials = default,
 			CancellationToken cancellationToken = default) =>
 			ListInternalAsync(new StatisticsReq.Types.Options {
-				All = new StatisticsReq.Types.Empty()
+				All = new Empty()
 			}, userCredentials, cancellationToken);
 	}
 }

--- a/src/EventStore.Client/Projections/EventStoreProjectionManagerGrpcClient.Update.cs
+++ b/src/EventStore.Client/Projections/EventStoreProjectionManagerGrpcClient.Update.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client.Shared;
 
 namespace EventStore.Client.Projections {
 	public partial class EventStoreProjectionManagerClient {
@@ -12,7 +13,7 @@ namespace EventStore.Client.Projections {
 			if (emitEnabled.HasValue) {
 				options.EmitEnabled = emitEnabled.Value;
 			} else {
-				options.NoEmitOptions = new UpdateReq.Types.Empty();
+				options.NoEmitOptions = new Empty();
 			}
 
 			using var call = _client.UpdateAsync(new UpdateReq {

--- a/src/EventStore.Client/Streams/AppendReq.cs
+++ b/src/EventStore.Client/Streams/AppendReq.cs
@@ -1,12 +1,14 @@
+using EventStore.Client.Shared;
+
 namespace EventStore.Client.Streams {
 	partial class AppendReq {
 		public AppendReq WithAnyStreamRevision(AnyStreamRevision expectedRevision) {
 			if (expectedRevision == AnyStreamRevision.Any) {
-				Options.Any = new Types.Empty();
+				Options.Any = new Empty();
 			} else if (expectedRevision == AnyStreamRevision.NoStream) {
-				Options.NoStream = new Types.Empty();
+				Options.NoStream = new Empty();
 			} else if (expectedRevision == AnyStreamRevision.StreamExists) {
-				Options.StreamExists = new Types.Empty();
+				Options.StreamExists = new Empty();
 			}
 
 			return this;

--- a/src/EventStore.Client/Streams/DeleteReq.cs
+++ b/src/EventStore.Client/Streams/DeleteReq.cs
@@ -1,12 +1,14 @@
+using EventStore.Client.Shared;
+
 namespace EventStore.Client.Streams {
 	partial class DeleteReq {
 		public DeleteReq WithAnyStreamRevision(AnyStreamRevision expectedRevision) {
 			if (expectedRevision == AnyStreamRevision.Any) {
-				Options.Any = new Types.Empty();
+				Options.Any = new Empty();
 			} else if (expectedRevision == AnyStreamRevision.NoStream) {
-				Options.NoStream = new Types.Empty();
+				Options.NoStream = new Empty();
 			} else if (expectedRevision == AnyStreamRevision.StreamExists) {
-				Options.StreamExists = new Types.Empty();
+				Options.StreamExists = new Empty();
 			}
 
 			return this;

--- a/src/EventStore.Client/Streams/ReadReq.cs
+++ b/src/EventStore.Client/Streams/ReadReq.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Client.Shared;
 
 namespace EventStore.Client.Streams {
 	partial class ReadReq {

--- a/src/EventStore.Client/Streams/TombstoneReq.cs
+++ b/src/EventStore.Client/Streams/TombstoneReq.cs
@@ -1,12 +1,14 @@
+using EventStore.Client.Shared;
+
 namespace EventStore.Client.Streams {
 	partial class TombstoneReq {
 		public TombstoneReq WithAnyStreamRevision(AnyStreamRevision expectedRevision) {
 			if (expectedRevision == AnyStreamRevision.Any) {
-				Options.Any = new Types.Empty();
+				Options.Any = new Empty();
 			} else if (expectedRevision == AnyStreamRevision.NoStream) {
-				Options.NoStream = new Types.Empty();
+				Options.NoStream = new Empty();
 			} else if (expectedRevision == AnyStreamRevision.StreamExists) {
-				Options.StreamExists = new Types.Empty();
+				Options.StreamExists = new Empty();
 			}
 
 			return this;

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -11,11 +11,12 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client;
 using EventStore.Client.PersistentSubscriptions;
+using EventStore.Client.Shared;
 using Google.Protobuf;
 using Grpc.Core;
 using Grpc.Core.Utils;
 using static EventStore.Core.Messages.ClientMessage.PersistentSubscriptionNackEvents;
-using UUID = EventStore.Client.PersistentSubscriptions.UUID;
+using UUID = EventStore.Client.Shared.UUID;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public partial class PersistentSubscriptions {
@@ -50,7 +51,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			subscriptionId = await enumerator.Started.ConfigureAwait(false);
 
 			await responseStream.WriteAsync(new ReadResp {
-				Empty = new ReadResp.Types.Empty()
+				Empty = new Empty()
 			}).ConfigureAwait(false);
 
 			while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
@@ -91,7 +92,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						ReadReq.Types.Options.Types.UUIDOption.ContentOneofCase.String => new UUID {
 							String = e.EventId.ToString()
 						},
-						_ => Uuid.FromGuid(e.EventId).ToPersistentSubscriptionsDto()
+						_ => Uuid.FromGuid(e.EventId).ToDto()
 					},
 					StreamName = e.EventStreamId,
 					StreamRevision = StreamRevision.FromInt64(e.EventNumber),
@@ -120,7 +121,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						e.OriginalPosition.Value.PreparePosition);
 					readEvent.CommitPosition = position.CommitPosition;
 				} else {
-					readEvent.NoPosition = new ReadResp.Types.Empty();
+					readEvent.NoPosition = new Empty();
 				}
 
 				return readEvent;

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -51,7 +51,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			subscriptionId = await enumerator.Started.ConfigureAwait(false);
 
 			await responseStream.WriteAsync(new ReadResp {
-				Empty = new Empty()
+				SubscriptionConfirmation = new ReadResp.Types.SubscriptionConfirmation {
+					SubscriptionId = subscriptionId
+				}
 			}).ConfigureAwait(false);
 
 			while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -5,9 +5,9 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client;
+using EventStore.Client.Shared;
 using EventStore.Client.Streams;
 using Grpc.Core;
-using UUID = EventStore.Client.Streams.UUID;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	partial class Streams {
@@ -100,13 +100,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						var response = new AppendResp();
 
 						if (completed.LastEventNumber == -1) {
-							response.NoStream = new AppendResp.Types.Empty();
+							response.NoStream = new Empty();
 						} else {
 							response.CurrentRevision = StreamRevision.FromInt64(completed.LastEventNumber);
 						}
 
 						if (completed.CommitPosition == -1) {
-							response.Empty = new AppendResp.Types.Empty();
+							response.Empty = new Empty();
 						} else {
 							var position = Position.FromInt64(completed.CommitPosition, completed.PreparePosition);
 							response.Position = new AppendResp.Types.Position {

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -106,7 +106,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						}
 
 						if (completed.CommitPosition == -1) {
-							response.Empty = new Empty();
+							response.NoPosition = new Empty();
 						} else {
 							var position = Position.FromInt64(completed.CommitPosition, completed.PreparePosition);
 							response.Position = new AppendResp.Types.Position {

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -38,7 +38,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					}
 				}
 				: new DeleteResp {
-					Empty = new Empty()
+					NoPosition = new Empty()
 				};
 		}
 
@@ -70,7 +70,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					}
 				}
 				: new TombstoneResp {
-					Empty = new Empty()
+					NoPosition = new Empty()
 				};
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client;
+using EventStore.Client.Shared;
 using EventStore.Client.Streams;
 using Grpc.Core;
 
@@ -37,7 +38,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					}
 				}
 				: new DeleteResp {
-					Empty = new DeleteResp.Types.Empty()
+					Empty = new Empty()
 				};
 		}
 
@@ -69,7 +70,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					}
 				}
 				: new TombstoneResp {
-					Empty = new TombstoneResp.Types.Empty()
+					Empty = new Empty()
 				};
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using EventStore.Core.Data;
 using EventStore.Core.Util;
 using EventStore.Client;
+using EventStore.Client.Shared;
 using EventStore.Client.Streams;
 using Google.Protobuf;
 using Grpc.Core;
@@ -180,7 +181,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						ReadReq.Types.Options.Types.UUIDOption.ContentOneofCase.String => new UUID {
 							String = e.EventId.ToString()
 						},
-						_ => Uuid.FromGuid(e.EventId).ToStreamsDto()
+						_ => Uuid.FromGuid(e.EventId).ToDto()
 					},
 					StreamName = e.EventStreamId,
 					StreamRevision = StreamRevision.FromInt64(e.EventNumber),
@@ -207,7 +208,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						e.OriginalPosition.Value.PreparePosition);
 					readEvent.CommitPosition = position.CommitPosition;
 				} else {
-					readEvent.NoPosition = new ReadResp.Types.Empty();
+					readEvent.NoPosition = new Empty();
 				}
 
 				return readEvent;

--- a/src/Protos/Grpc/persistent.proto
+++ b/src/Protos/Grpc/persistent.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package event_store.client.persistent_subscriptions;
 option java_package = "com.eventstore.client.persistentsubscriptions";
 
+import "shared.proto";
+
 service PersistentSubscriptions {
 	rpc Create (CreateReq) returns (CreateResp);
 	rpc Update (UpdateReq) returns (UpdateResp);
@@ -24,23 +26,23 @@ message ReadReq {
 
 		message UUIDOption {
 			oneof content {
-				Empty structured = 1;
-				Empty string = 2;
+				event_store.client.shared.Empty structured = 1;
+				event_store.client.shared.Empty string = 2;
 			}
 		}
 	}
 
 	message Ack {
 		bytes id = 1;
-		repeated UUID ids = 2;
+		repeated event_store.client.shared.UUID ids = 2;
 	}
 
 	message Nack {
 		bytes id = 1;
-		repeated UUID ids = 2;
+		repeated event_store.client.shared.UUID ids = 2;
 		Action action = 3;
 		string reason = 4;
-		
+
 		enum Action {
 			Unknown = 0;
 			Park = 1;
@@ -49,30 +51,26 @@ message ReadReq {
 			Stop = 4;
 		}
 	}
-
-	message Empty {
-
-	}
 }
 
 message ReadResp {
 	oneof content {
 		ReadEvent event = 1;
-		Empty empty = 2;
+		event_store.client.shared.Empty empty = 2;
 	}
 	message ReadEvent {
 		RecordedEvent event = 1;
 		RecordedEvent link = 2;
 		oneof position {
 			uint64 commit_position = 3;
-			Empty no_position = 4;
+			event_store.client.shared.Empty no_position = 4;
 		}
 		oneof count {
 			int32 retry_count = 5;
-			Empty empty = 6;			
+			event_store.client.shared.Empty empty = 6;
 		}
 		message RecordedEvent {
-			UUID id = 1;
+			event_store.client.shared.UUID id = 1;
 			string stream_name = 2;
 			uint64 stream_revision = 3;
 			uint64 prepare_position = 4;
@@ -81,8 +79,6 @@ message ReadResp {
 			bytes custom_metadata = 7;
 			bytes data = 8;
 		}
-	}
-	message Empty {
 	}
 }
 
@@ -166,16 +162,4 @@ message DeleteReq {
 }
 
 message DeleteResp {
-}
-
-message UUID {
-	oneof value {
-		Structured structured = 1;
-		string string = 2;
-	}
-
-	message Structured {
-		int64 most_significant_bits = 1;
-		int64 least_significant_bits = 2;
-	}
 }

--- a/src/Protos/Grpc/persistent.proto
+++ b/src/Protos/Grpc/persistent.proto
@@ -67,7 +67,7 @@ message ReadResp {
 		}
 		oneof count {
 			int32 retry_count = 5;
-			event_store.client.shared.Empty empty = 6;
+			event_store.client.shared.Empty no_retry_count = 6;
 		}
 		message RecordedEvent {
 			event_store.client.shared.UUID id = 1;

--- a/src/Protos/Grpc/persistent.proto
+++ b/src/Protos/Grpc/persistent.proto
@@ -56,7 +56,7 @@ message ReadReq {
 message ReadResp {
 	oneof content {
 		ReadEvent event = 1;
-		event_store.client.shared.Empty empty = 2;
+		SubscriptionConfirmation subscription_confirmation = 2;
 	}
 	message ReadEvent {
 		RecordedEvent event = 1;
@@ -79,6 +79,9 @@ message ReadResp {
 			bytes custom_metadata = 7;
 			bytes data = 8;
 		}
+	}
+	message SubscriptionConfirmation {
+		string subscription_id = 1;
 	}
 }
 

--- a/src/Protos/Grpc/projections.proto
+++ b/src/Protos/Grpc/projections.proto
@@ -3,6 +3,7 @@ package event_store.client.projections;
 option java_package = "com.eventstore.client.projections";
 
 import "google/protobuf/struct.proto";
+import "shared.proto";
 
 service Projections {
 	rpc Create (CreateReq) returns (CreateResp);
@@ -21,7 +22,7 @@ message CreateReq {
 
 	message Options {
 		oneof mode {
-			Empty one_time = 1;
+			event_store.client.shared.Empty one_time = 1;
 			Transient transient = 2;
 			Continuous continuous = 3;
 		}
@@ -34,8 +35,6 @@ message CreateReq {
 			string name = 1;
 			bool track_emitted_streams = 2;
 		}
-	}
-	message Empty {
 	}
 }
 
@@ -50,10 +49,8 @@ message UpdateReq {
 		string query = 2;
 		oneof emit_option {
 			bool emit_enabled = 3;
-			Empty no_emit_options = 4;
+			event_store.client.shared.Empty no_emit_options = 4;
 		}
-	}
-	message Empty {
 	}
 }
 
@@ -79,13 +76,11 @@ message StatisticsReq {
 	message Options {
 		oneof mode {
 			string name = 1;
-			Empty all = 2;
-			Empty transient = 3;
-			Empty continuous = 4;
-			Empty one_time = 5;
+			event_store.client.shared.Empty all = 2;
+			event_store.client.shared.Empty transient = 3;
+			event_store.client.shared.Empty continuous = 4;
+			event_store.client.shared.Empty one_time = 5;
 		}
-	}
-	message Empty {
 	}
 }
 

--- a/src/Protos/Grpc/shared.proto
+++ b/src/Protos/Grpc/shared.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+package event_store.client.shared;
+option java_package = "com.eventstore.client.shared";
+
+message UUID {
+	oneof value {
+		Structured structured = 1;
+		string string = 2;
+	}
+
+	message Structured {
+		int64 most_significant_bits = 1;
+		int64 least_significant_bits = 2;
+	}
+}
+message Empty {
+}

--- a/src/Protos/Grpc/streams.proto
+++ b/src/Protos/Grpc/streams.proto
@@ -146,7 +146,7 @@ message AppendResp {
 	}
 	oneof position_option {
 		Position position = 3;
-		event_store.client.shared.Empty empty = 4;
+		event_store.client.shared.Empty no_position = 4;
 	}
 
 	message Position {
@@ -172,7 +172,7 @@ message DeleteReq {
 message DeleteResp {
 	oneof position_option {
 		Position position = 1;
-		event_store.client.shared.Empty empty = 2;
+		event_store.client.shared.Empty no_position = 2;
 	}
 
 	message Position {
@@ -198,7 +198,7 @@ message TombstoneReq {
 message TombstoneResp {
 	oneof position_option {
 		Position position = 1;
-		event_store.client.shared.Empty empty = 2;
+		event_store.client.shared.Empty no_position = 2;
 	}
 
 	message Position {

--- a/src/Protos/Grpc/streams.proto
+++ b/src/Protos/Grpc/streams.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 package event_store.client.streams;
 option java_package = "com.eventstore.client.streams";
 
+import "shared.proto";
+
 service Streams {
 	rpc Read (ReadReq) returns (stream ReadResp);
 	rpc Append (stream AppendReq) returns (AppendResp);
@@ -25,7 +27,7 @@ message ReadReq {
 		}
 		oneof filter_option {
 			FilterOptions filter = 7;
-			Empty no_filter = 8;
+			event_store.client.shared.Empty no_filter = 8;
 		}
 		UUIDOption uuid_option = 9;
 
@@ -37,15 +39,15 @@ message ReadReq {
 			string stream_name = 1;
 			oneof revision_option {
 				uint64 revision = 2;
-				Empty start = 3;
-				Empty end = 4;
+				event_store.client.shared.Empty start = 3;
+				event_store.client.shared.Empty end = 4;
 			}
 		}
 		message AllOptions {
 			oneof all_option {
 				Position position = 1;
-				Empty start = 2;
-				Empty end = 3;
+				event_store.client.shared.Empty start = 2;
+				event_store.client.shared.Empty end = 3;
 			}
 		}
 		message SubscriptionOptions {
@@ -61,7 +63,7 @@ message ReadReq {
 			}
 			oneof window {
 				uint32 max = 3;
-				Empty count = 4;
+				event_store.client.shared.Empty count = 4;
 			}
 			uint32 checkpointIntervalMultiplier = 5;
 
@@ -72,12 +74,10 @@ message ReadReq {
 		}
 		message UUIDOption {
 			oneof content {
-				Empty structured = 1;
-				Empty string = 2;
+				event_store.client.shared.Empty structured = 1;
+				event_store.client.shared.Empty string = 2;
 			}
 		}
-	}
-	message Empty {
 	}
 }
 
@@ -93,11 +93,11 @@ message ReadResp {
 		RecordedEvent link = 2;
 		oneof position {
 			uint64 commit_position = 3;
-			Empty no_position = 4;
+			event_store.client.shared.Empty no_position = 4;
 		}
 
 		message RecordedEvent {
-			UUID id = 1;
+			event_store.client.shared.UUID id = 1;
 			string stream_name = 2;
 			uint64 stream_revision = 3;
 			uint64 prepare_position = 4;
@@ -114,8 +114,6 @@ message ReadResp {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
 	}
-	message Empty {
-	}
 }
 
 message AppendReq {
@@ -128,37 +126,32 @@ message AppendReq {
 		string stream_name = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			Empty no_stream = 3;
-			Empty any = 4;
-			Empty stream_exists = 5;
+			event_store.client.shared.Empty no_stream = 3;
+			event_store.client.shared.Empty any = 4;
+			event_store.client.shared.Empty stream_exists = 5;
 		}
 	}
 	message ProposedMessage {
-		UUID id = 1;
+		event_store.client.shared.UUID id = 1;
 		map<string, string> metadata = 2;
 		bytes custom_metadata = 3;
 		bytes data = 4;
 	}
-	message Empty {
-	}
-
 }
 
 message AppendResp {
 	oneof current_revision_option {
 		uint64 current_revision = 1;
-		Empty no_stream = 2;
+		event_store.client.shared.Empty no_stream = 2;
 	}
 	oneof position_option {
 		Position position = 3;
-		Empty empty = 4;
+		event_store.client.shared.Empty empty = 4;
 	}
 
 	message Position {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
-	}
-	message Empty {
 	}
 }
 
@@ -169,26 +162,22 @@ message DeleteReq {
 		string stream_name = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			Empty no_stream = 3;
-			Empty any = 4;
-			Empty stream_exists = 5;
+			event_store.client.shared.Empty no_stream = 3;
+			event_store.client.shared.Empty any = 4;
+			event_store.client.shared.Empty stream_exists = 5;
 		}
-	}
-	message Empty {
 	}
 }
 
 message DeleteResp {
 	oneof position_option {
 		Position position = 1;
-		Empty empty = 2;
+		event_store.client.shared.Empty empty = 2;
 	}
 
 	message Position {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
-	}
-	message Empty {
 	}
 }
 
@@ -199,37 +188,21 @@ message TombstoneReq {
 		string stream_name = 1;
 		oneof expected_stream_revision {
 			uint64 revision = 2;
-			Empty no_stream = 3;
-			Empty any = 4;
-			Empty stream_exists = 5;
+			event_store.client.shared.Empty no_stream = 3;
+			event_store.client.shared.Empty any = 4;
+			event_store.client.shared.Empty stream_exists = 5;
 		}
-	}
-	message Empty {
 	}
 }
 
 message TombstoneResp {
 	oneof position_option {
 		Position position = 1;
-		Empty empty = 2;
+		event_store.client.shared.Empty empty = 2;
 	}
 
 	message Position {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
-	}
-	message Empty {
-	}
-}
-
-message UUID {
-	oneof value {
-		Structured structured = 1;
-		string string = 2;
-	}
-
-	message Structured {
-		int64 most_significant_bits = 1;
-		int64 least_significant_bits = 2;
 	}
 }

--- a/src/Protos/Grpc/users.proto
+++ b/src/Protos/Grpc/users.proto
@@ -93,8 +93,6 @@ message DetailsResp {
 			int64 ticks_since_epoch = 1;
 		}
 	}
-	message Empty {
-	}
 }
 
 message ChangePasswordReq {


### PR DESCRIPTION
Some types are duplicated in our protos, namely `UUID` and `Empty`. This can be got around by using a shared proto and an import statement.

also fixes #2243