### PR TITLE
Releasing ExclusiveDbLock Should Shutdown Cleanly

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -529,8 +529,11 @@ namespace EventStore.ClusterNode {
 		protected override Task StartInternalAsync(CancellationToken cancellationToken) => Node.StartAsync(false);
 
 		protected override Task StopInternalAsync(CancellationToken cancellationToken) {
-			if (_dbLock != null && _dbLock.IsAcquired)
-				_dbLock.Release();
+			if (_dbLock != null && _dbLock.IsAcquired) {
+				using (_dbLock) {
+					_dbLock.Release();
+				}
+			}
 
 			return Node.StopAsync(cancellationToken: cancellationToken);
 		}

--- a/src/EventStore.Core.Tests/ExclusiveDbLockTests.cs
+++ b/src/EventStore.Core.Tests/ExclusiveDbLockTests.cs
@@ -7,12 +7,28 @@ namespace EventStore.Core.Tests {
 	public class ExclusiveDbLockTests {
 		[Test]
 		public async Task can_release_when_running_in_task_pool() {
-			var dbPath = $"/tmp/eventstore/{Guid.NewGuid()}";
-			using var sut = new ExclusiveDbLock(dbPath);
+			using var sut = new ExclusiveDbLock(GetDbPath());
 			Assert.True(sut.Acquire());
 			Assert.True(sut.IsAcquired);
 			await Task.Delay(1);
 			sut.Release();
 		}
+
+		[Test]
+		public void acquiring_twice_throws() {
+			using var sut = new ExclusiveDbLock(GetDbPath());
+			sut.Acquire();
+			Assert.Throws<InvalidOperationException>(() => sut.Acquire());
+		}
+
+		[Test]
+		public void releasing_before_acquiring_throws() {
+			using var sut = new ExclusiveDbLock(GetDbPath());
+			Assert.Throws<InvalidOperationException>(() => sut.Release());
+		}
+
+		private static string GetDbPath() => $"/tmp/eventstore/{Guid.NewGuid()}";
+
+
 	}
 }

--- a/src/EventStore.Core.Tests/ExclusiveDbLockTests.cs
+++ b/src/EventStore.Core.Tests/ExclusiveDbLockTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests {
+	[TestFixture]
+	public class ExclusiveDbLockTests {
+		[Test]
+		public async Task can_release_when_running_in_task_pool() {
+			var dbPath = $"/tmp/eventstore/{Guid.NewGuid()}";
+			var sut = new ExclusiveDbLock(dbPath);
+			Assert.True(sut.Acquire());
+			Assert.True(sut.IsAcquired);
+			await Task.Delay(1);
+			sut.Release();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/ExclusiveDbLockTests.cs
+++ b/src/EventStore.Core.Tests/ExclusiveDbLockTests.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.Tests {
 		[Test]
 		public async Task can_release_when_running_in_task_pool() {
 			var dbPath = $"/tmp/eventstore/{Guid.NewGuid()}";
-			var sut = new ExclusiveDbLock(dbPath);
+			using var sut = new ExclusiveDbLock(dbPath);
 			Assert.True(sut.Acquire());
 			Assert.True(sut.IsAcquired);
 			await Task.Delay(1);

--- a/src/EventStore.Core/ExclusiveDbLock.cs
+++ b/src/EventStore.Core/ExclusiveDbLock.cs
@@ -48,7 +48,11 @@ namespace EventStore.Core {
 		public void Release() {
 			if (!_acquired)
 				throw new InvalidOperationException($"DB mutex '{MutexName}' was not acquired.");
-			_dbMutex.ReleaseMutex();
+			try {
+				_dbMutex.ReleaseMutex();
+			} catch (ApplicationException ex) {
+				Log.Warning(ex, "Error occurred while releasing lock.");
+			}
 		}
 
 		public void Dispose() => _dbMutex?.Dispose();


### PR DESCRIPTION
Fixed: Logging `Object synchronization method was called from an unsynchronized method` as a warning instead of fatal when shutting down EventStore