### PR TITLE
Fix WhatIf Commandline Option #2397

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -25,6 +25,11 @@ namespace EventStore.ClusterNode {
 					Application.Exit(0, "Cancelled.");
 				};
 
+				if (hostedService.Options.WhatIf) {
+					Log.Information("Exiting with exit code: 0.\nExit reason: WhatIf option specified");
+					return (int)ExitCode.Success;
+				}
+
 				await CreateHostBuilder(hostedService, args)
 					.RunConsoleAsync(options => options.SuppressStatusMessages = true, cts.Token);
 				return await exitCodeSource.Task;

--- a/src/EventStore.Core/EventStoreHostedService.cs
+++ b/src/EventStore.Core/EventStoreHostedService.cs
@@ -92,9 +92,6 @@ namespace EventStore.Core {
 			Log.Information("{description,-25} {logsDirectory}", "LOGS:", logsDirectory);
 
 			Log.Information(EventStoreOptions.DumpOptions());
-
-			if (options.WhatIf)
-				Application.Exit(ExitCode.Success, "WhatIf option specified");
 		}
 
 		private string FormatExceptionMessage(Exception ex) {


### PR DESCRIPTION
Fixed: WhatIf option will now terminate the application if set.

`WhatIf` wasn't exiting the application because when we used to check if the `--what-if` parameter was passed, the [_exit] delegate was not assigned yet. I decided to move that test in the `Program` class to have a graceful exit. If I used `Application.Exit` instead, it would result in a nasty stacktrace. 

Fixes #2397 

 [_exit]: https://github.com/EventStore/EventStore/blob/master/src/EventStore.Common/Utils/Application.cs#L52