### PR TITLE
Add external gRPC endpoint for gossip

### DIFF
--- a/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
+++ b/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
@@ -366,6 +366,7 @@ namespace EventStore.Core.Tests.Authorization {
 				yield return CreateOperation(Operations.Node.Statistics.Custom);
 
 				yield return CreateOperation(Operations.Node.Gossip.Read);
+				yield return CreateOperation(Operations.Node.Gossip.ClientRead);
 
 				yield return (new Operation(Operations.Streams.Read).WithParameter(
 						Operations.Streams.Parameters.StreamId(_streamWithDefaultPermissions)),

--- a/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
@@ -53,6 +53,7 @@ namespace EventStore.Core.Authorization {
 			policy.Add(Operations.Node.Elections.LeaderIsResigningOk, isSystem);
 
 			policy.AllowAnonymous(Operations.Node.Gossip.Read);
+			policy.AllowAnonymous(Operations.Node.Gossip.ClientRead);
 			policy.Add(Operations.Node.Gossip.Update, isSystem);
 
 			policy.AddMatchAnyAssertion(Operations.Node.Shutdown, Grant.Allow, OperationsOrAdmins);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -699,6 +699,7 @@ namespace EventStore.Core {
 				_mainBus.Subscribe<GossipMessage.GotGossipSeedSources>(gossip);
 				_mainBus.Subscribe<GossipMessage.Gossip>(gossip);
 				_mainBus.Subscribe<GossipMessage.GossipReceived>(gossip);
+				_mainBus.Subscribe<GossipMessage.ReadGossip>(gossip);
 				_mainBus.Subscribe<SystemMessage.StateChangeMessage>(gossip);
 				_mainBus.Subscribe<GossipMessage.GossipSendFailed>(gossip);
 				_mainBus.Subscribe<GossipMessage.UpdateNodePriority>(gossip);

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Core.Services.Transport.Grpc.Cluster;
 using EventStore.Core.Services.Transport.Http;
 using EventStore.Core.Services.Transport.Http.Authentication;
 using EventStore.Core.TransactionLog.Chunks;
@@ -22,7 +23,7 @@ using MidFunc = System.Func<
 	System.Func<System.Threading.Tasks.Task>,
 	System.Threading.Tasks.Task
 >;
-using ElectionsService = EventStore.Core.Services.Transport.Grpc.Elections;
+using ElectionsService = EventStore.Core.Services.Transport.Grpc.Cluster.Elections;
 using Operations = EventStore.Core.Services.Transport.Grpc.Operations;
 
 namespace EventStore.Core {

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -25,6 +25,8 @@ using MidFunc = System.Func<
 >;
 using ElectionsService = EventStore.Core.Services.Transport.Grpc.Cluster.Elections;
 using Operations = EventStore.Core.Services.Transport.Grpc.Operations;
+using ClusterGossip = EventStore.Core.Services.Transport.Grpc.Cluster.Gossip;
+using ClientGossip = EventStore.Core.Services.Transport.Grpc.Gossip;
 
 namespace EventStore.Core {
 	public class ClusterVNodeStartup : IStartup, IHandle<SystemMessage.SystemReady>,
@@ -106,13 +108,14 @@ namespace EventStore.Core {
 						.UseMiddleware<KestrelToInternalBridgeMiddleware>()
 						.UseMiddleware<AuthorizationMiddleware>()
 						.UseLegacyHttp(internalDispatcher.InvokeAsync, _httpService)
-					)
+				)
 				.UseEndpoints(ep => ep.MapGrpcService<PersistentSubscriptions>())
 				.UseEndpoints(ep => ep.MapGrpcService<Users>())
 				.UseEndpoints(ep => ep.MapGrpcService<Streams>())
-				.UseEndpoints(ep => ep.MapGrpcService<Gossip>())
+				.UseEndpoints(ep => ep.MapGrpcService<ClusterGossip>())
 				.UseEndpoints(ep => ep.MapGrpcService<Elections>())
-				.UseEndpoints(ep => ep.MapGrpcService<Operations>());
+				.UseEndpoints(ep => ep.MapGrpcService<Operations>())
+				.UseEndpoints(ep => ep.MapGrpcService<ClientGossip>());
 
 			_subsystems
 				.Aggregate(app,(b, subsystem) => subsystem.Configure(b));
@@ -135,8 +138,9 @@ namespace EventStore.Core {
 						.AddSingleton(new PersistentSubscriptions(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Users(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Operations(_mainQueue, _authorizationProvider))
-						.AddSingleton(new Gossip(_mainQueue, _authorizationProvider))
+						.AddSingleton(new ClusterGossip(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Elections(_mainQueue, _authorizationProvider))
+						.AddSingleton(new ClientGossip(_mainQueue, _authorizationProvider))
 						.AddGrpc()
 						.AddServiceOptions<Streams>(options =>
 							options.MaxReceiveMessageSize = TFConsts.EffectiveMaxLogRecordSize)

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="EventStore.Plugins" Version="6.0.0-preview4" />
+		<PackageReference Include="EventStore.Plugins" Version="6.0.0-preview5" />
 		<PackageReference Include="Google.Protobuf" Version="3.11.3" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.27.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.27.0">

--- a/src/EventStore.Core/Messages/GossipMessage.cs
+++ b/src/EventStore.Core/Messages/GossipMessage.cs
@@ -60,6 +60,20 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class ReadGossip : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public readonly IEnvelope Envelope;
+
+			public ReadGossip(IEnvelope envelope) {
+				Envelope = envelope;
+			}
+		}
+
 		public class SendGossip : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
@@ -17,6 +17,7 @@ namespace EventStore.Core.Services.Gossip {
 		IHandle<GossipMessage.GotGossipSeedSources>,
 		IHandle<GossipMessage.Gossip>,
 		IHandle<GossipMessage.GossipReceived>,
+		IHandle<GossipMessage.ReadGossip>,
 		IHandle<SystemMessage.StateChangeMessage>,
 		IHandle<GossipMessage.GossipSendFailed>,
 		IHandle<SystemMessage.VNodeConnectionLost>,
@@ -169,6 +170,12 @@ namespace EventStore.Core.Services.Gossip {
 			if (_cluster.HasChangedSince(oldCluster))
 				LogClusterChange(oldCluster, _cluster, $"gossip received from [{message.Server}]");
 			_bus.Publish(new GossipMessage.GossipUpdated(_cluster));
+		}
+
+		public void Handle(GossipMessage.ReadGossip message) {
+			if (_cluster != null) {
+				message.Envelope.ReplyWith(new GossipMessage.SendGossip(_cluster, _memberInfo.HttpEndPoint));
+			}
 		}
 
 		public void Handle(SystemMessage.StateChangeMessage message) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Elections.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Elections.cs
@@ -9,7 +9,7 @@ using EventStore.Plugins.Authorization;
 using Grpc.Core;
 using ClusterInfo = EventStore.Core.Cluster.ClusterInfo;
 
-namespace EventStore.Core.Services.Transport.Grpc {
+namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 	partial class Elections {
 		private static readonly Empty EmptyResult = new Empty();
 		private readonly IPublisher _bus;

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
@@ -38,8 +38,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 				throw AccessDenied();
 			}
 			var tcs = new TaskCompletionSource<ClusterInfo>();
-			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs)),
-				new EventStore.Core.Cluster.ClusterInfo(), null));
+			_bus.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs))));
 			return await tcs.Task.ConfigureAwait(false);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
@@ -9,7 +9,7 @@ using EventStore.Core.Messaging;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 
-namespace EventStore.Core.Services.Transport.Grpc {
+namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 	partial class Gossip {
 		private readonly IPublisher _bus;
 		private readonly IAuthorizationProvider _authorizationProvider;

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.cs
@@ -1,4 +1,4 @@
-﻿namespace EventStore.Core.Services.Transport.Grpc {
+﻿namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 	public partial class Gossip : EventStore.Cluster.Gossip.GossipBase {
 	}
 	

--- a/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
@@ -13,7 +13,7 @@ using MemberInfo = EventStore.Client.Gossip.MemberInfo;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	partial class Gossip {
-		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.Read);
+		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.ClientRead);
 		public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
 			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken).ConfigureAwait(false)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
@@ -20,8 +20,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				throw AccessDenied();
 			}
 			var tcs = new TaskCompletionSource<ClusterInfo>();
-			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs)),
-				new EventStore.Core.Cluster.ClusterInfo(), null));
+			_bus.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs))));;
 			return await tcs.Task.ConfigureAwait(false);
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client.Gossip;
+using EventStore.Client.Shared;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Plugins.Authorization;
+using Grpc.Core;
+using static EventStore.Common.Utils.EndpointExtensions;
+using ClusterInfo = EventStore.Client.Gossip.ClusterInfo;
+using MemberInfo = EventStore.Client.Gossip.MemberInfo;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	partial class Gossip {
+		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.Read);
+		public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context) {
+			var user = context.GetHttpContext().User;
+			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw AccessDenied();
+			}
+			var tcs = new TaskCompletionSource<ClusterInfo>();
+			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs)),
+				new EventStore.Core.Cluster.ClusterInfo(), null));
+			return await tcs.Task.ConfigureAwait(false);
+		}
+
+		private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs) {
+			if (msg is GossipMessage.SendGossip received) {
+				tcs.TrySetResult(ToGrpcClusterInfo(received.ClusterInfo));
+			}
+		}
+
+		private ClusterInfo ToGrpcClusterInfo(Core.Cluster.ClusterInfo cluster) {
+			var members = Array.ConvertAll(cluster.Members, x => new MemberInfo {
+				InstanceId = Uuid.FromGuid(x.InstanceId).ToDto(),
+				TimeStamp = x.TimeStamp.ToTicksSinceEpoch(),
+				State = (MemberInfo.Types.VNodeState)x.State,
+				IsAlive = x.IsAlive,
+				HttpEndPoint = new EndPoint{
+					Address = x.HttpEndPoint.GetHost(),
+					Port = (uint)x.HttpEndPoint.GetPort()
+				}
+			}).ToArray();
+			var info = new ClusterInfo();
+			info.Members.AddRange(members);
+			return info;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/Gossip.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Gossip.cs
@@ -1,0 +1,15 @@
+using System;
+using EventStore.Core.Bus;
+using EventStore.Plugins.Authorization;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	partial class Gossip : EventStore.Client.Gossip.Gossip.GossipBase  {
+		private readonly IPublisher _bus;
+		private readonly IAuthorizationProvider _authorizationProvider;
+		public Gossip(IPublisher bus, IAuthorizationProvider authorizationProvider) {
+			_bus = bus;
+			_authorizationProvider =
+				authorizationProvider ?? throw new ArgumentNullException(nameof(authorizationProvider));
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
@@ -49,6 +49,13 @@ namespace EventStore.Client.Operations {
 	}
 }
 
+namespace EventStore.Client.Gossip {
+	partial class Gossip {
+		partial class GossipBase : ServiceBase {
+		}
+	}
+}
+
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	public class ServiceBase {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			var sendToHttpEnvelope = new SendToHttpEnvelope(
 				_networkSendQueue, entity, Format.SendGossip,
 				(e, m) => Configure.Ok(e.ResponseCodec.ContentType, Helper.UTF8NoBom, null, null, false));
-			Publish(new GossipMessage.GossipReceived(sendToHttpEnvelope, new ClusterInfo(new MemberInfo[0]), null));
+			Publish(new GossipMessage.ReadGossip(sendToHttpEnvelope));
 		}
 	}
 }

--- a/src/Protos/Grpc/gossip.proto
+++ b/src/Protos/Grpc/gossip.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+package event_store.client.gossip;
+option java_package = "com.eventstore.client.gossip";
+
+import "shared.proto";
+
+service Gossip {
+	rpc Read (event_store.client.shared.Empty) returns (ClusterInfo);
+}
+
+message ClusterInfo {
+	repeated MemberInfo members = 1;
+}
+
+message EndPoint {
+	string address = 1;
+	uint32 port = 2;
+}
+
+message MemberInfo {
+	enum VNodeState {
+		Initializing = 0;
+		DiscoverLeader = 1;
+		Unknown = 2;
+		PreReplica = 3;
+		CatchingUp = 4;
+		Clone = 5;
+		Follower = 6;
+		PreLeader = 7;
+		Leader = 8;
+		Manager = 9;
+		ShuttingDown = 10;
+		Shutdown = 11;
+		ReadOnlyLeaderless = 12;
+		PreReadOnlyReplica = 13;
+		ReadOnlyReplica = 14;
+		ResigningLeader = 15;
+	}
+	event_store.client.shared.UUID instance_id = 1;
+	int64 time_stamp = 2;
+	VNodeState state = 3;
+	bool is_alive = 4;
+	EndPoint http_end_point = 5;
+}


### PR DESCRIPTION
Added: An external gRPC endpoint for gossip


Fixes #2298
This PR depends on #2518. Thus it has been opened against the `fix-vnodestate` branch so that it's retargeted by github to master once `fix-vnodestate` is merged to master.

The accompanying client-side PR is available here: https://github.com/EventStore/EventStore-Client-Dotnet/pull/27

Note: Concerning authorization, we're using the existing `Node.Gossip.Read` operation here which already allows anonymous access: https://github.com/EventStore/EventStore/blob/e4577510bc5d0d5e9ddaf94c65caeadc969576f5/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs#L16
