### PR TITLE
Adds maxSearchWindow parameter to ExcludeSystemEvents

### DIFF
--- a/src/EventStore.Client.Common/Filter.cs
+++ b/src/EventStore.Client.Common/Filter.cs
@@ -100,8 +100,9 @@ namespace EventStore.Client {
 
 		public static readonly EventTypeFilter None = default;
 
-		public static readonly EventTypeFilter ExcludeSystemEvents =
-			new EventTypeFilter(RegularFilterExpression.ExcludeSystemEvents);
+		public static EventTypeFilter ExcludeSystemEvents(uint? maxSearchWindow = null) =>
+			new EventTypeFilter(maxSearchWindow, RegularFilterExpression.ExcludeSystemEvents);
+
 
 		public static IEventFilter Prefix(string prefix)
 			=> new EventTypeFilter(new PrefixFilterExpression(prefix));

--- a/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
+++ b/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -66,7 +67,8 @@ namespace EventStore.Client {
 			var settings = clientSettings ?? new EventStoreClientSettings {
 				CreateHttpMessageHandler = () => new ResponseVersionHandler {
 					InnerHandler = TestServer.CreateHandler()
-				}
+				},
+				OperationOptions = { TimeoutAfter = Debugger.IsAttached ? null : (TimeSpan?)TimeSpan.FromSeconds(30) }
 			};
 
 			Client = new EventStoreClient(settings);
@@ -157,7 +159,8 @@ namespace EventStore.Client {
 			private readonly ClusterVNode _node;
 
 			public TestClusterVNodeStartup(ClusterVNode node) {
-				if (node == null) throw new ArgumentNullException(nameof(node));
+				if (node == null)
+					throw new ArgumentNullException(nameof(node));
 				_node = node;
 			}
 

--- a/src/EventStore.Client.Tests/Streams/read_all_events_backward_filtered.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_backward_filtered.cs
@@ -100,7 +100,7 @@ namespace EventStore.Client.Streams {
 				_fixture.CreateTestEvents(count));
 
 			var events = await _fixture.Client.ReadAllAsync(Direction.Backwards, Position.End, maxCount,
-					filterOptions: new FilterOptions(EventTypeFilter.ExcludeSystemEvents))
+					filterOptions: new FilterOptions(EventTypeFilter.ExcludeSystemEvents()))
 				.Take(count)
 				.ToArrayAsync();
 

--- a/src/EventStore.Client.Tests/Streams/read_all_events_forwards_filtered.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_events_forwards_filtered.cs
@@ -100,7 +100,7 @@ namespace EventStore.Client.Streams {
 				_fixture.CreateTestEvents(count));
 
 			var events = await _fixture.Client.ReadAllAsync(Direction.Forwards, Position.Start, maxCount,
-					filterOptions: new FilterOptions(EventTypeFilter.ExcludeSystemEvents))
+					filterOptions: new FilterOptions(EventTypeFilter.ExcludeSystemEvents(40)))
 				.Take(count)
 				.ToArrayAsync();
 


### PR DESCRIPTION
  - Changes ExcludeSystemEvents to method so that it can
    take a parameter
  - Removes the gRPC default deadline when debugging for
    gRPC test fixtures
  - Fixes #2336