### PR TITLE
Handle successful resolved link event in EmittedStream.

### DIFF
--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -107,6 +107,7 @@ namespace EventStore.Projections.Core {
 			mainBus.Subscribe(ioDispatcher.ForwardReader);
 			mainBus.Subscribe(ioDispatcher.StreamDeleter);
 			mainBus.Subscribe(ioDispatcher.Writer);
+			mainBus.Subscribe(ioDispatcher.EventReader);
 			mainBus.Subscribe(ioDispatcher);
 
 			mainBus.Subscribe(projectionManagerMessageDispatcher);

--- a/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
@@ -108,6 +108,7 @@ namespace EventStore.Projections.Core {
 				coreInputBus.Subscribe<CoreProjectionManagementMessage.GetResult>(_projectionCoreService);
 				coreInputBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_ioDispatcher.ForwardReader);
 				coreInputBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+				coreInputBus.Subscribe<ClientMessage.ReadEventCompleted>(_ioDispatcher.EventReader);
 				coreInputBus.Subscribe<ClientMessage.WriteEventsCompleted>(_ioDispatcher.Writer);
 				coreInputBus.Subscribe<ClientMessage.DeleteStreamCompleted>(_ioDispatcher.StreamDeleter);
 				coreInputBus.Subscribe<IODispatcherDelayedMessage>(_ioDispatcher.Awaker);

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
-using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
@@ -701,7 +700,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 				if (report is EmittedEventResolutionNeeded resolution) {
 					_ioDispatcher.ReadEvent(resolution.StreamId, resolution.Revision, _writeAs, resp => {
-						OnEmittedLinkEventResolved(anyFound, eventToWrite, resp);
+						OnEmittedLinkEventResolved(anyFound, eventToWrite, resolution.TopCommitted, resp);
 					});
 					
 					break;
@@ -728,8 +727,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				if (!long.TryParse(parts[0], out long eventNumber))
 					throw new Exception($"Unexpected exception: Emitted event is an invalid link event: Body ({eventToWrite.Data}) CausedByTag ({eventToWrite.CausedByTag}) StreamId ({eventToWrite.StreamId})");
 				
-				_alreadyCommittedEvents.Push(topAlreadyCommitted);
-				return new EmittedEventResolutionNeeded(streamId, eventNumber);
+				return new EmittedEventResolutionNeeded(streamId, eventNumber, topAlreadyCommitted);
 			}
 
 			if (failed) {
@@ -742,14 +740,19 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		// Used when we need to resolve a link event to see if it points to an event that no longer exists. If that
 		// event no longer exists, we skip it and resume the recovery process.
-		private void OnEmittedLinkEventResolved(bool anyFound, EmittedEvent eventToWrite, ClientMessage.ReadEventCompleted resp) {
-			var topAlreadyCommitted = _alreadyCommittedEvents.Pop();
-			if (resp.Result != ReadEventResult.StreamDeleted && resp.Result != ReadEventResult.NotFound) {
+		private void OnEmittedLinkEventResolved(bool anyFound, EmittedEvent eventToWrite, Tuple<CheckpointTag, string, long> topAlreadyCommitted, ClientMessage.ReadEventCompleted resp) {
+			if (resp.Result != ReadEventResult.StreamDeleted && resp.Result != ReadEventResult.NotFound && resp.Result != ReadEventResult.NoStream && resp.Result != ReadEventResult.Success) {
 				throw CreateSequenceException(topAlreadyCommitted, eventToWrite);
 			}
 
-			Log.Verbose($"Emitted event ignored after resolution because it links to an event that no longer exists: eventId: {eventToWrite.EventId}, eventType: {eventToWrite.EventId}, checkpoint: {eventToWrite.CorrelationId}, causedBy: {eventToWrite.CausedBy}");
-			_pendingWrites.Dequeue();
+			if (resp.Result == ReadEventResult.Success) {
+				anyFound = true;
+				NotifyEventCommitted(eventToWrite, topAlreadyCommitted.Item3);
+				_pendingWrites.Dequeue();
+			} else {
+				Log.Verbose($"Emitted event ignored after resolution because it links to an event that no longer exists: eventId: {eventToWrite.EventId}, eventType: {eventToWrite.EventId}, checkpoint: {eventToWrite.CorrelationId}, causedBy: {eventToWrite.CausedBy}");	
+			}
+
 			SubmitWriteEventsInRecoveryLoop(anyFound);
 		}
 
@@ -818,12 +821,14 @@ namespace EventStore.Projections.Core.Services.Processing {
 	}
 
 	sealed class EmittedEventResolutionNeeded : IValidatedEmittedEvent {
-		public string StreamId { get; private set; }
-		public long Revision { get; private set; }
+		public string StreamId { get; }
+		public long Revision { get; }
+		public Tuple<CheckpointTag, string, long> TopCommitted { get; }
 
-		public EmittedEventResolutionNeeded(string streamId, long revision) {
+		public EmittedEventResolutionNeeded(string streamId, long revision, Tuple<CheckpointTag, string, long> topCommitted) {
 			StreamId = streamId;
 			Revision = revision;
+			TopCommitted = topCommitted;
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
+++ b/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
@@ -46,7 +46,6 @@ namespace EventStore.Projections.Core.Standard {
 		public void ConfigureSourceProcessingStrategy(SourceDefinitionBuilder builder) {
 			builder.FromAll();
 			builder.AllEvents();
-			builder.SetIncludeLinks();
 		}
 
 		public void Load(string state) {


### PR DESCRIPTION
Fix: Handle successful link event resolution when projections emit events.

Fix a #2447 oversight where we did nothing on successful link resolution, leading projection to no longer make progress.

Fixes #1938  