### PR TITLE
EventData byte[] -> ReadOnlyMemory<byte>

### DIFF
--- a/src/EventStore.Client.Tests.Common/StreamRevisionGreaterThanIntMaxValueFixture.cs
+++ b/src/EventStore.Client.Tests.Common/StreamRevisionGreaterThanIntMaxValueFixture.cs
@@ -64,7 +64,7 @@ namespace EventStore.Client {
 			TFChunkWriter writer,
 			string eventStreamId,
 			long eventNumber,
-			byte[] data,
+			ReadOnlyMemory<byte> data,
 			DateTime? timestamp = null,
 			Uuid eventId = default,
 			string eventType = "some-type") {

--- a/src/EventStore.Client.Tests/Streams/EventDataComparer.cs
+++ b/src/EventStore.Client.Tests/Streams/EventDataComparer.cs
@@ -10,11 +10,11 @@ namespace EventStore.Client.Streams
 			if (expected.Type != actual.EventType)
 				return false;
 
-			var expectedDataString = Helper.UTF8NoBom.GetString(expected.Data ?? new byte[0]);
-			var expectedMetadataString = Helper.UTF8NoBom.GetString(expected.Metadata ?? new byte[0]);
+			var expectedDataString = Helper.UTF8NoBom.GetString(expected.Data.Span);
+			var expectedMetadataString = Helper.UTF8NoBom.GetString(expected.Metadata.Span);
 
-			var actualDataString = Helper.UTF8NoBom.GetString(actual.Data ?? new byte[0]);
-			var actualMetadataDataString = Helper.UTF8NoBom.GetString(actual.Metadata ?? new byte[0]);
+			var actualDataString = Helper.UTF8NoBom.GetString(actual.Data.Span);
+			var actualMetadataDataString = Helper.UTF8NoBom.GetString(actual.Metadata.Span);
 
 			return expectedDataString == actualDataString && expectedMetadataString == actualMetadataDataString;
 		}

--- a/src/EventStore.Client.Tests/Streams/is_json.cs
+++ b/src/EventStore.Client.Tests/Streams/is_json.cs
@@ -48,8 +48,8 @@ namespace EventStore.Client.Streams {
 			Assert.Equal(isJson
 				? Constants.Metadata.ContentTypes.ApplicationJson
 				: Constants.Metadata.ContentTypes.ApplicationOctetStream, @event.Event.ContentType);
-			Assert.Equal(data, encoding.GetString(@event.Event.Data));
-			Assert.Equal(metadata, encoding.GetString(@event.Event.Metadata));
+			Assert.Equal(data, encoding.GetString(@event.Event.Data.Span));
+			Assert.Equal(metadata, encoding.GetString(@event.Event.Metadata.Span));
 		}
 
 		private string GetStreamName(bool isJson, string data, string metadata,

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_soft_deleted_stream.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forward_with_soft_deleted_stream.cs
@@ -30,7 +30,7 @@ namespace EventStore.Client.Streams {
 			var tombstone = events.Last();
 			Assert.Equal(SystemStreams.MetastreamOf(Stream), tombstone.Event.EventStreamId);
 			Assert.Equal(SystemEventTypes.StreamMetadata, tombstone.Event.EventType);
-			var metadata = JsonSerializer.Deserialize<StreamMetadata>(tombstone.Event.Data, new JsonSerializerOptions {
+			var metadata = JsonSerializer.Deserialize<StreamMetadata>(tombstone.Event.Data.Span, new JsonSerializerOptions {
 				Converters = { StreamMetadataJsonConverter.Instance }
 			});
 			Assert.True(metadata.TruncateBefore.HasValue);

--- a/src/EventStore.Client/EventData.cs
+++ b/src/EventStore.Client/EventData.cs
@@ -3,14 +3,13 @@ using System.Net.Http.Headers;
 
 namespace EventStore.Client {
 	public sealed class EventData {
-		public readonly byte[] Data;
+		public readonly ReadOnlyMemory<byte> Data;
 		public readonly Uuid EventId;
-		public readonly byte[] Metadata;
+		public readonly ReadOnlyMemory<byte> Metadata;
 		public readonly string Type;
 		public readonly string ContentType;
 
-		public EventData(Uuid eventId, string type, byte[] data, byte[] metadata = default,
-			string contentType = Constants.Metadata.ContentTypes.ApplicationJson) {
+		private EventData(Uuid eventId, string type, string contentType) {
 			if (eventId == Uuid.Empty) {
 				throw new ArgumentOutOfRangeException(nameof(eventId));
 			}
@@ -26,16 +25,28 @@ namespace EventStore.Client {
 			MediaTypeHeaderValue.Parse(contentType);
 
 			if (contentType != Constants.Metadata.ContentTypes.ApplicationJson &&
-			    contentType != Constants.Metadata.ContentTypes.ApplicationOctetStream) {
+				contentType != Constants.Metadata.ContentTypes.ApplicationOctetStream) {
 				throw new ArgumentOutOfRangeException(nameof(contentType), contentType,
 					$"Only {Constants.Metadata.ContentTypes.ApplicationJson} or {Constants.Metadata.ContentTypes.ApplicationOctetStream} are acceptable values.");
 			}
 
 			EventId = eventId;
 			Type = type;
+			ContentType = contentType;
+		}
+
+		public EventData(Uuid eventId, string type, byte[] data, byte[] metadata = default,
+			string contentType = Constants.Metadata.ContentTypes.ApplicationJson) : this(eventId, type, contentType) {
+
 			Data = data ?? Array.Empty<byte>();
 			Metadata = metadata ?? Array.Empty<byte>();
-			ContentType = contentType;
+		}
+
+		public EventData(Uuid eventId, string type, ReadOnlyMemory<byte> data, ReadOnlyMemory<byte>? metadata = default,
+			string contentType = Constants.Metadata.ContentTypes.ApplicationJson) : this(eventId, type, contentType) {
+
+			Data = data;
+			Metadata = metadata ?? Array.Empty<byte>();
 		}
 	}
 }

--- a/src/EventStore.Client/EventRecord.cs
+++ b/src/EventStore.Client/EventRecord.cs
@@ -7,8 +7,8 @@ namespace EventStore.Client {
 		public readonly Uuid EventId;
 		public readonly StreamRevision EventNumber;
 		public readonly string EventType;
-		public readonly byte[] Data;
-		public readonly byte[] Metadata;
+		public readonly ReadOnlyMemory<byte> Data;
+		public readonly ReadOnlyMemory<byte> Metadata;
 		public readonly DateTime Created;
 		public readonly Position Position;
 		public readonly string ContentType;

--- a/src/EventStore.Client/EventStoreClient.Append.cs
+++ b/src/EventStore.Client/EventStoreClient.Append.cs
@@ -108,8 +108,8 @@ namespace EventStore.Client {
 					await call.RequestStream.WriteAsync(new AppendReq {
 						ProposedMessage = new AppendReq.Types.ProposedMessage {
 							Id = e.EventId.ToDto(),
-							Data = ByteString.CopyFrom(e.Data),
-							CustomMetadata = ByteString.CopyFrom(e.Metadata),
+							Data = ByteString.CopyFrom(e.Data.Span),
+							CustomMetadata = ByteString.CopyFrom(e.Metadata.Span),
 							Metadata = {
 								{Constants.Metadata.Type, e.Type},
 								{Constants.Metadata.ContentType, e.ContentType}

--- a/src/EventStore.Client/EventStoreClient.Metadata.cs
+++ b/src/EventStore.Client/EventStoreClient.Metadata.cs
@@ -27,7 +27,7 @@ namespace EventStore.Client {
 			return metadata.Event == null
 				? StreamMetadataResult.None(streamName)
 				: StreamMetadataResult.Create(streamName, metadata.OriginalEventNumber,
-					JsonSerializer.Deserialize<StreamMetadata>(metadata.Event.Data,
+					JsonSerializer.Deserialize<StreamMetadata>(metadata.Event.Data.Span,
 						StreamMetadataJsonSerializerOptions));
 		}
 

--- a/src/EventStore.ClientAPI.Embedded/ClientMessageConverterExtensions.cs
+++ b/src/EventStore.ClientAPI.Embedded/ClientMessageConverterExtensions.cs
@@ -55,8 +55,8 @@ namespace EventStore.ClientAPI.Embedded {
 				eventRecord.EventStreamId, eventRecord.EventNumber,
 				eventRecord.EventId.ToByteArray(), eventRecord.EventType, eventRecord.IsJson ? 1 : 0,
 				eventRecord.IsJson ? 1 : 0,
-				eventRecord.Data,
-				eventRecord.Metadata,
+				eventRecord.Data.ToArray(),
+				eventRecord.Metadata.ToArray(),
 				eventRecord.TimeStamp.ToBinary(),
 				(long)(eventRecord.TimeStamp - new DateTime(1970, 1, 1)).TotalMilliseconds);
 		}

--- a/src/EventStore.Common/Utils/Json.cs
+++ b/src/EventStore.Common/Utils/Json.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
 using System.Xml;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -46,6 +43,11 @@ namespace EventStore.Common.Utils {
 			return result;
 		}
 
+		public static T ParseJson<T>(this ReadOnlyMemory<byte> json) {
+			var result = JsonConvert.DeserializeObject<T>(Helper.UTF8NoBom.GetString(json.Span), JsonSettings);
+			return result;
+		}
+
 		public static object DeserializeObject(JObject value, Type type, JsonSerializerSettings settings) {
 			JsonSerializer jsonSerializer = JsonSerializer.Create(settings);
 			return jsonSerializer.Deserialize(new JTokenReader(value), type);
@@ -71,6 +73,16 @@ namespace EventStore.Common.Utils {
 		public static bool IsValidJson(this byte[] value) {
 			try {
 				JToken.Parse(Helper.UTF8NoBom.GetString(value));
+			} catch {
+				return false;
+			}
+
+			return true;
+		}
+
+		public static bool IsValidJson(this ReadOnlyMemory<byte> value) {
+			try {
+				JToken.Parse(Helper.UTF8NoBom.GetString(value.Span));
 			} catch {
 				return false;
 			}

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -349,7 +349,7 @@ namespace EventStore.Core.Tests.Helpers {
 
 		private ResolvedEvent BuildEvent(EventRecord x, bool resolveLinks) {
 			if (x.EventType == "$>" && resolveLinks) {
-				var parts = Helper.UTF8NoBom.GetString(x.Data).Split(_linkToSeparator, 2);
+				var parts = Helper.UTF8NoBom.GetString(x.Data.Span).Split(_linkToSeparator, 2);
 				List<EventRecord> list;
 				if (_deletedStreams.Contains(parts[1]) || !_streams.TryGetValue(parts[1], out list))
 					return ResolvedEvent.ForFailedResolvedLink(x, ReadEventResult.StreamDeleted);
@@ -363,7 +363,7 @@ namespace EventStore.Core.Tests.Helpers {
 
 		private ResolvedEvent BuildEvent(EventRecord x, bool resolveLinks, long commitPosition) {
 			if (x.EventType == "$>" && resolveLinks) {
-				var parts = Helper.UTF8NoBom.GetString(x.Data).Split(_linkToSeparator, 2);
+				var parts = Helper.UTF8NoBom.GetString(x.Data.Span).Split(_linkToSeparator, 2);
 				var list = _streams[parts[1]];
 				var eventNumber = int.Parse(parts[0]);
 				var target = list[eventNumber];
@@ -544,7 +544,7 @@ namespace EventStore.Core.Tests.Helpers {
 			events = events.Take(events.Count - skip).ToList();
 			Assert.IsNotEmpty(events, message + "The stream is empty.");
 			var last = events[events.Count - 1];
-			Assert.AreEqual(data, Encoding.UTF8.GetString(last.Data));
+			Assert.AreEqual(data, Encoding.UTF8.GetString(last.Data.Span));
 		}
 
 		public void AssertLastEventJson<T>(string streamId, T json, string message = null, int skip = 0) {
@@ -572,7 +572,7 @@ namespace EventStore.Core.Tests.Helpers {
 			var message = string.Format("Invalid events in the '{0}' stream. ", streamId);
 			List<EventRecord> events;
 			Assert.That(_streams.TryGetValue(streamId, out events), message + "The stream does not exist.");
-			var eventsText = events.Skip(events.Count - data.Length).Select(v => Encoding.UTF8.GetString(v.Data))
+			var eventsText = events.Skip(events.Count - data.Length).Select(v => Encoding.UTF8.GetString(v.Data.Span))
 				.ToList();
 			if (data.Length > 0)
 				Assert.IsNotEmpty(events, message + "The stream is empty.");
@@ -590,7 +590,7 @@ namespace EventStore.Core.Tests.Helpers {
 			Assert.That(_streams.TryGetValue(streamId, out events), message + "The stream does not exist.");
 			var eventsText =
 				events.Skip(events.Count - data.Length)
-					.Select(v => new {Text = Encoding.UTF8.GetString(v.Data), EventType = v.EventType})
+					.Select(v => new {Text = Encoding.UTF8.GetString(v.Data.Span), EventType = v.EventType})
 					.Select(
 						v =>
 							v.EventType == SystemEventTypes.LinkTo
@@ -613,7 +613,7 @@ namespace EventStore.Core.Tests.Helpers {
 			return _streams[stream][(int)eventNumber].EventType + ":"
 			                                                    +
 			                                                    Encoding.UTF8.GetString(
-				                                                    _streams[stream][(int)eventNumber].Data);
+				                                                    _streams[stream][(int)eventNumber].Data.Span);
 		}
 
 		public void AssertStreamContains(string streamId, params string[] data) {
@@ -623,7 +623,7 @@ namespace EventStore.Core.Tests.Helpers {
 			if (data.Length > 0)
 				Assert.IsNotEmpty(events, message + "The stream is empty.");
 
-			var eventsData = new HashSet<string>(events.Select(v => Encoding.UTF8.GetString(v.Data)));
+			var eventsData = new HashSet<string>(events.Select(v => Encoding.UTF8.GetString(v.Data.Span)));
 			var missing = data.Where(v => !eventsData.Contains(v)).ToArray();
 
 			Assert.That(missing.Length == 0,

--- a/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
@@ -1,7 +1,4 @@
 using System;
-using System.IO;
-using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
@@ -67,7 +64,7 @@ namespace EventStore.Core.Tests.Services.Storage.Transactions {
 			for (int i = 0; i < 15; ++i) {
 				var result = ReadIndex.ReadEvent("ES", i);
 				Assert.AreEqual(ReadEventResult.Success, result.Result);
-				Assert.AreEqual(Helper.UTF8NoBom.GetBytes("data" + i), result.Record.Data);
+				Assert.AreEqual(Helper.UTF8NoBom.GetBytes("data" + i), result.Record.Data.ToArray());
 			}
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/auto_convertion.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/auto_convertion.cs
@@ -111,6 +111,10 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 			return Helper.UTF8NoBom.GetString(bytes ?? new byte[0]);
 		}
 
+		public static string AsString(ReadOnlyMemory<byte> bytes) {
+			return Helper.UTF8NoBom.GetString(bytes.Span);
+		}
+
 		private static string WrapIntoQuotes(string s) {
 			return string.Format("\"{0}\"", s);
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
@@ -280,7 +280,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 		}
 
 		private LogRecord CreateLogRecordV0(Rec rec, TransactionInfo transInfo, int transOffset, long logPos,
-			long expectedVersion, byte[] data, PrepareFlags flags) {
+			long expectedVersion, ReadOnlyMemory<byte> data, PrepareFlags flags) {
 			return new PrepareLogRecord(logPos,
 				Guid.NewGuid(),
 				rec.Id,

--- a/src/EventStore.Core.Tests/TransactionLog/prepare_log_record_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/prepare_log_record_should.cs
@@ -69,7 +69,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			});
 		}
 
-		[Test]
+		[Test, Ignore("ReadOnlyMemory will always convert back to empty array if initialized with null array.")]
 		public void throw_argumentnullexception_when_given_null_data() {
 			Assert.Throws<ArgumentNullException>(() => {
 				new PrepareLogRecord(0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "test", 0, DateTime.UtcNow,

--- a/src/EventStore.Core/Data/EventRecord.cs
+++ b/src/EventStore.Core/Data/EventRecord.cs
@@ -21,8 +21,8 @@ namespace EventStore.Core.Data {
 		public readonly DateTime TimeStamp;
 		public readonly PrepareFlags Flags;
 		public readonly string EventType;
-		public readonly byte[] Data;
-		public readonly byte[] Metadata;
+		public readonly ReadOnlyMemory<byte> Data;
+		public readonly ReadOnlyMemory<byte> Metadata;
 
 		public EventRecord(long eventNumber, PrepareLogRecord prepare) {
 			Ensure.Nonnegative(eventNumber, "eventNumber");
@@ -39,8 +39,8 @@ namespace EventStore.Core.Data {
 
 			Flags = prepare.Flags;
 			EventType = prepare.EventType ?? string.Empty;
-			Data = prepare.Data ?? Empty.ByteArray;
-			Metadata = prepare.Metadata ?? Empty.ByteArray;
+			Data = prepare.Data;
+			Metadata = prepare.Metadata;
 		}
 
 		public EventRecord(long eventNumber,
@@ -94,8 +94,8 @@ namespace EventStore.Core.Data {
 			       && TimeStamp.Equals(other.TimeStamp)
 			       && Flags.Equals(other.Flags)
 			       && string.Equals(EventType, other.EventType)
-			       && Data.SequenceEqual(other.Data)
-			       && Metadata.SequenceEqual(other.Metadata);
+			       && Data.Span.SequenceEqual(other.Data.Span)
+			       && Metadata.Span.SequenceEqual(other.Metadata.Span);
 		}
 
 		public override bool Equals(object obj) {
@@ -159,11 +159,11 @@ namespace EventStore.Core.Data {
 
 #if DEBUG
 		public string DebugDataView {
-			get { return Encoding.UTF8.GetString(Data); }
+			get { return Encoding.UTF8.GetString(Data.Span); }
 		}
 
 		public string DebugMetadataView {
-			get { return Encoding.UTF8.GetString(Metadata); }
+			get { return Encoding.UTF8.GetString(Metadata.Span); }
 		}
 #endif
 	}

--- a/src/EventStore.Core/Data/StreamMetadata.cs
+++ b/src/EventStore.Core/Data/StreamMetadata.cs
@@ -50,8 +50,8 @@ namespace EventStore.Core.Data {
 				MaxCount, MaxAge, TruncateBefore, TempStream, CacheControl, Acl);
 		}
 
-		public static StreamMetadata FromJsonBytes(byte[] json) {
-			using (var reader = new JsonTextReader(new StreamReader(new MemoryStream(json)))) {
+		public static StreamMetadata FromJsonBytes(ReadOnlyMemory<byte> json) {
+			using (var reader = new JsonTextReader(new StreamReader(new MemoryStream(json.ToArray())))) {
 				return FromJsonReader(reader);
 			}
 		}

--- a/src/EventStore.Core/Data/SystemSettings.cs
+++ b/src/EventStore.Core/Data/SystemSettings.cs
@@ -24,8 +24,8 @@ namespace EventStore.Core.Data {
 			return string.Format("UserStreamAcl: ({0}), SystemStreamAcl: ({1})", UserStreamAcl, SystemStreamAcl);
 		}
 
-		public static SystemSettings FromJsonBytes(byte[] json) {
-			using (var reader = new JsonTextReader(new StreamReader(new MemoryStream(json)))) {
+		public static SystemSettings FromJsonBytes(ReadOnlyMemory<byte> json) {
+			using (var reader = new JsonTextReader(new StreamReader(new MemoryStream(json.ToArray())))) {
 				Check(reader.Read(), reader);
 				Check(JsonToken.StartObject, reader);
 

--- a/src/EventStore.Core/Messages/HttpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/HttpClientMessageDto.cs
@@ -48,15 +48,14 @@ namespace EventStore.Core.Messages {
 				this.metadata = metadata;
 			}
 
-			public ClientEventText(Guid eventId, string eventType, byte[] data, byte[] metadata) {
+			public ClientEventText(Guid eventId, string eventType, ReadOnlyMemory<byte> data, ReadOnlyMemory<byte> metadata) {
 				Ensure.NotEmptyGuid(eventId, "eventId");
-				Ensure.NotNull(data, "data");
 
 				this.eventId = eventId;
 				this.eventType = eventType;
 
-				this.data = Helper.UTF8NoBom.GetString(data ?? LogRecord.NoData);
-				this.metadata = Helper.UTF8NoBom.GetString(metadata ?? LogRecord.NoData);
+				this.data = Helper.UTF8NoBom.GetString(data.Span);
+				this.metadata = Helper.UTF8NoBom.GetString(metadata.Span);
 			}
 		}
 
@@ -78,8 +77,8 @@ namespace EventStore.Core.Messages {
 					eventNumber = evnt.Event.EventNumber;
 					eventType = evnt.Event.EventType;
 					eventId = evnt.Event.EventId.ToString();
-					data = Helper.UTF8NoBom.GetString(evnt.Event.Data ?? Empty.ByteArray);
-					metadata = Helper.UTF8NoBom.GetString(evnt.Event.Metadata ?? Empty.ByteArray);
+					data = Helper.UTF8NoBom.GetString(evnt.Event.Data.Span);
+					metadata = Helper.UTF8NoBom.GetString(evnt.Event.Metadata.Span);
 				} else {
 					eventStreamId = null;
 					eventNumber = EventNumber.Invalid;

--- a/src/EventStore.Core/Messages/TcpClientMessageDtoExtensions.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDtoExtensions.cs
@@ -25,9 +25,9 @@ namespace EventStore.Core.Messages {
 				EventNumber = eventRecord.EventNumber;
 				EventId = eventRecord.EventId.ToByteArray();
 				EventType = eventRecord.EventType;
-				Data = eventRecord.Data;
+				Data = eventRecord.Data.ToArray();
 				Created = eventRecord.TimeStamp.ToBinary();
-				Metadata = eventRecord.Metadata;
+				Metadata = eventRecord.Metadata.ToArray();
 				var isJson = eventRecord.IsJson;
 				DataContentType = isJson ? 1 : 0;
 				MetadataContentType = isJson ? 1 : 0;
@@ -39,9 +39,9 @@ namespace EventStore.Core.Messages {
 				EventNumber = eventNumber;
 				EventId = eventRecord.EventId.ToByteArray();
 				EventType = eventRecord.EventType;
-				Data = eventRecord.Data;
+				Data = eventRecord.Data.ToArray();
 				Created = eventRecord.TimeStamp.ToBinary();
-				Metadata = eventRecord.Metadata;
+				Metadata = eventRecord.Metadata.ToArray();
 				var isJson = eventRecord.IsJson;
 				DataContentType = isJson ? 1 : 0;
 				MetadataContentType = isJson ? 1 : 0;

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnablePersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnablePersistentSubscriptionConsumerStrategy.cs
@@ -89,7 +89,7 @@
 
 			if (eventRecord.EventType == SystemEventTypes.LinkTo) // Unresolved link.
 			{
-				sourceStreamId = Helper.UTF8NoBom.GetString(eventRecord.Data);
+				sourceStreamId = Helper.UTF8NoBom.GetString(eventRecord.Data.Span);
 				int separatorIndex = sourceStreamId.IndexOf(LinkToSeparator);
 				if (separatorIndex != -1)
 				{

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedByCorrelationPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedByCorrelationPersistentSubscriptionConsumerStrategy.cs
@@ -1,5 +1,6 @@
 ﻿namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy
 {
+	using System;
 	using System.IO;
 	using Data;
 	using Index.Hashes;
@@ -27,8 +28,8 @@
 			return correlation;
 		}
 
-		private string CorrelationFromJsonBytes(byte[] toConvert) {
-			using (var reader = new JsonTextReader(new StreamReader(new MemoryStream(toConvert)))) {
+		private string CorrelationFromJsonBytes(ReadOnlyMemory<byte> toConvert) {
+			using (var reader = new JsonTextReader(new StreamReader(new MemoryStream(toConvert.ToArray())))) {
 				if (!reader.Read()) {
 					return null;
 				}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConfig.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConfig.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			return this.ToJsonBytes();
 		}
 
-		public static PersistentSubscriptionConfig FromSerializedForm(byte[] data) {
+		public static PersistentSubscriptionConfig FromSerializedForm(ReadOnlyMemory<byte> data) {
 			try {
 				var ret = data.ParseJson<PersistentSubscriptionConfig>();
 				if (ret.Version == null)

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionMessageParker.cs
@@ -53,7 +53,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private string GetLinkToFor(ResolvedEvent ev) {
 			if (ev.Event == null) // Unresolved link so just use the bad/deleted link data.
 			{
-				return Encoding.UTF8.GetString(ev.Link.Data);
+				return Encoding.UTF8.GetString(ev.Link.Data.Span);
 			}
 
 			return string.Format("{0}@{1}", ev.Event.EventNumber, ev.Event.EventStreamId);

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -440,7 +440,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private ResolvedEvent ResolveLinkToEvent(EventRecord eventRecord, long commitPosition) {
 			if (eventRecord.EventType == SystemEventTypes.LinkTo) {
 				try {
-					string[] parts = Helper.UTF8NoBom.GetString(eventRecord.Data).Split('@');
+					string[] parts = Helper.UTF8NoBom.GetString(eventRecord.Data.Span).Split('@');
 					long eventNumber = long.Parse(parts[0]);
 					string streamId = parts[1];
 

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -270,9 +270,9 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 						sb.Append(Environment.NewLine);
 						sb.Append("Type: " + p.EventType);
 						sb.Append(Environment.NewLine);
-						sb.Append("MetaData: " + Encoding.UTF8.GetString(p.Metadata));
+						sb.Append("MetaData: " + Encoding.UTF8.GetString(p.Metadata.Span));
 						sb.Append(Environment.NewLine);
-						sb.Append("Data: " + Encoding.UTF8.GetString(p.Data));
+						sb.Append("Data: " + Encoding.UTF8.GetString(p.Data.Span));
 						sb.Append(Environment.NewLine);
 					}
 
@@ -401,7 +401,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			return res.Result == ReadEventResult.Success ? DeserializeSystemSettings(res.Record.Data) : null;
 		}
 
-		private static SystemSettings DeserializeSystemSettings(byte[] settingsData) {
+		private static SystemSettings DeserializeSystemSettings(ReadOnlyMemory<byte> settingsData) {
 			try {
 				return SystemSettings.FromJsonBytes(settingsData);
 			} catch (Exception exc) {

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
@@ -34,9 +34,9 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 
 	public struct RawMetaInfo {
 		public readonly long MetaLastEventNumber;
-		public readonly byte[] RawMeta;
+		public readonly ReadOnlyMemory<byte> RawMeta;
 
-		public RawMetaInfo(long metaLastEventNumber, byte[] rawMeta) {
+		public RawMetaInfo(long metaLastEventNumber, ReadOnlyMemory<byte> rawMeta) {
 			MetaLastEventNumber = metaLastEventNumber;
 			RawMeta = rawMeta;
 		}
@@ -438,10 +438,10 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 
 		private struct StreamMeta {
-			public readonly byte[] RawMeta;
+			public readonly ReadOnlyMemory<byte> RawMeta;
 			public readonly StreamMetadata Meta;
 
-			public StreamMeta(byte[] rawMeta, StreamMetadata meta) {
+			public StreamMeta(ReadOnlyMemory<byte> rawMeta, StreamMetadata meta) {
 				RawMeta = rawMeta;
 				Meta = meta;
 			}

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -591,7 +591,7 @@ namespace EventStore.Core.Services.Storage {
 		private ResolvedEvent? ResolveLinkToEvent(EventRecord eventRecord, ClaimsPrincipal user, long? commitPosition) {
 			if (eventRecord.EventType == SystemEventTypes.LinkTo) {
 				try {
-					var parts = Helper.UTF8NoBom.GetString(eventRecord.Data).Split(LinkToSeparator, 2);
+					var parts = Helper.UTF8NoBom.GetString(eventRecord.Data.Span).Split(LinkToSeparator, 2);
 					long eventNumber = long.Parse(parts[0]);
 					var streamId = parts[1];
 

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -303,7 +303,7 @@ namespace EventStore.Core.Services.Storage {
 			SoftUndeleteStream(streamId, rawInfo.MetaLastEventNumber, rawInfo.RawMeta, recreateFromEventNumber);
 		}
 
-		private void SoftUndeleteStream(string streamId, long metaLastEventNumber, byte[] rawMeta, long recreateFrom) {
+		private void SoftUndeleteStream(string streamId, long metaLastEventNumber, ReadOnlyMemory<byte> rawMeta, long recreateFrom) {
 			byte[] modifiedMeta;
 			if (!SoftUndeleteRawMeta(rawMeta, recreateFrom, out modifiedMeta))
 				return;
@@ -318,9 +318,9 @@ namespace EventStore.Core.Services.Storage {
 			_indexWriter.PreCommit(new[] { res.Prepare });
 		}
 
-		public bool SoftUndeleteRawMeta(byte[] rawMeta, long recreateFromEventNumber, out byte[] modifiedMeta) {
+		public bool SoftUndeleteRawMeta(ReadOnlyMemory<byte> rawMeta, long recreateFromEventNumber, out byte[] modifiedMeta) {
 			try {
-				var jobj = JObject.Parse(Encoding.UTF8.GetString(rawMeta));
+				var jobj = JObject.Parse(Encoding.UTF8.GetString(rawMeta.Span));
 				jobj[SystemMetadata.TruncateBefore] = recreateFromEventNumber;
 				using (var memoryStream = new MemoryStream()) {
 					using (var jsonWriter = new JsonTextWriter(new StreamWriter(memoryStream))) {

--- a/src/EventStore.Core/Services/SubscriptionsService.cs
+++ b/src/EventStore.Core/Services/SubscriptionsService.cs
@@ -304,7 +304,7 @@ namespace EventStore.Core.Services {
 		private ResolvedEvent ResolveLinkToEvent(EventRecord eventRecord, long commitPosition) {
 			if (eventRecord.EventType == SystemEventTypes.LinkTo) {
 				try {
-					string[] parts = Helper.UTF8NoBom.GetString(eventRecord.Data).Split(_linkToSeparator, 2);
+					string[] parts = Helper.UTF8NoBom.GetString(eventRecord.Data.Span).Split(_linkToSeparator, 2);
 					long eventNumber = long.Parse(parts[0]);
 					string streamId = parts[1];
 

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -78,18 +78,18 @@ namespace EventStore.Core.Services {
 		public const string ScavengeMergeCompleted = "$scavengeMergeCompleted";
 		public const string ScavengeIndexCompleted = "$scavengeIndexCompleted";
 
-		public static string StreamReferenceEventToStreamId(string eventType, byte[] data) {
+		public static string StreamReferenceEventToStreamId(string eventType, ReadOnlyMemory<byte> data) {
 			string streamId = null;
 			switch (eventType) {
 				case LinkTo: {
-					string[] parts = Helper.UTF8NoBom.GetString(data).Split(_linkToSeparator, 2);
+					string[] parts = Helper.UTF8NoBom.GetString(data.Span).Split(_linkToSeparator, 2);
 					streamId = parts[1];
 					break;
 				}
 				case StreamReference:
 				case V1__StreamCreated__:
 				case V2__StreamCreated_InIndex: {
-					streamId = Helper.UTF8NoBom.GetString(data);
+					streamId = Helper.UTF8NoBom.GetString(data.Span);
 					break;
 				}
 				default:

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -5,14 +5,14 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using EventStore.Core.Bus;
-using EventStore.Core.Data;
-using EventStore.Core.Messages;
-using EventStore.Core.Messaging;
 using EventStore.Client;
 using EventStore.Client.PersistentSubscriptions;
 using EventStore.Client.Shared;
 using EventStore.Core.Authorization;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
 using Google.Protobuf;
 using Grpc.Core;
 using Grpc.Core.Utils;
@@ -114,8 +114,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							? Constants.Metadata.ContentTypes.ApplicationJson
 							: Constants.Metadata.ContentTypes.ApplicationOctetStream
 					},
-					Data = ByteString.CopyFrom(e.Data),
-					CustomMetadata = ByteString.CopyFrom(e.Metadata)
+					Data = ByteString.CopyFrom(e.Data.Span),
+					CustomMetadata = ByteString.CopyFrom(e.Metadata.Span)
 				};
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -223,8 +223,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							? Constants.Metadata.ContentTypes.ApplicationJson
 							: Constants.Metadata.ContentTypes.ApplicationOctetStream
 					},
-					Data = ByteString.CopyFrom(e.Data),
-					CustomMetadata = ByteString.CopyFrom(e.Metadata)
+					Data = ByteString.CopyFrom(e.Data.Span),
+					CustomMetadata = ByteString.CopyFrom(e.Metadata.Span)
 				};
 			}
 

--- a/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Services.Transport.Http {
 
 			switch (targetCodec.ContentType) {
 				case ContentType.Raw:
-					return evnt.Event.Data;
+					return evnt.Event.Data.ToArray();
 				case ContentType.Xml:
 				case ContentType.ApplicationXml: {
 					var serializeObject = JsonConvert.SerializeObject(dto.data);

--- a/src/EventStore.Core/Services/UserManagement/AllUsersReader.cs
+++ b/src/EventStore.Core/Services/UserManagement/AllUsersReader.cs
@@ -47,7 +47,7 @@ namespace EventStore.Core.Services.UserManagement {
 					foreach (var loginName in from eventData in result.Events
 						let @event = eventData.Event
 						where @event.EventType == UserEventType
-						let stringData = Helper.UTF8NoBom.GetString(@event.Data)
+						let stringData = Helper.UTF8NoBom.GetString(@event.Data.Span)
 						select stringData)
 						BeginReadUserDetails(loginName);
 

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 	}
 
 	public abstract class LogRecord {
-		public static readonly byte[] NoData = Empty.ByteArray;
+		public static readonly ReadOnlyMemory<byte> NoData = Empty.ByteArray;
 
 		public readonly LogRecordType RecordType;
 		public readonly byte Version;
@@ -53,7 +53,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 		public static PrepareLogRecord Prepare(long logPosition, Guid correlationId, Guid eventId, long transactionPos,
 			int transactionOffset,
 			string eventStreamId, long expectedVersion, PrepareFlags flags, string eventType,
-			byte[] data, byte[] metadata, DateTime? timeStamp = null) {
+			ReadOnlyMemory<byte> data, ReadOnlyMemory<byte> metadata, DateTime? timeStamp = null) {
 			return new PrepareLogRecord(logPosition, correlationId, eventId, transactionPos, transactionOffset,
 				eventStreamId, expectedVersion, timeStamp ?? DateTime.UtcNow, flags, eventType,
 				data, metadata);
@@ -66,7 +66,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 
 		public static PrepareLogRecord SingleWrite(long logPosition, Guid correlationId, Guid eventId,
 			string eventStreamId,
-			long expectedVersion, string eventType, byte[] data, byte[] metadata,
+			long expectedVersion, string eventType, ReadOnlyMemory<byte> data, ReadOnlyMemory<byte> metadata,
 			DateTime? timestamp = null, PrepareFlags? additionalFlags = null) {
 			return new PrepareLogRecord(logPosition, correlationId, eventId, logPosition, 0, eventStreamId,
 				expectedVersion,

--- a/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 		public readonly SystemRecordType SystemRecordType;
 		public readonly SystemRecordSerialization SystemRecordSerialization;
 		public readonly long Reserved;
-		public readonly byte[] Data;
+		public readonly ReadOnlyMemory<byte> Data;
 
 		public SystemLogRecord(long logPosition,
 			DateTime timeStamp,
@@ -84,7 +84,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 			writer.Write((byte)SystemRecordSerialization);
 			writer.Write(Reserved);
 			writer.Write(Data.Length);
-			writer.Write(Data);
+			writer.Write(Data.Span);
 		}
 
 		public bool Equals(SystemLogRecord other) {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_with_prerecorded_events_after_the_last_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/checkpoint_manager/multi_stream/when_starting_with_prerecorded_events_after_the_last_checkpoint.cs
@@ -100,7 +100,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection.checkpoint_
 			Assert.AreEqual(@"{""data"":""b""", message3.Data.Data);
 
 			Assert.AreEqual(@"dd", message1.Data.Metadata);
-			Assert.AreEqual(@"", message2.Data.Metadata);
+			Assert.IsNull(message2.Data.Metadata);
 			Assert.AreEqual(@"bb", message3.Data.Metadata);
 
 			Assert.AreEqual("{$o:\"org\"}", message1.Data.PositionMetadata);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_running_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_running_projection.cs
@@ -87,7 +87,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query {
 				List<EventRecord> resultsStream;
 				Assert.IsTrue((_streams.TryGetValue("$projections-test-projection-result", out resultsStream)));
 				Assert.AreEqual(1 + 1 /* $Eof*/, resultsStream.Count);
-				Assert.AreEqual("{\"data\": 1}", Encoding.UTF8.GetString(resultsStream[0].Data));
+				Assert.AreEqual("{\"data\": 1}", Encoding.UTF8.GetString(resultsStream[0].Data.Span));
 			}
 
 			[Test]

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -619,8 +619,7 @@ namespace EventStore.Projections.Core.Services.Management {
 
 		private void PersistedStateReadCompleted(ClientMessage.ReadStreamEventsBackwardCompleted completed) {
 			if (completed.Result == ReadStreamResult.Success && completed.Events.Length == 1) {
-				byte[] state = completed.Events[0].Event.Data;
-				var persistedState = state.ParseJson<PersistedState>();
+				var persistedState = completed.Events[0].Event.Data.ParseJson<PersistedState>();
 
 				_lastWrittenVersion = completed.Events[0].Event.EventNumber;
 				FixUpOldFormat(completed, persistedState);

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -701,7 +701,7 @@ namespace EventStore.Projections.Core.Services.Management {
 							continue;
 						}
 
-						var projectionName = Helper.UTF8NoBom.GetString(evnt.Event.Data);
+						var projectionName = Helper.UTF8NoBom.GetString(evnt.Event.Data.Span);
 						if (string.IsNullOrEmpty(projectionName)
 						    || _projections.ContainsKey(projectionName)) {
 							_logger.Warning(

--- a/src/EventStore.Projections.Core/Services/Processing/CheckpointTagExtensions.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CheckpointTagExtensions.cs
@@ -36,12 +36,27 @@ namespace EventStore.Projections.Core.Services.Processing {
 			return CheckpointTag.FromJson(reader, default(ProjectionVersion)).Tag;
 		}
 
+		public static CheckpointTag ParseCheckpointTagJson(this ReadOnlyMemory<byte> source) {
+			if (source.Length == 0)
+				return null;
+			var reader = new JsonTextReader(new StreamReader(new MemoryStream(source.ToArray())));
+			return CheckpointTag.FromJson(reader, default(ProjectionVersion)).Tag;
+		}
+
 		public static CheckpointTagVersion ParseCheckpointTagVersionExtraJson(this byte[] source,
 			ProjectionVersion current) {
 			if (source == null || source.Length == 0)
 				return new CheckpointTagVersion
 					{Version = new ProjectionVersion(current.ProjectionId, 0, 0), Tag = null};
 			var reader = new JsonTextReader(new StreamReader(new MemoryStream(source)));
+			return CheckpointTag.FromJson(reader, current);
+		}
+
+		public static CheckpointTagVersion ParseCheckpointTagVersionExtraJson(this ReadOnlyMemory<byte> source,
+			ProjectionVersion current) {
+			if (source.Length == 0)
+				return new CheckpointTagVersion { Version = new ProjectionVersion(current.ProjectionId, 0, 0), Tag = null };
+			var reader = new JsonTextReader(new StreamReader(new MemoryStream(source.ToArray())));
 			return CheckpointTag.FromJson(reader, current);
 		}
 

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointReader.cs
@@ -87,7 +87,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 						CheckpointLoaded(null, null);
 					} else {
 						//TODO: check epoch and correctly set _lastWrittenCheckpointEventNumber
-						var checkpointData = Helper.UTF8NoBom.GetString(checkpoint.Data);
+						var checkpointData = Helper.UTF8NoBom.GetString(checkpoint.Data.Span);
 						_lastWrittenCheckpointEventNumber = checkpoint.EventNumber;
 						var adjustedTag = parsed.Tag; // the same projection and epoch, handle upgrades internally
 						CheckpointLoaded(adjustedTag, checkpointData);

--- a/src/EventStore.Projections.Core/Services/Processing/DefaultCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/DefaultCheckpointManager.cs
@@ -124,7 +124,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					} else {
 						var loadedStateCheckpointTag = parsed.AdjustBy(_positionTagger, _projectionVersion);
 						var state = PartitionState.Deserialize(
-							Helper.UTF8NoBom.GetString(@event.Data), loadedStateCheckpointTag);
+							Helper.UTF8NoBom.GetString(@event.Data.Span), loadedStateCheckpointTag);
 						loadCompleted(state);
 						return;
 					}

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsDeleter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsDeleter.cs
@@ -98,7 +98,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 								});
 						});
 				} else {
-					var streamId = Helper.UTF8NoBom.GetString(onReadCompleted.Events[0].Event.Data);
+					var streamId = Helper.UTF8NoBom.GetString(onReadCompleted.Events[0].Event.Data.Span);
 					_ioDispatcher.DeleteStream(streamId, ExpectedVersion.Any, false, SystemAccounts.System,
 						x => DeleteStreamCompleted(x, onEmittedStreamsDeleted, streamId,
 							onReadCompleted.Events[0].OriginalEventNumber));

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsTracker.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsTracker.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				SystemAccounts.System, x => {
 					if (x.Events.Length > 0) {
 						for (int i = 0; i < x.Events.Length; i++) {
-							var streamId = Helper.UTF8NoBom.GetString(x.Events[i].Event.Data);
+							var streamId = Helper.UTF8NoBom.GetString(x.Events[i].Event.Data.Span);
 							lock (_locker) {
 								_streamIdCache.PutRecord(streamId, streamId, false);
 							}

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamMultiOutputCheckpointManager.cs
@@ -153,7 +153,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			//NOTE: we do manual link-to resolution as we write links to the position events
 			//      which may in turn be a link.  This is necessary to provide a correct 
 			//       ResolvedEvent when replaying from the -order stream
-			var linkTo = Helper.UTF8NoBom.GetString(@event.Data);
+			var linkTo = Helper.UTF8NoBom.GetString(@event.Data.Span);
 			string[] parts = linkTo.Split(_linkToSeparator, 2);
 			long eventNumber = long.Parse(parts[0]);
 			string streamId = parts[1];

--- a/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ResolvedEvent.cs
@@ -48,17 +48,17 @@ namespace EventStore.Projections.Core.Services.Processing {
 			Timestamp = positionEvent.TimeStamp;
 
 			//TODO: handle utf-8 conversion exception
-			Data = @event != null && @event.Data != null ? Helper.UTF8NoBom.GetString(@event.Data) : null;
-			Metadata = @event != null && @event.Metadata != null ? Helper.UTF8NoBom.GetString(@event.Metadata) : null;
+			Data = @event != null && @event.Data.Length > 0 ? Helper.UTF8NoBom.GetString(@event.Data.Span) : null;
+			Metadata = @event != null && @event.Metadata.Length > 0 ? Helper.UTF8NoBom.GetString(@event.Metadata.Span) : null;
 			PositionMetadata = _resolvedLinkTo
-				? (positionEvent.Metadata != null ? Helper.UTF8NoBom.GetString(positionEvent.Metadata) : null)
+				? (positionEvent.Metadata.Length > 0 ? Helper.UTF8NoBom.GetString(positionEvent.Metadata.Span) : null)
 				: null;
 			StreamMetadata = streamMetadata != null ? Helper.UTF8NoBom.GetString(streamMetadata) : null;
 
 			TFPos eventOrLinkTargetPosition;
 			if (_resolvedLinkTo) {
 				Dictionary<string, JToken> extraMetadata = null;
-				if (positionEvent.Metadata != null && positionEvent.Metadata.Length > 0) {
+				if (positionEvent.Metadata.Length > 0 && positionEvent.Metadata.Length > 0) {
 					//TODO: parse JSON only when unresolved link and just tag otherwise
 					CheckpointTag tag;
 					if (resolvedEvent.Link != null && resolvedEvent.Event == null) {

--- a/src/EventStore.Projections.Core/Standard/StreamDeletedHelper.cs
+++ b/src/EventStore.Projections.Core/Standard/StreamDeletedHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using EventStore.Core.Data;
 using EventStore.Core.Services;
 using EventStore.Projections.Core.Utils;
@@ -54,7 +55,7 @@ namespace EventStore.Projections.Core.Standard {
 		}
 
 		public static bool IsStreamDeletedEvent(
-			string streamOrMetaStreamId, string eventType, byte[] eventData, out string deletedPartitionStreamId) {
+			string streamOrMetaStreamId, string eventType, ReadOnlyMemory<byte> eventData, out string deletedPartitionStreamId) {
 			bool isMetaStream;
 			if (SystemStreams.IsMetastream(streamOrMetaStreamId)) {
 				isMetaStream = true;

--- a/src/EventStore.Projections.Core/Utils/EncodingExtensions.cs
+++ b/src/EventStore.Projections.Core/Utils/EncodingExtensions.cs
@@ -1,9 +1,14 @@
-﻿using EventStore.Common.Utils;
+﻿using System;
+using EventStore.Common.Utils;
 
 namespace EventStore.Projections.Core.Utils {
 	public static class EncodingExtensions {
 		public static string FromUtf8(this byte[] self) {
 			return Helper.UTF8NoBom.GetString(self);
+		}
+
+		public static string FromUtf8(this ReadOnlyMemory<byte> self) {
+			return Helper.UTF8NoBom.GetString(self.Span);
 		}
 
 		public static byte[] ToUtf8(this string self) {


### PR DESCRIPTION
Changed: Replace `byte[]` with `ReadOnlyMemory<byte>` to reduce allocations

Since `EventData` holds byte arrays we're having limited options of keeping allocations down. Trying to dig into what it would take to use `ReadOnlyMemory<byte>` instead of byte arrays.

Issue: #2309