### PR TITLE
Only Send View Change Proof on System Init

### DIFF
--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -83,6 +83,20 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(0)),
+			};
+			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
+		}
+	}
+	
+	public class when_system_init : ElectionsFixture {
+		public when_system_init()
+			: base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			_sut.Handle(new SystemMessage.SystemInit());
+		}
+
+		[Test]
+		public void should_start_view_change_proof_timer() {
+			var expected = new Message[] {
 				TimerMessage.Schedule.Create(
 					Core.Services.ElectionsService.SendViewChangeProofInterval,
 					new PublishEnvelope(_publisher),
@@ -116,10 +130,6 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(0)),
-				TimerMessage.Schedule.Create(
-					Core.Services.ElectionsService.SendViewChangeProofInterval,
-					new PublishEnvelope(_publisher),
-					new ElectionMessage.SendViewChangeProof()),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/no_quorum_cases.cs
@@ -31,7 +31,6 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		[Test]
 		public void elections_should_time_out() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
-			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
 		}
 	}
 
@@ -69,7 +68,6 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		[Test]
 		public void elections_should_time_out() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
-			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
 		}
 	}
 
@@ -118,7 +116,6 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		[Test]
 		public void elections_should_time_out() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
-			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
 		}
 	}
 
@@ -167,7 +164,6 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		[Test]
 		public void elections_should_time_out() {
 			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.ElectionsTimedOut>());
-			Assert.That(_electionsUnit.Publisher.Messages.ContainsSingle<ElectionMessage.SendViewChangeProof>());
 		}
 	}
 }


### PR DESCRIPTION
Changed: Start View Change Proof Timer on System Initialized only

Fixes #2328 
The existing behaviour causes a compounding effect whereby on the start of every election, a new view change proof timer is kicked off.