### PR TITLE
Grant users in the operations group the ability to restart projections

### DIFF
--- a/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
+++ b/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
@@ -294,13 +294,10 @@ namespace EventStore.Core.Tests.Authorization {
 			}
 
 			IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> AdminOperations() {
-				
-
 				yield return (new Operation(Operations.Streams.Read).WithParameter(
 						Operations.Streams.Parameters.StreamId("$$$scavenge")),
 					"$$$scavenge",
 					systemStreamPermission);
-				yield return CreateOperation(Operations.Projections.Restart);
 			}
 
 			IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> OpsOperations() {
@@ -326,6 +323,7 @@ namespace EventStore.Core.Tests.Authorization {
 				
 				yield return CreateOperation(Operations.Projections.ReadConfiguration);
 				yield return CreateOperation(Operations.Projections.Delete);
+				yield return CreateOperation(Operations.Projections.Restart);
 			}
 
 			IEnumerable<(Operation, string, StorageMessage.EffectiveAcl)> UserOperations() {

--- a/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
@@ -113,7 +113,7 @@ namespace EventStore.Core.Authorization {
 			policy.RequireAuthenticated(Operations.Projections.State);
 			policy.RequireAuthenticated(Operations.Projections.Status);
 			policy.RequireAuthenticated(Operations.Projections.Statistics);
-			policy.AddMatchAnyAssertion(Operations.Projections.Restart, Grant.Allow, Admins);
+			policy.AddMatchAnyAssertion(Operations.Projections.Restart, Grant.Allow, OperationsOrAdmins);
 
 			return new PolicyAuthorizationProvider(new PolicyEvaluator(policy.AsReadOnly()),
 				Log.ForContext<PolicyEvaluator>(), true, false);


### PR DESCRIPTION
Changed: Add the users in the $ops group the ability to restart the projection's subsystem.

Fixes https://github.com/EventStore/EventStore/issues/2525