### PR TITLE
Remove Force option

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -87,9 +87,6 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.ConnectionQueueSizeThresholdDescr, Opts.InterfacesGroup)]
 		public int ConnectionQueueSizeThreshold { get; set; }
 
-		[ArgDescription(Opts.ForceDescr, Opts.AppGroup)]
-		public bool Force { get; set; }
-
 		[ArgDescription(Opts.ClusterSizeDescr, Opts.ClusterGroup)]
 		public int ClusterSize { get; set; }
 
@@ -327,7 +324,6 @@ namespace EventStore.ClusterNode {
 			EnableExternalTCP = Opts.EnableExternalTCPDefault;
 			IntTcpPort = Opts.InternalTcpPortDefault;
 			ExtTcpPort = Opts.ExternalTcpPortDefault;
-			Force = Opts.ForceDefault;
 			ClusterSize = Opts.ClusterSizeDefault;
 			MinFlushDelayMs = Opts.MinFlushDelayMsDefault;
 			NodePriority = Opts.NodePriorityDefault;

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -80,14 +80,14 @@ namespace EventStore.ClusterNode {
 		protected override void PreInit(ClusterNodeOptions options) {
 			base.PreInit(options);
 
-			if (options.Db.StartsWith("~") && !options.Force) {
+			if (options.Db.StartsWith("~")) {
 				throw new ApplicationInitializationException(
-					"The given database path starts with a '~'. We don't expand '~'. You can use --force to override this error.");
+					"The given database path starts with a '~'. Event Store does not expand '~'.");
 			}
 
-			if (options.Log.StartsWith("~") && !options.Force) {
+			if (options.Log.StartsWith("~")) {
 				throw new ApplicationInitializationException(
-					"The given log path starts with a '~'. We don't expand '~'. You can use --force to override this error.");
+					"The given log path starts with a '~'. Event Store does not expand '~'.");
 			}
 
 			if (options.GossipSeed.Length > 1 && options.ClusterSize == 1) {

--- a/src/EventStore.Common/Options/IOptions.cs
+++ b/src/EventStore.Common/Options/IOptions.cs
@@ -4,7 +4,6 @@
 		bool Version { get; }
 		string Config { get; }
 		string Log { get; }
-		bool Force { get; }
 		bool WhatIf { get; }
 	}
 }

--- a/src/EventStore.Core.Tests/Common/EventStoreOptionsTests/TestArgs.cs
+++ b/src/EventStore.Core.Tests/Common/EventStoreOptionsTests/TestArgs.cs
@@ -9,7 +9,6 @@ namespace EventStore.Core.Tests.Common {
 		public string Log { get; set; }
 		public IPEndPoint[] GossipSeed { get; set; }
 		public bool WhatIf { get; set; }
-		public bool Force { get; set; }
 		public ProjectionType RunProjections { get; set; }
 
 		public int HttpPort { get; set; }

--- a/src/EventStore.TestClient/ClientOptions.cs
+++ b/src/EventStore.TestClient/ClientOptions.cs
@@ -28,7 +28,6 @@ namespace EventStore.TestClient {
 		public int ReadWindow { get; set; }
 		public int WriteWindow { get; set; }
 		public int PingWindow { get; set; }
-		[ArgDescription(Opts.ForceDescr)] public bool Force { get; set; }
 		public string[] Command { get; set; }
 		public bool Reconnect { get; set; }
 
@@ -49,7 +48,6 @@ namespace EventStore.TestClient {
 			ReadWindow = 2000;
 			WriteWindow = 2000;
 			PingWindow = 2000;
-			Force = false;
 			Reconnect = true;
 			UseTls = false;
 			TlsValidateServer = false;


### PR DESCRIPTION
Removed: Force option

Related to reviewing options in #2114

This option was used initially used to be able to force Event Store to run on unsupported versions of the Mono runtime or an unsupported GC such as boehm. This is no longer the case since Event Store has moved to .NET Core. The only other place this option is used is to force the use of a directory that starts with a `~` which we don't expand.

Do we want to keep this option around for future use or remove it?

- We need to update the command line documentation to remove this [here](https://eventstore.com/docs/server/command-line-arguments/index.html) if this PR does get accepted. (cc: @ChrisChinchilla)