### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
+++ b/src/EventStore.ClientAPI/Internal/EventStoreConnectionLogicHandler.cs
@@ -277,7 +277,7 @@ namespace EventStore.ClientAPI.Internal {
 						TcpFlags.Authenticated,
 						_authInfo.CorrelationId,
 						_settings.DefaultUserCredentials.AuthToken,
-						default)
+						null)
 					: new TcpPackage(TcpCommand.Authenticate,
 						TcpFlags.Authenticated,
 						_authInfo.CorrelationId,

--- a/src/EventStore.ClientAPI/SystemData/TcpPackage.cs
+++ b/src/EventStore.ClientAPI/SystemData/TcpPackage.cs
@@ -100,6 +100,11 @@ namespace EventStore.ClientAPI.SystemData {
 			: this(command, flags, correlationId, login, password, new ArraySegment<byte>(data ?? Empty.ByteArray)) {
 		}
 
+		public TcpPackage(TcpCommand command, TcpFlags flags, Guid correlationId, string authToken,
+			byte[] data)
+			: this(command, flags, correlationId, authToken, new ArraySegment<byte>(data ?? Empty.ByteArray)) {
+		}
+
 		public TcpPackage(TcpCommand command, TcpFlags flags, Guid correlationId, string login, string password,
 			ArraySegment<byte> data) : this(command, flags, correlationId, data) {
 			if ((flags & TcpFlags.Authenticated) != 0) {


### PR DESCRIPTION
Fixed: the default ArraySegment's data is null, not an empty array.