### PR TITLE
Set the default for the write timeout

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -400,6 +400,7 @@ namespace EventStore.ClusterNode {
 			UnsafeDisableFlushToDisk = Opts.UnsafeDisableFlushToDiskDefault;
 			PrepareTimeoutMs = Opts.PrepareTimeoutMsDefault;
 			CommitTimeoutMs = Opts.CommitTimeoutMsDefault;
+			WriteTimeoutMs = Opts.WriteTimeoutMsDefault;
 			DisableScavengeMerging = Opts.DisableScavengeMergeDefault;
 			ScavengeHistoryMaxAge = Opts.ScavengeHistoryMaxAgeDefault;
 			GossipOnExt = Opts.GossipOnExtDefault;


### PR DESCRIPTION
Changed: Set the default for the write timeout


The default for the write timeout wasn't set and resulted in the timeout being 0 ms. This resulted in any write from a client timing out immediately.