### PR TITLE
Discover an existing leader through gossip updates when a read-only replica starts up

### DIFF
--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -582,6 +582,9 @@ namespace EventStore.Core.Services {
 		public void Handle(LeaderDiscoveryMessage.LeaderFound message) {
 			if (_leader != null || _lastElectedLeader != null || _state != ElectionsState.Idle)
 				return;
+			if (_nodeInfo.IsReadOnlyReplica)
+				Log.Verbose("ELECTIONS: THIS NODE IS A READ ONLY REPLICA.");
+
 			Log.Information("ELECTIONS: Existing LEADER was discovered, updating information. M=[{leaderInternalHttp},{leaderId:B}])", message.Leader.InternalHttp, message.Leader.InstanceId);
 			_leader = message.Leader.InstanceId;
 			_lastElectedLeader = message.Leader.InstanceId;


### PR DESCRIPTION
Added: Discover an existing leader through gossip updates when a read-only replica starts up instead of triggering elections.


Fixes #2413 
This PR is similar to #2386 but for read-only replicas.