### PR TITLE
Extend response types to include StreamNotFound

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
@@ -8,7 +8,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Client;
+using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal static partial class Enumerators {
@@ -23,11 +23,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			private readonly CancellationTokenSource _disposedTokenSource;
 			private readonly ConcurrentQueue<ResolvedEvent> _buffer;
 			private readonly CancellationTokenRegistration _tokenRegistration;
+			private readonly Func<RpcException, Task> _handleFailure;
 
 			private StreamRevision _nextRevision;
 			private bool _isEnd;
 			private ResolvedEvent _current;
 			private ulong _readCount;
+			private RpcException _currentException;
 
 			public ResolvedEvent Current => _current;
 
@@ -39,6 +41,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				ClaimsPrincipal user,
 				bool requiresLeader,
 				DateTime deadline,
+				Func<RpcException, Task> handleFailure,
 				CancellationToken cancellationToken) {
 				if (bus == null) {
 					throw new ArgumentNullException(nameof(bus));
@@ -58,6 +61,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_deadline = deadline;
 				_disposedTokenSource = new CancellationTokenSource();
 				_buffer = new ConcurrentQueue<ResolvedEvent>();
+				_handleFailure = handleFailure;
 				_tokenRegistration = cancellationToken.Register(_disposedTokenSource.Dispose);
 			}
 
@@ -92,6 +96,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					(int)Math.Min(32, _maxCount), _resolveLinks, _requiresLeader, default, _user, _deadline));
 
 				if (!await readNextSource.Task.ConfigureAwait(false)) {
+					if (_currentException == null) return false;
+					
+					await _handleFailure(_currentException).ConfigureAwait(false);
+					_currentException = null;
+
 					return false;
 				}
 
@@ -131,7 +140,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							readNextSource.TrySetResult(true);
 							return;
 						case ReadStreamResult.NoStream:
-							readNextSource.TrySetException(RpcExceptions.StreamNotFound(_streamName));
+							_currentException = RpcExceptions.StreamNotFound(_streamName);
+							readNextSource.TrySetResult(false);
 							return;
 						case ReadStreamResult.StreamDeleted:
 							readNextSource.TrySetException(RpcExceptions.StreamDeleted(_streamName));

--- a/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				{Constants.Exceptions.LeaderEndpoint, leaderEndpoint.ToString()}
 			});
 
-		public static Exception StreamNotFound(string streamName) =>
+		public static RpcException StreamNotFound(string streamName) =>
 			new RpcException(new Status(StatusCode.NotFound, $"Event stream '{streamName}' is not found."), new Metadata {
 				{Constants.Exceptions.ExceptionKey, Constants.Exceptions.StreamNotFound},
 				{Constants.Exceptions.StreamName, streamName}

--- a/src/Protos/Grpc/streams.proto
+++ b/src/Protos/Grpc/streams.proto
@@ -86,6 +86,7 @@ message ReadResp {
 		ReadEvent event = 1;
 		SubscriptionConfirmation confirmation = 2;
 		Checkpoint checkpoint = 3;
+		StreamNotFound stream_not_found = 4;
 	}
 
 	message ReadEvent {
@@ -113,6 +114,9 @@ message ReadResp {
 	message Checkpoint {
 		uint64 commit_position = 1;
 		uint64 prepare_position = 2;
+	}
+	message StreamNotFound {
+	  	string stream_name = 1;
 	}
 }
 


### PR DESCRIPTION
Added: Extended the proto contract for read responses to include Stream Not Found.

Fixes https://github.com/EventStore/EventStore-Client-Dotnet/issues/14

This PR enables clients the ability not to have to handle rpc exceptions if for example the stream does not yet exist.