### PR TITLE
VNodeState in cluster.proto not matching EventStore.Core.Data.VNodeState

### DIFF
--- a/src/EventStore.Core/Data/VNodeState.cs
+++ b/src/EventStore.Core/Data/VNodeState.cs
@@ -1,21 +1,22 @@
 namespace EventStore.Core.Data {
+	//WARNING: new states must be added at the bottom of the enum otherwise it may break cluster and client compatibility
 	public enum VNodeState {
-		Initializing,
-		DiscoverLeader,
-		Unknown,
-		PreReplica,
-		CatchingUp,
-		Clone,
-		Follower,
-		PreLeader,
-		Leader,
-		Manager,
-		ShuttingDown,
-		Shutdown,
-		ReadOnlyLeaderless,
-		PreReadOnlyReplica,
-		ReadOnlyReplica,
-		ResigningLeader
+		Initializing = 0,
+		DiscoverLeader = 1,
+		Unknown = 2,
+		PreReplica = 3,
+		CatchingUp = 4,
+		Clone = 5,
+		Follower = 6,
+		PreLeader = 7,
+		Leader = 8,
+		Manager = 9,
+		ShuttingDown = 10,
+		Shutdown = 11,
+		ReadOnlyLeaderless = 12,
+		PreReadOnlyReplica = 13,
+		ReadOnlyReplica = 14,
+		ResigningLeader = 15
 	}
 
 	public static class VNodeStateExtensions {

--- a/src/Protos/Grpc/cluster.proto
+++ b/src/Protos/Grpc/cluster.proto
@@ -106,20 +106,21 @@ message EndPoint {
 message MemberInfo {
 	enum VNodeState {
 		Initializing = 0;
-		Unknown = 1;
-		PreReplica = 2;
-		CatchingUp = 3;
-		Clone = 4;
-		Follower = 5;
-		PreLeader = 6;
-		Leader = 7;
-		Manager = 8;
-		ShuttingDown = 9;
-		Shutdown = 10;
-		ReadOnlyLeaderless = 11;
-		PreReadOnlyReplica = 12;
-		ReadOnlyReplica = 13;
-		ResigningLeader = 14;
+		DiscoverLeader = 1;
+		Unknown = 2;
+		PreReplica = 3;
+		CatchingUp = 4;
+		Clone = 5;
+		Follower = 6;
+		PreLeader = 7;
+		Leader = 8;
+		Manager = 9;
+		ShuttingDown = 10;
+		Shutdown = 11;
+		ReadOnlyLeaderless = 12;
+		PreReadOnlyReplica = 13;
+		ReadOnlyReplica = 14;
+		ResigningLeader = 15;
 	}
 	event_store.client.shared.UUID instance_id = 1;
 	int64 time_stamp = 2;


### PR DESCRIPTION
Fixed: VNodeState in cluster.proto not matching EventStore.Core.Data.VNodeState


- Add warning about modifying the VNodeState enum and assign explicit values
- Add DiscoverLeader state to cluster.proto

DiscoverLeader state was added in PR #2386 but we did not update the cluster.proto file.
The reason this was not causing any noticeable issue between servers is that the same server versions were running together in a cluster. During gossip, typecasting EventStore.Core.Data.VNodeState to the protobuf enum would have the wrong value. However, when it would be deserialized on the other server, it would map back again to the correct value.