### PR TITLE
Centralize Authorization across all client endpoints

### DIFF
--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/Bugs/Issue_1125.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/Bugs/Issue_1125.cs
@@ -47,7 +47,12 @@ namespace EventStore.Client.PersistentSubscriptions.Bugs {
 					if (totalEvents == result) {
 						completed.TrySetResult(true);
 					}
-				})) {
+				}, (s, dr, e) => {
+					if (e != null)
+						completed.TrySetException(e);
+					else
+						completed.TrySetException(new Exception($"{dr}"));
+				}, userCredentials)) {
 				for (var i = 0; i < eventCount; i++) {
 					await _fixture.Client.AppendToStreamAsync(streamName, AnyStreamRevision.Any,
 						_fixture.CreateTestEvents());

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/a_nak_in_autoack_mode_drops_the_subscription.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/a_nak_in_autoack_mode_drops_the_subscription.cs
@@ -42,7 +42,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 				_subscription = Client.PersistentSubscriptions.Subscribe(Stream, Group,
 					delegate {
 						throw new Exception("test");
-					}, (subscription, reason, ex) => _subscriptionDroppedSource.SetResult((reason, ex)));
+					}, (subscription, reason, ex) => _subscriptionDroppedSource.SetResult((reason, ex)), TestCredentials.Root);
 			}
 
 			protected override Task When() =>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_max_one_client.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_max_one_client.cs
@@ -18,11 +18,11 @@ namespace EventStore.Client.PersistentSubscriptions {
 			var dropped = new TaskCompletionSource<(SubscriptionDroppedReason, Exception)>();
 
 			using var first = _fixture.Client.PersistentSubscriptions
-				.Subscribe(Stream, Group, delegate { return Task.CompletedTask; });
+				.Subscribe(Stream, Group, delegate { return Task.CompletedTask; }, userCredentials: TestCredentials.Root);
 			await first.Started.WithTimeout();
 			using var second = _fixture.Client.PersistentSubscriptions
 				.Subscribe(Stream, Group, delegate { return Task.CompletedTask; },
-					(s, r, e) => dropped.SetResult((r, e)));
+					(s, r, e) => dropped.SetResult((r, e)), userCredentials: TestCredentials.Root);
 			await second.Started.WithTimeout();
 
 			var (reason, exception) = await dropped.Task.WithTimeout();
@@ -37,12 +37,13 @@ namespace EventStore.Client.PersistentSubscriptions {
 			public Fixture() {
 			}
 
-			protected override Task Given() =>
-				Client.PersistentSubscriptions.CreateAsync(
+			protected override Task Given() {
+				return Client.PersistentSubscriptions.CreateAsync(
 					Stream,
 					Group,
 					new PersistentSubscriptionSettings(maxSubscriberCount: 1),
 					TestCredentials.Root);
+			}
 
 			protected override Task When() => Task.CompletedTask;
 		}

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_beginning_and_events_in_it.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_beginning_and_events_in_it.cs
@@ -47,7 +47,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
-					});
+					}, userCredentials:TestCredentials.TestUser1);
 				return _subscription.Started;
 			}
 

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_beginning_and_no_stream.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_beginning_and_no_stream.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
-					});
+					}, userCredentials:TestCredentials.TestUser1);
 			}
 
 			protected override Task When()

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_beginning_not_set_and_events_in_it_then_event_written.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_beginning_not_set_and_events_in_it_then_event_written.cs
@@ -48,7 +48,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
-					});
+					}, userCredentials:TestCredentials.TestUser1);
 			}
 
 			protected override Task When() =>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_two_and_no_stream.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_two_and_no_stream.cs
@@ -42,7 +42,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
-					});
+					}, userCredentials:TestCredentials.TestUser1);
 			}
 
 			protected override Task When()

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_x_set_and_events_in_it.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_x_set_and_events_in_it.cs
@@ -41,7 +41,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
-					});
+					}, userCredentials:TestCredentials.TestUser1);
 			}
 
 			protected override Task When() =>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_x_set_and_events_in_it_then_event_written.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_x_set_and_events_in_it_then_event_written.cs
@@ -46,7 +46,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
-					});
+					}, userCredentials:TestCredentials.TestUser1);
 			}
 
 			protected override Task When() =>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_x_set_higher_than_x_and_events_in_it_then_event_written.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_existing_with_start_from_x_set_higher_than_x_and_events_in_it_then_event_written.cs
@@ -49,7 +49,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
-					});
+					}, userCredentials:TestCredentials.TestUser1);
 			}
 
 			protected override Task When() =>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_non_existing_with_permissions.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_to_non_existing_with_permissions.cs
@@ -21,7 +21,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 				delegate {
 					return Task.CompletedTask;
 				},
-				(s, r, e) => dropped.TrySetResult((r, e)));
+				(s, r, e) => dropped.TrySetResult((r, e)), userCredentials: TestCredentials.Root);
 
 			var (reason, exception) = await dropped.Task.WithTimeout();
 

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_with_retries.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connect_with_retries.cs
@@ -43,7 +43,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 							await subscription.Nack(PersistentSubscriptionNakEventAction.Retry,
 								"Not yet tried enough times", e);
 						}
-					}, autoAck: false);
+					}, autoAck: false, userCredentials:TestCredentials.TestUser1);
 			}
 
 			protected override Task When() =>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connecting_to_a_persistent_subscription.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/connecting_to_a_persistent_subscription.cs
@@ -49,7 +49,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					(subscription, e, r, ct) => {
 						_firstEventSource.TrySetResult(e);
 						return Task.CompletedTask;
-					});
+					}, userCredentials:TestCredentials.TestUser1);
 			}
 
 			protected override Task When() =>

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/deleting_existing_with_subscriber.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/deleting_existing_with_subscriber.cs
@@ -27,7 +27,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					TestCredentials.Root);
 				_subscription = Client.PersistentSubscriptions.Subscribe(Stream, "groupname123",
 					(s, e, i, ct) => Task.CompletedTask,
-					(s, r, e) => _dropped.TrySetResult((r, e)));
+					(s, r, e) => _dropped.TrySetResult((r, e)), userCredentials:TestCredentials.Root);
 				await _subscription.Started;
 			}
 

--- a/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/update_existing_with_subscribers.cs
+++ b/src/EventStore.Client.PersistentSubscriptions.Tests/PersistentSubscriptions/update_existing_with_subscribers.cs
@@ -39,7 +39,7 @@ namespace EventStore.Client.PersistentSubscriptions {
 					TestCredentials.Root);
 				_subscription = Client.PersistentSubscriptions.Subscribe(Stream, Group,
 					delegate { return Task.CompletedTask; },
-					(subscription, reason, ex) => _droppedSource.TrySetResult((reason, ex)));
+					(subscription, reason, ex) => _droppedSource.TrySetResult((reason, ex)), userCredentials:TestCredentials.Root);
 				await _subscription.Started;
 			}
 

--- a/src/EventStore.Client.Projections.Tests/Projections/get_result.cs
+++ b/src/EventStore.Client.Projections.Tests/Projections/get_result.cs
@@ -11,7 +11,7 @@ namespace EventStore.Client.Projections {
 
 		[Fact]
 		public async Task returns_expected_result() {
-			var result = await _fixture.Client.ProjectionsManager.GetResultAsync<Result>(nameof(get_result));
+			var result = await _fixture.Client.ProjectionsManager.GetResultAsync<Result>(nameof(get_result), userCredentials: TestCredentials.TestUser1);
 			Assert.Equal(1, result.Count);
 		}
 

--- a/src/EventStore.Client.Projections.Tests/Projections/get_state.cs
+++ b/src/EventStore.Client.Projections.Tests/Projections/get_state.cs
@@ -11,7 +11,7 @@ namespace EventStore.Client.Projections {
 
 		[Fact]
 		public async Task returns_expected_result() {
-			var result = await _fixture.Client.ProjectionsManager.GetStateAsync<Result>(nameof(get_state));
+			var result = await _fixture.Client.ProjectionsManager.GetStateAsync<Result>(nameof(get_state), userCredentials: TestCredentials.TestUser1);
 			Assert.Equal(1, result.Count);
 		}
 

--- a/src/EventStore.Client.Projections.Tests/Projections/get_status.cs
+++ b/src/EventStore.Client.Projections.Tests/Projections/get_status.cs
@@ -13,7 +13,7 @@ namespace EventStore.Client.Projections {
 		[Fact]
 		public async Task returns_expected_result() {
 			var name = StandardProjections.Names.First();
-			var result = await _fixture.Client.ProjectionsManager.GetStatusAsync(name);
+			var result = await _fixture.Client.ProjectionsManager.GetStatusAsync(name, userCredentials: TestCredentials.TestUser1);
 
 			Assert.Equal(name, result.Name);
 		}

--- a/src/EventStore.Client.Tests/Streams/SecurityFixture.cs
+++ b/src/EventStore.Client.Tests/Streams/SecurityFixture.cs
@@ -52,23 +52,23 @@ namespace EventStore.Client.Streams {
 
 			await Task.WhenAll(userCreated.Values.Select(x => x.Task)).WithTimeout(TimeSpan.FromSeconds(10));
 
-			await Client.SetStreamMetadataAsync(NoAclStream, AnyStreamRevision.NoStream, new StreamMetadata());
+			await Client.SetStreamMetadataAsync(NoAclStream, AnyStreamRevision.NoStream, new StreamMetadata(), userCredentials: TestCredentials.TestAdmin);
 			await Client.SetStreamMetadataAsync(
 				ReadStream,
 				AnyStreamRevision.NoStream,
-				new StreamMetadata(acl: new StreamAcl(TestCredentials.TestUser1.Username)));
+				new StreamMetadata(acl: new StreamAcl(TestCredentials.TestUser1.Username)), userCredentials: TestCredentials.TestAdmin );
 			await Client.SetStreamMetadataAsync(
 				WriteStream,
 				AnyStreamRevision.NoStream,
-				new StreamMetadata(acl: new StreamAcl(writeRole: TestCredentials.TestUser1.Username)));
+				new StreamMetadata(acl: new StreamAcl(writeRole: TestCredentials.TestUser1.Username)), userCredentials: TestCredentials.TestAdmin );
 			await Client.SetStreamMetadataAsync(
 				MetaReadStream,
 				AnyStreamRevision.NoStream,
-				new StreamMetadata(acl: new StreamAcl(metaReadRole: TestCredentials.TestUser1.Username)));
+				new StreamMetadata(acl: new StreamAcl(metaReadRole: TestCredentials.TestUser1.Username)), userCredentials: TestCredentials.TestAdmin );
 			await Client.SetStreamMetadataAsync(
 				MetaWriteStream,
 				AnyStreamRevision.NoStream,
-				new StreamMetadata(acl: new StreamAcl(metaWriteRole: TestCredentials.TestUser1.Username)));
+				new StreamMetadata(acl: new StreamAcl(metaWriteRole: TestCredentials.TestUser1.Username)), userCredentials: TestCredentials.TestAdmin );
 
 			await Client.SetStreamMetadataAsync(
 				AllStream,
@@ -103,7 +103,8 @@ namespace EventStore.Client.Streams {
 					writeRole: SystemRoles.All,
 					readRole: SystemRoles.All,
 					metaWriteRole: SystemRoles.All,
-					metaReadRole: SystemRoles.All)));
+					metaReadRole: SystemRoles.All)),
+				userCredentials: TestCredentials.TestAdmin);
 
 			await Client.SetStreamMetadataAsync(
 				SystemAllStream,

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forwards_filtered.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forwards_filtered.cs
@@ -21,7 +21,7 @@ namespace EventStore.Client.Streams {
 
 			foreach (var e in events) {
 				await _fixture.Client.AppendToStreamAsync($"{streamPrefix}_{Guid.NewGuid():n}",
-					AnyStreamRevision.NoStream, new[] {e});
+					AnyStreamRevision.NoStream, new[] { e });
 			}
 
 			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100,
@@ -38,7 +38,7 @@ namespace EventStore.Client.Streams {
 
 			foreach (var e in events) {
 				await _fixture.Client.AppendToStreamAsync($"{streamPrefix}_{Guid.NewGuid():n}",
-					AnyStreamRevision.NoStream, new[] {e});
+					AnyStreamRevision.NoStream, new[] { e });
 			}
 
 			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100,
@@ -59,7 +59,7 @@ namespace EventStore.Client.Streams {
 
 			foreach (var e in events) {
 				await _fixture.Client.AppendToStreamAsync($"{streamPrefix}_{Guid.NewGuid():n}",
-					AnyStreamRevision.NoStream, new[] {e});
+					AnyStreamRevision.NoStream, new[] { e });
 			}
 
 			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100,
@@ -80,7 +80,7 @@ namespace EventStore.Client.Streams {
 
 			foreach (var e in events) {
 				await _fixture.Client.AppendToStreamAsync($"{streamPrefix}_{Guid.NewGuid():n}",
-					AnyStreamRevision.NoStream, new[] {e});
+					AnyStreamRevision.NoStream, new[] { e });
 			}
 
 			var result = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, 100,
@@ -100,7 +100,8 @@ namespace EventStore.Client.Streams {
 				_fixture.CreateTestEvents(count));
 
 			var events = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, maxCount,
-					filterOptions: new FilterOptions(EventTypeFilter.ExcludeSystemEvents(40)))
+					filterOptions: new FilterOptions(EventTypeFilter.ExcludeSystemEvents(40)), 
+					userCredentials: TestCredentials.Root)
 				.Take(count)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.UserManagement.Tests/Users/creating_a_user.cs
+++ b/src/EventStore.Client.UserManagement.Tests/Users/creating_a_user.cs
@@ -14,13 +14,13 @@ namespace EventStore.Client.Users {
 		public static IEnumerable<object[]> NullInputCases() {
 			var loginName = "ouro";
 			var fullName = "greg";
-			var groups = new[] {"foo", "bar"};
+			var groups = new[] { "foo", "bar" };
 			var password = "foofoofoo";
 
-			yield return new object[] {null, fullName, groups, password, nameof(loginName)};
-			yield return new object[] {loginName, null, groups, password, nameof(fullName)};
-			yield return new object[] {loginName, fullName, null, password, nameof(groups)};
-			yield return new object[] {loginName, fullName, groups, null, nameof(password)};
+			yield return new object[] { null, fullName, groups, password, nameof(loginName) };
+			yield return new object[] { loginName, null, groups, password, nameof(fullName) };
+			yield return new object[] { loginName, fullName, null, password, nameof(groups) };
+			yield return new object[] { loginName, fullName, groups, null, nameof(password) };
 		}
 
 		[Theory, MemberData(nameof(NullInputCases))]
@@ -35,12 +35,12 @@ namespace EventStore.Client.Users {
 		public static IEnumerable<object[]> EmptyInputCases() {
 			var loginName = "ouro";
 			var fullName = "greg";
-			var groups = new[] {"foo", "bar"};
+			var groups = new[] { "foo", "bar" };
 			var password = "foofoofoo";
 
-			yield return new object[] {string.Empty, fullName, groups, password, nameof(loginName)};
-			yield return new object[] {loginName, string.Empty, groups, password, nameof(fullName)};
-			yield return new object[] {loginName, fullName, groups, string.Empty, nameof(password)};
+			yield return new object[] { string.Empty, fullName, groups, password, nameof(loginName) };
+			yield return new object[] { loginName, string.Empty, groups, password, nameof(fullName) };
+			yield return new object[] { loginName, fullName, groups, string.Empty, nameof(password) };
 		}
 
 		[Theory, MemberData(nameof(EmptyInputCases))]
@@ -55,20 +55,25 @@ namespace EventStore.Client.Users {
 		[Theory, ClassData(typeof(InvalidCredentialsCases))]
 		public async Task with_user_with_insufficient_credentials_throws(string loginName,
 			UserCredentials userCredentials) {
-			await Assert.ThrowsAsync<NotAuthenticatedException>(
-				() => _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
-					"password", userCredentials));
+			if (userCredentials == null)
+				await Assert.ThrowsAsync<AccessDeniedException>(
+					() => _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", new[] { "foo", "bar" },
+						"password", userCredentials));
+			else
+				await Assert.ThrowsAsync<NotAuthenticatedException>(
+					() => _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", new[] { "foo", "bar" },
+						"password", userCredentials));
 		}
 
 		[Fact]
 		public async Task can_be_read() {
 			var loginName = Guid.NewGuid().ToString();
-			await _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"}, "password",
+			await _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", new[] { "foo", "bar" }, "password",
 				TestCredentials.Root);
 
 			var details = await _fixture.Client.UsersManager.GetUserAsync(loginName, TestCredentials.Root);
 
-			Assert.Equal(new UserDetails(loginName, "Full Name", new[] {"foo", "bar"}, false, details.DateLastUpdated),
+			Assert.Equal(new UserDetails(loginName, "Full Name", new[] { "foo", "bar" }, false, details.DateLastUpdated),
 				details);
 		}
 

--- a/src/EventStore.Client.UserManagement.Tests/Users/deleting_a_user.cs
+++ b/src/EventStore.Client.UserManagement.Tests/Users/deleting_a_user.cs
@@ -31,7 +31,11 @@ namespace EventStore.Client.Users {
 			UserCredentials userCredentials) {
 			await _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
 				"password", TestCredentials.Root);
-			await Assert.ThrowsAsync<NotAuthenticatedException>(
+			if(userCredentials == null)
+				await Assert.ThrowsAsync<AccessDeniedException>(
+				() => _fixture.Client.UsersManager.DeleteUserAsync(loginName, userCredentials));
+			else
+				await Assert.ThrowsAsync<NotAuthenticatedException>(
 				() => _fixture.Client.UsersManager.DeleteUserAsync(loginName, userCredentials));
 		}
 

--- a/src/EventStore.Client.UserManagement.Tests/Users/disabling_a_user.cs
+++ b/src/EventStore.Client.UserManagement.Tests/Users/disabling_a_user.cs
@@ -31,8 +31,11 @@ namespace EventStore.Client.Users {
 			UserCredentials userCredentials) {
 			await _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
 				"password", TestCredentials.Root);
-			await Assert.ThrowsAsync<NotAuthenticatedException>(
-				() => _fixture.Client.UsersManager.DisableUserAsync(loginName, userCredentials));
+			if (userCredentials == null)
+				await Assert.ThrowsAsync<AccessDeniedException>(() => _fixture.Client.UsersManager.DisableUserAsync(loginName, userCredentials));
+			else
+				await Assert.ThrowsAsync<NotAuthenticatedException>(
+					() => _fixture.Client.UsersManager.DisableUserAsync(loginName, userCredentials));
 		}
 
 		[Fact]

--- a/src/EventStore.Client.UserManagement.Tests/Users/enabling_a_user.cs
+++ b/src/EventStore.Client.UserManagement.Tests/Users/enabling_a_user.cs
@@ -31,8 +31,12 @@ namespace EventStore.Client.Users {
 			UserCredentials userCredentials) {
 			await _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", new[] {"foo", "bar"},
 				"password", TestCredentials.Root);
-			await Assert.ThrowsAsync<NotAuthenticatedException>(
-				() => _fixture.Client.UsersManager.EnableUserAsync(loginName, userCredentials));
+			if (userCredentials == null) 
+				await Assert.ThrowsAsync<AccessDeniedException>(
+					() => _fixture.Client.UsersManager.EnableUserAsync(loginName, userCredentials));
+			 else 
+				await Assert.ThrowsAsync<NotAuthenticatedException>(
+					() => _fixture.Client.UsersManager.EnableUserAsync(loginName, userCredentials));
 		}
 
 		[Fact]

--- a/src/EventStore.Client.UserManagement.Tests/Users/listing_users.cs
+++ b/src/EventStore.Client.UserManagement.Tests/Users/listing_users.cs
@@ -19,6 +19,7 @@ namespace EventStore.Client.Users {
 			var expected = new[] {
 					new UserDetails("admin", "Event Store Administrator", new[] {"$admins"}, false, default),
 					new UserDetails("ops", "Event Store Operations", new[] {"$ops"}, false, default),
+					new UserDetails(TestCredentials.TestUser1.Username, "test", Array.Empty<string>(), false, default), 
 				}.Concat(Array.ConvertAll(_fixture.Users, user => new UserDetails(
 					user.LoginName,
 					user.FullName,

--- a/src/EventStore.Client.UserManagement.Tests/Users/reset_user_password.cs
+++ b/src/EventStore.Client.UserManagement.Tests/Users/reset_user_password.cs
@@ -50,9 +50,14 @@ namespace EventStore.Client.Users {
 			UserCredentials userCredentials) {
 			await _fixture.Client.UsersManager.CreateUserAsync(loginName, "Full Name", Array.Empty<string>(),
 				"password", TestCredentials.Root);
-			await Assert.ThrowsAsync<NotAuthenticatedException>(
-				() => _fixture.Client.UsersManager.ResetPasswordAsync(loginName, "newPassword",
-					userCredentials));
+			if (userCredentials == null)
+				await Assert.ThrowsAsync<AccessDeniedException>(
+					() => _fixture.Client.UsersManager.ResetPasswordAsync(loginName, "newPassword",
+						userCredentials));
+			else
+				await Assert.ThrowsAsync<NotAuthenticatedException>(
+					() => _fixture.Client.UsersManager.ResetPasswordAsync(loginName, "newPassword",
+						userCredentials));
 		}
 
 		[Fact]

--- a/src/EventStore.Client/ClusterAwareHttpHandler.cs
+++ b/src/EventStore.Client/ClusterAwareHttpHandler.cs
@@ -21,7 +21,7 @@ namespace EventStore.Client {
 			CancellationToken cancellationToken) {
 			var endpointResolver = _endpoint;
 			try {
-				var endpoint = await endpointResolver.Value;
+				var endpoint = await endpointResolver.Value.ConfigureAwait(false);
 
 				request.RequestUri = new UriBuilder(Uri.UriSchemeHttps, endpoint.Address.ToString(), endpoint.Port,
 					request.RequestUri.PathAndQuery).Uri;

--- a/src/EventStore.ClientAPI.Embedded/AuthenticationExtensions.cs
+++ b/src/EventStore.ClientAPI.Embedded/AuthenticationExtensions.cs
@@ -4,6 +4,8 @@ using EventStore.ClientAPI.SystemData;
 using EventStore.Core.Authentication;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services;
+using EventStore.Core.Services.UserManagement;
 
 namespace EventStore.ClientAPI.Embedded {
 	internal static class AuthenticationExtensions {
@@ -11,7 +13,7 @@ namespace EventStore.ClientAPI.Embedded {
 			this IPublisher publisher, IAuthenticationProvider authenticationProvider, UserCredentials userCredentials,
 			Action<Exception> setException, Func<ClaimsPrincipal, Message> onUser) {
 			if (userCredentials == null) {
-				var message = onUser(null);
+				var message = onUser(SystemAccounts.Anonymous);
 
 				publisher.Publish(message);
 

--- a/src/EventStore.ClientAPI.Embedded/EmbeddedEventStoreConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EmbeddedEventStoreConnection.cs
@@ -1,6 +1,7 @@
 using EventStore.Core;
 using EventStore.Core.Authentication;
 using EventStore.Core.Bus;
+using EventStore.Core.Services;
 
 namespace EventStore.ClientAPI.Embedded {
 	/// <summary>
@@ -8,10 +9,10 @@ namespace EventStore.ClientAPI.Embedded {
 	/// </summary>
 	public static class EmbeddedEventStoreConnection {
 		private static IEventStoreConnection Create(IPublisher queue, ISubscriber bus,
-			IAuthenticationProvider authenticationProvider, ConnectionSettings connectionSettings,
+			IAuthenticationProvider authenticationProvider, AuthorizationGateway authorizationGateway, ConnectionSettings connectionSettings,
 			string connectionName = null) {
 			return new EventStoreEmbeddedNodeConnection(connectionSettings, connectionName, queue, bus,
-				authenticationProvider);
+				authenticationProvider, authorizationGateway);
 		}
 
 		/// <summary>
@@ -33,7 +34,7 @@ namespace EventStore.ClientAPI.Embedded {
 		/// <returns></returns>
 		public static IEventStoreConnection Create(ClusterVNode eventStore, ConnectionSettings connectionSettings,
 			string connectionName = null) {
-			return Create(eventStore.MainQueue, eventStore.MainBus, eventStore.InternalAuthenticationProvider,
+			return Create(eventStore.MainQueue, eventStore.MainBus, eventStore.InternalAuthenticationProvider, eventStore.AuthorizationGateway,
 				connectionSettings, connectionName);
 		}
 	}

--- a/src/EventStore.ClientAPI/EventStoreTransaction.cs
+++ b/src/EventStore.ClientAPI/EventStoreTransaction.cs
@@ -64,7 +64,7 @@ namespace EventStore.ClientAPI {
 		public Task WriteAsync(IEnumerable<EventData> events) {
 			if (_isRolledBack) throw new InvalidOperationException("Cannot write to a rolled-back transaction");
 			if (_isCommitted) throw new InvalidOperationException("Transaction is already committed");
-			return _connection.TransactionalWriteAsync(this, events);
+			return _connection.TransactionalWriteAsync(this, events, _userCredentials);
 		}
 
 		/// <summary>

--- a/src/EventStore.ClientAPIAcceptanceTests/EventTypeFilterCases.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/EventTypeFilterCases.cs
@@ -6,11 +6,11 @@ using System.Text.RegularExpressions;
 namespace EventStore.ClientAPI.Tests {
 	public class EventTypeFilterCases : IEnumerable<object[]> {
 		public IEnumerator<object[]> GetEnumerator() {
-			var useSslCases = new[] {true, false};
+			var useSslCases = new[] { true, false };
 
 			foreach (var useSsl in useSslCases) {
-				yield return new object[] {useSsl, EventTypePrefix, nameof(EventTypePrefix)};
-				yield return new object[] {useSsl, EventTypeRegex, nameof(EventTypeRegex)};
+				yield return new object[] { new Case(useSsl, FilterType.Prefix) };
+				yield return new object[] { new Case(useSsl, FilterType.Regex) };
 			}
 		}
 
@@ -20,5 +20,26 @@ namespace EventStore.ClientAPI.Tests {
 
 		private static readonly Func<string, Filter> EventTypeRegex = prefix =>
 			Filter.EventType.Regex(new Regex($"^{prefix}"));
+
+		public enum FilterType {
+			Prefix,
+			Regex
+		}
+
+		public class Case {
+			public Case(bool useSsl, FilterType filterType) {
+				UseSsl = useSsl;
+				FilterType = filterType;
+			}
+
+			public bool UseSsl { get; }
+			public FilterType FilterType { get; }
+			public Filter CreateFilter(string filter) => FilterType switch
+			{
+				FilterType.Prefix => EventTypePrefix(filter),
+				FilterType.Regex => EventTypeRegex(filter),
+				_ => throw new NotImplementedException()
+			};
+		}
 	}
 }

--- a/src/EventStore.ClientAPIAcceptanceTests/StreamIdFilterCases.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/StreamIdFilterCases.cs
@@ -20,5 +20,26 @@ namespace EventStore.ClientAPI.Tests {
 
 		private static readonly Func<string, Filter> StreamIdRegex = prefix =>
 			Filter.StreamId.Regex(new Regex($"^{prefix}"));
+
+		public enum FilterType {
+			Prefix, 
+			Regex
+		}
+		public class StreamIdFilterCase {
+			public StreamIdFilterCase(bool useSsl, FilterType filterType) {
+				UseSsl = useSsl;
+				FilterType = filterType;
+			}
+
+			public bool UseSsl { get; }
+			public FilterType FilterType { get; }
+
+			public Filter CreateFilter(string prefix) => FilterType switch
+			{
+				FilterType.Prefix => StreamIdPrefix(prefix),
+				FilterType.Regex => StreamIdRegex(prefix),
+				_ => throw new NotImplementedException(),
+			};
+		}
 	}
 }

--- a/src/EventStore.ClientAPIAcceptanceTests/connect_to_persistent_subscription.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/connect_to_persistent_subscription.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using EventStore.ClientAPI.Exceptions;
 using Xunit;
 
 namespace EventStore.ClientAPI.Tests {
@@ -12,26 +13,21 @@ namespace EventStore.ClientAPI.Tests {
 			_fixture = fixture;
 		}
 
-		[Theory(Skip = "busted on 5.x"), MemberData(nameof(UseSslTestCases))]
+		[Theory, MemberData(nameof(UseSslTestCases))]
 		public async Task that_does_not_exist_throws(bool useSsl) {
 			var streamName = $"{GetStreamName()}_{useSsl}";
 			var connection = _fixture.Connections[useSsl];
 
-			await Assert.ThrowsAsync<ArgumentException>(() => connection.ConnectToPersistentSubscriptionAsync(
+			var ex = await Record.ExceptionAsync(() => connection.ConnectToPersistentSubscriptionAsync(
 				streamName, Group,
 				delegate { return Task.CompletedTask; })).WithTimeout();
-		}
+			if (ex is AggregateException agg) {
+				agg = agg.Flatten();
+				ex = Assert.Single(agg.InnerExceptions);
+			}
 
-		[Theory, MemberData(nameof(UseSslTestCases))]
-		public async Task that_does_exist_succeeds(bool useSsl) {
-			var streamName = $"{GetStreamName()}_{useSsl}";
-			var connection = _fixture.Connections[useSsl];
+			Assert.IsType<AccessDeniedException>(ex);
 
-			await connection.CreatePersistentSubscriptionAsync(streamName, Group,
-				PersistentSubscriptionSettings.Create(), DefaultUserCredentials.Admin).WithTimeout();
-
-			await connection.ConnectToPersistentSubscriptionAsync(streamName, Group,
-				delegate { return Task.CompletedTask; }).WithTimeout();
 		}
 	}
 }

--- a/src/EventStore.ClientAPIAcceptanceTests/read_all_forward_filtered.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/read_all_forward_filtered.cs
@@ -35,23 +35,22 @@ namespace EventStore.ClientAPI.Tests {
 		}
 
 		[Theory, ClassData(typeof(EventTypeFilterCases))]
-		public async Task event_type_filter_returns_expected_result(bool useSsl, Func<string, Filter> getFilter,
-			string name) {
-			var eventTypePrefix = $"{GetStreamName()}_{useSsl}_{name}";
+		public async Task event_type_filter_returns_expected_result(EventTypeFilterCases.Case @case) {
+			var eventTypePrefix = $"{GetStreamName()}_{@case.UseSsl}_{@case.FilterType}";
 
 			var testEvents = _fixture.CreateTestEvents(10)
 				.Select(e =>
 					new EventData(e.EventId, $"{eventTypePrefix}-{Guid.NewGuid():n}", e.IsJson, e.Data, e.Metadata))
 				.ToArray();
 
-			var connection = _fixture.Connections[useSsl];
+			var connection = _fixture.Connections[@case.UseSsl];
 
 			foreach (var e in testEvents) {
 				await connection.AppendToStreamAsync(Guid.NewGuid().ToString("n"), ExpectedVersion.NoStream, e);
 			}
 
 			var result = await connection.FilteredReadAllEventsForwardAsync(
-				Position.Start, 4096, false, getFilter(eventTypePrefix)).WithTimeout();
+				Position.Start, 4096, false, @case.CreateFilter(eventTypePrefix)).WithTimeout();
 
 			Assert.Equal(ReadDirection.Forward, result.ReadDirection);
 			Assert.Equal(testEvents.Select(x => x.EventId), result.Events

--- a/src/EventStore.ClientAPIAcceptanceTests/subscribe_to_all_filtered.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/subscribe_to_all_filtered.cs
@@ -56,13 +56,13 @@ namespace EventStore.ClientAPI.Tests {
 		}
 
 		[Theory, ClassData(typeof(EventTypeFilterCases))]
-		public async Task event_type_concurrently(bool useSsl, Func<string, Filter> getFilter, string name) {
-			var eventTypePrefix = $"{GetStreamName()}_{useSsl}_{name}";
+		public async Task event_type_concurrently(EventTypeFilterCases.Case testCase) {
+			var eventTypePrefix = $"{GetStreamName()}_{testCase.UseSsl}_{testCase.FilterType}";
 
 			var eventAppearedSource1 = new TaskCompletionSource<ResolvedEvent>();
 			var eventAppearedSource2 = new TaskCompletionSource<ResolvedEvent>();
-			var connection = _fixture.Connections[useSsl];
-			var filter = getFilter(eventTypePrefix);
+			var connection = _fixture.Connections[testCase.UseSsl];
+			var filter = testCase.CreateFilter(eventTypePrefix);
 
 			using (await connection
 				.FilteredSubscribeToAllAsync(false, filter, EventAppeared1, subscriptionDropped: SubscriptionDropped1)

--- a/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
+++ b/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
@@ -1,0 +1,379 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Authorization;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Authorization {
+	public class LegacyPolicyVerification {
+		private const string _streamWithDefaultPermissions = "StreamWithDefaultPermissions";
+		private const string _streamWithCustomPermissions = "StreamWithCustomPermissions";
+
+		private readonly IAuthorizationProvider _authorizationProvider;
+		private readonly AclResponder _aclResponder;
+
+		public LegacyPolicyVerification() {
+			_aclResponder = new AclResponder();
+			_authorizationProvider = new LegacyAuthorizationProviderFactory().Build(_aclResponder);
+		}
+
+		public class PolicyVerificationParameters {
+			public ClaimsPrincipal User { get; }
+			public Operation Operation { get; }
+			public string Stream { get; }
+			public StorageMessage.EffectiveAcl StreamAcl { get; }
+			public bool IsAuthorized { get; }
+			public bool ShouldRequestAcl { get; }
+
+			public PolicyVerificationParameters(ClaimsPrincipal user, Operation operation, string stream, StorageMessage.EffectiveAcl streamAcl, bool isAuthorized, bool shouldRequestAcl) {
+				User = user;
+				Operation = operation;
+				Stream = stream;
+				StreamAcl = streamAcl;
+				IsAuthorized = isAuthorized;
+				ShouldRequestAcl = shouldRequestAcl;
+			}
+
+			public override string ToString() {
+				return $"{User?.Identity?.Name ?? "Anonymous (empty)"} {(IsAuthorized ? "is" : "is not")} authorized to perform operation {Operation}";
+			}
+		}
+
+		public static IEnumerable<PolicyVerificationParameters> PolicyTests() {
+			StorageMessage.EffectiveAcl systemStreamPermission = new StorageMessage.EffectiveAcl(
+				SystemSettings.Default.SystemStreamAcl,
+				SystemSettings.Default.SystemStreamAcl,
+				SystemSettings.Default.SystemStreamAcl
+			);
+
+			StorageMessage.EffectiveAcl defaultUseruserStreamPermission = new StorageMessage.EffectiveAcl(
+				SystemSettings.Default.UserStreamAcl,
+				SystemSettings.Default.UserStreamAcl,
+				SystemSettings.Default.UserStreamAcl
+			);
+
+			StorageMessage.EffectiveAcl userStreamPermission = new StorageMessage.EffectiveAcl(
+				new StreamAcl("test", "test", "test", "test", "test"),
+				SystemSettings.Default.UserStreamAcl,
+				SystemSettings.Default.UserStreamAcl
+			);
+
+			ClaimsPrincipal admin = CreatePrincipal("admin", SystemRoles.Admins);
+			ClaimsPrincipal userAdmin = CreatePrincipal("adminuser", SystemRoles.Admins);
+			ClaimsPrincipal ops = CreatePrincipal("ops", SystemRoles.Operations);
+			ClaimsPrincipal userOps = CreatePrincipal("opsuser", SystemRoles.Operations);
+			ClaimsPrincipal user1 = CreatePrincipal("test");
+			ClaimsPrincipal user2 = CreatePrincipal("test2");
+
+			var admins = new[] {admin, userAdmin};
+			var operations = new[] {ops, userOps};
+			var users = new[] {user1, user2};
+			var anonymous = new[]{new ClaimsPrincipal(), new ClaimsPrincipal(new ClaimsIdentity(new Claim[]{new Claim(ClaimTypes.Anonymous, ""), })), };
+			foreach (var user in admins) {
+				foreach (var operation in AdminOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						false
+					);
+				}
+				foreach (var operation in OpsOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						false
+					);
+				}
+
+				foreach (var operation in UserOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						false
+					);
+				}
+				
+				foreach (var operation in AuthenticatedOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						false
+					);
+				}
+				
+				foreach (var operation in AnonymousOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						false
+					);
+				}
+			}
+
+			foreach (var user in operations) {
+				foreach (var operation in AdminOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						false,
+						operation.Item3 != null
+					);
+				}
+				foreach (var operation in OpsOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						false
+					);
+				}
+
+				foreach (var operation in UserOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						operation.Item2 == null || operation.Item3 == defaultUseruserStreamPermission,
+						operation.Item2 != null
+					);
+				}
+
+				foreach (var operation in AuthenticatedOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						operation.Item2 != null
+					);
+				}
+
+				foreach (var operation in AnonymousOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						operation.Item2 != null
+					);
+				}
+			}
+
+			foreach (var user in users) {
+				foreach (var operation in AdminOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						false,
+						operation.Item3 != null
+					);
+				}
+				foreach (var operation in OpsOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						false,
+						false
+					);
+				}
+
+				foreach (var operation in UserOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						operation.Item2 == null || user.Identity.Name != "test2" || operation.Item3 == defaultUseruserStreamPermission,
+						operation.Item3 != null
+					);
+				}
+
+				foreach (var operation in AuthenticatedOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						operation.Item3 != null
+					);
+				}
+				foreach (var operation in AnonymousOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						operation.Item3 != null
+					);
+				}
+			}
+
+			foreach (var user in anonymous) {
+				foreach (var operation in AdminOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						false,
+						operation.Item3 != null
+					);
+				}
+				foreach (var operation in OpsOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						false,
+						operation.Item3 != null
+					);
+				}
+
+				foreach (var operation in UserOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						false,
+						false
+					);
+				}
+
+				foreach (var operation in AuthenticatedOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						false,
+						false
+					);
+				}
+				foreach (var operation in AnonymousOperations()) {
+					yield return new PolicyVerificationParameters(user,
+						operation.Item1, operation.Item2, operation.Item3,
+						true,
+						operation.Item3 != null
+					);
+				}
+			}
+
+			IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> AdminOperations() {
+				
+
+				yield return (new Operation(Operations.Streams.Read).WithParameter(
+						Operations.Streams.Parameters.StreamId("$$$scavenge")),
+					"$$$scavenge",
+					systemStreamPermission);
+				yield return CreateOperation(Operations.Projections.Restart);
+			}
+
+			IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> OpsOperations() {
+				yield return CreateOperation(Operations.Node.Information.Subsystems);
+
+				yield return CreateOperation(Operations.Node.Shutdown);
+				yield return CreateOperation(Operations.Node.Scavenge.Start);
+				yield return CreateOperation(Operations.Node.Scavenge.Stop);
+				yield return CreateOperation(Operations.Node.MergeIndexes);
+				yield return CreateOperation(Operations.Node.SetPriority);
+				yield return CreateOperation(Operations.Node.Resign);
+
+				yield return CreateOperation(Operations.Subscriptions.Create);
+				yield return CreateOperation(Operations.Subscriptions.Update);
+				yield return CreateOperation(Operations.Subscriptions.Delete);
+
+				yield return CreateOperation(Operations.Node.Information.Histogram);
+				yield return CreateOperation(Operations.Node.Information.Options);
+				yield return (new Operation(Operations.Subscriptions.ReplayParked).WithParameter(Operations.Subscriptions.Parameters.StreamId(_streamWithCustomPermissions)), _streamWithCustomPermissions, null);
+				yield return (new Operation(Operations.Subscriptions.ReplayParked).WithParameter(Operations.Subscriptions.Parameters.StreamId(_streamWithDefaultPermissions)), _streamWithDefaultPermissions, null);
+				
+				yield return CreateOperation(Operations.Projections.UpdateConfiguration);
+				
+				yield return CreateOperation(Operations.Projections.ReadConfiguration);
+				yield return CreateOperation(Operations.Projections.Delete);
+			}
+
+			IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> UserOperations() {
+				
+				yield return (new Operation(Operations.Subscriptions.ProcessMessages).WithParameter(Operations.Subscriptions.Parameters.StreamId(_streamWithCustomPermissions)), _streamWithCustomPermissions, userStreamPermission);
+				yield return (new Operation(Operations.Subscriptions.ProcessMessages).WithParameter(Operations.Subscriptions.Parameters.StreamId(_streamWithDefaultPermissions)), _streamWithDefaultPermissions, defaultUseruserStreamPermission);
+				yield return CreateOperation(Operations.Projections.List);
+				yield return CreateOperation(Operations.Projections.Abort);
+				yield return CreateOperation(Operations.Projections.Create);
+				yield return CreateOperation(Operations.Projections.DebugProjection);
+				yield return CreateOperation(Operations.Projections.Disable);
+				yield return CreateOperation(Operations.Projections.Enable);
+				yield return CreateOperation(Operations.Projections.Read);
+				yield return CreateOperation(Operations.Projections.Reset);
+				yield return CreateOperation(Operations.Projections.Update);
+				yield return CreateOperation(Operations.Projections.State);
+				yield return CreateOperation(Operations.Projections.Status);
+				yield return CreateOperation(Operations.Projections.Statistics);
+			}
+
+			IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> AuthenticatedOperations() {
+				yield return CreateOperation(Operations.Subscriptions.Statistics);
+				yield return CreateOperation(Operations.Projections.List);
+			}
+
+			IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> AnonymousOperations() {
+				yield return CreateOperation(Operations.Node.Redirect);
+				yield return CreateOperation(Operations.Node.StaticContent);
+				yield return CreateOperation(Operations.Node.Ping);
+				yield return CreateOperation(Operations.Node.Options);
+				yield return CreateOperation(Operations.Node.Information.Read);
+
+				yield return CreateOperation(Operations.Node.Information.Read);
+
+				yield return CreateOperation(Operations.Node.Statistics.Read);
+				yield return CreateOperation(Operations.Node.Statistics.Replication);
+				yield return CreateOperation(Operations.Node.Statistics.Tcp);
+				yield return CreateOperation(Operations.Node.Statistics.Custom);
+
+				yield return CreateOperation(Operations.Node.Elections.Prepare);
+				yield return CreateOperation(Operations.Node.Elections.PrepareOk);
+				yield return CreateOperation(Operations.Node.Elections.ViewChange);
+				yield return CreateOperation(Operations.Node.Elections.ViewChangeProof);
+				yield return CreateOperation(Operations.Node.Elections.Proposal);
+				yield return CreateOperation(Operations.Node.Elections.Accept);
+				yield return CreateOperation(Operations.Node.Elections.LeaderIsResigning);
+				yield return CreateOperation(Operations.Node.Elections.LeaderIsResigningOk);
+
+				yield return CreateOperation(Operations.Node.Gossip.Read);
+				yield return CreateOperation(Operations.Node.Gossip.Update);
+
+				yield return (new Operation(Operations.Streams.Read).WithParameter(
+						Operations.Streams.Parameters.StreamId(_streamWithDefaultPermissions)),
+					_streamWithDefaultPermissions, defaultUseruserStreamPermission);
+			}
+
+			
+
+			(Operation, string, StorageMessage.EffectiveAcl) CreateOperation(OperationDefinition def) {
+				return (new Operation(def),null, null);
+			}
+
+			ClaimsPrincipal CreatePrincipal(string name, params string[] roles) {
+				var claims =
+					(new[] {new Claim(ClaimTypes.Name, name)}).Concat(roles.Select(x => new Claim(ClaimTypes.Role, x)));
+				return new ClaimsPrincipal(new ClaimsIdentity(claims));
+			}
+		}
+
+
+		[Test]
+		public async Task VerifyPolicy([ValueSource(nameof(PolicyTests))]PolicyVerificationParameters pvp) {
+			_aclResponder.ExpectedAcl(pvp.Stream, pvp.StreamAcl);
+			var result = await _authorizationProvider.CheckAccessAsync(pvp.User, pvp.Operation, CancellationToken.None);
+			Assert.AreEqual(pvp.IsAuthorized, result,pvp.IsAuthorized?"was not authorized" : "was authorized");
+			Assert.AreEqual(pvp.ShouldRequestAcl,_aclResponder.MessageReceived,pvp.ShouldRequestAcl?"did not request acl":"requested acl");
+		}
+
+		
+		class AclResponder : IPublisher {
+			public bool MessageReceived { get; private set; }
+			private StorageMessage.EffectiveAcl _acl;
+			private string _expectedStream;
+
+			public AclResponder() {
+				MessageReceived = false;
+			}
+			public void Publish(Message message) {
+				MessageReceived = true;
+				Assert.IsInstanceOf<StorageMessage.EffectiveStreamAclRequest>(message);
+				var request = (StorageMessage.EffectiveStreamAclRequest)message;
+				Assert.AreEqual(_expectedStream, request.StreamId);
+				Assert.NotNull(request.Envelope);
+				request.Envelope.ReplyWith(new StorageMessage.EffectiveStreamAclResponse(_acl));
+			}
+
+			public void ExpectedAcl(string stream, StorageMessage.EffectiveAcl acl) {
+				MessageReceived = false;
+				if (stream == null) return;
+				_expectedStream = SystemStreams.IsMetastream(stream) ? SystemStreams.OriginalStreamOf(stream) : stream;
+				_acl = acl;
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Authorization/MultiClaimMatchTests.cs
+++ b/src/EventStore.Core.Tests/Authorization/MultiClaimMatchTests.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Authorization;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Authorization {
+	[TestFixture]
+	public class MultiClaimMatchTests {
+		[Test]
+		public async Task NoneMatchingHasMatches() {
+			var assertion = new MultipleClaimMatchAssertion(Grant.Deny, MultipleMatchMode.None,
+				new Claim("test1", "value1"), new Claim("test2", "value2"));
+			var cp = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {new Claim("test1", "value1")}));
+			var context = new EvaluationContext(new Operation("test", "test"), CancellationToken.None);
+			Assert.False(await assertion.Evaluate(cp, new Operation("test", "test"),
+				new PolicyInformation("test", 1, DateTimeOffset.MaxValue), context));
+			Assert.AreEqual(Grant.Unknown, context.Grant);
+		}
+
+		[Test]
+		public async Task NonMatchingHasNoMatches() {
+			var assertion = new MultipleClaimMatchAssertion(Grant.Deny, MultipleMatchMode.None,
+				new Claim("test1", "value1"), new Claim("test2", "value2"));
+			var cp = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] {new Claim("test3", "value3")}));
+			var context = new EvaluationContext(new Operation("test", "test"), CancellationToken.None);
+			Assert.True(await assertion.Evaluate(cp, new Operation("test", "test"),
+				new PolicyInformation("test", 1, DateTimeOffset.MaxValue), context));
+			Assert.AreEqual(Grant.Deny, context.Grant);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Authorization/TestAuthorizationProvider.cs
+++ b/src/EventStore.Core.Tests/Authorization/TestAuthorizationProvider.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Authorization;
+
+namespace EventStore.Core.Tests.Authorization {
+	class TestAuthorizationProvider : IAuthorizationProvider {
+		public ValueTask<bool> CheckAccessAsync(ClaimsPrincipal cp, Operation operation, CancellationToken ct) {
+			return new ValueTask<bool>(true);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/persistent_subscription_with_event_numbers_greater_than_2_billion.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/persistent_subscription_with_event_numbers_greater_than_2_billion.cs
@@ -58,7 +58,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 				receivedEvents.Add(e);
 				countdown.Signal();
 				return Task.CompletedTask;
-			});
+			}, userCredentials: DefaultData.AdminCredentials);
 
 			await _store.AppendToStreamAsync(_streamId, intMaxValue + 2, evnt);
 

--- a/src/EventStore.Core.Tests/ClientAPI/Security/authorized_default_credentials_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/authorized_default_credentials_security.cs
@@ -46,7 +46,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 
 			var transId = (await TransStart("write-stream", null, null)).TransactionId;
 			var trans = Connection.ContinueTransaction(transId, new UserCredentials("badlogin", "badpass"));
-			await trans.WriteAsync();
+			await AssertEx.ThrowsAsync<NotAuthenticatedException>(() => trans.WriteAsync());
 			await AssertEx.ThrowsAsync<NotAuthenticatedException>(() => trans.CommitAsync());
 
 			await AssertEx.ThrowsAsync<NotAuthenticatedException>(() => ReadMeta("metaread-stream", "badlogin", "badpass"));
@@ -70,7 +70,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 
 			var transId = (await TransStart("write-stream", null, null)).TransactionId;
 			var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-			await trans.WriteAsync();
+			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.WriteAsync());
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.CommitAsync());
 
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => ReadMeta("metaread-stream", "user2", "pa$$2"));

--- a/src/EventStore.Core.Tests/ClientAPI/Security/overriden_system_stream_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/overriden_system_stream_security.cs
@@ -51,7 +51,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 
 			var transId = (await TransStart(stream, "adm", "admpa$$")).TransactionId;
 			var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-			await trans.WriteAsync();
+			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.WriteAsync());
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.CommitAsync());
 
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => ReadMeta(stream, "user2", "pa$$2"));
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 
 			var transId = (await TransStart(stream, "adm", "admpa$$")).TransactionId;
 			var trans = Connection.ContinueTransaction(transId);
-			await trans.WriteAsync();
+			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.WriteAsync());
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.CommitAsync());
 
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => ReadMeta(stream, null, null));

--- a/src/EventStore.Core.Tests/ClientAPI/Security/overriden_user_stream_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/overriden_user_stream_security.cs
@@ -55,7 +55,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 			{
 				var transId = (await TransStart(stream, "adm", "admpa$$")).TransactionId;
 				var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-				await trans.WriteAsync();
+				await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.WriteAsync());
 				await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.CommitAsync());
 			}
 
@@ -79,7 +79,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 			{
 				var transId = (await TransStart(stream, "adm", "admpa$$")).TransactionId;
 				var trans = Connection.ContinueTransaction(transId);
-				await trans.WriteAsync();
+				await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.WriteAsync());
 				await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.CommitAsync());
 			}
 			;

--- a/src/EventStore.Core.Tests/ClientAPI/Security/system_stream_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/system_stream_security.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 
 			var transId = (await TransStart("$system-no-acl", "adm", "admpa$$")).TransactionId;
 			var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-			await trans.WriteAsync();
+			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.WriteAsync());
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.CommitAsync());
 
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => ReadMeta("$system-no-acl", "user1", "pa$$1"));
@@ -58,7 +58,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 
 			var transId = (await TransStart("$system-acl", "user1", "pa$$1")).TransactionId;
 			var trans = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-			await trans.WriteAsync();
+			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.WriteAsync());
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.CommitAsync());
 
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => ReadMeta("$system-acl", "user2", "pa$$2"));
@@ -119,7 +119,7 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 
 			var transId = (await TransStart("$system-adm", "adm", "admpa$$")).TransactionId;
 			var trans = Connection.ContinueTransaction(transId, new UserCredentials("user1", "pa$$1"));
-			await trans.WriteAsync();
+			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.WriteAsync());
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => trans.CommitAsync());
 
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => ReadMeta("$system-adm", "user1", "pa$$1"));

--- a/src/EventStore.Core.Tests/ClientAPI/Security/transactional_write_stream_security.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Security/transactional_write_stream_security.cs
@@ -34,25 +34,26 @@ namespace EventStore.Core.Tests.ClientAPI.Security {
 
 		[Test]
 		public async Task committing_transaction_with_not_existing_credentials_is_not_authenticated() {
-			var transId = (await TransStart("write-stream", "user1", "pa$$1")).TransactionId;
-			var t2 = Connection.ContinueTransaction(transId, new UserCredentials("badlogin", "badpass"));
-			await t2.WriteAsync(CreateEvents());
+			var t1 = await TransStart("write-stream", "user1", "pa$$1");
+			await t1.WriteAsync(CreateEvents());
+			var t2 = Connection.ContinueTransaction(t1.TransactionId, new UserCredentials("badlogin", "badpass"));
+			
 			await AssertEx.ThrowsAsync<NotAuthenticatedException>(() => t2.CommitAsync());
 		}
 
 		[Test]
 		public async Task committing_transaction_to_stream_with_no_credentials_is_denied() {
-			var transId = (await TransStart("write-stream", "user1", "pa$$1")).TransactionId;
-			var t2 = Connection.ContinueTransaction(transId);
-			await t2.WriteAsync();
+			var t1 = await TransStart("write-stream", "user1", "pa$$1");
+			await t1.WriteAsync();
+			var t2 = Connection.ContinueTransaction(t1.TransactionId);
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => t2.CommitAsync());
 		}
 
 		[Test]
 		public async Task committing_transaction_to_stream_with_not_authorized_user_credentials_is_denied() {
-			var transId = (await TransStart("write-stream", "user1", "pa$$1")).TransactionId;
-			var t2 = Connection.ContinueTransaction(transId, new UserCredentials("user2", "pa$$2"));
-			await t2.WriteAsync();
+			var t1 = await TransStart("write-stream", "user1", "pa$$1");
+			await t1.WriteAsync();
+			var t2 = Connection.ContinueTransaction(t1.TransactionId, new UserCredentials("user2", "pa$$2"));
 			await AssertEx.ThrowsAsync<AccessDeniedException>(() => t2.CommitAsync());
 		}
 

--- a/src/EventStore.Core.Tests/ClientAPI/UserManagement/reset_change_password.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/UserManagement/reset_change_password.cs
@@ -88,8 +88,7 @@ namespace EventStore.Core.Tests.ClientAPI.UserManagement {
 
 		[Test]
 		public async Task can_change_password() {
-			await _manager.ChangePasswordAsync(_username, "password", "fubar", new UserCredentials(_username, "password"))
-;
+			await _manager.ChangePasswordAsync(_username, "password", "fubar", new UserCredentials(_username, "password"));
 			var ex = await AssertEx.ThrowsAsync<UserCommandFailedException>(
 				() => _manager.ChangePasswordAsync(_username, "password", "foobar",
 					new UserCredentials(_username, "password"))

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
@@ -25,7 +25,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 							Console.Write("appeared");
 							return Task.CompletedTask;
 						},
-						(sub, reason, ex) => { });
+						(sub, reason, ex) => { },
+						DefaultData.AdminCredentials);
 					throw new Exception("should have thrown");
 				}).InnerException;
 			return Task.CompletedTask;
@@ -51,8 +52,13 @@ namespace EventStore.Core.Tests.ClientAPI {
 			.DoNotResolveLinkTos()
 			.StartFromCurrent();
 
+		protected override async Task Given() {
+			await _conn.CreatePersistentSubscriptionAsync(_stream, "agroupname17", _settings,
+				DefaultData.AdminCredentials);
+		}
+
 		protected override async Task When() {
-			await _conn.CreatePersistentSubscriptionAsync(_stream, "agroupname17", _settings, DefaultData.AdminCredentials)
+			
 ;
 			_sub = _conn.ConnectToPersistentSubscription(_stream,
 				"agroupname17",
@@ -60,11 +66,12 @@ namespace EventStore.Core.Tests.ClientAPI {
 					Console.Write("appeared");
 					return Task.CompletedTask;
 				},
-				(sub, reason, ex) => { });
+				(sub, reason, ex) => { },
+				DefaultData.AdminCredentials);
 		}
 
 		[Test]
-		public void the_subscription_suceeds() {
+		public void the_subscription_succeeds() {
 			Assert.IsNotNull(_sub);
 		}
 	}

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription_async.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription_async.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 					Console.Write("appeared");
 					return Task.CompletedTask;
 				},
-				(sub, reason, ex) => { }));
+				(sub, reason, ex) => { }, DefaultData.AdminCredentials));
 		}
 
 		[Test]
@@ -48,11 +48,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 					Console.Write("appeared");
 					return Task.CompletedTask;
 				},
-				(sub, reason, ex) => { });
+				(sub, reason, ex) => { }, DefaultData.AdminCredentials);
 		}
 
 		[Test]
-		public void the_subscription_suceeds() {
+		public void the_subscription_succeeds() {
 			Assert.IsNotNull(_sub);
 		}
 	}

--- a/src/EventStore.Core.Tests/ClientAPI/deleting_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/deleting_persistent_subscription.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				DefaultData.AdminCredentials);
 			_conn.ConnectToPersistentSubscription(_stream, "groupname123",
 				(s, e) => Task.CompletedTask,
-				(s, r, e) => _called.Set());
+				(s, r, e) => _called.Set(), DefaultData.AdminCredentials);
 		}
 
 		protected override Task When() {

--- a/src/EventStore.Core.Tests/ClientAPI/update_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/update_persistent_subscription.cs
@@ -52,7 +52,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 					_dropped.Set();
 					_reason = reason;
 					_exception = ex;
-				});
+				}, DefaultData.AdminCredentials);
 		}
 
 		protected override async Task When() {

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using EventStore.Core.Authentication;
 using EventStore.Core.Bus;
 using EventStore.Core.Services;
@@ -17,6 +18,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 
 	public class TestAuthenticationProvider : IAuthenticationProvider {
 		public void Authenticate(AuthenticationRequest authenticationRequest) {
+			authenticationRequest.Authenticated(new ClaimsPrincipal(new ClaimsIdentity(new []{new Claim(ClaimTypes.Name, authenticationRequest.Name), })));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
@@ -25,7 +25,11 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 
 		[OneTimeTearDown]
 		public virtual async Task TestFixtureTearDown() {
-			await _node.StopAsync();
+			try {
+				await _node.StopAsync();
+			} catch (OperationCanceledException) {
+
+			}
 		}
 
 		public abstract void Given();

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
 using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Cluster.Settings;
 using EventStore.Core.Messages;
@@ -119,7 +120,7 @@ namespace EventStore.Core.Tests.Helpers {
 				certificate, 1, false,
 				"", gossipSeeds, TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10),
 				disableInternalTls, false,TimeSpan.FromHours(1), StatsStorage.None, 0,
-				new InternalAuthenticationProviderFactory(), disableScavengeMerging: true, scavengeHistoryMaxAge: 30,
+				new InternalAuthenticationProviderFactory(), new LegacyAuthorizationProviderFactory(), disableScavengeMerging: true, scavengeHistoryMaxAge: 30,
 				adminOnPublic: true,
 				statsOnPublic: true, gossipOnPublic: true, gossipInterval: TimeSpan.FromSeconds(2),
 				gossipAllowedTimeDifference: TimeSpan.FromSeconds(1), gossipTimeout: TimeSpan.FromSeconds(3),

--- a/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
+++ b/src/EventStore.Core.Tests/Http/HttpBehaviorSpecification.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Collections.Specialized;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
@@ -11,15 +9,11 @@ using System.Net.Http.Headers;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml;
 using System.Xml.Linq;
 using EventStore.ClientAPI;
 using EventStore.Common.Utils;
 using EventStore.Core.Tests.ClientAPI.Helpers;
 using EventStore.Core.Tests.Helpers;
-using EventStore.Core.Tests.Http.Streams;
-using EventStore.Core.Tests.Http.Users;
-using NUnit.Framework;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using EventStore.ClientAPI.Transport.Http;
@@ -55,17 +49,12 @@ namespace EventStore.Core.Tests.Http {
 			_lastResponseBody = null;
 			_lastResponseBytes = null;
 			_lastJsonException = null;
-			try {
-				await Given().WithTimeout();
-			} catch (Exception ex) {
-				throw new Exception("Given Failed", ex);
-			}
 
-			try {
-				await When().WithTimeout();
-			} catch (Exception ex) {
-				throw new Exception("When Failed", ex);
-			}
+			await Given().WithTimeout();
+
+
+			await When().WithTimeout();
+
 		}
 
 		public string TestStream {

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/deleting.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/deleting.cs
@@ -92,7 +92,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 					_dropped.Set();
 					_reason = reason;
 					_exception = e;
-				});
+				}, DefaultData.AdminCredentials);
 		}
 
 		protected override async Task When() {

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using EventStore.ClientAPI;
-using EventStore.Core.Tests.Http.BasicAuthentication.basic_authentication;
 using EventStore.Transport.Http;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -173,7 +171,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 
 		[Test]
 		public void the_first_connection_has_user() {
-			Assert.AreEqual("anonymous", _json["connections"][0]["username"].Value<string>());
+			Assert.AreEqual("admin", _json["connections"][0]["username"].Value<string>());
 		}
 
 		[Test]
@@ -199,7 +197,8 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 					Console.WriteLine();
 					return Task.CompletedTask;
 				},
-				(subscription, reason, arg3) => Console.WriteLine());
+				(subscription, reason, arg3) => Console.WriteLine(),
+				DefaultData.AdminCredentials);
 			_conn.ConnectToPersistentSubscription(_streamName, "secondgroup",
 				(subscription, @event) => {
 					Console.WriteLine();
@@ -334,7 +333,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 					Console.WriteLine();
 					return Task.CompletedTask;
 				},
-				(subscription, reason, arg3) => Console.WriteLine());
+				(subscription, reason, arg3) => Console.WriteLine(), DefaultData.AdminCredentials);
 			_sub4 = _conn.ConnectToPersistentSubscription(_streamName, "secondgroup",
 				(subscription, @event) => {
 					Console.WriteLine();
@@ -450,7 +449,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 					Console.WriteLine();
 					return Task.CompletedTask;
 				},
-				(subscription, reason, arg3) => Console.WriteLine());
+				(subscription, reason, arg3) => Console.WriteLine(), DefaultData.AdminCredentials);
 			_sub2 = _conn.ConnectToPersistentSubscription(_streamName, _groupName,
 				(subscription, @event) => {
 					Console.WriteLine();

--- a/src/EventStore.Core.Tests/Http/TestController.cs
+++ b/src/EventStore.Core.Tests/Http/TestController.cs
@@ -7,6 +7,7 @@ using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
 using EventStore.Transport.Http.EntityManagement;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 
 namespace EventStore.Core.Tests.Http {
 	public class TestController : CommunicationController {
@@ -37,7 +38,7 @@ namespace EventStore.Core.Tests.Http {
 		private void Register(
 			IHttpService service, string uriTemplate, Action<HttpEntityManager, UriTemplateMatch> handler,
 			string httpMethod = HttpMethod.Get) {
-			Register(service, uriTemplate, httpMethod, handler, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, AuthorizationLevel.None);
+			Register(service, uriTemplate, httpMethod, handler, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, new Operation(Operations.Node.StaticContent));
 		}
 
 		private void Test1Handler(HttpEntityManager http, UriTemplateMatch match) {

--- a/src/EventStore.Core.Tests/Http/Users/users.cs
+++ b/src/EventStore.Core.Tests/Http/Users/users.cs
@@ -320,7 +320,8 @@ namespace EventStore.Core.Tests.Http.Users {
 			public async Task can_change_password_using_the_new_password() {
 				var response = await MakeJsonPost(
 					"/users/test1/command/change-password",
-					new { CurrentPassword = "NewPassword!", NewPassword = "TheVeryNewPassword!" });
+					new { CurrentPassword = "NewPassword!", NewPassword = "TheVeryNewPassword!" },
+					new NetworkCredential("test1", "NewPassword!"));
 				Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
 			}
 		}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Net;
 using EventStore.Common.Utils;
 using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Cluster.Settings;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.TransactionLog.Chunks;
@@ -31,7 +32,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				false, null, 1, false, "dns", new[] {GetLoopbackForPort(ManagerPort)},
 				TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(2),
 				TimeSpan.FromSeconds(2), true, false,TimeSpan.FromHours(1),
-				StatsStorage.StreamAndFile, 0, new InternalAuthenticationProviderFactory(), false, 30, true, true, true,
+				StatsStorage.StreamAndFile, 0, new InternalAuthenticationProviderFactory(), new LegacyAuthorizationProviderFactory(), false, 30, true, true, true,
 				TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1),
 				TimeSpan.FromSeconds(10),
 				TimeSpan.FromSeconds(10),

--- a/src/EventStore.Core.Tests/Services/Replication/MasterReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/MasterReplication/with_replication_service.cs
@@ -7,9 +7,11 @@ using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services;
 using EventStore.Core.Services.Replication;
 using EventStore.Core.Services.Transport.Tcp;
 using EventStore.Core.Tests.Authentication;
+using EventStore.Core.Tests.Authorization;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.Tests.Services.ElectionsService;
 using EventStore.Core.Tests.Services.Transport.Tcp;
@@ -91,6 +93,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				new InternalAuthenticationProvider(
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
 					new StubPasswordHashAlgorithm(), 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
 			var subRequest = new ReplicationMessage.ReplicaSubscriptionRequest(

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_successfully.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
@@ -24,13 +23,11 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 			   	streamId: _streamId,
 				betterOrdering: true,
 				expectedVersion: ExpectedVersion.Any,
-				user: null,
 				hardDelete: false,
 				commitSource: CommitSource);
 		}
 
 		protected override IEnumerable<Message> WithInitialMessages() {
-			yield return new StorageMessage.CheckStreamAccessCompleted(InternalCorrId, _streamId, null, StreamAccessType.Delete, new StreamAccess(true));
 			yield return new StorageMessage.CommitAck(InternalCorrId, commitPosition, 2, 3, 3);
 			}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_after_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_after_commit.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				false,
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_before_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_before_commit.cs
@@ -23,7 +23,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				_streamId,
 				true,
 				ExpectedVersion.Any,
-				null,
 				false,
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_stream_deleted.cs
@@ -20,7 +20,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				false,
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_after_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_after_commit.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				false,
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_before_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_before_commit.cs
@@ -20,7 +20,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				false,
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/FakeRequestManager.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/FakeRequestManager.cs
@@ -29,7 +29,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement {
 				 transactionId,
 				 waitForCommit)
 				{}
-		protected override Message AccessRequestMsg => throw new NotImplementedException();
 		protected override Message WriteRequestMsg => throw new NotImplementedException();
 		protected override Message ClientSuccessMsg => throw new NotImplementedException();
 		protected override Message ClientFailMsg => throw new NotImplementedException();

--- a/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
@@ -45,7 +45,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement {
 			Publisher.Messages.Clear();
 
 			Manager = OnManager(Publisher);
-			Dispatcher.Subscribe<StorageMessage.CheckStreamAccessCompleted>(Manager);
 			Dispatcher.Subscribe<StorageMessage.PrepareAck>(Manager);
 			Dispatcher.Subscribe<StorageMessage.CommitAck>(Manager);
 			Dispatcher.Subscribe<StorageMessage.InvalidTransaction>(Manager);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_completes_successfully.cs
@@ -24,7 +24,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				ClientCorrId,
 				transactionId,
 				true,				
-				null,
 				CommitSource);
 			}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_after_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_after_committed.cs
@@ -24,7 +24,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				ClientCorrId,
 				transactionId,
 				true,
-				null,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_before_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_before_committed.cs
@@ -23,7 +23,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				ClientCorrId,
 				transactionId,
 				true,
-				null,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_after_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_after_prepares.cs
@@ -22,7 +22,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				ClientCorrId,
 				transactionId,
 				true,
-				null,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_before_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_before_prepares.cs
@@ -21,8 +21,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,				
-				null,
+				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_stream_deleted.cs
@@ -20,8 +20,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,				
-				null,
+				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_timeout_before_cluster_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_timeout_before_cluster_commit.cs
@@ -21,8 +21,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,				
-				null,
+				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_start_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_start_completes_successfully.cs
@@ -22,7 +22,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				$"testStream-{nameof(when_transaction_commit_completes_successfully)}",
 				true,				
 				0,
-			    null,
 				CommitSource);
 			}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed.cs
@@ -23,7 +23,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				new[] {DummyEvent()},
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_committed.cs
@@ -23,7 +23,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				new[] {DummyEvent()},
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_not_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_not_committed.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				new[] {DummyEvent()},
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_stream_deleted.cs
@@ -20,7 +20,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				new[] {DummyEvent()},
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_cluster_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_cluster_commit.cs
@@ -23,7 +23,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				new[] {DummyEvent()},
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_local_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_local_commit.cs
@@ -20,7 +20,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				new[] {DummyEvent()},
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_before_local_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_before_local_commit.cs
@@ -20,7 +20,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				"test123",
 				true,
 				ExpectedVersion.Any,
-				null,
 				new[] {DummyEvent()},
 				CommitSource);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/when_creating_stream_request_manager.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/when_creating_stream_request_manager.cs
@@ -29,6 +29,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement {
 					ExpectedVersion,
 					new CommitSource()));
 		}
+
 		[Test]
 		public void null_envelope_throws_argument_null_exception() {
 			Assert.Throws<ArgumentNullException>(() =>

--- a/src/EventStore.Core.Tests/Services/Transport/Http/HttpBootstrap.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/HttpBootstrap.cs
@@ -9,13 +9,11 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		public static void Subscribe(IBus bus, KestrelHttpService service) {
 			bus.Subscribe<SystemMessage.SystemInit>(service);
 			bus.Subscribe<SystemMessage.BecomeShuttingDown>(service);
-			bus.Subscribe<HttpMessage.PurgeTimedOutRequests>(service);
 		}
 
 		public static void Unsubscribe(IBus bus, KestrelHttpService service) {
 			bus.Unsubscribe<SystemMessage.SystemInit>(service);
 			bus.Unsubscribe<SystemMessage.BecomeShuttingDown>(service);
-			bus.Unsubscribe<HttpMessage.PurgeTimedOutRequests>(service);
 		}
 
 		public static void RegisterPing(IHttpService service) {

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -3,17 +3,23 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using EventStore.Common.Utils;
+using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Core.Services.Transport.Http.Authentication;
-using EventStore.Transport.Http;
+using EventStore.Core.Tests.Authorization;
+using EventStore.Core.Tests.Common.VNodeBuilderTests;
+using EventStore.Core.Tests.TransactionLog;
 using EventStore.Transport.Http.Client;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using HttpResponse = EventStore.Transport.Http.HttpResponse;
 
 namespace EventStore.Core.Tests.Services.Transport.Http {
 	public class PortableServer {
@@ -33,6 +39,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		private readonly IPEndPoint _serverEndPoint;
 		private TestServer _server;
 		private HttpMessageHandler _httpMessageHandler;
+		private InternalDispatcherEndpoint _internalDispatcher;
 
 		public PortableServer(IPEndPoint serverEndPoint, int timeout = 10000) {
 			Ensure.NotNull(serverEndPoint, "serverEndPoint");
@@ -49,14 +56,20 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 
 			_service = new KestrelHttpService(ServiceAccessibility.Private, _bus, new NaiveUriRouter(),
 				_multiQueuedHandler, false, null, 0, false, _serverEndPoint);
+			_internalDispatcher = new InternalDispatcherEndpoint(queue, _multiQueuedHandler);
+			_bus.Subscribe(_internalDispatcher);
 			KestrelHttpService.CreateAndSubscribePipeline(pipelineBus);
 			bootstrap?.Invoke(_service);
 			_server = new TestServer(
 				new WebHostBuilder()
-					.UseStartup(new HttpServiceStartup(_service)));
+					.UseStartup(new ClusterVNodeStartup(Array.Empty<ISubsystem>(), queue, _bus, _multiQueuedHandler,
+						new IHttpAuthenticationProvider[] {
+							new BasicHttpAuthenticationProvider(new TestAuthenticationProvider()),
+							new AnonymousHttpAuthenticationProvider(),
+						}, new TestAuthorizationProvider(), new FakeReadIndex(_ => false), 1024 * 1024, _service)));
 			_httpMessageHandler = _server.CreateHandler();
 			_client = new HttpAsyncClient(_timeout, _httpMessageHandler);
-
+			
 			HttpBootstrap.Subscribe(_bus, _service);
 		}
 
@@ -98,16 +111,18 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		}
 
 		private class HttpServiceStartup : IStartup {
+			private readonly RequestDelegate _dispatcher;
 			private readonly KestrelHttpService _httpService;
 
-			public HttpServiceStartup(KestrelHttpService httpService) {
+			public HttpServiceStartup(RequestDelegate dispatcher, KestrelHttpService httpService) {
+				_dispatcher = dispatcher;
 				_httpService = httpService;
 			}
 			public IServiceProvider ConfigureServices(IServiceCollection services) => services
 				.AddRouting()
 				.BuildServiceProvider();
 
-			public void Configure(IApplicationBuilder app) => app.UseLegacyHttp(_httpService);
+			public void Configure(IApplicationBuilder app) => app.UseLegacyHttp(_dispatcher ,_httpService);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/speed_test.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Transport.Http;
@@ -105,14 +106,14 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		private void Register(string route, string verb) {
 			if (_router == null) {
 				_http.RegisterAction(
-					new ControllerAction(route, verb, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+					new ControllerAction(route, verb, Codec.NoCodecs, SupportedCodecs, new Operation()),
 					(x, y) => {
 						x.Reply(new byte[0], 200, "", "", Helper.UTF8NoBom, null, e => new Exception());
 						CountdownEvent.Signal();
 					});
 			} else {
 				_router.RegisterAction(
-					new ControllerAction(route, verb, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+					new ControllerAction(route, verb, Codec.NoCodecs, SupportedCodecs, new Operation()),
 					(x, y) => {
 						CountdownEvent.Signal();
 						return new RequestParams(TimeSpan.Zero);
@@ -130,100 +131,4 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		}
 	}
 
-	[TestFixture]
-	public class speed_test {
-		[Test, Ignore("speed test")]
-		public void of_http_requests_routing() {
-			const int iterations = 100000;
-
-			IPublisher inputBus = new NoopPublisher();
-			var bus = InMemoryBus.CreateTest();
-			var queue = new QueuedHandlerThreadPool(bus, "Test", new QueueStatsManager(), true, TimeSpan.FromMilliseconds(50));
-			var multiQueuedHandler = new MultiQueuedHandler(new IQueuedHandler[] { queue }, null);
-			var providers = new IHttpAuthenticationProvider[] { new AnonymousHttpAuthenticationProvider() };
-			var httpService = new KestrelHttpService(ServiceAccessibility.Public, inputBus,
-				new TrieUriRouter(), multiQueuedHandler, false, null, 0, false);
-			KestrelHttpService.CreateAndSubscribePipeline(bus);
-
-			using var server = new TestServer(new WebHostBuilder().UseStartup(new HttpServiceStartup(httpService)));
-			using var httpMessageHandler = server.CreateHandler();
-
-			var fakeController = new FakeController(iterations, null);
-			httpService.SetupController(fakeController);
-
-			httpService.Handle(new SystemMessage.SystemInit());
-
-			var rnd = new Random();
-			var sw = Stopwatch.StartNew();
-
-			var timeout = TimeSpan.FromMilliseconds(10000);
-			var httpClient = new HttpAsyncClient(timeout, httpMessageHandler);
-			for (int i = 0; i < iterations; ++i) {
-				var route = fakeController.BoundRoutes[rnd.Next(0, fakeController.BoundRoutes.Count)];
-
-				switch (route.Item2) {
-					case HttpMethod.Get:
-						httpClient.Get(route.Item1, x => { }, x => { throw new Exception(); });
-						break;
-					case HttpMethod.Post:
-						httpClient.Post(route.Item1, "abracadabra", ContentType.Json, x => { },
-							x => { throw new Exception(); });
-						break;
-					case HttpMethod.Delete:
-						httpClient.Delete(route.Item1, x => { }, x => { throw new Exception(); });
-						break;
-					case HttpMethod.Put:
-						httpClient.Put(route.Item1, "abracadabra", ContentType.Json, x => { },
-							x => { throw new Exception(); });
-						break;
-					default:
-						throw new Exception();
-				}
-			}
-
-			fakeController.CountdownEvent.Wait();
-			sw.Stop();
-
-			Console.WriteLine("{0} request done in {1} ({2:0.00} per sec)", iterations, sw.Elapsed,
-				1000.0 * iterations / sw.ElapsedMilliseconds);
-
-			httpService.Shutdown();
-			multiQueuedHandler.Stop();
-		}
-
-		[Test, Ignore("speed test")]
-		public void of_uri_router() {
-			const int iterations = 100000;
-
-			IUriRouter router = new TrieUriRouter();
-			var fakeController = new FakeController(iterations, router);
-			fakeController.Subscribe(null);
-
-			var rnd = new Random();
-			var sw = Stopwatch.StartNew();
-
-			for (int i = 0; i < iterations; ++i) {
-				var route = fakeController.BoundRoutes[rnd.Next(0, fakeController.BoundRoutes.Count)];
-				router.GetAllUriMatches(new Uri(route.Item1));
-			}
-
-			sw.Stop();
-
-			Console.WriteLine("{0} request done in {1} ({2:0.00} per sec)", iterations, sw.Elapsed,
-				1000.0 * iterations / sw.ElapsedMilliseconds);
-		}
-
-		class HttpServiceStartup : IStartup {
-			private readonly KestrelHttpService _httpService;
-
-			public HttpServiceStartup(KestrelHttpService httpService) {
-				_httpService = httpService;
-			}
-			public IServiceProvider ConfigureServices(IServiceCollection services) => services
-				.AddRouting()
-				.BuildServiceProvider();
-
-			public void Configure(IApplicationBuilder app) => app.UseLegacyHttp(_httpService);
-		}
-	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/uri_router_should.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/uri_router_should.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
@@ -36,71 +37,71 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 
 			var p = new RequestParams(TimeSpan.Zero);
 			_router.RegisterAction(
-				new ControllerAction("/", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+				new ControllerAction("/", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/{placeholder}", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/{placeholder}", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()),
 				(x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/halt", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/halt", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()),
 				(x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/streams/{stream}/{event}/backward/{count}?embed={embed}", HttpMethod.Get,
-					Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction(
 					"/projection/{name}?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}",
-					HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/s/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/streams/$all/", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/streams/$all/", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()),
 				(x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/streams/$$all", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/streams/$$all", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()),
 				(x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/streams/$mono?param={param}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 
 			_router.RegisterAction(
-				new ControllerAction("/streams/test", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/streams/test", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()),
 				(x, y) => p);
 			_router.RegisterAction(
-				new ControllerAction("/streams/test", HttpMethod.Post, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/streams/test", HttpMethod.Post, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()),
 				(x, y) => p);
 
 			_router.RegisterAction(
 				new ControllerAction("/t/{placeholder1}/{placholder2}/{placeholder3}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/{placeholder1}/{placholder2}/something", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/{placeholder1}/something/{placeholder3}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/{placeholder1}/something/something", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/something/{placholder2}/{placeholder3}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/something/{placholder2}/something", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/something/something/{placeholder3}", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 			_router.RegisterAction(
 				new ControllerAction("/t/something/something/something", HttpMethod.Get, Codec.NoCodecs,
-					FakeController.SupportedCodecs, AuthorizationLevel.None), (x, y) => p);
+					FakeController.SupportedCodecs, new Operation()), (x, y) => p);
 		}
 
 		[Test]
 		public void detect_duplicate_route() {
 			Assert.That(() =>
 					_router.RegisterAction(
-						new ControllerAction("/halt", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
+						new ControllerAction("/halt", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()),
 						(x, y) => new RequestParams(TimeSpan.Zero)),
 				Throws.Exception.InstanceOf<ArgumentException>().With.Message.EqualTo("Duplicate route."));
 		}
@@ -266,7 +267,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		public void match_greedy_route_in_the_root_to_any_path() {
 			var tmpRouter = _uriRouterFactory();
 			tmpRouter.RegisterAction(
-				new ControllerAction("/{*greedy}", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/{*greedy}", HttpMethod.Get, Codec.NoCodecs, FakeController.SupportedCodecs, new Operation()),
 				(x, y) => new RequestParams(TimeSpan.Zero));
 
 			var match = tmpRouter.GetAllUriMatches(Uri("/"));

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -12,6 +12,7 @@ using System.Text;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services;
+using EventStore.Core.Tests.Authorization;
 using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.Services.Transport.Tcp {
@@ -33,6 +34,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
 					new StubPasswordHashAlgorithm(), 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ConnectionQueueSizeThresholdDefault);
 		}

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -14,7 +14,9 @@ using System.Linq;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using System.Threading;
+using EventStore.Core.Services;
 using EventStore.Core.Settings;
+using EventStore.Core.Tests.Authorization;
 
 namespace EventStore.Core.Tests.Services.Transport.Tcp {
 	[TestFixture]
@@ -35,6 +37,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				new InternalAuthenticationProvider(
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
 					new StubPasswordHashAlgorithm(), 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
 
@@ -75,6 +78,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				publisher, dummyConnection, publisher,
 				new InternalAuthenticationProvider(new Core.Helpers.IODispatcher(publisher, new NoopEnvelope()),
 					new StubPasswordHashAlgorithm(), 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
 
@@ -109,6 +113,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { mre.Set(); },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
 
@@ -137,6 +142,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
 
@@ -169,6 +175,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { mre.Set(); },
 				ESConsts.UnrestrictedPendingSendBytes, ESConsts.MaxConnectionQueueSize);
 
@@ -201,6 +208,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { mre.Set(); },
 				ESConsts.UnrestrictedPendingSendBytes, ESConsts.MaxConnectionQueueSize);
 
@@ -233,6 +241,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { mre.Set(); },
 				ESConsts.UnrestrictedPendingSendBytes, ESConsts.MaxConnectionQueueSize);
 

--- a/src/EventStore.Core.Tests/SpecificationWithDirectoryPerTestFixture.cs
+++ b/src/EventStore.Core.Tests/SpecificationWithDirectoryPerTestFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
@@ -18,6 +19,7 @@ namespace EventStore.Core.Tests {
 
 		[OneTimeSetUp]
 		public virtual Task TestFixtureSetUp() {
+			ThreadPool.SetMinThreads(100, 1000);
 			var typeName = GetType().Name.Length > 30 ? GetType().Name.Substring(0, 30) : GetType().Name;
 			PathName = Path.Combine(Path.GetTempPath(), string.Format("{0}-{1}", Guid.NewGuid(), typeName));
 			Directory.CreateDirectory(PathName);

--- a/src/EventStore.Core.Tests/TransactionLog/FakeReadIndex.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/FakeReadIndex.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using EventStore.ClientAPI.Common;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
+using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Util;
@@ -79,6 +80,10 @@ namespace EventStore.Core.Tests.TransactionLog {
 			if (SystemStreams.IsMetastream(streamId))
 				return GetStreamLastEventNumber(SystemStreams.OriginalStreamOf(streamId));
 			return _isStreamDeleted(streamId) ? EventNumber.DeletedStream : 1000000;
+		}
+
+		public StorageMessage.EffectiveAcl GetEffectiveAcl(string streamId) {
+			throw new NotImplementedException();
 		}
 
 		public string GetEventStreamIdByTransactionId(long transactionId) {

--- a/src/EventStore.Core/Authorization/AllowAnonymousAssertion.cs
+++ b/src/EventStore.Core/Authorization/AllowAnonymousAssertion.cs
@@ -1,0 +1,17 @@
+﻿using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	internal class AllowAnonymousAssertion : IAssertion {
+		public Grant Grant { get; } = Grant.Allow;
+
+		public AssertionInformation Information { get; } =
+			new AssertionInformation("authenticated", "not anonymous", Grant.Unknown);
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			context.Add(new AssertionMatch(policy, new AssertionInformation("match", "allow anonymous", Grant.Allow)));
+			return new ValueTask<bool>(true);
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/AndAssertion.cs
+++ b/src/EventStore.Core/Authorization/AndAssertion.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	internal class AndAssertion : IAssertion {
+		private readonly ReadOnlyMemory<IAssertion> _assertions;
+		private readonly AssertionInformation _failedToMatchAllSubAssertions;
+
+		public AndAssertion(params IAssertion[] assertions) {
+			_assertions = assertions.OrderBy(x => x.Grant).ToArray();
+			_failedToMatchAllSubAssertions = new AssertionInformation("and",
+				$"({string.Join(",", _assertions.Span.ToArray().Select(x => x.ToString()))})", Grant.Deny);
+			Information = new AssertionInformation("and",
+				$"({string.Join(",", _assertions.ToArray().Select(x => x.ToString()))})", Grant.Unknown);
+		}
+
+		public AssertionInformation Information { get; }
+
+		public Grant Grant { get; } = Grant.Unknown;
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			var remaining = _assertions;
+			while (!remaining.IsEmpty && context.Grant != Grant.Deny) {
+				var pending = remaining.Span[0].Evaluate(cp, operation, policy, context);
+				remaining = remaining.Slice(1);
+				if (!pending.IsCompleted)
+					return EvaluateAsync(pending, remaining, cp, operation, policy, context);
+				if (!pending.Result) {
+					context.Add(new AssertionMatch(policy, _failedToMatchAllSubAssertions));
+					return new ValueTask<bool>(false);
+				}
+			}
+
+			return new ValueTask<bool>(true);
+		}
+
+		private async ValueTask<bool> EvaluateAsync(ValueTask<bool> pending, ReadOnlyMemory<IAssertion> remaining,
+			ClaimsPrincipal cp, Operation operation, PolicyInformation policy, EvaluationContext result) {
+			bool evaluated;
+			while ((evaluated = await pending.ConfigureAwait(false)) && !remaining.IsEmpty) {
+				pending = remaining.Span[0].Evaluate(cp, operation, policy, result);
+				remaining = remaining.Slice(1);
+			}
+
+			if (!evaluated)
+				result.Add(new AssertionMatch(policy, _failedToMatchAllSubAssertions));
+			return evaluated;
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/AssertionComparer.cs
+++ b/src/EventStore.Core/Authorization/AssertionComparer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace EventStore.Core.Authorization {
+	public sealed class AssertionComparer : IComparer<IAssertion> {
+		private static readonly MethodInfo OpenTypeComparer =
+			new Func<IAssertion, IAssertion, int>(Compare<object>).Method.GetGenericMethodDefinition();
+
+		private AssertionComparer() { }
+
+		public static IComparer<IAssertion> Instance { get; } = new AssertionComparer();
+
+		public int Compare(IAssertion x, IAssertion y) {
+			var grant = x.Grant.CompareTo(y.Grant);
+			if (grant != 0) return grant * -1;
+
+			var type = Comparer<Type>.Default.Compare(x.GetType(), y.GetType());
+			if (type != 0) return type;
+
+			var closed = (Func<IAssertion, IAssertion, int>)OpenTypeComparer.MakeGenericMethod(x.GetType())
+				.CreateDelegate(typeof(Func<IAssertion, IAssertion, int>));
+			return closed(x, y);
+		}
+
+		private static int Compare<T>(IAssertion x, IAssertion y) {
+			if (x is IComparable<T> comparable)
+				return comparable.CompareTo((T)y);
+			throw new NotSupportedException(
+				"Assertion classes must implement IComparable<T> where T is the Assertion class");
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/AssertionInformation.cs
+++ b/src/EventStore.Core/Authorization/AssertionInformation.cs
@@ -1,0 +1,15 @@
+﻿namespace EventStore.Core.Authorization {
+	public struct AssertionInformation {
+		public Grant Grant { get; }
+		private readonly string _assertion;
+
+		public AssertionInformation(string type, string assertion, Grant grant) {
+			Grant = grant;
+			_assertion = $"{type}:{assertion}:{grant}";
+		}
+
+		public override string ToString() {
+			return _assertion;
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/AssertionMatch.cs
+++ b/src/EventStore.Core/Authorization/AssertionMatch.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+
+namespace EventStore.Core.Authorization {
+	public readonly struct AssertionMatch {
+		public readonly PolicyInformation Policy;
+		public readonly AssertionInformation Assertion;
+		public readonly IReadOnlyList<Claim> Matches;
+
+		public AssertionMatch(PolicyInformation policy, AssertionInformation assertion, params Claim[] matches) : this(
+			policy, assertion, (IReadOnlyList<Claim>)matches) {
+		}
+
+		public AssertionMatch(PolicyInformation policy, AssertionInformation assertion, IReadOnlyList<Claim> matches) {
+			Policy = policy;
+			Assertion = assertion;
+			Matches = matches;
+		}
+
+		public override string ToString() {
+			return $"{Policy} : {Assertion}, ${string.Join(Environment.NewLine + "\t", Matches)}";
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/ClaimMatchAssertion.cs
+++ b/src/EventStore.Core/Authorization/ClaimMatchAssertion.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	public class ClaimMatchAssertion : IComparable<ClaimMatchAssertion>, IAssertion {
+		private readonly Claim _claim;
+
+		public ClaimMatchAssertion(Grant grant, Claim claim) {
+			_claim = claim;
+			Grant = grant;
+			Information = new AssertionInformation("equal", _claim.ToString(), grant);
+		}
+
+		public AssertionInformation Information { get; }
+
+		public Grant Grant { get; }
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			// ReSharper disable once PatternAlwaysOfType
+			if (cp.FindFirst(x =>
+				string.Equals(x.Type, _claim.Type, StringComparison.Ordinal) &&
+				string.Equals(x.Value, _claim.Value, StringComparison.Ordinal)) is Claim matched) {
+				context.Add(new AssertionMatch(policy, Information, matched));
+				return new ValueTask<bool>(true);
+			}
+
+			return new ValueTask<bool>(false);
+		}
+
+		public int CompareTo(ClaimMatchAssertion other) {
+			if (other == null)
+				throw new ArgumentNullException(nameof(other));
+
+			var grant = Grant.CompareTo(other.Grant);
+			if (grant != 0)
+				return grant * -1;
+			var type = string.CompareOrdinal(_claim.Type, other._claim.Type);
+			if (type != 0)
+				return type;
+			return string.CompareOrdinal(_claim.Value, other._claim.Value);
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/ClaimValueMatchesParameterValueAssertion.cs
+++ b/src/EventStore.Core/Authorization/ClaimValueMatchesParameterValueAssertion.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	public class ClaimValueMatchesParameterValueAssertion : IAssertion {
+		private readonly string _claimType;
+		private readonly string _parameterName;
+
+		public ClaimValueMatchesParameterValueAssertion(string claimType, string parameterName, Grant grant) {
+			_claimType = claimType;
+			_parameterName = parameterName;
+			Grant = grant;
+			Information = new AssertionInformation("match", $"{_claimType} : {_parameterName}", Grant);
+		}
+
+		public AssertionInformation Information { get; }
+		public Grant Grant { get; }
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			if (cp.FindFirst(_claimType) is Claim matchedClaim &&
+			    operation.Parameters.Span.Contains(new Parameter(_parameterName, matchedClaim.Value))) {
+				context.Add(new AssertionMatch(policy, Information, matchedClaim));
+				return new ValueTask<bool>(true);
+			}
+
+			return new ValueTask<bool>(false);
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/EvaluationContext.cs
+++ b/src/EventStore.Core/Authorization/EvaluationContext.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+
+namespace EventStore.Core.Authorization {
+	public class EvaluationContext {
+		private readonly List<AssertionMatch> _matches;
+		private readonly Operation _operation;
+
+		public EvaluationContext(Operation operation, CancellationToken cancellationToken) {
+			CancellationToken = cancellationToken;
+			_operation = operation;
+			_matches = new List<AssertionMatch>();
+			Grant = Grant.Unknown;
+		}
+
+		public CancellationToken CancellationToken { get; }
+		public Grant Grant { get; private set; }
+
+		public void Add(AssertionMatch match) {
+			if (match.Assertion.Grant > Grant)
+				Grant = match.Assertion.Grant;
+			_matches.Add(match);
+		}
+
+		public EvaluationResult ToResult() {
+			return new EvaluationResult(_operation, Grant, _matches);
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/EvaluationResult.cs
+++ b/src/EventStore.Core/Authorization/EvaluationResult.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EventStore.Core.Authorization {
+	public readonly struct EvaluationResult {
+		public readonly Grant Grant;
+		public readonly Operation Operation;
+		public readonly IReadOnlyList<AssertionMatch> Matches;
+
+		public EvaluationResult(Operation operation, Grant grant, params AssertionMatch[] matches) : this(operation,
+			grant, (IReadOnlyList<AssertionMatch>)matches) {
+		}
+
+		public EvaluationResult(Operation operation, Grant grant, IReadOnlyList<AssertionMatch> matches) {
+			Grant = grant;
+			Matches = matches;
+			Operation = operation;
+		}
+
+		public override string ToString() {
+			return $"{Operation} {Grant} : {string.Join(Environment.NewLine, Matches)}";
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/Grant.cs
+++ b/src/EventStore.Core/Authorization/Grant.cs
@@ -1,0 +1,7 @@
+﻿namespace EventStore.Core.Authorization {
+	public enum Grant {
+		Unknown = 0,
+		Allow = 1,
+		Deny = 2
+	}
+}

--- a/src/EventStore.Core/Authorization/IAssertion.cs
+++ b/src/EventStore.Core/Authorization/IAssertion.cs
@@ -1,0 +1,12 @@
+﻿using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	public interface IAssertion {
+		Grant Grant { get; }
+		AssertionInformation Information { get; }
+
+		ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context);
+	}
+}

--- a/src/EventStore.Core/Authorization/IAuthorizationProvider.cs
+++ b/src/EventStore.Core/Authorization/IAuthorizationProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	public interface IAuthorizationProvider {
+		ValueTask<bool> CheckAccessAsync(ClaimsPrincipal cp, Operation operation, CancellationToken ct);
+	}
+}

--- a/src/EventStore.Core/Authorization/IAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/IAuthorizationProviderFactory.cs
@@ -1,0 +1,7 @@
+﻿using EventStore.Core.Bus;
+
+namespace EventStore.Core.Authorization {
+	public interface IAuthorizationProviderFactory {
+		IAuthorizationProvider Build(IPublisher mainQueue);
+	}
+}

--- a/src/EventStore.Core/Authorization/IPolicyEvaluator.cs
+++ b/src/EventStore.Core/Authorization/IPolicyEvaluator.cs
@@ -1,0 +1,10 @@
+﻿using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	public interface IPolicyEvaluator {
+		ValueTask<EvaluationResult> EvaluateAsync(ClaimsPrincipal cp, Operation operation,
+			CancellationToken cancellationToken);
+	}
+}

--- a/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Security.Claims;
+using EventStore.Core.Bus;
+using EventStore.Core.Services;
+using Serilog;
+
+namespace EventStore.Core.Authorization {
+	public class LegacyAuthorizationProviderFactory : IAuthorizationProviderFactory {
+		private static readonly Claim[] Admins =
+			{new Claim(ClaimTypes.Role, SystemRoles.Admins), new Claim(ClaimTypes.Name, SystemUsers.Admin)};
+
+		private static readonly Claim[] OperationsOrAdmins = {
+			new Claim(ClaimTypes.Role, SystemRoles.Admins), new Claim(ClaimTypes.Name, SystemUsers.Admin),
+			new Claim(ClaimTypes.Role, SystemRoles.Operations), new Claim(ClaimTypes.Name, SystemUsers.Operations)
+		};
+
+		public IAuthorizationProvider Build(IPublisher mainQueue) {
+			var policy = new Policy("Legacy", 1, DateTimeOffset.MinValue);
+			var streamAssertion = new LegacyStreamPermissionAssertion(mainQueue);
+
+			policy.AllowAnonymous(Operations.Node.Redirect);
+			policy.AllowAnonymous(Operations.Node.StaticContent);
+			policy.AllowAnonymous(Operations.Node.Ping);
+			policy.AllowAnonymous(Operations.Node.Options);
+
+			policy.AllowAnonymous(Operations.Node.Information.Read);
+			policy.AddMatchAnyAssertion(Operations.Node.Information.Subsystems, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.Information.Histogram, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.Information.Options, Grant.Allow, OperationsOrAdmins);
+
+			policy.AllowAnonymous(Operations.Node.Statistics.Read);
+			policy.AllowAnonymous(Operations.Node.Statistics.Replication);
+			policy.AllowAnonymous(Operations.Node.Statistics.Tcp);
+			policy.AllowAnonymous(Operations.Node.Statistics.Custom);
+
+			policy.AllowAnonymous(Operations.Node.Elections.Prepare);
+			policy.AllowAnonymous(Operations.Node.Elections.PrepareOk);
+			policy.AllowAnonymous(Operations.Node.Elections.ViewChange);
+			policy.AllowAnonymous(Operations.Node.Elections.ViewChangeProof);
+			policy.AllowAnonymous(Operations.Node.Elections.Proposal);
+			policy.AllowAnonymous(Operations.Node.Elections.Accept);
+			policy.AllowAnonymous(Operations.Node.Elections.LeaderIsResigning);
+			policy.AllowAnonymous(Operations.Node.Elections.LeaderIsResigningOk);
+
+			policy.AllowAnonymous(Operations.Node.Gossip.Read);
+			policy.AllowAnonymous(Operations.Node.Gossip.Update);
+
+			policy.AddMatchAnyAssertion(Operations.Node.Shutdown, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.MergeIndexes, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.SetPriority, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.Resign, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.Scavenge.Start, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.Scavenge.Stop, Grant.Allow, OperationsOrAdmins);
+
+			var subscriptionAccess =
+				new AndAssertion(
+					new RequireAuthenticatedAssertion(),
+					new RequireStreamReadAssertion(streamAssertion));
+
+			policy.RequireAuthenticated(Operations.Subscriptions.Statistics);
+			policy.AddMatchAnyAssertion(Operations.Subscriptions.Create, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Subscriptions.Update, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Subscriptions.Delete, Grant.Allow, OperationsOrAdmins);
+			policy.Add(Operations.Subscriptions.ProcessMessages, subscriptionAccess);
+			policy.AddMatchAnyAssertion(Operations.Subscriptions.ReplayParked, Grant.Allow, OperationsOrAdmins);
+
+			policy.Add(Operations.Streams.Read, streamAssertion);
+			policy.Add(Operations.Streams.Write, streamAssertion);
+			policy.Add(Operations.Streams.Delete, streamAssertion);
+			policy.Add(Operations.Streams.MetadataRead, streamAssertion);
+			policy.Add(Operations.Streams.MetadataWrite, streamAssertion);
+
+			var matchUsername = new ClaimValueMatchesParameterValueAssertion(ClaimTypes.Name,
+				Operations.Users.Parameters.UserParameterName, Grant.Allow);
+			var isAdmin = new MultipleClaimMatchAssertion(Grant.Allow, MultipleMatchMode.Any, Admins);
+			policy.Add(Operations.Users.List, isAdmin);
+			policy.Add(Operations.Users.Create, isAdmin);
+			policy.Add(Operations.Users.Delete, isAdmin);
+			policy.Add(Operations.Users.Update, isAdmin);
+			policy.Add(Operations.Users.Enable, isAdmin);
+			policy.Add(Operations.Users.Disable, isAdmin);
+			policy.Add(Operations.Users.ResetPassword, isAdmin);
+			policy.RequireAuthenticated(Operations.Users.CurrentUser);
+			policy.Add(Operations.Users.Read, new OrAssertion(isAdmin, matchUsername));
+			policy.Add(Operations.Users.ChangePassword, matchUsername);
+
+
+			policy.RequireAuthenticated(Operations.Projections.List);
+
+			policy.RequireAuthenticated(Operations.Projections.Abort);
+			policy.RequireAuthenticated(Operations.Projections.Create);
+			policy.RequireAuthenticated(Operations.Projections.DebugProjection);
+			policy.AddMatchAnyAssertion(Operations.Projections.Delete, Grant.Allow, OperationsOrAdmins);
+			policy.RequireAuthenticated(Operations.Projections.Disable);
+			policy.RequireAuthenticated(Operations.Projections.Enable);
+			policy.RequireAuthenticated(Operations.Projections.Read);
+			policy.AddMatchAnyAssertion(Operations.Projections.ReadConfiguration, Grant.Allow, OperationsOrAdmins);
+			policy.RequireAuthenticated(Operations.Projections.Reset);
+			policy.RequireAuthenticated(Operations.Projections.Update);
+			policy.AddMatchAnyAssertion(Operations.Projections.UpdateConfiguration, Grant.Allow, OperationsOrAdmins);
+			policy.RequireAuthenticated(Operations.Projections.State);
+			policy.RequireAuthenticated(Operations.Projections.Status);
+			policy.RequireAuthenticated(Operations.Projections.Statistics);
+			policy.AddMatchAnyAssertion(Operations.Projections.Restart, Grant.Allow, Admins);
+
+			return new PolicyAuthorizationProvider(new PolicyEvaluator(policy.AsReadOnly()),
+				Log.ForContext<PolicyEvaluator>(), true, false);
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/LegacyStreamPermissionAssertion.cs
+++ b/src/EventStore.Core/Authorization/LegacyStreamPermissionAssertion.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services;
+
+namespace EventStore.Core.Authorization {
+	public class
+		LegacyStreamPermissionAssertion : IAssertion {
+		private readonly IPublisher _publisher;
+
+		public LegacyStreamPermissionAssertion(IPublisher publisher) {
+			_publisher = publisher;
+		}
+
+		public AssertionInformation Information { get; } =
+			new AssertionInformation("stream", "legacy acl", Grant.Unknown);
+
+		public Grant Grant { get; } = Grant.Unknown;
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			var streamId = FindStreamId(operation.Parameters.Span, context.CancellationToken);
+
+			if (streamId.IsCompleted)
+				return CheckStreamAccess(cp, operation, policy, context, streamId.Result);
+			return CheckStreamAccessAsync(streamId, cp, operation, policy, context);
+		}
+
+		private async ValueTask<bool> CheckStreamAccessAsync(ValueTask<string> pending, ClaimsPrincipal cp,
+			Operation operation, PolicyInformation policy, EvaluationContext result) {
+			var streamId = await pending.ConfigureAwait(false);
+			return await CheckStreamAccess(cp, operation, policy, result, streamId).ConfigureAwait(false);
+		}
+
+		private ValueTask<bool> CheckStreamAccess(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context, string streamId) {
+			if (streamId == null) {
+				context.Add(new AssertionMatch(policy,
+					new AssertionInformation("streamId", "streamId is null", Grant.Deny)));
+				return new ValueTask<bool>(true);
+			}
+
+			if (streamId == "")
+				streamId = SystemStreams.AllStream;
+			if (streamId == SystemStreams.AllStream &&
+			    (operation == Operations.Streams.Delete || operation == Operations.Streams.Write)) {
+				context.Add(new AssertionMatch(policy,
+					new AssertionInformation("streamId", $"{operation.Action} denied on $all", Grant.Deny)));
+				return new ValueTask<bool>(true);
+			}
+
+			var action = operation.Action;
+			if (SystemStreams.IsMetastream(streamId)) {
+				action = operation.Action switch {
+					"read" => "metadataRead",
+					"write" => "metadataWrite",
+					_ => null
+				};
+				streamId = SystemStreams.OriginalStreamOf(streamId);
+			}
+
+			return action switch {
+				"read" => Check(cp, operation, action, streamId, policy, context),
+				"write" => Check(cp, operation, action, streamId, policy, context),
+				"delete" => Check(cp, operation, action, streamId, policy, context),
+				"metadataWrite" => Check(cp, operation, action, streamId, policy, context),
+				"metadataRead" => Check(cp, operation, action, streamId, policy, context),
+				null => InvalidMetadataOperation(operation, policy, context),
+				_ => throw new ArgumentOutOfRangeException(nameof(operation.Action), action)
+			};
+		}
+
+		private ValueTask<bool> Check(ClaimsPrincipal cp, Operation operation, string action, string streamId,
+			PolicyInformation policy, EvaluationContext context) {
+			var preChecks = IsSystemOrAdmin(cp, operation, policy, context);
+			if (preChecks.IsCompleted && preChecks.Result) return preChecks;
+
+			return CheckAsync(preChecks, cp, action, streamId, policy, context);
+		}
+
+		private ValueTask<bool> IsSystemOrAdmin(ClaimsPrincipal cp, Operation operation,
+			PolicyInformation policy, EvaluationContext context) {
+			var isSystem = WellKnownAssertions.System.Evaluate(cp, operation, policy, context);
+			if (isSystem.IsCompleted) {
+				if (isSystem.Result)
+					return isSystem;
+				return WellKnownAssertions.Admin.Evaluate(cp, operation, policy, context);
+			}
+
+			// This should never be run, but is required for the compilation to be reasonable
+			return IsSystemOrAdminAsync(isSystem, cp, operation, policy, context);
+		}
+
+		private async ValueTask<bool> IsSystemOrAdminAsync(ValueTask<bool> isSystem, ClaimsPrincipal cp,
+			Operation operation,
+			PolicyInformation policy, EvaluationContext context) {
+			if (await isSystem.ConfigureAwait(false)) return true;
+
+			return await WellKnownAssertions.Admin.Evaluate(cp, operation, policy, context).ConfigureAwait(false);
+		}
+
+		private async ValueTask<bool> CheckAsync(ValueTask<bool> preChecks, ClaimsPrincipal cp, string action,
+			string streamId, PolicyInformation policy, EvaluationContext context) {
+			var isSystemOrAdmin = await preChecks.ConfigureAwait(false);
+			if (isSystemOrAdmin)
+				return true;
+			var acl = await StorageMessage.EffectiveAcl.LoadAsync(_publisher, streamId, context.CancellationToken)
+				.ConfigureAwait(false);
+			var roles = RolesFor(action, acl);
+			if (roles.Any(x => x == SystemRoles.All)) {
+				context.Add(new AssertionMatch(policy,
+					new AssertionInformation("stream", "public stream", Grant.Allow)));
+				return true;
+			}
+
+			for (int i = 0; i < roles.Length; i++) {
+				var role = roles[i];
+				if (cp.FindFirst(x => (x.Type == ClaimTypes.Name || x.Type == ClaimTypes.Role) && x.Value == role)
+					is Claim matched) {
+					context.Add(new AssertionMatch(policy, new AssertionInformation("role match", role, Grant.Allow),
+						matched));
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private ValueTask<bool> InvalidMetadataOperation(Operation operation, PolicyInformation policy,
+			EvaluationContext result) {
+			result.Add(new AssertionMatch(policy,
+				new AssertionInformation("metadata", $"invalid metadata operation {operation.Action}",
+					Grant.Deny)));
+			return new ValueTask<bool>(true);
+		}
+
+		private ValueTask<string> FindStreamId(ReadOnlySpan<Parameter> parameters,
+			CancellationToken cancellationToken) {
+			string transactionId = null;
+			for (int i = 0; i < parameters.Length; i++) {
+				if (parameters[i].Name == "streamId")
+					return new ValueTask<string>(parameters[i].Value);
+				if (parameters[i].Name == "transactionId")
+					transactionId = parameters[i].Value;
+			}
+
+			if (transactionId != null) return FindStreamFromTransactionId(long.Parse(transactionId), cancellationToken);
+			return new ValueTask<string>((string)null);
+		}
+
+		private ValueTask<string> FindStreamFromTransactionId(long transactionId, CancellationToken cancellationToken) {
+			var envelope = new StreamIdFromTransactionIdEnvelope();
+			_publisher.Publish(
+				new StorageMessage.StreamIdFromTransactionIdRequest(transactionId, envelope, cancellationToken));
+			return new ValueTask<string>(envelope.Task);
+		}
+
+		private string[] RolesFor(string action, StorageMessage.EffectiveAcl acl) {
+			return action switch {
+				"read" => acl.Stream?.ReadRoles ?? acl.System?.ReadRoles ?? acl.Default?.ReadRoles,
+				"write" => acl.Stream?.WriteRoles ?? acl.System?.WriteRoles ?? acl.Default?.WriteRoles,
+				"delete" => acl.Stream?.DeleteRoles ?? acl.System?.DeleteRoles ?? acl.Default?.DeleteRoles,
+				"metadataRead" => acl.Stream?.MetaReadRoles ?? acl.System?.MetaReadRoles ?? acl.Default?.MetaReadRoles,
+				"metadataWrite" => acl.Stream?.MetaWriteRoles ??
+				                   acl.System?.MetaWriteRoles ?? acl.Default?.MetaWriteRoles,
+				_ => Array.Empty<string>()
+			};
+		}
+
+		private class StreamIdFromTransactionIdEnvelope : IEnvelope {
+			private readonly TaskCompletionSource<string> _tcs;
+
+			public StreamIdFromTransactionIdEnvelope() {
+				_tcs = new TaskCompletionSource<string>();
+			}
+
+			public Task<string> Task => _tcs.Task;
+
+			public void ReplyWith<T>(T message) where T : Message {
+				if (message is StorageMessage.StreamIdFromTransactionIdResponse response)
+					_tcs.TrySetResult(response.StreamId);
+				else if (message is StorageMessage.OperationCancelledMessage cancelled)
+					_tcs.TrySetCanceled(cancelled.CancellationToken);
+				else
+					_tcs.TrySetException(new InvalidOperationException($"Wrong message type {message.GetType()}"));
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/MultipleClaimMatchAssertion.cs
+++ b/src/EventStore.Core/Authorization/MultipleClaimMatchAssertion.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	public class MultipleClaimMatchAssertion : IComparable<MultipleClaimMatchAssertion>, IAssertion {
+		private readonly IReadOnlyList<Claim> _claims;
+		private readonly MultipleMatchMode _mode;
+
+		public MultipleClaimMatchAssertion(Grant grant, MultipleMatchMode mode, params Claim[] claims) {
+			if (claims.Length == 0) throw new ArgumentException("Value cannot be an empty collection.", nameof(claims));
+
+
+			_mode = mode;
+			Grant = grant;
+			_claims = claims.OrderBy(x => x.Type).ToArray();
+			var sb = new StringBuilder();
+			foreach (var claim in _claims) sb.AppendLine($"{claim.Type} {claim.Value}");
+
+			var assertion = sb.ToString();
+			Information = mode switch {
+				MultipleMatchMode.All => new AssertionInformation("all", assertion, grant),
+				MultipleMatchMode.Any => new AssertionInformation("any", assertion, Grant),
+				MultipleMatchMode.None => new AssertionInformation("none", assertion, Grant),
+				_ => throw new ArgumentOutOfRangeException(nameof(mode))
+			};
+		}
+
+		public AssertionInformation Information { get; }
+
+		public Grant Grant { get; }
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			var matches = new List<Claim>(_claims.Count);
+
+			foreach (var claim in _claims)
+				if (cp.FindFirst(x =>
+					string.Equals(x.Type, claim.Type, StringComparison.Ordinal) &&
+					string.Equals(x.Value, claim.Value, StringComparison.Ordinal)) is Claim matched) {
+					matches.Add(matched);
+					if (_mode != MultipleMatchMode.All) break;
+				}
+
+			var matchFound = false;
+			switch (_mode) {
+				case MultipleMatchMode.All:
+					if (matches.Count == _claims.Count) {
+						context.Add(new AssertionMatch(policy, Information, matches));
+						matchFound = true;
+					}
+
+					break;
+				case MultipleMatchMode.Any:
+					if (matches.Count > 0) {
+						context.Add(new AssertionMatch(policy, Information, matches));
+						matchFound = true;
+					}
+
+					break;
+				case MultipleMatchMode.None:
+					if (matches.Count == 0) {
+						context.Add(new AssertionMatch(policy, Information, matches));
+						matchFound = true;
+					}
+
+					break;
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+
+
+			return new ValueTask<bool>(matchFound);
+		}
+
+
+		public int CompareTo(MultipleClaimMatchAssertion other) {
+			var grant = Grant.CompareTo(other.Grant);
+			if (grant != 0)
+				return grant * -1;
+			var length = Comparer<int>.Default.Compare(_claims.Count, other._claims.Count);
+			if (length != 0)
+				return length;
+			for (int i = 0; i < _claims.Count; i++) {
+				var type = string.CompareOrdinal(_claims[i].Type, other._claims[i].Type);
+				if (type != 0)
+					return type;
+				var value = string.CompareOrdinal(_claims[i].Value, other._claims[i].Value);
+				if (value != 0)
+					return value;
+			}
+
+			return 0;
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/MultipleMatchMode.cs
+++ b/src/EventStore.Core/Authorization/MultipleMatchMode.cs
@@ -1,0 +1,7 @@
+﻿namespace EventStore.Core.Authorization {
+	public enum MultipleMatchMode {
+		All,
+		Any,
+		None
+	}
+}

--- a/src/EventStore.Core/Authorization/Operation.cs
+++ b/src/EventStore.Core/Authorization/Operation.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Text;
+
+namespace EventStore.Core.Authorization {
+	public readonly struct Operation {
+		public string Resource { get; }
+		public string Action { get; }
+		public ReadOnlyMemory<Parameter> Parameters { get; }
+
+		public Operation(OperationDefinition definition) : this(definition.Resource, definition.Action) {
+		}
+
+		public Operation(string resource, string action) : this(resource, action, Array.Empty<Parameter>()) { }
+
+		public Operation WithParameter(string name, string value) {
+			return WithParameters(new Parameter(name, value));
+		}
+
+		public Operation WithParameter(Parameter parameter) {
+			return WithParameters(parameter);
+		}
+
+		public Operation WithParameters(ReadOnlyMemory<Parameter> parameters) {
+			var memory = new Memory<Parameter>(new Parameter[Parameters.Length + parameters.Length]);
+			if (!Parameters.IsEmpty) Parameters.CopyTo(memory);
+			parameters.CopyTo(memory.Slice(Parameters.Length));
+			return new Operation(Resource, Action, memory);
+		}
+
+		public Operation WithParameters(params Parameter[] parameters) {
+			return WithParameters(new ReadOnlyMemory<Parameter>(parameters));
+		}
+
+		public Operation(string resource, string action, Memory<Parameter> parameters) {
+			Resource = resource;
+			Action = action;
+			Parameters = parameters;
+		}
+
+		public static implicit operator OperationDefinition(Operation operation) {
+			return new OperationDefinition(operation.Resource, operation.Action);
+		}
+
+		public override string ToString() {
+			var sb = new StringBuilder();
+			sb.Append($"{Resource} : {Action}");
+			var parameters = Parameters.Span;
+			if (!parameters.IsEmpty) {
+				sb.Append(" p: {");
+				while (!parameters.IsEmpty) {
+					sb.Append($"{parameters[0].Name} : {parameters[0].Value}");
+					parameters = parameters.Slice(1);
+				}
+
+				sb.Append("}");
+			}
+
+			return sb.ToString();
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/OperationDefinition.cs
+++ b/src/EventStore.Core/Authorization/OperationDefinition.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace EventStore.Core.Authorization {
+	public readonly struct OperationDefinition : IEquatable<OperationDefinition> {
+		public string Resource { get; }
+		public string Action { get; }
+
+		public OperationDefinition(string resource, string action) {
+			Resource = resource;
+			Action = action;
+		}
+
+		public bool Equals(OperationDefinition other) {
+			return Resource == other.Resource && Action == other.Action;
+		}
+
+		public override bool Equals(object obj) {
+			return obj is OperationDefinition other && Equals(other);
+		}
+
+		public override int GetHashCode() {
+			unchecked {
+				return (Resource.GetHashCode() * 397) ^ Action.GetHashCode();
+			}
+		}
+
+		public static bool operator ==(OperationDefinition left, OperationDefinition right) {
+			return left.Equals(right);
+		}
+
+		public static bool operator !=(OperationDefinition left, OperationDefinition right) {
+			return !left.Equals(right);
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/Operations.cs
+++ b/src/EventStore.Core/Authorization/Operations.cs
@@ -1,0 +1,187 @@
+﻿namespace EventStore.Core.Authorization {
+	public static class Operations {
+		public static class Node {
+			private const string Resource = "node";
+			public static readonly OperationDefinition Redirect = new Operation(Resource, "redirect");
+			public static readonly OperationDefinition Options = new Operation(Resource, "options");
+			public static readonly OperationDefinition Ping = new Operation(Resource, "ping");
+
+			public static readonly OperationDefinition StaticContent =
+				new OperationDefinition(Resource + "/content", "read");
+
+			public static readonly OperationDefinition Shutdown = new OperationDefinition(Resource, "shutdown");
+			public static readonly OperationDefinition MergeIndexes = new OperationDefinition(Resource, "mergeIndexes");
+			public static readonly OperationDefinition SetPriority = new OperationDefinition(Resource, "setPriority");
+			public static readonly OperationDefinition Resign = new OperationDefinition(Resource, "resign");
+
+			public static class Scavenge {
+				private const string Resource = Node.Resource + "/scavenge";
+				public static readonly OperationDefinition Start = new OperationDefinition(Resource, "start");
+				public static readonly OperationDefinition Stop = new OperationDefinition(Resource, "stop");
+			}
+
+
+			public static class Information {
+				private const string Resource = Node.Resource + "/info";
+
+				public static readonly OperationDefinition Subsystems =
+					new OperationDefinition(Resource + "/subsystems", "read");
+
+				public static readonly OperationDefinition Histogram =
+					new OperationDefinition(Resource + "/histograms", "read");
+
+				public static readonly OperationDefinition Read = new OperationDefinition(Resource, "read");
+
+				public static readonly OperationDefinition Options =
+					new OperationDefinition(Resource + "/options", "read");
+			}
+
+			public static class Statistics {
+				private const string Resource = Node.Resource + "/stats";
+				public static readonly OperationDefinition Read = new OperationDefinition(Resource, "read");
+
+				public static readonly OperationDefinition Replication =
+					new OperationDefinition(Resource + "/replication", "read");
+
+				public static readonly OperationDefinition Tcp = new OperationDefinition(Resource + "/tcp", "read");
+
+				public static readonly OperationDefinition Custom =
+					new OperationDefinition(Resource + "/custom", "read");
+			}
+
+			public static class Elections {
+				private const string Resource = Node.Resource + "/elections";
+				public static readonly OperationDefinition ViewChange = new OperationDefinition(Resource, "viewchange");
+
+				public static readonly OperationDefinition ViewChangeProof =
+					new OperationDefinition(Resource, "viewchangeproof");
+
+				public static readonly OperationDefinition Prepare = new OperationDefinition(Resource, "prepare");
+				public static readonly OperationDefinition PrepareOk = new OperationDefinition(Resource, "prepareOk");
+				public static readonly OperationDefinition Proposal = new OperationDefinition(Resource, "proposal");
+				public static readonly OperationDefinition Accept = new OperationDefinition(Resource, "accept");
+
+				public static readonly OperationDefinition LeaderIsResigning =
+					new OperationDefinition(Resource, "leaderisresigning");
+
+				public static readonly OperationDefinition LeaderIsResigningOk =
+					new OperationDefinition(Resource, "leaderisresigningok");
+			}
+
+			public static class Gossip {
+				private const string Resource = Node.Resource + "/gossip";
+				public static readonly OperationDefinition Read = new OperationDefinition(Resource, "read");
+				public static readonly OperationDefinition Update = new OperationDefinition(Resource, "update");
+			}
+		}
+
+		public static class Streams {
+			private const string Resource = "streams";
+			public static readonly OperationDefinition Read = new OperationDefinition(Resource, "read");
+			public static readonly OperationDefinition Write = new OperationDefinition(Resource, "write");
+			public static readonly OperationDefinition Delete = new OperationDefinition(Resource, "delete");
+			public static readonly OperationDefinition MetadataRead = new OperationDefinition(Resource, "metadataRead");
+
+			public static readonly OperationDefinition MetadataWrite =
+				new OperationDefinition(Resource, "metadataWrite");
+
+			public static class Parameters {
+				public static Parameter StreamId(string streamId) => new Parameter("streamId", streamId);
+
+				public static Parameter TransactionId(long transactionId) =>
+					new Parameter("transactionId", transactionId.ToString("D"));
+			}
+		}
+
+		public static class Subscriptions {
+			private const string Resource = "subscriptions";
+			public static readonly OperationDefinition Statistics = new OperationDefinition(Resource, "statistics");
+			public static readonly OperationDefinition Create = new OperationDefinition(Resource, "create");
+			public static readonly OperationDefinition Update = new OperationDefinition(Resource, "update");
+			public static readonly OperationDefinition Delete = new OperationDefinition(Resource, "delete");
+			public static readonly OperationDefinition ReplayParked = new OperationDefinition(Resource, "replay");
+
+			public static readonly OperationDefinition ProcessMessages = new OperationDefinition(Resource, "process");
+
+
+			public static class Parameters {
+				public static Parameter SubscriptionId(string id) => new Parameter("subscriptionId", id);
+				public static Parameter StreamId(string streamId) => new Parameter("streamId", streamId);
+			}
+		}
+
+		public static class Users {
+			private const string Resource = "users";
+			public static readonly OperationDefinition Create = new OperationDefinition(Resource, "create");
+			public static readonly OperationDefinition Update = new OperationDefinition(Resource, "update");
+			public static readonly OperationDefinition Delete = new OperationDefinition(Resource, "delete");
+			public static readonly OperationDefinition List = new OperationDefinition(Resource, "list");
+			public static readonly OperationDefinition Read = new OperationDefinition(Resource, "read");
+			public static readonly OperationDefinition CurrentUser = new OperationDefinition(Resource, "self");
+			public static readonly OperationDefinition Enable = new OperationDefinition(Resource, "enable");
+			public static readonly OperationDefinition Disable = new OperationDefinition(Resource, "disable");
+
+			public static readonly OperationDefinition ResetPassword =
+				new OperationDefinition(Resource, "resetPassword");
+
+			public static readonly OperationDefinition ChangePassword =
+				new OperationDefinition(Resource, "updatePassword");
+
+			public static class Parameters {
+				public const string UserParameterName = "user";
+
+				public static Parameter User(string userId) {
+					return new Parameter(UserParameterName, userId);
+				}
+			}
+		}
+
+		public static class Projections {
+			private const string Resource = "projections";
+
+			public static readonly OperationDefinition Create = new OperationDefinition(Resource, "create");
+			public static readonly OperationDefinition Update = new OperationDefinition(Resource, "update");
+			public static readonly OperationDefinition Read = new OperationDefinition(Resource, "read");
+
+			public static readonly OperationDefinition Abort = new OperationDefinition(Resource, "abort");
+
+			public static readonly OperationDefinition List = new OperationDefinition(Resource, "list");
+			public static readonly OperationDefinition Restart = new OperationDefinition(Resource, "restart");
+			public static readonly OperationDefinition Delete = new OperationDefinition(Resource, "delete");
+			public static readonly OperationDefinition Enable = new OperationDefinition(Resource, "enable");
+			public static readonly OperationDefinition Disable = new OperationDefinition(Resource, "disable");
+			public static readonly OperationDefinition Reset = new OperationDefinition(Resource, "reset");
+
+			public static readonly OperationDefinition ReadConfiguration =
+				new OperationDefinition(Resource + "/configuration", "read");
+
+			public static readonly OperationDefinition UpdateConfiguration =
+				new OperationDefinition(Resource + "/configuration", "update");
+
+			public static readonly OperationDefinition Status = new OperationDefinition(Resource, "status");
+
+			//can be Partition based
+			public static readonly OperationDefinition State = new OperationDefinition(Resource, "state");
+			public static readonly OperationDefinition Result = new OperationDefinition(Resource, "state");
+
+			public static readonly OperationDefinition Statistics = new OperationDefinition(Resource, "statistics");
+
+			//This one is a bit weird
+			public static readonly OperationDefinition DebugProjection = new OperationDefinition(Resource, "debug");
+
+			public static class Parameters {
+				public static readonly Parameter Query = new Parameter("projectionType", "query");
+				public static readonly Parameter OneTime = new Parameter("projectionType", "onetime");
+				public static readonly Parameter Continuous = new Parameter("projectionType", "continuous");
+
+				public static Parameter Projection(string name) {
+					return new Parameter("projection", name);
+				}
+
+				public static Parameter RunAs(string name) {
+					return new Parameter("runas", name);
+				}
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/OrAssertion.cs
+++ b/src/EventStore.Core/Authorization/OrAssertion.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	internal class OrAssertion : IAssertion {
+		private readonly ReadOnlyMemory<IAssertion> _assertions;
+
+		public OrAssertion(params IAssertion[] assertions) {
+			_assertions = assertions.OrderBy(x => x.Grant).ToArray();
+			Information = new AssertionInformation("or", $"({string.Join(",", _assertions)})", Grant.Unknown);
+		}
+
+		public AssertionInformation Information { get; }
+
+		public Grant Grant { get; } = Grant.Unknown;
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			var remaining = _assertions;
+			while (!remaining.IsEmpty && context.Grant != Grant.Deny) {
+				var pending = remaining.Span[0].Evaluate(cp, operation, policy, context);
+				remaining = remaining.Slice(1);
+				if (!pending.IsCompleted)
+					return EvaluateAsync(pending, remaining, cp, operation, policy, context);
+				if (pending.Result) return new ValueTask<bool>(true);
+			}
+
+			return new ValueTask<bool>(false);
+		}
+
+		private async ValueTask<bool> EvaluateAsync(ValueTask<bool> pending, ReadOnlyMemory<IAssertion> remaining,
+			ClaimsPrincipal cp, Operation operation, PolicyInformation policy, EvaluationContext result) {
+			bool evaluated;
+			while (!(evaluated = await pending.ConfigureAwait(false)) && !remaining.IsEmpty) {
+				pending = remaining.Span[0].Evaluate(cp, operation, policy, result);
+				remaining = remaining.Slice(1);
+			}
+
+			return evaluated;
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/Parameter.cs
+++ b/src/EventStore.Core/Authorization/Parameter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace EventStore.Core.Authorization {
+	public readonly struct Parameter : IEquatable<Parameter> {
+		public Parameter(string name, string value) {
+			Name = name ?? throw new ArgumentNullException(nameof(name));
+			Value = value ?? throw new ArgumentNullException(nameof(value));
+		}
+
+		public string Name { get; }
+		public string Value { get; }
+
+		public bool Equals(Parameter other) {
+			return Name == other.Name && Value == other.Value;
+		}
+
+		public override bool Equals(object obj) {
+			return obj is Parameter other && Equals(other);
+		}
+
+		public override int GetHashCode() {
+			unchecked {
+				return (Name.GetHashCode() * 397) ^ Value.GetHashCode();
+			}
+		}
+
+		public static bool operator ==(Parameter left, Parameter right) {
+			return left.Equals(right);
+		}
+
+		public static bool operator !=(Parameter left, Parameter right) {
+			return !left.Equals(right);
+		}
+
+		public override string ToString() {
+			return $"{Name} : {Value}";
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/Policy.cs
+++ b/src/EventStore.Core/Authorization/Policy.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+
+namespace EventStore.Core.Authorization {
+	public class Policy {
+		private readonly Dictionary<OperationDefinition, List<IAssertion>> _assertions;
+		private readonly long _version;
+		private bool _sealed;
+
+		public Policy(string name, long version, DateTimeOffset validFrom) {
+			_version = version;
+			Name = name;
+			ValidFrom = validFrom;
+			_assertions = new Dictionary<OperationDefinition, List<IAssertion>>();
+			_sealed = false;
+		}
+
+		public string Name { get; }
+		public DateTimeOffset ValidFrom { get; }
+
+		public void AddMatchAnyAssertion(OperationDefinition operation, Grant grant, params Claim[] claims) {
+			var assertion = new MultipleClaimMatchAssertion(grant, MultipleMatchMode.Any, claims);
+			Add(operation, assertion);
+		}
+
+		public void AddClaimMatchAssertion(OperationDefinition operation, Grant grant, Claim claim) {
+			var assertion = new ClaimMatchAssertion(grant, claim);
+			Add(operation, assertion);
+		}
+
+		public void Add(OperationDefinition operation, IAssertion assertion) {
+			if (_sealed)
+				throw new InvalidOperationException("policy has been sealed and no further changes can be made");
+			if (!_assertions.TryGetValue(operation, out var assertions))
+				_assertions[operation] = assertions = new List<IAssertion>();
+			var insertAt = assertions.BinarySearch(assertion, AssertionComparer.Instance);
+			if (insertAt >= 0)
+				throw new InvalidOperationException("Assertion already exists");
+			assertions.Insert(~insertAt, assertion);
+		}
+
+		public ReadOnlyPolicy AsReadOnly() {
+			_sealed = true;
+			return new ReadOnlyPolicy(Name, _version, ValidFrom,
+				_assertions
+					.ToDictionary<KeyValuePair<OperationDefinition, List<IAssertion>>, OperationDefinition,
+						ReadOnlyMemory<IAssertion>>(x => x.Key, x => x.Value.ToArray()));
+		}
+
+		public void AllowAnonymous(in OperationDefinition operation) {
+			Add(operation, new AllowAnonymousAssertion());
+		}
+
+		public void RequireAuthenticated(in OperationDefinition operation) {
+			Add(operation, new RequireAuthenticatedAssertion());
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/PolicyAuthorizationProvider.cs
+++ b/src/EventStore.Core/Authorization/PolicyAuthorizationProvider.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Services.UserManagement;
+using Serilog;
+
+namespace EventStore.Core.Authorization {
+	public class PolicyAuthorizationProvider : IAuthorizationProvider {
+		private static readonly Stopwatch sw = Stopwatch.StartNew();
+		private readonly bool _logAuthorization;
+		private readonly ILogger _logger;
+		private readonly bool _logSuccesses;
+		private readonly IPolicyEvaluator _policyEvaluator;
+
+		public PolicyAuthorizationProvider(IPolicyEvaluator policyEvaluator, ILogger logger, bool logAuthorization,
+			bool logSuccesses) {
+			_policyEvaluator = policyEvaluator;
+			_logger = logger;
+			_logAuthorization = logAuthorization;
+			_logSuccesses = logSuccesses;
+		}
+
+		public ValueTask<bool> CheckAccessAsync(ClaimsPrincipal cp, Operation operation, CancellationToken ct) {
+			if (cp == null) cp = SystemAccounts.Anonymous;
+
+			try {
+				var startedAt = sw.Elapsed;
+				var evaluationTask = _policyEvaluator.EvaluateAsync(cp, operation, ct);
+				if (evaluationTask.IsCompleted)
+					return new ValueTask<bool>(LogAndCheck(startedAt, cp, evaluationTask.Result));
+
+				return CheckAccessAsync(startedAt, cp, evaluationTask);
+			} catch (Exception ex) {
+				_logger.Error(ex, "Error performing permission check for {identity}",
+					cp.FindFirst(ClaimTypes.Name)?.Value ?? "unknown");
+				return new ValueTask<bool>(false);
+			}
+		}
+
+		private async ValueTask<bool> CheckAccessAsync(TimeSpan startedAt, ClaimsPrincipal cp,
+			ValueTask<EvaluationResult> evaluationTask) {
+			try {
+				return LogAndCheck(startedAt, cp, await evaluationTask.ConfigureAwait(false));
+			} catch (Exception ex) {
+				_logger.Error(ex, "Error performing permission check for {identity}",
+					cp.FindFirst(ClaimTypes.Name)?.Value ?? "unknown");
+				return false;
+			}
+		}
+
+		private bool LogAndCheck(TimeSpan startedAt, ClaimsPrincipal cp, EvaluationResult result) {
+			if (_logAuthorization) {
+				if (result.Grant == Grant.Allow && _logSuccesses)
+					_logger.Information(
+						"Successful authorization check for {identity} in {duration} with {evaluationResult}",
+						cp.FindFirst(ClaimTypes.Name).Value, sw.Elapsed.Subtract(startedAt), result);
+				else if (result.Grant != Grant.Allow)
+					_logger.Warning("Failed authorization check for {identity} in {duration} with {evaluationResult}",
+						cp.FindFirst(ClaimTypes.Name)?.Value ?? "(anonymous)", startedAt, result);
+			}
+
+			return result.Grant == Grant.Allow;
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/PolicyEvaluator.cs
+++ b/src/EventStore.Core/Authorization/PolicyEvaluator.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	public class PolicyEvaluator : IPolicyEvaluator {
+		private static readonly AssertionInformation DeniedByDefault =
+			new AssertionInformation("default", "denied by default", Grant.Deny);
+
+		private readonly ReadOnlyPolicy _policy;
+		private readonly PolicyInformation _policyInfo;
+
+		public PolicyEvaluator(ReadOnlyPolicy policy) {
+			_policy = policy;
+			_policyInfo = policy.Information;
+		}
+
+		public ValueTask<EvaluationResult>
+			EvaluateAsync(ClaimsPrincipal cp, Operation operation, CancellationToken ct) {
+			var evaluation = new EvaluationContext(operation, ct);
+
+			if (_policy.TryGetAssertions(operation, out var assertions))
+				while (!assertions.IsEmpty && evaluation.Grant != Grant.Deny) {
+					if (ct.IsCancellationRequested) break;
+					var assertion = assertions.Span[0];
+					assertions = assertions.Slice(1);
+					var evaluate = assertion.Evaluate(cp, operation, _policyInfo, evaluation);
+					if (!evaluate.IsCompleted)
+						return EvaluateAsync(evaluate, cp, operation, assertions, evaluation, ct);
+				}
+
+			if (evaluation.Grant == Grant.Unknown) evaluation.Add(new AssertionMatch(_policyInfo, DeniedByDefault));
+
+			return new ValueTask<EvaluationResult>(evaluation.ToResult());
+		}
+
+		private async ValueTask<EvaluationResult> EvaluateAsync(
+			ValueTask<bool> pending,
+			ClaimsPrincipal cp,
+			Operation operation,
+			ReadOnlyMemory<IAssertion> assertions,
+			EvaluationContext evaluationContext,
+			CancellationToken ct) {
+			do {
+				if (ct.IsCancellationRequested) break;
+				await pending.ConfigureAwait(false);
+				if (ct.IsCancellationRequested) break;
+				if (assertions.IsEmpty) break;
+				pending = assertions.Span[0].Evaluate(cp, operation, _policyInfo, evaluationContext);
+				assertions = assertions.Slice(1);
+			} while (evaluationContext.Grant != Grant.Deny);
+
+			if (evaluationContext.Grant == Grant.Unknown)
+				evaluationContext.Add(new AssertionMatch(_policyInfo, DeniedByDefault));
+
+			return evaluationContext.ToResult();
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/PolicyInformation.cs
+++ b/src/EventStore.Core/Authorization/PolicyInformation.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace EventStore.Core.Authorization {
+	public class PolicyInformation {
+		public readonly DateTimeOffset Expires;
+		public readonly string Name;
+
+		public PolicyInformation(string name, long version, DateTimeOffset expires) {
+			Version = version;
+			Name = name;
+			Expires = expires;
+		}
+
+		public long Version { get; }
+
+		public override string ToString() {
+			return $"Policy : {Name} {Version} {Expires}";
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/ReadOnlyPolicy.cs
+++ b/src/EventStore.Core/Authorization/ReadOnlyPolicy.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EventStore.Core.Authorization {
+	public class ReadOnlyPolicy {
+		private readonly IReadOnlyDictionary<OperationDefinition, ReadOnlyMemory<IAssertion>> _assertions;
+		private readonly string _name;
+		private readonly DateTimeOffset _validFrom;
+		private readonly long _version;
+
+		public ReadOnlyPolicy(string name, long version, DateTimeOffset validFrom,
+			IReadOnlyDictionary<OperationDefinition, ReadOnlyMemory<IAssertion>> assertions) {
+			_name = name;
+			_version = version;
+			_validFrom = validFrom;
+			_assertions = assertions;
+		}
+
+		public PolicyInformation Information => new PolicyInformation(_name, _version, DateTimeOffset.MaxValue);
+
+		public bool TryGetAssertions(OperationDefinition operation, out ReadOnlyMemory<IAssertion> assertions) {
+			return _assertions.TryGetValue(operation, out assertions);
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/RequireAuthenticatedAssertion.cs
+++ b/src/EventStore.Core/Authorization/RequireAuthenticatedAssertion.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	internal class RequireAuthenticatedAssertion : IAssertion {
+		public Grant Grant { get; } = Grant.Unknown;
+
+		public AssertionInformation Information { get; } =
+			new AssertionInformation("match", "authenticated", Grant.Unknown);
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			if (!cp.Claims.Any() ||
+			    cp.Claims.Any(x => string.Equals(x.Type, ClaimTypes.Anonymous, StringComparison.Ordinal)))
+				context.Add(new AssertionMatch(policy, new AssertionInformation("match", "authenticated", Grant.Deny)));
+			else
+				context.Add(new AssertionMatch(policy,
+					new AssertionInformation("match", "authenticated", Grant.Allow)));
+			return new ValueTask<bool>(true);
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/RequireStreamReadAssertion.cs
+++ b/src/EventStore.Core/Authorization/RequireStreamReadAssertion.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Authorization {
+	public class RequireStreamReadAssertion : IAssertion {
+		private static readonly Operation StreamRead = new Operation(Operations.Streams.Read);
+		private readonly LegacyStreamPermissionAssertion _streamAssertion;
+
+		public RequireStreamReadAssertion(LegacyStreamPermissionAssertion streamAssertion) {
+			_streamAssertion = streamAssertion;
+			Information = streamAssertion.Information;
+		}
+
+		public AssertionInformation Information { get; }
+		public Grant Grant { get; } = Grant.Unknown;
+
+		public ValueTask<bool> Evaluate(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
+			EvaluationContext context) {
+			if (operation == Operations.Subscriptions.ProcessMessages ||
+			    operation == Operations.Subscriptions.ReplayParked) {
+				var stream = FindStreamId(operation.Parameters.Span);
+				return _streamAssertion.Evaluate(cp,
+					StreamRead.WithParameter(Operations.Streams.Parameters.StreamId(stream)), policy, context);
+			}
+
+			return new ValueTask<bool>(false);
+		}
+
+		private string FindStreamId(ReadOnlySpan<Parameter> parameters) {
+			for (int i = 0; i < parameters.Length; i++)
+				if (parameters[i].Name == "streamId")
+					return parameters[i].Value;
+
+			return null;
+		}
+	}
+}

--- a/src/EventStore.Core/Authorization/WellKnownAssertions.cs
+++ b/src/EventStore.Core/Authorization/WellKnownAssertions.cs
@@ -1,0 +1,12 @@
+﻿using System.Security.Claims;
+using EventStore.Core.Services;
+
+namespace EventStore.Core.Authorization {
+	public static class WellKnownAssertions {
+		public static readonly IAssertion System = new MultipleClaimMatchAssertion(Grant.Allow, MultipleMatchMode.All,
+			new Claim(ClaimTypes.Name, "system"), new Claim(ClaimTypes.Authentication, "ES-Legacy"));
+
+		public static readonly IAssertion Admin = new MultipleClaimMatchAssertion(Grant.Allow, MultipleMatchMode.Any,
+			new Claim(ClaimTypes.Name, "admin"), new Claim(ClaimTypes.Role, SystemRoles.Admins));
+	}
+}

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using EventStore.Common.Utils;
 using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
@@ -46,6 +47,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly StatsStorage StatsStorage;
 
 		public readonly IAuthenticationProviderFactory AuthenticationProviderFactory;
+		public readonly IAuthorizationProviderFactory AuthorizationProviderFactory;
 		public readonly bool DisableFirstLevelHttpAuthorization;
 		public readonly bool DisableScavengeMerging;
 		public readonly int ScavengeHistoryMaxAge;
@@ -115,6 +117,7 @@ namespace EventStore.Core.Cluster.Settings {
 			StatsStorage statsStorage,
 			int nodePriority,
 			IAuthenticationProviderFactory authenticationProviderFactory,
+			IAuthorizationProviderFactory authorizationProviderFactory,
 			bool disableScavengeMerging,
 			int scavengeHistoryMaxAge,
 			bool adminOnPublic,
@@ -223,6 +226,7 @@ namespace EventStore.Core.Cluster.Settings {
 			StatsStorage = statsStorage;
 
 			AuthenticationProviderFactory = authenticationProviderFactory;
+			AuthorizationProviderFactory = authorizationProviderFactory;
 			DisableFirstLevelHttpAuthorization = disableFirstLevelHttpAuthorization;
 
 			NodePriority = nodePriority;
@@ -285,6 +289,7 @@ namespace EventStore.Core.Cluster.Settings {
 			$"DisableInternalTls: {DisableInternalTls}\n" + $"DisableExternalTls: {DisableExternalTls}\n" +
 			$"StatsPeriod: {StatsPeriod}\n" + $"StatsStorage: {StatsStorage}\n" +
 			$"AuthenticationProviderFactory Type: {AuthenticationProviderFactory.GetType()}\n" +
+			$"AuthorizationProviderFactory  Type: {AuthorizationProviderFactory.GetType()}\n" +
 			$"NodePriority: {NodePriority}" + $"GossipInterval: {GossipInterval}\n" +
 			$"GossipAllowedTimeDifference: {GossipAllowedTimeDifference}\n" +
 			$"GossipTimeout: {GossipTimeout}\n" + $"HistogramEnabled: {EnableHistograms}\n" +

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Cluster.Settings;
 using EventStore.Core.Messages;
@@ -15,6 +17,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Net.Http.Headers;
 using HttpStatusCode = EventStore.Transport.Http.HttpStatusCode;
 using MidFunc = System.Func<
 	Microsoft.AspNetCore.Http.HttpContext,
@@ -22,35 +25,34 @@ using MidFunc = System.Func<
 	System.Threading.Tasks.Task
 >;
 using ElectionsService = EventStore.Core.Services.Transport.Grpc.Elections;
+using Operations = EventStore.Core.Services.Transport.Grpc.Operations;
 
 namespace EventStore.Core {
 	public class ClusterVNodeStartup : IStartup, IHandle<SystemMessage.SystemReady>,
 		IHandle<SystemMessage.BecomeShuttingDown> {
-		private static readonly PathString PersistentSegment =
-			"/event_store.client.persistent_subscriptions.PersistentSubscriptions";
-
-		private static readonly PathString StreamsSegment = "/event_store.client.streams.Streams";
-		private static readonly PathString UsersSegment = "/event_store.client.users.Users";
-		private static readonly PathString OperationsSegment = "/event_store.client.operations.Operations";
-		private static readonly PathString GossipSegment = "/event_store.cluster.Gossip";
-		private static readonly PathString ElectionsSegment = "/event_store.cluster.Elections";
 
 		private readonly ISubsystem[] _subsystems;
-		private readonly IQueuedHandler _mainQueue;
+		private readonly IPublisher _mainQueue;
+		private readonly ISubscriber _mainBus;
 		private readonly IReadOnlyList<IHttpAuthenticationProvider> _httpAuthenticationProviders;
 		private readonly IReadIndex _readIndex;
-		private readonly ClusterVNodeSettings _vNodeSettings;
+		private readonly int _maxAppendSize;
 		private readonly KestrelHttpService _externalHttpService;
 		private readonly StatusCheck _statusCheck;
 
 		private bool _ready;
+		private readonly IAuthorizationProvider _authorizationProvider;
+		private readonly MultiQueuedHandler _httpMessageHandler;
 
 		public ClusterVNodeStartup(
 			ISubsystem[] subsystems,
-			IQueuedHandler mainQueue,
+			IPublisher mainQueue,
+			ISubscriber mainBus,
+			MultiQueuedHandler httpMessageHandler,
 			IReadOnlyList<IHttpAuthenticationProvider> httpAuthenticationProviders,
+			IAuthorizationProvider authorizationProvider,
 			IReadIndex readIndex,
-			ClusterVNodeSettings vNodeSettings,
+			int maxAppendSize,
 			KestrelHttpService externalHttpService) {
 			if (subsystems == null) {
 				throw new ArgumentNullException(nameof(subsystems));
@@ -64,84 +66,83 @@ namespace EventStore.Core {
 				throw new ArgumentNullException(nameof(httpAuthenticationProviders));
 			}
 
+			if(authorizationProvider == null)
+				throw new ArgumentNullException(nameof(authorizationProvider));
+
 			if (readIndex == null) {
 				throw new ArgumentNullException(nameof(readIndex));
 			}
 
-			if (vNodeSettings == null) {
-				throw new ArgumentNullException(nameof(vNodeSettings));
-			}
+			Ensure.Positive(maxAppendSize, nameof(maxAppendSize));
 
 			if (externalHttpService == null) {
 				throw new ArgumentNullException(nameof(externalHttpService));
 			}
 
+			if (mainBus == null) {
+				throw new ArgumentNullException(nameof(mainBus));
+			}
 			_subsystems = subsystems;
 			_mainQueue = mainQueue;
+			_mainBus = mainBus;
+			_httpMessageHandler = httpMessageHandler;
 			_httpAuthenticationProviders = httpAuthenticationProviders;
+			_authorizationProvider = authorizationProvider;
 			_readIndex = readIndex;
-			_vNodeSettings = vNodeSettings;
+			_maxAppendSize = maxAppendSize;
 			_externalHttpService = externalHttpService;
 
 			_statusCheck = new StatusCheck(this);
 		}
 
 		public void Configure(IApplicationBuilder app) {
+			var grpc = new MediaTypeHeaderValue("application/grpc");
+			var internalDispatcher = new InternalDispatcherEndpoint(_mainQueue, _httpMessageHandler);
+			_mainBus.Subscribe(internalDispatcher);
 			app.Map("/health", _statusCheck.Configure)
-				.UseMiddleware<AuthenticationMiddleware>();
-			_subsystems
-				.Aggregate(app
-						.UseWhen(context => context.Request.Path.StartsWithSegments(PersistentSegment),
-							inner => inner.UseRouting().UseEndpoints(endpoint =>
-								endpoint.MapGrpcService<PersistentSubscriptions>()))
-						.UseWhen(context => context.Request.Path.StartsWithSegments(UsersSegment),
-							inner => inner.UseRouting().Use(RequireAuthenticated).UseEndpoints(endpoint =>
-								endpoint.MapGrpcService<Users>()))
-						.UseWhen(context => context.Request.Path.StartsWithSegments(StreamsSegment),
-							inner => inner.UseRouting().UseEndpoints(endpoint =>
-								endpoint.MapGrpcService<Streams>()))
-						.UseWhen(context => context.Request.Path.StartsWithSegments(GossipSegment),
-							inner => inner.UseRouting().UseEndpoints(endpoint =>
-								endpoint.MapGrpcService<Gossip>()))
-						.UseWhen(context => context.Request.Path.StartsWithSegments(ElectionsSegment),
-							inner => inner.UseRouting().UseEndpoints(endpoint =>
-								endpoint.MapGrpcService<Elections>()))
-						.UseWhen(context => context.Request.Path.StartsWithSegments(OperationsSegment),  // TODO JPB figure out how to delete this sadness
-							inner => inner.UseRouting().UseEndpoints(endpoint =>
-								endpoint.MapGrpcService<Operations>())),
-					(b, subsystem) => subsystem.Configure(b));
+				.UseMiddleware<AuthenticationMiddleware>()
+				.UseRouting()
+				.UseWhen(ctx => !(ctx.Request.GetTypedHeaders().ContentType?.IsSubsetOf(grpc)).GetValueOrDefault(false),
+					b => b
+						.UseMiddleware<KestrelToInternalBridgeMiddleware>()
+						.UseMiddleware<AuthorizationMiddleware>()
+						.UseLegacyHttp(internalDispatcher.InvokeAsync, _externalHttpService)
+					)
+				.UseEndpoints(ep => ep.MapGrpcService<PersistentSubscriptions>())
+				.UseEndpoints(ep => ep.MapGrpcService<Users>())
+				.UseEndpoints(ep => ep.MapGrpcService<Streams>())
+				.UseEndpoints(ep => ep.MapGrpcService<Gossip>())
+				.UseEndpoints(ep => ep.MapGrpcService<Elections>())
+				.UseEndpoints(ep => ep.MapGrpcService<Operations>());
 
-			app.UseLegacyHttp(_externalHttpService);
+			_subsystems
+				.Aggregate(app,(b, subsystem) => subsystem.Configure(b));
 		}
 
 		IServiceProvider IStartup.ConfigureServices(IServiceCollection services) => ConfigureServices(services)
 			.BuildServiceProvider();
 
-		public IServiceCollection ConfigureServices(IServiceCollection services) =>
-			_subsystems
+		public IServiceCollection ConfigureServices(IServiceCollection services) {
+
+			var bridge = new KestrelToInternalBridgeMiddleware(_externalHttpService.UriRouter, _externalHttpService.LogHttpRequests, _externalHttpService.AdvertiseAsAddress, _externalHttpService.AdvertiseAsPort);
+			return _subsystems
 				.Aggregate(services
 						.AddRouting()
 						.AddSingleton(_httpAuthenticationProviders)
+						.AddSingleton(_authorizationProvider)
 						.AddSingleton<AuthenticationMiddleware>()
+						.AddSingleton<AuthorizationMiddleware>()
+						.AddSingleton<KestrelToInternalBridgeMiddleware>(bridge)
 						.AddSingleton(_readIndex)
-						.AddSingleton(new Streams(_mainQueue, _readIndex,
-							_vNodeSettings.MaxAppendSize))
-						.AddSingleton(new PersistentSubscriptions(_mainQueue))
-						.AddSingleton(new Users(_mainQueue))
-						.AddSingleton(new Operations(_mainQueue))
-						.AddSingleton(new Gossip(_mainQueue))
-						.AddSingleton(new Elections(_mainQueue))
+						.AddSingleton(new Streams(_mainQueue, _readIndex, _maxAppendSize, _authorizationProvider))
+						.AddSingleton(new PersistentSubscriptions(_mainQueue, _authorizationProvider))
+						.AddSingleton(new Users(_mainQueue, _authorizationProvider))
+						.AddSingleton(new Operations(_mainQueue, _authorizationProvider))
+						.AddSingleton(new Gossip(_mainQueue, _authorizationProvider))
+						.AddSingleton(new Elections(_mainQueue, _authorizationProvider))
 						.AddGrpc().Services,
 					(s, subsystem) => subsystem.ConfigureServices(s));
-
-		private static RequestDelegate RequireAuthenticated(RequestDelegate next) =>
-			context => {
-				if (!context.User.HasClaim(x => x.Type == ClaimTypes.Anonymous)) {
-					return next(context);
-				}
-				context.Response.StatusCode = HttpStatusCode.Unauthorized;
-				return Task.CompletedTask;
-			};
+		}
 
 		public void Handle(SystemMessage.SystemReady message) => _ready = true;
 

--- a/src/EventStore.Core/EventStoreLegacyHttpMiddleware.cs
+++ b/src/EventStore.Core/EventStoreLegacyHttpMiddleware.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Security.Policy;
 using System.Threading.Tasks;
+using EventStore.Core.Authorization;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Transport.Http;
 using Microsoft.AspNetCore.Builder;
@@ -9,45 +12,48 @@ using Microsoft.AspNetCore.Http;
 namespace EventStore.Core {
 	public static class EventStoreLegacyHttpMiddleware {
 		public static IApplicationBuilder UseLegacyHttp(
-			this IApplicationBuilder app,
+			this IApplicationBuilder app, RequestDelegate dispatcher,
 			params IHttpService[] httpServices) {
 			if (app == null) throw new ArgumentNullException(nameof(app));
 			if (httpServices == null) throw new ArgumentNullException(nameof(httpServices));
 
 			var actions = httpServices
 				.SelectMany(x => x.Actions.Select(action =>
-					(ConvertToRoute(action.UriTemplate), action.HttpMethod, action.RequiredAuthorizationLevel)))
+					(ConvertToRoute(action.UriTemplate), action.HttpMethod, action.Operation)))
 				.ToArray();
 			return actions
 				.Concat(actions
 					.Select(_ => _.Item1)
-					.Select(route => (route, HttpMethod.Options, AuthorizationLevel.None)))
-				.Distinct()
+					.Select(route => (route, HttpMethod.Options, new Func<UriTemplateMatch, Operation>(_ => new Operation(Operations.Node.Options)))))
+				.Distinct(RouteAndMethodComparer.Instance)
 				.Aggregate(app.UseRouting(), RegisterRoute);
-
 			IApplicationBuilder RegisterRoute(
 				IApplicationBuilder builder,
-				(string route, string method, AuthorizationLevel authorizationLevel) action) => builder
+				(string route, string method, Func<UriTemplateMatch, Authorization.Operation> operation) action) => builder
 				.UseEndpoints(routeBuilder => routeBuilder
 					.MapMethods(
 						action.route,
 						action.method == HttpMethod.Get
 							? new[] {HttpMethod.Get, HttpMethod.Head}
 							: new[] {action.method},
-						HandleRequest)
-					.WithMetadata(new OptionalAuthorizationLevel(action.authorizationLevel)));
+						dispatcher)
+					.WithMetadata(action.operation));
 
 			static string ConvertToRoute(string uriTemplate) {
 				var route = uriTemplate.Split('?').First();
 				return System.Net.WebUtility.UrlDecode(route.EndsWith("/") ? route[..^1] : route);
 			}
+		} 
+		class RouteAndMethodComparer : EqualityComparer<(string, string, Func<UriTemplateMatch, Operation>)> {
+			public static readonly RouteAndMethodComparer Instance = new RouteAndMethodComparer();
+			public override bool Equals((string, string, Func<UriTemplateMatch, Operation>) x, (string, string, Func<UriTemplateMatch, Operation>) y) {
+				return string.Equals(x.Item1, y.Item1, StringComparison.Ordinal) &&
+				       string.Equals(x.Item2, y.Item2, StringComparison.Ordinal);
+			}
 
-			Task HandleRequest(HttpContext context) => httpServices
-				.FirstOrDefault(service => service
-					.EndPoints.Any(ipEndPoint =>
-						ipEndPoint.Port == context.Request.Host.Port))?
-				.AppFunc?
-				.Invoke(context) ?? Task.CompletedTask;
+			public override int GetHashCode((string, string, Func<UriTemplateMatch, Operation>) obj) {
+				return HashCode.Combine(obj.Item1, obj.Item2);
+			}
 		}
 	}
 }

--- a/src/EventStore.Core/Messages/HttpMessage.cs
+++ b/src/EventStore.Core/Messages/HttpMessage.cs
@@ -156,12 +156,6 @@ namespace EventStore.Core.Messages {
 			public override int MsgTypeId {
 				get { return TypeId; }
 			}
-
-			public readonly ServiceAccessibility Accessibility;
-
-			public PurgeTimedOutRequests(ServiceAccessibility accessibility) {
-				Accessibility = accessibility;
-			}
 		}
 
 		public class TextMessage : Message {

--- a/src/EventStore.Core/Services/AuthorizationGateway.cs
+++ b/src/EventStore.Core/Services/AuthorizationGateway.cs
@@ -1,0 +1,369 @@
+﻿using System;
+using System.Diagnostics;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Services {
+	public sealed class AuthorizationGateway {
+		private readonly IAuthorizationProvider _authorizationProvider;
+		private const string AccessDenied = "Access Denied";
+
+		private static readonly Func<ClientMessage.ReadEvent, Message> ReadEventDenied = msg =>
+			new ClientMessage.ReadEventCompleted(msg.CorrelationId, msg.EventStreamId, ReadEventResult.AccessDenied,
+				ResolvedEvent.EmptyEvent, StreamMetadata.Empty, false, AccessDenied);
+
+		private static readonly Func<ClientMessage.ReadAllEventsForward, Message> ReadAllEventsForwardDenied = msg =>
+			new ClientMessage.ReadAllEventsForwardCompleted(msg.CorrelationId, ReadAllResult.AccessDenied, AccessDenied,
+				Array.Empty<ResolvedEvent>(), StreamMetadata.Empty, false, 0, TFPos.Invalid, TFPos.Invalid,
+				TFPos.Invalid, default);
+
+		private static readonly Func<ClientMessage.ReadStreamEventsForward, Message> ReadStreamEventsForwardDenied =
+			msg => new ClientMessage.ReadStreamEventsForwardCompleted(msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount,ReadStreamResult.AccessDenied, Array.Empty<ResolvedEvent>(), StreamMetadata.Empty, false, AccessDenied, -1, default, true, default);
+
+		private static readonly Func<ClientMessage.ReadStreamEventsBackward, Message> ReadStreamEventsBackwardDenied =
+			msg => new ClientMessage.ReadStreamEventsBackwardCompleted(msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount,
+				ReadStreamResult.AccessDenied,Array.Empty<ResolvedEvent>(), StreamMetadata.Empty, default, AccessDenied, -1, default, true, default);
+
+		private static readonly Func<ClientMessage.WriteEvents, Message> WriteEventsDenied = msg =>
+			new ClientMessage.WriteEventsCompleted(msg.CorrelationId, OperationResult.AccessDenied, AccessDenied);
+
+		private static readonly Func<ClientMessage.DeleteStream, Message> DeleteStreamDenied = msg =>
+			new ClientMessage.DeleteStreamCompleted(msg.CorrelationId, OperationResult.AccessDenied, AccessDenied);
+
+		private static readonly Func<ClientMessage.SubscribeToStream, Message> SubscribeToStreamDenied = msg =>
+			new ClientMessage.SubscriptionDropped(msg.CorrelationId, SubscriptionDropReason.AccessDenied);
+		private static readonly Func<ClientMessage.FilteredSubscribeToStream, Message> FilteredSubscribeToStreamDenied =
+			msg =>
+				new ClientMessage.SubscriptionDropped(msg.CorrelationId, SubscriptionDropReason.AccessDenied);
+
+		private static readonly Func<ClientMessage.ReadAllEventsBackward, Message> ReadAllEventsBackwardDenied = msg =>
+			new ClientMessage.ReadAllEventsBackwardCompleted(msg.CorrelationId, ReadAllResult.AccessDenied,
+				AccessDenied,
+				Array.Empty<ResolvedEvent>(), StreamMetadata.Empty, false, 0, TFPos.Invalid, TFPos.Invalid,
+				TFPos.Invalid, default);
+
+		private static readonly Func<ClientMessage.FilteredReadAllEventsForward, Message>
+			FilteredReadAllEventsForwardDenied = msg =>
+				new ClientMessage.ReadAllEventsForwardCompleted(msg.CorrelationId, ReadAllResult.AccessDenied,
+					AccessDenied,
+					Array.Empty<ResolvedEvent>(), StreamMetadata.Empty, false, 0, TFPos.Invalid, TFPos.Invalid,
+					TFPos.Invalid, default);
+
+		private static readonly Func<ClientMessage.FilteredReadAllEventsBackward, Message>
+			FilteredReadAllEventsBackwardDenied = msg =>
+				new ClientMessage.ReadAllEventsBackwardCompleted(msg.CorrelationId, ReadAllResult.AccessDenied,
+					AccessDenied,
+					Array.Empty<ResolvedEvent>(), StreamMetadata.Empty, false, 0, TFPos.Invalid, TFPos.Invalid,
+					TFPos.Invalid, default);
+
+		private static readonly Func<ClientMessage.ConnectToPersistentSubscription, Message>
+			ConnectToPersistentSubscriptionDenied = msg =>
+				new ClientMessage.SubscriptionDropped(msg.CorrelationId, SubscriptionDropReason.AccessDenied);
+
+		private static readonly Func<ClientMessage.ReadNextNPersistentMessages, Message>
+			ReadNextNPersistedMessagesDenied = msg =>
+				new ClientMessage.ReadNextNPersistentMessagesCompleted(msg.CorrelationId,
+					ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.AccessDenied,
+					AccessDenied, Array.Empty<(ResolvedEvent, int)>());
+
+		private static readonly Func<ClientMessage.CreatePersistentSubscription, Message>
+			CreatePersistentSubscriptionDenied = msg =>
+				new ClientMessage.CreatePersistentSubscriptionCompleted(msg.CorrelationId,
+					ClientMessage.CreatePersistentSubscriptionCompleted.CreatePersistentSubscriptionResult.AccessDenied,
+					AccessDenied);
+
+		private static readonly Func<ClientMessage.UpdatePersistentSubscription, Message>
+			UpdatePersistentSubscriptionDenied = msg =>
+				new ClientMessage.UpdatePersistentSubscriptionCompleted(msg.CorrelationId,
+					ClientMessage.UpdatePersistentSubscriptionCompleted.UpdatePersistentSubscriptionResult.AccessDenied,
+					AccessDenied);
+
+		private static readonly Func<ClientMessage.ReplayParkedMessages, Message> ReplayAllParkedMessagesDenied =
+			msg => new ClientMessage.ReplayMessagesReceived(msg.CorrelationId,
+				ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied, AccessDenied);
+
+		private static readonly Func<ClientMessage.DeletePersistentSubscription, Message>
+			DeletePersistentSubscriptionDenied =
+				msg => new ClientMessage.DeletePersistentSubscriptionCompleted(msg.CorrelationId,
+					ClientMessage.DeletePersistentSubscriptionCompleted.DeletePersistentSubscriptionResult.AccessDenied,
+					AccessDenied);
+
+		private static readonly Func<ClientMessage.TransactionStart, Message> TransactionStartDenied = msg =>
+			new ClientMessage.TransactionStartCompleted(msg.CorrelationId, -1, OperationResult.AccessDenied,
+				AccessDenied);
+
+		private static readonly Func<ClientMessage.TransactionWrite, Message> TransactionWriteDenied = msg =>
+			new ClientMessage.TransactionWriteCompleted(msg.CorrelationId, msg.TransactionId,
+				OperationResult.AccessDenied, AccessDenied);
+
+		private static readonly Func<ClientMessage.TransactionCommit, Message> TransactionCommitDenied = msg =>
+			new ClientMessage.TransactionCommitCompleted(msg.CorrelationId, msg.TransactionId,
+				OperationResult.AccessDenied, AccessDenied);
+
+
+		private static readonly Operation ReadStream = new Operation(Operations.Streams.Read);
+		private static readonly Operation WriteStream = new Operation(Operations.Streams.Write);
+		private static readonly Operation DeleteStream = new Operation(Operations.Streams.Delete);
+		private static readonly Operation ReadEvent = ReadStream;
+		private static readonly Operation FilteredSubscribeToStream = ReadStream;
+
+		private static readonly Operation ReadAllStream =
+			new Operation(Operations.Streams.Read).WithParameter(
+				Operations.Streams.Parameters.StreamId(SystemStreams.AllStream));
+
+		private static readonly Operation CreatePersistentSubscription = new Operation(Operations.Subscriptions.Create);
+		private static readonly Operation UpdatePersistentSubscription = new Operation(Operations.Subscriptions.Update);
+		private static readonly Operation DeletePersistentSubscription = new Operation(Operations.Subscriptions.Delete);
+
+		private static readonly Operation
+			ReplayAllParkedMessages = new Operation(Operations.Subscriptions.ReplayParked);
+
+		private static readonly Operation ConnectToPersistentSubscription =
+			new Operation(Operations.Subscriptions.ProcessMessages);
+
+		public AuthorizationGateway(IAuthorizationProvider authorizationProvider) {
+			_authorizationProvider = authorizationProvider;
+		}
+
+		public void Authorize(Message toValidate, IPublisher destination) {
+			Ensure.NotNull(toValidate, nameof(toValidate));
+			Ensure.NotNull(destination, nameof(destination));
+			switch (toValidate) {
+				case ClientMessage.ReadNextNPersistentMessages msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.ReadStreamEventsBackward msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.ReadStreamEventsForward msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.UpdatePersistentSubscription msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.SubscribeToStream msg: 
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.ConnectToPersistentSubscription msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.CreatePersistentSubscription msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.DeletePersistentSubscription msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.DeleteStream msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.FilteredReadAllEventsBackward msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.FilteredReadAllEventsForward msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.FilteredSubscribeToStream msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.ReadAllEventsBackward msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.ReadAllEventsForward msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.ReplayParkedMessages msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.ReadEvent msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.WriteEvents msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.TransactionStart msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.TransactionWrite msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.TransactionCommit msg:
+					Authorize(msg, destination);
+					break;
+				case ClientMessage.PersistentSubscriptionAckEvents _:
+				case ClientMessage.PersistentSubscriptionNackEvents _:
+				case ClientMessage.UnsubscribeFromStream _:
+				case ClientMessage.NotHandled _:
+				case ClientMessage.WriteEventsCompleted _:
+				case ClientMessage.TransactionStartCompleted _:
+				case ClientMessage.TransactionWriteCompleted _:
+				case ClientMessage.TransactionCommitCompleted _:
+				case ClientMessage.DeleteStreamCompleted _:
+					destination.Publish(toValidate);
+					break;
+				case ReplicationMessage.AckLogPosition _:
+				case ReplicationMessage.CloneAssignment _:
+				case ReplicationMessage.CreateChunk _:
+				case ReplicationMessage.DataChunkBulk _:
+				case ReplicationMessage.DropSubscription _:
+				case ReplicationMessage.FollowerAssignment _:
+				case ReplicationMessage.GetReplicationStats _:
+				case ReplicationMessage.GetReplicationStatsCompleted _:
+				case ReplicationMessage.RawChunkBulk _:
+				case ReplicationMessage.ReconnectToLeader _:
+				case ReplicationMessage.ReplicaLogPositionAck _:
+				case ReplicationMessage.ReplicaSubscribed _:
+				case ReplicationMessage.ReplicaSubscriptionRetry _:
+				case ReplicationMessage.ReplicaSubscriptionRequest _:
+				case ReplicationMessage.SubscribeReplica _:
+				case ReplicationMessage.SubscribeToLeader _:
+				case ReplicationTrackingMessage.IndexedTo _:
+				case ReplicationTrackingMessage.LeaderReplicatedTo _:
+				case ReplicationTrackingMessage.ReplicaWriteAck _:
+				case ReplicationTrackingMessage.ReplicatedTo _:
+				case ReplicationTrackingMessage.WriterCheckpointFlushed _:
+					destination.Publish(toValidate);
+					break;
+				default:
+#if DEBUG
+					//This sucks, because if new tcp messages are added there is no way to be sure they have to be authorized...
+					//They should be caught by debug builds though
+					throw new ArgumentOutOfRangeException(nameof(toValidate), toValidate.GetType().FullName,
+						"Unhandled client message");
+#else
+						destination.Publish(toValidate);
+						break;
+#endif
+			}
+		}
+
+		private void Authorize(ClientMessage.SubscribeToStream msg, IPublisher destination) {
+			Authorize(msg.User, ReadStream.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, SubscribeToStreamDenied);
+		}
+
+		private void Authorize(ClientMessage.ReadEvent msg, IPublisher destination) {
+			Authorize(msg.User, ReadEvent.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, ReadEventDenied);
+		}
+
+		private void Authorize(ClientMessage.WriteEvents msg, IPublisher destination) {
+			Authorize(msg.User, WriteStream.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, WriteEventsDenied);
+		}
+
+		private void Authorize(ClientMessage.ReplayParkedMessages msg, IPublisher destination) {
+			Authorize(msg.User, ReplayAllParkedMessages, msg.Envelope, destination, msg, ReplayAllParkedMessagesDenied);
+		}
+
+		private void Authorize(ClientMessage.ReadAllEventsForward msg, IPublisher destination) {
+			Authorize(msg.User, ReadAllStream, msg.Envelope, destination, msg, ReadAllEventsForwardDenied);
+		}
+
+		private void Authorize(ClientMessage.ReadAllEventsBackward msg, IPublisher destination) {
+			Authorize(msg.User, ReadAllStream, msg.Envelope, destination, msg, ReadAllEventsBackwardDenied);
+		}
+
+		private void Authorize(ClientMessage.FilteredSubscribeToStream msg, IPublisher destination) {
+			Authorize(msg.User,
+				FilteredSubscribeToStream.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, FilteredSubscribeToStreamDenied);
+		}
+
+		private void Authorize(ClientMessage.FilteredReadAllEventsForward msg, IPublisher destination) {
+			Authorize(msg.User, ReadAllStream, msg.Envelope, destination, msg, FilteredReadAllEventsForwardDenied);
+		}
+
+		private void Authorize(ClientMessage.FilteredReadAllEventsBackward msg, IPublisher destination) {
+			Authorize(msg.User, ReadAllStream, msg.Envelope, destination, msg, FilteredReadAllEventsBackwardDenied);
+		}
+
+		private void Authorize(ClientMessage.DeleteStream msg, IPublisher destination) {
+			Authorize(msg.User, DeleteStream.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, DeleteStreamDenied);
+		}
+
+		private void Authorize(ClientMessage.DeletePersistentSubscription msg, IPublisher destination) {
+			Authorize(msg.User, DeletePersistentSubscription, msg.Envelope, destination, msg,
+				DeletePersistentSubscriptionDenied);
+		}
+
+		private void Authorize(ClientMessage.CreatePersistentSubscription msg, IPublisher destination) {
+			Authorize(msg.User, CreatePersistentSubscription, msg.Envelope, destination, msg,
+				CreatePersistentSubscriptionDenied);
+		}
+
+		private void Authorize(ClientMessage.ConnectToPersistentSubscription msg, IPublisher destination) {
+			Authorize(msg.User,
+				ConnectToPersistentSubscription.WithParameter(
+					Operations.Subscriptions.Parameters.StreamId(msg.EventStreamId)), msg.Envelope, destination, msg,
+				ConnectToPersistentSubscriptionDenied);
+		}
+
+		private void Authorize(ClientMessage.UpdatePersistentSubscription msg, IPublisher destination) {
+			Authorize(msg.User, UpdatePersistentSubscription, msg.Envelope, destination, msg,
+				UpdatePersistentSubscriptionDenied);
+		}
+
+		private void Authorize(ClientMessage.ReadStreamEventsForward msg, IPublisher destination) {
+			Authorize(msg.User, ReadStream.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, ReadStreamEventsForwardDenied);
+		}
+
+		private void Authorize(ClientMessage.ReadStreamEventsBackward msg, IPublisher destination) {
+			Authorize(msg.User, ReadStream.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, ReadStreamEventsBackwardDenied);
+		}
+
+		private void Authorize(ClientMessage.ReadNextNPersistentMessages msg, IPublisher destination) {
+			Authorize(msg.User, ReadStream.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, ReadNextNPersistedMessagesDenied);
+		}
+
+		private void Authorize(ClientMessage.TransactionStart msg, IPublisher destination) {
+			Authorize(msg.User, WriteStream.WithParameter(Operations.Streams.Parameters.StreamId(msg.EventStreamId)),
+				msg.Envelope, destination, msg, TransactionStartDenied);
+		}
+
+		private void Authorize(ClientMessage.TransactionWrite msg, IPublisher destination) {
+			Authorize(msg.User, WriteStream.WithParameter(Operations.Streams.Parameters.TransactionId(msg.TransactionId)),
+				msg.Envelope, destination, msg, TransactionWriteDenied);
+		}
+
+		private void Authorize(ClientMessage.TransactionCommit msg, IPublisher destination) {
+			Authorize(msg.User, WriteStream.WithParameter(Operations.Streams.Parameters.TransactionId(msg.TransactionId)),
+				msg.Envelope, destination, msg, TransactionCommitDenied);
+		}
+	
+
+	void Authorize<TRequest>(ClaimsPrincipal user, Operation operation, IEnvelope replyTo,
+			IPublisher destination, TRequest request, Func<TRequest, Message> createAccessDenied)
+			where TRequest : Message {
+			var accessCheck = _authorizationProvider.CheckAccessAsync(user, operation, CancellationToken.None);
+			if (!accessCheck.IsCompleted)
+				AuthorizeAsync(accessCheck, replyTo, destination, request, createAccessDenied);
+			else {
+				if(accessCheck.Result)
+					destination.Publish(request);
+				else {
+					replyTo.ReplyWith(createAccessDenied(request));
+				}
+			}
+		}
+
+		async void AuthorizeAsync<TRequest>(ValueTask<bool> accessCheck, IEnvelope replyTo, IPublisher destination, TRequest request,
+			Func<TRequest, Message> createAccessDenied) where TRequest : Message {
+			if (await accessCheck.ConfigureAwait(false)) {
+				destination.Publish(request);
+			} else {
+				replyTo.ReplyWith(createAccessDenied(request));
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -32,6 +32,7 @@ namespace EventStore.Core.Services.Replication {
 		private readonly IEpochManager _epochManager;
 		private readonly IPublisher _networkSendQueue;
 		private readonly IAuthenticationProvider _authProvider;
+		private readonly AuthorizationGateway _authorizationGateway;
 		private readonly VNodeInfo _nodeInfo;
 		private readonly bool _useSsl;
 		private readonly bool _sslValidateServer;
@@ -49,6 +50,7 @@ namespace EventStore.Core.Services.Replication {
 			IEpochManager epochManager,
 			IPublisher networkSendQueue,
 			IAuthenticationProvider authProvider,
+			AuthorizationGateway authorizationGateway,
 			VNodeInfo nodeInfo,
 			bool useSsl,
 			bool sslValidateServer,
@@ -60,6 +62,7 @@ namespace EventStore.Core.Services.Replication {
 			Ensure.NotNull(epochManager, "epochManager");
 			Ensure.NotNull(networkSendQueue, "networkSendQueue");
 			Ensure.NotNull(authProvider, "authProvider");
+			Ensure.NotNull(authorizationGateway, "authorizationGateway");
 			Ensure.NotNull(nodeInfo, "nodeInfo");
 
 			_publisher = publisher;
@@ -67,6 +70,7 @@ namespace EventStore.Core.Services.Replication {
 			_epochManager = epochManager;
 			_networkSendQueue = networkSendQueue;
 			_authProvider = authProvider;
+			_authorizationGateway = authorizationGateway;
 
 			_nodeInfo = nodeInfo;
 			_useSsl = useSsl;
@@ -159,6 +163,7 @@ namespace EventStore.Core.Services.Replication {
 				_sslClientCertificates,
 				_networkSendQueue,
 				_authProvider,
+				_authorizationGateway,
 				_heartbeatInterval,
 				_heartbeatTimeout,
 				OnConnectionEstablished,

--- a/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
@@ -1,16 +1,13 @@
 ﻿using System;
-using System.Security.Claims;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public class DeleteStream : RequestManagerBase {
 		private readonly bool _hardDelete;
 		private readonly string _streamId;
 		private readonly bool _betterOrdering;
-		private readonly ClaimsPrincipal _user;
 
 		public DeleteStream(
 					IPublisher publisher,
@@ -21,7 +18,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					string streamId,
 					bool betterOrdering,
 					long expectedVersion,
-					ClaimsPrincipal user,
 					bool hardDelete,
 					CommitSource commitSource)
 			: base(
@@ -37,19 +33,7 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 			_hardDelete = hardDelete;
 			_streamId = streamId;
 			_betterOrdering = betterOrdering;
-			_user = user;
 		}
-
-		protected override Message AccessRequestMsg =>
-				new StorageMessage.CheckStreamAccess(
-						WriteReplyEnvelope,
-						InternalCorrId,
-						_streamId,
-						null,
-						StreamAccessType.Delete,
-						_user,
-						_betterOrdering);
-
 
 		protected override Message WriteRequestMsg =>
 			new StorageMessage.WriteDelete(

--- a/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
@@ -11,7 +11,6 @@ using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public abstract class RequestManagerBase :
-		IHandle<StorageMessage.CheckStreamAccessCompleted>,
 		IHandle<StorageMessage.PrepareAck>,
 		IHandle<StorageMessage.CommitAck>,
 		IHandle<StorageMessage.InvalidTransaction>,
@@ -93,21 +92,13 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 			}
 		}
 		protected DateTime LiveUntil => NextTimeoutTime - _timeoutOffset;
-		protected abstract Message AccessRequestMsg { get; }
+		
 		protected abstract Message WriteRequestMsg { get; }
 		protected abstract Message ClientSuccessMsg { get; }
 		protected abstract Message ClientFailMsg { get; }
 		public void Start() {
 			NextTimeoutTime = DateTime.UtcNow + Timeout;
-			Publisher.Publish(AccessRequestMsg ?? WriteRequestMsg);
-		}
-		public void Handle(StorageMessage.CheckStreamAccessCompleted message) {
-			if (Interlocked.Read(ref _complete) == 1) { return; }
-			if (message.AccessResult.Granted) {
-				Publisher.Publish(WriteRequestMsg);
-			} else {
-				CompleteFailedRequest(OperationResult.AccessDenied, "Access denied.");
-			}
+			Publisher.Publish(WriteRequestMsg);
 		}
 
 		public void Handle(StorageMessage.PrepareAck message) {

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommit.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommit.cs
@@ -1,18 +1,14 @@
 ﻿using System;
-using System.Security.Claims;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public class TransactionCommit : RequestManagerBase,
 		IHandle<StorageMessage.CommitIndexed> {
 		private readonly TimeSpan _commitTimeout;
 		private readonly bool _betterOrdering;
-		private readonly ClaimsPrincipal _user;
 		private bool _transactionWritten;
-
 		public TransactionCommit(
 					IPublisher publisher,
 					TimeSpan prepareTimeout,
@@ -22,7 +18,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					Guid clientCorrId,
 					long transactionId,
 					bool betterOrdering,
-					ClaimsPrincipal user,
 					CommitSource commitSource)
 			: base(
 					 publisher,
@@ -37,19 +32,7 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 waitForCommit: true) {
 			_commitTimeout = commitTimeout;
 			_betterOrdering = betterOrdering;
-			_user = user;
 		}
-
-		protected override Message AccessRequestMsg =>
-				new StorageMessage.CheckStreamAccess(
-						WriteReplyEnvelope,
-						InternalCorrId,
-						null,
-						TransactionId,
-						StreamAccessType.Write,
-						_user,
-						_betterOrdering);
-
 
 		protected override Message WriteRequestMsg =>
 			new StorageMessage.WriteTransactionEnd(

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionStart.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionStart.cs
@@ -1,15 +1,12 @@
 ﻿using System;
-using System.Security.Claims;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public class TransactionStart : RequestManagerBase {
 		private readonly string _streamId;
 		private readonly bool _betterOrdering;
-		private readonly ClaimsPrincipal _user;
 
 		public TransactionStart(
 					IPublisher publisher,
@@ -20,7 +17,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					string streamId,
 					bool betterOrdering,
 					long expectedVersion,
-					ClaimsPrincipal user,
 					CommitSource commitSource)
 			: base(
 					 publisher,
@@ -33,19 +29,8 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 prepareCount: 1) {
 			_streamId = streamId;
 			_betterOrdering = betterOrdering;
-			_user = user;
 		}
-
-		protected override Message AccessRequestMsg =>
-				new StorageMessage.CheckStreamAccess(
-						WriteReplyEnvelope,
-						InternalCorrId,
-						_streamId,
-						null,
-						StreamAccessType.Write,
-						_user,
-						_betterOrdering);
-
+		
 		protected override Message WriteRequestMsg =>
 			new StorageMessage.WriteTransactionStart(
 					InternalCorrId,

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionWrite.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionWrite.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -6,7 +7,10 @@ using EventStore.Core.Messaging;
 
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public class TransactionWrite : RequestManagerBase {
+		private static readonly Operation Operation = new Operation(Operations.Streams.Write);
 		private readonly Event[] _events;
+		private long _transactionId;
+
 		public TransactionWrite(
 					IPublisher publisher,
 					TimeSpan timeout,
@@ -27,9 +31,9 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 prepareCount: events.Length,
 					 transactionId) {
 			_events = events;
+			_transactionId = transactionId;
 		}
-		protected override Message AccessRequestMsg => null; //we don't have a user on the tx write message
-
+		
 		protected override Message WriteRequestMsg =>
 			new StorageMessage.WriteTransactionData(
 					InternalCorrId,

--- a/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
@@ -1,18 +1,15 @@
 ﻿using System;
-using System.Security.Claims;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public class WriteEvents : RequestManagerBase {
 		private readonly string _streamId;
 		private readonly bool _betterOrdering;
-		private readonly ClaimsPrincipal _user;
 		private readonly Event[] _events;
-		private readonly StreamAccessType _accessType;
+
 		public WriteEvents(
 					IPublisher publisher,
 					TimeSpan timeout,
@@ -22,7 +19,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					string streamId,
 					bool betterOrdering,
 					long expectedVersion,
-					ClaimsPrincipal user,
 					Event[] events,
 					CommitSource commitSource)
 			: base(
@@ -36,24 +32,9 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 prepareCount: 0,
 					 waitForCommit: true) {
 			_streamId = streamId;
-			//this seems like it should work, but really really doesn't
-			//TODO(clc): confirm MetaWrite is implemented
-			//_accessType = SystemStreams.IsMetaStream(streamId) ? StreamAccessType.MetaWrite : StreamAccessType.Write;
-			_accessType = StreamAccessType.Write;
 			_betterOrdering = betterOrdering;
-			_user = user;
 			_events = events;
 		}
-
-		protected override Message AccessRequestMsg =>				
-				new StorageMessage.CheckStreamAccess(
-						WriteReplyEnvelope, 
-						InternalCorrId, 
-						_streamId, 
-						null, 
-						_accessType, 
-						_user, 
-						_betterOrdering);
 
 		protected override Message WriteRequestMsg =>
 			new StorageMessage.WritePrepares(

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -9,9 +9,6 @@ using EventStore.Core.Services.TimerService;
 using System.Diagnostics;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Histograms;
-using System.Threading;
-using System.Collections.Concurrent;
-using System.Linq;
 
 namespace EventStore.Core.Services.RequestManager {
 	public class RequestManagementService :		
@@ -22,7 +19,6 @@ namespace EventStore.Core.Services.RequestManager {
 		IHandle<ClientMessage.TransactionWrite>,
 		IHandle<ClientMessage.TransactionCommit>,
 		IHandle<StorageMessage.RequestCompleted>,
-		IHandle<StorageMessage.CheckStreamAccessCompleted>,
 		IHandle<StorageMessage.AlreadyCommitted>,
 		IHandle<StorageMessage.PrepareAck>,
 		IHandle<StorageMessage.CommitAck>,
@@ -51,7 +47,6 @@ namespace EventStore.Core.Services.RequestManager {
 			TimeSpan commitTimeout,
 			bool betterOrdering) {
 			Ensure.NotNull(bus, "bus");
-
 			_bus = bus;
 			_tickRequestMessage = TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
 				new PublishEnvelope(bus),
@@ -75,7 +70,6 @@ namespace EventStore.Core.Services.RequestManager {
 								message.EventStreamId,
 								_betterOrdering,
 								message.ExpectedVersion,
-								message.User,
 								message.Events,
 								_commitSource);
 			_currentRequests.Add(message.InternalCorrId, manager);
@@ -93,7 +87,6 @@ namespace EventStore.Core.Services.RequestManager {
 								message.EventStreamId,
 								_betterOrdering,
 								message.ExpectedVersion,
-								message.User,
 								message.HardDelete,
 								_commitSource);
 			_currentRequests.Add(message.InternalCorrId, manager);
@@ -111,7 +104,6 @@ namespace EventStore.Core.Services.RequestManager {
 								message.EventStreamId,
 								_betterOrdering,
 								message.ExpectedVersion,
-								message.User,
 								_commitSource);
 			_currentRequests.Add(message.InternalCorrId, manager);
 			_currentTimedRequests.Add(message.InternalCorrId, Stopwatch.StartNew());
@@ -143,7 +135,6 @@ namespace EventStore.Core.Services.RequestManager {
 								message.CorrelationId,
 								message.TransactionId,
 								_betterOrdering,
-								message.User,
 								_commitSource);
 			_currentRequests.Add(message.InternalCorrId, manager);
 			_currentTimedRequests.Add(message.InternalCorrId, Stopwatch.StartNew());
@@ -187,7 +178,6 @@ namespace EventStore.Core.Services.RequestManager {
 		public void Handle(ReplicationTrackingMessage.ReplicatedTo message) => _commitSource.Handle(message);
 		public void Handle(ReplicationTrackingMessage.IndexedTo message) => _commitSource.Handle(message);
 
-		public void Handle(StorageMessage.CheckStreamAccessCompleted message)  =>	DispatchInternal(message.CorrelationId, message);
 		public void Handle(StorageMessage.AlreadyCommitted message)  =>	DispatchInternal(message.CorrelationId, message);
 		public void Handle(StorageMessage.PrepareAck message)  =>	DispatchInternal(message.CorrelationId, message);
 		public void Handle(StorageMessage.CommitAck message)  =>	DispatchInternal(message.CorrelationId, message);

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IReadIndex.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IReadIndex.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using EventStore.Core.Data;
+using EventStore.Core.Messages;
 using EventStore.Core.Util;
 
 namespace EventStore.Core.Services.Storage.ReaderIndex {
@@ -43,9 +44,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		bool IsStreamDeleted(string streamId);
 		long GetStreamLastEventNumber(string streamId);
 		StreamMetadata GetStreamMetadata(string streamId);
-
+		StorageMessage.EffectiveAcl GetEffectiveAcl(string streamId);
 		string GetEventStreamIdByTransactionId(long transactionId);
-		StreamAccess CheckStreamAccess(string streamId, StreamAccessType streamAccessType, ClaimsPrincipal user);
 
 		void Close();
 		void Dispose();

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/ReadIndex.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/ReadIndex.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.DataStructures;
 using EventStore.Core.Index;
+using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -86,10 +87,6 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			return _indexReader.GetEventStreamIdByTransactionId(transactionId);
 		}
 
-		StreamAccess IReadIndex.CheckStreamAccess(string streamId, StreamAccessType streamAccessType, ClaimsPrincipal user) {
-			return _indexReader.CheckStreamAccess(streamId, streamAccessType, user);
-		}
-
 		IndexReadAllResult IReadIndex.ReadAllEventsForward(TFPos pos, int maxCount) {
 			return _allReader.ReadAllEventsForward(pos, maxCount);
 		}
@@ -106,6 +103,10 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 
 		IndexReadAllResult IReadIndex.ReadAllEventsBackward(TFPos pos, int maxCount) {
 			return _allReader.ReadAllEventsBackward(pos, maxCount);
+		}
+
+		public StorageMessage.EffectiveAcl GetEffectiveAcl(string streamId) {
+			return _indexReader.GetEffectiveAcl(streamId);
 		}
 
 		ReadIndexStats IReadIndex.GetStatistics() {

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -48,8 +48,9 @@ namespace EventStore.Core.Services.Storage {
 				storageReaderBuses[i].Subscribe<ClientMessage.ReadAllEventsBackward>(readerWorkers[i]);
 				storageReaderBuses[i].Subscribe<ClientMessage.FilteredReadAllEventsForward>(readerWorkers[i]);
 				storageReaderBuses[i].Subscribe<ClientMessage.FilteredReadAllEventsBackward>(readerWorkers[i]);
-				storageReaderBuses[i].Subscribe<StorageMessage.CheckStreamAccess>(readerWorkers[i]);
 				storageReaderBuses[i].Subscribe<StorageMessage.BatchLogExpiredMessages>(readerWorkers[i]);
+				storageReaderBuses[i].Subscribe<StorageMessage.EffectiveStreamAclRequest>(readerWorkers[i]);
+				storageReaderBuses[i].Subscribe<StorageMessage.StreamIdFromTransactionIdRequest>(readerWorkers[i]);
 			}
 
 			_workersMultiHandler = new MultiQueuedHandler(
@@ -69,8 +70,9 @@ namespace EventStore.Core.Services.Storage {
 			subscriber.Subscribe(_workersMultiHandler.WidenFrom<ClientMessage.ReadAllEventsBackward, Message>());
 			subscriber.Subscribe(_workersMultiHandler.WidenFrom<ClientMessage.FilteredReadAllEventsForward, Message>());
 			subscriber.Subscribe(_workersMultiHandler.WidenFrom<ClientMessage.FilteredReadAllEventsBackward, Message>());
-			subscriber.Subscribe(_workersMultiHandler.WidenFrom<StorageMessage.CheckStreamAccess, Message>());
 			subscriber.Subscribe(_workersMultiHandler.WidenFrom<StorageMessage.BatchLogExpiredMessages, Message>());
+			subscriber.Subscribe(_workersMultiHandler.WidenFrom<StorageMessage.EffectiveStreamAclRequest, Message>());
+			subscriber.Subscribe(_workersMultiHandler.WidenFrom<StorageMessage.StreamIdFromTransactionIdRequest, Message>());
 		}
 
 		void IHandle<SystemMessage.SystemInit>.Handle(SystemMessage.SystemInit message) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
@@ -1,7 +1,9 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Threading.Tasks;
 using EventStore.Client.Shared;
 using EventStore.Cluster;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
@@ -10,12 +12,19 @@ using Grpc.Core;
 namespace EventStore.Core.Services.Transport.Grpc {
 	partial class Gossip {
 		private readonly IPublisher _bus;
-
-		public Gossip(IPublisher bus) {
+		private readonly IAuthorizationProvider _authorizationProvider;
+		private static readonly Operation ReadOperation = new Operation(Authorization.Operations.Node.Gossip.Read);
+		private static readonly Operation UpdateOperation = new Operation(Authorization.Operations.Node.Gossip.Update);
+		public Gossip(IPublisher bus, IAuthorizationProvider authorizationProvider) {
 			_bus = bus;
+			_authorizationProvider = authorizationProvider ?? throw new ArgumentNullException(nameof(authorizationProvider));
 		}
 
 		public override async Task<ClusterInfo> Update(GossipRequest request, ServerCallContext context) {
+			var user = context.GetHttpContext().User;
+			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var clusterInfo = EventStore.Core.Cluster.ClusterInfo.FromGrpcClusterInfo(request.Info);
 			var tcs = new TaskCompletionSource<ClusterInfo>();
 			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs)),
@@ -24,6 +33,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		}
 
 		public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context) {
+			var user = context.GetHttpContext().User;
+			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var tcs = new TaskCompletionSource<ClusterInfo>();
 			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs)),
 				new EventStore.Core.Cluster.ClusterInfo(), null));

--- a/src/EventStore.Core/Services/Transport/Grpc/Operations.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Operations.cs
@@ -5,16 +5,20 @@ using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client.Operations;
+using EventStore.Core.Authorization;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public partial class Operations
 		: EventStore.Client.Operations.Operations.OperationsBase {
-		private readonly IQueuedHandler _queue;
+		private readonly IPublisher _publisher;
+		private readonly IAuthorizationProvider _authorizationProvider;
 
-		public Operations(IQueuedHandler queue) {
-			if (queue == null) throw new ArgumentNullException(nameof(queue));
-			_queue = queue;
+		public Operations(IPublisher publisher, IAuthorizationProvider authorizationProvider) {
+			if (publisher == null) throw new ArgumentNullException(nameof(publisher));
+			if (authorizationProvider == null) throw new ArgumentNullException(nameof(authorizationProvider));
+			_publisher = publisher;
+			_authorizationProvider = authorizationProvider;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.cs
@@ -1,15 +1,19 @@
 using System;
 using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public partial class PersistentSubscriptions
 		: EventStore.Client.PersistentSubscriptions.PersistentSubscriptions.PersistentSubscriptionsBase {
-		private readonly IQueuedHandler _queue;
+		private readonly IPublisher _publisher;
+		private readonly IAuthorizationProvider _authorizationProvider;
 
-		public PersistentSubscriptions(IQueuedHandler queue) {
-			if (queue == null) throw new ArgumentNullException(nameof(queue));
-			_queue = queue;
+		public PersistentSubscriptions(IPublisher publisher, IAuthorizationProvider authorizationProvider) {
+			if (publisher == null) throw new ArgumentNullException(nameof(publisher));
+			if (authorizationProvider == null) throw new ArgumentNullException(nameof(authorizationProvider));
+			_publisher = publisher;
+			_authorizationProvider = authorizationProvider;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
@@ -1,21 +1,24 @@
 using System;
-using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public partial class Streams : EventStore.Client.Streams.Streams.StreamsBase {
-		private readonly IQueuedHandler _queue;
+		private readonly IPublisher _publisher;
 		private readonly IReadIndex _readIndex;
 		private readonly int _maxAppendSize;
-
-		public Streams(IQueuedHandler queue, IReadIndex readIndex,
-			int maxAppendSize) {
-			if (queue == null) throw new ArgumentNullException(nameof(queue));
-
-			_queue = queue;
+		private readonly IAuthorizationProvider _provider;
+		private static readonly Operation ReadOperation = new Operation(Authorization.Operations.Streams.Read);
+		private static readonly Operation WriteOperation = new Operation(Authorization.Operations.Streams.Write);
+		private static readonly Operation DeleteOperation = new Operation(Authorization.Operations.Streams.Delete);
+		public Streams(IPublisher publisher, IReadIndex readIndex,
+			int maxAppendSize, IAuthorizationProvider provider) {
+			if (publisher == null) throw new ArgumentNullException(nameof(publisher));
+			_publisher = publisher;
 			_readIndex = readIndex;
 			_maxAppendSize = maxAppendSize;
+			_provider = provider;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.ChangePassword.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.ChangePassword.cs
@@ -2,21 +2,31 @@ using System.Threading.Tasks;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client.Users;
+using EventStore.Core.Authorization;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public partial class Users {
+		private static readonly Operation ChangePasswordOperation = new Operation(Authorization.Operations.Users.ChangePassword);
 		public override async Task<ChangePasswordResp> ChangePassword(ChangePasswordReq request,
 			ServerCallContext context) {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-
+			var changePasswordOperation = ChangePasswordOperation;
+			if (user?.Identity?.Name != null) {
+				changePasswordOperation =
+					changePasswordOperation.WithParameter(
+						Authorization.Operations.Users.Parameters.User(user.Identity.Name));
+			}
+			if (!await _authorizationProvider.CheckAccessAsync(user, changePasswordOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var changePasswordSource = new TaskCompletionSource<bool>();
 
 			var envelope = new CallbackEnvelope(OnMessage);
 
-			_queue.Publish(new UserManagementMessage.ChangePassword(envelope, user, options.LoginName,
+			_publisher.Publish(new UserManagementMessage.ChangePassword(envelope, user, options.LoginName,
 				options.CurrentPassword,
 				options.NewPassword));
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Delete.cs
@@ -2,20 +2,24 @@ using System.Threading.Tasks;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client.Users;
+using EventStore.Core.Authorization;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	partial class Users {
+		private static readonly Operation DeleteOperation = new Operation(Authorization.Operations.Users.Delete);
 		public override async Task<DeleteResp> Delete(DeleteReq request, ServerCallContext context) {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-
+			if (!await _authorizationProvider.CheckAccessAsync(user, DeleteOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var deleteSource = new TaskCompletionSource<bool>();
 
 			var envelope = new CallbackEnvelope(OnMessage);
 
-			_queue.Publish(new UserManagementMessage.Delete(envelope, user, options.LoginName));
+			_publisher.Publish(new UserManagementMessage.Delete(envelope, user, options.LoginName));
 
 			await deleteSource.Task.ConfigureAwait(false);
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Enable.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Enable.cs
@@ -2,20 +2,24 @@ using System.Threading.Tasks;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client.Users;
+using EventStore.Core.Authorization;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public partial class Users {
+		private static readonly Operation EnableOperation = new Operation(Authorization.Operations.Users.Enable);
 		public override async Task<EnableResp> Enable(EnableReq request, ServerCallContext context) {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-
+			if (!await _authorizationProvider.CheckAccessAsync(user, EnableOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var enableSource = new TaskCompletionSource<bool>();
 
 			var envelope = new CallbackEnvelope(OnMessage);
 
-			_queue.Publish(new UserManagementMessage.Enable(envelope, user, options.LoginName));
+			_publisher.Publish(new UserManagementMessage.Enable(envelope, user, options.LoginName));
 
 			await enableSource.Task.ConfigureAwait(false);
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.ResetPassword.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.ResetPassword.cs
@@ -2,21 +2,25 @@ using System.Threading.Tasks;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client.Users;
+using EventStore.Core.Authorization;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public partial class Users {
+		private static readonly Operation ResetOperation = new Operation(Authorization.Operations.Users.ResetPassword);
 		public override async Task<ResetPasswordResp> ResetPassword(ResetPasswordReq request,
 			ServerCallContext context) {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-
+			if (!await _authorizationProvider.CheckAccessAsync(user, ResetOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var resetPasswordSource = new TaskCompletionSource<bool>();
 
 			var envelope = new CallbackEnvelope(OnMessage);
 
-			_queue.Publish(
+			_publisher.Publish(
 				new UserManagementMessage.ResetPassword(envelope, user, options.LoginName, options.NewPassword));
 
 			await resetPasswordSource.Task.ConfigureAwait(false);

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Update.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Update.cs
@@ -3,20 +3,24 @@ using System.Threading.Tasks;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Client.Users;
+using EventStore.Core.Authorization;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	partial class Users {
+		private static readonly Operation UpdateOperation = new Operation(Authorization.Operations.Users.Update);
 		public override async Task<UpdateResp> Update(UpdateReq request, ServerCallContext context) {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-
+			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var updateSource = new TaskCompletionSource<bool>();
 
 			var envelope = new CallbackEnvelope(OnMessage);
 
-			_queue.Publish(new UserManagementMessage.Update(envelope, user, options.LoginName, options.FullName,
+			_publisher.Publish(new UserManagementMessage.Update(envelope, user, options.LoginName, options.FullName,
 				options.Groups.ToArray()));
 
 			await updateSource.Task.ConfigureAwait(false);

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.cs
@@ -1,17 +1,21 @@
 using System;
 using System.Threading.Tasks;
 using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using static EventStore.Core.Messages.UserManagementMessage;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public partial class Users : EventStore.Client.Users.Users.UsersBase {
-		private readonly IQueuedHandler _queue;
-		
-		public Users(IQueuedHandler queue) {
-			if (queue == null) throw new ArgumentNullException(nameof(queue));
-			_queue = queue;
+		private readonly IPublisher _publisher;
+		private IAuthorizationProvider _authorizationProvider;
+
+		public Users(IPublisher publisher, IAuthorizationProvider authorizationProvider) {
+			if (publisher == null) throw new ArgumentNullException(nameof(publisher));
+			if (authorizationProvider == null) throw new ArgumentNullException(nameof(authorizationProvider));
+			_publisher = publisher;
+			_authorizationProvider = authorizationProvider;
 		}
 
 		private static bool HandleErrors<T>(string loginName, Message message, TaskCompletionSource<T> source) {

--- a/src/EventStore.Core/Services/Transport/Http/AuthorizationMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AuthorizationMiddleware.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Common.Log;
+using EventStore.Core.Authorization;
+using EventStore.Transport.Http;
+using Microsoft.AspNetCore.Http;
+using Serilog;
+
+namespace EventStore.Core.Services.Transport.Http
+{
+	public class AuthorizationMiddleware : IMiddleware {
+		private static readonly ILogger Log = Serilog.Log.ForContext<AuthorizationMiddleware>();
+		private readonly IAuthorizationProvider _authorization;
+
+		public AuthorizationMiddleware(IAuthorizationProvider authorization) {
+			_authorization = authorization;
+		}
+		public async Task InvokeAsync(HttpContext context, RequestDelegate next) {
+			if (InternalHttpHelper.TryGetInternalContext(context, out var manager, out var match, out _)) {
+				if (await _authorization.CheckAccessAsync(manager.User, match.ControllerAction.Operation(match.TemplateMatch), context.RequestAborted).ConfigureAwait(false)) {
+					await next(context).ConfigureAwait(false);
+					return;
+				}
+
+				context.Response.StatusCode = HttpStatusCode.Unauthorized;
+				return;
+			}
+			//LOG
+			Log.Error("Failed to get internal http components for request {requestId}", context.TraceIdentifier);
+			context.Response.StatusCode = HttpStatusCode.InternalServerError;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Http/ControllerAction.cs
+++ b/src/EventStore.Core/Services/Transport/Http/ControllerAction.cs
@@ -1,12 +1,13 @@
 using System;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Transport.Http;
 
 namespace EventStore.Core.Services.Transport.Http {
 	public class ControllerAction {
 		public readonly string UriTemplate;
 		public readonly string HttpMethod;
-		public readonly AuthorizationLevel RequiredAuthorizationLevel;
+		public readonly Func<UriTemplateMatch, Operation> Operation;
 		public readonly ICodec[] SupportedRequestCodecs;
 		public readonly ICodec[] SupportedResponseCodecs;
 		public readonly ICodec DefaultResponseCodec;
@@ -15,7 +16,15 @@ namespace EventStore.Core.Services.Transport.Http {
 			string httpMethod,
 			ICodec[] requestCodecs,
 			ICodec[] responseCodecs,
-			AuthorizationLevel requiredAuthorizationLevel) {
+			Operation operation) :this(uriTemplate,httpMethod, requestCodecs, responseCodecs, _=>operation){
+
+		}
+
+		public ControllerAction(string uriTemplate,
+			string httpMethod,
+			ICodec[] requestCodecs,
+			ICodec[] responseCodecs,
+			Func<UriTemplateMatch, Operation> operation) {
 			Ensure.NotNull(uriTemplate, "uriTemplate");
 			Ensure.NotNull(httpMethod, "httpMethod");
 			Ensure.NotNull(requestCodecs, "requestCodecs");
@@ -27,7 +36,7 @@ namespace EventStore.Core.Services.Transport.Http {
 			SupportedRequestCodecs = requestCodecs;
 			SupportedResponseCodecs = responseCodecs;
 			DefaultResponseCodec = responseCodecs.Length > 0 ? responseCodecs[0] : null;
-			RequiredAuthorizationLevel = requiredAuthorizationLevel;
+			Operation = operation;
 		}
 
 		public bool Equals(ControllerAction other) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AdminController.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Transport.Http;
@@ -21,22 +22,22 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		protected override void SubscribeCore(IHttpService service) {
 			service.RegisterAction(
-				new ControllerAction("/admin/shutdown", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops),
+				new ControllerAction("/admin/shutdown", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Shutdown)),
 				OnPostShutdown);
 			service.RegisterAction(
 				new ControllerAction("/admin/scavenge?startFromChunk={startFromChunk}&threads={threads}",
-					HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops), OnPostScavenge);
+					HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Scavenge.Start)), OnPostScavenge);
 			service.RegisterAction(
 				new ControllerAction("/admin/scavenge/{scavengeId}", HttpMethod.Delete, Codec.NoCodecs,
-					SupportedCodecs, AuthorizationLevel.Ops), OnStopScavenge);
+					SupportedCodecs, new Operation(Operations.Node.Scavenge.Stop)), OnStopScavenge);
 			service.RegisterAction(
-				new ControllerAction("/admin/mergeindexes", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops),
+				new ControllerAction("/admin/mergeindexes", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.MergeIndexes)),
 				OnPostMergeIndexes);
 			service.RegisterAction(
-				new ControllerAction("/admin/node/priority/{nodePriority}", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops),
+				new ControllerAction("/admin/node/priority/{nodePriority}", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.SetPriority)),
 				OnSetNodePriority);
 			service.RegisterAction(
-				new ControllerAction("/admin/node/resign", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops),
+				new ControllerAction("/admin/node/resign", HttpMethod.Post, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Resign)),
 				OnResignNode);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/ClusterWebUIController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Util;
 using EventStore.Transport.Http;
@@ -29,7 +30,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			RegisterRedirectAction(service, "/web", "/web/index.html");
 
 			service.RegisterAction(
-				new ControllerAction("/sys/subsystems", HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.Json}, AuthorizationLevel.Ops),
+				new ControllerAction("/sys/subsystems", HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.Json}, new Operation(Operations.Node.Information.Subsystems)),
 				OnListNodeSubsystems);
 		}
 
@@ -51,7 +52,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					HttpMethod.Get,
 					Codec.NoCodecs,
 					new ICodec[] {Codec.ManualEncoding},
-					AuthorizationLevel.None),
+					new Operation(Operations.Node.Redirect)),
 				(http, match) => http.ReplyTextContent(
 					"Moved", 302, "Found", "text/plain",
 					new[] {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Transport.Http;
@@ -54,21 +55,39 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		protected void Register(IHttpService service, string uriTemplate, string httpMethod,
-			Action<HttpEntityManager, UriTemplateMatch> handler, ICodec[] requestCodecs, ICodec[] responseCodecs, AuthorizationLevel requiredAuthorizationLevel) {
-			service.RegisterAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs, requiredAuthorizationLevel),
+			Action<HttpEntityManager, UriTemplateMatch> handler, ICodec[] requestCodecs, ICodec[] responseCodecs, Operation operation) {
+			service.RegisterAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs, operation),
+				handler);
+		}
+
+		protected void Register(IHttpService service, string uriTemplate, string httpMethod,
+			Action<HttpEntityManager, UriTemplateMatch> handler, ICodec[] requestCodecs, ICodec[] responseCodecs, Func<UriTemplateMatch,Operation> operation) {
+			service.RegisterAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs, operation),
 				handler);
 		}
 
 		protected void RegisterCustom(IHttpService service, string uriTemplate, string httpMethod,
 			Func<HttpEntityManager, UriTemplateMatch, RequestParams> handler,
-			ICodec[] requestCodecs, ICodec[] responseCodecs, AuthorizationLevel requiredAuthorizationLevel) {
-			service.RegisterCustomAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs, requiredAuthorizationLevel),
+			ICodec[] requestCodecs, ICodec[] responseCodecs, Operation operation) {
+			service.RegisterCustomAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs, operation),
 				handler);
 		}
 
-		protected void RegisterUrlBased(IHttpService service, string uriTemplate, string httpMethod, AuthorizationLevel requiredAuthorizationLevel,
+		protected void RegisterCustom(IHttpService service, string uriTemplate, string httpMethod,
+			Func<HttpEntityManager, UriTemplateMatch, RequestParams> handler,
+			ICodec[] requestCodecs, ICodec[] responseCodecs, Func<UriTemplateMatch,Operation> operation) {
+			service.RegisterCustomAction(new ControllerAction(uriTemplate, httpMethod, requestCodecs, responseCodecs, operation),
+				handler);
+		}
+
+		protected void RegisterUrlBased(IHttpService service, string uriTemplate, string httpMethod, Operation operation,
 			Action<HttpEntityManager, UriTemplateMatch> action) {
-			Register(service, uriTemplate, httpMethod, action, Codec.NoCodecs, DefaultCodecs, requiredAuthorizationLevel);
+			Register(service, uriTemplate, httpMethod, action, Codec.NoCodecs, DefaultCodecs, operation);
+		}
+
+		protected void RegisterUrlBased(IHttpService service, string uriTemplate, string httpMethod, Func<UriTemplateMatch,Operation> operation,
+			Action<HttpEntityManager, UriTemplateMatch> action) {
+			Register(service, uriTemplate, httpMethod, action, Codec.NoCodecs, DefaultCodecs, operation);
 		}
 
 		protected static string MakeUrl(HttpEntityManager http, string path) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Net.Http;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Cluster;
 using EventStore.Core.Messages;
@@ -34,7 +35,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		protected override void SubscribeCore(IHttpService service) {
-			service.RegisterAction(new ControllerAction("/gossip", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+			service.RegisterAction(new ControllerAction("/gossip", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Gossip.Read)),
 				OnGetGossip);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/HistogramController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/HistogramController.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Text;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
 using EventStore.Transport.Http.EntityManagement;
@@ -15,7 +16,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		public void Subscribe(IHttpService service) {
 			Ensure.NotNull(service, "service");
 			service.RegisterAction(
-				new ControllerAction("/histogram/{name}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops),
+				new ControllerAction("/histogram/{name}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Information.Histogram)),
 				OnGetHistogram);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/HttpHelpers.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/HttpHelpers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
 using EventStore.Transport.Http.EntityManagement;
@@ -14,7 +15,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					HttpMethod.Get,
 					Codec.NoCodecs,
 					new ICodec[] {Codec.ManualEncoding},
-					AuthorizationLevel.None),
+					new Operation(Operations.Node.Redirect)),
 				(http, match) => http.ReplyTextContent(
 					"Moved", 302, "Found", "text/plain",
 					new[] {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Rags;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
@@ -29,10 +30,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		public void Subscribe(IHttpService service) {
 			Ensure.NotNull(service, "service");
-			service.RegisterAction(new ControllerAction("/info", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+			service.RegisterAction(new ControllerAction("/info", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Information.Read)),
 				OnGetInfo);
 			service.RegisterAction(
-				new ControllerAction("/info/options", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops), OnGetOptions);
+				new ControllerAction("/info/options", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Information.Options)), OnGetOptions);
 		}
 
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PingController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PingController.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Messages;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
@@ -15,7 +16,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		public void Subscribe(IHttpService service) {
 			Ensure.NotNull(service, "service");
-			service.RegisterAction(new ControllerAction("/ping", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+			service.RegisterAction(new ControllerAction("/ping", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Ping)),
 				OnGetPing);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/StatController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Transport.Http;
@@ -21,15 +22,15 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		protected override void SubscribeCore(IHttpService service) {
 			Ensure.NotNull(service, "service");
 
-			service.RegisterAction(new ControllerAction("/stats", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+			service.RegisterAction(new ControllerAction("/stats", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Statistics.Read)),
 				OnGetFreshStats);
 			service.RegisterAction(
-				new ControllerAction("/stats/replication", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/stats/replication", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Statistics.Replication)),
 				OnGetReplicationStats);
-			service.RegisterAction(new ControllerAction("/stats/tcp", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+			service.RegisterAction(new ControllerAction("/stats/tcp", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Statistics.Tcp)),
 				OnGetTcpConnectionStats);
 			service.RegisterAction(
-				new ControllerAction("/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.None),
+				new ControllerAction("/stats/{*statPath}", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Statistics.Custom)),
 				OnGetFreshStats);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/IHttpService.cs
+++ b/src/EventStore.Core/Services/Transport/Http/IHttpService.cs
@@ -36,6 +36,5 @@ namespace EventStore.Core.Services.Transport.Http {
 
 		void Shutdown();
 
-		RequestDelegate AppFunc { get; }
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/InternalDispatcherEndpoint.cs
+++ b/src/EventStore.Core/Services/Transport/Http/InternalDispatcherEndpoint.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Common.Log;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Services.Transport.Http.Messages;
+using EventStore.Transport.Http;
+using Microsoft.AspNetCore.Http;
+using Serilog;
+
+namespace EventStore.Core.Services.Transport.Http
+{
+	public class InternalDispatcherEndpoint : IHandle<HttpMessage.PurgeTimedOutRequests> {
+		private static readonly ILogger Log = Serilog.Log.ForContext<AuthorizationMiddleware>();
+		private readonly IPublisher _inputBus;
+		private readonly MultiQueuedHandler _requestsMultiHandler;
+		private static readonly TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
+		private readonly IEnvelope _publishEnvelope;
+		public InternalDispatcherEndpoint(IPublisher inputBus, MultiQueuedHandler requestsMultiHandler) {
+
+			_inputBus = inputBus;
+			_requestsMultiHandler = requestsMultiHandler;
+			_publishEnvelope = new PublishEnvelope(inputBus);
+		}
+		public void Handle(HttpMessage.PurgeTimedOutRequests message) {
+			
+			_requestsMultiHandler.PublishToAll(message);
+
+			_inputBus.Publish(
+				TimerMessage.Schedule.Create(
+					UpdateInterval, _publishEnvelope, message));
+		}
+
+		public Task InvokeAsync(HttpContext context) {
+			
+			if (InternalHttpHelper.TryGetInternalContext(context, out var manager, out var match, out var tcs)) {
+				_requestsMultiHandler.Publish(new AuthenticatedHttpRequestMessage(manager, match));
+				return tcs.Task;
+			}
+			Log.Error("Failed to get internal http components for request {requestId}", context.TraceIdentifier);
+			context.Response.StatusCode = HttpStatusCode.InternalServerError;
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Http/InternalHttpHelper.cs
+++ b/src/EventStore.Core/Services/Transport/Http/InternalHttpHelper.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading.Tasks;
+using EventStore.Transport.Http.EntityManagement;
+using Microsoft.AspNetCore.Http;
+
+namespace EventStore.Core.Services.Transport.Http
+{
+	public static class InternalHttpHelper {
+		public static bool TryGetInternalContext(HttpContext context, out HttpEntityManager manager, out UriToActionMatch match, out TaskCompletionSource<bool> tcs) {
+			manager = null;
+			match = null;
+			tcs = null;
+			return context.Items.TryGetValue(typeof(HttpEntityManager), out var untypedManager) &&
+			       context.Items.TryGetValue(typeof(UriToActionMatch), out var untypedMatch) &&
+			       context.Items.TryGetValue(typeof(TaskCompletionSource<bool>), out var untypedTcs) &&
+			       (manager = untypedManager as HttpEntityManager) != null &&
+			       (match = untypedMatch as UriToActionMatch) != null &&
+			       (tcs = untypedTcs as TaskCompletionSource<bool>) != null;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Http/KestrelToInternalBridgeMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/KestrelToInternalBridgeMiddleware.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using EventStore.Common.Log;
+using EventStore.Common.Utils;
+using EventStore.Transport.Http;
+using EventStore.Transport.Http.Codecs;
+using EventStore.Transport.Http.EntityManagement;
+using Microsoft.AspNetCore.Http;
+using Serilog;
+using HttpStatusCode = EventStore.Transport.Http.HttpStatusCode;
+
+namespace EventStore.Core.Services.Transport.Http
+{
+	public class KestrelToInternalBridgeMiddleware : IMiddleware {
+		private static readonly ILogger Log = Serilog.Log.ForContext<KestrelToInternalBridgeMiddleware>();
+		private readonly IUriRouter _uriRouter;
+		private readonly bool _logHttpRequests;
+		private readonly IPAddress _advertiseAsAddress;
+		private readonly int _advertiseAsPort;
+
+		public KestrelToInternalBridgeMiddleware(IUriRouter uriRouter, bool logHttpRequests, IPAddress advertiseAsAddress, int advertiseAsPort) {
+			_uriRouter = uriRouter;
+			_logHttpRequests = logHttpRequests;
+			_advertiseAsAddress =advertiseAsAddress;
+			_advertiseAsPort = advertiseAsPort;
+		}
+		private static bool TryMatch(HttpContext context, IUriRouter uriRouter, bool logHttpRequests, IPAddress advertiseAsAddress, int advertiseAsPort) {
+			var tcs = new TaskCompletionSource<bool>();
+			var httpEntity = new HttpEntity(new CoreHttpRequestAdapter(context.Request),
+				new CoreHttpResponseAdapter(context.Response), context.User, logHttpRequests,
+				advertiseAsAddress, advertiseAsPort, () => tcs.TrySetResult(true));
+			httpEntity.SetUser(context.User);
+
+			var request = httpEntity.Request;
+			try {
+				var allMatches = uriRouter.GetAllUriMatches(request.Url);
+				if (allMatches.Count == 0) {
+					NotFound(httpEntity);
+					return false;
+				}
+
+				var allowedMethods = GetAllowedMethods(allMatches);
+
+				if (request.HttpMethod.Equals(HttpMethod.Options, StringComparison.OrdinalIgnoreCase)) {
+					RespondWithOptions(httpEntity, allowedMethods);
+					return false;
+				}
+
+				var match = allMatches.LastOrDefault(
+					m => m.ControllerAction.HttpMethod.Equals(request.HttpMethod, StringComparison.OrdinalIgnoreCase));
+				if (match == null) {
+					MethodNotAllowed(httpEntity, allowedMethods);
+					return false;
+					;
+				}
+
+				ICodec requestCodec = null;
+				var supportedRequestCodecs = match.ControllerAction.SupportedRequestCodecs;
+				if (supportedRequestCodecs != null && supportedRequestCodecs.Length > 0) {
+					requestCodec = SelectRequestCodec(request.HttpMethod, request.ContentType, supportedRequestCodecs);
+					if (requestCodec == null) {
+						BadContentType(httpEntity, "Invalid or missing Content-Type");
+						return false;
+					}
+				}
+
+				ICodec responseCodec = SelectResponseCodec(request,
+					request.AcceptTypes,
+					match.ControllerAction.SupportedResponseCodecs,
+					match.ControllerAction.DefaultResponseCodec);
+				if (responseCodec == null) {
+					BadCodec(httpEntity, "Requested URI is not available in requested format");
+					return false;
+				}
+				try {
+					var manager =
+						httpEntity.CreateManager(requestCodec, responseCodec, allowedMethods, satisfied => { });
+					context.Items.Add(manager.GetType(), manager);
+					context.Items.Add(match.GetType(), match);
+					context.Items.Add(tcs.GetType(), tcs);
+					return true;
+				} catch (Exception exc) {
+					Log.Error(exc, "Error while handling HTTP request '{url}'.", request.Url);
+					InternalServerError(httpEntity);
+					
+				}
+			} catch (Exception exc) {
+				Log.Error(exc, "Unhandled exception while processing HTTP request at {url}.",
+					httpEntity.RequestedUrl);
+				InternalServerError(httpEntity);
+			}
+			return false;
+		}
+
+		private static string[] GetAllowedMethods(List<UriToActionMatch> allMatches) {
+			var allowedMethods = new string[allMatches.Count + 1];
+			for (int i = 0; i < allMatches.Count; ++i) {
+				allowedMethods[i] = allMatches[i].ControllerAction.HttpMethod;
+			}
+
+			//add options to the list of allowed request methods
+			allowedMethods[allMatches.Count] = HttpMethod.Options;
+			return allowedMethods;
+		}
+
+		private static void RespondWithOptions(HttpEntity httpEntity, string[] allowed) {
+			var entity = httpEntity.CreateManager(Codec.NoCodec, Codec.NoCodec, allowed, _ => { });
+			entity.ReplyStatus(HttpStatusCode.OK, "OK",
+				e => Log.Debug("Error while closing HTTP connection (http service core): {e}.", e.Message));
+		}
+
+		private static void MethodNotAllowed(HttpEntity httpEntity, string[] allowed) {
+			var entity = httpEntity.CreateManager(Codec.NoCodec, Codec.NoCodec, allowed, _ => { });
+			entity.ReplyStatus(HttpStatusCode.MethodNotAllowed, "Method Not Allowed",
+				e => Log.Debug("Error while closing HTTP connection (HTTP service core): {e}.", e.Message));
+		}
+
+		private static void NotFound(HttpEntity httpEntity) {
+			var entity = httpEntity.CreateManager();
+			entity.ReplyStatus(HttpStatusCode.NotFound, "Not Found",
+				e => Log.Debug("Error while closing HTTP connection (HTTP service core): {e}.", e.Message));
+		}
+
+		private static void InternalServerError(HttpEntity httpEntity) {
+			var entity = httpEntity.CreateManager();
+			entity.ReplyStatus(HttpStatusCode.InternalServerError, "Internal Server Error",
+				e => Log.Debug("Error while closing HTTP connection (HTTP service core): {e}.", e.Message));
+		}
+
+		private static void BadCodec(HttpEntity httpEntity, string reason) {
+			var entity = httpEntity.CreateManager();
+			entity.ReplyStatus(HttpStatusCode.NotAcceptable, reason,
+				e => Log.Debug("Error while closing HTTP connection (HTTP service core): {e}.", e.Message));
+		}
+
+		private static void BadContentType(HttpEntity httpEntity, string reason) {
+			var entity = httpEntity.CreateManager();
+			entity.ReplyStatus(HttpStatusCode.UnsupportedMediaType, reason,
+				e => Log.Debug("Error while closing HTTP connection (HTTP service core): {e}.", e.Message));
+		}
+
+		private static ICodec SelectRequestCodec(string method, string contentType, ICodec[] supportedCodecs) {
+			if (string.IsNullOrEmpty(contentType))
+				return supportedCodecs != null && supportedCodecs.Length > 0 ? null : Codec.NoCodec;
+			switch (method.ToUpper()) {
+				case HttpMethod.Post:
+				case HttpMethod.Put:
+				case HttpMethod.Delete:
+					return supportedCodecs.SingleOrDefault(c => c.CanParse(MediaType.Parse(contentType)));
+
+				default:
+					return Codec.NoCodec;
+			}
+		}
+
+		private static ICodec SelectResponseCodec(IHttpRequest query, string[] acceptTypes, ICodec[] supported,
+			ICodec @default) {
+			var requestedFormat = GetFormatOrDefault(query);
+			if (requestedFormat == null && acceptTypes.IsEmpty())
+				return @default;
+
+			if (requestedFormat != null)
+				return supported.FirstOrDefault(c => c.SuitableForResponse(MediaType.Parse(requestedFormat)));
+
+			return acceptTypes.Select(MediaType.TryParse)
+				.Where(x => x != null)
+				.OrderByDescending(v => v.Priority)
+				.Select(type => supported.FirstOrDefault(codec => codec.SuitableForResponse(type)))
+				.FirstOrDefault(corresponding => corresponding != null);
+		}
+
+		private static string GetFormatOrDefault(IHttpRequest request) {
+			var format = request.GetQueryStringValues("format").FirstOrDefault()?.ToLower();
+
+			switch (format) {
+				case null:
+				case "":
+					return null;
+				case "json":
+					return ContentType.Json;
+				case "text":
+					return ContentType.PlainText;
+				case "xml":
+					return ContentType.Xml;
+				case "atom":
+					return ContentType.Atom;
+				case "atomxj":
+					return ContentType.AtomJson;
+				case "atomsvc":
+					return ContentType.AtomServiceDoc;
+				case "atomsvcxj":
+					return ContentType.AtomServiceDocJson;
+				default:
+					throw new NotSupportedException("Unknown format requested");
+			}
+		}
+
+		public Task InvokeAsync(HttpContext context, RequestDelegate next) {
+			if(TryMatch(context, _uriRouter, _logHttpRequests, _advertiseAsAddress, _advertiseAsPort))
+				return next(context);
+			return Task.CompletedTask;
+		}
+
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Http/Messages/AuthenticatedHttpRequestMessage.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Messages/AuthenticatedHttpRequestMessage.cs
@@ -1,4 +1,5 @@
-﻿using EventStore.Core.Messaging;
+﻿using System;
+using EventStore.Core.Messaging;
 using EventStore.Transport.Http.EntityManagement;
 
 namespace EventStore.Core.Services.Transport.Http.Messages {
@@ -9,12 +10,12 @@ namespace EventStore.Core.Services.Transport.Http.Messages {
 			get { return TypeId; }
 		}
 
-		public readonly IHttpService HttpService;
-		public readonly HttpEntity Entity;
+		public readonly HttpEntityManager Manager;
+		public readonly UriToActionMatch Match;
 
-		public AuthenticatedHttpRequestMessage(IHttpService httpService, HttpEntity entity) {
-			HttpService = httpService;
-			Entity = entity;
+		public AuthenticatedHttpRequestMessage(HttpEntityManager manager,  UriToActionMatch match) {
+			Manager = manager;
+			Match = match;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		public static readonly TimeSpan ConnectionTimeout = TimeSpan.FromMilliseconds(1000);
 
 		private static readonly ILogger Log = Serilog.Log.ForContext<TcpConnectionManager>();
-
+		private static readonly ClaimsPrincipal Anonymous = new ClaimsPrincipal(new ClaimsIdentity(new[]{new Claim(ClaimTypes.Anonymous, ""), }));
 		public readonly Guid ConnectionId;
 		public readonly string ConnectionName;
 		public readonly IPEndPoint RemoteEndPoint;
@@ -67,6 +67,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private readonly int _connectionQueueSizeThreshold;
 
 		private readonly IAuthenticationProvider _authProvider;
+		private readonly AuthorizationGateway _authorization;
 		private UserCredentials _defaultUser;
 		private TcpServiceType _serviceType;
 
@@ -77,6 +78,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			ITcpConnection openedConnection,
 			IPublisher networkSendQueue,
 			IAuthenticationProvider authProvider,
+			AuthorizationGateway authorization,
 			TimeSpan heartbeatInterval,
 			TimeSpan heartbeatTimeout,
 			Action<TcpConnectionManager, SocketError> onConnectionClosed,
@@ -87,7 +89,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			Ensure.NotNull(openedConnection, "openedConnnection");
 			Ensure.NotNull(networkSendQueue, "networkSendQueue");
 			Ensure.NotNull(authProvider, "authProvider");
-
+			Ensure.NotNull(authorization, "authorization");
 			ConnectionId = openedConnection.ConnectionId;
 			ConnectionName = connectionName;
 
@@ -96,6 +98,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			_publisher = publisher;
 			_dispatcher = dispatcher;
 			_authProvider = authProvider;
+			_authorization = authorization;
 
 			_framer = new LengthPrefixMessageFramer();
 			_framer.RegisterMessageArrivedCallback(OnMessageArrived);
@@ -130,6 +133,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			X509CertificateCollection sslClientCertificates,
 			IPublisher networkSendQueue,
 			IAuthenticationProvider authProvider,
+			AuthorizationGateway authorization,
 			TimeSpan heartbeatInterval,
 			TimeSpan heartbeatTimeout,
 			Action<TcpConnectionManager> onConnectionEstablished,
@@ -138,6 +142,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			Ensure.NotNull(dispatcher, "dispatcher");
 			Ensure.NotNull(publisher, "publisher");
 			Ensure.NotNull(authProvider, "authProvider");
+			Ensure.NotNull(authorization, "authorization");
 			Ensure.NotNull(remoteEndPoint, "remoteEndPoint");
 			Ensure.NotNull(connector, "connector");
 
@@ -148,6 +153,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			_publisher = publisher;
 			_dispatcher = dispatcher;
 			_authProvider = authProvider;
+			_authorization = authorization;
 
 			_framer = new LengthPrefixMessageFramer();
 			_framer.RegisterMessageArrivedCallback(OnMessageArrived);
@@ -308,7 +314,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 							_authProvider.Authenticate(new TcpAuthRequest(this, package, defaultUser.Login,
 								defaultUser.Password));
 					} else {
-						UnwrapAndPublishPackage(package, null, null, null);
+						UnwrapAndPublishPackage(package, Anonymous, null, null);
 					}
 
 					break;
@@ -326,7 +332,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			}
 
 			if (message != null)
-				_publisher.Publish(message);
+				_authorization.Authorize(message, _publisher);
 			else
 				SendBadRequest(package.CorrelationId,
 					string.Format("Could not unwrap network package for command {0}.\n{1}", package.Command, error));

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpService.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpService.cs
@@ -39,6 +39,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private readonly bool _sslValidateClient;
 		private readonly int _connectionPendingSendBytesThreshold;
 		private readonly int _connectionQueueSizeThreshold;
+		private readonly AuthorizationGateway _authorizationGateway;
 
 		public TcpService(IPublisher publisher,
 			IPEndPoint serverEndPoint,
@@ -49,12 +50,13 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			TimeSpan heartbeatInterval,
 			TimeSpan heartbeatTimeout,
 			IAuthenticationProvider authProvider,
+			AuthorizationGateway authorizationGateway,
 			X509Certificate certificate,
 			bool sslValidateClient,
 			int connectionPendingSendBytesThreshold,
 			int connectionQueueSizeThreshold)
 			: this(publisher, serverEndPoint, networkSendQueue, serviceType, securityType, (_, __) => dispatcher,
-				heartbeatInterval, heartbeatTimeout, authProvider, certificate, sslValidateClient, connectionPendingSendBytesThreshold, connectionQueueSizeThreshold) {
+				heartbeatInterval, heartbeatTimeout, authProvider, authorizationGateway, certificate, sslValidateClient, connectionPendingSendBytesThreshold, connectionQueueSizeThreshold) {
 		}
 
 		public TcpService(IPublisher publisher,
@@ -66,6 +68,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			TimeSpan heartbeatInterval,
 			TimeSpan heartbeatTimeout,
 			IAuthenticationProvider authProvider,
+			AuthorizationGateway authorizationGateway,
 			X509Certificate certificate,
 			bool sslValidateClient,
 			int connectionPendingSendBytesThreshold,
@@ -75,6 +78,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			Ensure.NotNull(networkSendQueue, "networkSendQueue");
 			Ensure.NotNull(dispatcherFactory, "dispatcherFactory");
 			Ensure.NotNull(authProvider, "authProvider");
+			Ensure.NotNull(authorizationGateway, "authorizationGateway");
 			if (securityType == TcpSecurityType.Secure)
 				Ensure.NotNull(certificate, "certificate");
 
@@ -90,6 +94,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			_connectionPendingSendBytesThreshold = connectionPendingSendBytesThreshold;
 			_connectionQueueSizeThreshold = connectionQueueSizeThreshold;
 			_authProvider = authProvider;
+			_authorizationGateway = authorizationGateway;
 			_certificate = certificate;
 			_sslValidateClient = sslValidateClient;
 		}
@@ -126,6 +131,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 				conn,
 				_networkSendQueue,
 				_authProvider,
+				_authorizationGateway,
 				_heartbeatInterval,
 				_heartbeatTimeout,
 				(m, e) => _publisher.Publish(new TcpMessage.ConnectionClosed(m, e)),

--- a/src/EventStore.Core/Util/MiniWeb.cs
+++ b/src/EventStore.Core/Util/MiniWeb.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.Codecs;
@@ -29,7 +30,7 @@ namespace EventStore.Core.Util {
 			var pattern = _localWebRootPath + "/{*remaining_path}";
 			Logger.Verbose("Binding MiniWeb to {path}", pattern);
 			service.RegisterAction(
-				new ControllerAction(pattern, HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, AuthorizationLevel.None),
+				new ControllerAction(pattern, HttpMethod.Get, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, new Operation(Operations.Node.StaticContent)),
 				OnStaticContent);
 		}
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -9,6 +9,7 @@ using System.Security.Cryptography.X509Certificates;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
 using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Cluster.Settings;
 using EventStore.Core.Services.Gossip;
 using EventStore.Core.Services.Monitoring;
@@ -142,6 +143,7 @@ namespace EventStore.Core {
 		private bool _readOnlyReplica;
 		private bool _unsafeAllowSurplusNodes;
 		private Func<HttpMessageHandler> _createHttpMessageHandler;
+		private IAuthorizationProviderFactory _authorizationProviderFactory;
 
 		// ReSharper restore FieldCanBeMadeReadOnly.Local
 
@@ -192,6 +194,9 @@ namespace EventStore.Core {
 
 			_authenticationProviderFactory = new InternalAuthenticationProviderFactory();
 			_disableFirstLevelHttpAuthorization = Opts.DisableFirstLevelHttpAuthorizationDefault;
+
+			_authorizationProviderFactory = new LegacyAuthorizationProviderFactory();
+
 			_disableScavengeMerging = Opts.DisableScavengeMergeDefault;
 			_scavengeHistoryMaxAge = Opts.ScavengeHistoryMaxAgeDefault;
 			_adminOnPublic = Opts.AdminOnExtDefault;
@@ -1388,6 +1393,7 @@ namespace EventStore.Core {
 				_statsStorage,
 				_nodePriority,
 				_authenticationProviderFactory,
+				_authorizationProviderFactory,
 				_disableScavengeMerging,
 				_scavengeHistoryMaxAge,
 				_adminOnPublic,

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/with_standard_projections_running.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/with_standard_projections_running.cs
@@ -19,6 +19,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI {
 
 			[Test, Category("Network")]
 			public async Task deleted_stream_events_are_indexed() {
+				await Task.Delay(500).ConfigureAwait(false); //give the projection time to catchup...
 				var slice = await _conn.ReadStreamEventsForwardAsync("$ce-cat", 0, 10, true, _admin);
 				Assert.AreEqual(SliceReadStatus.Success, slice.Status);
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
@@ -3,18 +3,23 @@ using System.Threading.Tasks;
 using EventStore.Core;
 using EventStore.Core.Messaging;
 using EventStore.Client.Projections;
+using EventStore.Core.Authorization;
 using EventStore.Projections.Core.Messages;
 using Grpc.Core;
 
 namespace EventStore.Projections.Core.Services.Grpc {
 	public partial class ProjectionManagement {
+		private static readonly Operation DisableOperation = new Operation(Operations.Projections.Disable);
 		public override async Task<DisableResp> Disable(DisableReq request, ServerCallContext context) {
 			var disableSource = new TaskCompletionSource<bool>();
 
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-
+			if (!await _authorizationProvider.CheckAccessAsync(user, DisableOperation, context.CancellationToken)
+				.ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var name = options.Name;
 			var runAs = new ProjectionManagementMessage.RunAs(user);
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
@@ -3,18 +3,23 @@ using System.Threading.Tasks;
 using EventStore.Core;
 using EventStore.Core.Messaging;
 using EventStore.Client.Projections;
+using EventStore.Core.Authorization;
 using EventStore.Projections.Core.Messages;
 using Grpc.Core;
 
 namespace EventStore.Projections.Core.Services.Grpc {
 	public partial class ProjectionManagement {
+		private static readonly Operation ResetOperation = new Operation(Operations.Projections.Create);
 		public override async Task<ResetResp> Reset(ResetReq request, ServerCallContext context) {
 			var resetSource = new TaskCompletionSource<bool>();
 
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-
+			if (!await _authorizationProvider.CheckAccessAsync(user, ResetOperation, context.CancellationToken)
+				.ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
 			var name = options.Name;
 			var runAs = new ProjectionManagementMessage.RunAs(user);
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.cs
@@ -1,8 +1,7 @@
 using System;
 using System.Linq;
 using System.Text.Json;
-using EventStore.Core;
-using EventStore.Core.Authentication;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Transport.Grpc;
@@ -19,11 +18,13 @@ namespace EventStore.Client.Projections {
 namespace EventStore.Projections.Core.Services.Grpc {
 	public partial class ProjectionManagement : EventStore.Client.Projections.Projections.ProjectionsBase {
 		private readonly IQueuedHandler _queue;
-		
-		public ProjectionManagement(IQueuedHandler queue) {
-			if (queue == null) throw new ArgumentNullException(nameof(queue));
-			_queue = queue;
+		private readonly IAuthorizationProvider _authorizationProvider;
 
+		public ProjectionManagement(IQueuedHandler queue, IAuthorizationProvider authorizationProvider) {
+			if (queue == null) throw new ArgumentNullException(nameof(queue));
+			if (authorizationProvider == null) throw new ArgumentNullException(nameof(authorizationProvider));
+			_queue = queue;
+			_authorizationProvider = authorizationProvider;
 		}
 
 		private static Exception UnknownMessage<T>(Message message) where T : Message =>

--- a/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
+++ b/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using EventStore.Common.Utils;
+using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
@@ -49,56 +50,56 @@ namespace EventStore.Projections.Core.Services.Http {
 			HttpHelpers.RegisterRedirectAction(service, "/web/projections", "/web/projections.htm");
 
 			Register(service, "/projections",
-				HttpMethod.Get, OnProjections, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjections, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, new Operation(Operations.Projections.List));
 			Register(service, "/projections/restart",
-				HttpMethod.Post, OnProjectionsRestart, new ICodec[] { Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.Admin);
+				HttpMethod.Post, OnProjectionsRestart, new ICodec[] { Codec.ManualEncoding}, SupportedCodecs, new Operation(Operations.Projections.Restart));
 			Register(service, "/projections/any",
-				HttpMethod.Get, OnProjectionsGetAny, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionsGetAny, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.List));
 			Register(service, "/projections/all-non-transient",
-				HttpMethod.Get, OnProjectionsGetAllNonTransient, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionsGetAllNonTransient, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.List));
 			Register(service, "/projections/transient",
-				HttpMethod.Get, OnProjectionsGetTransient, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionsGetTransient, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.List));
 			Register(service, "/projections/onetime",
-				HttpMethod.Get, OnProjectionsGetOneTime, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionsGetOneTime, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.List));
 			Register(service, "/projections/continuous",
-				HttpMethod.Get, OnProjectionsGetContinuous, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionsGetContinuous, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.List));
 			Register(service, "/projections/transient?name={name}&type={type}&enabled={enabled}",
-				HttpMethod.Post, OnProjectionsPostTransient, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Post, OnProjectionsPostTransient, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, new Operation(Operations.Projections.Create).WithParameter(Operations.Projections.Parameters.Query));
 			Register(service,
 				"/projections/onetime?name={name}&type={type}&enabled={enabled}&checkpoints={checkpoints}&emit={emit}&trackemittedstreams={trackemittedstreams}",
-				HttpMethod.Post, OnProjectionsPostOneTime, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.Ops);
+				HttpMethod.Post, OnProjectionsPostOneTime, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, new Operation(Operations.Projections.Create).WithParameter(Operations.Projections.Parameters.OneTime));
 			Register(service,
 				"/projections/continuous?name={name}&type={type}&enabled={enabled}&emit={emit}&trackemittedstreams={trackemittedstreams}",
-				HttpMethod.Post, OnProjectionsPostContinuous, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.Ops);
+				HttpMethod.Post, OnProjectionsPostContinuous, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, new Operation(Operations.Projections.Create).WithParameter(Operations.Projections.Parameters.Continuous));
 			Register(service, "/projection/{name}/query?config={config}",
-				HttpMethod.Get, OnProjectionQueryGet, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionQueryGet, Codec.NoCodecs, new ICodec[] {Codec.ManualEncoding}, new Operation(Operations.Projections.Read));
 			Register(service, "/projection/{name}/query?type={type}&emit={emit}",
-				HttpMethod.Put, OnProjectionQueryPut, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, AuthorizationLevel.User); /* source of transient projections can be set by a normal user. Authorization checks are done internally for non-transient projections. */
+				HttpMethod.Put, OnProjectionQueryPut, new ICodec[] {Codec.ManualEncoding}, SupportedCodecs, new Operation(Operations.Projections.Update)); /* source of transient projections can be set by a normal user. Authorization checks are done internally for non-transient projections. */
 			Register(service, "/projection/{name}",
-				HttpMethod.Get, OnProjectionStatusGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionStatusGet, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.Status));
 			Register(service,
 				"/projection/{name}?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}&deleteEmittedStreams={deleteEmittedStreams}",
-				HttpMethod.Delete, OnProjectionDelete, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops);
+				HttpMethod.Delete, OnProjectionDelete, Codec.NoCodecs, SupportedCodecs,new Operation(Operations.Projections.Delete));
 			Register(service, "/projection/{name}/statistics",
-				HttpMethod.Get, OnProjectionStatisticsGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionStatisticsGet, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.Statistics));
 			Register(service, "/projections/read-events",
-				HttpMethod.Post, OnProjectionsReadEvents, SupportedCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Post, OnProjectionsReadEvents, SupportedCodecs, SupportedCodecs, new Operation(Operations.Projections.DebugProjection));
 			Register(service, "/projection/{name}/state?partition={partition}",
-				HttpMethod.Get, OnProjectionStateGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionStateGet, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.State));
 			Register(service, "/projection/{name}/result?partition={partition}",
-				HttpMethod.Get, OnProjectionResultGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User);
+				HttpMethod.Get, OnProjectionResultGet, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.Result));
 			Register(service, "/projection/{name}/command/disable?enableRunAs={enableRunAs}",
-				HttpMethod.Post, OnProjectionCommandDisable, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User); /* transient projections can be stopped by a normal user. Authorization checks are done internally for non-transient projections.*/
+				HttpMethod.Post, OnProjectionCommandDisable, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.Disable)); /* transient projections can be stopped by a normal user. Authorization checks are done internally for non-transient projections.*/
 			Register(service, "/projection/{name}/command/enable?enableRunAs={enableRunAs}",
-				HttpMethod.Post, OnProjectionCommandEnable, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User); /* transient projections can be enabled by a normal user. Authorization checks are done internally for non-transient projections.*/
+				HttpMethod.Post, OnProjectionCommandEnable, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.Enable)); /* transient projections can be enabled by a normal user. Authorization checks are done internally for non-transient projections.*/
 			Register(service, "/projection/{name}/command/reset?enableRunAs={enableRunAs}",
-				HttpMethod.Post, OnProjectionCommandReset, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User); /* transient projections can be reset by a normal user (when debugging). Authorization checks are done internally for non-transient projections.*/
+				HttpMethod.Post, OnProjectionCommandReset, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.Reset)); /* transient projections can be reset by a normal user (when debugging). Authorization checks are done internally for non-transient projections.*/
 			Register(service, "/projection/{name}/command/abort?enableRunAs={enableRunAs}",
-				HttpMethod.Post, OnProjectionCommandAbort, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.User); /* transient projections can be aborted by a normal user. Authorization checks are done internally for non-transient projections.*/
+				HttpMethod.Post, OnProjectionCommandAbort, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.Abort)); /* transient projections can be aborted by a normal user. Authorization checks are done internally for non-transient projections.*/
 			Register(service, "/projection/{name}/config",
-				HttpMethod.Get, OnProjectionConfigGet, Codec.NoCodecs, SupportedCodecs, AuthorizationLevel.Ops);
+				HttpMethod.Get, OnProjectionConfigGet, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Projections.ReadConfiguration));
 			Register(service, "/projection/{name}/config",
-				HttpMethod.Put, OnProjectionConfigPut, SupportedCodecs, SupportedCodecs, AuthorizationLevel.Ops);
+				HttpMethod.Put, OnProjectionConfigPut, SupportedCodecs, SupportedCodecs, new Operation(Operations.Projections.UpdateConfiguration));
 		}
 
 		private void OnProjections(HttpEntityManager http, UriTemplateMatch match) {


### PR DESCRIPTION
- Update tests to use correct credentials where necessary
- Keeps as close as possible to the current security model, but there are some security policies that were inconsistent between clients, particularly around streams and persistent subscriptions. These are now consistent