### PR TITLE
Default user and projections manager to https

### DIFF
--- a/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
+++ b/src/EventStore.ClientAPI/Projections/ProjectionsManager.cs
@@ -26,7 +26,7 @@ namespace EventStore.ClientAPI.Projections {
 		/// <param name="httpSchema">HTTP endpoint schema http|https.</param>
 		/// <param name="operationTimeout"></param>
 		public ProjectionsManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout,
-			HttpMessageHandler httpMessageHandler = null, string httpSchema = EndpointExtensions.HTTP_SCHEMA) {
+			HttpMessageHandler httpMessageHandler = null, string httpSchema = EndpointExtensions.HTTPS_SCHEMA) {
 			Ensure.NotNull(log, "log");
 			Ensure.NotNull(httpEndPoint, "httpEndPoint");
 

--- a/src/EventStore.ClientAPI/UserManagement/UsersManager.cs
+++ b/src/EventStore.ClientAPI/UserManagement/UsersManager.cs
@@ -26,7 +26,8 @@ namespace EventStore.ClientAPI.UserManagement {
 		/// <param name="operationTimeout"></param>
 		/// <param name="tlsTerminatedEndpoint"></param>
 		/// <param name="httpMessageHandler"></param>
-		public UsersManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout, bool tlsTerminatedEndpoint = false, HttpMessageHandler httpMessageHandler = null) {
+		public UsersManager(ILogger log, EndPoint httpEndPoint, TimeSpan operationTimeout,
+			bool tlsTerminatedEndpoint = true, HttpMessageHandler httpMessageHandler = null) {
 			Ensure.NotNull(log, "log");
 			Ensure.NotNull(httpEndPoint, "httpEndPoint");
 


### PR DESCRIPTION
Updated: Changed the default schema on the projection and users manager to be https.

Fixes #1371

We could look at aligning the projections and user manager as the one (`UsersManager`) currently accepts a bool to decide the schema whereas the other (`ProjectionsManager`) accepts the schema as a parameter.