### PR TITLE
Tag Bionic Container as ci for Integration Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,16 @@ jobs:
         tag-latest: false
         additional-tags: ${{ env.VERSION }}
         registry: https://docker.pkg.github.com
+    - name: Docker Push CI
+      uses: jen20/action-docker-build@v1
+      if: github.event_name == 'push' && matrix.container-runtime == 'bionic'
+      with:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        repository: docker.pkg.github.com/eventstore/eventstore/eventstore
+        tag-latest: false
+        additional-tags: ci
+        registry: https://docker.pkg.github.com
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
After some discussion about EventStore/EventStore-Client-Dotnet#1, we agreed that we did not want to continue changing the docker image tag every time we resolve an issue in the main repository. The best course of action is to update a specific tag (`ci`) and run integration tests against that.

Partiality fixes EventStore/home#115