### PR TITLE
Throw TimeoutException instead of RpcException when DeadlineExceeded

### DIFF
--- a/src/EventStore.Client.Common/Interceptors/TypedExceptionInterceptor.cs
+++ b/src/EventStore.Client.Common/Interceptors/TypedExceptionInterceptor.cs
@@ -122,7 +122,7 @@ namespace EventStore.Client {
 					_ => (Exception)new InvalidOperationException(ex.Message, ex)
 				},
 				false => ex.StatusCode switch {
-					StatusCode.DeadlineExceeded => ex,
+					StatusCode.DeadlineExceeded => new TimeoutException(ex.Message, ex),
 					StatusCode.Unauthenticated => new NotAuthenticatedException(ex.Message, ex),
 					_ => new InvalidOperationException(ex.Message, ex)
 				}

--- a/src/EventStore.Client.Tests/Streams/append_to_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/append_to_stream_with_timeout.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Net.Http;
-using System.Threading;
 using System.Threading.Tasks;
-using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.Streams {
@@ -17,22 +14,18 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task any_stream_revision_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.AppendToStreamAsync(stream, AnyStreamRevision.NoStream, _fixture.CreateTestEvents(),
 					options => options.TimeoutAfter = TimeSpan.Zero));
-
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		[Fact]
 		public async Task stream_revision_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.AppendToStreamAsync(stream, new StreamRevision(0), _fixture.CreateTestEvents(),
 					options => options.TimeoutAfter = TimeSpan.Zero));
-
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		public class Fixture : EventStoreGrpcFixture {

--- a/src/EventStore.Client.Tests/Streams/delete_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/delete_stream_with_timeout.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Net.Http;
 using System.Threading.Tasks;
-using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.Streams {
@@ -16,43 +14,35 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task any_stream_revision_soft_delete_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.SoftDeleteAsync(stream, AnyStreamRevision.Any,
 					options => options.TimeoutAfter = TimeSpan.Zero));
-
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		[Fact]
 		public async Task stream_revision_soft_delete_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.SoftDeleteAsync(stream, new StreamRevision(0),
 					options => options.TimeoutAfter = TimeSpan.Zero));
-
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		[Fact]
 		public async Task any_stream_revision_tombstoning_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.TombstoneAsync(stream, AnyStreamRevision.Any,
 					options => options.TimeoutAfter = TimeSpan.Zero));
-
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		[Fact]
 		public async Task stream_revision_tombstoning_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.TombstoneAsync(stream, new StreamRevision(0),
 					options => options.TimeoutAfter = TimeSpan.Zero));
-
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		public class Fixture : EventStoreGrpcFixture {

--- a/src/EventStore.Client.Tests/Streams/read_all_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/read_all_with_timeout.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
-using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.Streams {
@@ -16,12 +14,10 @@ namespace EventStore.Client.Streams {
 
 		[Fact]
 		public async Task fails_when_operation_expired() {
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() => _fixture.Client
+			await Assert.ThrowsAsync<TimeoutException>(() => _fixture.Client
 				.ReadAllAsync(Direction.Backwards, Position.Start, 1,
 					options => options.TimeoutAfter = TimeSpan.Zero)
 				.ToArrayAsync().AsTask());
-
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		public class Fixture : EventStoreGrpcFixture {

--- a/src/EventStore.Client.Tests/Streams/read_stream_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/read_stream_with_timeout.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
-using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.Streams {
@@ -18,12 +16,10 @@ namespace EventStore.Client.Streams {
 		public async Task fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() => _fixture.Client
+			await Assert.ThrowsAsync<TimeoutException>(() => _fixture.Client
 				.ReadStreamAsync(Direction.Backwards, stream, StreamRevision.End, 1,
 					options => options.TimeoutAfter = TimeSpan.Zero)
 				.ToArrayAsync().AsTask());
-			
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		public class Fixture : EventStoreGrpcFixture {

--- a/src/EventStore.Client.Tests/Streams/stream_metadata_with_timeout.cs
+++ b/src/EventStore.Client.Tests/Streams/stream_metadata_with_timeout.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Net.Http;
 using System.Threading.Tasks;
-using Grpc.Core;
 using Xunit;
 
 namespace EventStore.Client.Streams {
@@ -16,32 +14,26 @@ namespace EventStore.Client.Streams {
 		[Fact]
 		public async Task set_with_any_stream_revision_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.SetStreamMetadataAsync(stream, AnyStreamRevision.Any, new StreamMetadata(),
 					options => options.TimeoutAfter = TimeSpan.Zero));
-			
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		[Fact]
 		public async Task set_with_stream_revision_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
 
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.SetStreamMetadataAsync(stream, new StreamRevision(0), new StreamMetadata(),
 					options => options.TimeoutAfter = TimeSpan.Zero));
-			
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		[Fact]
 		public async Task get_fails_when_operation_expired() {
 			var stream = _fixture.GetStreamName();
-			var rpcException = await Assert.ThrowsAsync<RpcException>(() =>
+			await Assert.ThrowsAsync<TimeoutException>(() =>
 				_fixture.Client.GetStreamMetadataAsync(stream,
 					options => options.TimeoutAfter = TimeSpan.Zero));
-			
-			Assert.Equal(StatusCode.DeadlineExceeded, rpcException.StatusCode);
 		}
 
 		public class Fixture : EventStoreGrpcFixture {


### PR DESCRIPTION
Changed: Throw `TimeoutException` instead of `RpcException` in the Event Store gRPC Client when the gRPC Deadline has exceeded.


Fixes #2278