### PR TITLE
Fix regression

### DIFF
--- a/src/EventStore.Core/Authentication/InternalAuthentication/UserManagementService.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/UserManagementService.cs
@@ -204,18 +204,18 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 							NotifyInitialized();
 					});
 			} else {
-				_tcs.SetResult(true);
+				_tcs.TrySetResult(true);
 			}
 		}
 
 		public void Handle(SystemMessage.BecomeFollower message) {
-			_tcs.SetResult(true);
+			_tcs.TrySetResult(true);
 		}
 
 		private void NotifyInitialized() {
 			_numberOfStandardUsersToBeCreated -= 1;
 			if (_numberOfStandardUsersToBeCreated == 0) {
-				_tcs.SetResult(true);
+				_tcs.TrySetResult(true);
 			}
 		}
 


### PR DESCRIPTION
Fix bug introduced by f87b317b78248638aba18a6173e63b809ece5d66
- Use TrySetResult instead of SetResult so that exceptions are not thrown if setting result twice

Reproduction steps:
- Start a 3 node cluster
- Stop the leader node, this will force one of the 2 remaining nodes to become a leader and the other a follower.
- The following exceptions will be thrown:

On the new leader:
``` 
[ 6863,25,15:28:01.428,ERR] Error while processing message "EventStore.Core.Messages.ClientMessage+ReadStreamEventsBackwardCompleted" in queued handler '"Worker #1"'.
System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
   at System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
   at EventStore.Core.Authentication.InternalAuthentication.UserManagementService.NotifyInitialized() in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Authentication/InternalAuthentication/UserManagementService.cs:line 220
   at EventStore.Core.Authentication.InternalAuthentication.UserManagementService.<Handle>b__21_1(ReadStreamEventsBackwardCompleted completed) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Authentication/InternalAuthentication/UserManagementService.cs:line 205
   at EventStore.Core.Helpers.IODispatcher.<>c__DisplayClass24_0.<ReadBackward>b__0(ReadStreamEventsBackwardCompleted res) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Helpers/IODispatcher.cs:line 189
   at EventStore.Core.Messaging.RequestResponseDispatcher`2.Handle(TResponse message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Messaging/RequestResponseDispatcher.cs:line 69
   at EventStore.Core.Messaging.RequestResponseDispatcher`2.EventStore.Core.Bus.IHandle<TResponse>.Handle(TResponse message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Messaging/RequestResponseDispatcher.cs:line 48
   at EventStore.Core.Bus.MessageHandler`1.TryHandle(Message message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Bus/MessageHandler.cs:line 30
   at EventStore.Core.Bus.InMemoryBus.Publish(Message message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Bus/InMemoryBus.cs:line 290
   at EventStore.Core.Bus.QueuedHandlerThreadPool.ReadFromQueue(Object o) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs:line 119
```

On the follower:
```
[ 6904,12,15:28:01.430,ERR] Error while processing message "EventStore.Core.Messages.ReplicationMessage+FollowerAssignment" in queued handler '"MainQueue"'.
System.InvalidOperationException: An attempt was made to transition a task to a final state when it had already completed.
   at System.Threading.Tasks.TaskCompletionSource`1.SetResult(TResult result)
   at EventStore.Core.Authentication.InternalAuthentication.UserManagementService.Handle(BecomeFollower message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Authentication/Inte
rnalAuthentication/UserManagementService.cs:line 213
   at EventStore.Core.Bus.MessageHandler`1.TryHandle(Message message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Bus/MessageHandler.cs:line 30
   at EventStore.Core.Bus.InMemoryBus.Publish(Message message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Bus/InMemoryBus.cs:line 290
   at EventStore.Core.Services.VNode.ClusterVNodeController.Handle(BecomeFollower message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs:
line 417
   at EventStore.Core.Services.VNode.VNodeFSM.TryHandle(VNodeState state, Action`2[] handlers, Message message, Int32 msgTypeId) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Ser
vices/VNode/VNodeFSM.cs:line 105
   at EventStore.Core.Services.VNode.VNodeFSM.Handle(Message message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Services/VNode/VNodeFSM.cs:line 90
   at EventStore.Core.Services.VNode.ClusterVNodeController.Handle(FollowerAssignment message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Services/VNode/ClusterVNodeController
.cs:line 969
   at EventStore.Core.Services.VNode.VNodeFSM.TryHandle(VNodeState state, Action`2[] handlers, Message message, Int32 msgTypeId) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Ser
vices/VNode/VNodeFSM.cs:line 105
   at EventStore.Core.Services.VNode.VNodeFSM.Handle(Message message) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Services/VNode/VNodeFSM.cs:line 90
   at EventStore.Core.Bus.QueuedHandlerMRES.ReadFromQueue(Object o) in /home/shaan/Documents/Work/EventStore/EventStore/src/EventStore.Core/Bus/QueuedHandlerMRES.cs:line 119
```
- Due to the exception thrown in the InMemoryBus, the `BecomeFollower` message is not properly consumed by all consumers which causes the node to stay in `Clone` state.