### PR TITLE
Rely on the commit indexed instead of commit ack

### DIFF
--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_successfully.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_successfully.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 		}
 
 		protected override IEnumerable<Message> WithInitialMessages() {
-			yield return new StorageMessage.CommitAck(InternalCorrId, commitPosition, 2, 3, 3);
+			yield return new StorageMessage.CommitIndexed(InternalCorrId, commitPosition, 2, 3, 3);
 			}
 
 		protected override Message When() {

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_after_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_already_committed_after_commit.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 		}
 
 		protected override IEnumerable<Message> WithInitialMessages() {
-			yield return new StorageMessage.CommitAck(InternalCorrId, commitPosition, 2, 3, 3);
+			yield return new StorageMessage.CommitIndexed(InternalCorrId, commitPosition, 2, 3, 3);
 			yield return new ReplicationTrackingMessage.ReplicatedTo(commitPosition);		
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_after_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_gets_timeout_after_commit.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 		}
 
 		protected override IEnumerable<Message> WithInitialMessages() {
-			yield return new StorageMessage.CommitAck(InternalCorrId, _commitPosition, 500, 1, 1);			
+			yield return new StorageMessage.CommitIndexed(InternalCorrId, _commitPosition, 500, 1, 1);
 			yield return new ReplicationTrackingMessage.ReplicatedTo(_commitPosition);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
@@ -46,7 +46,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement {
 
 			Manager = OnManager(Publisher);
 			Dispatcher.Subscribe<StorageMessage.PrepareAck>(Manager);
-			Dispatcher.Subscribe<StorageMessage.CommitAck>(Manager);
 			Dispatcher.Subscribe<StorageMessage.InvalidTransaction>(Manager);
 			Dispatcher.Subscribe<StorageMessage.StreamDeleted>(Manager);
 			Dispatcher.Subscribe<StorageMessage.WrongExpectedVersion>(Manager);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/RequestManagerSpecification.cs
@@ -51,11 +51,9 @@ namespace EventStore.Core.Tests.Services.RequestManagement {
 			Dispatcher.Subscribe<StorageMessage.WrongExpectedVersion>(Manager);
 			Dispatcher.Subscribe<StorageMessage.AlreadyCommitted>(Manager);
 			Dispatcher.Subscribe<StorageMessage.RequestManagerTimerTick>(Manager);
+			Dispatcher.Subscribe<StorageMessage.CommitIndexed>(Manager);
 			Dispatcher.Subscribe<ReplicationTrackingMessage.IndexedTo>(CommitSource);
 			Dispatcher.Subscribe<ReplicationTrackingMessage.ReplicatedTo>(CommitSource);
-			if (Manager is TransactionCommit txCommitMrg) {
-				Dispatcher.Subscribe<StorageMessage.CommitIndexed>(txCommitMrg);
-			}
 
 			Manager.Start();
 			Given();

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -88,7 +88,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 										PrepareFlags));
 				LogPosition += 100;
 			}
-			Dispatcher.Publish(new StorageMessage.CommitAck(
+			Dispatcher.Publish(new StorageMessage.CommitIndexed(
 									message.CorrelationId, 
 									LogPosition, 
 									transactionPosition,

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -47,7 +47,6 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 				TimeSpan.FromSeconds(2));
 			Dispatcher.Subscribe<ClientMessage.WriteEvents>(Service);
 			Dispatcher.Subscribe<StorageMessage.PrepareAck>(Service);
-			Dispatcher.Subscribe<StorageMessage.CommitAck>(Service);
 			Dispatcher.Subscribe<StorageMessage.InvalidTransaction>(Service);
 			Dispatcher.Subscribe<StorageMessage.StreamDeleted>(Service);
 			Dispatcher.Subscribe<StorageMessage.WrongExpectedVersion>(Service);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/when_handling_write_stream.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/when_handling_write_stream.cs
@@ -10,6 +10,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 	public class when_handling_write_stream : RequestManagerServiceSpecification {
 		protected override void Given() {
 			Dispatcher.Publish(new ClientMessage.WriteEvents(InternalCorrId, ClientCorrId, Envelope, true, StreamId, ExpectedVersion.Any, new[] { DummyEvent() }, null));
+			Dispatcher.Publish(new StorageMessage.CommitIndexed(InternalCorrId, LogPosition, 2, 3, 3));
 			Dispatcher.Publish(new ReplicationTrackingMessage.ReplicatedTo(LogPosition));
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_after_committed.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/TransactionMgr/when_transaction_commit_gets_already_committed_after_committed.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.TransactionMgr {
 
 		protected override IEnumerable<Message> WithInitialMessages() {
 			yield return new StorageMessage.PrepareAck(InternalCorrId, transactionId, PrepareFlags.TransactionEnd);
-			yield return new StorageMessage.CommitAck(Guid.NewGuid(), commitPosition, transactionId, 0, 10);
+			yield return new StorageMessage.CommitIndexed(Guid.NewGuid(), commitPosition, transactionId, 0, 10);
 			yield return new ReplicationTrackingMessage.ReplicatedTo(commitPosition);
 			yield return new StorageMessage.CommitIndexed(InternalCorrId,commitPosition, transactionId,0,0);
 		}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_cluster_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_cluster_commit.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 
 		protected override IEnumerable<Message> WithInitialMessages() {
 			yield return new StorageMessage.PrepareAck(InternalCorrId, _prepareLogPosition, PrepareFlags.SingleWrite|PrepareFlags.Data);
-			yield return new StorageMessage.CommitAck(InternalCorrId, _commitPosition, 1, 0, 0);
+			yield return new StorageMessage.CommitIndexed(InternalCorrId, _commitPosition, 1, 0, 0);
 			yield return new ReplicationTrackingMessage.ReplicatedTo(_commitPosition);
 		}
 

--- a/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_local_commit.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/WriteStreamMgr/when_write_stream_gets_timeout_after_local_commit.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.WriteStreamMgr {
 		}
 
 		protected override IEnumerable<Message> WithInitialMessages() {				
-			yield return new StorageMessage.CommitAck(InternalCorrId, 1, 1, 0, 0);
+			yield return new StorageMessage.CommitIndexed(InternalCorrId, 1, 1, 0, 0);
 		}
 
 		protected override Message When() {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -518,7 +518,6 @@ namespace EventStore.Core {
 
 			_mainBus.Subscribe<StorageMessage.AlreadyCommitted>(requestManagement);
 
-			_mainBus.Subscribe<StorageMessage.CommitAck>(requestManagement);
 			_mainBus.Subscribe<StorageMessage.PrepareAck>(requestManagement);
 			_mainBus.Subscribe<ReplicationTrackingMessage.ReplicatedTo>(requestManagement);
 			_mainBus.Subscribe<ReplicationTrackingMessage.IndexedTo>(requestManagement);

--- a/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
@@ -12,7 +12,7 @@ using ILogger = Serilog.ILogger;
 namespace EventStore.Core.Services.RequestManager.Managers {
 	public abstract class RequestManagerBase :
 		IHandle<StorageMessage.PrepareAck>,
-		IHandle<StorageMessage.CommitAck>,
+		IHandle<StorageMessage.CommitIndexed>,
 		IHandle<StorageMessage.InvalidTransaction>,
 		IHandle<StorageMessage.StreamDeleted>,
 		IHandle<StorageMessage.WrongExpectedVersion>,
@@ -119,7 +119,7 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 			_allEventsWritten = _commitReceived && _allPreparesWritten;
 			if (_allEventsWritten) { AllEventsWritten(); }
 		}
-		public void Handle(StorageMessage.CommitAck message) {
+		public virtual void Handle(StorageMessage.CommitIndexed message) {
 			if (Interlocked.Read(ref _complete) == 1 || _commitReceived) { return; }
 			NextTimeoutTime = DateTime.UtcNow + Timeout;
 			_commitReceived = true;

--- a/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommit.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/TransactionCommit.cs
@@ -63,7 +63,9 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 					TransactionId,
 					Result,
 					FailureMessage);
-		public void Handle(StorageMessage.CommitIndexed message) {
+
+		public override void Handle(StorageMessage.CommitIndexed message) {
+			base.Handle(message);
 			_transactionWritten = true;
 			Committed();
 		}

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -21,7 +21,6 @@ namespace EventStore.Core.Services.RequestManager {
 		IHandle<StorageMessage.RequestCompleted>,
 		IHandle<StorageMessage.AlreadyCommitted>,
 		IHandle<StorageMessage.PrepareAck>,
-		IHandle<StorageMessage.CommitAck>,
 		IHandle<ReplicationTrackingMessage.ReplicatedTo>,
 		IHandle<ReplicationTrackingMessage.IndexedTo>,
 		IHandle<StorageMessage.CommitIndexed>,
@@ -172,7 +171,6 @@ namespace EventStore.Core.Services.RequestManager {
 
 		public void Handle(StorageMessage.AlreadyCommitted message)  =>	DispatchInternal(message.CorrelationId, message);
 		public void Handle(StorageMessage.PrepareAck message)  =>	DispatchInternal(message.CorrelationId, message);
-		public void Handle(StorageMessage.CommitAck message)  =>	DispatchInternal(message.CorrelationId, message);
 		public void Handle(StorageMessage.CommitIndexed message) =>	DispatchInternal(message.CorrelationId, message);
 		public void Handle(StorageMessage.WrongExpectedVersion message)  =>	DispatchInternal(message.CorrelationId, message);
 		public void Handle(StorageMessage.InvalidTransaction message)  =>	DispatchInternal(message.CorrelationId, message);


### PR DESCRIPTION
Changed: Use CommitIndexed instead of CommitAck for the completion of the Write Request

Fixes https://github.com/EventStore/home/issues/195

In most cases we want to only complete a request when the commit has been indexed.
The commit indexed gets published after the commit ack has been appropriately handled from the `IndexCommitterService`.

Relying on the `CommitAck` in the request manager will in most if not all cases delay the write completion as we want to make sure that the commit indexed position is after or equal to the commit ack position.