### PR TITLE
Increase Receive Limit to 16MB on Streams

### DIFF
--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using EventStore.Common.Utils;
 using EventStore.Core.Authentication;
@@ -9,7 +8,7 @@ using EventStore.Core.Authorization;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
-using EventStore.Core.Util;
+using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Cluster.Settings {
 	public class ClusterVNodeSettings {
@@ -184,8 +183,8 @@ namespace EventStore.Core.Cluster.Settings {
 			Ensure.Positive(commitAckCount, "commitAckCount");
 			Ensure.Positive(initializationThreads, "initializationThreads");
 			Ensure.NotNull(gossipAdvertiseInfo, "gossipAdvertiseInfo");
-			if (maxAppendSize > 1024 * 1024 * 16) {
-				throw new ArgumentOutOfRangeException(nameof(maxAppendSize), $"{nameof(maxAppendSize)} exceeded 16MB.");
+			if (maxAppendSize > TFConsts.EffectiveMaxLogRecordSize) {
+				throw new ArgumentOutOfRangeException(nameof(maxAppendSize), $"{nameof(maxAppendSize)} exceeded {TFConsts.EffectiveMaxLogRecordSize} bytes.");
 			}
 
 			if (discoverViaDns && string.IsNullOrWhiteSpace(clusterDns))

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -120,7 +120,6 @@ namespace EventStore.Core {
 			.BuildServiceProvider();
 
 		public IServiceCollection ConfigureServices(IServiceCollection services) {
-
 			var bridge = new KestrelToInternalBridgeMiddleware(_externalHttpService.UriRouter, _externalHttpService.LogHttpRequests, _externalHttpService.AdvertiseAsAddress, _externalHttpService.AdvertiseAsPort);
 			return _subsystems
 				.Aggregate(services
@@ -137,7 +136,9 @@ namespace EventStore.Core {
 						.AddSingleton(new Operations(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Gossip(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Elections(_mainQueue, _authorizationProvider))
-						.AddGrpc().Services,
+						.AddGrpc()
+						.AddServiceOptions<Streams>(options => options.MaxReceiveMessageSize = 1024 * 1024 * 16 + 2048)
+						.Services,
 					(s, subsystem) => subsystem.ConfigureServices(s));
 		}
 

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.Transport.Grpc;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Core.Services.Transport.Http.Authentication;
+using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Plugins.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -137,7 +138,8 @@ namespace EventStore.Core {
 						.AddSingleton(new Gossip(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Elections(_mainQueue, _authorizationProvider))
 						.AddGrpc()
-						.AddServiceOptions<Streams>(options => options.MaxReceiveMessageSize = 1024 * 1024 * 16 + 2048)
+						.AddServiceOptions<Streams>(options =>
+							options.MaxReceiveMessageSize = TFConsts.EffectiveMaxLogRecordSize)
 						.Services,
 					(s, subsystem) => subsystem.ConfigureServices(s));
 		}

--- a/src/EventStore.Core/Data/Event.cs
+++ b/src/EventStore.Core/Data/Event.cs
@@ -16,8 +16,11 @@ namespace EventStore.Core.Data {
 				metadata != null ? Helper.UTF8NoBom.GetBytes(metadata) : null) {
 		}
 
-		public static bool ExceedsMaximumSizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
-			(data?.Length ?? 0 + metadata?.Length ?? 0 + eventType.Length * 2) > TFConsts.MaxLogRecordSize - 10000;
+		public static int SizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
+			data?.Length ?? 0 + metadata?.Length ?? 0 + eventType.Length * 2;
+
+		private static bool ExceedsMaximumSizeOnDisk(string eventType, byte[] data, byte[] metadata) =>
+			SizeOnDisk(eventType, data, metadata) > TFConsts.EffectiveMaxLogRecordSize;
 
 		public Event(Guid eventId, string eventType, bool isJson, byte[] data, byte[] metadata) {
 			if (eventId == Guid.Empty)

--- a/src/EventStore.Core/Services/Transport/Grpc/Operations.Admin.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Operations.Admin.cs
@@ -2,22 +2,22 @@ using System;
 using System.Threading.Tasks;
 using EventStore.Client.Operations;
 using EventStore.Client.Shared;
-using EventStore.Core.Authorization;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	partial class Operations {
-		private static readonly Operation ShutdownOperation = new Operation(Authorization.Operations.Node.Shutdown);
+		private static readonly Operation ShutdownOperation = new Operation(Plugins.Authorization.Operations.Node.Shutdown);
 
 		private static readonly Operation MergeIndexesOperation =
-			new Operation(Authorization.Operations.Node.MergeIndexes);
+			new Operation(Plugins.Authorization.Operations.Node.MergeIndexes);
 
-		private static readonly Operation ResignOperation = new Operation(Authorization.Operations.Node.Resign);
+		private static readonly Operation ResignOperation = new Operation(Plugins.Authorization.Operations.Node.Resign);
 
 		private static readonly Operation SetNodePriorityOperation =
-			new Operation(Authorization.Operations.Node.SetPriority);
+			new Operation(Plugins.Authorization.Operations.Node.SetPriority);
 
 		private static readonly Empty EmptyResult = new Empty();
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFConsts.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFConsts.cs
@@ -3,7 +3,8 @@ using System;
 namespace EventStore.Core.TransactionLog.Chunks {
 	public static class TFConsts {
 		public const int MaxLogRecordSize = 16 * 1024 * 1024; // 16Mb ought to be enough for everything?.. ;)
-
+		public const int LogRecordOverheadSize = 10000;
+		public const int EffectiveMaxLogRecordSize = MaxLogRecordSize - LogRecordOverheadSize;
 		public const int MidpointsDepth = 10;
 
 		public const int ChunkSize = 256 * 1024 * 1024;

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.RestartSubsystem.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.RestartSubsystem.cs
@@ -1,10 +1,9 @@
 using System.Threading.Tasks;
 using EventStore.Core.Messaging;
 using EventStore.Client.Shared;
-using EventStore.Core.Authorization;
+using EventStore.Plugins.Authorization;
 using EventStore.Projections.Core.Messages;
 using Grpc.Core;
-using Operations = EventStore.Core.Authorization.Operations;
 
 namespace EventStore.Projections.Core.Services.Grpc {
 	public partial class ProjectionManagement {


### PR DESCRIPTION
Changed: Default Message Size for Streams endpoint is 16MB

Fixes #2372
Fixes EventStore/EventStore-Client-Java#15