### PR TITLE
Treat Warnings as Errors

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,3 +1,5 @@
 <Project>
-
+	<PropertyGroup>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	</PropertyGroup>
 </Project>

--- a/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
+++ b/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs
@@ -46,7 +46,7 @@ namespace EventStore.Client {
 					if (endpoint != null) {
 						return endpoint;
 					}
-				} catch (Exception exc) {
+				} catch (Exception) {
 				}
 
 				await Task.Delay(_discoveryInterval).ConfigureAwait(false);

--- a/src/EventStore.ClientAPI/Messages/ClientMessagesExtensions.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessagesExtensions.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Net;
 using System.Runtime.ExceptionServices;
-using EventStore.ClientAPI.Internal;
 
 namespace EventStore.ClientAPI.Messages {
 	internal static partial class ClientMessage {
 		public partial class NotHandled {
 			public partial class LeaderInfo {
 				public IPEndPoint ExternalTcpEndPoint {
-					get { return ExternalTcpAddress == null || ExternalTcpPort == null ? null :
+					get { return ExternalTcpAddress == null ? null :
 						new IPEndPoint(IPAddress.Parse(ExternalTcpAddress), ExternalTcpPort); }
 				}
 

--- a/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connecting_to_a_persistent_subscription.cs
@@ -57,9 +57,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				DefaultData.AdminCredentials);
 		}
 
-		protected override async Task When() {
-			
-;
+		protected override Task When() {
 			_sub = _conn.ConnectToPersistentSubscription(_stream,
 				"agroupname17",
 				(sub, e) => {
@@ -68,6 +66,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 				},
 				(sub, reason, ex) => { },
 				DefaultData.AdminCredentials);
+
+			return Task.CompletedTask;
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/creating.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/creating.cs
@@ -1,9 +1,7 @@
-﻿using System.Net;
-using EventStore.Core.Tests.Http.Users.users;
+﻿using EventStore.Core.Tests.Http.Users.users;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using HttpStatusCode = System.Net.HttpStatusCode;
 using HttpResponseMessage = System.Net.Http.HttpResponseMessage;
@@ -177,15 +175,12 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 
 	[TestFixture, Category("LongRunning")]
 	class when_creating_persistent_subscription_with_message_timeout_0 : with_admin_user {
-		protected List<object> Events;
 		protected string SubscriptionPath;
 		protected string GroupName;
 		protected HttpResponseMessage Response;
 		protected JObject SubsciptionInfo;
 
-		protected override async Task Given() {
-
-		}
+		protected override Task Given() => Task.CompletedTask;
 
 		protected override async Task When() {
 			GroupName = Guid.NewGuid().ToString();
@@ -220,15 +215,12 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 
 	[TestFixture, Category("LongRunning")]
 	class when_creating_persistent_subscription_without_message_timeout : with_admin_user {
-		protected List<object> Events;
 		protected string SubscriptionPath;
 		protected string GroupName;
 		protected HttpResponseMessage Response;
 		protected JObject SubsciptionInfo;
 
-		protected override async Task Given() {
-
-		}
+		protected override Task Given() => Task.CompletedTask;
 		protected override async Task When() {
 			GroupName = Guid.NewGuid().ToString();
 			SubscriptionPath = string.Format("/subscriptions/{0}/{1}", TestStream.Substring(9), GroupName);

--- a/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/when_cluster_receives_multiple_stale_acks.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/when_cluster_receives_multiple_stale_acks.cs
@@ -7,7 +7,6 @@ namespace EventStore.Core.Tests.Services.Replication.ReplicationTracking {
 	public class when_cluster_receives_multiple_stale_acks :
 		with_clustered_replication_tracking_service {
 		private readonly long _firstLogPosition = 2000;
-		private readonly long _secondLogPosition = 4000;
 		private readonly Guid _replica1 = Guid.NewGuid();
 		private readonly Guid _replica2 = Guid.NewGuid();
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -169,7 +169,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						_readIndex,
 						request.Options.Filter.WindowCase switch {
 							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
-							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter.Max
+							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter.Max,
+							_ => throw new InvalidOperationException()
 						},
 						request.Options.Filter.CheckpointIntervalMultiplier,
 						CheckpointReached,


### PR DESCRIPTION
Warnings are causing a lot of noise to show up in CI.

This PR removes any current warnings, and any future warnings will fail the build.