### PR TITLE
Check that the leader is still in a leader state

### DIFF
--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -879,8 +879,12 @@ namespace EventStore.Core.Services.VNode {
 					"There is NO LEADER or LEADER is DEAD according to GOSSIP. Starting new elections. LEADER: [{leader}].",
 					_leader);
 				_mainQueue.Publish(new ElectionMessage.StartElections());
+			} else if (leader.State != VNodeState.PreLeader && leader.State != VNodeState.Leader && leader.State != VNodeState.ResigningLeader) {
+				Log.Debug(
+					"LEADER node is still alive but is no longer in a LEADER state according to GOSSIP. Starting new elections. LEADER: [{leader}].",
+					_leader);
+				_mainQueue.Publish(new ElectionMessage.StartElections());
 			}
-
 			_outputBus.Publish(message);
 		}
 


### PR DESCRIPTION
Changed: Ensure that the leader is still in a leader state when gossip has changed. If not, start elections.

Fixes: https://github.com/EventStore/home/issues/111