### PR TITLE
Avoid parsing metadata if null in ByCorrelationId projection (Fix #2429)

### DIFF
--- a/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
+++ b/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
@@ -75,6 +75,9 @@ namespace EventStore.Projections.Core.Standard {
 			if (data.EventStreamId != data.PositionStreamId)
 				return false;
 
+			if (data.Metadata == null)
+				return false;
+
 			JObject metadata = null;
 
 			try {


### PR DESCRIPTION
Fixed: Fix ArgumentNullException in ByCorrelationId standard projection when the event's metadata is null.

Fixes #2429