### PR TITLE
Fix midpoint count overflow bug and off by one in GetDepth()

### DIFF
--- a/src/EventStore.Core.Tests/Index/IndexVAny/midpoint_assertions.cs
+++ b/src/EventStore.Core.Tests/Index/IndexVAny/midpoint_assertions.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Index.IndexVAny {
+	[TestFixture]
+	public class midpoint_assertions {
+		private const long MAX_INDEX_ENTRIES = 1000000000000L;
+	    private const int MAX_TEST_DEPTH = 35;
+	    private const int MAX_DEPTH = 28;
+	    private readonly byte[] IndexVersions = { PTableVersions.IndexV1,  PTableVersions.IndexV2,  PTableVersions.IndexV3, PTableVersions.IndexV4 };
+
+	    private static int getIncrement(long numIndexEntries) {
+		    if (numIndexEntries < 100) return 1;
+		    if (numIndexEntries < 1000000) return 1337;
+		    return 133333337;
+	    }
+
+		[Test]
+		public void file_size_should_be_greater_or_equal_after_adding_midpoints() {
+			foreach (var version in IndexVersions) {
+				for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES; numIndexEntries += getIncrement(numIndexEntries)) {
+					for (int minDepth = 0; minDepth <= MAX_TEST_DEPTH; minDepth++) {
+						string testCase = $"numIndexEntries: {numIndexEntries}, minDepth: {minDepth}, version: {version}";
+						var midpointCount = PTable.GetRequiredMidpointCountCached(numIndexEntries, version, minDepth);
+						if (version < PTableVersions.IndexV4) {
+							Assert.AreEqual(0, midpointCount, testCase);
+						} else {
+							Assert.GreaterOrEqual(midpointCount, Math.Min(1<<Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
+							Assert.LessOrEqual(midpointCount, Math.Max(2, numIndexEntries), testCase);
+						}
+
+						long fileSizeUpToIndexEntries = PTable.GetFileSizeUpToIndexEntries(numIndexEntries, version);
+						long fileSizeUpToMidpointEntries =
+							PTable.GetFileSizeUpToMidpointEntries(fileSizeUpToIndexEntries, midpointCount, version);
+
+						if (version < PTableVersions.IndexV4) {
+							Assert.AreEqual(fileSizeUpToIndexEntries, fileSizeUpToMidpointEntries, testCase);
+						} else {
+							Assert.GreaterOrEqual(fileSizeUpToMidpointEntries, fileSizeUpToIndexEntries, testCase);
+						}
+					}
+				}
+			}
+		}
+
+		[Test]
+		public void for_a_fixed_min_depth_and_increasing_index_entries_midpoint_count_should_increase_monotonically() {
+			for (int minDepth = 0; minDepth <= MAX_TEST_DEPTH; minDepth++) {
+				long prevMidpointCount = 0L;
+				for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES;  numIndexEntries += getIncrement(numIndexEntries)) {
+					string testCase = $"numIndexEntries: {numIndexEntries}, minDepth: {minDepth}";
+					var midpointCount = PTable.GetRequiredMidpointCountCached(numIndexEntries, PTableVersions.IndexV4, minDepth);
+					Assert.GreaterOrEqual(midpointCount, prevMidpointCount, testCase);
+					Assert.GreaterOrEqual(midpointCount, Math.Min(1<<Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
+					Assert.LessOrEqual(midpointCount, Math.Max(2, numIndexEntries), testCase);
+					prevMidpointCount = midpointCount;
+				}
+			}
+		}
+
+		[Test]
+		public void for_a_fixed_number_of_index_entries_and_increasing_min_depth_midpoint_count_should_increase_monotonically() {
+			for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES;  numIndexEntries += getIncrement(numIndexEntries)) {
+				long prevMidpointCount = 0L;
+				for (int minDepth = 0; minDepth <= MAX_TEST_DEPTH; minDepth++) {
+					string testCase = $"numIndexEntries: {numIndexEntries}, minDepth: {minDepth}";
+					var midpointCount = PTable.GetRequiredMidpointCountCached(numIndexEntries, PTableVersions.IndexV4, minDepth);
+					Assert.GreaterOrEqual(midpointCount, prevMidpointCount, testCase);
+					Assert.GreaterOrEqual(midpointCount, Math.Min(1<<Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
+					Assert.LessOrEqual(midpointCount, Math.Max(2, numIndexEntries), testCase);
+					prevMidpointCount = midpointCount;
+				}
+			}
+		}
+
+	}
+}

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -507,7 +507,7 @@ namespace EventStore.Core.Index {
 			if (dumpedEntryCount == numIndexEntries && requiredMidpointCount == midpoints.Count) {
 				//if these values don't match, something is wrong
 				bs.Flush();
-				fs.SetLength(fs.Position + midpoints.Count * indexEntrySize);
+				fs.SetLength(fs.Position + (long)midpoints.Count * indexEntrySize);
 				foreach (var pt in midpoints) {
 					AppendMidpointRecordTo(bs, buffer, version, pt, indexEntrySize);
 				}

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -689,7 +689,7 @@ namespace EventStore.Core.Index {
 		private static int GetDepth(long indexEntriesFileSize, int minDepth) {
 			minDepth = Math.Max(0, Math.Min(minDepth, 28));
 			if ((2L << 28) * 4096L < indexEntriesFileSize) return 28;
-			for (int i = 27; i > minDepth; i--) {
+			for (int i = 27; i >= minDepth; i--) {
 				if ((2L << i) * 4096L < indexEntriesFileSize) {
 					return i + 1;
 				}

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -198,7 +198,7 @@ namespace EventStore.Core.Index {
 			}
 		}
 
-		private static int GetIndexEntrySize(byte version) {
+		public static int GetIndexEntrySize(byte version) {
 			if (version == PTableVersions.IndexV1) {
 				return PTable.IndexEntryV1Size;
 			}
@@ -676,12 +676,12 @@ namespace EventStore.Core.Index {
 			}
 		}
 
-		private static long GetFileSizeUpToIndexEntries(long numIndexEntries, byte version) {
+		public static long GetFileSizeUpToIndexEntries(long numIndexEntries, byte version) {
 			int indexEntrySize = GetIndexEntrySize(version);
 			return (long)PTableHeader.Size + numIndexEntries * indexEntrySize;
 		}
 
-		private static long GetFileSizeUpToMidpointEntries(long currentPosition, long numMidpointEntries, byte version) {
+		public static long GetFileSizeUpToMidpointEntries(long currentPosition, long numMidpointEntries, byte version) {
 			int indexEntrySize = GetIndexEntrySize(version);
 			return currentPosition + numMidpointEntries * indexEntrySize;
 		}

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -507,7 +507,8 @@ namespace EventStore.Core.Index {
 			if (dumpedEntryCount == numIndexEntries && requiredMidpointCount == midpoints.Count) {
 				//if these values don't match, something is wrong
 				bs.Flush();
-				fs.SetLength(fs.Position + (long)midpoints.Count * indexEntrySize);
+				long fileSizeUpToMidpointEntries = GetFileSizeUpToMidpointEntries(fs.Position, midpoints.Count, version);
+				fs.SetLength(fileSizeUpToMidpointEntries);
 				foreach (var pt in midpoints) {
 					AppendMidpointRecordTo(bs, buffer, version, pt, indexEntrySize);
 				}
@@ -678,6 +679,11 @@ namespace EventStore.Core.Index {
 		private static long GetFileSizeUpToIndexEntries(long numIndexEntries, byte version) {
 			int indexEntrySize = GetIndexEntrySize(version);
 			return (long)PTableHeader.Size + numIndexEntries * indexEntrySize;
+		}
+
+		private static long GetFileSizeUpToMidpointEntries(long currentPosition, long numMidpointEntries, byte version) {
+			int indexEntrySize = GetIndexEntrySize(version);
+			return currentPosition + numMidpointEntries * indexEntrySize;
 		}
 
 		private static int GetDepth(long indexEntriesFileSize, int minDepth) {

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -687,6 +687,7 @@ namespace EventStore.Core.Index {
 		}
 
 		private static int GetDepth(long indexEntriesFileSize, int minDepth) {
+			minDepth = Math.Max(0, Math.Min(minDepth, 28));
 			if ((2L << 28) * 4096L < indexEntriesFileSize) return 28;
 			for (int i = 27; i > minDepth; i--) {
 				if ((2L << i) * 4096L < indexEntriesFileSize) {


### PR DESCRIPTION
Fixed: Overflow bug when setting file size based on number of midpoints
Fixed: Off by one in GetDepth() which can cause less midpoints to be computed when increasing IndexCacheDepth in some cases


This PR fixes two issues. The second issue which is not serious was discovered after writing tests for the first issue.

## Issue 1: Overflow bug (serious issue)
Thanks to @Slav for reporting this issue. After analysis, we found the following overflow bug.
- midpoints.Count * indexEntrySize can overflow if there is a large number of midpoints
- This can occur in particular if (using an `IndexCacheDepth` > 26 and generating a PTable having >= 89478486 index entries ) or with a PTable having more than 11453246122 entries if using the default `IndexCacheDepth` = 16. (explained below)
- If the result of the overflow is negative, it can result in truncation of the index file since FileStream.SetLength() will be called with a size less than the current file size.
- If the result of the overflow is non-negative, there should be no negative impact since data will continue to be appended to the index file.
- Having an index cache depth > 26 causes the issue:
```
num_midpoints > 2147483647 (int.MaxValue) / 24 (midpoint entry size)
num_midpoints = 2^index_cache_depth
2 ^ index_cache_depth > 2147483647 / 24
index_cache_depth > log2(2147483647 / 24)
index_cache_depth > 26.415 >= 27
```
- An index cache depth of 27 corresponds to the following number of index entries with a default IndexCacheDepth = 16 setting
```
According to: https://github.com/EventStore/EventStore/blob/master/src/EventStore.Core/Index/PTableConstruction.cs#L686

(2 ^ (depth-1)) * 4096 < indexEntriesFileSize
indexEntriesFileSize > (2 ^ (depth-1)) * 4096
numIndexEntries = indexEntriesFileSize / 24
numIndexEntries > (2 ^ (depth-1)) * 4096 / 24

depth = 27
numIndexEntries > 11453246122
```

To summarize:
- With default `IndexCacheDepth = 16` setting, a PTable with more than 11453246122 index entries (11.4 billion) is required for the overflow to occur (quite rare)
- With `IndexCacheDepth >= 27`, a PTable having >= 89478486 index entries (all index entries will be midpoints and 89478486 * 24 > Int.MaxValue) is required for the overflow to occur.

### Failing test
Failing test: `file_size_should_be_greater_or_equal_after_adding_midpoints`. Can be tested by changing `numMidpointEntries` to an `int` in `GetFileSizeUpToMidpointEntries`

## Issue 2: Off by one in GetDepth()
This commit: 0d2d116928ab04dcc7c79bb8a7996f7caac70148 fixes an off by one in GetDepth which causes the following test to fail: `for_a_fixed_number_of_index_entries_and_increasing_min_depth_midpoint_count_should_increase_monotically`

Basically, a depth of `minDepth+1` is not being tested in the loop. There are cases where, increasing the `IndexCacheDepth` does not increase the number of midpoints due to this bug.
