### PR TITLE
Correct Java package names for protobuf packages

### DIFF
--- a/src/Protos/Grpc/cluster.proto
+++ b/src/Protos/Grpc/cluster.proto
@@ -1,5 +1,6 @@
-﻿syntax = "proto3";
+syntax = "proto3";
 package event_store.cluster;
+option java_package = "com.eventstore.dbclient.proto.cluster";
 
 import "shared.proto";
 

--- a/src/Protos/Grpc/gossip.proto
+++ b/src/Protos/Grpc/gossip.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.gossip;
-option java_package = "com.eventstore.client.gossip";
+option java_package = "com.eventstore.dbclient.proto.gossip";
 
 import "shared.proto";
 

--- a/src/Protos/Grpc/operations.proto
+++ b/src/Protos/Grpc/operations.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.operations;
-option java_package = "com.eventstore.client.operations";
+option java_package = "com.eventstore.dbclient.proto.operations";
 
 import "shared.proto";
 

--- a/src/Protos/Grpc/persistent.proto
+++ b/src/Protos/Grpc/persistent.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.persistent_subscriptions;
-option java_package = "com.eventstore.client.persistentsubscriptions";
+option java_package = "com.eventstore.dbclient.proto.persistentsubscriptions";
 
 import "shared.proto";
 

--- a/src/Protos/Grpc/projections.proto
+++ b/src/Protos/Grpc/projections.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.projections;
-option java_package = "com.eventstore.client.projections";
+option java_package = "com.eventstore.dbclient.proto.projections";
 
 import "google/protobuf/struct.proto";
 import "shared.proto";

--- a/src/Protos/Grpc/shared.proto
+++ b/src/Protos/Grpc/shared.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.shared;
-option java_package = "com.eventstore.client.shared";
+option java_package = "com.eventstore.dbclient.proto.shared";
 
 message UUID {
 	oneof value {

--- a/src/Protos/Grpc/streams.proto
+++ b/src/Protos/Grpc/streams.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.streams;
-option java_package = "com.eventstore.client.streams";
+option java_package = "com.eventstore.dbclient.proto.streams";
 
 import "shared.proto";
 

--- a/src/Protos/Grpc/users.proto
+++ b/src/Protos/Grpc/users.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 package event_store.client.users;
-option java_package = "com.eventstore.client.users";
+option java_package = "com.eventstore.dbclient.proto.users";
 
 service Users {
 	rpc Create (CreateReq) returns (CreateResp);


### PR DESCRIPTION
Fixed: Correct the Java package names in protocol buffers definitions

This commit moves the `java_package` directive for each of the gRPC protocol buffers definitions to point to the correct package for our new client: `com.eventstore.dbclient.proto.*`

It also removes a stray byte order mark.