### PR TITLE
Fixed Test client not respecting --tls-validate-server=False

### DIFF
--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -180,7 +180,7 @@ namespace EventStore.TestClient {
 					endpoint.GetHost(),
 					endpoint.ResolveDnsToIPAddress(),
 					TcpConnectionManager.ConnectionTimeout,
-					(cert,chain,err) => (err == SslPolicyErrors.None, err.ToString()),
+					(cert,chain,err) => (err == SslPolicyErrors.None || !ValidateServer, err.ToString()),
 					null,
 					onConnectionEstablished,
 					onConnectionFailed,


### PR DESCRIPTION
Fixed: Test client not respecting --tls-validate-server=False

Fixes #2468 