### PR TITLE
Add MaxTruncation safety feature

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -316,6 +316,9 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.WriteStatsToDbDescr, Opts.DbGroup)]
 		public bool WriteStatsToDb { get; set; }
 
+		[ArgDescription(Opts.MaxTruncationDescr, Opts.DbGroup)]
+		public long MaxTruncation { get; set; }
+
 		public ClusterNodeOptions() {
 			Config = "";
 			Help = Opts.ShowHelpDefault;
@@ -443,6 +446,8 @@ namespace EventStore.ClusterNode {
 			MaxAutoMergeIndexLevel = Opts.MaxAutoMergeIndexLevelDefault;
 
 			WriteStatsToDb = Opts.WriteStatsToDbDefault;
+
+			MaxTruncation = Opts.MaxTruncationDefault;
 		}
 	}
 }

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -187,6 +187,7 @@ namespace EventStore.ClusterNode {
 				builder = builder.WithStatsStorage(StatsStorage.File);
 			}
 
+			
 			builder.WithInternalTcpOn(intTcp)
 				.WithInternalSecureTcpOn(intSecTcp)
 				.WithExternalTcpOn(extTcp)
@@ -234,7 +235,8 @@ namespace EventStore.ClusterNode {
 				.WithConnectionQueueSizeThreshold(options.ConnectionQueueSizeThreshold)
 				.WithChunkInitialReaderCount(options.ChunkInitialReaderCount)
 				.WithInitializationThreads(options.InitializationThreads)
-				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel);
+				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel)
+				.WithMaxTruncation(options.MaxTruncation);
 
 			if (options.GossipSeed.Length > 0)
 				builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -8,7 +8,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 	public static class TFChunkHelper {
 		public static TFChunkDbConfig CreateDbConfig(string pathName, long writerCheckpointPosition,
 			long chaserCheckpointPosition = 0,
-			long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000) {
+			long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000,
+			long maxTruncation = -1) {
 			return new TFChunkDbConfig(pathName,
 				new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
 				chunkSize,
@@ -18,7 +19,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(epochCheckpointPosition),
 				new InMemoryCheckpoint(truncateCheckpoint),
 				new InMemoryCheckpoint(-1),
-				Opts.ChunkInitialReaderCountDefault);
+				Opts.ChunkInitialReaderCountDefault,
+				maxTruncation: maxTruncation);
 		}
 
 		public static TFChunkDbConfig CreateDbConfig(string pathName, ICheckpoint writerCheckpoint,

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using EventStore.Core.Tests.TransactionLog.Validation;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Truncation {
+	[TestFixture]
+	public class when_truncating_against_max_truncation_config : SpecificationWithDirectoryPerTestFixture {
+		private TFChunkDbConfig _config;
+
+		[OneTimeSetUp]
+		public override void TestFixtureSetUp() {
+			base.TestFixtureSetUp();
+
+			// epoch = 5500, truncate to 0, max truncation = 1000
+			_config = TFChunkHelper.CreateDbConfig(PathName, 11111, 5500, 5500, 0, 1000, maxTruncation: 1000);
+
+			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
+			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));
+			DbUtil.CreateMultiChunk(_config, 3, 10, GetFilePathFor("chunk-000003.000001"));
+			DbUtil.CreateMultiChunk(_config, 3, 10, GetFilePathFor("chunk-000003.000002"));
+			DbUtil.CreateMultiChunk(_config, 7, 8, GetFilePathFor("chunk-000007.000001"));
+			DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
+		}
+
+		[OneTimeTearDown]
+		public override void TestFixtureTearDown() {
+			base.TestFixtureTearDown();
+		}
+
+		[Test]
+		public void truncate_above_max_throws_exception() {
+
+			Assert.Throws<Exception>(() => {
+				var truncator = new TFChunkDbTruncator(_config);
+				truncator.TruncateDb(0);
+			});
+		}
+
+		[Test]
+		public void truncate_within_max_does_not_throw_exception() {
+
+			Assert.DoesNotThrow(() => {
+				var truncator = new TFChunkDbTruncator(_config);
+				truncator.TruncateDb(4800);
+			});
+		}
+	}
+}

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -81,6 +81,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool ReduceFileCachePressure;
 		public readonly int InitializationThreads;
 		public readonly int MaxAutoMergeIndexLevel;
+		public readonly long MaxTruncation;
 
 		public readonly bool GossipOnSingleNode;
 		public readonly bool FaultOutOfOrderProjections;
@@ -155,7 +156,8 @@ namespace EventStore.Core.Cluster.Settings {
 			bool structuredLog = false,
 			int maxAutoMergeIndexLevel = 1000,
 			bool disableFirstLevelHttpAuthorization = false,
-			bool logFailedAuthenticationAttempts = false) {
+			bool logFailedAuthenticationAttempts = false,
+			long maxTruncation = -1) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.NotNull(internalTcpEndPoint, "internalTcpEndPoint");
 			Ensure.NotNull(externalTcpEndPoint, "externalTcpEndPoint");
@@ -258,6 +260,8 @@ namespace EventStore.Core.Cluster.Settings {
 			MaxAutoMergeIndexLevel = maxAutoMergeIndexLevel;
 			FaultOutOfOrderProjections = faultOutOfOrderProjections;
 			StructuredLog = structuredLog;
+
+			MaxTruncation = maxTruncation;
 		}
 
 		public override string ToString() {
@@ -302,7 +306,8 @@ namespace EventStore.Core.Cluster.Settings {
 			                     + "ReduceFileCachePressure: {38}\n"
 			                     + "InitializationThreads: {39}\n"
 			                     + "StructuredLog: {40}\n"
-								 + "DisableFirstLevelHttpAuthorization: {41}\n",
+								 + "DisableFirstLevelHttpAuthorization: {41}\n"
+								 + "MaxTruncation: {42}\n",
 				NodeInfo.InstanceId,
 				NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
 				NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -322,7 +327,7 @@ namespace EventStore.Core.Cluster.Settings {
 				EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge,
 				ConnectionPendingSendBytesThreshold, ChunkInitialReaderCount,
 				ReduceFileCachePressure, InitializationThreads, StructuredLog,
-				DisableFirstLevelHttpAuthorization);
+				DisableFirstLevelHttpAuthorization, MaxTruncation);
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -105,7 +105,8 @@ namespace EventStore.Core {
 
 		protected virtual void OnNodeStatusChanged(VNodeStatusChangeArgs e) {
 			EventHandler<VNodeStatusChangeArgs> handler = NodeStatusChanged;
-			if (handler != null) handler(this, e);
+			if (handler != null)
+				handler(this, e);
 		}
 
 
@@ -194,6 +195,7 @@ namespace EventStore.Core {
 					"Truncate checkpoint is present. Truncate: {truncatePosition} (0x{truncatePosition:X}), Writer: {writerCheckpoint} (0x{writerCheckpoint:X}), Chaser: {chaserCheckpoint} (0x{chaserCheckpoint:X}), Epoch: {epochCheckpoint} (0x{epochCheckpoint:X})",
 					truncPos, truncPos, writerCheckpoint, writerCheckpoint, chaserCheckpoint, chaserCheckpoint,
 					epochCheckpoint, epochCheckpoint);
+
 				var truncator = new TFChunkDbTruncator(db.Config);
 				truncator.TruncateDb(truncPos);
 			}
@@ -636,8 +638,8 @@ namespace EventStore.Core {
 			if (subsystems != null) {
 				foreach (var subsystem in subsystems) {
 					var http = isSingleNode
-						? new[] {_externalHttpService}
-						: new[] {_internalHttpService, _externalHttpService};
+						? new[] { _externalHttpService }
+						: new[] { _internalHttpService, _externalHttpService };
 					subsystem.Register(new StandardComponents(db, _mainQueue, _mainBus, _timerService, _timeProvider,
 						httpSendService, http, _workersHandler));
 				}
@@ -657,7 +659,8 @@ namespace EventStore.Core {
 		public void StopNonblocking(bool exitProcess, bool shutdownHttp) {
 			_mainQueue.Publish(new ClientMessage.RequestShutdown(exitProcess, shutdownHttp));
 
-			if (_subsystems == null) return;
+			if (_subsystems == null)
+				return;
 			foreach (var subsystem in _subsystems)
 				subsystem.Stop();
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -19,6 +19,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly int InitialReaderCount;
 		public readonly bool OptimizeReadSideCache;
 		public readonly bool ReduceFileCachePressure;
+		public readonly long MaxTruncation;
 
 		public TFChunkDbConfig(string path,
 			IFileNamingStrategy fileNamingStrategy,
@@ -34,7 +35,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			bool unbuffered = false,
 			bool writethrough = false,
 			bool optimizeReadSideCache = false,
-			bool reduceFileCachePressure = false) {
+			bool reduceFileCachePressure = false,
+			long maxTruncation = -1) {
 			Ensure.NotNullOrEmpty(path, "path");
 			Ensure.NotNull(fileNamingStrategy, "fileNamingStrategy");
 			Ensure.Positive(chunkSize, "chunkSize");
@@ -61,6 +63,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			InitialReaderCount = initialReaderCount;
 			OptimizeReadSideCache = optimizeReadSideCache;
 			ReduceFileCachePressure = reduceFileCachePressure;
+			MaxTruncation = maxTruncation;
 		}
 	}
 }

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -431,5 +431,10 @@ namespace EventStore.Core.Util {
 
 		public const string WriteStatsToDbDescr = "Set this option to write statistics to the database.";
 		public const bool WriteStatsToDbDefault = true;
+
+		public static readonly long MaxTruncationDefault = -1;
+		public const string MaxTruncationDescr =
+			"When truncate.chk is set, the database will be truncated on startup.  This is a safety check to ensure large amounts of data truncation does not happen accidentally.  This value should be set in the low 10,000s for allow for standard cluster recovery operations. -1 is no max (default).";
+
 	}
 }

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -136,6 +136,7 @@ namespace EventStore.Core {
 		private int _maxAutoMergeIndexLevel;
 
 		private bool _gossipOnSingleNode;
+		private long _maxTruncation;
 
 		// ReSharper restore FieldCanBeMadeReadOnly.Local
 
@@ -231,6 +232,7 @@ namespace EventStore.Core {
 			_faultOutOfOrderProjections = Opts.FaultOutOfOrderProjectionsDefault;
 			_reduceFileCachePressure = Opts.ReduceFileCachePressureDefault;
 			_initializationThreads = Opts.InitializationThreadsDefault;
+			_maxTruncation = Opts.MaxTruncationDefault;
 		}
 
 		protected VNodeBuilder WithSingleNodeSettings() {
@@ -1065,6 +1067,16 @@ namespace EventStore.Core {
 		}
 
 		/// <summary>
+		/// Sets the max truncation length (max difference between epoch.chk and truncate.chk).  -1 to disable.
+		/// </summary>
+		/// <param name="maxTruncation">The max difference between epoch and truncate checkpoints to limit any accidental truncations.</param>
+		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+		public VNodeBuilder WithMaxTruncation(long maxTruncation) {
+			_maxTruncation = maxTruncation;
+			return this;
+		}
+
+		/// <summary>
 		/// Sets the Server SSL Certificate
 		/// </summary>
 		/// <param name="sslCertificate">The server SSL certificate to use</param>
@@ -1342,6 +1354,7 @@ namespace EventStore.Core {
 				_chunkInitialReaderCount,
 				_optimizeIndexMerge,
 				_reduceFileCachePressure,
+				_maxTruncation,
 				_log);
 			FileStreamExtensions.ConfigureFlush(disableFlushToDisk: _unsafeDisableFlushToDisk);
 
@@ -1418,7 +1431,8 @@ namespace EventStore.Core {
 				_structuredLog,
 				_maxAutoMergeIndexLevel,
 				_disableFirstLevelHttpAuthorization,
-				_logFailedAuthenticationAttempts);
+				_logFailedAuthenticationAttempts,
+				_maxTruncation);
 
 			var infoController = new InfoController(options, _projectionType);
 
@@ -1470,6 +1484,7 @@ namespace EventStore.Core {
 			int chunkInitialReaderCount,
 			bool optimizeReadSideCache,
 			bool reduceFileCachePressure,
+			long maxTruncation,
 			ILogger log) {
 			ICheckpoint writerChk;
 			ICheckpoint chaserChk;
@@ -1538,7 +1553,8 @@ namespace EventStore.Core {
 				unbuffered,
 				writethrough,
 				optimizeReadSideCache,
-				reduceFileCachePressure);
+				reduceFileCachePressure,
+				maxTruncation);
 
 			return nodeConfig;
 		}


### PR DESCRIPTION
This feature was built to avoid huge unexpected truncations due to misconfiguration.

Today I did some rejigging of our EventStore deployment mechanism, after testing on a development and UAT environment, I pushed my changes live.  We don't take deploying EventStore lightly but this change seemed relatively harmless but little did I know, a 1 character mistake ended up truncating our entire data set on 4 of our 5 nodes (approx 800GB of data in total).  Essentially I had typed an IP address wrong and the deployment process automatically creates a DNS entry to our gossip DNS entry.  That one (bad) mistake ended up causing a potentially catastrophic loss of data (outside of backups obviously).

Unfortunately upon deployment with this misconfiguration, there was another cluster (with a completely different dataset) running on this erroneous IP address.  On top of this, it also shared the same port setup (something we try to avoid but didn't achieve that here).  This meant that these two clusters quickly merged due to the gossip networks joining one another.  The cluster I was deploying then quickly logged the below and truncated their *entire* dataset:

```
Master [10.194.0.10:5412,{ebd4c7e7-efe1-4419-a6a0-624865099018}] subscribed us at 0 (0x0), which is less than our last epoch and LastCommitPosition 225919458447 (0x3499D95C8F) >= lastEpoch.EpochPosition 225919442304 (0x3499D91D80). That might be bad, especially if the LastCommitPosition is way beyond EpochPosition.
......
Truncate checkpoint is present. Truncate: 0 (0x0), Writer: 225919474285 (0x3499D99A6D), Chaser: 225919474285 (0x3499D99A6D), Epoch: 225919442304 (0x3499D91D80)
```

To be clear, this is absolutely not a bug but I feel it's a bit 'violent' for a database to completely wipe itself following such a "small" misconfiguration.

In this PR, I've added a `MaxTruncation` value which can be configured to a small value (say `20,000` to allow for "usual" truncations during failovers/re-elections etc) but doesn't allow huge truncations to occur without someone changing the config.  If you manually set the truncate.chk then you should also ensure that your configuration `MaxTruncation` value is set to `-1` or removed (defaults to `-1`).  It would be a huge weight off our minds to know that instead of wiping all data, it would go into an infinite restart loop (with clear logs as to why) if something like this occurs in the future.

We did manage to fully recover from this incident fairly easily by copying the intact data from our last remaining node across the other nodes, restarting the 2nd cluster it accidently joined (so it reset the cluster definition) and starting up the cluster.