### PR TITLE
Add MaxTruncation safety feature

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -303,6 +303,9 @@ namespace EventStore.ClusterNode {
 
 		[ArgDescription(Opts.WriteStatsToDbDescr, Opts.DbGroup)]
 		public bool WriteStatsToDb { get; set; }
+		
+		[ArgDescription(Opts.MaxTruncationDescr, Opts.DbGroup)]
+		public long MaxTruncation { get; set; }
 
 		[ArgDescription(Opts.MaxAppendSizeDecr, Opts.AppGroup)]
 		public int MaxAppendSize { get; set; }
@@ -440,6 +443,7 @@ namespace EventStore.ClusterNode {
 			MaxAutoMergeIndexLevel = Opts.MaxAutoMergeIndexLevelDefault;
 
 			WriteStatsToDb = Opts.WriteStatsToDbDefault;
+			MaxTruncation = Opts.MaxTruncationDefault;
 			MaxAppendSize = Opts.MaxAppendSizeDefault;
 
 			Dev = Opts.DevDefault;

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -265,6 +265,7 @@ namespace EventStore.ClusterNode {
 				.WithChunkInitialReaderCount(options.ChunkInitialReaderCount)
 				.WithInitializationThreads(options.InitializationThreads)
 				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel)
+				.WithMaxTruncation(options.MaxTruncation)
 				.WithMaxAppendSize(options.MaxAppendSize)
 				.WithEnableAtomPubOverHTTP(options.EnableAtomPubOverHTTP);
 

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -9,7 +9,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 	public static class TFChunkHelper {
 		public static TFChunkDbConfig CreateDbConfig(string pathName, long writerCheckpointPosition,
 			long chaserCheckpointPosition = 0,
-			long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000) {
+			long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000,
+			long maxTruncation = -1) {
 			return new TFChunkDbConfig(pathName,
 				new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
 				chunkSize,
@@ -21,7 +22,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(-1), 
 				new InMemoryCheckpoint(-1),
 				Constants.TFChunkInitialReaderCountDefault, 
-				Constants.TFChunkMaxReaderCountDefault);
+				Constants.TFChunkMaxReaderCountDefault,
+				maxTruncation: maxTruncation);
 		}
 
 		public static TFChunkDbConfig CreateDbConfig(string pathName, ICheckpoint writerCheckpoint,

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using EventStore.Core.Tests.TransactionLog.Validation;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog.Truncation {
+	[TestFixture]
+	public class when_truncating_against_max_truncation_config : SpecificationWithDirectoryPerTestFixture {
+		private TFChunkDbConfig _config;
+
+		[OneTimeSetUp]
+		public override async Task TestFixtureSetUp() {
+			await base.TestFixtureSetUp();
+
+			// epoch = 5500, truncate to 0, max truncation = 1000
+			_config = TFChunkHelper.CreateDbConfig(PathName, 11111, 5500, 5500, 0, 1000, maxTruncation: 1000);
+
+			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
+			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));
+			DbUtil.CreateMultiChunk(_config, 3, 10, GetFilePathFor("chunk-000003.000001"));
+			DbUtil.CreateMultiChunk(_config, 3, 10, GetFilePathFor("chunk-000003.000002"));
+			DbUtil.CreateMultiChunk(_config, 7, 8, GetFilePathFor("chunk-000007.000001"));
+			DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
+		}
+
+		[OneTimeTearDown]
+		public override Task TestFixtureTearDown() {
+			return base.TestFixtureTearDown();
+		}
+
+		[Test]
+		public void truncate_above_max_throws_exception() {
+			Assert.Throws<Exception>(() => {
+				var truncator = new TFChunkDbTruncator(_config);
+				truncator.TruncateDb(0);
+			});
+		}
+
+		[Test]
+		public void truncate_within_max_does_not_throw_exception() {
+
+			Assert.DoesNotThrow(() => {
+				var truncator = new TFChunkDbTruncator(_config);
+				truncator.TruncateDb(4800);
+			});
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
@@ -13,8 +13,8 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			// epoch = 5500, truncate to 0, max truncation = 1000
-			_config = TFChunkHelper.CreateDbConfig(PathName, 11111, 5500, 5500, 0, 1000, maxTruncation: 1000);
+			// writer checkpoint = 5500, truncate to 0, max truncation = 1000
+			_config = TFChunkHelper.CreateDbConfig(PathName, 5500, 5500, 5500, 0, 1000, maxTruncation: 1000);
 
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -85,6 +85,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool ReduceFileCachePressure;
 		public readonly int InitializationThreads;
 		public readonly int MaxAutoMergeIndexLevel;
+		public readonly long MaxTruncation;
 
 		public readonly bool GossipOnSingleNode;
 		public readonly bool FaultOutOfOrderProjections;
@@ -160,6 +161,7 @@ namespace EventStore.Core.Cluster.Settings {
 			int maxAutoMergeIndexLevel = 1000,
 			bool disableFirstLevelHttpAuthorization = false,
 			bool logFailedAuthenticationAttempts = false,
+			long maxTruncation = -1,
 			bool readOnlyReplica = false,
 			int maxAppendSize = 1024 * 1024,
 			bool unsafeAllowSurplusNodes = false,
@@ -272,6 +274,7 @@ namespace EventStore.Core.Cluster.Settings {
 			MaxAppendSize = maxAppendSize;
 			PTableMaxReaderCount = ptableMaxReaderCount;
 			UnsafeAllowSurplusNodes = unsafeAllowSurplusNodes;
+			MaxTruncation = maxTruncation;
 		}
 
 		public override string ToString() =>
@@ -303,7 +306,8 @@ namespace EventStore.Core.Cluster.Settings {
 			$"InitializationThreads: {InitializationThreads}\n" +
 			$"DisableFirstLevelHttpAuthorization: {DisableFirstLevelHttpAuthorization}\n" +
 			$"ReadOnlyReplica: {ReadOnlyReplica}\n" +
-			$"UnsafeAllowSurplusNodes: {UnsafeAllowSurplusNodes}\n" + 
-			$"DeadMemberRemovalPeriod: {DeadMemberRemovalPeriod}\n";
+			$"UnsafeAllowSurplusNodes: {UnsafeAllowSurplusNodes}\n" +
+			$"DeadMemberRemovalPeriod: {DeadMemberRemovalPeriod}\n" +
+			$"MaxTruncation: {MaxTruncation}\n";
 	}
 }

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -9,6 +9,7 @@ using EventStore.Core.Authorization;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.Util;
 
 namespace EventStore.Core.Cluster.Settings {
 	public class ClusterVNodeSettings {
@@ -161,7 +162,7 @@ namespace EventStore.Core.Cluster.Settings {
 			int maxAutoMergeIndexLevel = 1000,
 			bool disableFirstLevelHttpAuthorization = false,
 			bool logFailedAuthenticationAttempts = false,
-			long maxTruncation = -1,
+			long maxTruncation = 256 * 1024 * 1024,
 			bool readOnlyReplica = false,
 			int maxAppendSize = 1024 * 1024,
 			bool unsafeAllowSurplusNodes = false,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -21,6 +21,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly int MaxReaderCount;
 		public readonly bool OptimizeReadSideCache;
 		public readonly bool ReduceFileCachePressure;
+		public readonly long MaxTruncation;
 
 		public TFChunkDbConfig(string path,
 			IFileNamingStrategy fileNamingStrategy,
@@ -38,7 +39,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			bool unbuffered = false,
 			bool writethrough = false,
 			bool optimizeReadSideCache = false,
-			bool reduceFileCachePressure = false) {
+			bool reduceFileCachePressure = false,
+			long maxTruncation = -1) {
 			Ensure.NotNullOrEmpty(path, "path");
 			Ensure.NotNull(fileNamingStrategy, "fileNamingStrategy");
 			Ensure.Positive(chunkSize, "chunkSize");
@@ -69,6 +71,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			MaxReaderCount = maxReaderCount;
 			OptimizeReadSideCache = optimizeReadSideCache;
 			ReduceFileCachePressure = reduceFileCachePressure;
+			MaxTruncation = maxTruncation;
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			bool writethrough = false,
 			bool optimizeReadSideCache = false,
 			bool reduceFileCachePressure = false,
-			long maxTruncation = -1) {
+			long maxTruncation = 256 * 1024 * 1024) {
 			Ensure.NotNullOrEmpty(path, "path");
 			Ensure.NotNull(fileNamingStrategy, "fileNamingStrategy");
 			Ensure.Positive(chunkSize, "chunkSize");

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
@@ -15,6 +15,16 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		}
 
 		public void TruncateDb(long truncateChk) {
+			var epoch = _config.EpochCheckpoint.Read();
+			var requestedTruncation = _config.EpochCheckpoint.Read() - truncateChk;
+			if (_config.MaxTruncation >= 0 && requestedTruncation > _config.MaxTruncation) {
+				Log.Error(
+					"MaxTruncation is set and truncate checkpoint is out of bounds. MaxTruncation {maxTruncation} vs requested truncation {requestedTruncation} [{epochChk} => {truncateChk}].  To proceed, set MaxTruncation to -1 (no max) or greater than {requestedTruncationHint}.",
+					_config.MaxTruncation, requestedTruncation, epoch, truncateChk, requestedTruncation);
+				throw new Exception(
+					string.Format("MaxTruncation is set ({0}) and truncate checkpoint is out of bounds (requested truncation is {1} [{2} => {3}]).", _config.MaxTruncation, requestedTruncation, epoch, truncateChk));
+			}
+			
 			var writerChk = _config.WriterCheckpoint.Read();
 			var oldLastChunkNum = (int)(writerChk / _config.ChunkSize);
 			var newLastChunkNum = (int)(truncateChk / _config.ChunkSize);

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
@@ -15,17 +15,16 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		}
 
 		public void TruncateDb(long truncateChk) {
-			var epoch = _config.EpochCheckpoint.Read();
-			var requestedTruncation = _config.EpochCheckpoint.Read() - truncateChk;
+			var writerChk = _config.WriterCheckpoint.Read();
+			var requestedTruncation = writerChk - truncateChk;
 			if (_config.MaxTruncation >= 0 && requestedTruncation > _config.MaxTruncation) {
 				Log.Error(
-					"MaxTruncation is set and truncate checkpoint is out of bounds. MaxTruncation {maxTruncation} vs requested truncation {requestedTruncation} [{epochChk} => {truncateChk}].  To proceed, set MaxTruncation to -1 (no max) or greater than {requestedTruncationHint}.",
-					_config.MaxTruncation, requestedTruncation, epoch, truncateChk, requestedTruncation);
+					"MaxTruncation is set and truncate checkpoint is out of bounds. MaxTruncation {maxTruncation} vs requested truncation {requestedTruncation} [{writerChk} => {truncateChk}].  To proceed, set MaxTruncation to -1 (no max) or greater than {requestedTruncationHint}.",
+					_config.MaxTruncation, requestedTruncation, writerChk, truncateChk, requestedTruncation);
 				throw new Exception(
-					string.Format("MaxTruncation is set ({0}) and truncate checkpoint is out of bounds (requested truncation is {1} [{2} => {3}]).", _config.MaxTruncation, requestedTruncation, epoch, truncateChk));
+					string.Format("MaxTruncation is set ({0}) and truncate checkpoint is out of bounds (requested truncation is {1} [{2} => {3}]).", _config.MaxTruncation, requestedTruncation, writerChk, truncateChk));
 			}
 			
-			var writerChk = _config.WriterCheckpoint.Read();
 			var oldLastChunkNum = (int)(writerChk / _config.ChunkSize);
 			var newLastChunkNum = (int)(truncateChk / _config.ChunkSize);
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -434,6 +434,10 @@ namespace EventStore.Core.Util {
 		public const string WriteStatsToDbDescr = "Set this option to write statistics to the database.";
 		public const bool WriteStatsToDbDefault = false;
 		
+		public const string MaxTruncationDescr =
+			"When truncate.chk is set, the database will be truncated on startup. This is a safety check to ensure large amounts of data truncation does not happen accidentally. This value should be set in the low 10,000s for allow for standard cluster recovery operations. -1 is no max (default).";
+		public static readonly long MaxTruncationDefault = 256 * 1024 * 1024;
+		
 		public const string DevDescr = "Enable Development Mode for Event Store.";
 		public const bool DevDefault = false;
 	}

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -435,7 +435,7 @@ namespace EventStore.Core.Util {
 		public const bool WriteStatsToDbDefault = false;
 		
 		public const string MaxTruncationDescr =
-			"When truncate.chk is set, the database will be truncated on startup. This is a safety check to ensure large amounts of data truncation does not happen accidentally. This value should be set in the low 10,000s for allow for standard cluster recovery operations. -1 is no max (default).";
+			"When truncate.chk is set, the database will be truncated on startup. This is a safety check to ensure large amounts of data truncation does not happen accidentally. This value should be set in the low 10,000s for allow for standard cluster recovery operations. -1 is no max.";
 		public static readonly long MaxTruncationDefault = 256 * 1024 * 1024;
 		
 		public const string DevDescr = "Enable Development Mode for Event Store.";


### PR DESCRIPTION
Added: Max Truncation Safety Feature to avoid large unexpected truncations due to misconfiguration

Original PR by @megakid here https://github.com/EventStore/EventStore/pull/2415

This feature was built to avoid huge unexpected truncations due to misconfiguration.

Today I did some rejigging of our EventStore deployment mechanism, after testing on a development and UAT environment, I pushed my changes live.  We don't take deploying EventStore lightly but this change seemed relatively harmless but little did I know, a 1 character mistake ended up truncating our entire data set on 4 of our 5 nodes (approx 800GB of data in total).  Essentially I had typed an IP address wrong and the deployment process automatically creates a DNS entry to our gossip DNS entry.  That one (bad) mistake ended up causing a potentially catastrophic loss of data (outside of backups obviously).

Unfortunately upon deployment with this misconfiguration, there was another cluster (with a completely different dataset) running on this erroneous IP address.  On top of this, it also shared the same port setup (something we try to avoid but didn't achieve that here).  This meant that these two clusters quickly merged due to the gossip networks joining one another.  The cluster I was deploying then quickly logged the below and truncated their *entire* dataset:

```
Master [10.194.0.10:5412,{ebd4c7e7-efe1-4419-a6a0-624865099018}] subscribed us at 0 (0x0), which is less than our last epoch and LastCommitPosition 225919458447 (0x3499D95C8F) >= lastEpoch.EpochPosition 225919442304 (0x3499D91D80). That might be bad, especially if the LastCommitPosition is way beyond EpochPosition.
......
Truncate checkpoint is present. Truncate: 0 (0x0), Writer: 225919474285 (0x3499D99A6D), Chaser: 225919474285 (0x3499D99A6D), Epoch: 225919442304 (0x3499D91D80)
```

To be clear, this is absolutely not a bug but I feel it's a bit 'violent' for a database to completely wipe itself following such a "small" misconfiguration.

In this PR, I've added a `MaxTruncation` value which can be configured to a small value (say `20,000` to allow for "usual" truncations during failovers/re-elections etc) but doesn't allow huge truncations to occur without someone changing the config.  If you manually set the truncate.chk then you should also ensure that your configuration `MaxTruncation` value is set to `-1` or removed (defaults to `-1`).  It would be a huge weight off our minds to know that instead of wiping all data, it would go into an infinite restart loop (with clear logs as to why) if something like this occurs in the future.

We did manage to fully recover from this incident fairly easily by copying the intact data from our last remaining node across the other nodes, restarting the 2nd cluster it accidently joined (so it reset the cluster definition) and starting up the cluster.