### PR TITLE
Thread Through Cancellation Token on Appends and Deletes

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -241,6 +241,9 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.CommitTimeoutMsDescr, Opts.DbGroup)]
 		public int CommitTimeoutMs { get; set; }
 
+		[ArgDescription(Opts.WriteTimeoutMsDescr, Opts.DbGroup)]
+		public int WriteTimeoutMs { get; set; }
+
 		[ArgDescription(Opts.UnsafeDisableFlushToDiskDescr, Opts.DbGroup)]
 		public bool UnsafeDisableFlushToDisk { get; set; }
 

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -244,6 +244,7 @@ namespace EventStore.ClusterNode {
 				.WithMinFlushDelay(TimeSpan.FromMilliseconds(options.MinFlushDelayMs))
 				.WithPrepareTimeout(TimeSpan.FromMilliseconds(options.PrepareTimeoutMs))
 				.WithCommitTimeout(TimeSpan.FromMilliseconds(options.CommitTimeoutMs))
+				.WithWriteTimeout(TimeSpan.FromMilliseconds(options.WriteTimeoutMs))
 				.WithStatsPeriod(TimeSpan.FromSeconds(options.StatsPeriodSec))
 				.WithDeadMemberRemovalPeriod(TimeSpan.FromSeconds(options.DeadMemberRemovalPeriodSec))
 				.WithPrepareCount(prepareCount)

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
@@ -62,6 +62,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building {
 			Assert.AreEqual(1, _settings.CommitAckCount, "CommitAckCount");
 			Assert.AreEqual(Opts.PrepareTimeoutMsDefault, _settings.PrepareTimeout.TotalMilliseconds, "PrepareTimeout");
 			Assert.AreEqual(Opts.CommitTimeoutMsDefault, _settings.CommitTimeout.TotalMilliseconds, "CommitTimeout");
+			Assert.AreEqual(Opts.WriteTimeoutMsDefault, _settings.WriteTimeout.TotalMilliseconds, "WriteTimeout");
 
 			Assert.AreEqual(Opts.IntTcpHeartbeatIntervalDefault, _settings.IntTcpHeartbeatInterval.TotalMilliseconds,
 				"IntTcpHeartbeatInterval");

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -117,8 +117,8 @@ namespace EventStore.Core.Tests.Helpers {
 					null, null, 0, 0), enableTrustedAuth,
 				certificate, 1, false,
 				"", gossipSeeds, TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10),
-				disableInternalTls, false,TimeSpan.FromHours(1), StatsStorage.None, 0,
-				new AuthenticationProviderFactory(components =>
+				TimeSpan.FromSeconds(10), disableInternalTls, false,TimeSpan.FromHours(1), StatsStorage.None, 0,
+				new AuthenticationProviderFactory(components => 
 					new InternalAuthenticationProviderFactory(components)),
 				new AuthorizationProviderFactory(components =>
 					new LegacyAuthorizationProviderFactory(components.MainQueue)),

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using EventStore.Common.Utils;
 using EventStore.Core.Authentication;
 using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Authorization;
@@ -31,9 +32,9 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					null, null, 0, 0),
 				false, null, 1, false, "dns", new[] {GetLoopbackForPort(ManagerPort)},
 				TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(2),
-				TimeSpan.FromSeconds(2), true, false,TimeSpan.FromHours(1),
-				StatsStorage.StreamAndFile, 0, 
-				new AuthenticationProviderFactory(components => 
+				TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(2), true, false,TimeSpan.FromHours(1),
+				StatsStorage.StreamAndFile, 0,
+				new AuthenticationProviderFactory(components =>
 					new InternalAuthenticationProviderFactory(components)),
 				new AuthorizationProviderFactory(components =>
 					new LegacyAuthorizationProviderFactory(components.MainQueue)), false, 30, true, true,

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -18,6 +18,7 @@ using EventStore.Core.Tests.Services.Transport.Tcp;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.Util;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
@@ -88,7 +89,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			var tcpConn = new DummyTcpConnection() { ConnectionId = replicaId };
 
 			manager = new TcpConnectionManager(
-				"Test Subscription Connection manager", TcpServiceType.External, new ClientTcpDispatcher(),
+				"Test Subscription Connection manager", TcpServiceType.External, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				InMemoryBus.CreateTest(), tcpConn, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -44,6 +44,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 			Service = new RequestManagementService(
 				Dispatcher,
 				TimeSpan.FromSeconds(2),
+				TimeSpan.FromSeconds(2),
 				TimeSpan.FromSeconds(2));
 			Dispatcher.Subscribe<ClientMessage.WriteEvents>(Service);
 			Dispatcher.Subscribe<StorageMessage.PrepareAck>(Service);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -44,7 +44,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 			Service = new RequestManagementService(
 				Dispatcher,
 				TimeSpan.FromSeconds(2),
-				TimeSpan.FromSeconds(2),
 				TimeSpan.FromSeconds(2));
 			Dispatcher.Subscribe<ClientMessage.WriteEvents>(Service);
 			Dispatcher.Subscribe<StorageMessage.PrepareAck>(Service);

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -26,11 +26,11 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 
 		[OneTimeSetUp]
 		public void Setup() {
-			_dispatcher = new ClientTcpDispatcher();
+			_dispatcher = new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault);
 
 			var dummyConnection = new DummyTcpConnection();
 			_connection = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(
 					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
 					new StubPasswordHashAlgorithm(), 1, false),

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -17,6 +17,7 @@ using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Services;
 using EventStore.Core.Settings;
 using EventStore.Core.Tests.Authorization;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.Services.Transport.Tcp {
 	[TestFixture]
@@ -32,7 +33,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			var dummyConnection = new DummyTcpConnection();
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
@@ -74,7 +75,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			}));
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.Internal, new ClientTcpDispatcher(),
+				Guid.NewGuid().ToString(), TcpServiceType.Internal, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				publisher, dummyConnection, publisher,
 				new InternalAuthenticationProvider(publisher, new Core.Helpers.IODispatcher(publisher, new NoopEnvelope()),
 					new StubPasswordHashAlgorithm(), 1, false),
@@ -109,7 +110,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.PendingSendBytes = _connectionPendingSendBytesThreshold + 1000;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(),
@@ -139,7 +140,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.PendingSendBytes = 0;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
@@ -172,7 +173,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.PendingSendBytes = _connectionPendingSendBytesThreshold + 1000;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
@@ -205,7 +206,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.SendQueueSize = ESConsts.MaxConnectionQueueSize - 1;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
@@ -238,7 +239,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			dummyConnection.SendQueueSize = ESConsts.MaxConnectionQueueSize + 1;
 
 			var tcpConnectionManager = new TcpConnectionManager(
-				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(),
+				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(Opts.WriteTimeoutMsDefault),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -36,6 +36,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly int CommitAckCount;
 		public readonly TimeSpan PrepareTimeout;
 		public readonly TimeSpan CommitTimeout;
+		public readonly TimeSpan WriteTimeout;
 
 		public readonly int NodePriority;
 
@@ -111,6 +112,7 @@ namespace EventStore.Core.Cluster.Settings {
 			int commitAckCount,
 			TimeSpan prepareTimeout,
 			TimeSpan commitTimeout,
+			TimeSpan writeTimeout,
 			bool disableInternalTls,
 			bool disableExternalTls,
 			TimeSpan statsPeriod,
@@ -216,6 +218,7 @@ namespace EventStore.Core.Cluster.Settings {
 			CommitAckCount = commitAckCount;
 			PrepareTimeout = prepareTimeout;
 			CommitTimeout = commitTimeout;
+			WriteTimeout = writeTimeout;
 
 			DisableInternalTls = disableInternalTls;
 			DisableExternalTls = disableExternalTls;
@@ -284,6 +287,7 @@ namespace EventStore.Core.Cluster.Settings {
 			$"ClusterNodeCount: {ClusterNodeCount}\n" + $"MinFlushDelay: {MinFlushDelay}\n" +
 			$"PrepareAckCount: {PrepareAckCount}\n" + $"CommitAckCount: {CommitAckCount}\n" +
 			$"PrepareTimeout: {PrepareTimeout}\n" + $"CommitTimeout: {CommitTimeout}\n" +
+			$"WriteTimeout: {WriteTimeout}\n" +
 			$"DisableInternalTls: {DisableInternalTls}\n" + $"DisableExternalTls: {DisableExternalTls}\n" +
 			$"StatsPeriod: {StatsPeriod}\n" + $"StatsStorage: {StatsStorage}\n" +
 			$"AuthenticationProviderFactory Type: {AuthenticationProviderFactory.GetType()}\n" +

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -502,7 +502,8 @@ namespace EventStore.Core {
 			var requestManagement = new RequestManagementService(
 				_mainQueue,
 				vNodeSettings.PrepareTimeout,
-				vNodeSettings.CommitTimeout);
+				vNodeSettings.CommitTimeout,
+				vNodeSettings.WriteTimeout);
 
 			_mainBus.Subscribe<SystemMessage.SystemInit>(requestManagement);
 			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(requestManagement);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -338,9 +338,7 @@ namespace EventStore.Core {
 			var httpPipe = new HttpMessagePipe();
 			var httpSendService = new HttpSendService(httpPipe, forwardRequests: true);
 			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(httpSendService);
-			SubscribeWorkers(bus => {
-				bus.Subscribe<HttpMessage.HttpSend>(httpSendService);
-			});
+			SubscribeWorkers(bus => bus.Subscribe<HttpMessage.HttpSend>(httpSendService));
 
 			var grpcSendService = new GrpcSendService(_eventStoreClusterClientCache);
 			_mainBus.Subscribe(new WideningHandler<GrpcMessage.SendOverGrpc, Message>(_workersHandler));
@@ -463,7 +461,7 @@ namespace EventStore.Core {
 			var histogramController = new HistogramController();
 			var statController = new StatController(monitoringQueue, _workersHandler);
 			var atomController = new AtomController(_mainQueue, _workersHandler,
-				vNodeSettings.DisableHTTPCaching);
+				vNodeSettings.DisableHTTPCaching, vNodeSettings.WriteTimeout);
 			var gossipController = new GossipController(_mainQueue, _workersHandler, vNodeSettings.GossipTimeout,
 				_httpMessageHandler);
 			var persistentSubscriptionController =

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -160,10 +160,11 @@ namespace EventStore.Core.Messages {
 			public readonly string EventStreamId;
 			public readonly long ExpectedVersion;
 			public readonly Event[] Events;
+			public readonly CancellationToken CancellationToken;
 
 			public WriteEvents(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
-				string eventStreamId, long expectedVersion, Event[] events,
-				ClaimsPrincipal user, string login = null, string password = null)
+				string eventStreamId, long expectedVersion, Event[] events, ClaimsPrincipal user, string login = null,
+				string password = null, CancellationToken cancellationToken = default)
 				: base(internalCorrId, correlationId, envelope, requireLeader, user, login, password) {
 				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
 				if (expectedVersion < Data.ExpectedVersion.StreamExists ||
@@ -174,6 +175,7 @@ namespace EventStore.Core.Messages {
 				EventStreamId = eventStreamId;
 				ExpectedVersion = expectedVersion;
 				Events = events;
+				CancellationToken = cancellationToken;
 			}
 
 			public WriteEvents(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
@@ -448,10 +450,11 @@ namespace EventStore.Core.Messages {
 			public readonly string EventStreamId;
 			public readonly long ExpectedVersion;
 			public readonly bool HardDelete;
+			public readonly CancellationToken CancellationToken;
 
 			public DeleteStream(Guid internalCorrId, Guid correlationId, IEnvelope envelope, bool requireLeader,
-				string eventStreamId, long expectedVersion, bool hardDelete,
-				ClaimsPrincipal user, string login = null, string password = null)
+				string eventStreamId, long expectedVersion, bool hardDelete, ClaimsPrincipal user, string login = null,
+				string password = null, CancellationToken cancellationToken = default)
 				: base(internalCorrId, correlationId, envelope, requireLeader, user, login, password) {
 				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
 				if (expectedVersion < Data.ExpectedVersion.Any)
@@ -460,6 +463,7 @@ namespace EventStore.Core.Messages {
 				EventStreamId = eventStreamId;
 				ExpectedVersion = expectedVersion;
 				HardDelete = hardDelete;
+				CancellationToken = cancellationToken;
 			}
 		}
 
@@ -968,7 +972,7 @@ namespace EventStore.Core.Messages {
 				IsEndOfStream = isEndOfStream;
 			}
 		}
-		
+
 		public class FilteredReadAllEventsBackward : ReadRequestMessage {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 
@@ -1003,7 +1007,7 @@ namespace EventStore.Core.Messages {
 				EventFilter = eventFilter;
 			}
 		}
-		
+
 		public class FilteredReadAllEventsBackwardCompleted : ReadResponseMessage {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 
@@ -1424,7 +1428,7 @@ namespace EventStore.Core.Messages {
 				SubscriptionId = subscriptionId;
 			}
 		}
-		
+
 		public class ReplayParkedMessages : ReadRequestMessage {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 
@@ -1514,7 +1518,7 @@ namespace EventStore.Core.Messages {
 				ResolveLinkTos = resolveLinkTos;
 			}
 		}
-		
+
 		public class FilteredSubscribeToStream : ReadRequestMessage {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 
@@ -1540,7 +1544,7 @@ namespace EventStore.Core.Messages {
 				CheckpointInterval = checkpointInterval;
 			}
 		}
-		
+
 		public class CheckpointReached : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -37,24 +37,20 @@ namespace EventStore.Core.Messages {
 			public CancellationToken CancellationToken { get; }
 			public readonly Event[] Events;
 
-			public readonly DateTime LiveUntil;
-
 			public WritePrepares(Guid correlationId, IEnvelope envelope, string eventStreamId, long expectedVersion,
-				Event[] events, DateTime liveUntil, CancellationToken cancellationToken) {
+				Event[] events, CancellationToken cancellationToken) {
 				CorrelationId = correlationId;
 				Envelope = envelope;
 				EventStreamId = eventStreamId;
 				ExpectedVersion = expectedVersion;
 				CancellationToken = cancellationToken;
 				Events = events;
-
-				LiveUntil = liveUntil;
 			}
 
 			public override string ToString() {
 				return string.Format(
-					"WRITE_PREPARES: CorrelationId: {0}, EventStreamId: {1}, ExpectedVersion: {2}, LiveUntil: {3}",
-					CorrelationId, EventStreamId, ExpectedVersion, LiveUntil);
+					"WRITE_PREPARES: CorrelationId: {0}, EventStreamId: {1}, ExpectedVersion: {2}",
+					CorrelationId, EventStreamId, ExpectedVersion);
 			}
 		}
 
@@ -72,10 +68,8 @@ namespace EventStore.Core.Messages {
 			public CancellationToken CancellationToken { get; }
 			public readonly bool HardDelete;
 
-			public readonly DateTime LiveUntil;
-
 			public WriteDelete(Guid correlationId, IEnvelope envelope, string eventStreamId, long expectedVersion,
-				bool hardDelete, DateTime liveUntil, CancellationToken cancellationToken = default) {
+				bool hardDelete, CancellationToken cancellationToken = default) {
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				Ensure.NotNull(envelope, "envelope");
 				Ensure.NotNull(eventStreamId, "eventStreamId");
@@ -86,8 +80,6 @@ namespace EventStore.Core.Messages {
 				ExpectedVersion = expectedVersion;
 				CancellationToken = cancellationToken;
 				HardDelete = hardDelete;
-
-				LiveUntil = liveUntil;
 			}
 		}
 

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Common.Utils;
-using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.Messages {
@@ -37,16 +34,18 @@ namespace EventStore.Core.Messages {
 
 			public string EventStreamId { get; private set; }
 			public long ExpectedVersion { get; private set; }
+			public CancellationToken CancellationToken { get; }
 			public readonly Event[] Events;
 
 			public readonly DateTime LiveUntil;
 
 			public WritePrepares(Guid correlationId, IEnvelope envelope, string eventStreamId, long expectedVersion,
-				Event[] events, DateTime liveUntil) {
+				Event[] events, DateTime liveUntil, CancellationToken cancellationToken) {
 				CorrelationId = correlationId;
 				Envelope = envelope;
 				EventStreamId = eventStreamId;
 				ExpectedVersion = expectedVersion;
+				CancellationToken = cancellationToken;
 				Events = events;
 
 				LiveUntil = liveUntil;
@@ -70,12 +69,13 @@ namespace EventStore.Core.Messages {
 			public IEnvelope Envelope { get; private set; }
 			public string EventStreamId { get; private set; }
 			public long ExpectedVersion { get; private set; }
+			public CancellationToken CancellationToken { get; }
 			public readonly bool HardDelete;
 
 			public readonly DateTime LiveUntil;
 
 			public WriteDelete(Guid correlationId, IEnvelope envelope, string eventStreamId, long expectedVersion,
-				bool hardDelete, DateTime liveUntil) {
+				bool hardDelete, DateTime liveUntil, CancellationToken cancellationToken = default) {
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				Ensure.NotNull(envelope, "envelope");
 				Ensure.NotNull(eventStreamId, "eventStreamId");
@@ -84,6 +84,7 @@ namespace EventStore.Core.Messages {
 				Envelope = envelope;
 				EventStreamId = eventStreamId;
 				ExpectedVersion = expectedVersion;
+				CancellationToken = cancellationToken;
 				HardDelete = hardDelete;
 
 				LiveUntil = liveUntil;
@@ -542,11 +543,11 @@ namespace EventStore.Core.Messages {
 		public class StreamIdFromTransactionIdResponse : Message {
 			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
 			public readonly string StreamId;
-			
+
 			public StreamIdFromTransactionIdResponse(string streamId){
 				StreamId = streamId;
 			}
-			
+
 			public override int MsgTypeId {
 				get { return TypeId; }
 			}

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Services.Replication {
 		private readonly TimeSpan _heartbeatTimeout;
 		private readonly TimeSpan _heartbeatInterval;
 
-		private readonly InternalTcpDispatcher _tcpDispatcher = new InternalTcpDispatcher();
+		private readonly InternalTcpDispatcher _tcpDispatcher;
 
 		private VNodeState _state = VNodeState.Initializing;
 		private TcpConnectionManager _connection;
@@ -56,7 +56,8 @@ namespace EventStore.Core.Services.Replication {
 			bool sslValidateServer,
 			X509CertificateCollection sslClientCertificates,
 			TimeSpan heartbeatTimeout,
-			TimeSpan heartbeatInterval) {
+			TimeSpan heartbeatInterval,
+			TimeSpan writeTimeout) {
 			Ensure.NotNull(publisher, "publisher");
 			Ensure.NotNull(db, "db");
 			Ensure.NotNull(epochManager, "epochManager");
@@ -80,6 +81,7 @@ namespace EventStore.Core.Services.Replication {
 			_heartbeatInterval = heartbeatInterval;
 
 			_connector = new TcpClientConnector();
+			_tcpDispatcher = new InternalTcpDispatcher(writeTimeout);
 		}
 
 		public void Handle(SystemMessage.StateChangeMessage message) {

--- a/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
@@ -43,7 +43,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					_streamId,
 					ExpectedVersion,
 					_hardDelete,
-					LiveUntil,
 					_cancellationToken);
 
 		protected override Message ClientSuccessMsg =>

--- a/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
@@ -6,6 +7,7 @@ using EventStore.Core.Messaging;
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public class DeleteStream : RequestManagerBase {
 		private readonly bool _hardDelete;
+		private readonly CancellationToken _cancellationToken;
 		private readonly string _streamId;
 
 		public DeleteStream(
@@ -17,7 +19,8 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					string streamId,
 					long expectedVersion,
 					bool hardDelete,
-					CommitSource commitSource)
+					CommitSource commitSource,
+					CancellationToken cancellationToken = default)
 			: base(
 					 publisher,
 					 timeout,
@@ -29,6 +32,7 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 prepareCount: 0,
 					 waitForCommit: true) {
 			_hardDelete = hardDelete;
+			_cancellationToken = cancellationToken;
 			_streamId = streamId;
 		}
 
@@ -39,7 +43,8 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					_streamId,
 					ExpectedVersion,
 					_hardDelete,
-					LiveUntil);
+					LiveUntil,
+					_cancellationToken);
 
 		protected override Message ClientSuccessMsg =>
 			 new ClientMessage.DeleteStreamCompleted(

--- a/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
@@ -42,7 +42,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					_streamId,
 					ExpectedVersion,
 					_events,
-					LiveUntil,
 					_cancellationToken);
 
 

--- a/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -8,17 +9,17 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 	public class WriteEvents : RequestManagerBase {
 		private readonly string _streamId;
 		private readonly Event[] _events;
-
-		public WriteEvents(
-					IPublisher publisher,
-					TimeSpan timeout,
-					IEnvelope clientResponseEnvelope,
-					Guid internalCorrId,
-					Guid clientCorrId,
-					string streamId,
-					long expectedVersion,
-					Event[] events,
-					CommitSource commitSource)
+		private readonly CancellationToken _cancellationToken;
+		public WriteEvents(IPublisher publisher,
+			TimeSpan timeout,
+			IEnvelope clientResponseEnvelope,
+			Guid internalCorrId,
+			Guid clientCorrId,
+			string streamId,
+			long expectedVersion,
+			Event[] events,
+			CommitSource commitSource,
+			CancellationToken cancellationToken = default)
 			: base(
 					 publisher,
 					 timeout,
@@ -31,6 +32,7 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 waitForCommit: true) {
 			_streamId = streamId;
 			_events = events;
+			_cancellationToken = cancellationToken;
 		}
 
 		protected override Message WriteRequestMsg =>
@@ -40,7 +42,8 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					_streamId,
 					ExpectedVersion,
 					_events,
-					LiveUntil);
+					LiveUntil,
+					_cancellationToken);
 
 
 		protected override Message ClientSuccessMsg =>

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -37,14 +37,12 @@ namespace EventStore.Core.Services.RequestManager {
 		private const string _requestManagerHistogram = "request-manager";
 		private readonly TimeSpan _prepareTimeout;
 		private readonly TimeSpan _commitTimeout;
-		private readonly TimeSpan _writeTimeout;
 		private readonly CommitSource _commitSource;
 		private VNodeState _nodeState;		
 
 		public RequestManagementService(IPublisher bus,
 			TimeSpan prepareTimeout,
-			TimeSpan commitTimeout,
-			TimeSpan writeTimeout) {
+			TimeSpan commitTimeout) {
 			Ensure.NotNull(bus, "bus");
 			_bus = bus;
 			_tickRequestMessage = TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
@@ -53,14 +51,13 @@ namespace EventStore.Core.Services.RequestManager {
 
 			_prepareTimeout = prepareTimeout;
 			_commitTimeout = commitTimeout;
-			_writeTimeout = writeTimeout;
 			_commitSource = new CommitSource();
 		}
 		
 		public void Handle(ClientMessage.WriteEvents message) {
 			var manager = new WriteEvents(
 								_bus,
-								_writeTimeout,
+								_commitTimeout,
 								message.Envelope,
 								message.InternalCorrId,
 								message.CorrelationId,
@@ -77,7 +74,7 @@ namespace EventStore.Core.Services.RequestManager {
 		public void Handle(ClientMessage.DeleteStream message) {
 			var manager = new DeleteStream(
 								_bus,
-								_writeTimeout,
+								_commitTimeout,
 								message.Envelope,
 								message.InternalCorrId,
 								message.CorrelationId,

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -228,7 +228,7 @@ namespace EventStore.Core.Services.Storage {
 			Interlocked.Decrement(ref FlushMessagesInQueue);
 
 			try {
-				if (msg.LiveUntil < DateTime.UtcNow)
+				if (msg.LiveUntil < DateTime.UtcNow || msg.CancellationToken.IsCancellationRequested)
 					return;
 
 				string streamId = msg.EventStreamId;
@@ -339,7 +339,7 @@ namespace EventStore.Core.Services.Storage {
 		void IHandle<StorageMessage.WriteDelete>.Handle(StorageMessage.WriteDelete message) {
 			Interlocked.Decrement(ref FlushMessagesInQueue);
 			try {
-				if (message.LiveUntil < DateTime.UtcNow)
+				if (message.LiveUntil < DateTime.UtcNow || message.CancellationToken.IsCancellationRequested)
 					return;
 
 				var eventId = Guid.NewGuid();

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -228,7 +228,7 @@ namespace EventStore.Core.Services.Storage {
 			Interlocked.Decrement(ref FlushMessagesInQueue);
 
 			try {
-				if (msg.LiveUntil < DateTime.UtcNow || msg.CancellationToken.IsCancellationRequested)
+				if (msg.CancellationToken.IsCancellationRequested)
 					return;
 
 				string streamId = msg.EventStreamId;
@@ -339,7 +339,7 @@ namespace EventStore.Core.Services.Storage {
 		void IHandle<StorageMessage.WriteDelete>.Handle(StorageMessage.WriteDelete message) {
 			Interlocked.Decrement(ref FlushMessagesInQueue);
 			try {
-				if (message.LiveUntil < DateTime.UtcNow || message.CancellationToken.IsCancellationRequested)
+				if (message.CancellationToken.IsCancellationRequested)
 					return;
 
 				var eventId = Guid.NewGuid();

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -85,7 +85,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				streamName,
 				expectedVersion,
 				events.ToArray(),
-				user));
+				user,
+				cancellationToken: context.CancellationToken));
 
 			return await appendResponseSource.Task.ConfigureAwait(false);
 

--- a/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelHttpService.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Security.Claims;
-using System.Threading.Tasks;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
@@ -13,9 +9,6 @@ using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.Transport.Http.Messages;
 using EventStore.Core.Settings;
 using EventStore.Transport.Http.EntityManagement;
-using EventStore.Core.Services.Transport.Http.Authentication;
-using Microsoft.AspNetCore.Http;
-using HttpStatusCode = EventStore.Transport.Http.HttpStatusCode;
 using ILogger = Serilog.ILogger;
 using MidFunc = System.Func<
 	Microsoft.AspNetCore.Http.HttpContext,

--- a/src/EventStore.Core/Services/Transport/Http/KestrelToInternalBridgeMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelToInternalBridgeMiddleware.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
-using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
@@ -12,8 +11,7 @@ using Microsoft.AspNetCore.Http;
 using Serilog;
 using HttpStatusCode = EventStore.Transport.Http.HttpStatusCode;
 
-namespace EventStore.Core.Services.Transport.Http
-{
+namespace EventStore.Core.Services.Transport.Http {
 	public class KestrelToInternalBridgeMiddleware : IMiddleware {
 		private static readonly ILogger Log = Serilog.Log.ForContext<KestrelToInternalBridgeMiddleware>();
 		private readonly IUriRouter _uriRouter;
@@ -29,10 +27,8 @@ namespace EventStore.Core.Services.Transport.Http
 		}
 		private static bool TryMatch(HttpContext context, IUriRouter uriRouter, bool logHttpRequests, IPAddress advertiseAsAddress, int advertiseAsPort) {
 			var tcs = new TaskCompletionSource<bool>();
-			var httpEntity = new HttpEntity(new CoreHttpRequestAdapter(context.Request),
-				new CoreHttpResponseAdapter(context.Response), context.User, logHttpRequests,
-				advertiseAsAddress, advertiseAsPort, () => tcs.TrySetResult(true));
-			httpEntity.SetUser(context.User);
+			var httpEntity = new HttpEntity(context, logHttpRequests, advertiseAsAddress, advertiseAsPort,
+				() => tcs.TrySetResult(true));
 
 			var request = httpEntity.Request;
 			try {
@@ -202,6 +198,5 @@ namespace EventStore.Core.Services.Transport.Http
 				return next(context);
 			return Task.CompletedTask;
 		}
-
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using EventStore.Common.Utils;
@@ -11,7 +10,11 @@ using EventStore.Core.Util;
 
 namespace EventStore.Core.Services.Transport.Tcp {
 	public class ClientTcpDispatcher : ClientWriteTcpDispatcher {
-		public ClientTcpDispatcher() {
+		public ClientTcpDispatcher(int writeTimeoutMs)
+			: this(TimeSpan.FromMilliseconds(writeTimeoutMs)) {
+		}
+
+		public ClientTcpDispatcher(TimeSpan writeTimeout) : base(writeTimeout) {
 			AddUnwrapper(TcpCommand.Ping, UnwrapPing, ClientVersion.V2);
 			AddWrapper<TcpMessage.PongMessage>(WrapPong, ClientVersion.V2);
 

--- a/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
@@ -7,11 +7,10 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.TransactionLog.Chunks;
-using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.Services.Transport.Tcp {
 	public class InternalTcpDispatcher : ClientWriteTcpDispatcher {
-		public InternalTcpDispatcher() {		
+		public InternalTcpDispatcher(TimeSpan writeTimeout) : base(writeTimeout) {
 			AddUnwrapper(TcpCommand.LeaderReplicatedTo, UnwrapReplicatedTo, ClientVersion.V2);
 			AddWrapper<ReplicationTrackingMessage.ReplicatedTo>(WrapReplicatedTo, ClientVersion.V2);
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -172,6 +172,9 @@ namespace EventStore.Core.Util {
 		public const string CommitTimeoutMsDescr = "Commit timeout (in milliseconds).";
 		public static readonly int CommitTimeoutMsDefault = 2000; // 2 seconds
 
+		public const string WriteTimeoutMsDescr = "Write timeout (in milliseconds).";
+		public static readonly int WriteTimeoutMsDefault = 2000; // 2 seconds
+
 		public const string LogHttpRequestsDescr = "Log Http Requests and Responses before processing them.";
 		public static readonly bool LogHttpRequestsDefault = false;
 		

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -66,6 +66,7 @@ namespace EventStore.Core {
 		protected int _commitAckCount;
 		protected TimeSpan _prepareTimeout;
 		protected TimeSpan _commitTimeout;
+		protected TimeSpan _writeTimeout;
 
 		protected int _nodePriority;
 
@@ -183,6 +184,7 @@ namespace EventStore.Core {
 			_commitAckCount = 1;
 			_prepareTimeout = TimeSpan.FromMilliseconds(Opts.PrepareTimeoutMsDefault);
 			_commitTimeout = TimeSpan.FromMilliseconds(Opts.CommitTimeoutMsDefault);
+			_writeTimeout = TimeSpan.FromMilliseconds(Opts.WriteTimeoutMsDefault);
 
 			_nodePriority = Opts.NodePriorityDefault;
 
@@ -832,6 +834,16 @@ namespace EventStore.Core {
 		}
 
 		/// <summary>
+		/// Sets the write timeout
+		/// </summary>
+		/// <param name="writeTimeout">The write timeout</param>
+		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+		public VNodeBuilder WithWriteTimeout(TimeSpan writeTimeout) {
+			_writeTimeout = writeTimeout;
+			return this;
+		}
+
+		/// <summary>
 		/// Sets the period between statistics gathers
 		/// </summary>
 		/// <param name="statsPeriod">The period between statistics gathers</param>
@@ -1390,6 +1402,7 @@ namespace EventStore.Core {
 				_commitAckCount,
 				_prepareTimeout,
 				_commitTimeout,
+				_writeTimeout,
 				_disableInternalTls,
 				_disableExternalTls,
 				_statsPeriod,


### PR DESCRIPTION
Changed: Use cooperative cancellation instead of timeouts to cancel appends and deletes

Fixes #2277