### PR TITLE
Prevent the same index and database path from being specified

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -83,6 +83,13 @@ namespace EventStore.ClusterNode {
 					"The given database path starts with a '~'. Event Store does not expand '~'.");
 			}
 
+			string absolutePathIndex = Path.GetFullPath(options.Index);
+			string absolutePathDb = Path.GetFullPath(options.Db);
+			if(absolutePathDb.Equals(absolutePathIndex))
+			{
+				throw new ApplicationInitializationException($"The given database ({absolutePathDb}) and index ({absolutePathIndex}) paths cannot point to the same directory.");
+			}
+
 			if (options.Log.StartsWith("~")) {
 				throw new ApplicationInitializationException(
 					"The given log path starts with a '~'. Event Store does not expand '~'.");


### PR DESCRIPTION
The index system deletes anything that's not in the index map on startup. If the same index/db path is specified, the index system will delete all chunk files. To remedy this, we do a check to prevent the same index and database path from being used when EventStore starts up.
