### PR TITLE
Tcp connections should have Ssl enabled by default

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -27,8 +27,8 @@ namespace EventStore.ClientAPI {
 		private TimeSpan _operationTimeoutCheckPeriod = Consts.DefaultOperationTimeoutCheckPeriod;
 
 		private UserCredentials _defaultUserCredentials;
-		private bool _useSslConnection;
-		private bool _validateServer;
+		private bool _useSslConnection = true;
+		private bool _validateServer = true;
 
 		private bool _failOnNoServerResponse;
 		private TimeSpan _heartbeatInterval = TimeSpan.FromMilliseconds(750);
@@ -248,15 +248,22 @@ namespace EventStore.ClientAPI {
 			_defaultUserCredentials = userCredentials;
 			return this;
 		}
+		
+		/// <summary>
+		/// Disables TLS
+		/// </summary>
+		/// <returns></returns>
+		public ConnectionSettingsBuilder DisableTls() {
+			_useSslConnection = false;
+			return this;
+		}
 
 		/// <summary>
-		/// Uses a SSL connection over TCP. This should generally be used with authentication.
+		/// Disables Server Certificate Validation
 		/// </summary>
-		/// <param name="validateServer">Whether to accept connection from server with not trusted certificate.</param>
 		/// <returns></returns>
-		public ConnectionSettingsBuilder UseSslConnection(bool validateServer) {
-			_useSslConnection = true;
-			_validateServer = validateServer;
+		public ConnectionSettingsBuilder DisableServerCertificateValidation() {
+			_validateServer = false;
 			return this;
 		}
 

--- a/src/EventStore.ClientAPIAcceptanceTests/ConnectionSettingsBuilderExtensions.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/ConnectionSettingsBuilderExtensions.cs
@@ -7,7 +7,7 @@ namespace EventStore.ClientAPI.Tests {
 			=> useSsl ? builder.UseSslConnection(Guid.NewGuid().ToString("n"), false) : builder;
 		#elif CLIENT_API || CLIENT_API_EMBEDDED
 		public static ConnectionSettingsBuilder UseSsl(this ConnectionSettingsBuilder builder, bool useSsl)
-			=> useSsl ? builder.UseSslConnection(false) : builder;
+			=> useSsl ? builder.DisableServerCertificateValidation() : builder.DisableTls();
 		#endif
 	}
 }

--- a/src/EventStore.Core.Tests/ClientAPI/Helpers/TestConnection.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/Helpers/TestConnection.cs
@@ -37,8 +37,12 @@ namespace EventStore.Core.Tests.ClientAPI.Helpers {
 				.FailOnNoServerResponse()
 				//.SetOperationTimeoutTo(TimeSpan.FromDays(1))
 				;
-			if (tcpType == TcpType.Ssl)
-				settings.UseSslConnection(false);
+			if (tcpType == TcpType.Ssl) {
+				settings.DisableServerCertificateValidation();
+			} else {
+				settings.DisableTls();
+			}
+
 			return settings;
 		}
 	}

--- a/src/EventStore.Core.Tests/ClientAPI/connect.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connect.cs
@@ -39,8 +39,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.WithConnectionTimeoutOf(TimeSpan.FromSeconds(10))
 				.SetReconnectionDelayTo(TimeSpan.FromMilliseconds(0))
 				.FailOnNoServerResponse();
-			if (_tcpType == TcpType.Ssl)
-				settings.UseSslConnection(false);
+			if (_tcpType == TcpType.Ssl) {
+				settings.DisableServerCertificateValidation();
+			} else {
+				settings.DisableTls();
+			}
 
 			var ip = IPAddress.Loopback;
 			int port = PortsHelper.GetAvailablePort(ip);
@@ -67,8 +70,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 					.WithConnectionTimeoutOf(TimeSpan.FromSeconds(10))
 					.SetReconnectionDelayTo(TimeSpan.FromMilliseconds(0))
 					.FailOnNoServerResponse();
-			if (_tcpType == TcpType.Ssl)
-				settings.UseSslConnection(false);
+			if (_tcpType == TcpType.Ssl) {
+				settings.DisableServerCertificateValidation();
+			} else {
+				settings.DisableTls();
+			}
 
 			var ip = IPAddress.Loopback;
 			int port = PortsHelper.GetAvailablePort(ip);
@@ -112,8 +118,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 					.FailOnNoServerResponse()
 					.WithConnectionTimeoutOf(TimeSpan.FromMilliseconds(1000));
 
-			if (_tcpType == TcpType.Ssl)
-				settings.UseSslConnection(false);
+			if (_tcpType == TcpType.Ssl) {
+				settings.DisableServerCertificateValidation();
+			} else {
+				settings.DisableTls();
+			}
 
 			var ip = new IPAddress(new byte[]
 				{8, 8, 8, 8}); //NOTE: This relies on Google DNS server being configured to swallow nonsense traffic

--- a/src/EventStore.Core.Tests/ClientAPI/soft_delete.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/soft_delete.cs
@@ -33,7 +33,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 		}
 
 		protected virtual IEventStoreConnection BuildConnection(MiniNode node) {
-			return EventStoreConnection.Create(node.TcpEndPoint.ToESTcpUri());
+			return EventStoreConnection.Create(
+				ConnectionSettings.Create().DisableTls().Build(),
+				node.TcpEndPoint.ToESTcpUri());
 		}
 
 		[Test, Category("LongRunning"), Category("Network")]

--- a/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
+++ b/src/EventStore.Core.Tests/Http/PersistentSubscription/statistics.cs
@@ -440,7 +440,7 @@ namespace EventStore.Core.Tests.Http.PersistentSubscription {
 			.StartFromCurrent();
 
 		protected override async Task Given() {
-			_conn = EventStoreConnection.Create(_node.TcpEndPoint);
+			_conn = EventStoreConnection.Create(ConnectionSettings.Create().DisableTls().Build(), _node.TcpEndPoint);
 			await _conn.ConnectAsync();
 			await _conn.CreatePersistentSubscriptionAsync(_streamName, _groupName, _settings,
 				DefaultData.AdminCredentials);

--- a/src/EventStore.Core.Tests/Services/Replication/ReadOnlyReplica/connecting_to_read_only_replica.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReadOnlyReplica/connecting_to_read_only_replica.cs
@@ -27,6 +27,7 @@ namespace EventStore.Core.Tests.Replication.ReadOnlyReplica {
 
 		protected override IEventStoreConnection CreateConnection() {
 			var settings = ConnectionSettings.Create()
+				.DisableTls()
 				.PerformOnAnyNode();
 			return EventStoreConnection.Create(settings, _nodes[2].ExternalTcpEndPoint);
 		}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_tcp_stats_from_stat_controller.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/when_getting_tcp_stats_from_stat_controller.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		protected override async Task Given() {
 			_url = _node.HttpEndPoint.ToHttpUrl(EndpointExtensions.HTTP_SCHEMA, "/stats/tcp");
 
-			var settings = ConnectionSettings.Create();
+			var settings = ConnectionSettings.Create().DisableTls();
 			_connection = EventStoreConnection.Create(settings, _node.TcpEndPoint, _clientConnectionName);
 			await _connection.ConnectAsync();
 


### PR DESCRIPTION
Changed: Removed UseSslConnection from the Tcp Client API Connection Settings Builder and replaced it with DisableTls and DisableServerCertificateValidation to resemble the options on the server more closely.


Fixes #2500

The server will by default have SSL enabled by default and therefor the client needs to have SSL enabled by default.

**Notes**
- This is a breaking API change. This might be fine as we haven't yet released the client apart from the Release Candidate.
- Once a client connection is dropped, we do see this stack trace on the server which might not provide a *warm and fuzzy* feeling to the consumer.
```
System.IO.IOException: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host..
 ---> System.Net.Sockets.SocketException (10054): An existing connection was forcibly closed by the remote host.
   --- End of inner exception stack trace ---
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.GetResult(Int16 token)
   at System.Net.Security.SslStream.<FillBufferAsync>g__InternalFillBufferAsync|215_0[TReadAdapter](TReadAdapter adap, ValueTask`1 task, Int32 min, Int32 initial)
   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)
   at System.Threading.Tasks.TaskToApm.End[TResult](IAsyncResult asyncResult)
   at System.Net.Security.SslStream.EndRead(IAsyncResult asyncResult)
   at EventStore.Transport.Tcp.TcpConnectionSsl.OnEndRead(IAsyncResult ar) in C:\src\EventStore.Transport.Tcp\TcpConnectionSsl.cs:line 427
```