### PR TITLE
Update licenses

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -36,65 +36,6 @@ credit them along with listing their licensing terms here.
 Along with each is a note detailing the form the dependency takes. Nothing is
 implied by the order in which dependencies are presented here.
 
-## PowerArgs
-
-*(Note: we use a modified version of PowerArgs, and have included the code in
-our repository rather than via NuGet or as a separate DLL)*
-
-Copyright (c) 2013 Adam Abdelhamed
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-## NLog
-
-Copyright (c) 2004-2018 Jaroslaw Kowalski <jaak@jkowalski.net>, Kim Christensen, Julian Verdurmen
-
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-* Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of Jaroslaw Kowalski nor the names of its
-  contributors may be used to endorse or promote products derived from this
-  software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
-THE POSSIBILITY OF SUCH DAMAGE.
-
-
 ## Newtonsoft Json.NET
 
 *(Note: The Newtonsoft Json.NET library is internalized in the
@@ -272,11 +213,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
 
 ## HdrHistogram
+
 The code in this repository code was Written by Gil Tene, Michael Barker,
 and Matt Warren, and released to the public domain, as explained at
 http://creativecommons.org/publicdomain/zero/1.0/
 
 ## NUnit & NUnit3TestAdapter
+
 Copyright (c) 2004-2015 Charlie Poole
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -284,3 +227,158 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## xUnit.net
+
+Copyright (c) .NET Foundation and Contributors
+All Rights Reserved
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Serilog
+
+Copyright (c) Serilog
+All Rights Reserved
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## gRPC .NET
+
+Copyright (c) gRPC
+All Rights Reserved
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## ConfigureAwaitChecker
+
+MIT License
+
+Copyright (c) 2017 Jiri Cincura
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Google protobuf
+
+Copyright 2008 Google Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Code generated by the Protocol Buffer compiler is owned by the owner
+of the input file used when generating it.  This code is not
+standalone and requires a support library to be linked with it.  This
+support library is itself covered by the above license.
+
+## Compare-Net-Objects
+
+Microsoft Public License (Ms-PL)
+
+This license governs use of the accompanying software. If you use the software, you accept this license. If you do not accept the license, do not use the software.
+1. Definitions
+The terms "reproduce," "reproduction," "derivative works," and "distribution" have the same meaning here as under U.S. copyright law.
+A "contribution" is the original software, or any additions or changes to the software.
+A "contributor" is any person that distributes its contribution under this license.
+"Licensed patents" are a contributor's patent claims that read directly on its contribution.
+
+2. Grant of Rights
+(A) Copyright Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free copyright license to reproduce its contribution, prepare derivative works of its contribution, and distribute its contribution or any derivative works that you create.
+(B) Patent Grant- Subject to the terms of this license, including the license conditions and limitations in section 3, each contributor grants you a non-exclusive, worldwide, royalty-free license under its licensed patents to make, have made, use, sell, offer for sale, import, and/or otherwise dispose of its contribution in the software or derivative works of the contribution in the software.
+
+3. Conditions and Limitations
+(A) No Trademark License- This license does not grant you rights to use any contributors' name, logo, or trademarks.
+(B) If you bring a patent claim against any contributor over patents that you claim are infringed by the software, your patent license from such contributor to the software ends automatically.
+(C) If you distribute any portion of the software, you must retain all copyright, patent, trademark, and attribution notices that are present in the software.
+(D) If you distribute any portion of the software in source code form, you may do so only under this license by including a complete copy of this license with your distribution. If you distribute any portion of the software in compiled or object code form, you may only do so under a license that complies with this license.
+(E) The software is licensed "as-is." You bear the risk of using it. The contributors give no express warranties, guarantees or conditions. You may have additional consumer rights under your local laws which this license cannot change. To the extent permitted under your local laws, the contributors exclude the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+
+## Mono.Posix.NETStandard
+
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -407,3 +407,81 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
 SOFTWARE.
+
+## System.Linq.Async (from rxteam / .NET foundation)
+
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+
+## Dependencies from Microsoft under the MIT License (MIT)
+- Microsoft.CSharp
+- Microsoft.Diagnostics.NETCore.Client
+- Microsoft.Diagnostics.Tracing.TraceEvent
+- Microsoft.Extensions.Configuration.Json
+- Microsoft.Extensions.FileProviders.Composite
+- Microsoft.NETFramework.ReferenceAssemblies
+- System.ComponentModel.Composition
+- System.Diagnostics.PerformanceCounter
+- System.Net.Http
+- System.ServiceModel.Http
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.
+
+## Dependencies from Microsoft under the Apache 2.0 License
+- Microsoft.AspNetCore.TestHost
+- Microsoft.Extensions.FileProviders.Embedded
+- Microsoft.Net.Http.Headers
+- Microsoft.SourceLink.GitHub
+
+Copyright (c) Microsoft Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -382,3 +382,28 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## System.UriTemplate (under src/EventStore.NETCore.Compatibility)
+*Note: The code for System.UriTemplate has been copied from the reference source for .NET 4.8 with some modifications.*
+
+The MIT License (MIT)
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy 
+of this software and associated documentation files (the "Software"), to deal 
+in the Software without restriction, including without limitation the rights 
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is 
+furnished to do so, subject to the following conditions: 
+
+The above copyright notice and this permission notice shall be included in all 
+copies or substantial portions of the Software. 
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE 
+SOFTWARE.

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -37,6 +37,7 @@
 		<ProjectReference Include="..\EventStore.Rags\EventStore.Rags.csproj" />
 		<ProjectReference Include="..\EventStore.Transport.Http\EventStore.Transport.Http.csproj" />
 		<ProjectReference Include="..\EventStore.Transport.Tcp\EventStore.Transport.Tcp.csproj" />
+		<ProjectReference Include="..\EventStore.NETCore.Compatibility\EventStore.NETCore.Compatibility.csproj" />
 	</ItemGroup>
 	<ItemGroup>
 		<Protobuf Include="../Protos/Grpc/*.proto" Exclude="../Protos/Grpc/projections.proto;../Protos/Grpc/cluster.proto" GrpcServices="Server" LinkBase="Services/Transport/Grpc" ProtoRoot="../Protos/Grpc" />

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -22,7 +22,6 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
-		<PackageReference Include="SimpleSyndicate.UriTemplate" Version="1.0.3" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
 		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <Platform>x64</Platform>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
+  </ItemGroup>
 </Project>

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Platform>x64</Platform>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+  </PropertyGroup>
+</Project>

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/Collections/ObjectModel/FreezableCollection.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/Collections/ObjectModel/FreezableCollection.cs
@@ -1,0 +1,78 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System.Collections.ObjectModel
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ServiceModel;
+
+    class FreezableCollection<T> : Collection<T>, ICollection<T>
+    {
+        bool frozen;
+
+        public FreezableCollection()
+            : base()
+        {
+        }
+
+        public FreezableCollection(IList<T> list)
+            : base(list)
+        {
+        }
+
+        public bool IsFrozen
+        {
+            get
+            {
+                return this.frozen;
+            }
+        }
+
+        bool ICollection<T>.IsReadOnly
+        {
+            get
+            {
+                return this.frozen;
+            }
+        }
+
+        public void Freeze()
+        {
+            this.frozen = true;
+        }
+
+        protected override void ClearItems()
+        {
+            ThrowIfFrozen();
+            base.ClearItems();
+        }
+
+        protected override void InsertItem(int index, T item)
+        {
+            ThrowIfFrozen();
+            base.InsertItem(index, item);
+        }
+
+        protected override void RemoveItem(int index)
+        {
+            ThrowIfFrozen();
+            base.RemoveItem(index);
+        }
+
+        protected override void SetItem(int index, T item)
+        {
+            ThrowIfFrozen();
+            base.SetItem(index, item);
+        }
+
+        void ThrowIfFrozen()
+        {
+            if (this.frozen)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.ObjectIsReadOnly));
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplate.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplate.cs
@@ -1,0 +1,1732 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Collections.Specialized;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.Text;
+    using System.Threading;
+    using System.Runtime.CompilerServices;
+    using System.Globalization;
+
+    [TypeForwardedFrom("System.ServiceModel.Web, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
+    public class UriTemplate
+    {
+        internal readonly int firstOptionalSegment;
+
+        internal readonly string originalTemplate;
+        internal readonly Dictionary<string, UriTemplateQueryValue> queries; // keys are original case specified in UriTemplate constructor, dictionary ignores case
+        internal readonly List<UriTemplatePathSegment> segments;
+        internal const string WildcardPath = "*";
+        readonly Dictionary<string, string> additionalDefaults; // keys are original case specified in UriTemplate constructor, dictionary ignores case
+        readonly string fragment;
+
+        readonly bool ignoreTrailingSlash;
+
+        const string NullableDefault = "null";
+        readonly WildcardInfo wildcard;
+        IDictionary<string, string> defaults;
+        ConcurrentDictionary<string, string> unescapedDefaults;
+
+        VariablesCollection variables;
+
+        // constructors validates that template is well-formed
+        public UriTemplate(string template)
+            : this(template, false)
+        {
+        }
+        public UriTemplate(string template, bool ignoreTrailingSlash)
+            : this(template, ignoreTrailingSlash, null)
+        {
+        }
+        public UriTemplate(string template, IDictionary<string, string> additionalDefaults)
+            : this(template, false, additionalDefaults)
+        {
+        }
+        public UriTemplate(string template, bool ignoreTrailingSlash, IDictionary<string, string> additionalDefaults)
+        {
+            if (template == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("template");
+            }
+            this.originalTemplate = template;
+            this.ignoreTrailingSlash = ignoreTrailingSlash;
+            this.segments = new List<UriTemplatePathSegment>();
+            this.queries = new Dictionary<string, UriTemplateQueryValue>(StringComparer.OrdinalIgnoreCase);
+
+            // parse it
+            string pathTemplate;
+            string queryTemplate;
+            // ignore a leading slash
+            if (template.StartsWith("/", StringComparison.Ordinal))
+            {
+                template = template.Substring(1);
+            }
+            // pull out fragment
+            int fragmentStart = template.IndexOf('#');
+            if (fragmentStart == -1)
+            {
+                this.fragment = "";
+            }
+            else
+            {
+                this.fragment = template.Substring(fragmentStart + 1);
+                template = template.Substring(0, fragmentStart);
+            }
+            // pull out path and query
+            int queryStart = template.IndexOf('?');
+            if (queryStart == -1)
+            {
+                queryTemplate = string.Empty;
+                pathTemplate = template;
+            }
+            else
+            {
+                queryTemplate = template.Substring(queryStart + 1);
+                pathTemplate = template.Substring(0, queryStart);
+            }
+            template = null; // to ensure we don't accidentally reference this variable any more
+
+            // setup path template and validate
+            if (!string.IsNullOrEmpty(pathTemplate))
+            {
+                int startIndex = 0;
+                while (startIndex < pathTemplate.Length)
+                {
+                    // Identify the next segment
+                    int endIndex = pathTemplate.IndexOf('/', startIndex);
+                    string segment;
+                    if (endIndex != -1)
+                    {
+                        segment = pathTemplate.Substring(startIndex, endIndex + 1 - startIndex);
+                        startIndex = endIndex + 1;
+                    }
+                    else
+                    {
+                        segment = pathTemplate.Substring(startIndex);
+                        startIndex = pathTemplate.Length;
+                    }
+                    // Checking for wildcard segment ("*") or ("{*<var name>}")
+                    UriTemplatePartType wildcardType;
+                    if ((startIndex == pathTemplate.Length) &&
+                        UriTemplateHelpers.IsWildcardSegment(segment, out wildcardType))
+                    {
+                        switch (wildcardType)
+                        {
+                            case UriTemplatePartType.Literal:
+                                this.wildcard = new WildcardInfo(this);
+                                break;
+
+                            case UriTemplatePartType.Variable:
+                                this.wildcard = new WildcardInfo(this, segment);
+                                break;
+
+                            default:
+                                Fx.Assert("Error in identifying the type of the wildcard segment");
+                                break;
+                        }
+                    }
+                    else
+                    {
+                        this.segments.Add(UriTemplatePathSegment.CreateFromUriTemplate(segment, this));
+                    }
+                }
+            }
+
+            // setup query template and validate
+            if (!string.IsNullOrEmpty(queryTemplate))
+            {
+                int startIndex = 0;
+                while (startIndex < queryTemplate.Length)
+                {
+                    // Identify the next query part
+                    int endIndex = queryTemplate.IndexOf('&', startIndex);
+                    int queryPartStart = startIndex;
+                    int queryPartEnd;
+                    if (endIndex != -1)
+                    {
+                        queryPartEnd = endIndex;
+                        startIndex = endIndex + 1;
+                        if (startIndex >= queryTemplate.Length)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                                SR.UTQueryCannotEndInAmpersand, this.originalTemplate)));
+                        }
+                    }
+                    else
+                    {
+                        queryPartEnd = queryTemplate.Length;
+                        startIndex = queryTemplate.Length;
+                    }
+                    // Checking query part type; identifying key and value
+                    int equalSignIndex = queryTemplate.IndexOf('=', queryPartStart, queryPartEnd - queryPartStart);
+                    string key;
+                    string value;
+                    if (equalSignIndex >= 0)
+                    {
+                        key = queryTemplate.Substring(queryPartStart, equalSignIndex - queryPartStart);
+                        value = queryTemplate.Substring(equalSignIndex + 1, queryPartEnd - equalSignIndex - 1);
+                    }
+                    else
+                    {
+                        key = queryTemplate.Substring(queryPartStart, queryPartEnd - queryPartStart);
+                        value = null;
+                    }
+                    if (string.IsNullOrEmpty(key))
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                            SR.UTQueryCannotHaveEmptyName, this.originalTemplate)));
+                    }
+                    if (UriTemplateHelpers.IdentifyPartType(key) != UriTemplatePartType.Literal)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("template", SR.GetString(
+                            SR.UTQueryMustHaveLiteralNames, this.originalTemplate));
+                    }
+                    // Adding a new entry to the queries dictionary
+                    key = UrlUtility.UrlDecode(key, Encoding.UTF8);
+                    if (this.queries.ContainsKey(key))
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                            SR.UTQueryNamesMustBeUnique, this.originalTemplate)));
+                    }
+                    this.queries.Add(key, UriTemplateQueryValue.CreateFromUriTemplate(value, this));
+                }
+            }
+
+            // Process additional defaults (if has some) :
+            if (additionalDefaults != null)
+            {
+                if (this.variables == null)
+                {
+                    if (additionalDefaults.Count > 0)
+                    {
+                        this.additionalDefaults = new Dictionary<string, string>(additionalDefaults, StringComparer.OrdinalIgnoreCase);
+                    }
+                }
+                else
+                {
+                    foreach (KeyValuePair<string, string> kvp in additionalDefaults)
+                    {
+                        string uppercaseKey = kvp.Key.ToUpperInvariant();
+                        if ((this.variables.DefaultValues != null) && this.variables.DefaultValues.ContainsKey(uppercaseKey))
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("additionalDefaults",
+                                SR.GetString(SR.UTAdditionalDefaultIsInvalid, kvp.Key, this.originalTemplate));
+                        }
+                        if (this.variables.PathSegmentVariableNames.Contains(uppercaseKey))
+                        {
+                            this.variables.AddDefaultValue(uppercaseKey, kvp.Value);
+                        }
+                        else if (this.variables.QueryValueVariableNames.Contains(uppercaseKey))
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                                SR.GetString(SR.UTDefaultValueToQueryVarFromAdditionalDefaults, this.originalTemplate,
+                                uppercaseKey)));
+                        }
+                        else if (string.Compare(kvp.Value, UriTemplate.NullableDefault, StringComparison.OrdinalIgnoreCase) == 0)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                                SR.GetString(SR.UTNullableDefaultAtAdditionalDefaults, this.originalTemplate,
+                                uppercaseKey)));
+                        }
+                        else
+                        {
+                            if (this.additionalDefaults == null)
+                            {
+                                this.additionalDefaults = new Dictionary<string, string>(additionalDefaults.Count, StringComparer.OrdinalIgnoreCase);
+                            }
+                            this.additionalDefaults.Add(kvp.Key, kvp.Value);
+                        }
+                    }
+                }
+            }
+
+            // Validate defaults (if should)
+            if ((this.variables != null) && (this.variables.DefaultValues != null))
+            {
+                this.variables.ValidateDefaults(out this.firstOptionalSegment);
+            }
+            else
+            {
+                this.firstOptionalSegment = this.segments.Count;
+            }
+        }
+
+        public IDictionary<string, string> Defaults
+        {
+            get
+            {
+                if (this.defaults == null)
+                {
+                    Interlocked.CompareExchange<IDictionary<string, string>>(ref this.defaults, new UriTemplateDefaults(this), null);
+                }
+                return this.defaults;
+            }
+        }
+        public bool IgnoreTrailingSlash
+        {
+            get
+            {
+                return this.ignoreTrailingSlash;
+            }
+        }
+        public ReadOnlyCollection<string> PathSegmentVariableNames
+        {
+            get
+            {
+                if (this.variables == null)
+                {
+                    return VariablesCollection.EmptyCollection;
+                }
+                else
+                {
+                    return this.variables.PathSegmentVariableNames;
+                }
+            }
+        }
+        public ReadOnlyCollection<string> QueryValueVariableNames
+        {
+            get
+            {
+                if (this.variables == null)
+                {
+                    return VariablesCollection.EmptyCollection;
+                }
+                else
+                {
+                    return this.variables.QueryValueVariableNames;
+                }
+            }
+        }
+
+        internal bool HasNoVariables
+        {
+            get
+            {
+                return (this.variables == null);
+            }
+        }
+        internal bool HasWildcard
+        {
+            get
+            {
+                return (this.wildcard != null);
+            }
+        }
+
+        // make a Uri by subbing in the values, throw on bad input
+        public Uri BindByName(Uri baseAddress, IDictionary<string, string> parameters)
+        {
+            return BindByName(baseAddress, parameters, false);
+        }
+        public Uri BindByName(Uri baseAddress, IDictionary<string, string> parameters, bool omitDefaults)
+        {
+            if (baseAddress == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("baseAddress");
+            }
+            if (!baseAddress.IsAbsoluteUri)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("baseAddress", SR.GetString(
+                    SR.UTBadBaseAddress));
+            }
+
+            BindInformation bindInfo;
+            if (this.variables == null)
+            {
+                bindInfo = PrepareBindInformation(parameters, omitDefaults);
+            }
+            else
+            {
+                bindInfo = this.variables.PrepareBindInformation(parameters, omitDefaults);
+            }
+            return Bind(baseAddress, bindInfo, omitDefaults);
+        }
+        public Uri BindByName(Uri baseAddress, NameValueCollection parameters)
+        {
+            return BindByName(baseAddress, parameters, false);
+        }
+        public Uri BindByName(Uri baseAddress, NameValueCollection parameters, bool omitDefaults)
+        {
+            if (baseAddress == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("baseAddress");
+            }
+            if (!baseAddress.IsAbsoluteUri)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("baseAddress", SR.GetString(
+                    SR.UTBadBaseAddress));
+            }
+
+            BindInformation bindInfo;
+            if (this.variables == null)
+            {
+                bindInfo = PrepareBindInformation(parameters, omitDefaults);
+            }
+            else
+            {
+                bindInfo = this.variables.PrepareBindInformation(parameters, omitDefaults);
+            }
+            return Bind(baseAddress, bindInfo, omitDefaults);
+        }
+        public Uri BindByPosition(Uri baseAddress, params string[] values)
+        {
+            if (baseAddress == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("baseAddress");
+            }
+            if (!baseAddress.IsAbsoluteUri)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("baseAddress", SR.GetString(
+                    SR.UTBadBaseAddress));
+            }
+
+            BindInformation bindInfo;
+            if (this.variables == null)
+            {
+                if (values.Length > 0)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(SR.GetString(
+                        SR.UTBindByPositionNoVariables, this.originalTemplate, values.Length)));
+                }
+                bindInfo = new BindInformation(this.additionalDefaults);
+            }
+            else
+            {
+                bindInfo = this.variables.PrepareBindInformation(values);
+            }
+            return Bind(baseAddress, bindInfo, false);
+        }
+
+        // A note about UriTemplate equivalency:
+        //  The introduction of defaults and, more over, terminal defaults, broke the simple
+        //  intuative notion of equivalency between templates. We will define equivalent
+        //  templates as such based on the structure of them and not based on the set of uri
+        //  that are matched by them. The result is that, even though they do not match the
+        //  same set of uri's, the following templates are equivalent:
+        //      - "/foo/{bar}"
+        //      - "/foo/{bar=xyz}"
+        //  A direct result from the support for 'terminal defaults' is that the IsPathEquivalentTo
+        //  method, which was used both to determine the equivalence between templates, as 
+        //  well as verify that all the templates, combined together in the same PathEquivalentSet, 
+        //  are equivalent in thier path is no longer valid for both purposes. We will break 
+        //  it to two distinct methods, each will be called in a different case.
+        public bool IsEquivalentTo(UriTemplate other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+            if (other.segments == null || other.queries == null)
+            {
+                // they never are null, but PreSharp is complaining, 
+                // and warning suppression isn't working
+                return false;
+            }
+            if (!IsPathFullyEquivalent(other))
+            {
+                return false;
+            }
+            if (!IsQueryEquivalent(other))
+            {
+                return false;
+            }
+            Fx.Assert(UriTemplateEquivalenceComparer.Instance.GetHashCode(this) == UriTemplateEquivalenceComparer.Instance.GetHashCode(other), "bad GetHashCode impl");
+            return true;
+        }
+
+        public UriTemplateMatch Match(Uri baseAddress, Uri candidate)
+        {
+            if (baseAddress == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("baseAddress");
+            }
+            if (!baseAddress.IsAbsoluteUri)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("baseAddress", SR.GetString(
+                    SR.UTBadBaseAddress));
+            }
+            if (candidate == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("candidate");
+            }
+
+            // ensure that the candidate is 'under' the base address
+            if (!candidate.IsAbsoluteUri)
+            {
+                return null;
+            }
+            string basePath = UriTemplateHelpers.GetUriPath(baseAddress);
+            string candidatePath = UriTemplateHelpers.GetUriPath(candidate);
+            if (candidatePath.Length < basePath.Length)
+            {
+                return null;
+            }
+            if (!candidatePath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
+            {
+                return null;
+            }
+
+            // Identifying the relative segments \ checking matching to the path :
+            int numSegmentsInBaseAddress = baseAddress.Segments.Length;
+            string[] candidateSegments = candidate.Segments;
+            int numMatchedSegments;
+            Collection<string> relativeCandidateSegments;
+            if (!IsCandidatePathMatch(numSegmentsInBaseAddress, candidateSegments,
+                out numMatchedSegments, out relativeCandidateSegments))
+            {
+                return null;
+            }
+            // Checking matching to the query (if should) :
+            NameValueCollection candidateQuery = null;
+            if (!UriTemplateHelpers.CanMatchQueryTrivially(this))
+            {
+                candidateQuery = UriTemplateHelpers.ParseQueryString(candidate.Query);
+                if (!UriTemplateHelpers.CanMatchQueryInterestingly(this, candidateQuery, false))
+                {
+                    return null;
+                }
+            }
+
+            // We matched; lets build the UriTemplateMatch
+            return CreateUriTemplateMatch(baseAddress, candidate, null, numMatchedSegments,
+                relativeCandidateSegments, candidateQuery);
+        }
+
+        public override string ToString()
+        {
+            return this.originalTemplate;
+        }
+
+        internal string AddPathVariable(UriTemplatePartType sourceNature, string varDeclaration)
+        {
+            bool hasDefaultValue;
+            return AddPathVariable(sourceNature, varDeclaration, out hasDefaultValue);
+        }
+        internal string AddPathVariable(UriTemplatePartType sourceNature, string varDeclaration,
+            out bool hasDefaultValue)
+        {
+            if (this.variables == null)
+            {
+                this.variables = new VariablesCollection(this);
+            }
+            return this.variables.AddPathVariable(sourceNature, varDeclaration, out hasDefaultValue);
+        }
+        internal string AddQueryVariable(string varDeclaration)
+        {
+            if (this.variables == null)
+            {
+                this.variables = new VariablesCollection(this);
+            }
+            return this.variables.AddQueryVariable(varDeclaration);
+        }
+
+        internal UriTemplateMatch CreateUriTemplateMatch(Uri baseUri, Uri uri, object data,
+            int numMatchedSegments, Collection<string> relativePathSegments, NameValueCollection uriQuery)
+        {
+            UriTemplateMatch result = new UriTemplateMatch();
+            result.RequestUri = uri;
+            result.BaseUri = baseUri;
+            if (uriQuery != null)
+            {
+                result.SetQueryParameters(uriQuery);
+            }
+            result.SetRelativePathSegments(relativePathSegments);
+            result.Data = data;
+            result.Template = this;
+            for (int i = 0; i < numMatchedSegments; i++)
+            {
+                this.segments[i].Lookup(result.RelativePathSegments[i], result.BoundVariables);
+            }
+            if (this.wildcard != null)
+            {
+                this.wildcard.Lookup(numMatchedSegments, result.RelativePathSegments,
+                    result.BoundVariables);
+            }
+            else if (numMatchedSegments < this.segments.Count)
+            {
+                BindTerminalDefaults(numMatchedSegments, result.BoundVariables);
+            }
+            if (this.queries.Count > 0)
+            {
+                foreach (KeyValuePair<string, UriTemplateQueryValue> kvp in this.queries)
+                {
+                    kvp.Value.Lookup(result.QueryParameters[kvp.Key], result.BoundVariables);
+                    //UriTemplateHelpers.AssertCanonical(varName);
+                }
+            }
+            if (this.additionalDefaults != null)
+            {
+                foreach (KeyValuePair<string, string> kvp in this.additionalDefaults)
+                {
+                    result.BoundVariables.Add(kvp.Key, UnescapeDefaultValue(kvp.Value));
+                }
+            }
+            Fx.Assert(result.RelativePathSegments.Count - numMatchedSegments >= 0, "bad segment computation");
+            result.SetWildcardPathSegmentsStart(numMatchedSegments);
+
+            return result;
+        }
+
+        internal bool IsPathPartiallyEquivalentAt(UriTemplate other, int segmentsCount)
+        {
+            // Refer to the note on template equivalency at IsEquivalentTo
+            // This method checks if any uri with given number of segments, which can be matched
+            //  by this template, can be also matched by the other template.
+            Fx.Assert(segmentsCount >= this.firstOptionalSegment - 1, "How can that be? The Trie is constructed that way!");
+            Fx.Assert(segmentsCount <= this.segments.Count, "How can that be? The Trie is constructed that way!");
+            Fx.Assert(segmentsCount >= other.firstOptionalSegment - 1, "How can that be? The Trie is constructed that way!");
+            Fx.Assert(segmentsCount <= other.segments.Count, "How can that be? The Trie is constructed that way!");
+            for (int i = 0; i < segmentsCount; ++i)
+            {
+                if (!this.segments[i].IsEquivalentTo(other.segments[i],
+                    ((i == segmentsCount - 1) && (this.ignoreTrailingSlash || other.ignoreTrailingSlash))))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+        internal bool IsQueryEquivalent(UriTemplate other)
+        {
+            if (this.queries.Count != other.queries.Count)
+            {
+                return false;
+            }
+            foreach (string key in this.queries.Keys)
+            {
+                UriTemplateQueryValue utqv = this.queries[key];
+                UriTemplateQueryValue otherUtqv;
+                if (!other.queries.TryGetValue(key, out otherUtqv))
+                {
+                    return false;
+                }
+                if (!utqv.IsEquivalentTo(otherUtqv))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        internal static Uri RewriteUri(Uri uri, string host)
+        {
+            if (!string.IsNullOrEmpty(host))
+            {
+                string originalHostHeader = uri.Host + ((!uri.IsDefaultPort) ? ":" + uri.Port.ToString(CultureInfo.InvariantCulture) : string.Empty);
+                if (!String.Equals(originalHostHeader, host, StringComparison.OrdinalIgnoreCase))
+                {
+                    Uri sourceUri = new Uri(String.Format(CultureInfo.InvariantCulture, "{0}://{1}", uri.Scheme, host));
+                    return (new UriBuilder(uri) { Host = sourceUri.Host, Port = sourceUri.Port }).Uri;
+                }
+            }
+            return uri;
+        }
+
+        Uri Bind(Uri baseAddress, BindInformation bindInfo, bool omitDefaults)
+        {
+            UriBuilder result = new UriBuilder(baseAddress);
+            int parameterIndex = 0;
+            int lastPathParameter = ((this.variables == null) ? -1 : this.variables.PathSegmentVariableNames.Count - 1);
+            int lastPathParameterToBind;
+            if (lastPathParameter == -1)
+            {
+                lastPathParameterToBind = -1;
+            }
+            else if (omitDefaults)
+            {
+                lastPathParameterToBind = bindInfo.LastNonDefaultPathParameter;
+            }
+            else
+            {
+                lastPathParameterToBind = bindInfo.LastNonNullablePathParameter;
+            }
+            string[] parameters = bindInfo.NormalizedParameters;
+            IDictionary<string, string> extraQueryParameters = bindInfo.AdditionalParameters;
+            // Binding the path :
+            StringBuilder pathString = new StringBuilder(result.Path);
+            if (pathString[pathString.Length - 1] != '/')
+            {
+                pathString.Append('/');
+            }
+            if (lastPathParameterToBind < lastPathParameter)
+            {
+                // Binding all the parameters we need
+                int segmentIndex = 0;
+                while (parameterIndex <= lastPathParameterToBind)
+                {
+                    Fx.Assert(segmentIndex < this.segments.Count,
+                        "Calculation of LastNonDefaultPathParameter,lastPathParameter or parameterIndex failed");
+                    this.segments[segmentIndex++].Bind(parameters, ref parameterIndex, pathString);
+                }
+                Fx.Assert(parameterIndex == lastPathParameterToBind + 1,
+                    "That is the exit criteria from the loop");
+                // Maybe we have some literals yet to bind
+                Fx.Assert(segmentIndex < this.segments.Count,
+                    "Calculation of LastNonDefaultPathParameter,lastPathParameter or parameterIndex failed");
+                while (this.segments[segmentIndex].Nature == UriTemplatePartType.Literal)
+                {
+                    this.segments[segmentIndex++].Bind(parameters, ref parameterIndex, pathString);
+                    Fx.Assert(parameterIndex == lastPathParameterToBind + 1,
+                        "We have moved the parameter index in a literal binding");
+                    Fx.Assert(segmentIndex < this.segments.Count,
+                        "Calculation of LastNonDefaultPathParameter,lastPathParameter or parameterIndex failed");
+                }
+                // We're done; skip to the beggining of the query parameters
+                parameterIndex = lastPathParameter + 1;
+            }
+            else if (this.segments.Count > 0 || this.wildcard != null)
+            {
+                for (int i = 0; i < this.segments.Count; i++)
+                {
+                    this.segments[i].Bind(parameters, ref parameterIndex, pathString);
+                }
+                if (this.wildcard != null)
+                {
+                    this.wildcard.Bind(parameters, ref parameterIndex, pathString);
+                }
+            }
+            if (this.ignoreTrailingSlash && (pathString[pathString.Length - 1] == '/'))
+            {
+                pathString.Remove(pathString.Length - 1, 1);
+            }
+            result.Path = pathString.ToString();
+            // Binding the query :
+            if ((this.queries.Count != 0) || (extraQueryParameters != null))
+            {
+                StringBuilder query = new StringBuilder("");
+                foreach (string key in this.queries.Keys)
+                {
+                    this.queries[key].Bind(key, parameters, ref parameterIndex, query);
+                }
+                if (extraQueryParameters != null)
+                {
+                    foreach (string key in extraQueryParameters.Keys)
+                    {
+                        if (this.queries.ContainsKey(key.ToUpperInvariant()))
+                        {
+                            // This can only be if the key passed has the same name as some literal key
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("parameters", SR.GetString(
+                                SR.UTBothLiteralAndNameValueCollectionKey, key));
+                        }
+                        string value = extraQueryParameters[key];
+                        string escapedValue = (string.IsNullOrEmpty(value) ? string.Empty : UrlUtility.UrlEncode(value, Encoding.UTF8));
+                        query.AppendFormat("&{0}={1}", UrlUtility.UrlEncode(key, Encoding.UTF8), escapedValue);
+                    }
+                }
+                if (query.Length != 0)
+                {
+                    query.Remove(0, 1); // remove extra leading '&'
+                }
+                result.Query = query.ToString();
+            }
+            // Adding the fragment (if needed)
+            if (this.fragment != null)
+            {
+                result.Fragment = this.fragment;
+            }
+
+            return result.Uri;
+        }
+        void BindTerminalDefaults(int numMatchedSegments, NameValueCollection boundParameters)
+        {
+            Fx.Assert(!this.HasWildcard, "There are no terminal default when ends with wildcard");
+            Fx.Assert(numMatchedSegments < this.segments.Count, "Otherwise - no defaults to bind");
+            Fx.Assert(this.variables != null, "Otherwise - no default values to bind");
+            Fx.Assert(this.variables.DefaultValues != null, "Otherwise - no default values to bind");
+            for (int i = numMatchedSegments; i < this.segments.Count; i++)
+            {
+                switch (this.segments[i].Nature)
+                {
+                    case UriTemplatePartType.Variable:
+                        {
+                            UriTemplateVariablePathSegment vps = this.segments[i] as UriTemplateVariablePathSegment;
+                            Fx.Assert(vps != null, "How can that be? That its nature");
+                            this.variables.LookupDefault(vps.VarName, boundParameters);
+                        }
+                        break;
+
+                    default:
+                        Fx.Assert("We only support terminal defaults on Variable segments");
+                        break;
+                }
+            }
+        }
+
+        bool IsCandidatePathMatch(int numSegmentsInBaseAddress, string[] candidateSegments,
+            out int numMatchedSegments, out Collection<string> relativeSegments)
+        {
+            int numRelativeSegments = candidateSegments.Length - numSegmentsInBaseAddress;
+            Fx.Assert(numRelativeSegments >= 0, "bad segments num");
+            relativeSegments = new Collection<string>();
+            bool isStillMatch = true;
+            int relativeSegmentsIndex = 0;
+            while (isStillMatch && (relativeSegmentsIndex < numRelativeSegments))
+            {
+                string segment = candidateSegments[relativeSegmentsIndex + numSegmentsInBaseAddress];
+                // Mathcing to next regular segment in the template (if there is one); building the wire segment representation
+                if (relativeSegmentsIndex < this.segments.Count)
+                {
+                    bool ignoreSlash = (this.ignoreTrailingSlash && (relativeSegmentsIndex == numRelativeSegments - 1));
+                    UriTemplateLiteralPathSegment lps = UriTemplateLiteralPathSegment.CreateFromWireData(segment);
+                    if (!this.segments[relativeSegmentsIndex].IsMatch(lps, ignoreSlash))
+                    {
+                        isStillMatch = false;
+                        break;
+                    }
+                    string relPathSeg = Uri.UnescapeDataString(segment);
+                    if (lps.EndsWithSlash)
+                    {
+                        Fx.Assert(relPathSeg.EndsWith("/", StringComparison.Ordinal), "problem with relative path segment");
+                        relPathSeg = relPathSeg.Substring(0, relPathSeg.Length - 1); // trim slash
+                    }
+                    relativeSegments.Add(relPathSeg);
+                }
+                // Checking if the template has a wild card ('*') or a final star var segment ("{*<var name>}"
+                else if (this.HasWildcard)
+                {
+                    break;
+                }
+                else
+                {
+                    isStillMatch = false;
+                    break;
+                }
+                relativeSegmentsIndex++;
+            }
+            if (isStillMatch)
+            {
+                numMatchedSegments = relativeSegmentsIndex;
+                // building the wire representation to segments that were matched to a wild card
+                if (relativeSegmentsIndex < numRelativeSegments)
+                {
+                    while (relativeSegmentsIndex < numRelativeSegments)
+                    {
+                        string relPathSeg = Uri.UnescapeDataString(candidateSegments[relativeSegmentsIndex + numSegmentsInBaseAddress]);
+                        if (relPathSeg.EndsWith("/", StringComparison.Ordinal))
+                        {
+                            relPathSeg = relPathSeg.Substring(0, relPathSeg.Length - 1); // trim slash
+                        }
+                        relativeSegments.Add(relPathSeg);
+                        relativeSegmentsIndex++;
+                    }
+                }
+                // Checking if we matched all required segments already
+                else if (numMatchedSegments < this.firstOptionalSegment)
+                {
+                    isStillMatch = false;
+                }
+            }
+            else
+            {
+                numMatchedSegments = 0;
+            }
+
+            return isStillMatch;
+        }
+
+        bool IsPathFullyEquivalent(UriTemplate other)
+        {
+            // Refer to the note on template equivalency at IsEquivalentTo
+            // This method checks if both templates has a fully equivalent path.
+            if (this.HasWildcard != other.HasWildcard)
+            {
+                return false;
+            }
+            if (this.segments.Count != other.segments.Count)
+            {
+                return false;
+            }
+            for (int i = 0; i < this.segments.Count; ++i)
+            {
+                if (!this.segments[i].IsEquivalentTo(other.segments[i],
+                    (i == this.segments.Count - 1) && !this.HasWildcard && (this.ignoreTrailingSlash || other.ignoreTrailingSlash)))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        BindInformation PrepareBindInformation(IDictionary<string, string> parameters, bool omitDefaults)
+        {
+            if (parameters == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            }
+
+            IDictionary<string, string> extraParameters = new Dictionary<string, string>(UriTemplateHelpers.GetQueryKeyComparer());
+            foreach (KeyValuePair<string, string> kvp in parameters)
+            {
+                if (string.IsNullOrEmpty(kvp.Key))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("parameters",
+                        SR.GetString(SR.UTBindByNameCalledWithEmptyKey));
+                }
+
+                extraParameters.Add(kvp);
+            }
+            BindInformation bindInfo;
+            ProcessDefaultsAndCreateBindInfo(omitDefaults, extraParameters, out bindInfo);
+            return bindInfo;
+        }
+        BindInformation PrepareBindInformation(NameValueCollection parameters, bool omitDefaults)
+        {
+            if (parameters == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+            }
+
+            IDictionary<string, string> extraParameters = new Dictionary<string, string>(UriTemplateHelpers.GetQueryKeyComparer());
+            foreach (string key in parameters.AllKeys)
+            {
+                if (string.IsNullOrEmpty(key))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("parameters",
+                        SR.GetString(SR.UTBindByNameCalledWithEmptyKey));
+                }
+
+                extraParameters.Add(key, parameters[key]);
+            }
+            BindInformation bindInfo;
+            ProcessDefaultsAndCreateBindInfo(omitDefaults, extraParameters, out bindInfo);
+            return bindInfo;
+        }
+        void ProcessDefaultsAndCreateBindInfo(bool omitDefaults, IDictionary<string, string> extraParameters,
+            out BindInformation bindInfo)
+        {
+            Fx.Assert(extraParameters != null, "We are expected to create it at the calling PrepareBindInformation");
+            if (this.additionalDefaults != null)
+            {
+                if (omitDefaults)
+                {
+                    foreach (KeyValuePair<string, string> kvp in this.additionalDefaults)
+                    {
+                        string extraParameter;
+                        if (extraParameters.TryGetValue(kvp.Key, out extraParameter))
+                        {
+                            if (string.Compare(extraParameter, kvp.Value, StringComparison.Ordinal) == 0)
+                            {
+                                extraParameters.Remove(kvp.Key);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (KeyValuePair<string, string> kvp in this.additionalDefaults)
+                    {
+                        if (!extraParameters.ContainsKey(kvp.Key))
+                        {
+                            extraParameters.Add(kvp.Key, kvp.Value);
+                        }
+                    }
+                }
+            }
+            if (extraParameters.Count == 0)
+            {
+                extraParameters = null;
+            }
+            bindInfo = new BindInformation(extraParameters);
+        }
+
+        string UnescapeDefaultValue(string escapedValue)
+        {
+            if (string.IsNullOrEmpty(escapedValue))
+            {
+                return escapedValue;
+            }
+            if (this.unescapedDefaults == null)
+            {
+                this.unescapedDefaults = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+            }
+
+            return this.unescapedDefaults.GetOrAdd(escapedValue, Uri.UnescapeDataString);
+        }
+
+        struct BindInformation
+        {
+            IDictionary<string, string> additionalParameters;
+            int lastNonDefaultPathParameter;
+            int lastNonNullablePathParameter;
+            string[] normalizedParameters;
+
+            public BindInformation(string[] normalizedParameters, int lastNonDefaultPathParameter,
+                int lastNonNullablePathParameter, IDictionary<string, string> additionalParameters)
+            {
+                this.normalizedParameters = normalizedParameters;
+                this.lastNonDefaultPathParameter = lastNonDefaultPathParameter;
+                this.lastNonNullablePathParameter = lastNonNullablePathParameter;
+                this.additionalParameters = additionalParameters;
+            }
+            public BindInformation(IDictionary<string, string> additionalParameters)
+            {
+                this.normalizedParameters = null;
+                this.lastNonDefaultPathParameter = -1;
+                this.lastNonNullablePathParameter = -1;
+                this.additionalParameters = additionalParameters;
+            }
+
+            public IDictionary<string, string> AdditionalParameters
+            {
+                get
+                {
+                    return this.additionalParameters;
+                }
+            }
+            public int LastNonDefaultPathParameter
+            {
+                get
+                {
+                    return this.lastNonDefaultPathParameter;
+                }
+            }
+            public int LastNonNullablePathParameter
+            {
+                get
+                {
+                    return this.lastNonNullablePathParameter;
+                }
+            }
+            public string[] NormalizedParameters
+            {
+                get
+                {
+                    return this.normalizedParameters;
+                }
+            }
+        }
+
+        class UriTemplateDefaults : IDictionary<string, string>
+        {
+            Dictionary<string, string> defaults;
+            ReadOnlyCollection<string> keys;
+            ReadOnlyCollection<string> values;
+
+            public UriTemplateDefaults(UriTemplate template)
+            {
+                this.defaults = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if ((template.variables != null) && (template.variables.DefaultValues != null))
+                {
+                    foreach (KeyValuePair<string, string> kvp in template.variables.DefaultValues)
+                    {
+                        this.defaults.Add(kvp.Key, kvp.Value);
+                    }
+                }
+                if (template.additionalDefaults != null)
+                {
+                    foreach (KeyValuePair<string, string> kvp in template.additionalDefaults)
+                    {
+                        this.defaults.Add(kvp.Key.ToUpperInvariant(), kvp.Value);
+                    }
+                }
+                this.keys = new ReadOnlyCollection<string>(new List<string>(this.defaults.Keys));
+                this.values = new ReadOnlyCollection<string>(new List<string>(this.defaults.Values));
+            }
+
+            // ICollection<KeyValuePair<string, string>> Members
+            public int Count
+            {
+                get
+                {
+                    return this.defaults.Count;
+                }
+            }
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return true;
+                }
+            }
+
+            // IDictionary<string, string> Members
+            public ICollection<string> Keys
+            {
+                get
+                {
+                    return this.keys;
+                }
+            }
+            public ICollection<string> Values
+            {
+                get
+                {
+                    return this.values;
+                }
+            }
+            public string this[string key]
+            {
+                get
+                {
+                    return this.defaults[key];
+                }
+                set
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                        SR.GetString(SR.UTDefaultValuesAreImmutable)));
+                }
+            }
+
+            public void Add(string key, string value)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                    SR.GetString(SR.UTDefaultValuesAreImmutable)));
+            }
+
+            public void Add(KeyValuePair<string, string> item)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                    SR.GetString(SR.UTDefaultValuesAreImmutable)));
+            }
+            public void Clear()
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                    SR.GetString(SR.UTDefaultValuesAreImmutable)));
+            }
+            public bool Contains(KeyValuePair<string, string> item)
+            {
+                return (this.defaults as ICollection<KeyValuePair<string, string>>).Contains(item);
+            }
+            public bool ContainsKey(string key)
+            {
+                return this.defaults.ContainsKey(key);
+            }
+            public void CopyTo(KeyValuePair<string, string>[] array, int arrayIndex)
+            {
+                (this.defaults as ICollection<KeyValuePair<string, string>>).CopyTo(array, arrayIndex);
+            }
+
+            // IEnumerable<KeyValuePair<string, string>> Members
+            public IEnumerator<KeyValuePair<string, string>> GetEnumerator()
+            {
+                return this.defaults.GetEnumerator();
+            }
+            public bool Remove(string key)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                    SR.GetString(SR.UTDefaultValuesAreImmutable)));
+            }
+            public bool Remove(KeyValuePair<string, string> item)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new NotSupportedException(
+                    SR.GetString(SR.UTDefaultValuesAreImmutable)));
+            }
+
+            // IEnumerable Members
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            {
+                return this.defaults.GetEnumerator();
+            }
+            public bool TryGetValue(string key, out string value)
+            {
+                return this.defaults.TryGetValue(key, out value);
+            }
+        }
+
+        class VariablesCollection
+        {
+            readonly UriTemplate owner;
+            static ReadOnlyCollection<string> emptyStringCollection = null;
+            Dictionary<string, string> defaultValues; // key is the variable name (in uppercase; as appear in the variable names lists)
+            int firstNullablePathVariable;
+            List<string> pathSegmentVariableNames; // ToUpperInvariant, in order they occur in the original template string
+            ReadOnlyCollection<string> pathSegmentVariableNamesSnapshot = null;
+            List<UriTemplatePartType> pathSegmentVariableNature;
+            List<string> queryValueVariableNames; // ToUpperInvariant, in order they occur in the original template string
+            ReadOnlyCollection<string> queryValueVariableNamesSnapshot = null;
+
+            public VariablesCollection(UriTemplate owner)
+            {
+                this.owner = owner;
+                this.pathSegmentVariableNames = new List<string>();
+                this.pathSegmentVariableNature = new List<UriTemplatePartType>();
+                this.queryValueVariableNames = new List<string>();
+                this.firstNullablePathVariable = -1;
+            }
+
+            public static ReadOnlyCollection<string> EmptyCollection
+            {
+                get
+                {
+                    if (emptyStringCollection == null)
+                    {
+                        emptyStringCollection = new ReadOnlyCollection<string>(new List<string>());
+                    }
+                    return emptyStringCollection;
+                }
+            }
+
+            public Dictionary<string, string> DefaultValues
+            {
+                get
+                {
+                    return this.defaultValues;
+                }
+            }
+            public ReadOnlyCollection<string> PathSegmentVariableNames
+            {
+                get
+                {
+                    if (this.pathSegmentVariableNamesSnapshot == null)
+                    {
+                        Interlocked.CompareExchange<ReadOnlyCollection<string>>(ref this.pathSegmentVariableNamesSnapshot, new ReadOnlyCollection<string>(
+                            this.pathSegmentVariableNames), null);
+                    }
+                    return this.pathSegmentVariableNamesSnapshot;
+                }
+            }
+            public ReadOnlyCollection<string> QueryValueVariableNames
+            {
+                get
+                {
+                    if (this.queryValueVariableNamesSnapshot == null)
+                    {
+                        Interlocked.CompareExchange<ReadOnlyCollection<string>>(ref this.queryValueVariableNamesSnapshot, new ReadOnlyCollection<string>(
+                            this.queryValueVariableNames), null);
+                    }
+                    return this.queryValueVariableNamesSnapshot;
+                }
+            }
+
+            public void AddDefaultValue(string varName, string value)
+            {
+                int varIndex = this.pathSegmentVariableNames.IndexOf(varName);
+                Fx.Assert(varIndex != -1, "Adding default value is restricted to path variables");
+                if ((this.owner.wildcard != null) && this.owner.wildcard.HasVariable &&
+                    (varIndex == this.pathSegmentVariableNames.Count - 1))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.GetString(SR.UTStarVariableWithDefaultsFromAdditionalDefaults,
+                        this.owner.originalTemplate, varName)));
+                }
+                if (this.pathSegmentVariableNature[varIndex] != UriTemplatePartType.Variable)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.GetString(SR.UTDefaultValueToCompoundSegmentVarFromAdditionalDefaults,
+                        this.owner.originalTemplate, varName)));
+                }
+                if (string.IsNullOrEmpty(value) ||
+                    (string.Compare(value, UriTemplate.NullableDefault, StringComparison.OrdinalIgnoreCase) == 0))
+                {
+                    value = null;
+                }
+                if (this.defaultValues == null)
+                {
+                    this.defaultValues = new Dictionary<string, string>();
+                }
+                this.defaultValues.Add(varName, value);
+            }
+
+            public string AddPathVariable(UriTemplatePartType sourceNature, string varDeclaration, out bool hasDefaultValue)
+            {
+                Fx.Assert(sourceNature != UriTemplatePartType.Literal, "Literal path segments can't be the source for path variables");
+                string varName;
+                string defaultValue;
+                ParseVariableDeclaration(varDeclaration, out varName, out defaultValue);
+                hasDefaultValue = (defaultValue != null);
+                if (varName.IndexOf(UriTemplate.WildcardPath, StringComparison.Ordinal) != -1)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTInvalidWildcardInVariableOrLiteral, this.owner.originalTemplate, UriTemplate.WildcardPath)));
+                }
+                string uppercaseVarName = varName.ToUpperInvariant();
+                if (this.pathSegmentVariableNames.Contains(uppercaseVarName) ||
+                    this.queryValueVariableNames.Contains(uppercaseVarName))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.GetString(SR.UTVarNamesMustBeUnique, this.owner.originalTemplate, varName)));
+                }
+                this.pathSegmentVariableNames.Add(uppercaseVarName);
+                this.pathSegmentVariableNature.Add(sourceNature);
+                if (hasDefaultValue)
+                {
+                    if (defaultValue == string.Empty)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                            SR.GetString(SR.UTInvalidDefaultPathValue, this.owner.originalTemplate,
+                            varDeclaration, varName)));
+                    }
+                    if (string.Compare(defaultValue, UriTemplate.NullableDefault, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        defaultValue = null;
+                    }
+                    if (this.defaultValues == null)
+                    {
+                        this.defaultValues = new Dictionary<string, string>();
+                    }
+                    this.defaultValues.Add(uppercaseVarName, defaultValue);
+                }
+                return uppercaseVarName;
+            }
+            public string AddQueryVariable(string varDeclaration)
+            {
+                string varName;
+                string defaultValue;
+                ParseVariableDeclaration(varDeclaration, out varName, out defaultValue);
+                if (varName.IndexOf(UriTemplate.WildcardPath, StringComparison.Ordinal) != -1)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTInvalidWildcardInVariableOrLiteral, this.owner.originalTemplate, UriTemplate.WildcardPath)));
+                }
+                if (defaultValue != null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.GetString(SR.UTDefaultValueToQueryVar, this.owner.originalTemplate,
+                        varDeclaration, varName)));
+                }
+                string uppercaseVarName = varName.ToUpperInvariant();
+                if (this.pathSegmentVariableNames.Contains(uppercaseVarName) ||
+                    this.queryValueVariableNames.Contains(uppercaseVarName))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.GetString(SR.UTVarNamesMustBeUnique, this.owner.originalTemplate, varName)));
+                }
+                this.queryValueVariableNames.Add(uppercaseVarName);
+                return uppercaseVarName;
+            }
+
+            public void LookupDefault(string varName, NameValueCollection boundParameters)
+            {
+                Fx.Assert(this.defaultValues.ContainsKey(varName), "Otherwise, we don't have a value to bind");
+                boundParameters.Add(varName, owner.UnescapeDefaultValue(this.defaultValues[varName]));
+            }
+
+            public BindInformation PrepareBindInformation(IDictionary<string, string> parameters, bool omitDefaults)
+            {
+                if (parameters == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+                }
+
+                string[] normalizedParameters = PrepareNormalizedParameters();
+                IDictionary<string, string> extraParameters = null;
+                foreach (string key in parameters.Keys)
+                {
+                    ProcessBindParameter(key, parameters[key], normalizedParameters, ref extraParameters);
+                }
+                BindInformation bindInfo;
+                ProcessDefaultsAndCreateBindInfo(omitDefaults, normalizedParameters, extraParameters, out bindInfo);
+                return bindInfo;
+            }
+            public BindInformation PrepareBindInformation(NameValueCollection parameters, bool omitDefaults)
+            {
+                if (parameters == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("parameters");
+                }
+
+                string[] normalizedParameters = PrepareNormalizedParameters();
+                IDictionary<string, string> extraParameters = null;
+                foreach (string key in parameters.AllKeys)
+                {
+                    ProcessBindParameter(key, parameters[key], normalizedParameters, ref extraParameters);
+                }
+                BindInformation bindInfo;
+                ProcessDefaultsAndCreateBindInfo(omitDefaults, normalizedParameters, extraParameters, out bindInfo);
+                return bindInfo;
+            }
+            public BindInformation PrepareBindInformation(params string[] parameters)
+            {
+                if (parameters == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("values");
+                }
+                if ((parameters.Length < this.pathSegmentVariableNames.Count) ||
+                    (parameters.Length > this.pathSegmentVariableNames.Count + this.queryValueVariableNames.Count))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTBindByPositionWrongCount, this.owner.originalTemplate,
+                        this.pathSegmentVariableNames.Count, this.queryValueVariableNames.Count,
+                        parameters.Length)));
+                }
+
+                string[] normalizedParameters;
+                if (parameters.Length == this.pathSegmentVariableNames.Count + this.queryValueVariableNames.Count)
+                {
+                    normalizedParameters = parameters;
+                }
+                else
+                {
+                    normalizedParameters = new string[this.pathSegmentVariableNames.Count + this.queryValueVariableNames.Count];
+                    parameters.CopyTo(normalizedParameters, 0);
+                    for (int i = parameters.Length; i < normalizedParameters.Length; i++)
+                    {
+                        normalizedParameters[i] = null;
+                    }
+                }
+                int lastNonDefaultPathParameter;
+                int lastNonNullablePathParameter;
+                LoadDefaultsAndValidate(normalizedParameters, out lastNonDefaultPathParameter,
+                    out lastNonNullablePathParameter);
+                return new BindInformation(normalizedParameters, lastNonDefaultPathParameter,
+                    lastNonNullablePathParameter, this.owner.additionalDefaults);
+            }
+            public void ValidateDefaults(out int firstOptionalSegment)
+            {
+                Fx.Assert(this.defaultValues != null, "We are checking this condition from the c'tor");
+                Fx.Assert(this.pathSegmentVariableNames.Count > 0, "Otherwise, how can we have default values");
+                // Finding the first valid nullable defaults
+                for (int i = this.pathSegmentVariableNames.Count - 1; (i >= 0) && (this.firstNullablePathVariable == -1); i--)
+                {
+                    string varName = this.pathSegmentVariableNames[i];
+                    string defaultValue;
+                    if (!this.defaultValues.TryGetValue(varName, out defaultValue))
+                    {
+                        this.firstNullablePathVariable = i + 1;
+                    }
+                    else if (defaultValue != null)
+                    {
+                        this.firstNullablePathVariable = i + 1;
+                    }
+                }
+                if (this.firstNullablePathVariable == -1)
+                {
+                    this.firstNullablePathVariable = 0;
+                }
+                // Making sure that there are no nullables to the left of the first valid nullable
+                if (this.firstNullablePathVariable > 1)
+                {
+                    for (int i = this.firstNullablePathVariable - 2; i >= 0; i--)
+                    {
+                        string varName = this.pathSegmentVariableNames[i];
+                        string defaultValue;
+                        if (this.defaultValues.TryGetValue(varName, out defaultValue))
+                        {
+                            if (defaultValue == null)
+                            {
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                                    SR.GetString(SR.UTNullableDefaultMustBeFollowedWithNullables, this.owner.originalTemplate,
+                                    varName, this.pathSegmentVariableNames[i + 1])));
+                            }
+                        }
+                    }
+                }
+                // Making sure that there are no Literals\WildCards to the right
+                // Based on the fact that only Variable Path Segments support default values,
+                //  if firstNullablePathVariable=N and pathSegmentVariableNames.Count=M then
+                //  the nature of the last M-N path segments should be StringNature.Variable; otherwise,
+                //  there was a literal segment in between. Also, there shouldn't be a wildcard.
+                if (this.firstNullablePathVariable < this.pathSegmentVariableNames.Count)
+                {
+                    if (this.owner.HasWildcard)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                            SR.GetString(SR.UTNullableDefaultMustNotBeFollowedWithWildcard,
+                            this.owner.originalTemplate, this.pathSegmentVariableNames[this.firstNullablePathVariable])));
+                    }
+                    for (int i = this.pathSegmentVariableNames.Count - 1; i >= this.firstNullablePathVariable; i--)
+                    {
+                        int segmentIndex = this.owner.segments.Count - (this.pathSegmentVariableNames.Count - i);
+                        if (this.owner.segments[segmentIndex].Nature != UriTemplatePartType.Variable)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                                SR.GetString(SR.UTNullableDefaultMustNotBeFollowedWithLiteral,
+                                this.owner.originalTemplate, this.pathSegmentVariableNames[this.firstNullablePathVariable],
+                                this.owner.segments[segmentIndex].OriginalSegment)));
+                        }
+                    }
+                }
+                // Now that we have the firstNullablePathVariable set, lets calculate the firstOptionalSegment.
+                //  We already knows that the last M-N path segments (when M=pathSegmentVariableNames.Count and
+                //  N=firstNullablePathVariable) are optional (see the previos comment). We will start there and
+                //  move to the left, stopping at the first segment, which is not a variable or is a variable
+                //  and doesn't have a default value.
+                int numNullablePathVariables = (this.pathSegmentVariableNames.Count - this.firstNullablePathVariable);
+                firstOptionalSegment = this.owner.segments.Count - numNullablePathVariables;
+                if (!this.owner.HasWildcard)
+                {
+                    while (firstOptionalSegment > 0)
+                    {
+                        UriTemplatePathSegment ps = this.owner.segments[firstOptionalSegment - 1];
+                        if (ps.Nature != UriTemplatePartType.Variable)
+                        {
+                            break;
+                        }
+                        UriTemplateVariablePathSegment vps = (ps as UriTemplateVariablePathSegment);
+                        Fx.Assert(vps != null, "Should be; that's his nature");
+                        if (!this.defaultValues.ContainsKey(vps.VarName))
+                        {
+                            break;
+                        }
+                        firstOptionalSegment--;
+                    }
+                }
+            }
+
+            void AddAdditionalDefaults(ref IDictionary<string, string> extraParameters)
+            {
+                if (extraParameters == null)
+                {
+                    extraParameters = this.owner.additionalDefaults;
+                }
+                else
+                {
+                    foreach (KeyValuePair<string, string> kvp in this.owner.additionalDefaults)
+                    {
+                        if (!extraParameters.ContainsKey(kvp.Key))
+                        {
+                            extraParameters.Add(kvp.Key, kvp.Value);
+                        }
+                    }
+                }
+            }
+            void LoadDefaultsAndValidate(string[] normalizedParameters, out int lastNonDefaultPathParameter,
+                out int lastNonNullablePathParameter)
+            {
+                // First step - loading defaults
+                for (int i = 0; i < this.pathSegmentVariableNames.Count; i++)
+                {
+                    if (string.IsNullOrEmpty(normalizedParameters[i]) && (this.defaultValues != null))
+                    {
+                        this.defaultValues.TryGetValue(this.pathSegmentVariableNames[i], out normalizedParameters[i]);
+                    }
+                }
+                // Second step - calculating bind constrains
+                lastNonDefaultPathParameter = this.pathSegmentVariableNames.Count - 1;
+                if ((this.defaultValues != null) &&
+                    (this.owner.segments[this.owner.segments.Count - 1].Nature != UriTemplatePartType.Literal))
+                {
+                    bool foundNonDefaultPathParameter = false;
+                    while (!foundNonDefaultPathParameter && (lastNonDefaultPathParameter >= 0))
+                    {
+                        string defaultValue;
+                        if (this.defaultValues.TryGetValue(this.pathSegmentVariableNames[lastNonDefaultPathParameter],
+                            out defaultValue))
+                        {
+                            if (string.Compare(normalizedParameters[lastNonDefaultPathParameter],
+                                defaultValue, StringComparison.Ordinal) != 0)
+                            {
+                                foundNonDefaultPathParameter = true;
+                            }
+                            else
+                            {
+                                lastNonDefaultPathParameter--;
+                            }
+                        }
+                        else
+                        {
+                            foundNonDefaultPathParameter = true;
+                        }
+                    }
+                }
+                if (this.firstNullablePathVariable > lastNonDefaultPathParameter)
+                {
+                    lastNonNullablePathParameter = this.firstNullablePathVariable - 1;
+                }
+                else
+                {
+                    lastNonNullablePathParameter = lastNonDefaultPathParameter;
+                }
+                // Third step - validate
+                for (int i = 0; i <= lastNonNullablePathParameter; i++)
+                {
+                    // Skip validation for terminating star variable segment :
+                    if (this.owner.HasWildcard && this.owner.wildcard.HasVariable &&
+                        (i == this.pathSegmentVariableNames.Count - 1))
+                    {
+                        continue;
+                    }
+                    // Validate
+                    if (string.IsNullOrEmpty(normalizedParameters[i]))
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("parameters",
+                            SR.GetString(SR.BindUriTemplateToNullOrEmptyPathParam, this.pathSegmentVariableNames[i]));
+                    }
+                }
+            }
+            void ParseVariableDeclaration(string varDeclaration, out string varName, out string defaultValue)
+            {
+                if ((varDeclaration.IndexOf('{') != -1) || (varDeclaration.IndexOf('}') != -1))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTInvalidVarDeclaration, this.owner.originalTemplate, varDeclaration)));
+                }
+                int equalSignIndex = varDeclaration.IndexOf('=');
+                switch (equalSignIndex)
+                {
+                    case -1:
+                        varName = varDeclaration;
+                        defaultValue = null;
+                        break;
+
+                    case 0:
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                            SR.GetString(SR.UTInvalidVarDeclaration, this.owner.originalTemplate, varDeclaration)));
+
+                    default:
+                        varName = varDeclaration.Substring(0, equalSignIndex);
+                        defaultValue = varDeclaration.Substring(equalSignIndex + 1);
+                        if (defaultValue.IndexOf('=') != -1)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                                SR.GetString(SR.UTInvalidVarDeclaration, this.owner.originalTemplate, varDeclaration)));
+                        }
+                        break;
+                }
+            }
+            string[] PrepareNormalizedParameters()
+            {
+                string[] normalizedParameters = new string[this.pathSegmentVariableNames.Count + this.queryValueVariableNames.Count];
+                for (int i = 0; i < normalizedParameters.Length; i++)
+                {
+                    normalizedParameters[i] = null;
+                }
+                return normalizedParameters;
+            }
+            void ProcessBindParameter(string name, string value, string[] normalizedParameters,
+                ref IDictionary<string, string> extraParameters)
+            {
+                if (string.IsNullOrEmpty(name))
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("parameters",
+                        SR.GetString(SR.UTBindByNameCalledWithEmptyKey));
+                }
+
+                string uppercaseVarName = name.ToUpperInvariant();
+                int pathVarIndex = this.pathSegmentVariableNames.IndexOf(uppercaseVarName);
+                if (pathVarIndex != -1)
+                {
+                    normalizedParameters[pathVarIndex] = (string.IsNullOrEmpty(value) ? string.Empty : value);
+                    return;
+                }
+                int queryVarIndex = this.queryValueVariableNames.IndexOf(uppercaseVarName);
+                if (queryVarIndex != -1)
+                {
+                    normalizedParameters[this.pathSegmentVariableNames.Count + queryVarIndex] = (string.IsNullOrEmpty(value) ? string.Empty : value);
+                    return;
+                }
+                if (extraParameters == null)
+                {
+                    extraParameters = new Dictionary<string, string>(UriTemplateHelpers.GetQueryKeyComparer());
+                }
+                extraParameters.Add(name, value);
+            }
+            void ProcessDefaultsAndCreateBindInfo(bool omitDefaults, string[] normalizedParameters,
+                IDictionary<string, string> extraParameters, out BindInformation bindInfo)
+            {
+                int lastNonDefaultPathParameter;
+                int lastNonNullablePathParameter;
+                LoadDefaultsAndValidate(normalizedParameters, out lastNonDefaultPathParameter,
+                    out lastNonNullablePathParameter);
+                if (this.owner.additionalDefaults != null)
+                {
+                    if (omitDefaults)
+                    {
+                        RemoveAdditionalDefaults(ref extraParameters);
+                    }
+                    else
+                    {
+                        AddAdditionalDefaults(ref extraParameters);
+                    }
+                }
+                bindInfo = new BindInformation(normalizedParameters, lastNonDefaultPathParameter,
+                    lastNonNullablePathParameter, extraParameters);
+            }
+            void RemoveAdditionalDefaults(ref IDictionary<string, string> extraParameters)
+            {
+                if (extraParameters == null)
+                {
+                    return;
+                }
+
+                foreach (KeyValuePair<string, string> kvp in this.owner.additionalDefaults)
+                {
+                    string extraParameter;
+                    if (extraParameters.TryGetValue(kvp.Key, out extraParameter))
+                    {
+                        if (string.Compare(extraParameter, kvp.Value, StringComparison.Ordinal) == 0)
+                        {
+                            extraParameters.Remove(kvp.Key);
+                        }
+                    }
+                }
+                if (extraParameters.Count == 0)
+                {
+                    extraParameters = null;
+                }
+            }
+        }
+
+        class WildcardInfo
+        {
+            readonly UriTemplate owner;
+            readonly string varName;
+
+            public WildcardInfo(UriTemplate owner)
+            {
+                this.varName = null;
+                this.owner = owner;
+            }
+            public WildcardInfo(UriTemplate owner, string segment)
+            {
+                Fx.Assert(!segment.EndsWith("/", StringComparison.Ordinal), "We are expecting to check this earlier");
+
+                bool hasDefault;
+                this.varName = owner.AddPathVariable(UriTemplatePartType.Variable,
+                    segment.Substring(1 + WildcardPath.Length, segment.Length - 2 - WildcardPath.Length),
+                    out hasDefault);
+                // Since this is a terminating star segment there shouldn't be a default
+                if (hasDefault)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.GetString(SR.UTStarVariableWithDefaults, owner.originalTemplate,
+                        segment, this.varName)));
+                }
+                this.owner = owner;
+            }
+
+            internal bool HasVariable
+            {
+                get
+                {
+                    return (!string.IsNullOrEmpty(this.varName));
+                }
+            }
+
+            public void Bind(string[] values, ref int valueIndex, StringBuilder path)
+            {
+                if (HasVariable)
+                {
+                    Fx.Assert(valueIndex < values.Length, "Not enough values to bind");
+                    if (string.IsNullOrEmpty(values[valueIndex]))
+                    {
+                        valueIndex++;
+                    }
+                    else
+                    {
+                        path.Append(values[valueIndex++]);
+                    }
+                }
+            }
+            public void Lookup(int numMatchedSegments, Collection<string> relativePathSegments,
+                NameValueCollection boundParameters)
+            {
+                Fx.Assert(numMatchedSegments == this.owner.segments.Count, "We should have matched the other segments");
+                if (HasVariable)
+                {
+                    StringBuilder remainingPath = new StringBuilder();
+                    for (int i = numMatchedSegments; i < relativePathSegments.Count; i++)
+                    {
+                        if (i < relativePathSegments.Count - 1)
+                        {
+                            remainingPath.AppendFormat("{0}/", relativePathSegments[i]);
+                        }
+                        else
+                        {
+                            remainingPath.Append(relativePathSegments[i]);
+                        }
+                    }
+                    boundParameters.Add(this.varName, remainingPath.ToString());
+                }
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateCompoundPathSegment.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateCompoundPathSegment.cs
@@ -1,0 +1,487 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.Text;
+
+    // Thin wrapper around formatted string; use type system to help ensure we
+    // are doing canonicalization right/consistently - the literal sections are held in an
+    // un-escaped format
+    // We are assuming that the string will be always built as Lit{Var}Lit[{Var}Lit[{Var}Lit[...]]],
+    // when the first and last literals may be empty
+    class UriTemplateCompoundPathSegment : UriTemplatePathSegment, IComparable<UriTemplateCompoundPathSegment>
+    {
+        readonly string firstLiteral;
+        readonly List<VarAndLitPair> varLitPairs;
+
+        CompoundSegmentClass csClass;
+
+        UriTemplateCompoundPathSegment(string originalSegment, bool endsWithSlash, string firstLiteral)
+            : base(originalSegment, UriTemplatePartType.Compound, endsWithSlash)
+        {
+            this.firstLiteral = firstLiteral;
+            this.varLitPairs = new List<VarAndLitPair>();
+        }
+        public static new UriTemplateCompoundPathSegment CreateFromUriTemplate(string segment, UriTemplate template)
+        {
+            string origSegment = segment;
+            bool endsWithSlash = segment.EndsWith("/", StringComparison.Ordinal);
+            if (endsWithSlash)
+            {
+                segment = segment.Remove(segment.Length - 1);
+            }
+
+            int nextVarStart = segment.IndexOf("{", StringComparison.Ordinal);
+            Fx.Assert(nextVarStart >= 0, "The method is only called after identifying a '{' character in the segment");
+            string firstLiteral = ((nextVarStart > 0) ? segment.Substring(0, nextVarStart) : string.Empty);
+            if (firstLiteral.IndexOf(UriTemplate.WildcardPath, StringComparison.Ordinal) != -1)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                    SR.GetString(SR.UTInvalidWildcardInVariableOrLiteral, template.originalTemplate, UriTemplate.WildcardPath)));
+            }
+            UriTemplateCompoundPathSegment result = new UriTemplateCompoundPathSegment(origSegment, endsWithSlash,
+                ((firstLiteral != string.Empty) ? Uri.UnescapeDataString(firstLiteral) : string.Empty));
+            do
+            {
+                int nextVarEnd = segment.IndexOf("}", nextVarStart + 1, StringComparison.Ordinal);
+                if (nextVarEnd < nextVarStart + 2)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTInvalidFormatSegmentOrQueryPart, segment)));
+                }
+                bool hasDefault;
+                string varName = template.AddPathVariable(UriTemplatePartType.Compound,
+                    segment.Substring(nextVarStart + 1, nextVarEnd - nextVarStart - 1), out hasDefault);
+                if (hasDefault)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                        SR.GetString(SR.UTDefaultValueToCompoundSegmentVar, template, origSegment, varName)));
+                }
+                nextVarStart = segment.IndexOf("{", nextVarEnd + 1, StringComparison.Ordinal);
+                string literal;
+                if (nextVarStart > 0)
+                {
+                    if (nextVarStart == nextVarEnd + 1)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("template",
+                            SR.GetString(SR.UTDoesNotSupportAdjacentVarsInCompoundSegment, template, segment));
+                    }
+                    literal = segment.Substring(nextVarEnd + 1, nextVarStart - nextVarEnd - 1);
+                }
+                else if (nextVarEnd + 1 < segment.Length)
+                {
+                    literal = segment.Substring(nextVarEnd + 1);
+                }
+                else
+                {
+                    literal = string.Empty;
+                }
+                if (literal.IndexOf(UriTemplate.WildcardPath, StringComparison.Ordinal) != -1)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTInvalidWildcardInVariableOrLiteral, template.originalTemplate, UriTemplate.WildcardPath)));
+                }
+                if (literal.IndexOf('}') != -1)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTInvalidFormatSegmentOrQueryPart, segment)));
+                }
+                result.varLitPairs.Add(new VarAndLitPair(varName, ((literal == string.Empty) ? string.Empty : Uri.UnescapeDataString(literal))));
+            } while (nextVarStart > 0);
+
+            if (string.IsNullOrEmpty(result.firstLiteral))
+            {
+                if (string.IsNullOrEmpty(result.varLitPairs[result.varLitPairs.Count - 1].Literal))
+                {
+                    result.csClass = CompoundSegmentClass.HasNoPrefixNorSuffix;
+                }
+                else
+                {
+                    result.csClass = CompoundSegmentClass.HasOnlySuffix;
+                }
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(result.varLitPairs[result.varLitPairs.Count - 1].Literal))
+                {
+                    result.csClass = CompoundSegmentClass.HasOnlyPrefix;
+                }
+                else
+                {
+                    result.csClass = CompoundSegmentClass.HasPrefixAndSuffix;
+                }
+            }
+
+            return result;
+        }
+
+        public override void Bind(string[] values, ref int valueIndex, StringBuilder path)
+        {
+            Fx.Assert(valueIndex + this.varLitPairs.Count <= values.Length, "Not enough values to bind");
+            path.Append(this.firstLiteral);
+            for (int pairIndex = 0; pairIndex < this.varLitPairs.Count; pairIndex++)
+            {
+                path.Append(values[valueIndex++]);
+                path.Append(this.varLitPairs[pairIndex].Literal);
+            }
+            if (this.EndsWithSlash)
+            {
+                path.Append("/");
+            }
+        }
+        public override bool IsEquivalentTo(UriTemplatePathSegment other, bool ignoreTrailingSlash)
+        {
+            if (other == null)
+            {
+                Fx.Assert("why would we ever call this?");
+                return false;
+            }
+            if (!ignoreTrailingSlash && (this.EndsWithSlash != other.EndsWithSlash))
+            {
+                return false;
+            }
+            UriTemplateCompoundPathSegment otherAsCompound = other as UriTemplateCompoundPathSegment;
+            if (otherAsCompound == null)
+            {
+                // if other can't be cast as a compound then it can't be equivalent
+                return false;
+            }
+            if (this.varLitPairs.Count != otherAsCompound.varLitPairs.Count)
+            {
+                return false;
+            }
+            if (StringComparer.OrdinalIgnoreCase.Compare(this.firstLiteral, otherAsCompound.firstLiteral) != 0)
+            {
+                return false;
+            }
+            for (int pairIndex = 0; pairIndex < this.varLitPairs.Count; pairIndex++)
+            {
+                if (StringComparer.OrdinalIgnoreCase.Compare(this.varLitPairs[pairIndex].Literal,
+                    otherAsCompound.varLitPairs[pairIndex].Literal) != 0)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        public override bool IsMatch(UriTemplateLiteralPathSegment segment, bool ignoreTrailingSlash)
+        {
+            if (!ignoreTrailingSlash && (this.EndsWithSlash != segment.EndsWithSlash))
+            {
+                return false;
+            }
+            return TryLookup(segment.AsUnescapedString(), null);
+        }
+        public override void Lookup(string segment, NameValueCollection boundParameters)
+        {
+            if (!TryLookup(segment, boundParameters))
+            {
+                Fx.Assert("How can that be? Lookup is expected to be called after IsMatch");
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                    SR.GetString(SR.UTCSRLookupBeforeMatch)));
+            }
+        }
+
+        bool TryLookup(string segment, NameValueCollection boundParameters)
+        {
+            int segmentPosition = 0;
+            if (!string.IsNullOrEmpty(this.firstLiteral))
+            {
+                if (segment.StartsWith(this.firstLiteral, StringComparison.Ordinal))
+                {
+                    segmentPosition = this.firstLiteral.Length;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            for (int pairIndex = 0; pairIndex < this.varLitPairs.Count - 1; pairIndex++)
+            {
+                int nextLiteralPosition = segment.IndexOf(this.varLitPairs[pairIndex].Literal, segmentPosition, StringComparison.Ordinal);
+                if (nextLiteralPosition < segmentPosition + 1)
+                {
+                    return false;
+                }
+                if (boundParameters != null)
+                {
+                    string varValue = segment.Substring(segmentPosition, nextLiteralPosition - segmentPosition);
+                    boundParameters.Add(this.varLitPairs[pairIndex].VarName, varValue);
+                }
+                segmentPosition = nextLiteralPosition + this.varLitPairs[pairIndex].Literal.Length;
+            }
+            if (segmentPosition < segment.Length)
+            {
+                if (string.IsNullOrEmpty(this.varLitPairs[varLitPairs.Count - 1].Literal))
+                {
+                    if (boundParameters != null)
+                    {
+                        boundParameters.Add(this.varLitPairs[varLitPairs.Count - 1].VarName,
+                            segment.Substring(segmentPosition));
+                    }
+                    return true;
+                }
+                else if ((segmentPosition + this.varLitPairs[varLitPairs.Count - 1].Literal.Length < segment.Length) &&
+                    segment.EndsWith(this.varLitPairs[varLitPairs.Count - 1].Literal, StringComparison.Ordinal))
+                {
+                    if (boundParameters != null)
+                    {
+                        boundParameters.Add(this.varLitPairs[varLitPairs.Count - 1].VarName,
+                            segment.Substring(segmentPosition, segment.Length - segmentPosition - this.varLitPairs[varLitPairs.Count - 1].Literal.Length));
+                    }
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        // A note about comparing compound segments:
+        //  We are using this for generating the sorted collections at the nodes of the UriTemplateTrieNode.
+        //  The idea is that we are sorting the segments based on preferred matching, when we have two
+        //  compound segments matching the same wire segment, we will give preference to the preceding one.
+        //  The order is based on the following concepts:
+        //   - We are defining four classes of compound segments: prefix+suffix, prefix-only, suffix-only 
+        //      and none
+        //   - Whenever we are comparing segments from different class the preferred one is the segment with
+        //      the prefared class, based on the order we defined them (p+s \ p \ s \ n).
+        //   - Within each class the preference is based on the prefix\suffix, while prefix has precedence 
+        //      over suffix if both exists.
+        //   - If after comparing the class, as well as the prefix\suffix, we didn't reach to a conclusion,
+        //      the preference is given to the segment with more variables parts.
+        //  This order mostly follows the intuitive common sense; the major issue comes from preferring the
+        //  prefix over the suffix in the case where both exist. This is derived from the problematic of any
+        //  other type of solution that don't prefere the prefix over the suffix or vice versa. To better 
+        //  understanding lets considered the following example:
+        //   In comparing 'foo{x}bar' and 'food{x}ar', unless we are preferring prefix or suffix, we have
+        //   to state that they have the same order. So is the case with 'foo{x}babar' and 'food{x}ar', which
+        //   will lead us to claiming the 'foo{x}bar' and 'foo{x}babar' are from the same order, which they
+        //   clearly are not. 
+        //  Taking other approaches to this problem results in similar cases. The only solution is preferring
+        //  either the prefix or the suffix over the other; since we already preferred prefix over suffix
+        //  implicitly (we preferred the prefix only class over the suffix only, we also prefared literal
+        //  over variable, if in the same path segment) that still maintain consistency.
+        //  Therefore:
+        //    - 'food{var}' should be before 'foo{var}'; '{x}.{y}.{z}' should be before '{x}.{y}'.
+        //    - the order between '{var}bar' and '{var}qux' is not important
+        //    - '{x}.{y}' and '{x}_{y}' should have the same order
+        //    - 'foo{x}bar' is less preferred than 'food{x}ar'
+        //  In the above third case - if we are opening the table with allowDuplicate=false, we will throw;
+        //  if we are opening it with allowDuplicate=true we will let it go and might match both templates
+        //  for certain wire candidates.
+        int IComparable<UriTemplateCompoundPathSegment>.CompareTo(UriTemplateCompoundPathSegment other)
+        {
+            Fx.Assert(other != null, "We are only expected to get here for comparing real compound segments");
+
+            switch (this.csClass)
+            {
+                case CompoundSegmentClass.HasPrefixAndSuffix:
+                    switch (other.csClass)
+                    {
+                        case CompoundSegmentClass.HasPrefixAndSuffix:
+                            return CompareToOtherThatHasPrefixAndSuffix(other);
+
+                        case CompoundSegmentClass.HasOnlyPrefix:
+                        case CompoundSegmentClass.HasOnlySuffix:
+                        case CompoundSegmentClass.HasNoPrefixNorSuffix:
+                            return -1;
+
+                        default:
+                            Fx.Assert("Invalid other.CompoundSegmentClass");
+                            return 0;
+                    }
+
+                case CompoundSegmentClass.HasOnlyPrefix:
+                    switch (other.csClass)
+                    {
+                        case CompoundSegmentClass.HasPrefixAndSuffix:
+                            return 1;
+
+                        case CompoundSegmentClass.HasOnlyPrefix:
+                            return CompareToOtherThatHasOnlyPrefix(other);
+
+                        case CompoundSegmentClass.HasOnlySuffix:
+                        case CompoundSegmentClass.HasNoPrefixNorSuffix:
+                            return -1;
+
+                        default:
+                            Fx.Assert("Invalid other.CompoundSegmentClass");
+                            return 0;
+                    }
+
+                case CompoundSegmentClass.HasOnlySuffix:
+                    switch (other.csClass)
+                    {
+                        case CompoundSegmentClass.HasPrefixAndSuffix:
+                        case CompoundSegmentClass.HasOnlyPrefix:
+                            return 1;
+
+                        case CompoundSegmentClass.HasOnlySuffix:
+                            return CompareToOtherThatHasOnlySuffix(other);
+
+                        case CompoundSegmentClass.HasNoPrefixNorSuffix:
+                            return -1;
+
+                        default:
+                            Fx.Assert("Invalid other.CompoundSegmentClass");
+                            return 0;
+                    }
+
+                case CompoundSegmentClass.HasNoPrefixNorSuffix:
+                    switch (other.csClass)
+                    {
+                        case CompoundSegmentClass.HasPrefixAndSuffix:
+                        case CompoundSegmentClass.HasOnlyPrefix:
+                        case CompoundSegmentClass.HasOnlySuffix:
+                            return 1;
+
+                        case CompoundSegmentClass.HasNoPrefixNorSuffix:
+                            return CompareToOtherThatHasNoPrefixNorSuffix(other);
+
+                        default:
+                            Fx.Assert("Invalid other.CompoundSegmentClass");
+                            return 0;
+                    }
+
+                default:
+                    Fx.Assert("Invalid this.CompoundSegmentClass");
+                    return 0;
+            }
+        }
+        int CompareToOtherThatHasPrefixAndSuffix(UriTemplateCompoundPathSegment other)
+        {
+            Fx.Assert(this.csClass == CompoundSegmentClass.HasPrefixAndSuffix, "Otherwise, how did we got here?");
+            Fx.Assert(other.csClass == CompoundSegmentClass.HasPrefixAndSuffix, "Otherwise, how did we got here?");
+
+            // In this case we are determining the order based on the prefix of the two segments,
+            //  then by their suffix and then based on the number of variables
+            int prefixOrder = ComparePrefixToOtherPrefix(other);
+            if (prefixOrder == 0)
+            {
+                int suffixOrder = CompareSuffixToOtherSuffix(other);
+                if (suffixOrder == 0)
+                {
+                    return (other.varLitPairs.Count - this.varLitPairs.Count);
+                }
+                else
+                {
+                    return suffixOrder;
+                }
+            }
+            else
+            {
+                return prefixOrder;
+            }
+        }
+        int CompareToOtherThatHasOnlyPrefix(UriTemplateCompoundPathSegment other)
+        {
+            Fx.Assert(this.csClass == CompoundSegmentClass.HasOnlyPrefix, "Otherwise, how did we got here?");
+            Fx.Assert(other.csClass == CompoundSegmentClass.HasOnlyPrefix, "Otherwise, how did we got here?");
+
+            // In this case we are determining the order based on the prefix of the two segments,
+            //  then based on the number of variables
+            int prefixOrder = ComparePrefixToOtherPrefix(other);
+            if (prefixOrder == 0)
+            {
+                return (other.varLitPairs.Count - this.varLitPairs.Count);
+            }
+            else
+            {
+                return prefixOrder;
+            }
+        }
+        int CompareToOtherThatHasOnlySuffix(UriTemplateCompoundPathSegment other)
+        {
+            Fx.Assert(this.csClass == CompoundSegmentClass.HasOnlySuffix, "Otherwise, how did we got here?");
+            Fx.Assert(other.csClass == CompoundSegmentClass.HasOnlySuffix, "Otherwise, how did we got here?");
+
+            // In this case we are determining the order based on the suffix of the two segments,
+            //  then based on the number of variables
+            int suffixOrder = CompareSuffixToOtherSuffix(other);
+            if (suffixOrder == 0)
+            {
+                return (other.varLitPairs.Count - this.varLitPairs.Count);
+            }
+            else
+            {
+                return suffixOrder;
+            }
+        }
+        int CompareToOtherThatHasNoPrefixNorSuffix(UriTemplateCompoundPathSegment other)
+        {
+            Fx.Assert(this.csClass == CompoundSegmentClass.HasNoPrefixNorSuffix, "Otherwise, how did we got here?");
+            Fx.Assert(other.csClass == CompoundSegmentClass.HasNoPrefixNorSuffix, "Otherwise, how did we got here?");
+
+            // In this case the order is determined by the number of variables
+            return (other.varLitPairs.Count - this.varLitPairs.Count);
+        }
+        int ComparePrefixToOtherPrefix(UriTemplateCompoundPathSegment other)
+        {
+            return string.Compare(other.firstLiteral, this.firstLiteral, StringComparison.OrdinalIgnoreCase);
+        }
+        int CompareSuffixToOtherSuffix(UriTemplateCompoundPathSegment other)
+        {
+            string reversedSuffix = ReverseString(this.varLitPairs[this.varLitPairs.Count - 1].Literal);
+            string reversedOtherSuffix = ReverseString(other.varLitPairs[other.varLitPairs.Count - 1].Literal);
+            return string.Compare(reversedOtherSuffix, reversedSuffix, StringComparison.OrdinalIgnoreCase);
+        }
+        static string ReverseString(string stringToReverse)
+        {
+            char[] reversedString = new char[stringToReverse.Length];
+            for (int i = 0; i < stringToReverse.Length; i++)
+            {
+                reversedString[i] = stringToReverse[stringToReverse.Length - i - 1];
+            }
+            return new string(reversedString);
+        }
+
+        enum CompoundSegmentClass
+        {
+            Undefined,
+            HasPrefixAndSuffix,
+            HasOnlyPrefix,
+            HasOnlySuffix,
+            HasNoPrefixNorSuffix
+        }
+
+        struct VarAndLitPair
+        {
+            readonly string literal;
+            readonly string varName;
+
+            public VarAndLitPair(string varName, string literal)
+            {
+                this.varName = varName;
+                this.literal = literal;
+            }
+
+            public string Literal
+            {
+                get
+                {
+                    return this.literal;
+                }
+            }
+            public string VarName
+            {
+                get
+                {
+                    return this.varName;
+                }
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateEquivalenceComparer.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateEquivalenceComparer.cs
@@ -1,0 +1,57 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+#pragma warning disable 1634, 1691 // Stops compiler from warning about unknown warnings (for Presharp)
+
+namespace System
+{
+    using System.Collections.Generic;
+    using System.ServiceModel;
+    using System.Runtime.CompilerServices;
+
+    [TypeForwardedFrom("System.ServiceModel.Web, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
+    public class UriTemplateEquivalenceComparer : IEqualityComparer<UriTemplate>
+    {
+        static UriTemplateEquivalenceComparer instance;
+        internal static UriTemplateEquivalenceComparer Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    // lock-free, fine if we allocate more than one
+                    instance = new UriTemplateEquivalenceComparer();
+                }
+                return instance;
+            }
+        }
+
+        public bool Equals(UriTemplate x, UriTemplate y)
+        {
+            if (x == null)
+            {
+                return y == null;
+            }
+            return x.IsEquivalentTo(y);
+        }
+        public int GetHashCode(UriTemplate obj)
+        {
+            if (obj == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("obj");
+            }
+#pragma warning disable 56506 // obj.xxx is never null
+            // prefer final literal segment (common literal prefixes are common in some scenarios)
+            for (int i = obj.segments.Count - 1; i >= 0; --i)
+            {
+                if (obj.segments[i].Nature == UriTemplatePartType.Literal)
+                {
+                    return obj.segments[i].GetHashCode();
+                }
+            }
+            return obj.segments.Count + obj.queries.Count;
+#pragma warning restore 56506
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateHelpers.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateHelpers.cs
@@ -1,0 +1,388 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Generic;
+    using System.Collections.Specialized;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+
+    static class UriTemplateHelpers
+    {
+        static UriTemplateQueryComparer queryComparer = new UriTemplateQueryComparer();
+        static UriTemplateQueryKeyComparer queryKeyComperar = new UriTemplateQueryKeyComparer();
+
+        [Conditional("DEBUG")]
+        public static void AssertCanonical(string s)
+        {
+            Fx.Assert(s == s.ToUpperInvariant(), "non-canonicalized");
+        }
+        public static bool CanMatchQueryInterestingly(UriTemplate ut, NameValueCollection query, bool mustBeEspeciallyInteresting)
+        {
+            if (ut.queries.Count == 0)
+            {
+                return false; // trivial, not interesting
+            }
+            string[] queryKeys = query.AllKeys;
+            foreach (KeyValuePair<string, UriTemplateQueryValue> kvp in ut.queries)
+            {
+                string queryKeyName = kvp.Key;
+                if (kvp.Value.Nature == UriTemplatePartType.Literal)
+                {
+                    bool queryKeysContainsQueryVarName = false;
+                    for (int i = 0; i < queryKeys.Length; ++i)
+                    {
+                        if (StringComparer.OrdinalIgnoreCase.Equals(queryKeys[i], queryKeyName))
+                        {
+                            queryKeysContainsQueryVarName = true;
+                            break;
+                        }
+                    }
+                    if (!queryKeysContainsQueryVarName)
+                    {
+                        return false;
+                    }
+                    if (kvp.Value == UriTemplateQueryValue.Empty)
+                    {
+                        if (!string.IsNullOrEmpty(query[queryKeyName]))
+                        {
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        if (((UriTemplateLiteralQueryValue)(kvp.Value)).AsRawUnescapedString() != query[queryKeyName])
+                        {
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    if (mustBeEspeciallyInteresting && Array.IndexOf(queryKeys, queryKeyName) == -1)
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        public static bool CanMatchQueryTrivially(UriTemplate ut)
+        {
+            return (ut.queries.Count == 0);
+        }
+
+        public static void DisambiguateSamePath(UriTemplate[] array, int a, int b, bool allowDuplicateEquivalentUriTemplates)
+        {
+            // [a,b) all have same path
+            // ensure queries make them unambiguous
+            Fx.Assert(b > a, "array bug");
+            // sort empty queries to front
+            Array.Sort<UriTemplate>(array, a, b - a, queryComparer);
+            if (b - a == 1)
+            {
+                return; // if only one, cannot be ambiguous
+            }
+            if (!allowDuplicateEquivalentUriTemplates)
+            {
+                // ensure at most one empty query and ignore it
+                if (array[a].queries.Count == 0)
+                {
+                    a++;
+                }
+                if (array[a].queries.Count == 0)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                        SR.UTTDuplicate, array[a].ToString(), array[a - 1].ToString())));
+                }
+                if (b - a == 1)
+                {
+                    return; // if only one, cannot be ambiguous
+                }
+            }
+            else
+            {
+                while (a < b && array[a].queries.Count == 0)  // all equivalent
+                {
+                    a++;
+                }
+                if (b - a <= 1)
+                {
+                    return;
+                }
+            }
+            Fx.Assert(b > a, "array bug");
+            // now consider non-empty queries
+            // more than one, so enforce that
+            // forall
+            //   exist set of querystringvars S where
+            //     every op has literal value foreach var in S, and
+            //     those literal tuples are different
+            EnsureQueriesAreDistinct(array, a, b, allowDuplicateEquivalentUriTemplates);
+        }
+
+        public static IEqualityComparer<string> GetQueryKeyComparer()
+        {
+            return queryKeyComperar;
+        }
+
+        public static string GetUriPath(Uri uri)
+        {
+            return uri.GetComponents(UriComponents.Path | UriComponents.KeepDelimiter, UriFormat.Unescaped);
+        }
+        public static bool HasQueryLiteralRequirements(UriTemplate ut)
+        {
+            foreach (UriTemplateQueryValue utqv in ut.queries.Values)
+            {
+                if (utqv.Nature == UriTemplatePartType.Literal)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public static UriTemplatePartType IdentifyPartType(string part)
+        {
+            // Identifying the nature of a string - Literal|Compound|Variable
+            // Algorithem is based on the following steps:
+            // - Finding the position of the first open curlly brace ('{') and close curlly brace ('}') 
+            //    in the string
+            // - If we don't find any this is a Literal
+            // - otherwise, we validate that position of the close brace is at least two characters from 
+            //    the position of the open brace
+            // - Then we identify if we are dealing with a compound string or a single variable string
+            //    + var name is not at the string start --> Compound
+            //    + var name is shorter then the entire string (End < Length-2 or End==Length-2 
+            //       and string ends with '/') --> Compound
+            //    + otherwise --> Variable
+            int varStartIndex = part.IndexOf("{", StringComparison.Ordinal);
+            int varEndIndex = part.IndexOf("}", StringComparison.Ordinal);
+            if (varStartIndex == -1)
+            {
+                if (varEndIndex != -1)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTInvalidFormatSegmentOrQueryPart, part)));
+                }
+                return UriTemplatePartType.Literal;
+            }
+            else
+            {
+                if (varEndIndex < varStartIndex + 2)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                        SR.GetString(SR.UTInvalidFormatSegmentOrQueryPart, part)));
+                }
+                if (varStartIndex > 0)
+                {
+                    return UriTemplatePartType.Compound;
+                }
+                else if ((varEndIndex < part.Length - 2) ||
+                    ((varEndIndex == part.Length - 2) && !part.EndsWith("/", StringComparison.Ordinal)))
+                {
+                    return UriTemplatePartType.Compound;
+                }
+                else
+                {
+                    return UriTemplatePartType.Variable;
+                }
+            }
+        }
+        public static bool IsWildcardPath(string path)
+        {
+            if (path.IndexOf('/') != -1)
+            {
+                return false;
+            }
+            UriTemplatePartType partType;
+            return IsWildcardSegment(path, out partType);
+        }
+
+        [SuppressMessage("Microsoft.Design", "CA1021:AvoidOutParameters", Justification = "This is internal method that needs to return multiple things")]
+        public static bool IsWildcardSegment(string segment, out UriTemplatePartType type)
+        {
+            type = IdentifyPartType(segment);
+            switch (type)
+            {
+                case UriTemplatePartType.Literal:
+                    return (string.Compare(segment, UriTemplate.WildcardPath, StringComparison.Ordinal) == 0);
+
+                case UriTemplatePartType.Compound:
+                    return false;
+
+                case UriTemplatePartType.Variable:
+                    return ((segment.IndexOf(UriTemplate.WildcardPath, StringComparison.Ordinal) == 1) &&
+                        !segment.EndsWith("/", StringComparison.Ordinal) &&
+                        (segment.Length > UriTemplate.WildcardPath.Length + 2));
+
+                default:
+                    Fx.Assert("Bad part type identification !");
+                    return false;
+            }
+        }
+        public static NameValueCollection ParseQueryString(string query)
+        {
+            // We are adjusting the parsing of UrlUtility.ParseQueryString, which identify
+            //  ?wsdl as a null key with wsdl as a value
+            NameValueCollection result = UrlUtility.ParseQueryString(query);
+            string nullKeyValuesString = result[(string)null];
+            if (!string.IsNullOrEmpty(nullKeyValuesString))
+            {
+                result.Remove(null);
+                string[] nullKeyValues = nullKeyValuesString.Split(',');
+                for (int i = 0; i < nullKeyValues.Length; i++)
+                {
+                    result.Add(nullKeyValues[i], null);
+                }
+            }
+            return result;
+        }
+        static bool AllTemplatesAreEquivalent(IList<UriTemplate> array, int a, int b)
+        {
+            for (int i = a; i < b - 1; ++i)
+            {
+                if (!array[i].IsEquivalentTo(array[i + 1]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static void EnsureQueriesAreDistinct(UriTemplate[] array, int a, int b, bool allowDuplicateEquivalentUriTemplates)
+        {
+            Dictionary<string, byte> queryVarNamesWithLiteralVals = new Dictionary<string, byte>(StringComparer.OrdinalIgnoreCase);
+            for (int i = a; i < b; ++i)
+            {
+                foreach (KeyValuePair<string, UriTemplateQueryValue> kvp in array[i].queries)
+                {
+                    if (kvp.Value.Nature == UriTemplatePartType.Literal)
+                    {
+                        if (!queryVarNamesWithLiteralVals.ContainsKey(kvp.Key))
+                        {
+                            queryVarNamesWithLiteralVals.Add(kvp.Key, 0);
+                        }
+                    }
+                }
+            }
+            // now we have set of possibilities:
+            // further refine to only those for whom all templates have literals
+            Dictionary<string, byte> queryVarNamesAllLiterals = new Dictionary<string, byte>(queryVarNamesWithLiteralVals);
+            for (int i = a; i < b; ++i)
+            {
+                foreach (string s in queryVarNamesWithLiteralVals.Keys)
+                {
+                    if (!array[i].queries.ContainsKey(s) || (array[i].queries[s].Nature != UriTemplatePartType.Literal))
+                    {
+                        queryVarNamesAllLiterals.Remove(s);
+                    }
+                }
+            }
+            queryVarNamesWithLiteralVals = null; // ensure we don't reference this variable any more
+            // now we have the set of names that every operation has as a literal
+            if (queryVarNamesAllLiterals.Count == 0)
+            {
+                if (allowDuplicateEquivalentUriTemplates && AllTemplatesAreEquivalent(array, a, b))
+                {
+                    // we're ok, do nothing
+                }
+                else
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                        SR.UTTOtherAmbiguousQueries, array[a].ToString())));
+                }
+            }
+            // now just ensure that each template has a unique tuple of values for the names
+            string[][] upsLits = new string[b - a][];
+            for (int i = 0; i < b - a; ++i)
+            {
+                upsLits[i] = GetQueryLiterals(array[i + a], queryVarNamesAllLiterals);
+            }
+            for (int i = 0; i < b - a; ++i)
+            {
+                for (int j = i + 1; j < b - a; ++j)
+                {
+                    if (Same(upsLits[i], upsLits[j]))
+                    {
+                        if (!array[i + a].IsEquivalentTo(array[j + a]))
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                                SR.UTTAmbiguousQueries, array[a + i].ToString(), array[j + a].ToString())));
+                        }
+                        Fx.Assert(array[i + a].IsEquivalentTo(array[j + a]), "bad equiv logic");
+                        if (!allowDuplicateEquivalentUriTemplates)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                                SR.UTTDuplicate, array[a + i].ToString(), array[j + a].ToString())));
+                        }
+                    }
+                }
+            }
+            // we're good.  whew!
+        }
+        static string[] GetQueryLiterals(UriTemplate up, Dictionary<string, byte> queryVarNames)
+        {
+            string[] queryLitVals = new string[queryVarNames.Count];
+            int i = 0;
+            foreach (string queryVarName in queryVarNames.Keys)
+            {
+                Fx.Assert(up.queries.ContainsKey(queryVarName), "query doesn't have name");
+                UriTemplateQueryValue utqv = up.queries[queryVarName];
+                Fx.Assert(utqv.Nature == UriTemplatePartType.Literal, "query for name is not literal");
+                if (utqv == UriTemplateQueryValue.Empty)
+                {
+                    queryLitVals[i] = null;
+                }
+                else
+                {
+                    queryLitVals[i] = ((UriTemplateLiteralQueryValue)(utqv)).AsRawUnescapedString();
+                }
+                ++i;
+            }
+            return queryLitVals;
+        }
+        static bool Same(string[] a, string[] b)
+        {
+            Fx.Assert(a.Length == b.Length, "arrays not same length");
+            for (int i = 0; i < a.Length; ++i)
+            {
+                if (a[i] != b[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        class UriTemplateQueryComparer : IComparer<UriTemplate>
+        {
+            public int Compare(UriTemplate x, UriTemplate y)
+            {
+                // sort the empty queries to the front
+                return Comparer<int>.Default.Compare(x.queries.Count, y.queries.Count);
+            }
+        }
+        class UriTemplateQueryKeyComparer : IEqualityComparer<string>
+        {
+            public bool Equals(string x, string y)
+            {
+                return (string.Compare(x, y, StringComparison.OrdinalIgnoreCase) == 0);
+            }
+            public int GetHashCode(string obj)
+            {
+                if (obj == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("obj");
+                }
+                return obj.ToUpperInvariant().GetHashCode();
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateLiteralPathSegment.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateLiteralPathSegment.cs
@@ -1,0 +1,143 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Specialized;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.Text;
+
+    // thin wrapper around string; use type system to help ensure we
+    // are doing canonicalization right/consistently
+    class UriTemplateLiteralPathSegment : UriTemplatePathSegment, IComparable<UriTemplateLiteralPathSegment>
+    {
+
+        // segment doesn't store trailing slash
+        readonly string segment;
+        static Uri dummyUri = new Uri("http://localhost");
+
+        UriTemplateLiteralPathSegment(string segment)
+            : base(segment, UriTemplatePartType.Literal, segment.EndsWith("/", StringComparison.Ordinal))
+        {
+            Fx.Assert(segment != null, "bad literal segment");
+            if (this.EndsWithSlash)
+            {
+                this.segment = segment.Remove(segment.Length - 1);
+            }
+            else
+            {
+                this.segment = segment;
+            }
+        }
+        public static new UriTemplateLiteralPathSegment CreateFromUriTemplate(string segment, UriTemplate template)
+        {
+            // run it through UriBuilder to escape-if-necessary it
+            if (string.Compare(segment, "/", StringComparison.Ordinal) == 0)
+            {
+                // running an empty segment through UriBuilder has unexpected/wrong results
+                return new UriTemplateLiteralPathSegment("/");
+            }
+            if (segment.IndexOf(UriTemplate.WildcardPath, StringComparison.Ordinal) != -1)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new FormatException(
+                    SR.GetString(SR.UTInvalidWildcardInVariableOrLiteral, template.originalTemplate, UriTemplate.WildcardPath)));
+            }
+            // '*' is not usually escaped by the Uri\UriBuilder to %2a, since we forbid passing a
+            // clear character and the workaroud is to pass the escaped form, we should replace the
+            // escaped form with the regular one.
+            segment = segment.Replace("%2a", "*").Replace("%2A", "*");
+            UriBuilder ub = new UriBuilder(dummyUri);
+            ub.Path = segment;
+            string escapedIfNecessarySegment = ub.Uri.AbsolutePath.Substring(1);
+            if (escapedIfNecessarySegment == string.Empty)
+            {
+                // This path through UriBuilder will sometimes '----' various segments
+                // such as '../' and './'.  When this happens and the result is an empty
+                // string, we should just throw and tell the user we don't handle that.
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("segment",
+                    SR.GetString(SR.UTInvalidFormatSegmentOrQueryPart, segment));
+            }
+            return new UriTemplateLiteralPathSegment(escapedIfNecessarySegment);
+        }
+        public static UriTemplateLiteralPathSegment CreateFromWireData(string segment)
+        {
+            return new UriTemplateLiteralPathSegment(segment);
+        }
+
+        public string AsUnescapedString()
+        {
+            Fx.Assert(this.segment != null, "this should only be called by Bind\\Lookup");
+            return Uri.UnescapeDataString(this.segment);
+        }
+        public override void Bind(string[] values, ref int valueIndex, StringBuilder path)
+        {
+            if (this.EndsWithSlash)
+            {
+                path.AppendFormat("{0}/", AsUnescapedString());
+            }
+            else
+            {
+                path.Append(AsUnescapedString());
+            }
+        }
+
+        public int CompareTo(UriTemplateLiteralPathSegment other)
+        {
+            return StringComparer.OrdinalIgnoreCase.Compare(this.segment, other.segment);
+        }
+
+        public override bool Equals(object obj)
+        {
+            UriTemplateLiteralPathSegment lps = obj as UriTemplateLiteralPathSegment;
+            if (lps == null)
+            {
+                Fx.Assert("why would we ever call this?");
+                return false;
+            }
+            else
+            {
+                return ((this.EndsWithSlash == lps.EndsWithSlash) &&
+                    StringComparer.OrdinalIgnoreCase.Equals(this.segment, lps.segment));
+            }
+        }
+        public override int GetHashCode()
+        {
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(this.segment);
+        }
+
+        public override bool IsEquivalentTo(UriTemplatePathSegment other, bool ignoreTrailingSlash)
+        {
+            if (other == null)
+            {
+                Fx.Assert("why would we ever call this?");
+                return false;
+            }
+            if (other.Nature != UriTemplatePartType.Literal)
+            {
+                return false;
+            }
+            UriTemplateLiteralPathSegment otherAsLiteral = other as UriTemplateLiteralPathSegment;
+            Fx.Assert(otherAsLiteral != null, "The nature requires that this will be OK");
+            return IsMatch(otherAsLiteral, ignoreTrailingSlash);
+        }
+        public override bool IsMatch(UriTemplateLiteralPathSegment segment, bool ignoreTrailingSlash)
+        {
+            if (!ignoreTrailingSlash && (segment.EndsWithSlash != this.EndsWithSlash))
+            {
+                return false;
+            }
+            return (CompareTo(segment) == 0);
+        }
+        public bool IsNullOrEmpty()
+        {
+            return string.IsNullOrEmpty(this.segment);
+        }
+        public override void Lookup(string segment, NameValueCollection boundParameters)
+        {
+            Fx.Assert(StringComparer.OrdinalIgnoreCase.Compare(AsUnescapedString(), segment) == 0,
+                "How can that be? Lookup is expected to be called after IsMatch");
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateLiteralQueryValue.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateLiteralQueryValue.cs
@@ -1,0 +1,85 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Specialized;
+    using System.Runtime;
+    using System.ServiceModel.Channels;
+    using System.Text;
+
+    // thin wrapper around string; use type system to help ensure we
+    // are doing canonicalization right/consistently
+    class UriTemplateLiteralQueryValue : UriTemplateQueryValue, IComparable<UriTemplateLiteralQueryValue>
+    {
+        readonly string value; // an unescaped representation
+
+        UriTemplateLiteralQueryValue(string value)
+            : base(UriTemplatePartType.Literal)
+        {
+            Fx.Assert(value != null, "bad literal value");
+            this.value = value;
+        }
+        public static UriTemplateLiteralQueryValue CreateFromUriTemplate(string value)
+        {
+            return new UriTemplateLiteralQueryValue(UrlUtility.UrlDecode(value, Encoding.UTF8));
+        }
+
+        public string AsEscapedString()
+        {
+            return UrlUtility.UrlEncode(this.value, Encoding.UTF8);
+        }
+        public string AsRawUnescapedString()
+        {
+            return this.value;
+        }
+        public override void Bind(string keyName, string[] values, ref int valueIndex, StringBuilder query)
+        {
+            query.AppendFormat("&{0}={1}", UrlUtility.UrlEncode(keyName, Encoding.UTF8), AsEscapedString());
+        }
+
+        public int CompareTo(UriTemplateLiteralQueryValue other)
+        {
+            return string.Compare(this.value, other.value, StringComparison.Ordinal);
+        }
+
+        public override bool Equals(object obj)
+        {
+            UriTemplateLiteralQueryValue lqv = obj as UriTemplateLiteralQueryValue;
+            if (lqv == null)
+            {
+                Fx.Assert("why would we ever call this?");
+                return false;
+            }
+            else
+            {
+                return this.value == lqv.value;
+            }
+        }
+        public override int GetHashCode()
+        {
+            return this.value.GetHashCode();
+        }
+
+        public override bool IsEquivalentTo(UriTemplateQueryValue other)
+        {
+            if (other == null)
+            {
+                Fx.Assert("why would we ever call this?");
+                return false;
+            }
+            if (other.Nature != UriTemplatePartType.Literal)
+            {
+                return false;
+            }
+            UriTemplateLiteralQueryValue otherAsLiteral = other as UriTemplateLiteralQueryValue;
+            Fx.Assert(otherAsLiteral != null, "The nature requires that this will be OK");
+            return (CompareTo(otherAsLiteral) == 0);
+        }
+        public override void Lookup(string value, NameValueCollection boundParameters)
+        {
+            Fx.Assert(string.Compare(this.value, value, StringComparison.Ordinal) == 0, "How can that be?");
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateMatch.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateMatch.cs
@@ -1,0 +1,177 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.ObjectModel;
+    using System.Collections.Specialized;
+    using System.Runtime;
+    using System.Runtime.CompilerServices;
+    using System.ServiceModel.Channels;
+    using System.Net;
+
+    [TypeForwardedFrom("System.ServiceModel.Web, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
+    public class UriTemplateMatch
+    {
+        Uri baseUri;
+        NameValueCollection boundVariables;
+        object data;
+        NameValueCollection queryParameters;
+        Collection<string> relativePathSegments;
+        Uri requestUri;
+        UriTemplate template;
+        Collection<string> wildcardPathSegments;
+        int wildcardSegmentsStartOffset = -1;
+        Uri originalBaseUri;
+        HttpRequestMessageProperty requestProp;
+
+        public UriTemplateMatch()
+        {
+        }
+
+        public Uri BaseUri   // the base address, untouched
+        {
+            get
+            {
+                if (this.baseUri == null && this.originalBaseUri != null)
+                {
+                    this.baseUri = UriTemplate.RewriteUri(this.originalBaseUri, this.requestProp.Headers[HttpRequestHeader.Host]);
+                }
+                return this.baseUri;
+            }
+            set
+            {
+                this.baseUri = value;
+                this.originalBaseUri = null;
+                this.requestProp = null;
+            }
+        }
+        public NameValueCollection BoundVariables // result of TryLookup, values are decoded
+        {
+            get
+            {
+                if (this.boundVariables == null)
+                {
+                    this.boundVariables = new NameValueCollection();
+                }
+                return this.boundVariables;
+            }
+        }
+        public object Data
+        {
+            get
+            {
+                return this.data;
+            }
+            set
+            {
+                this.data = value;
+            }
+        }
+        public NameValueCollection QueryParameters  // the result of UrlUtility.ParseQueryString (keys and values are decoded)
+        {
+            get
+            {
+                if (this.queryParameters == null)
+                {
+                    PopulateQueryParameters();
+                }
+                return this.queryParameters;
+            }
+        }
+        public Collection<string> RelativePathSegments  // entire Path (after the base address), decoded
+        {
+            get
+            {
+                if (this.relativePathSegments == null)
+                {
+                    this.relativePathSegments = new Collection<string>();
+                }
+                return this.relativePathSegments;
+            }
+        }
+        public Uri RequestUri  // uri on the wire, untouched
+        {
+            get
+            {
+                return this.requestUri;
+            }
+            set
+            {
+                this.requestUri = value;
+            }
+        }
+        public UriTemplate Template // which one got matched
+        {
+            get
+            {
+                return this.template;
+            }
+            set
+            {
+                this.template = value;
+            }
+        }
+        public Collection<string> WildcardPathSegments  // just the Path part matched by "*", decoded
+        {
+            get
+            {
+                if (this.wildcardPathSegments == null)
+                {
+                    PopulateWildcardSegments();
+                }
+                return this.wildcardPathSegments;
+            }
+        }
+
+        internal void SetQueryParameters(NameValueCollection queryParameters)
+        {
+            this.queryParameters = new NameValueCollection(queryParameters);
+        }
+        internal void SetRelativePathSegments(Collection<string> segments)
+        {
+            Fx.Assert(segments != null, "segments != null");
+            this.relativePathSegments = segments;
+        }
+        internal void SetWildcardPathSegmentsStart(int startOffset)
+        {
+            Fx.Assert(startOffset >= 0, "startOffset >= 0");
+            this.wildcardSegmentsStartOffset = startOffset;
+        }
+
+        internal void SetBaseUri(Uri originalBaseUri, HttpRequestMessageProperty requestProp)
+        {
+            this.baseUri = null;
+            this.originalBaseUri = originalBaseUri;
+            this.requestProp = requestProp;
+        }
+
+        void PopulateQueryParameters()
+        {
+            if (this.requestUri != null)
+            {
+                this.queryParameters = UriTemplateHelpers.ParseQueryString(this.requestUri.Query);
+            }
+            else
+            {
+                this.queryParameters = new NameValueCollection();
+            }
+        }
+        void PopulateWildcardSegments()
+        {
+            if (wildcardSegmentsStartOffset != -1)
+            {
+                this.wildcardPathSegments = new Collection<string>();
+                for (int i = this.wildcardSegmentsStartOffset; i < this.RelativePathSegments.Count; ++i)
+                {
+                    this.wildcardPathSegments.Add(this.RelativePathSegments[i]);
+                }
+            }
+            else
+            {
+                this.wildcardPathSegments = new Collection<string>();
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateMatchException.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateMatchException.cs
@@ -1,0 +1,30 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Runtime.Serialization;
+    using System.Runtime.CompilerServices;
+
+    [TypeForwardedFrom("System.ServiceModel.Web, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
+    [Serializable]
+    public class UriTemplateMatchException : SystemException
+    {
+        public UriTemplateMatchException()
+        {
+        }
+        public UriTemplateMatchException(string message)
+            : base(message)
+        {
+        }
+        public UriTemplateMatchException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+        protected UriTemplateMatchException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplatePartType.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplatePartType.cs
@@ -1,0 +1,13 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    enum UriTemplatePartType
+    {
+        Literal,
+        Compound,
+        Variable
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplatePathPartiallyEquivalentSet.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplatePathPartiallyEquivalentSet.cs
@@ -1,0 +1,41 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Generic;
+
+    // This class was named UriTemplatePathEquivalentSet in the Orcas bits, where it used to
+    //  represent a set of uri templates, which are equivalent in thier path. The introduction
+    //  of terminal defaults, caused it to be no longer true; now it is representing a set
+    //  of templates, which are equivalent in their path till a certian point, which is stored
+    //  in the segmentsCount field. To highlight that fact the class was renamed as
+    //  UriTemplatePathPartiallyEquivalentSet.
+    class UriTemplatePathPartiallyEquivalentSet
+    {
+        List<KeyValuePair<UriTemplate, object>> kvps;
+        int segmentsCount;
+
+        public UriTemplatePathPartiallyEquivalentSet(int segmentsCount)
+        {
+            this.segmentsCount = segmentsCount;
+            this.kvps = new List<KeyValuePair<UriTemplate, object>>();
+        }
+        public List<KeyValuePair<UriTemplate, object>> Items
+        {
+            get
+            {
+                return this.kvps;
+            }
+        }
+
+        public int SegmentsCount
+        {
+            get
+            {
+                return this.segmentsCount;
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplatePathSegment.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplatePathSegment.cs
@@ -1,0 +1,89 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Specialized;
+    using System.Diagnostics;
+    using System.Runtime;
+    using System.Text;
+
+    // This represents a Path segment, which can either be a Literal, a Variable or a Compound
+    [DebuggerDisplay("Segment={originalSegment} Nature={nature}")]
+    abstract class UriTemplatePathSegment
+    {
+        readonly bool endsWithSlash;
+        readonly UriTemplatePartType nature;
+        readonly string originalSegment;
+
+        protected UriTemplatePathSegment(string originalSegment, UriTemplatePartType nature,
+            bool endsWithSlash)
+        {
+            this.originalSegment = originalSegment;
+            this.nature = nature;
+            this.endsWithSlash = endsWithSlash;
+        }
+        public bool EndsWithSlash
+        {
+            get
+            {
+                return this.endsWithSlash;
+            }
+        }
+        public UriTemplatePartType Nature
+        {
+            get
+            {
+                return this.nature;
+            }
+        }
+
+        public string OriginalSegment
+        {
+            get
+            {
+                return this.originalSegment;
+            }
+        }
+        public static UriTemplatePathSegment CreateFromUriTemplate(string segment, UriTemplate template)
+        {
+            // Identifying the type of segment - Literal|Compound|Variable
+            switch (UriTemplateHelpers.IdentifyPartType(segment))
+            {
+                case UriTemplatePartType.Literal:
+                    return UriTemplateLiteralPathSegment.CreateFromUriTemplate(segment, template);
+
+                case UriTemplatePartType.Compound:
+                    return UriTemplateCompoundPathSegment.CreateFromUriTemplate(segment, template);
+
+                case UriTemplatePartType.Variable:
+                    if (segment.EndsWith("/", StringComparison.Ordinal))
+                    {
+                        string varName = template.AddPathVariable(UriTemplatePartType.Variable,
+                            segment.Substring(1, segment.Length - 3));
+                        return new UriTemplateVariablePathSegment(segment, true, varName);
+                    }
+                    else
+                    {
+                        string varName = template.AddPathVariable(UriTemplatePartType.Variable,
+                            segment.Substring(1, segment.Length - 2));
+                        return new UriTemplateVariablePathSegment(segment, false, varName);
+                    }
+
+                default:
+                    Fx.Assert("Invalid value from IdentifyStringNature");
+                    return null;
+            }
+        }
+        public abstract void Bind(string[] values, ref int valueIndex, StringBuilder path);
+
+        public abstract bool IsEquivalentTo(UriTemplatePathSegment other, bool ignoreTrailingSlash);
+        public bool IsMatch(UriTemplateLiteralPathSegment segment)
+        {
+            return IsMatch(segment, false);
+        }
+        public abstract bool IsMatch(UriTemplateLiteralPathSegment segment, bool ignoreTrailingSlash);
+        public abstract void Lookup(string segment, NameValueCollection boundParameters);
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateQueryValue.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateQueryValue.cs
@@ -1,0 +1,105 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Specialized;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.ServiceModel.Channels;
+    using System.Text;
+
+    // This represents a Query value, which can either be Empty, a Literal or a Variable
+    abstract class UriTemplateQueryValue
+    {
+
+        readonly UriTemplatePartType nature;
+        static UriTemplateQueryValue empty = new EmptyUriTemplateQueryValue();
+
+        protected UriTemplateQueryValue(UriTemplatePartType nature)
+        {
+            this.nature = nature;
+        }
+
+        public static UriTemplateQueryValue Empty
+        {
+            get
+            {
+                return UriTemplateQueryValue.empty;
+            }
+        }
+
+        public UriTemplatePartType Nature
+        {
+            get
+            {
+                return this.nature;
+            }
+        }
+        public static UriTemplateQueryValue CreateFromUriTemplate(string value, UriTemplate template)
+        {
+            // Checking for empty value
+            if (value == null)
+            {
+                return UriTemplateQueryValue.Empty;
+            }
+            // Identifying the type of value - Literal|Compound|Variable
+            switch (UriTemplateHelpers.IdentifyPartType(value))
+            {
+                case UriTemplatePartType.Literal:
+                    return UriTemplateLiteralQueryValue.CreateFromUriTemplate(value);
+
+                case UriTemplatePartType.Compound:
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                        SR.UTQueryCannotHaveCompoundValue, template.originalTemplate)));
+
+                case UriTemplatePartType.Variable:
+                    return new UriTemplateVariableQueryValue(template.AddQueryVariable(value.Substring(1, value.Length - 2)));
+
+                default:
+                    Fx.Assert("Invalid value from IdentifyStringNature");
+                    return null;
+            }
+        }
+
+        public static bool IsNullOrEmpty(UriTemplateQueryValue utqv)
+        {
+            if (utqv == null)
+            {
+                return true;
+            }
+            if (utqv == UriTemplateQueryValue.Empty)
+            {
+                return true;
+            }
+            return false;
+        }
+        public abstract void Bind(string keyName, string[] values, ref int valueIndex, StringBuilder query);
+
+        public abstract bool IsEquivalentTo(UriTemplateQueryValue other);
+        public abstract void Lookup(string value, NameValueCollection boundParameters);
+
+        class EmptyUriTemplateQueryValue : UriTemplateQueryValue
+        {
+            public EmptyUriTemplateQueryValue()
+                : base(UriTemplatePartType.Literal)
+            {
+            }
+            public override void Bind(string keyName, string[] values, ref int valueIndex, StringBuilder query)
+            {
+                query.AppendFormat("&{0}", UrlUtility.UrlEncode(keyName, Encoding.UTF8));
+            }
+
+            public override bool IsEquivalentTo(UriTemplateQueryValue other)
+            {
+                return (other == UriTemplateQueryValue.Empty);
+            }
+            public override void Lookup(string value, NameValueCollection boundParameters)
+            {
+                Fx.Assert(string.IsNullOrEmpty(value), "shouldn't have a value");
+            }
+        }
+    }
+
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTable.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTable.cs
@@ -1,0 +1,608 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Collections.Specialized;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime;
+    using System.ServiceModel;
+    using System.Runtime.CompilerServices;
+
+    // this class is thread-safe
+    [TypeForwardedFrom("System.ServiceModel.Web, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35")]
+    public class UriTemplateTable
+    {
+        Uri baseAddress;
+        string basePath;
+        Dictionary<string, FastPathInfo> fastPathTable; // key is uri.PathAndQuery, fastPathTable may be null
+        bool noTemplateHasQueryPart;
+        int numSegmentsInBaseAddress;
+        Uri originalUncanonicalizedBaseAddress;
+        UriTemplateTrieNode rootNode;
+        UriTemplatesCollection templates;
+        object thisLock;
+        bool addTrailingSlashToBaseAddress;
+
+        public UriTemplateTable()
+            : this(null, null, true)
+        {
+        }
+        public UriTemplateTable(IEnumerable<KeyValuePair<UriTemplate, object>> keyValuePairs)
+            : this(null, keyValuePairs, true)
+        {
+        }
+        public UriTemplateTable(Uri baseAddress)
+            : this(baseAddress, null, true)
+        {
+        }
+
+        internal UriTemplateTable(Uri baseAddress, bool addTrailingSlashToBaseAddress)
+            : this(baseAddress, null, addTrailingSlashToBaseAddress)
+        {
+        }
+
+        public UriTemplateTable(Uri baseAddress, IEnumerable<KeyValuePair<UriTemplate, object>> keyValuePairs)
+            : this(baseAddress, keyValuePairs, true)
+        {
+        }
+
+        internal UriTemplateTable(Uri baseAddress, IEnumerable<KeyValuePair<UriTemplate, object>> keyValuePairs, bool addTrailingSlashToBaseAddress)
+        {
+            if (baseAddress != null && !baseAddress.IsAbsoluteUri)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("baseAddress", SR.GetString(
+                    SR.UTTMustBeAbsolute));
+            }
+            
+            this.addTrailingSlashToBaseAddress = addTrailingSlashToBaseAddress;
+            this.originalUncanonicalizedBaseAddress = baseAddress;
+            
+            if (keyValuePairs != null)
+            {
+                this.templates = new UriTemplatesCollection(keyValuePairs);
+            }
+            else
+            {
+                this.templates = new UriTemplatesCollection();
+            }
+
+            this.thisLock = new object();
+            this.baseAddress = baseAddress;
+            NormalizeBaseAddress();
+        }
+
+        public Uri BaseAddress
+        {
+            get
+            {
+                return this.baseAddress;
+            }
+            set
+            {
+                if (value == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("value");
+                }
+                lock (this.thisLock)
+                {
+                    if (this.IsReadOnly)
+                    {
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(
+                            SR.GetString(SR.UTTCannotChangeBaseAddress)));
+                    }
+                    else
+                    {
+                        if (!value.IsAbsoluteUri)
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument("value", SR.GetString(
+                                SR.UTTBaseAddressMustBeAbsolute));
+                        }
+                        else
+                        {
+                            this.originalUncanonicalizedBaseAddress = value;
+                            this.baseAddress = value;
+                            NormalizeBaseAddress();
+                        }
+                    }
+                }
+            }
+        }
+
+        public Uri OriginalBaseAddress
+        {
+            get
+            {
+                return this.originalUncanonicalizedBaseAddress;
+            }
+        }
+
+        public bool IsReadOnly
+        {
+            get
+            {
+                return this.templates.IsFrozen;
+            }
+        }
+        public IList<KeyValuePair<UriTemplate, object>> KeyValuePairs
+        {
+            get
+            {
+                return this.templates;
+            }
+        }
+
+        public void MakeReadOnly(bool allowDuplicateEquivalentUriTemplates)
+        {
+            // idempotent
+            lock (this.thisLock)
+            {
+                if (!this.IsReadOnly)
+                {
+                    this.templates.Freeze();
+                    Validate(allowDuplicateEquivalentUriTemplates);
+                    ConstructFastPathTable();
+                }
+            }
+        }
+        public Collection<UriTemplateMatch> Match(Uri uri)
+        {
+            if (uri == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("uri");
+            }
+            if (!uri.IsAbsoluteUri)
+            {
+                return None();
+            }
+
+            this.MakeReadOnly(true);
+
+            // Matching path :
+            Collection<String> relativeSegments;
+            IList<UriTemplateTableMatchCandidate> candidates;
+            if (!FastComputeRelativeSegmentsAndLookup(uri, out relativeSegments, out candidates))
+            {
+                return None();
+            }
+            // Matching query :
+            NameValueCollection queryParameters = null;
+            if (!this.noTemplateHasQueryPart && AtLeastOneCandidateHasQueryPart(candidates))
+            {
+                Collection<UriTemplateTableMatchCandidate> nextCandidates = new Collection<UriTemplateTableMatchCandidate>();
+                Fx.Assert(nextCandidates.Count == 0, "nextCandidates should be empty");
+
+                // then deal with query
+                queryParameters = UriTemplateHelpers.ParseQueryString(uri.Query);
+                bool mustBeEspeciallyInteresting = NoCandidateHasQueryLiteralRequirementsAndThereIsAnEmptyFallback(candidates);
+                for (int i = 0; i < candidates.Count; i++)
+                {
+                    if (UriTemplateHelpers.CanMatchQueryInterestingly(candidates[i].Template, queryParameters, mustBeEspeciallyInteresting))
+                    {
+                        nextCandidates.Add(candidates[i]);
+                    }
+                }
+                if (nextCandidates.Count > 1)
+                {
+                    Fx.Assert(AllEquivalent(nextCandidates, 0, nextCandidates.Count), "demux algorithm problem, multiple non-equivalent matches");
+                }
+
+                if (nextCandidates.Count == 0)
+                {
+                    for (int i = 0; i < candidates.Count; i++)
+                    {
+                        if (UriTemplateHelpers.CanMatchQueryTrivially(candidates[i].Template))
+                        {
+                            nextCandidates.Add(candidates[i]);
+                        }
+                    }
+                }
+                if (nextCandidates.Count == 0)
+                {
+                    return None();
+                }
+                if (nextCandidates.Count > 1)
+                {
+                    Fx.Assert(AllEquivalent(nextCandidates, 0, nextCandidates.Count), "demux algorithm problem, multiple non-equivalent matches");
+                }
+
+                candidates = nextCandidates;
+            }
+            // Verifying that we have not broken the allowDuplicates settings because of terminal defaults
+            //  This situation can be caused when we are hosting ".../" and ".../{foo=xyz}" in the same
+            //  table. They are not equivalent; yet they reside together in the same path partially-equivalent
+            //  set. If we hit a uri that ends up in that particular end-of-path set, we want to provide the
+            //  user only the 'best' match and not both; thus preventing inconsistancy between the MakeReadonly
+            //  settings and the matching results. We will assume that the 'best' matches will be the ones with
+            //  the smallest number of segments - this will prefer ".../" over ".../{x=1}[/...]".
+            if (NotAllCandidatesArePathFullyEquivalent(candidates))
+            {
+                Collection<UriTemplateTableMatchCandidate> nextCandidates = new Collection<UriTemplateTableMatchCandidate>();
+                int minSegmentsCount = -1;
+                for (int i = 0; i < candidates.Count; i++)
+                {
+                    UriTemplateTableMatchCandidate candidate = candidates[i];
+                    if (minSegmentsCount == -1)
+                    {
+                        minSegmentsCount = candidate.Template.segments.Count;
+                        nextCandidates.Add(candidate);
+                    }
+                    else if (candidate.Template.segments.Count < minSegmentsCount)
+                    {
+                        minSegmentsCount = candidate.Template.segments.Count;
+                        nextCandidates.Clear();
+                        nextCandidates.Add(candidate);
+                    }
+                    else if (candidate.Template.segments.Count == minSegmentsCount)
+                    {
+                        nextCandidates.Add(candidate);
+                    }
+                }
+                Fx.Assert(minSegmentsCount != -1, "At least the first entry in the list should be kept");
+                Fx.Assert(nextCandidates.Count >= 1, "At least the first entry in the list should be kept");
+                Fx.Assert(nextCandidates[0].Template.segments.Count == minSegmentsCount, "Trivial");
+                candidates = nextCandidates;
+            }
+
+            // Building the actual result
+            Collection<UriTemplateMatch> actualResults = new Collection<UriTemplateMatch>();
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                UriTemplateTableMatchCandidate candidate = candidates[i];
+                UriTemplateMatch match = candidate.Template.CreateUriTemplateMatch(this.originalUncanonicalizedBaseAddress,
+                    uri, candidate.Data, candidate.SegmentsCount, relativeSegments, queryParameters);
+                actualResults.Add(match);
+            }
+            return actualResults;
+        }
+        public UriTemplateMatch MatchSingle(Uri uri)
+        {
+            Collection<UriTemplateMatch> c = this.Match(uri);
+            if (c.Count == 0)
+            {
+                return null;
+            }
+            if (c.Count == 1)
+            {
+                return c[0];
+            }
+            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new UriTemplateMatchException(SR.GetString(
+                SR.UTTMultipleMatches)));
+        }
+
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "This method is called within a Debug assert")]
+        static bool AllEquivalent(IList<UriTemplateTableMatchCandidate> list, int a, int b)
+        {
+            for (int i = a; i < b - 1; ++i)
+            {
+                if (!list[i].Template.IsPathPartiallyEquivalentAt(list[i + 1].Template, list[i].SegmentsCount))
+                {
+                    return false;
+                }
+                if (!list[i].Template.IsQueryEquivalent(list[i + 1].Template))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        static bool AtLeastOneCandidateHasQueryPart(IList<UriTemplateTableMatchCandidate> candidates)
+        {
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                if (!UriTemplateHelpers.CanMatchQueryTrivially(candidates[i].Template))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+        static bool NoCandidateHasQueryLiteralRequirementsAndThereIsAnEmptyFallback(
+            IList<UriTemplateTableMatchCandidate> candidates)
+        {
+            bool thereIsAmEmptyFallback = false;
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                if (UriTemplateHelpers.HasQueryLiteralRequirements(candidates[i].Template))
+                {
+                    return false;
+                }
+                if (candidates[i].Template.queries.Count == 0)
+                {
+                    thereIsAmEmptyFallback = true;
+                }
+            }
+            return thereIsAmEmptyFallback;
+        }
+
+        static Collection<UriTemplateMatch> None()
+        {
+            return new Collection<UriTemplateMatch>();
+        }
+        static bool NotAllCandidatesArePathFullyEquivalent(IList<UriTemplateTableMatchCandidate> candidates)
+        {
+            if (candidates.Count <= 1)
+            {
+                return false;
+            }
+
+            int segmentsCount = -1;
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                if (segmentsCount == -1)
+                {
+                    segmentsCount = candidates[i].Template.segments.Count;
+                }
+                else if (segmentsCount != candidates[i].Template.segments.Count)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        bool ComputeRelativeSegmentsAndLookup(Uri uri,
+            ICollection<string> relativePathSegments, // add to this
+            ICollection<UriTemplateTableMatchCandidate> candidates) // matched candidates
+        {
+            string[] uriSegments = uri.Segments;
+            int numRelativeSegments = uriSegments.Length - this.numSegmentsInBaseAddress;
+            Fx.Assert(numRelativeSegments >= 0, "bad num segments");
+            UriTemplateLiteralPathSegment[] uSegments = new UriTemplateLiteralPathSegment[numRelativeSegments];
+            for (int i = 0; i < numRelativeSegments; ++i)
+            {
+                string seg = uriSegments[i + this.numSegmentsInBaseAddress];
+                // compute representation for matching
+                UriTemplateLiteralPathSegment lps = UriTemplateLiteralPathSegment.CreateFromWireData(seg);
+                uSegments[i] = lps;
+                // compute representation to project out into results
+                string relPathSeg = Uri.UnescapeDataString(seg);
+                if (lps.EndsWithSlash)
+                {
+                    Fx.Assert(relPathSeg.EndsWith("/", StringComparison.Ordinal), "problem with relative path segment");
+                    relPathSeg = relPathSeg.Substring(0, relPathSeg.Length - 1); // trim slash
+                }
+                relativePathSegments.Add(relPathSeg);
+            }
+            return rootNode.Match(uSegments, candidates);
+        }
+        void ConstructFastPathTable()
+        {
+            this.noTemplateHasQueryPart = true;
+            foreach (KeyValuePair<UriTemplate, object> kvp in this.templates)
+            {
+                UriTemplate ut = kvp.Key;
+                if (!UriTemplateHelpers.CanMatchQueryTrivially(ut))
+                {
+                    this.noTemplateHasQueryPart = false;
+                }
+                if (ut.HasNoVariables && !ut.HasWildcard)
+                {
+                    // eligible for fast path
+                    if (this.fastPathTable == null)
+                    {
+                        this.fastPathTable = new Dictionary<string, FastPathInfo>();
+                    }
+                    Uri uri = ut.BindByPosition(this.originalUncanonicalizedBaseAddress);
+                    string uriPath = UriTemplateHelpers.GetUriPath(uri);
+                    if (this.fastPathTable.ContainsKey(uriPath))
+                    {
+                        // nothing to do, we've already seen it
+                    }
+                    else
+                    {
+                        FastPathInfo fpInfo = new FastPathInfo();
+                        if (ComputeRelativeSegmentsAndLookup(uri, fpInfo.RelativePathSegments,
+                            fpInfo.Candidates))
+                        {
+                            fpInfo.Freeze();
+                            this.fastPathTable.Add(uriPath, fpInfo);
+                        }
+                    }
+                }
+            }
+        }
+        // this method checks the literal cache for a match if none, goes through the slower path of cracking the segments
+        bool FastComputeRelativeSegmentsAndLookup(Uri uri, out Collection<string> relativePathSegments,
+            out IList<UriTemplateTableMatchCandidate> candidates)
+        {
+            // Consider fast-path and lookup
+            // return false if not under base uri
+            string uriPath = UriTemplateHelpers.GetUriPath(uri);
+            FastPathInfo fpInfo = null;
+            if ((this.fastPathTable != null) && this.fastPathTable.TryGetValue(uriPath, out fpInfo))
+            {
+                relativePathSegments = fpInfo.RelativePathSegments;
+                candidates = fpInfo.Candidates;
+                VerifyThatFastPathAndSlowPathHaveSameResults(uri, relativePathSegments, candidates);
+                return true;
+            }
+            else
+            {
+                relativePathSegments = new Collection<string>();
+                candidates = new Collection<UriTemplateTableMatchCandidate>();
+                return SlowComputeRelativeSegmentsAndLookup(uri, uriPath, relativePathSegments, candidates);
+            }
+        }
+
+        void NormalizeBaseAddress()
+        {
+            if (this.baseAddress != null)
+            {
+                // ensure trailing slash on baseAddress, so that IsBaseOf will work later
+                UriBuilder ub = new UriBuilder(this.baseAddress);
+                if (this.addTrailingSlashToBaseAddress && !ub.Path.EndsWith("/", StringComparison.Ordinal))
+                {
+                    ub.Path = ub.Path + "/";
+                }
+                ub.Host = "localhost"; // always normalize to localhost
+                ub.Port = -1;
+                ub.UserName = null;
+                ub.Password = null;
+                ub.Path = ub.Path.ToUpperInvariant();
+                ub.Scheme = Uri.UriSchemeHttp;
+                this.baseAddress = ub.Uri;
+                basePath = UriTemplateHelpers.GetUriPath(this.baseAddress);
+            }
+        }
+        bool SlowComputeRelativeSegmentsAndLookup(Uri uri, string uriPath, Collection<string> relativePathSegments,
+            ICollection<UriTemplateTableMatchCandidate> candidates)
+        {
+            // ensure 'under' the base address
+            if (uriPath.Length < basePath.Length)
+            {
+                return false;
+            }
+
+            if (!uriPath.StartsWith(basePath, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+            else
+            {
+                // uriPath StartsWith basePath, but this check is not enough - basePath 'service1' should not match with uriPath 'service123'
+                // make sure that after the match the next character is /, this is to avoid a uriPath of the form /service12/ matching with a basepath of the form /service1
+                if (uriPath.Length > basePath.Length && !basePath.EndsWith("/", StringComparison.Ordinal) && uriPath[basePath.Length] != '/')
+                {
+                    return false;
+                }
+            }
+
+            return ComputeRelativeSegmentsAndLookup(uri, relativePathSegments, candidates);
+        }
+
+        void Validate(bool allowDuplicateEquivalentUriTemplates)
+        {
+            if (this.baseAddress == null)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                    SR.UTTBaseAddressNotSet)));
+            }
+            this.numSegmentsInBaseAddress = this.baseAddress.Segments.Length;
+            if (this.templates.Count == 0)
+            {
+                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                    SR.UTTEmptyKeyValuePairs)));
+            }
+            // build the trie and
+            // validate that forall Uri u, at most one UriTemplate is a best match for u
+            rootNode = UriTemplateTrieNode.Make(this.templates, allowDuplicateEquivalentUriTemplates);
+        }
+        [Conditional("DEBUG")]
+        void VerifyThatFastPathAndSlowPathHaveSameResults(Uri uri, Collection<string> fastPathRelativePathSegments,
+            IList<UriTemplateTableMatchCandidate> fastPathCandidates)
+        {
+            Collection<string> slowPathRelativePathSegments = new Collection<string>();
+            List<UriTemplateTableMatchCandidate> slowPathCandidates = new List<UriTemplateTableMatchCandidate>();
+            if (!SlowComputeRelativeSegmentsAndLookup(uri, UriTemplateHelpers.GetUriPath(uri),
+                slowPathRelativePathSegments, slowPathCandidates))
+            {
+                Fx.Assert("fast path yielded a result but slow path yielded no result");
+            }
+            // compare results
+            if (fastPathRelativePathSegments.Count != slowPathRelativePathSegments.Count)
+            {
+                Fx.Assert("fast path yielded different number of segments from slow path");
+            }
+            for (int i = 0; i < fastPathRelativePathSegments.Count; ++i)
+            {
+                if (fastPathRelativePathSegments[i] != slowPathRelativePathSegments[i])
+                {
+                    Fx.Assert("fast path yielded different segments from slow path");
+                }
+            }
+            if (fastPathCandidates.Count != slowPathCandidates.Count)
+            {
+                Fx.Assert("fast path yielded different number of candidates from slow path");
+            }
+            for (int i = 0; i < fastPathCandidates.Count; i++)
+            {
+                if (!slowPathCandidates.Contains(fastPathCandidates[i]))
+                {
+                    Fx.Assert("fast path yielded different candidates from slow path");
+                }
+            }
+        }
+
+        class FastPathInfo
+        {
+            FreezableCollection<UriTemplateTableMatchCandidate> candidates;
+            FreezableCollection<string> relativePathSegments;
+
+            public FastPathInfo()
+            {
+                this.relativePathSegments = new FreezableCollection<string>();
+                this.candidates = new FreezableCollection<UriTemplateTableMatchCandidate>();
+            }
+            public Collection<UriTemplateTableMatchCandidate> Candidates
+            {
+                get
+                {
+                    return this.candidates;
+                }
+            }
+
+            public Collection<string> RelativePathSegments
+            {
+                get
+                {
+                    return this.relativePathSegments;
+                }
+            }
+
+            public void Freeze()
+            {
+                this.relativePathSegments.Freeze();
+                this.candidates.Freeze();
+            }
+        }
+
+        class UriTemplatesCollection : FreezableCollection<KeyValuePair<UriTemplate, object>>
+        {
+            public UriTemplatesCollection()
+                : base()
+            {
+            }
+            [SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors", Justification = "This is a private class; virtual methods cannot be overriden")]
+            public UriTemplatesCollection(IEnumerable<KeyValuePair<UriTemplate, object>> keyValuePairs)
+                : base()
+            {
+                foreach (KeyValuePair<UriTemplate, object> kvp in keyValuePairs)
+                {
+                    ThrowIfInvalid(kvp.Key, "keyValuePairs");
+                    base.Add(kvp);
+                }
+            }
+
+            protected override void InsertItem(int index, KeyValuePair<UriTemplate, object> item)
+            {
+                ThrowIfInvalid(item.Key, "item");
+                base.InsertItem(index, item);
+            }
+            protected override void SetItem(int index, KeyValuePair<UriTemplate, object> item)
+            {
+                ThrowIfInvalid(item.Key, "item");
+                base.SetItem(index, item);
+            }
+
+            static void ThrowIfInvalid(UriTemplate template, string argName)
+            {
+                if (template == null)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(argName,
+                        SR.GetString(SR.UTTNullTemplateKey));
+                }
+                if (template.IgnoreTrailingSlash)
+                {
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperArgument(argName,
+                        SR.GetString(SR.UTTInvalidTemplateKey, template));
+                }
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTableMatchCandidate.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTableMatchCandidate.cs
@@ -1,0 +1,42 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    struct UriTemplateTableMatchCandidate
+    {
+        readonly object data;
+        readonly int segmentsCount;
+        readonly UriTemplate template;
+
+        public UriTemplateTableMatchCandidate(UriTemplate template, int segmentsCount, object data)
+        {
+            this.template = template;
+            this.segmentsCount = segmentsCount;
+            this.data = data;
+        }
+        public object Data
+        {
+            get
+            {
+                return this.data;
+            }
+        }
+        public int SegmentsCount
+        {
+            get
+            {
+                return this.segmentsCount;
+            }
+        }
+
+        public UriTemplate Template
+        {
+            get
+            {
+                return this.template;
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTrieIntraNodeLocation.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTrieIntraNodeLocation.cs
@@ -1,0 +1,15 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    enum UriTemplateTrieIntraNodeLocation
+    {
+        BeforeLiteral,
+        AfterLiteral,
+        AfterCompound,
+        AfterVariable,
+    }
+
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTrieLocation.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTrieLocation.cs
@@ -1,0 +1,18 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    class UriTemplateTrieLocation
+    {
+        public UriTemplateTrieIntraNodeLocation locationWithin;
+        public UriTemplateTrieNode node;
+        public UriTemplateTrieLocation(UriTemplateTrieNode n, UriTemplateTrieIntraNodeLocation i)
+        {
+            this.node = n;
+            this.locationWithin = i;
+        }
+    }
+
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTrieNode.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateTrieNode.cs
@@ -1,0 +1,806 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Runtime;
+    using System.ServiceModel;
+
+    class UriTemplateTrieNode
+    {
+        int depth; // relative segment depth (root = 0)
+        UriTemplatePathPartiallyEquivalentSet endOfPath; // matches the non-existent segment at the end of a slash-terminated path
+        AscendingSortedCompoundSegmentsCollection<UriTemplatePathPartiallyEquivalentSet> finalCompoundSegment; // matches e.g. "{var}.{var}"
+        Dictionary<UriTemplateLiteralPathSegment, UriTemplatePathPartiallyEquivalentSet> finalLiteralSegment; // matches e.g. "segmentThatDoesntEndInSlash"
+        UriTemplatePathPartiallyEquivalentSet finalVariableSegment; // matches e.g. "{var}"
+        AscendingSortedCompoundSegmentsCollection<UriTemplateTrieLocation> nextCompoundSegment; // all are AfterLiteral; matches e.g. "{var}.{var}/"
+        Dictionary<UriTemplateLiteralPathSegment, UriTemplateTrieLocation> nextLiteralSegment; // all are BeforeLiteral; matches e.g. "path/"
+        UriTemplateTrieLocation nextVariableSegment; // is BeforeLiteral; matches e.g. "{var}/"
+        UriTemplateTrieLocation onFailure; // points to parent, at 'after me'
+        UriTemplatePathPartiallyEquivalentSet star; // matches any "extra/path/segments" at the end
+
+        UriTemplateTrieNode(int depth)
+        {
+            this.depth = depth;
+            this.nextLiteralSegment = null;
+            this.nextCompoundSegment = null;
+            this.finalLiteralSegment = null;
+            this.finalCompoundSegment = null;
+            this.finalVariableSegment = new UriTemplatePathPartiallyEquivalentSet(depth + 1);
+            this.star = new UriTemplatePathPartiallyEquivalentSet(depth);
+            this.endOfPath = new UriTemplatePathPartiallyEquivalentSet(depth);
+        }
+
+        public static UriTemplateTrieNode Make(IEnumerable<KeyValuePair<UriTemplate, object>> keyValuePairs,
+            bool allowDuplicateEquivalentUriTemplates)
+        {
+            // given a UTT at MakeReadOnly time, build the trie
+            // note that root.onFailure == null;
+            UriTemplateTrieNode root = new UriTemplateTrieNode(0);
+            foreach (KeyValuePair<UriTemplate, object> kvp in keyValuePairs)
+            {
+                Add(root, kvp);
+            }
+            Validate(root, allowDuplicateEquivalentUriTemplates);
+            return root;
+        }
+
+        public bool Match(UriTemplateLiteralPathSegment[] wireData, ICollection<UriTemplateTableMatchCandidate> candidates)
+        {
+            UriTemplateTrieLocation currentLocation = new UriTemplateTrieLocation(this, UriTemplateTrieIntraNodeLocation.BeforeLiteral);
+            return GetMatch(currentLocation, wireData, candidates);
+        }
+
+        static void Add(UriTemplateTrieNode root, KeyValuePair<UriTemplate, object> kvp)
+        {
+            // Currently UTT doesn't support teplates with ignoreTrailingSlash == true; thus we
+            //  don't care about supporting it in the trie as well.
+            UriTemplateTrieNode current = root;
+            UriTemplate ut = kvp.Key;
+            bool needProcessingOnFinalNode = ((ut.segments.Count == 0) || ut.HasWildcard ||
+                ut.segments[ut.segments.Count - 1].EndsWithSlash);
+            for (int i = 0; i < ut.segments.Count; ++i)
+            {
+                if (i >= ut.firstOptionalSegment)
+                {
+                    current.endOfPath.Items.Add(kvp);
+                }
+                UriTemplatePathSegment ps = ut.segments[i];
+                if (!ps.EndsWithSlash)
+                {
+                    Fx.Assert(i == ut.segments.Count - 1, "only the last segment can !EndsWithSlash");
+                    Fx.Assert(!ut.HasWildcard, "path star cannot have !EndsWithSlash");
+                    switch (ps.Nature)
+                    {
+                        case UriTemplatePartType.Literal:
+                            current.AddFinalLiteralSegment(ps as UriTemplateLiteralPathSegment, kvp);
+                            break;
+
+                        case UriTemplatePartType.Compound:
+                            current.AddFinalCompoundSegment(ps as UriTemplateCompoundPathSegment, kvp);
+                            break;
+
+                        case UriTemplatePartType.Variable:
+                            current.finalVariableSegment.Items.Add(kvp);
+                            break;
+
+                        default:
+                            Fx.Assert("Invalid value as PathSegment.Nature");
+                            break;
+                    }
+                }
+                else
+                {
+                    Fx.Assert(ps.EndsWithSlash, "ps.EndsWithSlash");
+                    switch (ps.Nature)
+                    {
+                        case UriTemplatePartType.Literal:
+                            current = current.AddNextLiteralSegment(ps as UriTemplateLiteralPathSegment);
+                            break;
+
+                        case UriTemplatePartType.Compound:
+                            current = current.AddNextCompoundSegment(ps as UriTemplateCompoundPathSegment);
+                            break;
+
+                        case UriTemplatePartType.Variable:
+                            current = current.AddNextVariableSegment();
+                            break;
+
+                        default:
+                            Fx.Assert("Invalid value as PathSegment.Nature");
+                            break;
+                    }
+                }
+            }
+            if (needProcessingOnFinalNode)
+            {
+                // if the last segment ended in a slash, there is still more to do
+                if (ut.HasWildcard)
+                {
+                    // e.g. "path1/path2/*"
+                    current.star.Items.Add(kvp);
+                }
+                else
+                {
+                    // e.g. "path1/path2/"
+                    current.endOfPath.Items.Add(kvp);
+                }
+            }
+        }
+
+        static bool CheckMultipleMatches(IList<IList<UriTemplateTrieLocation>> locationsSet, UriTemplateLiteralPathSegment[] wireData,
+            ICollection<UriTemplateTableMatchCandidate> candidates)
+        {
+            bool result = false;
+            for (int i = 0; ((i < locationsSet.Count) && !result); i++)
+            {
+                for (int j = 0; j < locationsSet[i].Count; j++)
+                {
+                    if (GetMatch(locationsSet[i][j], wireData, candidates))
+                    {
+                        result = true;
+                    }
+                }
+            }
+            return result;
+        }
+        static bool GetMatch(UriTemplateTrieLocation location, UriTemplateLiteralPathSegment[] wireData,
+            ICollection<UriTemplateTableMatchCandidate> candidates)
+        {
+            int initialDepth = location.node.depth;
+            SingleLocationOrLocationsSet nextStep;
+            UriTemplatePathPartiallyEquivalentSet answer;
+            do
+            {
+                if (TryMatch(wireData, location, out answer, out nextStep))
+                {
+                    if (answer != null)
+                    {
+                        for (int i = 0; i < answer.Items.Count; i++)
+                        {
+                            candidates.Add(new UriTemplateTableMatchCandidate(answer.Items[i].Key, answer.SegmentsCount,
+                                answer.Items[i].Value));
+                        }
+                    }
+                    return true;
+                }
+                if (nextStep.IsSingle)
+                {
+                    location = nextStep.SingleLocation;
+                }
+                else
+                {
+                    Fx.Assert(nextStep.LocationsSet != null, "This should be set to a valid value by TryMatch");
+                    if (CheckMultipleMatches(nextStep.LocationsSet, wireData, candidates))
+                    {
+                        return true;
+                    }
+                    location = GetFailureLocationFromLocationsSet(nextStep.LocationsSet);
+                }
+            } while ((location != null) && (location.node.depth >= initialDepth));
+
+            // we walked the whole trie down and found nothing
+            return false;
+        }
+        static bool TryMatch(UriTemplateLiteralPathSegment[] wireUriSegments, UriTemplateTrieLocation currentLocation,
+            out UriTemplatePathPartiallyEquivalentSet success, out SingleLocationOrLocationsSet nextStep)
+        {
+            // if returns true, success is set to answer
+            // if returns false, nextStep is set to next place to look
+            success = null;
+            nextStep = new SingleLocationOrLocationsSet();
+
+            if (wireUriSegments.Length <= currentLocation.node.depth)
+            {
+                Fx.Assert(wireUriSegments.Length == 0 || wireUriSegments[wireUriSegments.Length - 1].EndsWithSlash,
+                    "we should not have traversed this deep into the trie unless the wire path ended in a slash");
+
+                if (currentLocation.node.endOfPath.Items.Count != 0)
+                {
+                    // exact match of e.g. "path1/path2/"
+                    success = currentLocation.node.endOfPath;
+                    return true;
+                }
+                else if (currentLocation.node.star.Items.Count != 0)
+                {
+                    // inexact match of e.g. WIRE("path1/path2/") against TEMPLATE("path1/path2/*")
+                    success = currentLocation.node.star;
+                    return true;
+                }
+                else
+                {
+                    nextStep = new SingleLocationOrLocationsSet(currentLocation.node.onFailure);
+                    return false;
+                }
+            }
+            else
+            {
+                UriTemplateLiteralPathSegment curWireSeg = wireUriSegments[currentLocation.node.depth];
+                bool considerLiteral = false;
+                bool considerCompound = false;
+                bool considerVariable = false;
+                bool considerStar = false;
+                switch (currentLocation.locationWithin)
+                {
+                    case UriTemplateTrieIntraNodeLocation.BeforeLiteral:
+                        considerLiteral = true;
+                        considerCompound = true;
+                        considerVariable = true;
+                        considerStar = true;
+                        break;
+                    case UriTemplateTrieIntraNodeLocation.AfterLiteral:
+                        considerLiteral = false;
+                        considerCompound = true;
+                        considerVariable = true;
+                        considerStar = true;
+                        break;
+                    case UriTemplateTrieIntraNodeLocation.AfterCompound:
+                        considerLiteral = false;
+                        considerCompound = false;
+                        considerVariable = true;
+                        considerStar = true;
+                        break;
+                    case UriTemplateTrieIntraNodeLocation.AfterVariable:
+                        considerLiteral = false;
+                        considerCompound = false;
+                        considerVariable = false;
+                        considerStar = true;
+                        break;
+                    default:
+                        Fx.Assert("bad kind");
+                        break;
+                }
+                if (curWireSeg.EndsWithSlash)
+                {
+                    IList<IList<UriTemplateTrieLocation>> compoundLocationsSet;
+
+                    if (considerLiteral && currentLocation.node.nextLiteralSegment != null &&
+                        currentLocation.node.nextLiteralSegment.ContainsKey(curWireSeg))
+                    {
+                        nextStep = new SingleLocationOrLocationsSet(currentLocation.node.nextLiteralSegment[curWireSeg]);
+                        return false;
+                    }
+                    else if (considerCompound && currentLocation.node.nextCompoundSegment != null &&
+                        AscendingSortedCompoundSegmentsCollection<UriTemplateTrieLocation>.Lookup(currentLocation.node.nextCompoundSegment, curWireSeg, out compoundLocationsSet))
+                    {
+                        nextStep = new SingleLocationOrLocationsSet(compoundLocationsSet);
+                        return false;
+                    }
+                    else if (considerVariable && currentLocation.node.nextVariableSegment != null &&
+                        !curWireSeg.IsNullOrEmpty())
+                    {
+                        nextStep = new SingleLocationOrLocationsSet(currentLocation.node.nextVariableSegment);
+                        return false;
+                    }
+                    else if (considerStar && currentLocation.node.star.Items.Count != 0)
+                    {
+                        // matches e.g. WIRE("path1/path2/path3") and TEMPLATE("path1/*")
+                        success = currentLocation.node.star;
+                        return true;
+                    }
+                    else
+                    {
+                        nextStep = new SingleLocationOrLocationsSet(currentLocation.node.onFailure);
+                        return false;
+                    }
+                }
+                else
+                {
+                    IList<IList<UriTemplatePathPartiallyEquivalentSet>> compoundPathEquivalentSets;
+
+                    Fx.Assert(!curWireSeg.EndsWithSlash, "!curWireSeg.EndsWithSlash");
+                    Fx.Assert(!curWireSeg.IsNullOrEmpty(), "!curWireSeg.IsNullOrEmpty()");
+                    if (considerLiteral && currentLocation.node.finalLiteralSegment != null &&
+                        currentLocation.node.finalLiteralSegment.ContainsKey(curWireSeg))
+                    {
+                        // matches e.g. WIRE("path1/path2") and TEMPLATE("path1/path2")
+                        success = currentLocation.node.finalLiteralSegment[curWireSeg];
+                        return true;
+                    }
+                    else if (considerCompound && currentLocation.node.finalCompoundSegment != null &&
+                        AscendingSortedCompoundSegmentsCollection<UriTemplatePathPartiallyEquivalentSet>.Lookup(currentLocation.node.finalCompoundSegment, curWireSeg, out compoundPathEquivalentSets))
+                    {
+                        // matches e.g. WIRE("path1/path2") and TEMPLATE("path1/p{var}th2")
+                        // we should take only the highest order match!
+                        Fx.Assert(compoundPathEquivalentSets.Count >= 1, "Lookup is expected to return false otherwise");
+                        Fx.Assert(compoundPathEquivalentSets[0].Count > 0, "Find shouldn't return empty sublists");
+                        if (compoundPathEquivalentSets[0].Count == 1)
+                        {
+                            success = compoundPathEquivalentSets[0][0];
+                        }
+                        else
+                        {
+                            success = new UriTemplatePathPartiallyEquivalentSet(currentLocation.node.depth + 1);
+                            for (int i = 0; i < compoundPathEquivalentSets[0].Count; i++)
+                            {
+                                success.Items.AddRange(compoundPathEquivalentSets[0][i].Items);
+                            }
+                        }
+                        return true;
+                    }
+                    else if (considerVariable && currentLocation.node.finalVariableSegment.Items.Count != 0)
+                    {
+                        // matches e.g. WIRE("path1/path2") and TEMPLATE("path1/{var}")
+                        success = currentLocation.node.finalVariableSegment;
+                        return true;
+                    }
+                    else if (considerStar && currentLocation.node.star.Items.Count != 0)
+                    {
+                        // matches e.g. WIRE("path1/path2") and TEMPLATE("path1/*")
+                        success = currentLocation.node.star;
+                        return true;
+                    }
+                    else
+                    {
+                        nextStep = new SingleLocationOrLocationsSet(currentLocation.node.onFailure);
+                        return false;
+                    }
+                }
+            }
+        }
+
+        static UriTemplateTrieLocation GetFailureLocationFromLocationsSet(IList<IList<UriTemplateTrieLocation>> locationsSet)
+        {
+            Fx.Assert(locationsSet != null, "Shouldn't be called on null set");
+            Fx.Assert(locationsSet.Count > 0, "Shouldn't be called on empty set");
+            Fx.Assert(locationsSet[0] != null, "Shouldn't be called on a set with null sub-lists");
+            Fx.Assert(locationsSet[0].Count > 0, "Shouldn't be called on a set with empty sub-lists");
+
+            return locationsSet[0][0].node.onFailure;
+        }
+
+        static void Validate(UriTemplateTrieNode root, bool allowDuplicateEquivalentUriTemplates)
+        {
+            // walk the entire tree, and ensure that each PathEquivalentSet is ok (no ambiguous queries),
+            // verify thst compound segments didn't add potentialy multiple matchs;
+            // also Assert various data-structure invariants
+            Queue<UriTemplateTrieNode> nodesQueue = new Queue<UriTemplateTrieNode>();
+
+            UriTemplateTrieNode current = root;
+            while (true)
+            {
+                // validate all the PathEquivalentSets that live in this node
+                Validate(current.endOfPath, allowDuplicateEquivalentUriTemplates);
+                Validate(current.finalVariableSegment, allowDuplicateEquivalentUriTemplates);
+                Validate(current.star, allowDuplicateEquivalentUriTemplates);
+                if (current.finalLiteralSegment != null)
+                {
+                    foreach (KeyValuePair<UriTemplateLiteralPathSegment, UriTemplatePathPartiallyEquivalentSet> kvp in current.finalLiteralSegment)
+                    {
+                        Validate(kvp.Value, allowDuplicateEquivalentUriTemplates);
+                    }
+                }
+                if (current.finalCompoundSegment != null)
+                {
+                    IList<IList<UriTemplatePathPartiallyEquivalentSet>> pesLists = current.finalCompoundSegment.Values;
+                    for (int i = 0; i < pesLists.Count; i++)
+                    {
+                        if (!allowDuplicateEquivalentUriTemplates && (pesLists[i].Count > 1))
+                        {
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                                SR.UTTDuplicate, pesLists[i][0].Items[0].Key.ToString(), pesLists[i][1].Items[0].Key.ToString())));
+                        }
+                        for (int j = 0; j < pesLists[i].Count; j++)
+                        {
+                            Validate(pesLists[i][j], allowDuplicateEquivalentUriTemplates);
+                        }
+                    }
+                }
+                // deal with children of this node
+                if (current.nextLiteralSegment != null)
+                {
+                    foreach (KeyValuePair<UriTemplateLiteralPathSegment, UriTemplateTrieLocation> kvp in current.nextLiteralSegment)
+                    {
+                        Fx.Assert(kvp.Value.locationWithin == UriTemplateTrieIntraNodeLocation.BeforeLiteral, "forward-pointers should always point to a BeforeLiteral location");
+                        Fx.Assert(kvp.Value.node.depth == current.depth + 1, "kvp.Value.node.depth == current.depth + 1");
+                        Fx.Assert(kvp.Value.node.onFailure.node == current, "back pointer should point back to here");
+                        Fx.Assert(kvp.Value.node.onFailure.locationWithin == UriTemplateTrieIntraNodeLocation.AfterLiteral, "back-pointer should be AfterLiteral");
+                        nodesQueue.Enqueue(kvp.Value.node);
+                    }
+                }
+                if (current.nextCompoundSegment != null)
+                {
+                    IList<IList<UriTemplateTrieLocation>> locations = current.nextCompoundSegment.Values;
+                    for (int i = 0; i < locations.Count; i++)
+                    {
+                        if (!allowDuplicateEquivalentUriTemplates && (locations[i].Count > 1))
+                        {
+                            // In the future we might ease up the restrictions and verify if there is realy
+                            // a potential multiple match here; for now we are throwing.
+                            UriTemplate firstTemplate = FindAnyUriTemplate(locations[i][0].node);
+                            UriTemplate secondTemplate = FindAnyUriTemplate(locations[i][1].node);
+                            throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidOperationException(SR.GetString(
+                                SR.UTTDuplicate, firstTemplate.ToString(), secondTemplate.ToString())));
+                        }
+                        for (int j = 0; j < locations[i].Count; j++)
+                        {
+                            UriTemplateTrieLocation location = locations[i][j];
+                            Fx.Assert(location.locationWithin == UriTemplateTrieIntraNodeLocation.BeforeLiteral, "forward-pointers should always point to a BeforeLiteral location");
+                            Fx.Assert(location.node.depth == current.depth + 1, "kvp.Value.node.depth == current.depth + 1");
+                            Fx.Assert(location.node.onFailure.node == current, "back pointer should point back to here");
+                            Fx.Assert(location.node.onFailure.locationWithin == UriTemplateTrieIntraNodeLocation.AfterCompound, "back-pointer should be AfterCompound");
+                            nodesQueue.Enqueue(location.node);
+                        }
+                    }
+                }
+                if (current.nextVariableSegment != null)
+                {
+                    Fx.Assert(current.nextVariableSegment.locationWithin == UriTemplateTrieIntraNodeLocation.BeforeLiteral, "forward-pointers should always point to a BeforeLiteral location");
+                    Fx.Assert(current.nextVariableSegment.node.depth == current.depth + 1, "current.nextVariableSegment.node.depth == current.depth + 1");
+                    Fx.Assert(current.nextVariableSegment.node.onFailure.node == current, "back pointer should point back to here");
+                    Fx.Assert(current.nextVariableSegment.node.onFailure.locationWithin == UriTemplateTrieIntraNodeLocation.AfterVariable, "back-pointer should be AfterVariable");
+                    nodesQueue.Enqueue(current.nextVariableSegment.node);
+                }
+                // move on to next bit of work
+                if (nodesQueue.Count == 0)
+                {
+                    break;
+                }
+                current = nodesQueue.Dequeue();
+            }
+        }
+        static void Validate(UriTemplatePathPartiallyEquivalentSet pes, bool allowDuplicateEquivalentUriTemplates)
+        {
+            // A set with 0 or 1 items is valid by definition
+            if (pes.Items.Count < 2)
+            {
+                return;
+            }
+            // Assert all paths are partially-equivalent
+            for (int i = 0; i < pes.Items.Count - 1; ++i)
+            {
+                Fx.Assert(pes.Items[i].Key.IsPathPartiallyEquivalentAt(pes.Items[i + 1].Key, pes.SegmentsCount),
+                    "all elements of a PES must be path partially-equivalent");
+            }
+            // We will check that the queries disambiguate only for templates, which are
+            //  matched completely at the segments count; templates, which are match at
+            //  that point due to terminal defaults, will be ruled out.
+            UriTemplate[] a = new UriTemplate[pes.Items.Count];
+            int arrayIndex = 0;
+            foreach (KeyValuePair<UriTemplate, object> kvp in pes.Items)
+            {
+                if (pes.SegmentsCount < kvp.Key.segments.Count)
+                {
+                    continue;
+                }
+                Fx.Assert(arrayIndex < a.Length, "We made enough room for all the items");
+                a[arrayIndex++] = kvp.Key;
+            }
+            // Ensure that queries disambiguate (if needed) :
+            if (arrayIndex > 0)
+            {
+                UriTemplateHelpers.DisambiguateSamePath(a, 0, arrayIndex, allowDuplicateEquivalentUriTemplates);
+            }
+        }
+
+        static UriTemplate FindAnyUriTemplate(UriTemplateTrieNode node)
+        {
+            while (node != null)
+            {
+                if (node.endOfPath.Items.Count > 0)
+                {
+                    return node.endOfPath.Items[0].Key;
+                }
+                if (node.finalVariableSegment.Items.Count > 0)
+                {
+                    return node.finalVariableSegment.Items[0].Key;
+                }
+                if (node.star.Items.Count > 0)
+                {
+                    return node.star.Items[0].Key;
+                }
+                if (node.finalLiteralSegment != null)
+                {
+                    UriTemplatePathPartiallyEquivalentSet pes =
+                        GetAnyDictionaryValue<UriTemplatePathPartiallyEquivalentSet>(node.finalLiteralSegment);
+                    Fx.Assert(pes.Items.Count > 0, "Otherwise, why creating the dictionary?");
+                    return pes.Items[0].Key;
+                }
+                if (node.finalCompoundSegment != null)
+                {
+                    UriTemplatePathPartiallyEquivalentSet pes = node.finalCompoundSegment.GetAnyValue();
+                    Fx.Assert(pes.Items.Count > 0, "Otherwise, why creating the collection?");
+                    return pes.Items[0].Key;
+                }
+
+                if (node.nextLiteralSegment != null)
+                {
+                    UriTemplateTrieLocation location =
+                        GetAnyDictionaryValue<UriTemplateTrieLocation>(node.nextLiteralSegment);
+                    node = location.node;
+                }
+                else if (node.nextCompoundSegment != null)
+                {
+                    UriTemplateTrieLocation location = node.nextCompoundSegment.GetAnyValue();
+                    node = location.node;
+                }
+                else if (node.nextVariableSegment != null)
+                {
+                    node = node.nextVariableSegment.node;
+                }
+                else
+                {
+                    node = null;
+                }
+            }
+            Fx.Assert("How did we got here without finding a UriTemplate earlier?");
+            return null;
+        }
+        static T GetAnyDictionaryValue<T>(IDictionary<UriTemplateLiteralPathSegment, T> dictionary)
+        {
+            using (IEnumerator<T> valuesEnumerator = dictionary.Values.GetEnumerator())
+            {
+                valuesEnumerator.MoveNext();
+                return valuesEnumerator.Current;
+            }
+        }
+
+        void AddFinalCompoundSegment(UriTemplateCompoundPathSegment cps, KeyValuePair<UriTemplate, object> kvp)
+        {
+            Fx.Assert(cps != null, "must be - based on the segment nature");
+            if (this.finalCompoundSegment == null)
+            {
+                this.finalCompoundSegment = new AscendingSortedCompoundSegmentsCollection<UriTemplatePathPartiallyEquivalentSet>();
+            }
+            UriTemplatePathPartiallyEquivalentSet pes = this.finalCompoundSegment.Find(cps);
+            if (pes == null)
+            {
+                pes = new UriTemplatePathPartiallyEquivalentSet(this.depth + 1);
+                this.finalCompoundSegment.Add(cps, pes);
+            }
+            pes.Items.Add(kvp);
+        }
+        void AddFinalLiteralSegment(UriTemplateLiteralPathSegment lps, KeyValuePair<UriTemplate, object> kvp)
+        {
+            Fx.Assert(lps != null, "must be - based on the segment nature");
+            if (this.finalLiteralSegment != null && this.finalLiteralSegment.ContainsKey(lps))
+            {
+                this.finalLiteralSegment[lps].Items.Add(kvp);
+            }
+            else
+            {
+                if (this.finalLiteralSegment == null)
+                {
+                    this.finalLiteralSegment = new Dictionary<UriTemplateLiteralPathSegment, UriTemplatePathPartiallyEquivalentSet>();
+                }
+                UriTemplatePathPartiallyEquivalentSet pes = new UriTemplatePathPartiallyEquivalentSet(this.depth + 1);
+                pes.Items.Add(kvp);
+                this.finalLiteralSegment.Add(lps, pes);
+            }
+        }
+        UriTemplateTrieNode AddNextCompoundSegment(UriTemplateCompoundPathSegment cps)
+        {
+            Fx.Assert(cps != null, "must be - based on the segment nature");
+            if (this.nextCompoundSegment == null)
+            {
+                this.nextCompoundSegment = new AscendingSortedCompoundSegmentsCollection<UriTemplateTrieLocation>();
+            }
+            UriTemplateTrieLocation nextLocation = this.nextCompoundSegment.Find(cps);
+            if (nextLocation == null)
+            {
+                UriTemplateTrieNode nextNode = new UriTemplateTrieNode(this.depth + 1);
+                nextNode.onFailure = new UriTemplateTrieLocation(this, UriTemplateTrieIntraNodeLocation.AfterCompound);
+                nextLocation = new UriTemplateTrieLocation(nextNode, UriTemplateTrieIntraNodeLocation.BeforeLiteral);
+                this.nextCompoundSegment.Add(cps, nextLocation);
+            }
+            return nextLocation.node;
+        }
+        UriTemplateTrieNode AddNextLiteralSegment(UriTemplateLiteralPathSegment lps)
+        {
+            Fx.Assert(lps != null, "must be - based on the segment nature");
+            if (this.nextLiteralSegment != null && this.nextLiteralSegment.ContainsKey(lps))
+            {
+                return this.nextLiteralSegment[lps].node;
+            }
+            else
+            {
+                if (this.nextLiteralSegment == null)
+                {
+                    this.nextLiteralSegment = new Dictionary<UriTemplateLiteralPathSegment, UriTemplateTrieLocation>();
+                }
+                UriTemplateTrieNode newNode = new UriTemplateTrieNode(this.depth + 1);
+                newNode.onFailure = new UriTemplateTrieLocation(this, UriTemplateTrieIntraNodeLocation.AfterLiteral);
+                this.nextLiteralSegment.Add(lps, new UriTemplateTrieLocation(newNode, UriTemplateTrieIntraNodeLocation.BeforeLiteral));
+                return newNode;
+            }
+        }
+        UriTemplateTrieNode AddNextVariableSegment()
+        {
+            if (this.nextVariableSegment != null)
+            {
+                return this.nextVariableSegment.node;
+            }
+            else
+            {
+                UriTemplateTrieNode newNode = new UriTemplateTrieNode(this.depth + 1);
+                newNode.onFailure = new UriTemplateTrieLocation(this, UriTemplateTrieIntraNodeLocation.AfterVariable);
+                this.nextVariableSegment = new UriTemplateTrieLocation(newNode, UriTemplateTrieIntraNodeLocation.BeforeLiteral);
+                return newNode;
+            }
+        }
+
+        struct SingleLocationOrLocationsSet
+        {
+            readonly bool isSingle;
+            readonly IList<IList<UriTemplateTrieLocation>> locationsSet;
+            readonly UriTemplateTrieLocation singleLocation;
+
+            public SingleLocationOrLocationsSet(UriTemplateTrieLocation singleLocation)
+            {
+                this.isSingle = true;
+                this.singleLocation = singleLocation;
+                this.locationsSet = null;
+            }
+            public SingleLocationOrLocationsSet(IList<IList<UriTemplateTrieLocation>> locationsSet)
+            {
+                this.isSingle = false;
+                this.singleLocation = null;
+                this.locationsSet = locationsSet;
+            }
+
+            public bool IsSingle
+            {
+                get
+                {
+                    return this.isSingle;
+                }
+            }
+            public IList<IList<UriTemplateTrieLocation>> LocationsSet
+            {
+                get
+                {
+                    Fx.Assert(!this.isSingle, "!this.isSingle");
+                    return this.locationsSet;
+                }
+            }
+            public UriTemplateTrieLocation SingleLocation
+            {
+                get
+                {
+                    Fx.Assert(this.isSingle, "this.isSingle");
+                    return this.singleLocation;
+                }
+            }
+        }
+
+        class AscendingSortedCompoundSegmentsCollection<T>
+            where T : class
+        {
+            SortedList<UriTemplateCompoundPathSegment, Collection<CollectionItem>> items;
+
+            public AscendingSortedCompoundSegmentsCollection()
+            {
+                this.items = new SortedList<UriTemplateCompoundPathSegment, Collection<AscendingSortedCompoundSegmentsCollection<T>.CollectionItem>>();
+            }
+
+            public IList<IList<T>> Values
+            {
+                get
+                {
+                    IList<IList<T>> results = new List<IList<T>>(this.items.Count);
+                    for (int i = 0; i < this.items.Values.Count; i++)
+                    {
+                        results.Add(new List<T>(this.items.Values[i].Count));
+                        Fx.Assert(results.Count == i + 1, "We are adding item for each values collection");
+                        for (int j = 0; j < this.items.Values[i].Count; j++)
+                        {
+                            results[i].Add(this.items.Values[i][j].Value);
+                            Fx.Assert(results[i].Count == j + 1, "We are adding item for each value in the collection");
+                        }
+                        Fx.Assert(results[i].Count == this.items.Values[i].Count, "We were supposed to add an item for each value in the collection");
+                    }
+                    Fx.Assert(results.Count == this.items.Values.Count, "We were supposed to add a sub-list for each values collection");
+                    return results;
+                }
+            }
+
+            public void Add(UriTemplateCompoundPathSegment segment, T value)
+            {
+                int index = this.items.IndexOfKey(segment);
+                if (index == -1)
+                {
+                    Collection<CollectionItem> subItems = new Collection<CollectionItem>();
+                    subItems.Add(new CollectionItem(segment, value));
+                    this.items.Add(segment, subItems);
+                }
+                else
+                {
+                    Collection<CollectionItem> subItems = this.items.Values[index];
+                    subItems.Add(new CollectionItem(segment, value));
+                }
+            }
+
+            public T Find(UriTemplateCompoundPathSegment segment)
+            {
+                int index = this.items.IndexOfKey(segment);
+                if (index == -1)
+                {
+                    return null;
+                }
+                Collection<CollectionItem> subItems = this.items.Values[index];
+                for (int i = 0; i < subItems.Count; i++)
+                {
+                    if (subItems[i].Segment.IsEquivalentTo(segment, false))
+                    {
+                        return subItems[i].Value;
+                    }
+                }
+                return null;
+            }
+            public IList<IList<T>> Find(UriTemplateLiteralPathSegment wireData)
+            {
+                IList<IList<T>> results = new List<IList<T>>();
+                for (int i = 0; i < this.items.Values.Count; i++)
+                {
+                    List<T> sameOrderResults = null;
+                    for (int j = 0; j < this.items.Values[i].Count; j++)
+                    {
+                        if (this.items.Values[i][j].Segment.IsMatch(wireData))
+                        {
+                            if (sameOrderResults == null)
+                            {
+                                sameOrderResults = new List<T>();
+                            }
+                            sameOrderResults.Add(this.items.Values[i][j].Value);
+                        }
+                    }
+                    if (sameOrderResults != null)
+                    {
+                        results.Add(sameOrderResults);
+                    }
+                }
+                return results;
+            }
+
+            public T GetAnyValue()
+            {
+                if (this.items.Values.Count > 0)
+                {
+                    Fx.Assert(this.items.Values[0].Count > 0, "We are not adding a sub-list unless there is at list one item");
+                    return this.items.Values[0][0].Value;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            public static bool Lookup(AscendingSortedCompoundSegmentsCollection<T> collection,
+                UriTemplateLiteralPathSegment wireData, out IList<IList<T>> results)
+            {
+                results = collection.Find(wireData);
+                return ((results != null) && (results.Count > 0));
+            }
+
+            struct CollectionItem
+            {
+                UriTemplateCompoundPathSegment segment;
+                T value;
+
+                public CollectionItem(UriTemplateCompoundPathSegment segment, T value)
+                {
+                    this.segment = segment;
+                    this.value = value;
+                }
+
+                public UriTemplateCompoundPathSegment Segment
+                {
+                    get
+                    {
+                        return this.segment;
+                    }
+                }
+                public T Value
+                {
+                    get
+                    {
+                        return this.value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateVariablePathSegment.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateVariablePathSegment.cs
@@ -1,0 +1,69 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Specialized;
+    using System.Runtime;
+    using System.Text;
+
+    class UriTemplateVariablePathSegment : UriTemplatePathSegment
+    {
+        readonly string varName;
+
+        public UriTemplateVariablePathSegment(string originalSegment, bool endsWithSlash, string varName)
+            : base(originalSegment, UriTemplatePartType.Variable, endsWithSlash)
+        {
+            Fx.Assert(!string.IsNullOrEmpty(varName), "bad variable segment");
+            this.varName = varName;
+        }
+
+        public string VarName
+        {
+            get
+            {
+                return this.varName;
+            }
+        }
+        public override void Bind(string[] values, ref int valueIndex, StringBuilder path)
+        {
+            Fx.Assert(valueIndex < values.Length, "Not enough values to bind");
+            if (this.EndsWithSlash)
+            {
+                path.AppendFormat("{0}/", values[valueIndex++]);
+            }
+            else
+            {
+                path.Append(values[valueIndex++]);
+            }
+        }
+
+        public override bool IsEquivalentTo(UriTemplatePathSegment other, bool ignoreTrailingSlash)
+        {
+            if (other == null)
+            {
+                Fx.Assert("why would we ever call this?");
+                return false;
+            }
+            if (!ignoreTrailingSlash && (this.EndsWithSlash != other.EndsWithSlash))
+            {
+                return false;
+            }
+            return (other.Nature == UriTemplatePartType.Variable);
+        }
+        public override bool IsMatch(UriTemplateLiteralPathSegment segment, bool ignoreTrailingSlash)
+        {
+            if (!ignoreTrailingSlash && (this.EndsWithSlash != segment.EndsWithSlash))
+            {
+                return false;
+            }
+            return (!segment.IsNullOrEmpty());
+        }
+        public override void Lookup(string segment, NameValueCollection boundParameters)
+        {
+            Fx.Assert(!string.IsNullOrEmpty(segment), "How can that be? Lookup is expected to be called after IsMatch");
+            boundParameters.Add(this.varName, segment);
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateVariableQueryValue.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/UriTemplateVariableQueryValue.cs
@@ -1,0 +1,49 @@
+//----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//----------------------------------------------------------------
+
+namespace System
+{
+    using System.Collections.Specialized;
+    using System.Runtime;
+    using System.ServiceModel.Channels;
+    using System.Text;
+
+    class UriTemplateVariableQueryValue : UriTemplateQueryValue
+    {
+        readonly string varName;
+
+        public UriTemplateVariableQueryValue(string varName)
+            : base(UriTemplatePartType.Variable)
+        {
+            Fx.Assert(!string.IsNullOrEmpty(varName), "bad variable segment");
+            this.varName = varName;
+        }
+        public override void Bind(string keyName, string[] values, ref int valueIndex, StringBuilder query)
+        {
+            Fx.Assert(valueIndex < values.Length, "Not enough values to bind");
+            if (values[valueIndex] == null)
+            {
+                valueIndex++;
+            }
+            else
+            {
+                query.AppendFormat("&{0}={1}", UrlUtility.UrlEncode(keyName, Encoding.UTF8), UrlUtility.UrlEncode(values[valueIndex++], Encoding.UTF8));
+            }
+        }
+
+        public override bool IsEquivalentTo(UriTemplateQueryValue other)
+        {
+            if (other == null)
+            {
+                Fx.Assert("why would we ever call this?");
+                return false;
+            }
+            return (other.Nature == UriTemplatePartType.Variable);
+        }
+        public override void Lookup(string value, NameValueCollection boundParameters)
+        {
+            boundParameters.Add(this.varName, value);
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/DiagnosticUtility.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/DiagnosticUtility.cs
@@ -1,0 +1,18 @@
+
+namespace System.ServiceModel {
+	internal sealed class DiagnosticUtility {
+		internal sealed class ExceptionUtility {
+			internal static Exception ThrowHelperArgumentNull(string paramName) {
+				throw new ArgumentNullException(paramName);
+			}
+
+			internal static Exception ThrowHelperArgument(string paramName, string message) {
+				throw new ArgumentException(message, paramName);
+			}
+
+			internal static Exception ThrowHelperError(Exception exception) {
+				throw exception;
+			}
+		}
+	}
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/Fx.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/Fx.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics;
+
+namespace System.Runtime {
+	internal sealed class Fx {
+		internal static void Assert(bool condition, string message) {
+			Debug.Assert(condition, message);
+		}
+
+		internal static void Assert(string message) {
+			Debug.Assert(false, message);
+		}
+
+		internal static class Exception {
+			public static System.Exception ArgumentNull(string paramName) {
+				throw new ArgumentNullException(paramName);
+			}
+		}
+	}
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/SR.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/SR.cs
@@ -1,0 +1,135 @@
+namespace System.ServiceModel
+{
+	using System.Globalization;
+    using System.Resources;
+    using System.Threading;
+
+    internal sealed class SR
+    {
+	    internal const string BindUriTemplateToNullOrEmptyPathParam = "BindUriTemplateToNullOrEmptyPathParam";
+	    internal const string ObjectIsReadOnly = "ObjectIsReadOnly";
+        internal const string UTAdditionalDefaultIsInvalid = "UTAdditionalDefaultIsInvalid";
+        internal const string UTBadBaseAddress = "UTBadBaseAddress";
+        internal const string UTBindByNameCalledWithEmptyKey = "UTBindByNameCalledWithEmptyKey";
+        internal const string UTBindByPositionNoVariables = "UTBindByPositionNoVariables";
+        internal const string UTBindByPositionWrongCount = "UTBindByPositionWrongCount";
+        internal const string UTBothLiteralAndNameValueCollectionKey = "UTBothLiteralAndNameValueCollectionKey";
+        internal const string UTCSRLookupBeforeMatch = "UTCSRLookupBeforeMatch";
+        internal const string UTDefaultValuesAreImmutable = "UTDefaultValuesAreImmutable";
+        internal const string UTDefaultValueToCompoundSegmentVar = "UTDefaultValueToCompoundSegmentVar";
+        internal const string UTDefaultValueToCompoundSegmentVarFromAdditionalDefaults = "UTDefaultValueToCompoundSegmentVarFromAdditionalDefaults";
+        internal const string UTDefaultValueToQueryVar = "UTDefaultValueToQueryVar";
+        internal const string UTDefaultValueToQueryVarFromAdditionalDefaults = "UTDefaultValueToQueryVarFromAdditionalDefaults";
+        internal const string UTDoesNotSupportAdjacentVarsInCompoundSegment = "UTDoesNotSupportAdjacentVarsInCompoundSegment";
+        internal const string UTInvalidDefaultPathValue = "UTInvalidDefaultPathValue";
+        internal const string UTInvalidFormatSegmentOrQueryPart = "UTInvalidFormatSegmentOrQueryPart";
+        internal const string UTInvalidVarDeclaration = "UTInvalidVarDeclaration";
+        internal const string UTInvalidWildcardInVariableOrLiteral = "UTInvalidWildcardInVariableOrLiteral";
+        internal const string UTNullableDefaultAtAdditionalDefaults = "UTNullableDefaultAtAdditionalDefaults";
+        internal const string UTNullableDefaultMustBeFollowedWithNullables = "UTNullableDefaultMustBeFollowedWithNullables";
+        internal const string UTNullableDefaultMustNotBeFollowedWithLiteral = "UTNullableDefaultMustNotBeFollowedWithLiteral";
+        internal const string UTNullableDefaultMustNotBeFollowedWithWildcard = "UTNullableDefaultMustNotBeFollowedWithWildcard";
+        internal const string UTQueryCannotEndInAmpersand = "UTQueryCannotEndInAmpersand";
+        internal const string UTQueryCannotHaveCompoundValue = "UTQueryCannotHaveCompoundValue";
+        internal const string UTQueryCannotHaveEmptyName = "UTQueryCannotHaveEmptyName";
+        internal const string UTQueryMustHaveLiteralNames = "UTQueryMustHaveLiteralNames";
+        internal const string UTQueryNamesMustBeUnique = "UTQueryNamesMustBeUnique";
+        internal const string UTStarVariableWithDefaults = "UTStarVariableWithDefaults";
+        internal const string UTStarVariableWithDefaultsFromAdditionalDefaults = "UTStarVariableWithDefaultsFromAdditionalDefaults";
+        internal const string UTTAmbiguousQueries = "UTTAmbiguousQueries";
+        internal const string UTTBaseAddressMustBeAbsolute = "UTTBaseAddressMustBeAbsolute";
+        internal const string UTTBaseAddressNotSet = "UTTBaseAddressNotSet";
+        internal const string UTTCannotChangeBaseAddress = "UTTCannotChangeBaseAddress";
+        internal const string UTTDuplicate = "UTTDuplicate";
+        internal const string UTTEmptyKeyValuePairs = "UTTEmptyKeyValuePairs";
+        internal const string UTTInvalidTemplateKey = "UTTInvalidTemplateKey";
+        internal const string UTTMultipleMatches = "UTTMultipleMatches";
+        internal const string UTTMustBeAbsolute = "UTTMustBeAbsolute";
+        internal const string UTTNullTemplateKey = "UTTNullTemplateKey";
+        internal const string UTTOtherAmbiguousQueries = "UTTOtherAmbiguousQueries";
+        internal const string UTVarNamesMustBeUnique = "UTVarNamesMustBeUnique";
+
+        private ResourceManager resources;
+        private static System.ServiceModel.SR loader;
+
+        internal SR()
+        {
+            this.resources = new ResourceManager("System.ServiceModel", base.GetType().Assembly);
+        }
+
+        private static System.ServiceModel.SR GetLoader()
+        {
+            if (loader == null)
+            {
+                System.ServiceModel.SR sr = new System.ServiceModel.SR();
+                Interlocked.CompareExchange<System.ServiceModel.SR>(ref loader, sr, null);
+            }
+            return loader;
+        }
+
+        public static object GetObject(string name)
+        {
+            System.ServiceModel.SR loader = GetLoader();
+            if (loader == null)
+            {
+                return null;
+            }
+            return loader.resources.GetObject(name, Culture);
+        }
+
+        public static string GetString(string name)
+        {
+            System.ServiceModel.SR loader = GetLoader();
+            if (loader == null)
+            {
+                return null;
+            }
+            return loader.resources.GetString(name, Culture);
+        }
+
+        public static string GetString(string name, params object[] args)
+        {
+            System.ServiceModel.SR loader = GetLoader();
+            if (loader == null)
+            {
+                return null;
+            }
+            string format = loader.resources.GetString(name, Culture);
+            if ((args == null) || (args.Length <= 0))
+            {
+                return format;
+            }
+            for (int i = 0; i < args.Length; i++)
+            {
+                string str2 = args[i] as string;
+                if ((str2 != null) && (str2.Length > 0x400))
+                {
+                    args[i] = str2.Substring(0, 0x3fd) + "...";
+                }
+            }
+            return string.Format(CultureInfo.CurrentCulture, format, args);
+        }
+
+        public static string GetString(string name, out bool usedFallback)
+        {
+            usedFallback = false;
+            return GetString(name);
+        }
+
+        private static CultureInfo Culture
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public static ResourceManager Resources
+        {
+            get
+            {
+                return GetLoader().resources;
+            }
+        }
+    }
+}

--- a/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/UrlUtility.cs
+++ b/src/EventStore.NETCore.Compatibility/System.UriTemplate/stubs/UrlUtility.cs
@@ -1,0 +1,634 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.Runtime
+{
+    using System.Collections;
+    using System.Collections.Specialized;
+    using System.Runtime.Serialization;
+    using System.Text;
+
+    //copied from System.Web.HttpUtility code (renamed here) to remove dependency on System.Web.dll
+    internal sealed class UrlUtility
+    {
+        //  Query string parsing support
+        public static NameValueCollection ParseQueryString(string query)
+        {
+            return ParseQueryString(query, Encoding.UTF8);
+        }
+
+        public static NameValueCollection ParseQueryString(string query, Encoding encoding)
+        {
+            if (query == null)
+            {
+                throw Fx.Exception.ArgumentNull("query");
+            }
+
+            if (encoding == null)
+            {
+                throw Fx.Exception.ArgumentNull("encoding");
+            }
+
+            if (query.Length > 0 && query[0] == '?')
+            {
+                query = query.Substring(1);
+            }
+
+            return new HttpValueCollection(query, encoding);
+        }
+
+        public static string UrlEncode(string str)
+        {
+            if (str == null)
+            {
+                return null;
+            }
+            return UrlEncode(str, Encoding.UTF8);
+        }
+
+        // URL encodes a path portion of a URL string and returns the encoded string.
+        public static string UrlPathEncode(string str)
+        {
+            if (str == null)
+            {
+                return null;
+            }
+
+            // recurse in case there is a query string
+            int i = str.IndexOf('?');
+            if (i >= 0)
+            {
+                return UrlPathEncode(str.Substring(0, i)) + str.Substring(i);
+            }
+
+            // encode DBCS characters and spaces only
+            return UrlEncodeSpaces(UrlEncodeNonAscii(str, Encoding.UTF8));
+        }
+
+        public static string UrlEncode(string str, Encoding encoding)
+        {
+            if (str == null)
+            {
+                return null;
+            }
+            return Encoding.ASCII.GetString(UrlEncodeToBytes(str, encoding));
+        }
+
+        public static string UrlEncodeUnicode(string str)
+        {
+            if (str == null)
+                return null;
+            return UrlEncodeUnicodeStringToStringInternal(str, false);
+
+        }
+
+        private static string UrlEncodeUnicodeStringToStringInternal(string s, bool ignoreAscii)
+        {
+            int l = s.Length;
+            StringBuilder sb = new StringBuilder(l);
+
+            for (int i = 0; i < l; i++)
+            {
+                char ch = s[i];
+
+                if ((ch & 0xff80) == 0)
+                {  // 7 bit?
+                    if (ignoreAscii || IsSafe(ch))
+                    {
+                        sb.Append(ch);
+                    }
+                    else if (ch == ' ')
+                    {
+                        sb.Append('+');
+                    }
+                    else
+                    {
+                        sb.Append('%');
+                        sb.Append(IntToHex((ch >> 4) & 0xf));
+                        sb.Append(IntToHex((ch) & 0xf));
+                    }
+                }
+                else
+                { // arbitrary Unicode?
+                    sb.Append("%u");
+                    sb.Append(IntToHex((ch >> 12) & 0xf));
+                    sb.Append(IntToHex((ch >> 8) & 0xf));
+                    sb.Append(IntToHex((ch >> 4) & 0xf));
+                    sb.Append(IntToHex((ch) & 0xf));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        //  Helper to encode the non-ASCII url characters only
+        static string UrlEncodeNonAscii(string str, Encoding e)
+        {
+            if (string.IsNullOrEmpty(str))
+            {
+                return str;
+            }
+            if (e == null)
+            {
+                e = Encoding.UTF8;
+            }
+            byte[] bytes = e.GetBytes(str);
+            bytes = UrlEncodeBytesToBytesInternalNonAscii(bytes, 0, bytes.Length, false);
+            return Encoding.ASCII.GetString(bytes);
+        }
+
+        //  Helper to encode spaces only
+        static string UrlEncodeSpaces(string str)
+        {
+            if (str != null && str.IndexOf(' ') >= 0)
+            {
+                str = str.Replace(" ", "%20");
+            }
+            return str;
+        }
+
+        public static byte[] UrlEncodeToBytes(string str, Encoding e)
+        {
+            if (str == null)
+            {
+                return null;
+            }
+            byte[] bytes = e.GetBytes(str);
+            return UrlEncodeBytesToBytesInternal(bytes, 0, bytes.Length, false);
+        }
+
+        //public static string UrlDecode(string str)
+        //{
+        //    if (str == null)
+        //        return null;
+        //    return UrlDecode(str, Encoding.UTF8);
+        //}
+
+        public static string UrlDecode(string str, Encoding e)
+        {
+            if (str == null)
+            {
+                return null;
+            }
+            return UrlDecodeStringFromStringInternal(str, e);
+        }
+
+        //  Implementation for encoding
+        static byte[] UrlEncodeBytesToBytesInternal(byte[] bytes, int offset, int count, bool alwaysCreateReturnValue)
+        {
+            int cSpaces = 0;
+            int cUnsafe = 0;
+
+            // count them first
+            for (int i = 0; i < count; i++)
+            {
+                char ch = (char)bytes[offset + i];
+
+                if (ch == ' ')
+                {
+                    cSpaces++;
+                }
+                else if (!IsSafe(ch))
+                {
+                    cUnsafe++;
+                }
+            }
+
+            // nothing to expand?
+            if (!alwaysCreateReturnValue && cSpaces == 0 && cUnsafe == 0)
+            {
+                return bytes;
+            }
+
+            // expand not 'safe' characters into %XX, spaces to +s
+            byte[] expandedBytes = new byte[count + cUnsafe * 2];
+            int pos = 0;
+
+            for (int i = 0; i < count; i++)
+            {
+                byte b = bytes[offset + i];
+                char ch = (char)b;
+
+                if (IsSafe(ch))
+                {
+                    expandedBytes[pos++] = b;
+                }
+                else if (ch == ' ')
+                {
+                    expandedBytes[pos++] = (byte)'+';
+                }
+                else
+                {
+                    expandedBytes[pos++] = (byte)'%';
+                    expandedBytes[pos++] = (byte)IntToHex((b >> 4) & 0xf);
+                    expandedBytes[pos++] = (byte)IntToHex(b & 0x0f);
+                }
+            }
+
+            return expandedBytes;
+        }
+
+
+        static bool IsNonAsciiByte(byte b)
+        {
+            return (b >= 0x7F || b < 0x20);
+        }
+
+        static byte[] UrlEncodeBytesToBytesInternalNonAscii(byte[] bytes, int offset, int count, bool alwaysCreateReturnValue)
+        {
+            int cNonAscii = 0;
+
+            // count them first
+            for (int i = 0; i < count; i++)
+            {
+                if (IsNonAsciiByte(bytes[offset + i]))
+                {
+                    cNonAscii++;
+                }
+            }
+
+            // nothing to expand?
+            if (!alwaysCreateReturnValue && cNonAscii == 0)
+            {
+                return bytes;
+            }
+
+            // expand not 'safe' characters into %XX, spaces to +s
+            byte[] expandedBytes = new byte[count + cNonAscii * 2];
+            int pos = 0;
+
+            for (int i = 0; i < count; i++)
+            {
+                byte b = bytes[offset + i];
+
+                if (IsNonAsciiByte(b))
+                {
+                    expandedBytes[pos++] = (byte)'%';
+                    expandedBytes[pos++] = (byte)IntToHex((b >> 4) & 0xf);
+                    expandedBytes[pos++] = (byte)IntToHex(b & 0x0f);
+                }
+                else
+                {
+                    expandedBytes[pos++] = b;
+                }
+            }
+
+            return expandedBytes;
+        }
+
+        static string UrlDecodeStringFromStringInternal(string s, Encoding e)
+        {
+            int count = s.Length;
+            UrlDecoder helper = new UrlDecoder(count, e);
+
+            // go through the string's chars collapsing %XX and %uXXXX and
+            // appending each char as char, with exception of %XX constructs
+            // that are appended as bytes
+
+            for (int pos = 0; pos < count; pos++)
+            {
+                char ch = s[pos];
+
+                if (ch == '+')
+                {
+                    ch = ' ';
+                }
+                else if (ch == '%' && pos < count - 2)
+                {
+                    if (s[pos + 1] == 'u' && pos < count - 5)
+                    {
+                        int h1 = HexToInt(s[pos + 2]);
+                        int h2 = HexToInt(s[pos + 3]);
+                        int h3 = HexToInt(s[pos + 4]);
+                        int h4 = HexToInt(s[pos + 5]);
+
+                        if (h1 >= 0 && h2 >= 0 && h3 >= 0 && h4 >= 0)
+                        {   // valid 4 hex chars
+                            ch = (char)((h1 << 12) | (h2 << 8) | (h3 << 4) | h4);
+                            pos += 5;
+
+                            // only add as char
+                            helper.AddChar(ch);
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        int h1 = HexToInt(s[pos + 1]);
+                        int h2 = HexToInt(s[pos + 2]);
+
+                        if (h1 >= 0 && h2 >= 0)
+                        {     // valid 2 hex chars
+                            byte b = (byte)((h1 << 4) | h2);
+                            pos += 2;
+
+                            // don't add as char
+                            helper.AddByte(b);
+                            continue;
+                        }
+                    }
+                }
+
+                if ((ch & 0xFF80) == 0)
+                {
+                    helper.AddByte((byte)ch); // 7 bit have to go as bytes because of Unicode
+                }
+                else
+                {
+                    helper.AddChar(ch);
+                }
+            }
+
+            return helper.GetString();
+        }
+
+        // Private helpers for URL encoding/decoding
+        static int HexToInt(char h)
+        {
+            return (h >= '0' && h <= '9') ? h - '0' :
+            (h >= 'a' && h <= 'f') ? h - 'a' + 10 :
+            (h >= 'A' && h <= 'F') ? h - 'A' + 10 :
+            -1;
+        }
+
+        static char IntToHex(int n)
+        {
+            //WCF CHANGE: CHANGED FROM Debug.Assert() to Fx.Assert()
+            Fx.Assert(n < 0x10, "n < 0x10");
+
+            if (n <= 9)
+            {
+                return (char)(n + (int)'0');
+            }
+            else
+            {
+                return (char)(n - 10 + (int)'a');
+            }
+        }
+
+        // Set of safe chars, from RFC 1738.4 minus '+'
+        internal static bool IsSafe(char ch)
+        {
+            if (ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' || ch >= '0' && ch <= '9')
+            {
+                return true;
+            }
+
+            switch (ch)
+            {
+                case '-':
+                case '_':
+                case '.':
+                case '!':
+                case '*':
+                case '\'':
+                case '(':
+                case ')':
+                    return true;
+            }
+
+            return false;
+        }
+
+        // Internal class to facilitate URL decoding -- keeps char buffer and byte buffer, allows appending of either chars or bytes
+        class UrlDecoder
+        {
+            int _bufferSize;
+
+            // Accumulate characters in a special array
+            int _numChars;
+            char[] _charBuffer;
+
+            // Accumulate bytes for decoding into characters in a special array
+            int _numBytes;
+            byte[] _byteBuffer;
+
+            // Encoding to convert chars to bytes
+            Encoding _encoding;
+
+            void FlushBytes()
+            {
+                if (_numBytes > 0)
+                {
+                    _numChars += _encoding.GetChars(_byteBuffer, 0, _numBytes, _charBuffer, _numChars);
+                    _numBytes = 0;
+                }
+            }
+
+            internal UrlDecoder(int bufferSize, Encoding encoding)
+            {
+                _bufferSize = bufferSize;
+                _encoding = encoding;
+
+                _charBuffer = new char[bufferSize];
+                // byte buffer created on demand
+            }
+
+            internal void AddChar(char ch)
+            {
+                if (_numBytes > 0)
+                {
+                    FlushBytes();
+                }
+
+                _charBuffer[_numChars++] = ch;
+            }
+
+            internal void AddByte(byte b)
+            {
+                // if there are no pending bytes treat 7 bit bytes as characters
+                // this optimization is temp disable as it doesn't work for some encodings
+
+                //if (_numBytes == 0 && ((b & 0x80) == 0)) {
+                //    AddChar((char)b);
+                //}
+                //else
+
+                {
+                    if (_byteBuffer == null)
+                    {
+                        _byteBuffer = new byte[_bufferSize];
+                    }
+
+                    _byteBuffer[_numBytes++] = b;
+                }
+            }
+
+            internal string GetString()
+            {
+                if (_numBytes > 0)
+                {
+                    FlushBytes();
+                }
+
+                if (_numChars > 0)
+                {
+                    return new String(_charBuffer, 0, _numChars);
+                }
+                else
+                {
+                    return string.Empty;
+                }
+            }
+        }
+
+        [Serializable]
+        class HttpValueCollection : NameValueCollection
+        {
+            internal HttpValueCollection(string str, Encoding encoding)
+                : base(StringComparer.OrdinalIgnoreCase)
+            {
+                if (!string.IsNullOrEmpty(str))
+                {
+                    FillFromString(str, true, encoding);
+                }
+
+                IsReadOnly = false;
+            }
+
+            protected HttpValueCollection(SerializationInfo info, StreamingContext context)
+                : base(info, context)
+            {
+            }
+
+            internal void FillFromString(string s, bool urlencoded, Encoding encoding)
+            {
+                int l = (s != null) ? s.Length : 0;
+                int i = 0;
+
+                while (i < l)
+                {
+                    // find next & while noting first = on the way (and if there are more)
+
+                    int si = i;
+                    int ti = -1;
+
+                    while (i < l)
+                    {
+                        char ch = s[i];
+
+                        if (ch == '=')
+                        {
+                            if (ti < 0)
+                                ti = i;
+                        }
+                        else if (ch == '&')
+                        {
+                            break;
+                        }
+
+                        i++;
+                    }
+
+                    // extract the name / value pair
+
+                    string name = null;
+                    string value = null;
+
+                    if (ti >= 0)
+                    {
+                        name = s.Substring(si, ti - si);
+                        value = s.Substring(ti + 1, i - ti - 1);
+                    }
+                    else
+                    {
+                        value = s.Substring(si, i - si);
+                    }
+
+                    // add name / value pair to the collection
+
+                    if (urlencoded)
+                    {
+                        base.Add(
+                           UrlUtility.UrlDecode(name, encoding),
+                           UrlUtility.UrlDecode(value, encoding));
+                    }
+                    else
+                    {
+                        base.Add(name, value);
+                    }
+
+                    // trailing '&'
+
+                    if (i == l - 1 && s[i] == '&')
+                    {
+                        base.Add(null, string.Empty);
+                    }
+
+                    i++;
+                }
+            }
+
+            public override string ToString()
+            {
+                return ToString(true, null);
+            }
+
+            string ToString(bool urlencoded, IDictionary excludeKeys)
+            {
+                int n = Count;
+                if (n == 0)
+                    return string.Empty;
+
+                StringBuilder s = new StringBuilder();
+                string key, keyPrefix, item;
+
+                for (int i = 0; i < n; i++)
+                {
+                    key = GetKey(i);
+
+                    if (excludeKeys != null && key != null && excludeKeys[key] != null)
+                    {
+                        continue;
+                    }
+                    if (urlencoded)
+                    {
+                        key = UrlUtility.UrlEncodeUnicode(key);
+                    }
+                    keyPrefix = (!string.IsNullOrEmpty(key)) ? (key + "=") : string.Empty;
+
+                    ArrayList values = (ArrayList)BaseGet(i);
+                    int numValues = (values != null) ? values.Count : 0;
+
+                    if (s.Length > 0)
+                    {
+                        s.Append('&');
+                    }
+
+                    if (numValues == 1)
+                    {
+                        s.Append(keyPrefix);
+                        item = (string)values[0];
+                        if (urlencoded)
+                            item = UrlUtility.UrlEncodeUnicode(item);
+                        s.Append(item);
+                    }
+                    else if (numValues == 0)
+                    {
+                        s.Append(keyPrefix);
+                    }
+                    else
+                    {
+                        for (int j = 0; j < numValues; j++)
+                        {
+                            if (j > 0)
+                            {
+                                s.Append('&');
+                            }
+                            s.Append(keyPrefix);
+                            item = (string)values[j];
+                            if (urlencoded)
+                            {
+                                item = UrlUtility.UrlEncodeUnicode(item);
+                            }
+                            s.Append(item);
+                        }
+                    }
+                }
+
+                return s.ToString();
+            }
+        }
+    }
+}

--- a/src/EventStore.sln
+++ b/src/EventStore.sln
@@ -55,6 +55,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.ClientAPI.Embedd
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.ClientAPI.v5.Tests", "EventStore.ClientAPI.v5.Tests\EventStore.ClientAPI.v5.Tests.csproj", "{8B3FDD14-C959-4859-80C4-B157D1D94969}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventStore.NETCore.Compatibility", "EventStore.NETCore.Compatibility\EventStore.NETCore.Compatibility.csproj", "{066B6514-86A0-41D8-BB6A-D9B05141D026}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -145,6 +147,10 @@ Global
 		{8B3FDD14-C959-4859-80C4-B157D1D94969}.Debug|x64.Build.0 = Debug|x64
 		{8B3FDD14-C959-4859-80C4-B157D1D94969}.Release|x64.ActiveCfg = Release|x64
 		{8B3FDD14-C959-4859-80C4-B157D1D94969}.Release|x64.Build.0 = Release|x64
+		{066B6514-86A0-41D8-BB6A-D9B05141D026}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{066B6514-86A0-41D8-BB6A-D9B05141D026}.Debug|x64.Build.0 = Debug|Any CPU
+		{066B6514-86A0-41D8-BB6A-D9B05141D026}.Release|x64.ActiveCfg = Release|Any CPU
+		{066B6514-86A0-41D8-BB6A-D9B05141D026}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Changed: License information
Added: A new project `EventStore.NETCore.Compatibility` which takes the code for `System.UriTemplate` from .NET Framework 4.8 reference source (MIT-licensed) instead of depending on `SimpleSyndicate.UriTemplate` (no license)


Fixes #2261 