### PR TITLE
Fix recursive lock causing deadlock in TCP connections

### DIFF
--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -69,7 +69,6 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		private readonly object _sendLock = new object();
 		private bool _isSending;
 		private volatile int _closed;
-		private int _dispatchingData; //states: 0 - not dispatching data, 1 - dispatching data, 2 - final state, data should not be dispatched after reaching this state
 
 		private Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> _receiveCallback;
 		private readonly Action<ITcpConnection, SocketError> _onConnectionClosed;
@@ -261,16 +260,7 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 				_receiveCallback = null;
 			}
 
-			var oldState = Interlocked.CompareExchange(ref _dispatchingData, 1, 0);
-			if (oldState == 0 || oldState == 1) { //oldState can be 1 if there's a recursive ReceiveAsync call in the callback
-				try {
-					callback(this, res);
-				} finally {
-					if (oldState == 0) {
-						Interlocked.Exchange(ref _dispatchingData, 0);
-					}
-				}
-			}
+			callback(this, res);
 
 			int bytes = 0;
 			for (int i = 0, n = res.Count; i < n; ++i) {
@@ -289,10 +279,6 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 			if (Interlocked.CompareExchange(ref _closed, 1, 0) != 0)
 				return;
 #pragma warning restore 420
-
-			SpinWait spinWait = new SpinWait();
-			while(Interlocked.CompareExchange(ref _dispatchingData, 2, 0) != 0)
-				spinWait.SpinOnce();
 
 			NotifyClosed();
 

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
@@ -64,9 +64,10 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		private readonly MemoryStream _memoryStream = new MemoryStream();
 
 		private readonly object _streamLock = new object();
+		private readonly object _closeLock = new object();
 		private bool _isSending;
 		private int _receiveHandling;
-		private int _isClosed;
+		private volatile bool _isClosed;
 
 		private Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> _receiveCallback;
 		private readonly Action<ITcpConnection, SocketError> _onConnectionClosed;
@@ -376,7 +377,10 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 						res.Add(piece);
 					}
 
-					callback(this, res);
+					lock (_closeLock) {
+						if(!_isClosed)
+							callback(this, res);
+					}
 
 					int bytes = 0;
 					for (int i = 0, n = res.Count; i < n; ++i) {
@@ -397,8 +401,10 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		}
 
 		private void CloseInternal(SocketError socketError, string reason) {
-			if (Interlocked.CompareExchange(ref _isClosed, 1, 0) != 0)
-				return;
+			lock (_closeLock) {
+				if (_isClosed) return;
+				_isClosed = true;
+			}
 
 			NotifyClosed();
 

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnectionSsl.cs
@@ -65,7 +65,7 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 
 		private readonly object _streamLock = new object();
 		private bool _isSending;
-		private int _receiveHandling; //states: 0 - not receiving data, 1 - receiving/dispatching data, 2 - final state, no data received/dispatched after reaching this state
+		private int _receiveHandling;
 		private int _isClosed;
 
 		private Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> _receiveCallback;
@@ -399,10 +399,6 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		private void CloseInternal(SocketError socketError, string reason) {
 			if (Interlocked.CompareExchange(ref _isClosed, 1, 0) != 0)
 				return;
-
-			SpinWait spinWait = new SpinWait();
-			while(Interlocked.CompareExchange(ref _receiveHandling, 2, 0) != 0)
-				spinWait.SpinOnce();
 
 			NotifyClosed();
 

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Tests.ClientAPI;
+using EventStore.Core.Tests.Integration;
+using EventStore.Transport.Tcp;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Tcp {
+
+	[TestFixture]
+	public class when_invalid_data_is_sent_over_tcp : specification_with_cluster {
+
+		[Timeout(5000)]
+		[TestCase("InternalTcpEndPoint", false)]
+		[TestCase("InternalTcpSecEndPoint", true)]
+		[TestCase("ExternalTcpEndPoint", false)]
+		[TestCase("ExternalTcpSecEndPoint", true)]
+		public void connection_should_be_closed_by_remote_party(string endpointProperty, bool secure) {
+			IPEndPoint endpoint = (IPEndPoint)_nodes[0].GetType().GetProperty(endpointProperty).GetValue(_nodes[0], null);
+			var connectedEvent = new ManualResetEvent(false);
+			var closedEvent = new ManualResetEvent(false);
+			ITcpConnection connection;
+			if (!secure) {
+				connection = TcpConnection.CreateConnectingTcpConnection(
+					Guid.NewGuid(),
+					endpoint,
+					new TcpClientConnector(),
+					TimeSpan.FromSeconds(5),
+					(conn) => connectedEvent.Set(),
+					(conn, error) => {
+						Assert.Fail($"Connection failed: {error}");
+					},
+					false);
+			} else {
+				connection = TcpConnectionSsl.CreateConnectingConnection(
+					Guid.NewGuid(),
+					endpoint,
+					false,
+					null,
+					new TcpClientConnector(),
+					TimeSpan.FromSeconds(5),
+					(conn) => connectedEvent.Set(),
+					(conn, error) => {
+						Assert.Fail($"Connection failed: {error}");
+					},
+					false);
+			}
+
+			connection.ConnectionClosed += (conn, error) => {
+				closedEvent.Set();
+			};
+
+			connectedEvent.WaitOne();
+			var data = new List<ArraySegment<byte>> {
+				new ArraySegment<byte>(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+			};
+			connection.EnqueueSend(data);
+			closedEvent.WaitOne();
+			connection.Close("intentional close");
+		}
+	}
+}

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -86,8 +86,9 @@ namespace EventStore.Transport.Tcp {
 
 		private readonly object _receivingLock = new object();
 		private readonly object _sendLock = new object();
+		private readonly object _closeLock = new object();
 		private bool _isSending;
-		private volatile int _closed;
+		private volatile bool _isClosed;
 
 		private Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> _receiveCallback;
 
@@ -185,7 +186,7 @@ namespace EventStore.Transport.Tcp {
 			} else {
 				NotifySendCompleted(socketArgs.Count);
 
-				if (_closed != 0)
+				if (_isClosed)
 					ReturnSendingSocketArgs();
 				else {
 					lock (_sendLock) {
@@ -296,7 +297,10 @@ namespace EventStore.Transport.Tcp {
 				data[i] = new ArraySegment<byte>(d.Buf.Array, d.Buf.Offset, d.DataLen);
 			}
 
-			callback(this, data);
+			lock (_closeLock) {
+				if(!_isClosed)
+					callback(this, data);
+			}
 
 			for (int i = 0, n = res.Count; i < n; ++i) {
 				BufferManager.CheckIn(res[i].Buf); // dispose buffers
@@ -310,10 +314,10 @@ namespace EventStore.Transport.Tcp {
 		}
 
 		private void CloseInternal(SocketError socketError, string reason) {
-#pragma warning disable 420
-			if (Interlocked.CompareExchange(ref _closed, 1, 0) != 0)
-				return;
-#pragma warning restore 420
+			lock (_closeLock) {
+				if (_isClosed) return;
+				_isClosed = true;
+			}
 
 			NotifyClosed();
 

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -88,7 +88,6 @@ namespace EventStore.Transport.Tcp {
 		private readonly object _sendLock = new object();
 		private bool _isSending;
 		private volatile int _closed;
-		private int _dispatchingData; //states: 0 - not dispatching data, 1 - dispatching data, 2 - final state, data should not be dispatched after reaching this state
 
 		private Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> _receiveCallback;
 
@@ -297,16 +296,7 @@ namespace EventStore.Transport.Tcp {
 				data[i] = new ArraySegment<byte>(d.Buf.Array, d.Buf.Offset, d.DataLen);
 			}
 
-			var oldState = Interlocked.CompareExchange(ref _dispatchingData, 1, 0);
-			if (oldState == 0 || oldState == 1) { //oldState can be 1 if there's a recursive ReceiveAsync call in the callback
-				try {
-					callback(this, data);
-				} finally {
-					if (oldState == 0) {
-						Interlocked.Exchange(ref _dispatchingData, 0);
-					}
-				}
-			}
+			callback(this, data);
 
 			for (int i = 0, n = res.Count; i < n; ++i) {
 				BufferManager.CheckIn(res[i].Buf); // dispose buffers
@@ -324,10 +314,6 @@ namespace EventStore.Transport.Tcp {
 			if (Interlocked.CompareExchange(ref _closed, 1, 0) != 0)
 				return;
 #pragma warning restore 420
-
-			SpinWait spinWait = new SpinWait();
-			while(Interlocked.CompareExchange(ref _dispatchingData, 2, 0) != 0)
-				spinWait.SpinOnce();
 
 			NotifyClosed();
 

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -97,7 +97,7 @@ namespace EventStore.Transport.Tcp {
 
 		private readonly object _streamLock = new object();
 		private bool _isSending;
-		private int _receiveHandling; //states: 0 - not receiving data, 1 - receiving/dispatching data, 2 - final state, no data received/dispatched after reaching this state
+		private int _receiveHandling;
 		private int _isClosed;
 
 		private Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> _receiveCallback;
@@ -526,10 +526,6 @@ namespace EventStore.Transport.Tcp {
 		private void CloseInternal(SocketError socketError, string reason) {
 			if (Interlocked.CompareExchange(ref _isClosed, 1, 0) != 0)
 				return;
-
-			SpinWait spinWait = new SpinWait();
-			while(Interlocked.CompareExchange(ref _receiveHandling, 2, 0) != 0)
-				spinWait.SpinOnce();
 
 			NotifyClosed();
 


### PR DESCRIPTION
Fixes #2318

This fixes a regression introduced by commit 68cd7f0b979e95739d11e2138280a88e4dbd9467.

It is possible for `connection.Close()` to be called from the [callback](https://github.com/EventStore/EventStore/commit/68cd7f0b979e95739d11e2138280a88e4dbd9467#diff-a976f5fbfba0888ba9072863f48146aaR259) for example, when there is a TCP framing error (can be tested with `curl -v http://localhost:1113/` where 1113 is the external TCP port)
 
If this happens, it results into a recursive lock which causes a deadlock since the thread doing the callback keeps spinning [here](https://github.com/EventStore/EventStore/commit/68cd7f0b979e95739d11e2138280a88e4dbd9467#diff-a976f5fbfba0888ba9072863f48146aaR286), waiting for the callback to complete.

This fix reverts the commit 68cd7f0b979e95739d11e2138280a88e4dbd9467 and uses a simple lock statement instead which already supports recursive locking.

It would also have been possible to fix the issue by keeping the previous code and saving the callback thread ID and verifying if the closed is being done from the same thread but in this context there is no significant performance benefit compared to using a simple lock since contention will occur only when closing the TCP connection while data is being dispatched.