### PR TITLE
Patch version information when building the docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,17 @@ jobs:
         dotnet tool restore
         version=$(dotnet tool run minver -- --tag-prefix=oss-v)-${{ matrix.container-runtime }}
         echo "::set-env name=VERSION::${version}"
+
+        version_info=$(dotnet tool run minver -- --tag-prefix=oss-v 2>&1)
+        echo "::set-env name=VERSION_INFO::${version_info}"
     - name: Build
       run: |
         docker build \
           --tag eventstore \
           --build-arg RUNTIME=${{ matrix.runtime }} \
           --build-arg CONTAINER_RUNTIME=${{ matrix.container-runtime }} \
+          --build-arg VERSION="${{ env.VERSION }}" \
+          --build-arg VERSION_INFO="${{ env.VERSION_INFO }}" \
           .
     - name: Run Tests
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 ARG CONTAINER_RUNTIME=bionic
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-bionic AS build
 ARG RUNTIME=linux-x64
+ARG VERSION="0.0.0"
+ARG VERSION_INFO=""
 
 WORKDIR /build/ci
 
@@ -16,7 +18,10 @@ RUN dotnet restore --runtime=${RUNTIME}
 
 COPY ./src .
 
-RUN dotnet build --configuration=Release --runtime=${RUNTIME} --no-restore --framework=netcoreapp3.1
+RUN \
+    chmod +x /build/ci/patch-version-info.sh \
+    && ../ci/patch-version-info.sh "${VERSION}" "${VERSION_INFO}" \
+    && dotnet build --configuration=Release --runtime=${RUNTIME} --no-restore --framework=netcoreapp3.1
 
 FROM build as test
 ARG RUNTIME=linux-x64

--- a/ci/patch-version-info.sh
+++ b/ci/patch-version-info.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+function patchVersionInfo {
+    version=$1
+    version_info=$2
+    if [[ "$version" == "" ]] ; then
+        $version="Unknown"
+    fi
+
+    commitRegex="Commit: ([^,]*)"
+    tagRegex="Tag: '(.*)'"
+
+    commit="Unknown"
+    commitTimestamp="Unknown"
+    tag="Unknown"
+
+    if [[ $version_info =~ $commitRegex ]]
+    then
+        commit=${BASH_REMATCH[1]}
+    fi
+
+    if [[ $version_info =~ $tagRegex ]]
+    then
+        tag=${BASH_REMATCH[1]}
+    fi
+
+    newVersion="public static readonly string Version = \"$version\";"
+    newBranch="public static readonly string Branch = \"$tag\";"
+    newCommitHash="public static readonly string Hashtag = \"$commit\";"
+    newTimestamp="public static readonly string Timestamp = \"$commitTimestamp\";"
+
+    versionPattern="public static readonly string Version .*$"
+    branchPattern="public static readonly string Branch .*$"
+    commitHashPattern="public static readonly string Hashtag .*$"
+    timestampPattern="public static readonly string Timestamp .*$"
+
+    files=$( find . -name "VersionInfo.cs" )
+
+    for file in $files
+    do
+        tempfile="$file.tmp"
+        sed -e "s/$versionPattern/$newVersion/" \
+            -e "s/$branchPattern/$newBranch/" \
+            -e "s/$commitHashPattern/$newCommitHash/" \
+            -e "s/$timestampPattern/$newTimestamp/" \
+            "$file" > "$tempfile"
+
+        cat "$tempfile"
+        mv "$tempfile" "$file"
+        echo "Patched $file with version information"
+    done
+}
+
+patchVersionInfo "$1" "$2"


### PR DESCRIPTION
Changed: Patch the version files when building the docker container so that the logs reflect that information.

Fixes https://github.com/EventStore/TrainStation/issues/23

The Event Store docker container has the version information zeroed out. It's useful information for when we just logs. I have kept the `container-runtime` as part of the information which provides some nice extra metadata.

`Minver` doesn't provide the `commit` and the `tag` for good reason but only the calculated version. We can however extract this information from `stderr` which is where it writes this information to. We have done that here.

**Current**
```
❯ docker run --rm -it eventstore/eventstore:20.6.0-rc-buster-slim
[    1, 1,07:34:11.092,INF]
"ES VERSION:"             "0.0.0.0" ("Unknown"/"Unknown", "Unknown")
```

With this PR
```
❯ docker run --rm -it 08e614bb146c
[    1, 1,07:44:00.360,INF]
"ES VERSION:"             "20.6.0-rc-buster-slim" ("oss-v20.6.24"/"49460af", "Unknown")
```
and if the docker image is built locally without the build arguments
```
❯ docker run --rm -it 6d58ab5a4545
[    1, 1,07:54:06.977,INF]
"ES VERSION:"             "0.0.0" ("Unknown"/"Unknown", "Unknown")
```