### PR TITLE
Always honor NodePreference.Leader in ClusterDnsEndPointDiscoverer

### DIFF
--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -221,6 +221,10 @@ namespace EventStore.ClientAPI.Internal {
 				case NodePreference.Random:
 					RandomShuffle(nodes, 0, nodes.Length - 1);
 					break;
+				case NodePreference.Leader:
+					nodes = nodes.OrderBy(nodeEntry => nodeEntry.State != ClusterMessages.VNodeState.Leader)
+						.ToArray(); // OrderBy is a stable sort and only affects order of matching entries
+					break;
 				case NodePreference.Follower:
 					nodes = nodes.OrderBy(nodeEntry => 
 							nodeEntry.State != ClusterMessages.VNodeState.Follower &&

--- a/src/EventStore.ClientAPI/Messages/ClusterMessages.cs
+++ b/src/EventStore.ClientAPI/Messages/ClusterMessages.cs
@@ -65,24 +65,26 @@ namespace EventStore.ClientAPI.Messages {
 			}
 		}
 
+		//The order specified in this enum is important.
+		//It defines the default sorting order (descending, ignoring a few specific states) used in ClusterDnsEndPointDiscoverer when choosing which node the client should connect to.
 		public enum VNodeState {
-			Initializing,
-			Unknown,
-			PreReplica,
-			CatchingUp,
-			Clone,
-			Slave,
-			Follower,
-			PreMaster,
-			PreLeader,
-			Master,
-			Leader,
-			Manager,
-			ShuttingDown,
-			Shutdown,
-			ReadOnlyLeaderless,
-			PreReadOnlyReplica,
-			ReadOnlyReplica
+			Initializing = 1,
+			ReadOnlyLeaderless = 2,
+			Unknown = 3,
+			PreReadOnlyReplica = 4,
+			PreReplica = 5,
+			CatchingUp = 6,
+			Clone = 7,
+			ReadOnlyReplica = 8,
+			Slave = 9,
+			Follower = 10,
+			PreMaster = 11,
+			PreLeader = 12,
+			Master = 13,
+			Leader = 14,
+			Manager = 15,
+			ShuttingDown = 16,
+			Shutdown = 17
 		}
 	}
 }


### PR DESCRIPTION
Fixed: NodePreference.Leader is not always honored in ClusterDnsEndPointDiscoverer


Fixes #2416
*Reproduction steps*
- Connect to a cluster having 2 nodes and a read-only replica with default settings and verbose logging on using the TCP client.
- The client will connect to the ReadOnlyReplica instead of the Leader:
```
Discovering: found best choice [127.0.0.1:0,127.0.0.1:3103] (ReadOnlyReplica)
```

- Explicitly sort nodes giving preference to VNodeState.Leader when NodePreference.Leader is specified to make the code clearer and avoid future bugs.
- Reorder the VNodeState enum and add a comment mentioning that the order in the VNodeState enum is important