### PR TITLE
Remove SendOverHttp and other unused http messages

### DIFF
--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -132,10 +132,9 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			return removedList.ToArray();
 		}
 
-		public Message[] RepublishFromPublisher(bool skipScheduledMessages = false) {
-			var httpAndOtherMessages = Publisher.Messages.ToLookup(x => (x is HttpMessage.SendOverHttp));
-			var httpMessages = httpAndOtherMessages[true].ToList();
-			var messages = httpAndOtherMessages[false].ToList();
+		public void RepublishFromPublisher(bool skipScheduledMessages = false) {
+			var messages = new List<Message>();
+			messages.AddRange(Publisher.Messages);
 			Publisher.Messages.Clear();
 
 			messages.Where(x => !(x is TimerMessage.Schedule)).ToList()
@@ -151,9 +150,6 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						x.Reply();
 					});
 			}
-
-			var notConsumed = (messages.Concat(httpMessages)).ToArray();
-			return notConsumed;
 		}
 
 		public bool IsCurrent(IPEndPoint endPoint) {

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/InnerBusMessagesProcessor.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/InnerBusMessagesProcessor.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 
 		public void Handle(Message message) {
 			// timer message and SendOverGrpc is handled differently
-			if (message is TimerMessage.Schedule || message is HttpMessage.SendOverHttp)
+			if (message is TimerMessage.Schedule)
 				return;
 
 			_runner.Enqueue(_endPoint, message, _bus); // process with no delay and no reorderings

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -416,13 +416,8 @@ namespace EventStore.Core {
 			var httpPipe = new HttpMessagePipe();
 			var httpSendService = new HttpSendService(httpPipe, forwardRequests: true);
 			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(httpSendService);
-			_mainBus.Subscribe(new WideningHandler<HttpMessage.SendOverHttp, Message>(_workersHandler));
 			SubscribeWorkers(bus => {
 				bus.Subscribe<HttpMessage.HttpSend>(httpSendService);
-				bus.Subscribe<HttpMessage.HttpSendPart>(httpSendService);
-				bus.Subscribe<HttpMessage.HttpBeginSend>(httpSendService);
-				bus.Subscribe<HttpMessage.HttpEndSend>(httpSendService);
-				bus.Subscribe<HttpMessage.SendOverHttp>(httpSendService);
 			});
 
 			var grpcSendService = new GrpcSendService(_eventStoreClusterClientCache);
@@ -437,7 +432,7 @@ namespace EventStore.Core {
 			var pingController = new PingController();
 			var histogramController = new HistogramController();
 			var statController = new StatController(monitoringQueue, _workersHandler);
-			var atomController = new AtomController(httpSendService, _mainQueue, _workersHandler,
+			var atomController = new AtomController(_mainQueue, _workersHandler,
 				vNodeSettings.DisableHTTPCaching);
 			var gossipController = new GossipController(_mainQueue, _workersHandler, vNodeSettings.GossipTimeout,
 				_httpMessageHandler);

--- a/src/EventStore.Core/Messages/HttpMessage.cs
+++ b/src/EventStore.Core/Messages/HttpMessage.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Net;
-using EventStore.Common.Utils;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Transport.Http.EntityManagement;
@@ -56,66 +54,6 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
-		public class HttpBeginSend : HttpSendMessage {
-			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
-
-			public override int MsgTypeId {
-				get { return TypeId; }
-			}
-
-			public readonly ResponseConfiguration Configuration;
-
-			public HttpBeginSend(Guid correlationId, IEnvelope envelope,
-				HttpEntityManager httpEntityManager, ResponseConfiguration configuration)
-				: base(correlationId, envelope, httpEntityManager) {
-				Configuration = configuration;
-			}
-		}
-
-		public class HttpSendPart : HttpSendMessage {
-			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
-
-			public override int MsgTypeId {
-				get { return TypeId; }
-			}
-
-			public readonly string Data;
-
-			public HttpSendPart(Guid correlationId, IEnvelope envelope, HttpEntityManager httpEntityManager,
-				string data)
-				: base(correlationId, envelope, httpEntityManager) {
-				Data = data;
-			}
-		}
-
-		public class HttpEndSend : HttpSendMessage {
-			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
-
-			public override int MsgTypeId {
-				get { return TypeId; }
-			}
-
-			public HttpEndSend(Guid correlationId, IEnvelope envelope, HttpEntityManager httpEntityManager)
-				: base(correlationId, envelope, httpEntityManager) {
-			}
-		}
-
-		public class HttpCompleted : Message {
-			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
-
-			public override int MsgTypeId {
-				get { return TypeId; }
-			}
-
-			public readonly Guid CorrelationId;
-			public readonly HttpEntityManager HttpEntityManager;
-
-			public HttpCompleted(Guid correlationId, HttpEntityManager httpEntityManager) {
-				CorrelationId = correlationId;
-				HttpEntityManager = httpEntityManager;
-			}
-		}
-
 		public class DeniedToHandle : Message {
 			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
 
@@ -129,24 +67,6 @@ namespace EventStore.Core.Messages {
 			public DeniedToHandle(DenialReason reason, string details) {
 				Reason = reason;
 				Details = details;
-			}
-		}
-
-		public class SendOverHttp : Message {
-			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
-
-			public override int MsgTypeId {
-				get { return TypeId; }
-			}
-
-			public readonly IPEndPoint EndPoint;
-			public readonly Message Message;
-			public readonly DateTime LiveUntil;
-
-			public SendOverHttp(IPEndPoint endPoint, Message message, DateTime liveUntil) {
-				EndPoint = endPoint;
-				Message = message;
-				LiveUntil = liveUntil;
 			}
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -90,12 +90,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			HtmlFeedCodec // initialization order matters
 		};
 
-		private readonly IHttpForwarder _httpForwarder;
 		private readonly IPublisher _networkSendQueue;
 
-		public AtomController(IHttpForwarder httpForwarder, IPublisher publisher, IPublisher networkSendQueue,
+		public AtomController(IPublisher publisher, IPublisher networkSendQueue,
 			bool disableHTTPCaching = false) : base(publisher) {
-			_httpForwarder = httpForwarder;
 			_networkSendQueue = networkSendQueue;
 
 			if (disableHTTPCaching) {


### PR DESCRIPTION
Removed: Unused HTTP messages

The calls that used these messages now go over gRPC.