### PR TITLE
Deprecate atomPub

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -66,6 +66,13 @@ namespace EventStore.ClusterNode {
 					x.Source = "Set by 'Development Mode' mode";
 				}
 
+				if (x.Name == nameof(ClusterNodeOptions.EnableAtomPubOverHTTP)
+				    && x.Source == "<DEFAULT>"
+				    && developmentMode) {
+					x.Value = true;
+					x.Source = "Set by 'Development Mode' mode";
+				}
+
 				return x;
 			});
 		}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -139,7 +139,8 @@ namespace EventStore.Core.Tests.Helpers {
 				readOnlyReplica: readOnlyReplica,
 				ptableMaxReaderCount: Constants.PTableMaxReaderCountDefault,
 				enableExternalTCP: true,
-				gossipOverHttps: UseHttpsInternally());
+				gossipOverHttps: UseHttpsInternally(),
+				enableAtomPubOverHTTP: true);
 			_isReadOnlyReplica = readOnlyReplica;
 
 			Log.Information(

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -107,7 +107,8 @@ namespace EventStore.Core.Tests.Helpers {
 				.AdvertiseHttpPortAs(advertisedHttpPort)
 				.WithHashCollisionReadLimitOf(hashCollisionReadLimit)
 				.WithIndexBitnessVersion(indexBitnessVersion)
-				.EnableExternalTCP();
+				.EnableExternalTCP()
+				.WithEnableAtomPubOverHTTP(true);
 
 			if (enableTrustedAuth)
 				builder.EnableTrustedAuth();

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -228,7 +228,7 @@ namespace EventStore.Core.Util {
 		public const string EnableAtomPubOverHTTPDescr =
 			"Enable AtomPub over HTTP Interface.";
 
-		public static readonly bool EnableAtomPubOverHTTPDefault = true;
+		public static readonly bool EnableAtomPubOverHTTPDefault = false;
 
 		/*
 		 *  SINGLE NODE OPTIONS

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1482,6 +1482,7 @@ namespace EventStore.Core {
 			var infoController = new InfoController(options, new Dictionary<string, bool> {
 				{"projections", _projectionType != ProjectionType.None},
 				{"userManagement", _authenticationProviderIsInternal},
+				{"atomPub", _enableAtomPubOverHTTP}
 			});
 
 			var writerCheckpoint = _db.Config.WriterCheckpoint.Read();


### PR DESCRIPTION
Changed: Disable atomPub by default except when in dev mode.

Fixes: https://github.com/eventstore/home/issues/194

- Disable atomPub by default except when in dev mode.
- Add an `AtomPub` feature to the features list sent to the admin UI through the info controller.