### PR TITLE
Test nodes can leave the database until the test fixture deletes the root directory

### DIFF
--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -10,7 +10,7 @@ namespace EventStore.Core.Tests.Integration {
 			await base.Given();
 
 			for (int i = 0; i < 9; i++) {
-				await _nodes[i % 3].Shutdown();
+				await _nodes[i % 3].Shutdown(keepDb: true);
 
 				var node = CreateNode(i % 3, _nodeEndpoints[i % 3],
 					new[] {_nodeEndpoints[(i+1)%3].InternalHttp, _nodeEndpoints[(i+2)%3].InternalHttp});


### PR DESCRIPTION
Fix: When restarting each node one at a time, should keep db as the test fixture will remove the root directory. This test fails the CI quite often.

Fixes https://github.com/EventStore/EventStore/issues/2481
