### PR TITLE
Fix Subtle Integer Wrap Around Bug w/ Large Event Counts

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
@@ -84,7 +84,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				_bus.Publish(new ClientMessage.ReadAllEventsBackward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage),
-					commitPosition, preparePosition, Math.Min(32, (int)_maxCount),
+					commitPosition, preparePosition, (int)Math.Min(32, _maxCount),
 					_resolveLinks, _requiresLeader, default, _user, _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
@@ -83,7 +83,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				_bus.Publish(new ClientMessage.ReadAllEventsForward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage),
-					commitPosition, preparePosition, Math.Min(32, (int)_maxCount),
+					commitPosition, preparePosition, (int)Math.Min(32, _maxCount),
 					_resolveLinks, _requiresLeader, default, _user, expires: _deadline));
 
 				if (_disposedTokenSource.IsCancellationRequested) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
@@ -89,7 +89,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				_bus.Publish(new ClientMessage.ReadStreamEventsBackward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage), _streamName, _nextRevision.ToInt64(),
-					Math.Min(32, (int)_maxCount), _resolveLinks, _requiresLeader, default, _user, _deadline));
+					(int)Math.Min(32, _maxCount), _resolveLinks, _requiresLeader, default, _user, _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
 					return false;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
@@ -88,7 +88,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				_bus.Publish(new ClientMessage.ReadStreamEventsForward(
 					correlationId, correlationId, new CallbackEnvelope(OnMessage), _streamName, _nextRevision.ToInt64(),
-					Math.Min(32, (int)_maxCount), _resolveLinks, _requiresLeader, default, _user, expires: _deadline));
+					(int)Math.Min(32, _maxCount), _resolveLinks, _requiresLeader, default, _user, expires: _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
 					return false;


### PR DESCRIPTION
Bug: Event Counts in GRPC Transport no longer wrap to negative values if > int.MaxValue