### PR TITLE
Replace custom HttpClient with HttpMessageHandler

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -1,7 +1,7 @@
-﻿using System;
+using System;
+using System.Net.Http;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
-using EventStore.ClientAPI.Transport.Http;
 
 namespace EventStore.ClientAPI {
 	/// <summary>
@@ -35,9 +35,9 @@ namespace EventStore.ClientAPI {
 		public readonly ILogger Log;
 
 		/// <summary>
-		/// Allows overriding the HTTPClient <see cref="IHttpClient"/>
+		/// Allows overriding the <see cref="HttpMessageHandler"/> used when issuing Http requests
 		/// </summary>
-		public IHttpClient CustomHttpClient { get; set; }
+		public readonly HttpMessageHandler CustomHttpMessageHandler;
 
 		/// <summary>
 		/// Whether to use excessive logging of <see cref="EventStoreConnection"/> internal logic.
@@ -178,7 +178,7 @@ namespace EventStore.ClientAPI {
 			int externalGossipPort,
 			TimeSpan gossipTimeout,
 			NodePreference nodePreference,
-			IHttpClient customHttpClient) {
+			HttpMessageHandler customHttpMessageHandler) {
 
 			Ensure.NotNull(log, "log");
 			Ensure.Positive(maxQueueSize, "maxQueueSize");
@@ -222,7 +222,7 @@ namespace EventStore.ClientAPI {
 			ExternalGossipPort = externalGossipPort;
 			GossipTimeout = gossipTimeout;
 			NodePreference = nodePreference;
-			CustomHttpClient = customHttpClient;
+			CustomHttpMessageHandler = customHttpMessageHandler;
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using EventStore.ClientAPI.Common.Log;
 using EventStore.ClientAPI.Common.Utils;
 using EventStore.ClientAPI.SystemData;
-using EventStore.ClientAPI.Transport.Http;
 
 namespace EventStore.ClientAPI {
 	/// <summary>
@@ -40,19 +40,19 @@ namespace EventStore.ClientAPI {
 		private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
 		private GossipSeed[] _gossipSeeds;
 		private NodePreference _nodePreference = NodePreference.Leader;
-		private IHttpClient _customHttpClient = null;
+		private HttpMessageHandler _customHttpMessageHandler;
 
 
 		internal ConnectionSettingsBuilder() {
 		}
 
 		/// <summary>
-		/// Configures the connection to use a custom <see cref="IHttpClient"/>.
+		/// Configures a custom <see cref="HttpMessageHandler"/> to use when issuing Http requests
 		/// </summary>
-		/// <param name="client">The <see cref="IHttpClient"/> to use.</param>
+		/// <param name="httpMessageHandler">The <see cref="HttpMessageHandler"/> to use.</param>
 		/// <returns></returns>
-		public ConnectionSettingsBuilder UseCustomHttpClient(IHttpClient client) {
-			_customHttpClient = client;
+		public ConnectionSettingsBuilder UseCustomHttpMessageHandler(HttpMessageHandler httpMessageHandler) {
+			_customHttpMessageHandler = httpMessageHandler;
 			return this;
 		}
 
@@ -479,7 +479,7 @@ namespace EventStore.ClientAPI {
 				_gossipExternalHttpPort,
 				_gossipTimeout,
 				_nodePreference,
-				_customHttpClient);
+				_customHttpMessageHandler);
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -102,7 +102,7 @@ namespace EventStore.ClientAPI {
 						connectionSettings.ClientConnectionTimeout, connectionSettings.ClusterDns,
 						connectionSettings.GossipSeeds, connectionSettings.MaxDiscoverAttempts,
 						connectionSettings.ExternalGossipPort, connectionSettings.GossipTimeout,
-						connectionSettings.NodePreference, connectionSettings.CustomHttpClient);
+						connectionSettings.NodePreference, connectionSettings.CustomHttpMessageHandler);
 				}
 
 				if (scheme == "discover") {
@@ -208,7 +208,8 @@ namespace EventStore.ClientAPI {
 				clusterSettings.ExternalGossipPort,
 				clusterSettings.GossipSeeds,
 				clusterSettings.GossipTimeout,
-				clusterSettings.NodePreference);
+				clusterSettings.NodePreference,
+				connectionSettings.CustomHttpMessageHandler);
 
 			return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
 				connectionName);


### PR DESCRIPTION
Changed: Replaced `UseCustomHttpClient` in the ConnectionSettingsBuilder for the TCP client with `UseCustomHttpMessageHandler`

The HttpClient provided by `UseCustomHttpClient` was no longer being used because the `ClusterDnsEndPointDiscoverer` only accepts a message handler.