### PR TITLE
Return -1 as the Log Position when an idempotent write to a deleted stream occurs

### DIFF
--- a/src/EventStore.Core.Tests/Integration/Idempotency/when_soft_deleted_stream_is_written_to_idempotently.cs
+++ b/src/EventStore.Core.Tests/Integration/Idempotency/when_soft_deleted_stream_is_written_to_idempotently.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.UserManagement;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Integration.Idempotency {
+	public class when_soft_deleted_stream_is_written_to_idempotently : specification_with_a_single_node {
+		private readonly string _streamId;
+		private readonly Event[] _events;
+
+		public when_soft_deleted_stream_is_written_to_idempotently() {
+			_streamId = $"{nameof(when_soft_deleted_stream_is_written_to_idempotently)}-{Guid.NewGuid()}";
+			_events = new[] {new Event(Guid.NewGuid(), "event-type", false, new byte[] { }, new byte[] { })};
+		}
+
+		protected override async Task Given() {
+			var writeEventsCompleted = new TaskCompletionSource<bool>();
+			_node.Node.MainQueue.Publish(new ClientMessage.WriteEvents(Guid.NewGuid(), Guid.NewGuid(),
+				new CallbackEnvelope(
+					_ => {
+						writeEventsCompleted.SetResult(true);
+					}), false, _streamId, ExpectedVersion.NoStream, _events, SystemAccounts.System));
+
+			await writeEventsCompleted.Task
+				.WithTimeout(TimeSpan.FromSeconds(2));
+
+			var deleteStreamCompleted = new TaskCompletionSource<bool>();
+			_node.Node.MainQueue.Publish(new ClientMessage.DeleteStream(Guid.NewGuid(), Guid.NewGuid(),
+				new CallbackEnvelope(
+					_ => {
+						deleteStreamCompleted.SetResult(true);
+					}), false, _streamId, ExpectedVersion.Any, false, SystemAccounts.System));
+
+			await deleteStreamCompleted.Task
+				.WithTimeout(TimeSpan.FromSeconds(2));
+		}
+
+		[Test]
+		public async Task should_return_negative_1_as_log_position() {
+			var writeEventsCompleted = new TaskCompletionSource<ClientMessage.WriteEventsCompleted>();
+			
+			_node.Node.MainQueue.Publish(new ClientMessage.WriteEvents(Guid.NewGuid(), Guid.NewGuid(),
+				new CallbackEnvelope(
+					msg => {
+						writeEventsCompleted.SetResult(msg as ClientMessage.WriteEventsCompleted);
+					}), false, _streamId, ExpectedVersion.NoStream, _events, SystemAccounts.System));
+			
+			var completed = await writeEventsCompleted.Task
+				.WithTimeout(TimeSpan.FromSeconds(2));
+			
+			Assert.AreEqual(-1, completed.CommitPosition);
+			Assert.AreEqual(-1, completed.PreparePosition);
+		}
+	}
+}

--- a/src/EventStore.Core/Messages/StorageMessage.cs
+++ b/src/EventStore.Core/Messages/StorageMessage.cs
@@ -315,7 +315,6 @@ namespace EventStore.Core.Messages {
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
 				Ensure.Nonnegative(firstEventNumber, "FirstEventNumber");
-				Ensure.Positive(logPosition, nameof(logPosition));
 
 				CorrelationId = correlationId;
 				EventStreamId = eventStreamId;


### PR DESCRIPTION
Changed: Removed the constraint in AlreadyCommitted for Log Position to be positive.


@thefringeninja raised an [issue as a pull request](https://github.com/EventStore/EventStore/pull/2323) via a client test that would crash the server if the following series of events take place.
1. Write an event to a stream
2. Delete the stream
3. Write the same event as in step 1 to the same stream (idempotent write)

Results in the server crashing due to `AlreadyCommitted` requiring the `LogPosition` to be positive.
This constraint was added in https://github.com/EventStore/EventStore/pull/2219 which results in a regression.

**Notes**
- Log Position and the constraint was added to `AlreadyCommitted` in https://github.com/EventStore/EventStore/pull/2219
- In Event Store 5.x, we returned -1 as the Log Position in the scenario above.
- We also don't appear to be consuming this Log Position internally and it's only for client consumption, which makes the impact a little less critical for this case.