### PR TITLE
Enable the test client to connect to host or ip

### DIFF
--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -233,7 +233,7 @@ namespace EventStore.Core.Util {
 		/*
 		 *  SINGLE NODE OPTIONS
 		 */
-		public const string IpDescr = "The IP address to bind to.";
+		public const string HostDescr = "The Host to bind to.";
 		public static readonly IPAddress IpDefault = IPAddress.Loopback;
 
 		public const string TcpPortDescr = "The port to run the TCP server on.";

--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -21,8 +21,8 @@ namespace EventStore.TestClient {
 		public readonly bool InteractiveMode;
 
 		public readonly ClientOptions Options;
-		public readonly IPEndPoint TcpEndpoint;
-		public readonly IPEndPoint HttpEndpoint;
+		public readonly EndPoint TcpEndpoint;
+		public readonly EndPoint HttpEndpoint;
 		public readonly bool UseSsl;
 		public readonly bool ValidateServer;
 
@@ -36,8 +36,8 @@ namespace EventStore.TestClient {
 		public Client(ClientOptions options) {
 			Options = options;
 
-			TcpEndpoint = new IPEndPoint(options.Ip, options.TcpPort);
-			HttpEndpoint = new IPEndPoint(options.Ip, options.HttpPort);
+			TcpEndpoint = new DnsEndPoint(options.Host, options.TcpPort);
+			HttpEndpoint = new DnsEndPoint(options.Host, options.HttpPort);
 
 			UseSsl = options.UseTls;
 			ValidateServer = options.TlsValidateServer;
@@ -177,8 +177,8 @@ namespace EventStore.TestClient {
 			if (UseSsl) {
 				connection = _connector.ConnectSslTo(
 					Guid.NewGuid(),
-					endpoint.Address.ToString(),
-					endpoint,
+					endpoint.GetHost(),
+					endpoint.ResolveDnsToIPAddress(),
 					TcpConnectionManager.ConnectionTimeout,
 					(cert,chain,err) => (err == SslPolicyErrors.None, err.ToString()),
 					null,
@@ -188,7 +188,7 @@ namespace EventStore.TestClient {
 			} else {
 				connection = _connector.ConnectTo(
 					Guid.NewGuid(),
-					endpoint,
+					endpoint.ResolveDnsToIPAddress(),
 					TcpConnectionManager.ConnectionTimeout,
 					onConnectionEstablished,
 					onConnectionFailed,

--- a/src/EventStore.TestClient/ClientOptions.cs
+++ b/src/EventStore.TestClient/ClientOptions.cs
@@ -21,7 +21,7 @@ namespace EventStore.TestClient {
 		[ArgDescription(Opts.WhatIfDescr, Opts.AppGroup)]
 		public bool WhatIf { get; set; }
 
-		[ArgDescription(Opts.IpDescr)] public IPAddress Ip { get; set; }
+		[ArgDescription(Opts.HostDescr)] public string Host { get; set; }
 		[ArgDescription(Opts.TcpPortDescr)] public int TcpPort { get; set; }
 		[ArgDescription(Opts.HttpPortDescr)] public int HttpPort { get; set; }
 		public int Timeout { get; set; }
@@ -41,7 +41,7 @@ namespace EventStore.TestClient {
 			Version = Opts.ShowVersionDefault;
 			Log = Locations.DefaultTestClientLogDirectory;
 			WhatIf = Opts.WhatIfDefault;
-			Ip = IPAddress.Loopback;
+			Host = IPAddress.Loopback.ToString();
 			TcpPort = 1113;
 			HttpPort = 2113;
 			Timeout = -1;

--- a/src/EventStore.TestClient/Commands/PingProcessor.cs
+++ b/src/EventStore.TestClient/Commands/PingProcessor.cs
@@ -18,7 +18,7 @@ namespace EventStore.TestClient.Commands {
 				context,
 				connectionEstablished: conn => {
 					var package = new TcpPackage(TcpCommand.Ping, Guid.NewGuid(), null);
-					context.Log.Information("[{ip}:{tcpPort}]: PING...", context.Client.Options.Ip,
+					context.Log.Information("[{ip}:{tcpPort}]: PING...", context.Client.Options.Host,
 						context.Client.Options.TcpPort);
 					conn.EnqueueSend(package.AsByteArray());
 				},
@@ -28,7 +28,7 @@ namespace EventStore.TestClient.Commands {
 						return;
 					}
 
-					context.Log.Information("[{ip}:{tcpPort}]: PONG!", context.Client.Options.Ip,
+					context.Log.Information("[{ip}:{tcpPort}]: PONG!", context.Client.Options.Host,
 						context.Client.Options.TcpPort);
 					context.Success();
 					conn.Close();

--- a/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
+++ b/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.ClientAPI;
+using EventStore.Common.Utils;
 
 namespace EventStore.TestClient.Commands {
 	internal class SubscriptionStressTestProcessor : ICmdProcessor {
@@ -29,8 +30,7 @@ namespace EventStore.TestClient.Commands {
 					.UseCustomLogger(new ClientApiLoggerBridge(context.Log))
 					.FailOnNoServerResponse()
 				/*.EnableVerboseLogging()*/,
-				new Uri(string.Format("tcp://{0}:{1}", context.Client.TcpEndpoint.Address,
-					context.Client.TcpEndpoint.Port)));
+				new Uri($"tcp://{context.Client.TcpEndpoint.GetHost()}:{context.Client.TcpEndpoint.GetPort()}"));
 			conn.ConnectAsync().Wait();
 
 			long appearedCnt = 0;

--- a/src/EventStore.TestClient/Commands/TcpSanitazationCheckProcessor.cs
+++ b/src/EventStore.TestClient/Commands/TcpSanitazationCheckProcessor.cs
@@ -5,6 +5,7 @@ using System.Net.Sockets;
 using System.Threading;
 using EventStore.Core.Services.Transport.Tcp;
 using System.Linq;
+using EventStore.Common.Utils;
 using EventStore.Transport.Tcp;
 using ILogger = Serilog.ILogger;
 
@@ -104,13 +105,11 @@ namespace EventStore.TestClient.Commands {
 			return true;
 		}
 
-		private void SendRaw(IPEndPoint endPoint, byte[] package) {
-			using (var client = new TcpClient()) {
-				client.Connect(endPoint);
-				using (var stream = client.GetStream()) {
-					stream.Write(package, 0, package.Length);
-				}
-			}
+		private void SendRaw(EndPoint endPoint, byte[] package) {
+			using var client = new TcpClient();
+			client.Connect(endPoint.ResolveDnsToIPAddress());
+			using var stream = client.GetStream();
+			stream.Write(package, 0, package.Length);
 		}
 	}
 }

--- a/src/EventStore.TestClient/Commands/WriteFloodClientApiProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodClientApiProcessor.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.Common.Log;
+using EventStore.Common.Utils;
 using ExpectedVersion = EventStore.Core.Data.ExpectedVersion;
 
 namespace EventStore.TestClient.Commands {
@@ -69,8 +70,7 @@ namespace EventStore.TestClient.Commands {
 					.FailOnNoServerResponse();
 
 				var client = EventStoreConnection.Create(settings,
-					new Uri(string.Format("tcp://{0}:{1}", context.Client.TcpEndpoint.Address,
-						context.Client.TcpEndpoint.Port)));
+					new Uri($"tcp://{context.Client.TcpEndpoint.GetHost()}:{context.Client.TcpEndpoint.GetPort()}"));
 				clients.Add(client);
 
 				threads.Add(new Thread(_ => {


### PR DESCRIPTION
Changed: Enable the Test Client to connect to a dns or ip endpoint

Fixes https://github.com/EventStore/EventStore/issues/2467