### PR TITLE
Ignore invalid link events (Fix #2414).

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/v8/when_running_a_projection_emitting_invalid_events.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/v8/when_running_a_projection_emitting_invalid_events.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.v8 {
+	public class when_running_a_v8_projection_emitting_invalid_events : TestFixtureWithJsProjection {
+		protected override void Given() {
+			_projection = @"
+                fromAll().when({$any: 
+                    function(state, event) {
+                        emit('', '', {});
+                    return {};
+                }});
+            ";
+		}
+		
+		[Test, Category("v8")]
+		public void process_event_ignores_emitted_event() {
+			string state;
+			EmittedEventEnvelope[] emittedEvents;
+			_stateHandler.ProcessEvent(
+				"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
+				"metadata",
+				@"{""a"":""b""}", out state, out emittedEvents);
+
+			Assert.IsNull(emittedEvents);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/v8/when_running_a_v8_projection_emitting_invalid_links.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/v8/when_running_a_v8_projection_emitting_invalid_links.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.v8 {
+	public class when_running_a_v8_projection_emitting_invalid_links : TestFixtureWithJsProjection {
+		protected override void Given() {
+			_projection = @"
+                fromAll().when({$any: 
+                    function(state, event) {
+                        event.sequenceNumber = null;
+                    linkTo('output-stream', event);
+                    return {};
+                }});
+            ";
+		}
+		
+		[Test, Category("v8")]
+		public void process_event_ignores_emitted_event() {
+			string state;
+			EmittedEventEnvelope[] emittedEvents;
+			_stateHandler.ProcessEvent(
+				"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
+				"metadata",
+				@"{""a"":""b""}", out state, out emittedEvents);
+
+			Assert.IsNull(emittedEvents);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/v8/V8ProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/v8/V8ProjectionStateHandler.cs
@@ -10,6 +10,7 @@ using EventStore.Projections.Core.v8;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Linq;
+using Serilog;
 
 namespace EventStore.Projections.Core.Services.v8 {
 	public class V8ProjectionStateHandler : IProjectionStateHandler {
@@ -18,6 +19,8 @@ namespace EventStore.Projections.Core.Services.v8 {
 		private List<EmittedEventEnvelope> _emittedEvents;
 		private CheckpointTag _eventPosition;
 		private bool _disposed;
+		private static readonly char[] LinkToSeparator = { '@' };
+		private static readonly string LinkType = "$>";
 
 		public V8ProjectionStateHandler(
 			string preludeName, string querySource, Func<string, Tuple<string, string>> getModuleSource,
@@ -66,6 +69,16 @@ namespace EventStore.Projections.Core.Services.v8 {
 				throw new ArgumentException("Failed to deserialize emitted event JSON", ex);
 			}
 
+			if (!IsValidEvent(emittedEvent)) {
+				Log.Warning($"Invalid emitted event was ignored: streamId: [{emittedEvent.streamId}], eventType: [{emittedEvent.eventName}], payload: [{emittedEvent.body}]");
+				return;
+			}
+			
+			if (emittedEvent.eventName.Equals(LinkType) && !IsValidLinkEvent(emittedEvent)) {
+				Log.Warning($"Invalid emitted link event was ignored: streamId: [{emittedEvent.streamId}], eventType: [{emittedEvent.eventName}], payload: [{emittedEvent.body}]");
+				return;
+			}
+			
 			if (_emittedEvents == null)
 				_emittedEvents = new List<EmittedEventEnvelope>();
 			_emittedEvents.Add(
@@ -219,6 +232,16 @@ namespace EventStore.Projections.Core.Services.v8 {
 
 		public IQuerySources GetSourceDefinition() {
 			return GetQuerySourcesDefinition();
+		}
+		
+		private static bool IsValidEvent(EmittedEventJsonContract @event) {
+			return !(@event.eventName.IsEmptyString() || @event.streamId.IsEmptyString() || @event.isJson && @event.body.IsEmptyString());
+		}
+		
+		// This function assumes 'IsValidEvent' was called upfront.
+		private static bool IsValidLinkEvent(EmittedEventJsonContract @event) {
+			var parts = @event.body.Split(LinkToSeparator, 2);
+			return long.TryParse(parts[0], out long _);
 		}
 	}
 }


### PR DESCRIPTION
Fixed: No longer raise an exception when reading a linked event with a bad payload.

Fix #2414

- [x] Fix link event resolution.
- [x] Prevent the projection from writing a malformed (link) event.
- [x] Add tests.

When an user-defined projection emits a malformed (link) event, we ignore them and a warning like the following is displayed:

```
[ 7420,24,15:08:03.897,WRN] Invalid emitted link event was ignored: streamId: [$CustomStream], eventType: [$>], payload: [undefined@undefined]
```