### PR TITLE
Connect to existing master when a node starts up instead of triggering unnecessary elections

### DIFF
--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -1,0 +1,39 @@
+﻿using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Core.Data;
+
+namespace EventStore.Core.Tests.Integration {
+	public class when_restarting_one_node_at_a_time : specification_with_cluster {
+		protected override async Task Given() {
+			await base.Given();
+
+			for (int i = 0; i < 9; i++) {
+				await _nodes[i % 3].Shutdown();
+
+				var node = CreateNode(i % 3, _nodeEndpoints[i % 3],
+					new[] {_nodeEndpoints[(i+1)%3].InternalHttp, _nodeEndpoints[(i+2)%3].InternalHttp});
+				node.Start();
+				_nodes[i % 3] = node;
+
+				await Task.WhenAll(_nodes.Select(x => x.Started)).WithTimeout(TimeSpan.FromSeconds(30));
+			}
+		}
+
+		[Test]
+		public void cluster_should_stabilize() {
+			var leaders = 0;
+			var followers = 0;
+
+			for (int i = 0; i < 3; i++) {
+				var state = _nodes[i].NodeState;
+				if (state == VNodeState.Leader) leaders++;
+				else if (state == VNodeState.Follower) followers++;
+			}
+
+			Assert.AreEqual(1, leaders);
+			Assert.AreEqual(2, followers);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -1286,4 +1286,81 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
 	}
+
+	public class when_a_leader_is_found_during_leader_discovery_and_new_elections_occur_with_previous_leader_alive : ElectionsFixture {
+		public when_a_leader_is_found_during_leader_discovery_and_new_elections_occur_with_previous_leader_alive() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			_sut.Handle(new LeaderDiscoveryMessage.LeaderFound(_nodeTwo));
+			_sut.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, _timeProvider.UtcNow, VNodeState.Leader, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_propose_previously_elected_leader() {
+			_sut.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 3));
+			_publisher.Messages.Clear();
+
+			_sut.Handle(new ElectionMessage.PrepareOk(3, _nodeThree.InstanceId, _nodeThree.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+
+			var proposalHttpMessage = _publisher.Messages.OfType<GrpcMessage.SendOverGrpc>()
+				.FirstOrDefault(x => x.Message is ElectionMessage.Proposal);
+			var proposalMessage = (ElectionMessage.Proposal)proposalHttpMessage.Message;
+
+			Assert.AreEqual(_nodeTwo.InstanceId, proposalMessage.LeaderId);
+			Assert.AreEqual(_nodeTwo.InternalHttp, proposalMessage.LeaderInternalHttp);
+		}
+	}
+
+	public class when_a_leader_is_found_during_leader_discovery_and_new_elections_occur_with_previous_leader_dead : ElectionsFixture {
+		public when_a_leader_is_found_during_leader_discovery_and_new_elections_occur_with_previous_leader_dead() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			_sut.Handle(new LeaderDiscoveryMessage.LeaderFound(_nodeTwo));
+			_sut.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, _timeProvider.UtcNow, VNodeState.Leader, false, _epochId),
+				MemberInfoFromVNode(_nodeThree, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void should_propose_previously_elected_leader() {
+			_sut.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 4));
+			_publisher.Messages.Clear();
+
+			_sut.Handle(new ElectionMessage.PrepareOk(4, _nodeThree.InstanceId, _nodeThree.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+
+			var proposalHttpMessage = _publisher.Messages.OfType<GrpcMessage.SendOverGrpc>()
+				.FirstOrDefault(x => x.Message is ElectionMessage.Proposal);
+			var proposalMessage = (ElectionMessage.Proposal)proposalHttpMessage.Message;
+
+			Assert.AreNotEqual(_nodeTwo.InstanceId, proposalMessage.LeaderId);
+			Assert.AreNotEqual(_nodeTwo.InternalHttp, proposalMessage.LeaderInternalHttp);
+		}
+	}
+
+	public class when_a_leader_is_found_during_leader_discovery : ElectionsFixture {
+		public when_a_leader_is_found_during_leader_discovery() :
+			base(NodeFactory(3, false), NodeFactory(2, false), NodeFactory(1, false)) {
+			_sut.Handle(new LeaderDiscoveryMessage.LeaderFound(_nodeTwo));
+			_sut.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(
+				MemberInfoFromVNode(_node, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeTwo, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId),
+				MemberInfoFromVNode(_nodeThree, _timeProvider.UtcNow, VNodeState.Unknown, true, _epochId))));
+		}
+
+		[Test]
+		public void view_change_should_trigger_new_elections() {
+			_sut.Handle(new ElectionMessage.ViewChange(_nodeTwo.InstanceId, _nodeTwo.InternalHttp, 3));
+			_publisher.Messages.Clear();
+
+			_sut.Handle(new ElectionMessage.PrepareOk(3, _nodeThree.InstanceId, _nodeThree.InternalHttp, 0, 0,
+				_epochId, 0, 0, 0, 0));
+
+			Assert.NotNull(_publisher.Messages.OfType<GrpcMessage.SendOverGrpc>().FirstOrDefault());
+		}
+	}
+
 }

--- a/src/EventStore.Core/Data/VNodeState.cs
+++ b/src/EventStore.Core/Data/VNodeState.cs
@@ -1,6 +1,7 @@
 namespace EventStore.Core.Data {
 	public enum VNodeState {
 		Initializing,
+		DiscoverLeader,
 		Unknown,
 		PreReplica,
 		CatchingUp,

--- a/src/EventStore.Core/Messages/LeaderDiscoveryMessage.cs
+++ b/src/EventStore.Core/Messages/LeaderDiscoveryMessage.cs
@@ -1,0 +1,31 @@
+using System.Threading;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Messages {
+	public static class LeaderDiscoveryMessage {
+		public class LeaderFound : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public readonly VNodeInfo Leader;
+
+			public LeaderFound(VNodeInfo leader) {
+				Ensure.NotNull(leader, "leader");
+				Leader = leader;
+			}
+		}
+
+		public class DiscoveryTimeout : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -174,6 +174,18 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class BecomeDiscoverLeader : StateChangeMessage {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public BecomeDiscoverLeader(Guid correlationId)
+				: base(correlationId, VNodeState.DiscoverLeader) {
+			}
+		}
+
 		public class BecomeResigningLeader : StateChangeMessage {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -43,6 +43,7 @@ namespace EventStore.Core.Services {
 					_leaderInfo = ((SystemMessage.ReplicaStateMessage)message).Leader;
 					break;
 				case VNodeState.Initializing:
+				case VNodeState.DiscoverLeader:
 				case VNodeState.Unknown:
 				case VNodeState.PreLeader:
 				case VNodeState.Leader:

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -89,6 +89,7 @@ namespace EventStore.Core.Services.Replication {
 
 			switch (message.State) {
 				case VNodeState.Initializing:
+				case VNodeState.DiscoverLeader:
 				case VNodeState.Unknown:
 				case VNodeState.ReadOnlyLeaderless:
 				case VNodeState.PreLeader:


### PR DESCRIPTION
Fixed: Connect to existing master when a node starts up instead of triggering unnecessary elections if a quorum of nodes is already present.


Mitigates #2213

When a node starts up, make a few attempts to discover if there is an existing Leader through gossip updates.

- If there's an existing Leader, connect directly to it by going to the Pre-Replica state
- otherwise go to the Unknown state which will trigger elections.

This avoids unnecessary elections when a quorum number of nodes is already present but a new node is starting up to join the cluster or a Follower node is restarted.