### PR TITLE
Prepare authorization interfaces for extraction

### DIFF
--- a/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
+++ b/src/EventStore.Client.Tests.Common/EventStoreGrpcFixture.cs
@@ -88,7 +88,9 @@ namespace EventStore.Client {
 			=> new EventData(Uuid.NewUuid(), type, Encoding.UTF8.GetBytes($@"{{""x"":{index}}}"));
 
 		public virtual async Task InitializeAsync() {
-			await Node.StartAsync(true);
+			await Node.StartAsync(true)
+				.WithTimeout(TimeSpan.FromMinutes(5))
+				.ConfigureAwait(false);
 			var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 			var envelope  = new CallbackEnvelope(m => {
 				if (m is UserManagementMessage.ResponseMessage rm) {

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -219,10 +219,16 @@ namespace EventStore.ClusterNode {
 
 		[ArgDescription(Opts.DisableExternalTlsDescr, Opts.InterfacesGroup)]
 		public bool DisableExternalTls { get; set; }
+		
+		[ArgDescription(Opts.AuthorizationTypeDescr, Opts.AuthGroup)]
+		public string AuthorizationType { get; set; }
 
 		[ArgDescription(Opts.AuthenticationTypeDescr, Opts.AuthGroup)]
 		public string AuthenticationType { get; set; }
 
+		[ArgDescription(Opts.AuthorizationConfigFileDescr, Opts.AuthGroup)]
+		public string AuthorizationConfig { get; set; }
+		
 		[ArgDescription(Opts.AuthenticationConfigFileDescr, Opts.AuthGroup)]
 		public string AuthenticationConfig { get; set; }
 
@@ -381,6 +387,8 @@ namespace EventStore.ClusterNode {
 			DisableInternalTls = Opts.DisableInternalTlsDefault;
 			DisableExternalTls = Opts.DisableExternalTlsDefault;
 
+			AuthorizationType = Opts.AuthorizationTypeDefault;
+			AuthorizationConfig = Opts.AuthorizationConfigFileDefault;
 			AuthenticationType = Opts.AuthenticationTypeDefault;
 			AuthenticationConfig = Opts.AuthenticationConfigFileDefault;
 			DisableFirstLevelHttpAuthorization = Opts.DisableFirstLevelHttpAuthorizationDefault;

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -16,10 +16,9 @@ using EventStore.Core.Authentication;
 using EventStore.Core.PluginModel;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.Transport.Http.Controllers;
-using EventStore.Core.Util;
 using System.Threading.Tasks;
 using EventStore.Core.Authentication.InternalAuthentication;
-using EventStore.Core.Services;
+using EventStore.Core.Authorization;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using EventStore.Rags;
 
@@ -358,14 +357,23 @@ namespace EventStore.ClusterNode {
 			} else if (!options.Dev)
 				throw new Exception("A TLS Certificate is required unless development mode (--dev) is set.");
 
+			var authorizationConfig = String.IsNullOrEmpty(options.AuthorizationConfig)
+				? options.Config
+				: options.AuthorizationConfig;
 			var authenticationConfig = String.IsNullOrEmpty(options.AuthenticationConfig)
 				? options.Config
 				: options.AuthenticationConfig;
+			
 			var plugInContainer = FindPlugins();
+			
+			var authorizationProviderFactory =
+				GetAuthorizationProviderFactory(options.AuthorizationType, authorizationConfig, plugInContainer);
 			var authenticationProviderFactory =
 				GetAuthenticationProviderFactory(options.AuthenticationType, authenticationConfig, plugInContainer);
+			
 			var consumerStrategyFactories = GetPlugInConsumerStrategyFactories(plugInContainer);
 			builder.WithAuthenticationProviderFactory(authenticationProviderFactory);
+			builder.WithAuthorizationProvider(authorizationProviderFactory);
 			var subsystemFactories = GetPlugInSubsystemFactories(plugInContainer);
 
 			foreach (var subsystemFactory in subsystemFactories) {
@@ -394,6 +402,40 @@ namespace EventStore.ClusterNode {
 			}
 
 			return strategyFactories.ToArray();
+		}
+		
+		private static AuthorizationProviderFactory GetAuthorizationProviderFactory(string authorizationType,
+			string authorizationConfigFile, CompositionContainer plugInContainer) {
+			var potentialPlugins = plugInContainer.GetExports<IAuthorizationPlugin>();
+
+			var authorizationTypeToPlugin = new Dictionary<string, AuthorizationProviderFactory> {
+				{"internal", new AuthorizationProviderFactory(components =>
+					new LegacyAuthorizationProviderFactory(components.MainQueue)) }
+			};
+
+			foreach (var potentialPlugin in potentialPlugins) {
+				try {
+					var plugin = potentialPlugin.Value;
+					var commandLine = plugin.CommandLineName.ToLowerInvariant();
+					Log.Information(
+						"Loaded authorization plugin: {plugin} version {version} (Command Line: {commandLine})",
+						plugin.Name, plugin.Version, commandLine);
+					authorizationTypeToPlugin.Add(commandLine,
+						new AuthorizationProviderFactory(_ => plugin.GetAuthorizationProviderFactory(authorizationConfigFile)));
+				} catch (CompositionException ex) {
+					Log.Error(ex, "Error loading authentication plugin.");
+				}
+			}
+
+			if (!authorizationTypeToPlugin.TryGetValue(authorizationType.ToLowerInvariant(), out var factory)) {
+				throw new ApplicationInitializationException(
+					$"The authorization type {authorizationType} is not recognised. If this is supposed " +
+					$"to be provided by an authorization plugin, confirm the plugin DLL is located in {Locations.PluginsDirectory}." +
+					Environment.NewLine +
+					$"Valid options for authorization are: {string.Join(", ", authorizationTypeToPlugin.Keys)}.");
+			}
+
+			return factory;
 		}
 
 		private static AuthenticationProviderFactory GetAuthenticationProviderFactory(string authenticationType,

--- a/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
+++ b/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.Authorization {
 
 		public LegacyPolicyVerification() {
 			_aclResponder = new AclResponder();
-			_authorizationProvider = new LegacyAuthorizationProviderFactory().Build(_aclResponder);
+			_authorizationProvider = new LegacyAuthorizationProviderFactory(_aclResponder).Build();
 		}
 
 		public class PolicyVerificationParameters {

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -118,9 +118,11 @@ namespace EventStore.Core.Tests.Helpers {
 				certificate, 1, false,
 				"", gossipSeeds, TFConsts.MinFlushDelayMs, 3, 2, 2, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10),
 				disableInternalTls, false,TimeSpan.FromHours(1), StatsStorage.None, 0,
-				new AuthenticationProviderFactory(components => 
+				new AuthenticationProviderFactory(components =>
 					new InternalAuthenticationProviderFactory(components)),
-				new LegacyAuthorizationProviderFactory(), disableScavengeMerging: true, scavengeHistoryMaxAge: 30,
+				new AuthorizationProviderFactory(components =>
+					new LegacyAuthorizationProviderFactory(components.MainQueue)),
+				disableScavengeMerging: true, scavengeHistoryMaxAge: 30,
 				adminOnPublic: true,
 				statsOnPublic: true, gossipOnPublic: true, gossipInterval: TimeSpan.FromSeconds(2),
 				gossipAllowedTimeDifference: TimeSpan.FromSeconds(1), gossipTimeout: TimeSpan.FromSeconds(3),

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -35,14 +35,15 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				StatsStorage.StreamAndFile, 0, 
 				new AuthenticationProviderFactory(components => 
 					new InternalAuthenticationProviderFactory(components)),
-				new LegacyAuthorizationProviderFactory(), false, 30, true, true, true,
-				TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1),
+				new AuthorizationProviderFactory(components =>
+					new LegacyAuthorizationProviderFactory(components.MainQueue)), false, 30, true, true,
+				true, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1),
 				TimeSpan.FromSeconds(10),
 				TimeSpan.FromSeconds(10),
 				TimeSpan.FromSeconds(10),
 				TimeSpan.FromSeconds(10), 
 				TimeSpan.FromSeconds(1800),
-				 true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false,
+				true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false,
 				false, false,
 				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ConnectionQueueSizeThresholdDefault,
 				Constants.PTableMaxReaderCountDefault,

--- a/src/EventStore.Core/Authorization/AuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/AuthorizationProviderFactory.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace EventStore.Core.Authorization
+{
+	public class AuthorizationProviderFactory {
+		private readonly Func<AuthorizationProviderFactoryComponents, IAuthorizationProviderFactory>
+			_authorizationProviderFactory;
+
+		public AuthorizationProviderFactory(
+			Func<AuthorizationProviderFactoryComponents, IAuthorizationProviderFactory>
+				authorizationProviderFactory) {
+			_authorizationProviderFactory = authorizationProviderFactory;
+		}
+
+		public IAuthorizationProviderFactory GetFactory(
+			AuthorizationProviderFactoryComponents authorizationProviderFactoryComponents) =>
+			_authorizationProviderFactory(authorizationProviderFactoryComponents);
+	}
+}

--- a/src/EventStore.Core/Authorization/AuthorizationProviderFactoryComponents.cs
+++ b/src/EventStore.Core/Authorization/AuthorizationProviderFactoryComponents.cs
@@ -1,0 +1,7 @@
+using EventStore.Core.Bus;
+
+namespace EventStore.Core.Authorization {
+	public class AuthorizationProviderFactoryComponents {
+		public IPublisher MainQueue { get; set; }
+	}
+}

--- a/src/EventStore.Core/Authorization/IAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/IAuthorizationProviderFactory.cs
@@ -1,7 +1,5 @@
-﻿using EventStore.Core.Bus;
-
 namespace EventStore.Core.Authorization {
 	public interface IAuthorizationProviderFactory {
-		IAuthorizationProvider Build(IPublisher mainQueue);
+		IAuthorizationProvider Build();
 	}
 }

--- a/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
@@ -6,6 +6,8 @@ using Serilog;
 
 namespace EventStore.Core.Authorization {
 	public class LegacyAuthorizationProviderFactory : IAuthorizationProviderFactory {
+		private readonly IPublisher _mainQueue;
+
 		private static readonly Claim[] Admins =
 			{new Claim(ClaimTypes.Role, SystemRoles.Admins), new Claim(ClaimTypes.Name, SystemUsers.Admin)};
 
@@ -14,9 +16,13 @@ namespace EventStore.Core.Authorization {
 			new Claim(ClaimTypes.Role, SystemRoles.Operations), new Claim(ClaimTypes.Name, SystemUsers.Operations)
 		};
 
-		public IAuthorizationProvider Build(IPublisher mainQueue) {
+		public LegacyAuthorizationProviderFactory(IPublisher mainQueue) {
+			_mainQueue = mainQueue;
+		}
+
+		public IAuthorizationProvider Build() {
 			var policy = new Policy("Legacy", 1, DateTimeOffset.MinValue);
-			var streamAssertion = new LegacyStreamPermissionAssertion(mainQueue);
+			var streamAssertion = new LegacyStreamPermissionAssertion(_mainQueue);
 
 			policy.AllowAnonymous(Operations.Node.Redirect);
 			policy.AllowAnonymous(Operations.Node.StaticContent);

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -47,7 +47,8 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly StatsStorage StatsStorage;
 
 		public readonly AuthenticationProviderFactory AuthenticationProviderFactory;
-		public readonly IAuthorizationProviderFactory AuthorizationProviderFactory;
+		public readonly AuthorizationProviderFactory AuthorizationProviderFactory;
+
 		public readonly bool DisableFirstLevelHttpAuthorization;
 		public readonly bool DisableScavengeMerging;
 		public readonly int ScavengeHistoryMaxAge;
@@ -116,7 +117,7 @@ namespace EventStore.Core.Cluster.Settings {
 			StatsStorage statsStorage,
 			int nodePriority,
 			AuthenticationProviderFactory authenticationProviderFactory,
-			IAuthorizationProviderFactory authorizationProviderFactory,
+			AuthorizationProviderFactory authorizationProviderFactory,
 			bool disableScavengeMerging,
 			int scavengeHistoryMaxAge,
 			bool adminOnPublic,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -377,11 +377,14 @@ namespace EventStore.Core {
 					_mainQueue.Publish(new AuthenticationMessage.AuthenticationProviderInitialized());
 				}
 			});
-
 			Ensure.NotNull(_authenticationProvider, nameof(_authenticationProvider));
 
-			_authorizationProvider = vNodeSettings.AuthorizationProviderFactory.Build(_mainQueue);
+			_authorizationProvider = vNodeSettings.AuthorizationProviderFactory
+				.GetFactory(new AuthorizationProviderFactoryComponents {
+					MainQueue = _mainQueue
+				}).Build();
 			Ensure.NotNull(_authorizationProvider, "authorizationProvider");
+
 			AuthorizationGateway = new AuthorizationGateway(_authorizationProvider);
 			{
 				// EXTERNAL TCP

--- a/src/EventStore.Core/PluginModel/IAuthorizationPlugin.cs
+++ b/src/EventStore.Core/PluginModel/IAuthorizationPlugin.cs
@@ -1,0 +1,12 @@
+using EventStore.Core.Authorization;
+
+namespace EventStore.Core.PluginModel {
+	public interface IAuthorizationPlugin {
+		string Name { get; }
+		string Version { get; }
+
+		string CommandLineName { get; }
+
+		IAuthorizationProviderFactory GetAuthorizationProviderFactory(string authorizationConfigPath);
+	}
+}

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -396,8 +396,16 @@ namespace EventStore.Core.Util {
 		/*
 		 * Authentication/Authorization Options
 		 */
+		public const string AuthorizationTypeDescr = "The type of authorization to use.";
+		public static readonly string AuthorizationTypeDefault = "internal";
+		
 		public const string AuthenticationTypeDescr = "The type of authentication to use.";
 		public static readonly string AuthenticationTypeDefault = "internal";
+		
+		public const string AuthorizationConfigFileDescr =
+			"Path to the configuration file for authorization configuration (if applicable).";
+		
+		public static readonly string AuthorizationConfigFileDefault = string.Empty;
 
 		public const string AuthenticationConfigFileDescr =
 			"Path to the configuration file for authentication configuration (if applicable).";

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -143,7 +143,7 @@ namespace EventStore.Core {
 		private bool _readOnlyReplica;
 		private bool _unsafeAllowSurplusNodes;
 		private Func<HttpMessageHandler> _createHttpMessageHandler;
-		private IAuthorizationProviderFactory _authorizationProviderFactory;
+		private AuthorizationProviderFactory _authorizationProviderFactory;
 
 		// ReSharper restore FieldCanBeMadeReadOnly.Local
 
@@ -197,7 +197,8 @@ namespace EventStore.Core {
 
 			_disableFirstLevelHttpAuthorization = Opts.DisableFirstLevelHttpAuthorizationDefault;
 
-			_authorizationProviderFactory = new LegacyAuthorizationProviderFactory();
+			_authorizationProviderFactory = new AuthorizationProviderFactory(components =>
+				new LegacyAuthorizationProviderFactory(components.MainQueue));
 
 			_disableScavengeMerging = Opts.DisableScavengeMergeDefault;
 			_scavengeHistoryMaxAge = Opts.ScavengeHistoryMaxAgeDefault;
@@ -992,6 +993,16 @@ namespace EventStore.Core {
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
 		public VNodeBuilder EnableTrustedAuth() {
 			_enableTrustedAuth = true;
+			return this;
+		}
+		
+		/// <summary>
+		/// Sets the authorization provider factory to use
+		/// </summary>
+		/// <param name="authorizationProviderFactory">The authorization provider factory to use </param>
+		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+		public VNodeBuilder WithAuthorizationProvider(AuthorizationProviderFactory authorizationProviderFactory) {
+			_authorizationProviderFactory = authorizationProviderFactory;
 			return this;
 		}
 


### PR DESCRIPTION
Changed: Prepared the authorization interfaces for plugin extraction
Added: The following options have been added `AuthorizationType` and `AuthorizationConfig` to mirror that of the existing `AuthenticationType` and `AuthenticationConfig`.

Partially fixes: https://github.com/EventStore/EventStore.CommercialHA/issues/128