### PR TITLE
Fixed missing field for API Test Cluster Fixture in Embedded project

### DIFF
--- a/src/EventStore.ClientAPI.Embedded.Tests/EventStoreClientAPIClusterFixture.Embedded.cs
+++ b/src/EventStore.ClientAPI.Embedded.Tests/EventStoreClientAPIClusterFixture.Embedded.cs
@@ -1,0 +1,9 @@
+using System;
+using EventStore.ClientAPI;
+using EventStore.ClientAPI.Embedded;
+
+namespace EventStore.ClientAPI.Tests {
+	partial class EventStoreClientAPIClusterFixture {
+		private const bool UseLoggerBridge = false;
+	}
+}


### PR DESCRIPTION
Fixed: Compiling EventStore in Debug Mode

Excluding files from the test fixture import skipped the `UseLoggerBridge` const in the EventStoreClientAPIClusterFixture partial class for the EventStore.ClientAPI.Embedded.Tests project

Resovles #2508 

