### PR TITLE
Extend proto to define append response types

### DIFF
--- a/src/Protos/Grpc/streams.proto
+++ b/src/Protos/Grpc/streams.proto
@@ -140,18 +140,37 @@ message AppendReq {
 }
 
 message AppendResp {
-	oneof current_revision_option {
-		uint64 current_revision = 1;
-		event_store.client.shared.Empty no_stream = 2;
-	}
-	oneof position_option {
-		Position position = 3;
-		event_store.client.shared.Empty no_position = 4;
+	oneof result {
+		Success success = 1;
+		WrongExpectedVersion wrong_expected_version = 2;
 	}
 
 	message Position {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
+	}
+
+	message Success {
+		oneof current_revision_option {
+			uint64 current_revision = 1;
+			event_store.client.shared.Empty no_stream = 2;
+		}
+		oneof position_option {
+			Position position = 3;
+			event_store.client.shared.Empty no_position = 4;
+		}
+	}
+
+	message WrongExpectedVersion {
+	  oneof current_revision_option {
+		  uint64 current_revision = 1;
+		  event_store.client.shared.Empty no_stream = 2;
+	  }
+	  oneof expected_revision_option {
+		  uint64 expected_revision = 3;
+		  event_store.client.shared.Empty any = 4;
+		  event_store.client.shared.Empty stream_exists = 5;
+		}
 	}
 }
 


### PR DESCRIPTION
Changed: Appends will now return a oneof response types which currently is either a `Success` or a `WrongExpectedVersion`.

In an effort to reduce rpc exceptions being thrown from the server, we are extending the protocol to return responses which can be converted into errors or exceptions on the client side.

The `WrongExpectedVersion` error is described as the following:
**current_revision** is either an **actual revision** (as a `ulong`) _or_ `no_stream` (which is the default)
**expected_revision** is either an **actual revision** (as a `ulong`) _or_ `stream_exists` _or_ `any`.

Currently a write can fail for `Any` expected version of some of the events of in a batch has been written.

