### PR TITLE
Set the prepare position to the prepare position instead of the transaction position

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -181,9 +181,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					}
 				});
 
-			ReadResp.Types.ReadEvent.Types.RecordedEvent ConvertToRecordedEvent(EventRecord e, long? commitPosition) {
+			ReadResp.Types.ReadEvent.Types.RecordedEvent ConvertToRecordedEvent(EventRecord e, long? commitPosition,
+				long? preparePosition) {
 				if (e == null) return null;
-				var position = Position.FromInt64(commitPosition ?? e.LogPosition, e.TransactionPosition);
+				var position = Position.FromInt64(commitPosition ?? -1, preparePosition ?? -1);
 				return new ReadResp.Types.ReadEvent.Types.RecordedEvent {
 					Id = uuidOptionsCase switch {
 						ReadReq.Types.Options.Types.UUIDOption.ContentOneofCase.String => new UUID {
@@ -209,8 +210,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			ReadResp.Types.ReadEvent ConvertToReadEvent(ResolvedEvent e) {
 				var readEvent = new ReadResp.Types.ReadEvent {
-					Link = ConvertToRecordedEvent(e.Link, e.OriginalPosition?.CommitPosition),
-					Event = ConvertToRecordedEvent(e.Event, e.OriginalPosition?.CommitPosition)
+					Link = ConvertToRecordedEvent(e.Link, e.OriginalPosition?.CommitPosition, e.OriginalPosition?.PreparePosition),
+					Event = ConvertToRecordedEvent(e.Event, e.OriginalPosition?.CommitPosition, e.OriginalPosition?.PreparePosition)
 				};
 				if (e.OriginalPosition.HasValue) {
 					var position = Position.FromInt64(


### PR DESCRIPTION
Changed: For gRPC use the `commit` and `prepare` positions from the `ResolvedEvent` instead of the `Transaction Position` as the `Prepare Position` and the `Log Position` in the case where the commit position is `null`.

Fixes https://github.com/EventStore/EventStore-Client-Dotnet/issues/20