### PR TITLE
Upgrade to Dotnet SDK 3.1.201

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Dotnet
       uses: actions/setup-dotnet@v1.4.0
       with:
-        dotnet-version: '3.1.102'
+        dotnet-version: '3.1.201'
     - name: Calculate Version
       run: |
         git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -102,7 +102,7 @@ jobs:
     - name: Install Dotnet
       uses: actions/setup-dotnet@v1.4.0
       with:
-        dotnet-version: '3.1.102'
+        dotnet-version: '3.1.201'
     - name: Calculate Version
       shell: bash
       run: |

--- a/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
+++ b/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 	</ItemGroup>

--- a/src/EventStore.Client.Operations.Tests/EventStore.Client.Operations.Tests.csproj
+++ b/src/EventStore.Client.Operations.Tests/EventStore.Client.Operations.Tests.csproj
@@ -6,25 +6,25 @@
 				<Platforms>x64</Platforms>
 		</PropertyGroup>
 		<ItemGroup>
-				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1"/>
-				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0"/>
-				<PackageReference Include="Serilog" Version="2.9.0"/>
-				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0"/>
-				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2"/>
+				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
+				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
 				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
-				<PackageReference Include="System.Reactive" Version="4.3.1"/>
-				<PackageReference Include="xunit" Version="2.4.1"/>
+				<PackageReference Include="System.Reactive" Version="4.3.1" />
+				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>
 						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 				</PackageReference>
 		</ItemGroup>
 		<ItemGroup>
-				<ProjectReference Include="..\EventStore.Client.Operations\EventStore.Client.Operations.csproj"/>
-				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj"/>
-				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj"/>
+				<ProjectReference Include="..\EventStore.Client.Operations\EventStore.Client.Operations.csproj" />
+				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
+				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-				<Compile Include="..\EventStore.Client.Tests.Common\*.cs" Exclude="..\EventStore.Client.Tests.Common\StreamRevisionGreaterThanIntMaxValueFixture.cs"/>
+				<Compile Include="..\EventStore.Client.Tests.Common\*.cs" Exclude="..\EventStore.Client.Tests.Common\StreamRevisionGreaterThanIntMaxValueFixture.cs" />
 		</ItemGroup>
 </Project>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/EventStore.Client.PersistentSubscriptions.Tests.csproj
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/EventStore.Client.PersistentSubscriptions.Tests.csproj
@@ -6,25 +6,25 @@
 				<Platforms>x64</Platforms>
 		</PropertyGroup>
 		<ItemGroup>
-				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1"/>
-				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0"/>
-				<PackageReference Include="Serilog" Version="2.9.0"/>
-				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0"/>
-				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2"/>
-				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0"/>
-				<PackageReference Include="System.Reactive" Version="4.3.2"/>
-				<PackageReference Include="xunit" Version="2.4.1"/>
+				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
+				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+				<PackageReference Include="System.Reactive" Version="4.3.2" />
+				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>
 						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 				</PackageReference>
 		</ItemGroup>
 		<ItemGroup>
-				<ProjectReference Include="..\EventStore.Client\EventStore.Client.csproj"/>
-				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj"/>
-				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj"/>
+				<ProjectReference Include="..\EventStore.Client\EventStore.Client.csproj" />
+				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
+				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-				<Compile Include="..\EventStore.Client.Tests.Common\*.cs"/>
+				<Compile Include="..\EventStore.Client.Tests.Common\*.cs" />
 		</ItemGroup>
 </Project>

--- a/src/EventStore.Client.Projections.Tests/EventStore.Client.Projections.Tests.csproj
+++ b/src/EventStore.Client.Projections.Tests/EventStore.Client.Projections.Tests.csproj
@@ -6,35 +6,35 @@
 				<Platforms>x64</Platforms>
 		</PropertyGroup>
 		<ItemGroup>
-				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1"/>
-				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0"/>
-				<PackageReference Include="Serilog" Version="2.9.0"/>
-				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0"/>
-				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2"/>
-				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0"/>
-				<PackageReference Include="System.Reactive" Version="4.3.2"/>
-				<PackageReference Include="xunit" Version="2.4.1"/>
+				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
+				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+				<PackageReference Include="System.Reactive" Version="4.3.2" />
+				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>
 						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 				</PackageReference>
 		</ItemGroup>
 		<ItemGroup>
-				<ProjectReference Include="..\EventStore.Client\EventStore.Client.csproj"/>
-				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj"/>
-				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj"/>
+				<ProjectReference Include="..\EventStore.Client\EventStore.Client.csproj" />
+				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
+				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-				<Compile Include="..\EventStore.Client.Tests.Common\*.cs"/>
+				<Compile Include="..\EventStore.Client.Tests.Common\*.cs" />
 		</ItemGroup>
 		<PropertyGroup>
 				<IsMac>false</IsMac>
 				<IsMac Condition="'$(OS)' == 'Unix' And Exists ('/Library/Frameworks')">true</IsMac>
 		</PropertyGroup>
 		<Target BeforeTargets="BeforeBuild" Name="ProjectionDependencies">
-				<Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\linux\libjs1.so" DestinationFolder="$(OutDir)" Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'false'"/>
-				<Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\mac\libjs1.dylib" DestinationFolder="$(OutDir)" Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'true'"/>
-				<Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\win\js1.dll" DestinationFolder="$(OutDir)" Condition=" '$(OS)' == 'Windows_NT' "/>
-				<Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\win\js1.pdb" DestinationFolder="$(OutDir)" Condition=" '$(OS)' == 'Windows_NT' "/>
+				<Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\linux\libjs1.so" DestinationFolder="$(OutDir)" Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'false'" />
+				<Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\mac\libjs1.dylib" DestinationFolder="$(OutDir)" Condition="'$(OS)' != 'Windows_NT' And '$(IsMac)' == 'true'" />
+				<Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\win\js1.dll" DestinationFolder="$(OutDir)" Condition=" '$(OS)' == 'Windows_NT' " />
+				<Copy ContinueOnError="ErrorAndStop" SourceFiles="..\libs\x64\win\js1.pdb" DestinationFolder="$(OutDir)" Condition=" '$(OS)' == 'Windows_NT' " />
 		</Target>
 </Project>

--- a/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
+++ b/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
@@ -181,10 +181,7 @@ namespace EventStore.Client {
 			public IServiceProvider ConfigureServices(IServiceCollection services) =>
 				_node.Startup.ConfigureServices(services);
 
-			public void Configure(IApplicationBuilder app) => _node.Startup.Configure(app.Use(CompleteResponse));
-
-			private static RequestDelegate CompleteResponse(RequestDelegate next) => context =>
-				next(context).ContinueWith(_ => context.Response.Body.FlushAsync());
+			public void Configure(IApplicationBuilder app) => _node.Startup.Configure(app);
 		}
 	}
 }

--- a/src/EventStore.Client.Tests/EventStore.Client.Tests.csproj
+++ b/src/EventStore.Client.Tests/EventStore.Client.Tests.csproj
@@ -6,25 +6,25 @@
 				<Platforms>x64</Platforms>
 		</PropertyGroup>
 		<ItemGroup>
-				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1"/>
-				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0"/>
-				<PackageReference Include="Serilog" Version="2.9.0"/>
-				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0"/>
-				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2"/>
-				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0"/>
-				<PackageReference Include="System.Reactive" Version="4.3.2"/>
-				<PackageReference Include="xunit" Version="2.4.1"/>
+				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
+				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+				<PackageReference Include="System.Reactive" Version="4.3.2" />
+				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>
 						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 				</PackageReference>
 		</ItemGroup>
 		<ItemGroup>
-				<ProjectReference Include="..\EventStore.Client\EventStore.Client.csproj"/>
-				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj"/>
-				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj"/>
+				<ProjectReference Include="..\EventStore.Client\EventStore.Client.csproj" />
+				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
+				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-				<Compile Include="..\EventStore.Client.Tests.Common\*.cs"/>
+				<Compile Include="..\EventStore.Client.Tests.Common\*.cs" />
 		</ItemGroup>
 </Project>

--- a/src/EventStore.Client.UserManagement.Tests/EventStore.Client.UserManagement.Tests.csproj
+++ b/src/EventStore.Client.UserManagement.Tests/EventStore.Client.UserManagement.Tests.csproj
@@ -6,25 +6,25 @@
 				<Platforms>x64</Platforms>
 		</PropertyGroup>
 		<ItemGroup>
-				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1"/>
-				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0"/>
-				<PackageReference Include="Serilog" Version="2.9.0"/>
-				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0"/>
-				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2"/>
-				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0"/>
-				<PackageReference Include="System.Reactive" Version="4.3.1"/>
-				<PackageReference Include="xunit" Version="2.4.1"/>
+				<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
+				<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+				<PackageReference Include="Serilog.Sinks.Observable" Version="2.0.2" />
+				<PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+				<PackageReference Include="System.Reactive" Version="4.3.1" />
+				<PackageReference Include="xunit" Version="2.4.1" />
 				<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 						<PrivateAssets>all</PrivateAssets>
 						<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 				</PackageReference>
 		</ItemGroup>
 		<ItemGroup>
-				<ProjectReference Include="..\EventStore.Client\EventStore.Client.csproj"/>
-				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj"/>
-				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj"/>
+				<ProjectReference Include="..\EventStore.Client\EventStore.Client.csproj" />
+				<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
+				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		</ItemGroup>
 		<ItemGroup>
-				<Compile Include="..\EventStore.Client.Tests.Common\*.cs"/>
+				<Compile Include="..\EventStore.Client.Tests.Common\*.cs" />
 		</ItemGroup>
 </Project>

--- a/src/EventStore.Client/EventStore.Client.csproj
+++ b/src/EventStore.Client/EventStore.Client.csproj
@@ -29,10 +29,10 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.3" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
-		<PackageReference Include="System.Text.Json" Version="4.7.0" />
+		<PackageReference Include="System.Text.Json" Version="4.7.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<Protobuf Include="../Protos/Grpc/*.proto" Exclude="../Protos/Grpc/operations.proto" Access="internal" GrpcServices="Client" ProtoRoot="../Protos/Grpc" />

--- a/src/EventStore.ClientAPI.Embedded.Tests/EventStore.ClientAPI.Embedded.Tests.csproj
+++ b/src/EventStore.ClientAPI.Embedded.Tests/EventStore.ClientAPI.Embedded.Tests.csproj
@@ -8,7 +8,7 @@
 		<DefineConstants>CLIENT_API_EMBEDDED</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.ClientAPI.Tests/EventStore.ClientAPI.Tests.csproj
+++ b/src/EventStore.ClientAPI.Tests/EventStore.ClientAPI.Tests.csproj
@@ -8,7 +8,7 @@
 		<DefineConstants>CLIENT_API</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.ClientAPI.v5.Tests/EventStore.ClientAPI.v5.Tests.csproj
+++ b/src/EventStore.ClientAPI.v5.Tests/EventStore.ClientAPI.v5.Tests.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="5.0.5" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
 			<PrivateAssets>all</PrivateAssets>

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -10,23 +10,23 @@
 						<PrivateAssets>all</PrivateAssets>
 						<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 				</PackageReference>
-				<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.1"/>
-				<PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="3.1.1"/>
-				<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.1"/>
-				<PackageReference Include="Newtonsoft.Json" Version="11.0.2"/>
-				<PackageReference Include="Serilog" Version="2.9.0"/>
-				<PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1"/>
-				<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0"/>
-				<PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0"/>
-				<PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0"/>
-				<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0"/>
-				<PackageReference Include="Serilog.Sinks.Async" Version="1.4.0"/>
-				<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1"/>
-				<PackageReference Include="Serilog.Sinks.File" Version="4.1.0"/>
+				<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
+				<PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="3.1.3" />
+				<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.3" />
+				<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+				<PackageReference Include="Serilog" Version="2.9.0" />
+				<PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
+				<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+				<PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0" />
+				<PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
+				<PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+				<PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
+				<PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+				<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
 				<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
 		</ItemGroup>
 		<ItemGroup>
-				<ProjectReference Include="..\EventStore.Common.Utils\EventStore.Common.Utils.csproj"/>
-				<ProjectReference Include="..\EventStore.Rags\EventStore.Rags.csproj"/>
+				<ProjectReference Include="..\EventStore.Common.Utils\EventStore.Common.Utils.csproj" />
+				<ProjectReference Include="..\EventStore.Rags\EventStore.Rags.csproj" />
 		</ItemGroup>
 </Project>

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -7,9 +7,9 @@
 		<Platforms>x64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.1" />
+		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.3" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 		<PackageReference Include="CompareNETObjects" Version="4.65.0" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -7,20 +7,20 @@
 		<Platforms>x64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
+			<FrameworkReference Include="Microsoft.AspNetCore.App" />
+	</ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Google.Protobuf" Version="3.11.3" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
-		<PackageReference Include="Grpc.Core" Version="2.27.0" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.27.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.27.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
 		<PackageReference Include="SimpleSyndicate.UriTemplate" Version="1.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
 		<PackageReference Include="System.Linq.Async" Version="4.0.0" />

--- a/src/EventStore.Core/Services/Transport/Grpc/AsyncStreamExtensions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/AsyncStreamExtensions.cs
@@ -1,0 +1,39 @@
+#region Copyright notice and license
+
+// Copyright 2015 gRPC authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#endregion
+
+using System;
+using System.Threading.Tasks;
+using Grpc.Core;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	/// <summary>
+	/// Extension methods that simplify work with gRPC streaming calls.
+	/// </summary>
+	public static class AsyncStreamExtensions {
+		/// <summary>
+		/// Reads the entire stream and executes an async action for each element.
+		/// </summary>
+		public static async ValueTask ForEachAsync<T>(this IAsyncStreamReader<T> streamReader,
+			Func<T, ValueTask> asyncAction)
+			where T : class {
+			while (await streamReader.MoveNext().ConfigureAwait(false)) {
+				await asyncAction(streamReader.Current).ConfigureAwait(false);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -69,7 +69,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				}).ConfigureAwait(false);
 			}
 
-			Task HandleAckNack(ReadReq request) {
+			ValueTask HandleAckNack(ReadReq request) {
 				_publisher.Publish(request.ContentCase switch {
 					ReadReq.ContentOneofCase.Ack => (Message)
 					new ClientMessage.PersistentSubscriptionAckEvents(
@@ -90,7 +90,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_ => throw new InvalidOperationException()
 				});
 
-				return Task.CompletedTask;
+				return new ValueTask(Task.CompletedTask);
 			}
 
 			ReadResp.Types.ReadEvent.Types.RecordedEvent ConvertToRecordedEvent(EventRecord e, long? commitPosition) {

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -13,7 +13,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 	</ItemGroup>

--- a/src/EventStore.Rags.Tests/EventStore.Rags.Tests.csproj
+++ b/src/EventStore.Rags.Tests/EventStore.Rags.Tests.csproj
@@ -14,7 +14,7 @@
 		</Content>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
 	</ItemGroup>

--- a/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
+++ b/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
@@ -6,8 +6,7 @@
 		<Platforms>x64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
+		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 		<PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
 	</ItemGroup>
 	<ItemGroup>


### PR DESCRIPTION
Changed: updated to dotnet sdk 3.1.201

dotnet 3.1.2 came out yesterday, which includes dotnet/aspnetcore#17158. This will obviate the need to stand up kestrel when we test anything that uses BiD streaming.