### PR TITLE
Debug to Information for Gossip and Elections Services

### DIFF
--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.Elections.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.Elections.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Cluster {
 		public void SendViewChange(ElectionMessage.ViewChange msg, IPEndPoint destinationEndpoint, DateTime deadline) {
 			SendViewChangeAsync(msg.ServerId, msg.ServerInternalHttp, msg.AttemptedView, deadline).ContinueWith(r => {
 				if (r.Exception != null) {
-					Log.Error(r.Exception, "View Change Send Failed to {Server}", destinationEndpoint);
+					Log.Information(r.Exception, "View Change Send Failed to {Server}", destinationEndpoint);
 				}
 			});
 		}
@@ -21,7 +21,7 @@ namespace EventStore.Core.Cluster {
 			SendViewChangeProofAsync(msg.ServerId, msg.ServerInternalHttp, msg.InstalledView, deadline).ContinueWith(
 				r => {
 					if (r.Exception != null) {
-						Log.Error(r.Exception, "View Change Proof Send Failed to {Server}",
+						Log.Information(r.Exception, "View Change Proof Send Failed to {Server}",
 							destinationEndpoint);
 					}
 				});
@@ -30,7 +30,7 @@ namespace EventStore.Core.Cluster {
 		public void SendPrepare(ElectionMessage.Prepare msg, IPEndPoint destinationEndpoint, DateTime deadline) {
 			SendPrepareAsync(msg.ServerId, msg.ServerInternalHttp, msg.View, deadline).ContinueWith(r => {
 				if (r.Exception != null) {
-					Log.Error(r.Exception, "Prepare Send Failed to {Server}", destinationEndpoint);
+					Log.Information(r.Exception, "Prepare Send Failed to {Server}", destinationEndpoint);
 				}
 			});
 		}
@@ -43,7 +43,7 @@ namespace EventStore.Core.Cluster {
 					prepareOk.ChaserCheckpoint, prepareOk.NodePriority, deadline)
 				.ContinueWith(r => {
 					if (r.Exception != null) {
-						Log.Error(r.Exception, "Prepare OK Send Failed to {Server}",
+						Log.Information(r.Exception, "Prepare OK Send Failed to {Server}",
 							destinationEndpoint);
 					}
 				});
@@ -58,7 +58,7 @@ namespace EventStore.Core.Cluster {
 					deadline)
 				.ContinueWith(r => {
 					if (r.Exception != null) {
-						Log.Error(r.Exception, "Proposal Send Failed to {Server}",
+						Log.Information(r.Exception, "Proposal Send Failed to {Server}",
 							destinationEndpoint);
 					}
 				});
@@ -69,7 +69,7 @@ namespace EventStore.Core.Cluster {
 					accept.View, deadline)
 				.ContinueWith(r => {
 					if (r.Exception != null) {
-						Log.Error(r.Exception, "Accept Send Failed to {Server}", destinationEndpoint);
+						Log.Information(r.Exception, "Accept Send Failed to {Server}", destinationEndpoint);
 					}
 				});
 		}
@@ -78,7 +78,7 @@ namespace EventStore.Core.Cluster {
 			DateTime deadline) {
 			SendLeaderIsResigningAsync(resigning.LeaderId, resigning.LeaderInternalHttp, deadline).ContinueWith(r => {
 				if (r.Exception != null) {
-					Log.Error(r.Exception, "Leader is Resigning Send Failed to {Server}", destinationEndpoint);
+					Log.Information(r.Exception, "Leader is Resigning Send Failed to {Server}", destinationEndpoint);
 				}
 			});
 		}
@@ -88,7 +88,7 @@ namespace EventStore.Core.Cluster {
 			SendLeaderIsResigningOkAsync(resigningOk.LeaderId, resigningOk.LeaderInternalHttp,
 				resigningOk.ServerId, resigningOk.ServerInternalHttp, deadline).ContinueWith(r => {
 				if (r.Exception != null) {
-					Log.Error(r.Exception, "Leader is Resigning Ok Send Failed to {Server}", destinationEndpoint);
+					Log.Information(r.Exception, "Leader is Resigning Ok Send Failed to {Server}", destinationEndpoint);
 				}
 			});
 		}

--- a/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
@@ -184,13 +184,13 @@ namespace EventStore.Core.Services.Gossip {
 				return;
 
 			if (CurrentLeader != null && node.InstanceId == CurrentLeader.InstanceId) {
-				Log.Debug(
+				Log.Information(
 					"Leader [{leaderEndPoint}, {instanceId:B}] appears to be DEAD (Gossip send failed); wait for TCP to decide.",
 					message.Recipient, node.InstanceId);
 				return;
 			}
 
-			Log.Debug("Looks like node [{nodeEndPoint}] is DEAD (Gossip send failed).", message.Recipient);
+			Log.Information("Looks like node [{nodeEndPoint}] is DEAD (Gossip send failed).", message.Recipient);
 
 			var oldCluster = _cluster;
 			_cluster = UpdateCluster(_cluster, x => x.Is(message.Recipient)
@@ -207,7 +207,7 @@ namespace EventStore.Core.Services.Gossip {
 			if (node == null || !node.IsAlive)
 				return;
 
-			Log.Debug("Looks like node [{nodeEndPoint}] is DEAD (TCP connection lost). Issuing a gossip to confirm.",
+			Log.Information("Looks like node [{nodeEndPoint}] is DEAD (TCP connection lost). Issuing a gossip to confirm.",
 				message.VNodeEndPoint);
 			_bus.Publish(new GrpcMessage.SendOverGrpc(node.InternalHttpEndPoint,
 				new GossipMessage.GetGossip(), _timeProvider.LocalTime.Add(GossipTimeout)));
@@ -217,7 +217,7 @@ namespace EventStore.Core.Services.Gossip {
 			if (_state != GossipState.Working)
 				return;
 
-			Log.Debug("Gossip Received, The node [{nodeEndpoint}] is not DEAD.", message.Server);
+			Log.Information("Gossip Received, The node [{nodeEndpoint}] is not DEAD.", message.Server);
 
 			var oldCluster = _cluster;
 			_cluster = MergeClusters(_cluster,
@@ -235,7 +235,7 @@ namespace EventStore.Core.Services.Gossip {
 			if (_state != GossipState.Working)
 				return;
 
-			Log.Debug("Gossip Failed, The node [{nodeEndpoint}] is being marked as DEAD.",
+			Log.Information("Gossip Failed, The node [{nodeEndpoint}] is being marked as DEAD.",
 				message.Recipient);
 
 			var oldCluster = _cluster;
@@ -338,7 +338,7 @@ namespace EventStore.Core.Services.Gossip {
 				.OrderByDescending(x => x.InternalHttpEndPoint, ipEndPointComparer).ToList();
 			List<MemberInfo> newMembers = newCluster.Members
 				.OrderByDescending(x => x.InternalHttpEndPoint, ipEndPointComparer).ToList();
-			Log.Debug(
+			Log.Information(
 				"CLUSTER HAS CHANGED {source}"
 				+ "\nOld:"
 				+ "\n{oldMembers}"


### PR DESCRIPTION
The information is useful for diagnosing issues with support and as such we are raising the log level from Debug to Information. These should not fill the server logs as an excessive logging from these components could be a potential issue with the cluster.

In addition the EventStoreClusterClient Send Failures have been downgraded from errors to information as sending can fail under normal cluster operation.