### PR TITLE
Send the replication checkpoint when a node subscribes to the leader

### DIFF
--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replication_service_recieves_leader_log_commited_to.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replication_service_recieves_leader_log_commited_to.cs
@@ -16,10 +16,10 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 		public void replicated_to_should_be_sent_to_subscriptions() {
 			AssertEx.IsOrBecomesTrue(() => TcpSends.Count > 4, msg:"TcpSend msg not recieved");
 			var sends = TcpSends.Where(tcpSend => tcpSend.Message is ReplicationTrackingMessage.ReplicatedTo).ToList();
-			Assert.AreEqual(3,sends.Count);
-			Assert.IsTrue(sends.Any( msg=> msg.ConnectionManager.ConnectionId == ReplicaSubscriptionId));
-			Assert.IsTrue(sends.Any( msg=> msg.ConnectionManager.ConnectionId == ReplicaSubscriptionId2));
-			Assert.IsTrue(sends.Any( msg=> msg.ConnectionManager.ConnectionId == ReadOnlyReplicaSubscriptionId));
+			Assert.AreEqual(3 * 2,sends.Count); //one ReplicatedTo message in sent when the subscription is added and the second one in When()
+			Assert.AreEqual(2, sends.Count( msg=> msg.ConnectionManager.ConnectionId == ReplicaSubscriptionId));
+			Assert.AreEqual(2, sends.Count( msg=> msg.ConnectionManager.ConnectionId == ReplicaSubscriptionId2));
+			Assert.AreEqual(2, sends.Count( msg=> msg.ConnectionManager.ConnectionId == ReadOnlyReplicaSubscriptionId));
 			
 		}
 	}

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -150,6 +150,9 @@ namespace EventStore.Core.Services.Replication {
 						"There is already a subscription with SubscriptionID {0:B}: {1}.\nSubscription we tried to add: {2}",
 						subscription.SubscriptionId, existingSubscr, subscription));
 					subscription.Dispose();
+				} else {
+					var replicationCheckpoint = _db.Config.ReplicationCheckpoint.Read();
+					subscription.SendMessage(new ReplicationTrackingMessage.ReplicatedTo(replicationCheckpoint));
 				}
 			}
 		}


### PR DESCRIPTION
Changed: Send the last replication checkpoint when a node subscribes to the leader


This PR fixes a change of behaviour introduced by: 6764127066fb663f7c20e59e05fcf75aab480314 and a76cf52f9c159ba56b981fbb31949468e4f6763c . Thanks to @hayley-jean for noticing this bug.

## Before these 2 commits

### Any node joining a cluster causes a write
Reason: Before these changes, elections would always be triggered when a node joins the cluster. The new master writes an epoch record just after elections. Thus, this write causes the replication checkpoint to advance.

## After these 2 commits (elections no longer triggered when joining)

### Follower nodes still cause a write when joining a cluster.
Reason: Follower nodes write to the `$scavenges` stream's metadata as soon as their state changes to `Follower`: https://github.com/EventStore/EventStore/blob/master/src/EventStore.Core/Services/Storage/StorageScavenger.cs#L50

### Read-only replica nodes do not cause any writes when joining a cluster.
This is the actual change in behaviour which causes the following bug:

Reproduction steps:
- Start a 3 node cluster and wait for it to stabilize (2 nodes are enough)
- Start a read-only replica (delete any existing database first) and wait for it to join the cluster
- Try to read any stream from the read-only replica, for example:
`curl -u "admin:changeit" -k -v 'https://127.0.0.1:3104/streams/test/0'`
- It will return a `401 Unauthorized` error message although all the cluster's data has been replicated to the read-only replica.
- Additionally, as soon as you write an event to the cluster, and run the same curl command, you can now read the event.

The issue is that the leader sends the updated replication checkpoint to all subscriptions only when there is a write but due to the change in behaviour causing no writes when the read-only replica joins, the read-only replica does not receive the updated replication checkpoint. Thus, the read-only replica's index stays behind and does not get updated (until another write occurs on the cluster)

The reason the same bug does not occur for follower nodes is due to the write done to the `$$$scavenges` stream as explained above.

## Fix
The PR fixes this problem by sending the replication checkpoint to any node just after it subscribes to the leader.