### PR TITLE
Set requires leader on the server side gRPC methods

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
@@ -17,6 +17,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly ulong _maxCount;
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
+			private readonly bool _requiresLeader;
 			private readonly DateTime _deadline;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
@@ -34,6 +35,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				ulong maxCount,
 				bool resolveLinks,
 				ClaimsPrincipal user,
+				bool requiresLeader,
 				DateTime deadline,
 				CancellationToken cancellationToken) {
 				if (bus == null) {
@@ -45,6 +47,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_maxCount = maxCount;
 				_resolveLinks = resolveLinks;
 				_user = user;
+				_requiresLeader = requiresLeader;
 				_deadline = deadline;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
@@ -82,7 +85,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.ReadAllEventsBackward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage),
 					commitPosition, preparePosition, Math.Min(32, (int)_maxCount),
-					_resolveLinks, false, default, _user, _deadline));
+					_resolveLinks, _requiresLeader, default, _user, _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
 					return false;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
@@ -20,6 +20,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly Util.IEventFilter _eventFilter;
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
+			private readonly bool _requiresLeader;
 			private readonly DateTime _deadline;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
@@ -39,6 +40,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				IEventFilter eventFilter,
 				uint? maxSearchWindow,
 				ClaimsPrincipal user,
+				bool requiresLeader,
 				DateTime deadline,
 				CancellationToken cancellationToken) {
 				if (bus == null) {
@@ -64,6 +66,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_maxSearchWindow = maxSearchWindow ?? (uint)maxCount;
 				_resolveLinks = resolveLinks;
 				_user = user;
+				_requiresLeader = requiresLeader;
 				_deadline = deadline;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
@@ -100,7 +103,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.FilteredReadAllEventsBackward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage),
 					commitPosition, preparePosition, Math.Min(32, (int)_maxCount),
-					_resolveLinks, false, (int) _maxSearchWindow, default, _eventFilter, _user, expires: _deadline));
+					_resolveLinks, _requiresLeader, (int) _maxSearchWindow, default, _eventFilter, _user, expires: _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
 					return false;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
@@ -17,6 +17,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly ulong _maxCount;
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
+			private readonly bool _requiresLeader;
 			private readonly DateTime _deadline;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
@@ -34,6 +35,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				ulong maxCount,
 				bool resolveLinks,
 				ClaimsPrincipal user,
+				bool requiresLeader,
 				DateTime deadline,
 				CancellationToken cancellationToken) {
 				if (bus == null) {
@@ -45,6 +47,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_maxCount = maxCount;
 				_resolveLinks = resolveLinks;
 				_user = user;
+				_requiresLeader = requiresLeader;
 				_deadline = deadline;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
@@ -81,7 +84,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.ReadAllEventsForward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage),
 					commitPosition, preparePosition, Math.Min(32, (int)_maxCount),
-					_resolveLinks, false, default, _user, expires: _deadline));
+					_resolveLinks, _requiresLeader, default, _user, expires: _deadline));
 
 				if (_disposedTokenSource.IsCancellationRequested) {
 					return false;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
@@ -20,6 +20,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly uint _maxSearchWindow;
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
+			private readonly bool _requiresLeader;
 			private readonly DateTime _deadline;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
@@ -39,6 +40,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				IEventFilter eventFilter,
 				uint? maxSearchWindow,
 				ClaimsPrincipal user,
+				bool requiresLeader,
 				DateTime deadline,
 				CancellationToken cancellationToken) {
 				if (bus == null) {
@@ -64,6 +66,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_eventFilter = eventFilter;
 				_resolveLinks = resolveLinks;
 				_user = user;
+				_requiresLeader = requiresLeader;
 				_deadline = deadline;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
@@ -99,7 +102,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				_bus.Publish(new ClientMessage.FilteredReadAllEventsForward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage), commitPosition, preparePosition,
-					Math.Min(32, (int)_maxCount), _resolveLinks, false, (int)_maxSearchWindow, default, _eventFilter,
+					Math.Min(32, (int)_maxCount), _resolveLinks, _requiresLeader, (int)_maxSearchWindow, default, _eventFilter,
 					_user, expires: _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
@@ -18,6 +18,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly ulong _maxCount;
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
+			private readonly bool _requiresLeader;
 			private readonly DateTime _deadline;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
@@ -36,6 +37,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				ulong maxCount,
 				bool resolveLinks,
 				ClaimsPrincipal user,
+				bool requiresLeader,
 				DateTime deadline,
 				CancellationToken cancellationToken) {
 				if (bus == null) {
@@ -52,6 +54,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_maxCount = maxCount;
 				_resolveLinks = resolveLinks;
 				_user = user;
+				_requiresLeader = requiresLeader;
 				_deadline = deadline;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
@@ -86,7 +89,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				_bus.Publish(new ClientMessage.ReadStreamEventsBackward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage), _streamName, _nextRevision.ToInt64(),
-					Math.Min(32, (int)_maxCount), _resolveLinks, false, default, _user, _deadline));
+					Math.Min(32, (int)_maxCount), _resolveLinks, _requiresLeader, default, _user, _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
 					return false;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
@@ -18,6 +18,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly ulong _maxCount;
 			private readonly bool _resolveLinks;
 			private readonly ClaimsPrincipal _user;
+			private readonly bool _requiresLeader;
 			private readonly DateTime _deadline;
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
@@ -36,6 +37,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				ulong maxCount,
 				bool resolveLinks,
 				ClaimsPrincipal user,
+				bool requiresLeader,
 				DateTime deadline,
 				CancellationToken cancellationToken) {
 				if (bus == null) {
@@ -52,6 +54,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_maxCount = maxCount;
 				_resolveLinks = resolveLinks;
 				_user = user;
+				_requiresLeader = requiresLeader;
 				_deadline = deadline;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
@@ -85,7 +88,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				_bus.Publish(new ClientMessage.ReadStreamEventsForward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage), _streamName, _nextRevision.ToInt64(),
-					Math.Min(32, (int)_maxCount), _resolveLinks, false, default, _user, expires: _deadline));
+					Math.Min(32, (int)_maxCount), _resolveLinks, _requiresLeader, default, _user, expires: _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
 					return false;

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -75,7 +75,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				correlationId,
 				correlationId,
 				envelope,
-				true,
+				requiresLeader,
 				streamName,
 				expectedVersion,
 				events.ToArray(),

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
 using EventStore.Core.Util;
@@ -29,6 +28,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var uuidOptionsCase = options.UuidOption.ContentCase;
 
 			var user = context.GetHttpContext().User;
+			var requiresLeader = GetRequiresLeader(context.RequestHeaders);
 
 			await using var enumerator =
 				(streamOptionsCase, countOptionsCase, readDirection, filterOptionsCase) switch {
@@ -43,6 +43,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.Count,
 						request.Options.ResolveLinks,
 						user,
+						requiresLeader,
 						context.Deadline,
 						context.CancellationToken),
 					(StreamOptionOneofCase.Stream,
@@ -55,6 +56,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.Count,
 						request.Options.ResolveLinks,
 						user,
+						requiresLeader,
 						context.Deadline,
 						context.CancellationToken),
 					(StreamOptionOneofCase.All,
@@ -66,6 +68,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.Count,
 						request.Options.ResolveLinks,
 						user,
+						requiresLeader,
 						context.Deadline,
 						context.CancellationToken),
 					(StreamOptionOneofCase.All,
@@ -83,6 +86,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							_ => throw new InvalidOperationException()
 						},
 						user,
+						requiresLeader,
 						context.Deadline,
 						context.CancellationToken),
 					(StreamOptionOneofCase.All,
@@ -94,6 +98,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.Count,
 						request.Options.ResolveLinks,
 						user,
+						requiresLeader,
 						context.Deadline,
 						context.CancellationToken),
 					(StreamOptionOneofCase.All,
@@ -111,6 +116,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							_ => throw new InvalidOperationException()
 						},
 						user,
+						requiresLeader,
 						context.Deadline,
 						context.CancellationToken),
 					(StreamOptionOneofCase.Stream,
@@ -122,6 +128,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.Stream.ToSubscriptionStreamRevision(),
 						request.Options.ResolveLinks,
 						user,
+						requiresLeader,
 						_readIndex,
 						context.CancellationToken),
 					(StreamOptionOneofCase.All,
@@ -132,6 +139,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.All.ToSubscriptionPosition(),
 						request.Options.ResolveLinks,
 						user,
+						requiresLeader,
 						_readIndex,
 						context.CancellationToken),
 					(StreamOptionOneofCase.All,
@@ -143,6 +151,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.ResolveLinks,
 						ConvertToEventFilter(request.Options.Filter),
 						user,
+						requiresLeader,
 						_readIndex,
 						request.Options.Filter.WindowCase switch {
 							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,


### PR DESCRIPTION
There were a couple of operations where the `requiresLeader` was explicitly set to false.