### PR TITLE
Remove Better Ordering

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -238,10 +238,6 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.UnsafeDisableFlushToDiskDescr, Opts.DbGroup)]
 		public bool UnsafeDisableFlushToDisk { get; set; }
 
-
-		[ArgDescription(Opts.BetterOrderingDescr, Opts.DbGroup)]
-		public bool BetterOrdering { get; set; }
-
 		[ArgDescription(Opts.UnsafeIgnoreHardDeleteDescr, Opts.DbGroup)]
 		public bool UnsafeIgnoreHardDelete { get; set; }
 
@@ -354,7 +350,6 @@ namespace EventStore.ClusterNode {
 			ProjectionsQueryExpiry = Opts.ProjectionsQueryExpiryDefault;
 			FaultOutOfOrderProjections = Opts.FaultOutOfOrderProjectionsDefault;
 			WorkerThreads = Opts.WorkerThreadsDefault;
-			BetterOrdering = Opts.BetterOrderingDefault;
 
 			EnableTrustedAuth = Opts.EnableTrustedAuthDefault;
 

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -305,8 +305,6 @@ namespace EventStore.ClusterNode {
 				builder.WithUnsafeIgnoreHardDelete();
 			if (options.UnsafeDisableFlushToDisk)
 				builder.WithUnsafeDisableFlushToDisk();
-			if (options.BetterOrdering)
-				builder.WithBetterOrdering();
 			if (options.DisableInternalTls)
 				builder.DisableInternalTls();
 			if (options.DisableExternalTls)

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
@@ -60,7 +60,6 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building {
 				"StartStandardProjections");
 			Assert.AreEqual(Opts.UnsafeIgnoreHardDeleteDefault, _settings.UnsafeIgnoreHardDeletes,
 				"UnsafeIgnoreHardDeletes");
-			Assert.AreEqual(Opts.BetterOrderingDefault, _settings.BetterOrdering, "BetterOrdering");
 			Assert.That(string.IsNullOrEmpty(_settings.Index), "IndexPath");
 			Assert.AreEqual(1, _settings.PrepareAckCount, "PrepareAckCount");
 			Assert.AreEqual(1, _settings.CommitAckCount, "CommitAckCount");
@@ -141,7 +140,6 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building {
 				"StartStandardProjections");
 			Assert.AreEqual(Opts.UnsafeIgnoreHardDeleteDefault, _settings.UnsafeIgnoreHardDeletes,
 				"UnsafeIgnoreHardDeletes");
-			Assert.AreEqual(Opts.BetterOrderingDefault, _settings.BetterOrdering, "BetterOrdering");
 			Assert.That(string.IsNullOrEmpty(_settings.Index), "IndexPath");
 			Assert.AreEqual(Opts.PrepareTimeoutMsDefault, _settings.PrepareTimeout.TotalMilliseconds, "PrepareTimeout");
 			Assert.AreEqual(Opts.CommitTimeoutMsDefault, _settings.CommitTimeout.TotalMilliseconds, "CommitTimeout");

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_single_node_and_custom_settings.cs
@@ -269,18 +269,6 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building {
 	}
 
 	[TestFixture]
-	public class with_better_ordering_enabled : SingleNodeScenario {
-		public override void Given() {
-			_builder.WithBetterOrdering();
-		}
-
-		[Test]
-		public void should_set_better_ordering() {
-			Assert.IsTrue(_settings.BetterOrdering);
-		}
-	}
-
-	[TestFixture]
 	public class with_custom_index_path : SingleNodeScenario {
 		public override void Given() {
 			_builder.WithIndexPath("index");

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_successfully.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				InternalCorrId,
 				ClientCorrId,
 			   	streamId: _streamId,
-				betterOrdering: true,
 				expectedVersion: ExpectedVersion.Any,
 				hardDelete: false,
 				commitSource: CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_after_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_after_commit.cs
@@ -19,7 +19,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				false,
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_before_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_before_commit.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				InternalCorrId,
 				ClientCorrId,
 				_streamId,
-				true,
 				ExpectedVersion.Any,
 				false,
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_stream_deleted.cs
@@ -18,7 +18,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				false,
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_after_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_after_commit.cs
@@ -19,7 +19,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				false,
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_before_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_before_commit.cs
@@ -18,7 +18,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				false,
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -42,10 +42,9 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 			Dispatcher.Subscribe<StorageMessage.RequestCompleted>(this);
 
 			Service = new RequestManagementService(
-				Dispatcher, 
-				TimeSpan.FromSeconds(2), 
+				Dispatcher,
 				TimeSpan.FromSeconds(2),
-				false);
+				TimeSpan.FromSeconds(2));
 			Dispatcher.Subscribe<ClientMessage.WriteEvents>(Service);
 			Dispatcher.Subscribe<StorageMessage.PrepareAck>(Service);
 			Dispatcher.Subscribe<StorageMessage.CommitAck>(Service);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_completes_successfully.cs
@@ -23,7 +23,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,				
 				CommitSource);
 			}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_after_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_after_committed.cs
@@ -23,7 +23,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_before_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_before_committed.cs
@@ -22,7 +22,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_after_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_after_prepares.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_before_prepares.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_prepare_timeout_before_prepares.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_stream_deleted.cs
@@ -20,7 +20,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_timeout_before_cluster_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_timeout_before_cluster_commit.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				transactionId,
-				true,
 				CommitSource);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_start_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_start_completes_successfully.cs
@@ -20,7 +20,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 				InternalCorrId,
 				ClientCorrId,
 				$"testStream-{nameof(when_transaction_commit_completes_successfully)}",
-				true,				
 				0,
 				CommitSource);
 			}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				new[] {DummyEvent()},
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_committed.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				new[] {DummyEvent()},
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_not_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_already_committed_and_log_is_not_committed.cs
@@ -19,7 +19,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				new[] {DummyEvent()},
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_stream_deleted.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_stream_deleted.cs
@@ -18,7 +18,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				new[] {DummyEvent()},
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_cluster_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_cluster_commit.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				new[] {DummyEvent()},
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_local_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_local_commit.cs
@@ -18,7 +18,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				new[] {DummyEvent()},
 				CommitSource);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_before_local_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_before_local_commit.cs
@@ -18,7 +18,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 				InternalCorrId,
 				ClientCorrId,
 				"test123",
-				true,
 				ExpectedVersion.Any,
 				new[] {DummyEvent()},
 				CommitSource);

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -74,7 +74,6 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly byte IndexBitnessVersion;
 		public readonly bool OptimizeIndexMerge;
 
-		public readonly bool BetterOrdering;
 		public readonly string Index;
 		public readonly int ReaderThreadsCount;
 		public readonly IPersistentSubscriptionConsumerStrategyFactory[] AdditionalConsumerStrategies;
@@ -147,7 +146,6 @@ namespace EventStore.Core.Cluster.Settings {
 			bool optimizeIndexMerge = false,
 			IPersistentSubscriptionConsumerStrategyFactory[] additionalConsumerStrategies = null,
 			bool unsafeIgnoreHardDeletes = false,
-			bool betterOrdering = false,
 			int readerThreadsCount = 4,
 			bool alwaysKeepScavenged = false,
 			bool gossipOnSingleNode = false,
@@ -258,7 +256,6 @@ namespace EventStore.Core.Cluster.Settings {
 			OptimizeIndexMerge = optimizeIndexMerge;
 			Index = index;
 			UnsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
-			BetterOrdering = betterOrdering;
 			ReaderThreadsCount = readerThreadsCount;
 			AlwaysKeepScavenged = alwaysKeepScavenged;
 			SkipIndexScanOnReads = skipIndexScanOnReads;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -491,8 +491,7 @@ namespace EventStore.Core {
 			var requestManagement = new RequestManagementService(
 				_mainQueue,
 				vNodeSettings.PrepareTimeout,
-				vNodeSettings.CommitTimeout,
-				vNodeSettings.BetterOrdering);
+				vNodeSettings.CommitTimeout);
 
 			_mainBus.Subscribe<SystemMessage.SystemInit>(requestManagement);
 			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(requestManagement);

--- a/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
@@ -7,7 +7,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 	public class DeleteStream : RequestManagerBase {
 		private readonly bool _hardDelete;
 		private readonly string _streamId;
-		private readonly bool _betterOrdering;
 
 		public DeleteStream(
 					IPublisher publisher,
@@ -16,7 +15,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					Guid internalCorrId,
 					Guid clientCorrId,
 					string streamId,
-					bool betterOrdering,
 					long expectedVersion,
 					bool hardDelete,
 					CommitSource commitSource)
@@ -32,7 +30,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 waitForCommit: true) {
 			_hardDelete = hardDelete;
 			_streamId = streamId;
-			_betterOrdering = betterOrdering;
 		}
 
 		protected override Message WriteRequestMsg =>

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommit.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommit.cs
@@ -7,7 +7,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 	public class TransactionCommit : RequestManagerBase,
 		IHandle<StorageMessage.CommitIndexed> {
 		private readonly TimeSpan _commitTimeout;
-		private readonly bool _betterOrdering;
 		private bool _transactionWritten;
 		public TransactionCommit(
 					IPublisher publisher,
@@ -17,7 +16,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					Guid internalCorrId,
 					Guid clientCorrId,
 					long transactionId,
-					bool betterOrdering,
 					CommitSource commitSource)
 			: base(
 					 publisher,
@@ -31,7 +29,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 prepareCount: 1,
 					 waitForCommit: true) {
 			_commitTimeout = commitTimeout;
-			_betterOrdering = betterOrdering;
 		}
 
 		protected override Message WriteRequestMsg =>

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionStart.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionStart.cs
@@ -6,7 +6,6 @@ using EventStore.Core.Messaging;
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public class TransactionStart : RequestManagerBase {
 		private readonly string _streamId;
-		private readonly bool _betterOrdering;
 
 		public TransactionStart(
 					IPublisher publisher,
@@ -15,7 +14,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					Guid internalCorrId,
 					Guid clientCorrId,
 					string streamId,
-					bool betterOrdering,
 					long expectedVersion,
 					CommitSource commitSource)
 			: base(
@@ -28,7 +26,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 commitSource,
 					 prepareCount: 1) {
 			_streamId = streamId;
-			_betterOrdering = betterOrdering;
 		}
 		
 		protected override Message WriteRequestMsg =>

--- a/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/WriteEvents.cs
@@ -7,7 +7,6 @@ using EventStore.Core.Messaging;
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public class WriteEvents : RequestManagerBase {
 		private readonly string _streamId;
-		private readonly bool _betterOrdering;
 		private readonly Event[] _events;
 
 		public WriteEvents(
@@ -17,7 +16,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					Guid internalCorrId,
 					Guid clientCorrId,
 					string streamId,
-					bool betterOrdering,
 					long expectedVersion,
 					Event[] events,
 					CommitSource commitSource)
@@ -32,7 +30,6 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					 prepareCount: 0,
 					 waitForCommit: true) {
 			_streamId = streamId;
-			_betterOrdering = betterOrdering;
 			_events = events;
 		}
 

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -35,7 +35,6 @@ namespace EventStore.Core.Services.RequestManager {
 		private readonly Dictionary<Guid, RequestManagerBase> _currentRequests = new Dictionary<Guid, RequestManagerBase>();
 		private readonly Dictionary<Guid, Stopwatch> _currentTimedRequests = new Dictionary<Guid, Stopwatch>();
 		private const string _requestManagerHistogram = "request-manager";
-		private readonly bool _betterOrdering;
 		private readonly TimeSpan _prepareTimeout;
 		private readonly TimeSpan _commitTimeout;
 		private readonly CommitSource _commitSource;
@@ -44,8 +43,7 @@ namespace EventStore.Core.Services.RequestManager {
 		public RequestManagementService(
 			IPublisher bus,
 			TimeSpan prepareTimeout,
-			TimeSpan commitTimeout,
-			bool betterOrdering) {
+			TimeSpan commitTimeout) {
 			Ensure.NotNull(bus, "bus");
 			_bus = bus;
 			_tickRequestMessage = TimerMessage.Schedule.Create(TimeSpan.FromMilliseconds(1000),
@@ -54,12 +52,9 @@ namespace EventStore.Core.Services.RequestManager {
 
 			_prepareTimeout = prepareTimeout;
 			_commitTimeout = commitTimeout;
-			_betterOrdering = betterOrdering;
 			_commitSource = new CommitSource();
 		}
 		
-		
-
 		public void Handle(ClientMessage.WriteEvents message) {
 			var manager = new WriteEvents(
 								_bus,
@@ -68,7 +63,6 @@ namespace EventStore.Core.Services.RequestManager {
 								message.InternalCorrId,
 								message.CorrelationId,
 								message.EventStreamId,
-								_betterOrdering,
 								message.ExpectedVersion,
 								message.Events,
 								_commitSource);
@@ -85,7 +79,6 @@ namespace EventStore.Core.Services.RequestManager {
 								message.InternalCorrId,
 								message.CorrelationId,
 								message.EventStreamId,
-								_betterOrdering,
 								message.ExpectedVersion,
 								message.HardDelete,
 								_commitSource);
@@ -102,7 +95,6 @@ namespace EventStore.Core.Services.RequestManager {
 								message.InternalCorrId,
 								message.CorrelationId,
 								message.EventStreamId,
-								_betterOrdering,
 								message.ExpectedVersion,
 								_commitSource);
 			_currentRequests.Add(message.InternalCorrId, manager);
@@ -134,7 +126,6 @@ namespace EventStore.Core.Services.RequestManager {
 								message.InternalCorrId,
 								message.CorrelationId,
 								message.TransactionId,
-								_betterOrdering,
 								_commitSource);
 			_currentRequests.Add(message.InternalCorrId, manager);
 			_currentTimedRequests.Add(message.InternalCorrId, Stopwatch.StartNew());

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -172,11 +172,6 @@ namespace EventStore.Core.Util {
 		public const string CommitTimeoutMsDescr = "Commit timeout (in milliseconds).";
 		public static readonly int CommitTimeoutMsDefault = 2000; // 2 seconds
 
-		public const string BetterOrderingDescr =
-			"Enable Queue affinity on reads during write process to try to get better ordering.";
-
-		public static readonly bool BetterOrderingDefault = false;
-
 		public const string LogHttpRequestsDescr = "Log Http Requests and Responses before processing them.";
 		public static readonly bool LogHttpRequestsDefault = false;
 		

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -229,7 +229,6 @@ namespace EventStore.Core {
 			_indexBitnessVersion = Opts.IndexBitnessVersionDefault;
 			_optimizeIndexMerge = Opts.OptimizeIndexMergeDefault;
 			_unsafeIgnoreHardDelete = Opts.UnsafeIgnoreHardDeleteDefault;
-			_betterOrdering = Opts.BetterOrderingDefault;
 			_unsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
 			_alwaysKeepScavenged = Opts.AlwaysKeepScavengedDefault;
 			_skipIndexScanOnReads = Opts.SkipIndexScanOnReadsDefault;
@@ -986,15 +985,6 @@ namespace EventStore.Core {
 		}
 
 		/// <summary>
-		/// Enable Queue affinity on reads during write process to try to get better ordering.
-		/// </summary>
-		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-		public VNodeBuilder WithBetterOrdering() {
-			_betterOrdering = true;
-			return this;
-		}
-
-		/// <summary>
 		/// Enable trusted authentication by an intermediary in the HTTP
 		/// </summary>
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
@@ -1424,7 +1414,6 @@ namespace EventStore.Core {
 				_optimizeIndexMerge,
 				consumerStrategies,
 				_unsafeIgnoreHardDelete,
-				_betterOrdering,
 				_readerThreadsCount,
 				_alwaysKeepScavenged,
 				_gossipOnSingleNode,


### PR DESCRIPTION
Removed: Better ordering

Reported as an [issue](https://github.com/EventStore/EventStore/issues/858) which was resolved by introducing [better ordering](https://github.com/EventStore/EventStore/pull/862)

The feature was originally added with the attempt to result in better ordering when writing events for the same stream.

This was always a best attempt and doesn't really work reliably.