### PR TITLE
Always checkpoint when the appropriate number of messages are handled

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_that_do_not_pass_event_filter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_that_do_not_pass_event_filter.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Text;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Messages;
+using NUnit.Framework;
+using EventStore.Core.Tests.Services.TimeService;
+
+namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
+	[TestFixture]
+	public class
+		when_handling_events_that_exceed_unhandled_bytes_threshold_and_checkpoint_after_reached :
+			TestFixtureWithProjectionSubscription {
+		protected override void Given() {
+			_source = source => {
+				source.FromAll();
+				source.IncludeEvent("specific-event");
+			};
+			_checkpointAfterMs = 1000;
+			_checkpointProcessedEventsThreshold = 1;
+			_checkpointUnhandledBytesThreshold = 4096;
+			_timeProvider = new FakeTimeProvider();
+		}
+
+		protected override void When() {
+			var firstPosition = new TFPos(200, 200);	
+			var secondPosition = new TFPos(
+				firstPosition.CommitPosition + _checkpointUnhandledBytesThreshold + 1, 
+				firstPosition.PreparePosition + _checkpointUnhandledBytesThreshold + 1);
+			
+			_subscription.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					Guid.NewGuid(), firstPosition, "test-stream", 1, false, Guid.NewGuid(),
+					"bad-event-type", false, new byte[0], new byte[0]));
+			_checkpointHandler.HandledMessages.Clear();
+			((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
+			_subscription.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					Guid.NewGuid(), secondPosition, "test-stream", 1, false, Guid.NewGuid(),
+					"bad-event-type", false, new byte[0], new byte[0]));
+		}
+
+		[Test]
+		public void checkpoint_is_suggested() {
+			Assert.AreEqual(1, _checkpointHandler.HandledMessages.Count);
+		}
+	}
+	
+	[TestFixture]
+	public class
+		when_handling_events_where_checkpoint_after_reached_does_not_exceed_unhandled_bytes_threshold :
+			TestFixtureWithProjectionSubscription {
+		protected override void Given() {
+			_source = source => {
+				source.FromAll();
+				source.IncludeEvent("specific-event");
+			};
+			_checkpointAfterMs = 1000;
+			_checkpointProcessedEventsThreshold = 1;
+			_checkpointUnhandledBytesThreshold = 4096;
+			_timeProvider = new FakeTimeProvider();
+		}
+
+		protected override void When() {
+			var firstPosition = new TFPos(200, 200);	
+			var secondPosition = new TFPos(
+				firstPosition.CommitPosition + _checkpointUnhandledBytesThreshold - 1, 
+				firstPosition.PreparePosition + _checkpointUnhandledBytesThreshold - 1);
+			
+			_subscription.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					Guid.NewGuid(), firstPosition, "test-stream", 1, false, Guid.NewGuid(),
+					"bad-event-type", false, new byte[0], new byte[0]));
+			_checkpointHandler.HandledMessages.Clear();
+			((FakeTimeProvider)_timeProvider).AddToUtcTime(TimeSpan.FromMilliseconds(_checkpointAfterMs + 1));
+			_subscription.Handle(
+				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+					Guid.NewGuid(), secondPosition, "test-stream", 1, false, Guid.NewGuid(),
+					"bad-event-type", false, new byte[0], new byte[0]));
+		}
+
+		[Test]
+		public void checkpoint_is_not_suggested() {
+			Assert.AreEqual(0, _checkpointHandler.HandledMessages.Count);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
@@ -606,15 +606,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 								var link = @event.Link;
 								var data = @event.Event;
 								var byStream = link != null && _streamToEventType.ContainsKey(link.EventStreamId);
-								string adjustedPositionStreamId;
-								var isDeleteStreamEvent =
-									StreamDeletedHelper.IsStreamDeletedEvent(
-										@event.OriginalStreamId, @event.OriginalEvent.EventType,
-										@event.OriginalEvent.Data, out adjustedPositionStreamId);
 								if (data == null)
 									continue;
-								var eventType = isDeleteStreamEvent ? "$deleted" : data.EventType;
-								var byEvent = link == null && _eventTypes.Contains(eventType);
 								var originalTfPosition = @event.OriginalPosition.Value;
 								if (byStream) {
 									// ignore data just update positions
@@ -626,7 +619,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 									DeliverEventRetrievedFromTf(
 										unresolvedLinkEvent, 100.0f * link.LogPosition / message.TfLastCommitPosition,
 										originalTfPosition);
-								} else if (byEvent) {
+								} else {
 									DeliverEventRetrievedFromTf(
 										@event, 100.0f * data.LogPosition / message.TfLastCommitPosition,
 										originalTfPosition);

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
@@ -79,14 +79,6 @@ namespace EventStore.Projections.Core.Services.Processing {
 			var roundedProgress = (float)Math.Round(message.Progress, 1);
 			bool progressChanged = _progress != roundedProgress;
 
-			if (
-				!_eventFilter.PassesSource(
-					message.Data.ResolvedLinkTo, message.Data.PositionStreamId, message.Data.EventType)) {
-				if (progressChanged)
-					PublishProgress(roundedProgress);
-				return;
-			}
-
 			// NOTE: after joining heading distribution point it delivers all cached events to the subscription
 			// some of this events we may have already received. The delivered events may have different order 
 			// (in case of partially ordered cases multi-stream reader etc). We discard all the messages that are not 


### PR DESCRIPTION
Changed: Allow a projection to be able to checkpoint regardless of whether the event filter passes.

Fixes #2001

We are currently blocking projection checkpointing from happening due to
 checking the projection's filter source before allowing the rest of the
 event processing to occur.

Removing this check will allow regular checkpointing behaviour to occur.
The check will still happen further down as part of the `Passes` method
which calls `PassesSource` internally.