### PR TITLE
Set UseSslConnection=false and ValidateServer=false in connection string where required

### DIFF
--- a/src/EventStore.ClientAPI.Tests/EventStoreClientAPIClusterFixture.Tcp.cs
+++ b/src/EventStore.ClientAPI.Tests/EventStoreClientAPIClusterFixture.Tcp.cs
@@ -30,7 +30,8 @@ namespace EventStore.ClientAPI.Tests {
 			var settings = configureSettings ?? DefaultConfigureSettingsForConnectionString;
 			var host = useDnsEndPoint ? "localhost" : IPAddress.Loopback.ToString();
 
-			if (useSsl) settings += "UseSslConnection=true;";
+			if (useSsl) settings += "UseSslConnection=true;ValidateServer=false;";
+			else settings += "UseSslConnection=false;";
 
 			var gossipSeeds = GetGossipSeedEndPointsExceptFor(-1, useDnsEndPoint);
 			var gossipSeedsString = "";

--- a/src/EventStore.ClientAPI.Tests/EventStoreClientAPIFixture.Tcp.cs
+++ b/src/EventStore.ClientAPI.Tests/EventStoreClientAPIFixture.Tcp.cs
@@ -29,6 +29,7 @@ namespace EventStore.ClientAPI.Tests {
 			port ??= (useSsl ? ExternalSecurePort : ExternalPort);
 
 			if (useSsl) settings += $"UseSslConnection=true;ValidateServer=false;";
+			else settings += "UseSslConnection=false;";
 
 			var connectionString = $"ConnectTo=tcp://{host}:{port};{settings}";
 			return EventStoreConnection.Create(connectionString);


### PR DESCRIPTION
Changed: Set UseSslConnection=false and ValidateServer=false in connection string tests where required


This is a follow up PR to fix failing tests in #2487 which was merged after: #2503 but it was not noticed since CI was run on #2487 before #2503 was merged.