### PR TITLE
Perform Database Check only w/ Both Index and Db Specified

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -83,11 +83,13 @@ namespace EventStore.ClusterNode {
 					"The given database path starts with a '~'. Event Store does not expand '~'.");
 			}
 
-			string absolutePathIndex = Path.GetFullPath(options.Index);
-			string absolutePathDb = Path.GetFullPath(options.Db);
-			if(absolutePathDb.Equals(absolutePathIndex))
-			{
-				throw new ApplicationInitializationException($"The given database ({absolutePathDb}) and index ({absolutePathIndex}) paths cannot point to the same directory.");
+			if (options.Index != null && options.Db != null) {
+				string absolutePathIndex = Path.GetFullPath(options.Index);
+				string absolutePathDb = Path.GetFullPath(options.Db);
+				if (absolutePathDb.Equals(absolutePathIndex)) {
+					throw new ApplicationInitializationException(
+						$"The given database ({absolutePathDb}) and index ({absolutePathIndex}) paths cannot point to the same directory.");
+				}
 			}
 
 			if (options.Log.StartsWith("~")) {


### PR DESCRIPTION
Fixed: When starting Event Store without an Index Path specified (as is the case when running in memory), the server would crash with a `NullReferenceException`.