### PR TITLE
Authenticate other nodes as system users

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
@@ -1,0 +1,101 @@
+﻿using System.IO;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Transport.Http.Authentication;
+using EventStore.Core.Services.UserManagement;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
+	public class TestFixtureWithClientCertificateHttpAuthenticationProvider {
+		protected ClientCertificateAuthenticationProvider _provider;
+
+		protected void SetUpProvider(bool validationResult = true) {
+			_provider = new ClientCertificateAuthenticationProvider(x => (validationResult, null),
+				new X509Certificate2Collection());
+		}
+
+		protected static X509Certificate2 LoadTestClientCertificate() {
+			using var stream = Assembly.GetExecutingAssembly()
+				.GetManifestResourceStream(
+					"EventStore.Core.Tests.Services.Transport.Tcp.test_certificates.node2.node2.p12");
+			using var mem = new MemoryStream();
+			stream.CopyTo(mem);
+			return new X509Certificate2(mem.ToArray(), "password");
+		}
+	}
+
+	[TestFixture]
+	public class
+		when_handling_a_request_without_a_client_certificate :
+			TestFixtureWithClientCertificateHttpAuthenticationProvider {
+		private bool _authenticateResult;
+
+		[SetUp]
+		public void SetUp() {
+			SetUpProvider(true);
+			var context = new DefaultHttpContext();
+			Assert.IsNull(context.Connection.ClientCertificate);
+			_authenticateResult = _provider.Authenticate(context, out _);
+		}
+
+		[Test]
+		public void returns_false() {
+			Assert.IsFalse(_authenticateResult);
+		}
+	}
+
+	[TestFixture]
+	public class
+		when_handling_a_request_with_a_client_certificate_that_fails_validation :
+			TestFixtureWithClientCertificateHttpAuthenticationProvider {
+		private bool _authenticateResult;
+
+		[SetUp]
+		public void SetUp() {
+			SetUpProvider(validationResult: false);
+			var context = new DefaultHttpContext();
+			context.Connection.ClientCertificate = LoadTestClientCertificate();
+			_authenticateResult = _provider.Authenticate(context, out _);
+		}
+
+		[Test]
+		public void returns_false() {
+			Assert.IsFalse(_authenticateResult);
+		}
+	}
+
+
+	[TestFixture]
+	public class
+		when_handling_a_request_with_a_client_certificate_that_passes_validation :
+			TestFixtureWithClientCertificateHttpAuthenticationProvider {
+		private HttpAuthenticationRequest _authenticateRequest;
+		private bool _authenticateResult;
+		private HttpContext _context;
+
+		[SetUp]
+		public void SetUp() {
+			SetUpProvider(validationResult: true);
+			_context = new DefaultHttpContext();
+			_context.Connection.ClientCertificate = LoadTestClientCertificate();
+			_authenticateResult = _provider.Authenticate(_context, out _authenticateRequest);
+		}
+
+		[Test]
+		public void returns_true() {
+			Assert.IsTrue(_authenticateResult);
+		}
+
+		[Test]
+		public async Task passes_authentication() {
+			Assert.IsTrue(await _authenticateRequest.AuthenticateAsync());
+		}
+
+		[Test]
+		public void sets_user_to_system_user() {
+			Assert.AreEqual(SystemAccounts.System.Claims, _context.User.Claims);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
@@ -11,18 +11,8 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 	public class TestFixtureWithClientCertificateHttpAuthenticationProvider {
 		protected ClientCertificateAuthenticationProvider _provider;
 
-		protected void SetUpProvider(bool validationResult = true) {
-			_provider = new ClientCertificateAuthenticationProvider(x => (validationResult, null),
-				new X509Certificate2Collection());
-		}
-
-		protected static X509Certificate2 LoadTestClientCertificate() {
-			using var stream = Assembly.GetExecutingAssembly()
-				.GetManifestResourceStream(
-					"EventStore.Core.Tests.Services.Transport.Tcp.test_certificates.node2.node2.p12");
-			using var mem = new MemoryStream();
-			stream.CopyTo(mem);
-			return new X509Certificate2(mem.ToArray(), "password");
+		protected void SetUpProvider() {
+			_provider = new ClientCertificateAuthenticationProvider();
 		}
 	}
 
@@ -34,7 +24,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 
 		[SetUp]
 		public void SetUp() {
-			SetUpProvider(true);
+			SetUpProvider();
 			var context = new DefaultHttpContext();
 			Assert.IsNull(context.Connection.ClientCertificate);
 			_authenticateResult = _provider.Authenticate(context, out _);
@@ -48,28 +38,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 
 	[TestFixture]
 	public class
-		when_handling_a_request_with_a_client_certificate_that_fails_validation :
-			TestFixtureWithClientCertificateHttpAuthenticationProvider {
-		private bool _authenticateResult;
-
-		[SetUp]
-		public void SetUp() {
-			SetUpProvider(validationResult: false);
-			var context = new DefaultHttpContext();
-			context.Connection.ClientCertificate = LoadTestClientCertificate();
-			_authenticateResult = _provider.Authenticate(context, out _);
-		}
-
-		[Test]
-		public void returns_false() {
-			Assert.IsFalse(_authenticateResult);
-		}
-	}
-
-
-	[TestFixture]
-	public class
-		when_handling_a_request_with_a_client_certificate_that_passes_validation :
+		when_handling_a_request_with_a_client_certificate :
 			TestFixtureWithClientCertificateHttpAuthenticationProvider {
 		private HttpAuthenticationRequest _authenticateRequest;
 		private bool _authenticateResult;
@@ -77,9 +46,9 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 
 		[SetUp]
 		public void SetUp() {
-			SetUpProvider(validationResult: true);
+			SetUpProvider();
 			_context = new DefaultHttpContext();
-			_context.Connection.ClientCertificate = LoadTestClientCertificate();
+			_context.Connection.ClientCertificate = new X509Certificate2();
 			_authenticateResult = _provider.Authenticate(_context, out _authenticateRequest);
 		}
 

--- a/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Linq;
 using System.Security.Claims;
 using EventStore.Core.Bus;
 using EventStore.Core.Services;
+using EventStore.Core.Services.UserManagement;
 using EventStore.Plugins.Authorization;
 using Serilog;
 
@@ -40,17 +42,18 @@ namespace EventStore.Core.Authorization {
 			policy.AllowAnonymous(Operations.Node.Statistics.Tcp);
 			policy.AllowAnonymous(Operations.Node.Statistics.Custom);
 
-			policy.AllowAnonymous(Operations.Node.Elections.Prepare);
-			policy.AllowAnonymous(Operations.Node.Elections.PrepareOk);
-			policy.AllowAnonymous(Operations.Node.Elections.ViewChange);
-			policy.AllowAnonymous(Operations.Node.Elections.ViewChangeProof);
-			policy.AllowAnonymous(Operations.Node.Elections.Proposal);
-			policy.AllowAnonymous(Operations.Node.Elections.Accept);
-			policy.AllowAnonymous(Operations.Node.Elections.LeaderIsResigning);
-			policy.AllowAnonymous(Operations.Node.Elections.LeaderIsResigningOk);
+			var isSystem = new MultipleClaimMatchAssertion(Grant.Allow, MultipleMatchMode.All, SystemAccounts.System.Claims.ToArray());
+			policy.Add(Operations.Node.Elections.Prepare, isSystem);
+			policy.Add(Operations.Node.Elections.PrepareOk, isSystem);
+			policy.Add(Operations.Node.Elections.ViewChange, isSystem);
+			policy.Add(Operations.Node.Elections.ViewChangeProof, isSystem);
+			policy.Add(Operations.Node.Elections.Proposal, isSystem);
+			policy.Add(Operations.Node.Elections.Accept, isSystem);
+			policy.Add(Operations.Node.Elections.LeaderIsResigning, isSystem);
+			policy.Add(Operations.Node.Elections.LeaderIsResigningOk, isSystem);
 
 			policy.AllowAnonymous(Operations.Node.Gossip.Read);
-			policy.AllowAnonymous(Operations.Node.Gossip.Update);
+			policy.Add(Operations.Node.Gossip.Update, isSystem);
 
 			policy.AddMatchAnyAssertion(Operations.Node.Shutdown, Grant.Allow, OperationsOrAdmins);
 			policy.AddMatchAnyAssertion(Operations.Node.MergeIndexes, Grant.Allow, OperationsOrAdmins);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -120,7 +120,6 @@ namespace EventStore.Core {
 		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _internalClientCertificateValidator;
 		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _externalClientCertificateValidator;
 		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _externalServerCertificateValidator;
-		private readonly Func<X509Chain, ValueTuple<bool, string>> _nodeClientCertificateValidator;
 		private readonly ClusterVNodeSettings _vNodeSettings;
 		private readonly ClusterVNodeStartup _startup;
 		private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
@@ -168,7 +167,6 @@ namespace EventStore.Core {
 			_internalClientCertificateValidator = (cert, chain, errors) =>  ValidateClientCertificateWithTrustedRootCerts(cert, chain, errors, _vNodeSettings.TrustedRootCerts);
 			_externalClientCertificateValidator = delegate { return (true, null); };
 			_externalServerCertificateValidator = (cert, chain, errors) => ValidateServerCertificateWithTrustedRootCerts(cert, chain, errors, _vNodeSettings.TrustedRootCerts);
-			_nodeClientCertificateValidator = (certChain) => ValidateNodeClientCertificateWithTrustedRootCerts(certChain, _vNodeSettings.TrustedRootCerts);
 
 			var forwardingProxy = new MessageForwardingProxy();
 			if (vNodeSettings.EnableHistograms) {
@@ -453,7 +451,7 @@ namespace EventStore.Core {
 			});
 
 			var httpAuthenticationProviders = new List<IHttpAuthenticationProvider> {
-				new ClientCertificateAuthenticationProvider(_nodeClientCertificateValidator, _vNodeSettings.TrustedRootCerts),
+				new ClientCertificateAuthenticationProvider(),
 				new BasicHttpAuthenticationProvider(_authenticationProvider),
 			};
 			if (vNodeSettings.EnableTrustedAuth)
@@ -877,29 +875,24 @@ namespace EventStore.Core {
 
 			//client certificates need to be strictly validated against the set of trusted root certificates
 			//but this is not required for server certificates since the client is already validating the CN/SAN against the IP address/hostname it's connecting to
-			if (certificateOrigin == "client")
-				return ValidateNodeClientCertificateWithTrustedRootCerts(newChain, trustedRootCerts);
-			return (true, null);
-		}
-		
-		public static ValueTuple<bool, string> ValidateNodeClientCertificateWithTrustedRootCerts(
-			X509Chain certificateChain, X509Certificate2Collection trustedCerts) {
-			var chainRoot = certificateChain.ChainElements[^1].Certificate;
-			var chainRootIsTrusted = false;
-			if (trustedCerts != null) {
-				foreach (var rootCert in trustedCerts) {
-					if (chainRoot.RawData.SequenceEqual(rootCert.RawData)) {
-						chainRootIsTrusted = true;
-						break;
+			if (certificateOrigin == "client") {
+				var chainRoot = newChain.ChainElements[^1].Certificate;
+				var chainRootIsTrusted = false;
+				if (trustedRootCerts != null) {
+					foreach (var rootCert in trustedRootCerts) {
+						if (chainRoot.RawData.SequenceEqual(rootCert.RawData)) {
+							chainRootIsTrusted = true;
+							break;
+						}
 					}
+				}
+
+				if (!chainRootIsTrusted) {
+					return (false,
+						$"The certificate provided by the {certificateOrigin} does not have a root certificate present in the list of trusted root certificates");
 				}
 			}
 
-			if (!chainRootIsTrusted) {
-				return (false,
-					$"The certificate provided by the client does not have a root certificate present in the list of trusted root certificates");
-			}
-			
 			return (true, null);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Core.Services.UserManagement;
+using Microsoft.AspNetCore.Http;
+
+namespace EventStore.Core.Services.Transport.Http.Authentication {
+	public class ClientCertificateAuthenticationProvider : IHttpAuthenticationProvider {
+		private readonly Func<X509Chain, (bool, string)> _validateNodeClientCertificate;
+		private readonly X509Certificate2Collection _trustedRootCerts;
+
+		public ClientCertificateAuthenticationProvider(
+			Func<X509Chain, ValueTuple<bool, string>> validateNodeClientCertificate,
+			X509Certificate2Collection trustedRootCerts) {
+			_validateNodeClientCertificate = validateNodeClientCertificate;
+			_trustedRootCerts = trustedRootCerts;
+		}
+
+		public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
+			request = null;
+			if (context.Connection.ClientCertificate is null) return false;
+
+			var newChain = new X509Chain {
+				ChainPolicy = {
+					RevocationMode = X509RevocationMode.NoCheck
+				}
+			};
+
+			if (_trustedRootCerts != null) {
+				foreach (var cert in _trustedRootCerts)
+					newChain.ChainPolicy.ExtraStore.Add(cert);
+			}
+
+			newChain.Build(new X509Certificate2(context.Connection.ClientCertificate));
+
+			var (isValid, msg) = _validateNodeClientCertificate(newChain);
+			if (!isValid) return false;
+
+			request = new HttpAuthenticationRequest(context, "system", "");
+			request.Authenticated(SystemAccounts.System);
+			return true;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
@@ -1,40 +1,11 @@
-﻿using System;
-using System.Security.Cryptography.X509Certificates;
-using EventStore.Core.Services.UserManagement;
+﻿using EventStore.Core.Services.UserManagement;
 using Microsoft.AspNetCore.Http;
 
 namespace EventStore.Core.Services.Transport.Http.Authentication {
 	public class ClientCertificateAuthenticationProvider : IHttpAuthenticationProvider {
-		private readonly Func<X509Chain, (bool, string)> _validateNodeClientCertificate;
-		private readonly X509Certificate2Collection _trustedRootCerts;
-
-		public ClientCertificateAuthenticationProvider(
-			Func<X509Chain, ValueTuple<bool, string>> validateNodeClientCertificate,
-			X509Certificate2Collection trustedRootCerts) {
-			_validateNodeClientCertificate = validateNodeClientCertificate;
-			_trustedRootCerts = trustedRootCerts;
-		}
-
 		public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
 			request = null;
 			if (context.Connection.ClientCertificate is null) return false;
-
-			var newChain = new X509Chain {
-				ChainPolicy = {
-					RevocationMode = X509RevocationMode.NoCheck
-				}
-			};
-
-			if (_trustedRootCerts != null) {
-				foreach (var cert in _trustedRootCerts)
-					newChain.ChainPolicy.ExtraStore.Add(cert);
-			}
-
-			newChain.Build(new X509Certificate2(context.Connection.ClientCertificate));
-
-			var (isValid, msg) = _validateNodeClientCertificate(newChain);
-			if (!isValid) return false;
-
 			request = new HttpAuthenticationRequest(context, "system", "");
 			request.Authenticated(SystemAccounts.System);
 			return true;


### PR DESCRIPTION
Changed: Authenticate requests as the system user if they provide a valid client certificate with the provided trusted root certificate
Changed: Require a system user for gossip update, and for all election operations

Related to #2330 
This will allow us to securely provide gossip over the external endpoint, which should enable us to remove the internal http interface.

- Add `ClientCertificateAuthenticationProvider` to `HttpAuthenticationProviders`