### PR TITLE
Drop macOS as a supported server OS in CI

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,5 +1,6 @@
 resources:
 - repo: self
+
 jobs:
 - job: vulnerability_scan
   displayName: Vulnerability Scan
@@ -20,6 +21,7 @@ jobs:
       version: '3.1.100'
   - bash: cd src/ && dotnet restore EventStore.sln && dotnet tool install --tool-path . dotnet-retire && ./dotnet-retire -p EventStore.sln
     displayName: 'Run dotnet-retire'
+
 - job: windows_x64
   strategy:
     matrix:
@@ -65,42 +67,6 @@ jobs:
     inputs:
       artifactName: windows-netcoreapp3-$(Configuration)
       pathToPublish: '$(Build.SourcesDirectory)\bin\'
-
-- job: macos_x64
-  strategy:
-    matrix:
-      RELEASE:
-        Configuration: release
-  displayName: 'macOS x64'
-  timeoutInMinutes: 30
-  pool:
-    vmImage: 'macOS 10.13'
-  steps:
-  - checkout: self 
-    fetchDepth: 1
-  - task: UseDotNet@1
-    displayName: 'Install .NET Core 3.x SDK'
-    inputs:
-      packageType: 'sdk'
-      version: '3.1.100'
-  - bash: dotnet build -c $(Configuration) src/EventStore.sln
-    displayName: Compile
-  - bash: find ./src -maxdepth 1 -type d -name "*.Tests" -print0| xargs -0 -n1 dotnet test -v normal -c $(Configuration) --logger trx --blame --settings ./ci/ci.runsettings
-    displayName: Run Tests
-  - task: PublishTestResults@2
-    displayName: Publish Test Results
-    condition: succeededOrFailed()
-    inputs:
-      testRunTitle: "MacOS 10.13"
-      platform: "MacOS 10.13"
-      testRunner: VSTest
-      testResultsFiles: '**/*.trx'
-  - task: PublishBuildArtifacts@1
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
-    displayName: Publish Artifacts
-    inputs:
-      artifactName: macos-netcoreapp3-$(Configuration)
-      pathToPublish: '$(Build.SourcesDirectory)/bin/'
 
 - job: ubuntu_x64
   strategy:


### PR DESCRIPTION
Since we have switched client access to gRPC, we have been unable to support macOS as a server target without disabling TLS, thanks to a lack of support for server-side Application-Layer Protocol Negotiation (ALPN) in Security.framework, and a lack of willingness on our part to commit to doing something like binding to OpenSSL on macOS.

This is tracked in grpc/grpc-dotnet#416.

Consequently we've decided to remove the build for macOS for the Event Store server, which this commit does. Note the _client_ will still need to be supported and tested on macOS, and we will do this by moving the gRPC client into a submodule of the server.