### PR TITLE
Rename Disable Tls options to be more explicit as to what they are disabling

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -205,11 +205,11 @@ namespace EventStore.ClusterNode {
 		[ArgDescription(Opts.CertificateThumbprintDescr, Opts.CertificatesFromStoreGroup)]
 		public string CertificateThumbprint { get; set; }
 
-		[ArgDescription(Opts.DisableInternalTlsDescr, Opts.InterfacesGroup)]
-		public bool DisableInternalTls { get; set; }
+		[ArgDescription(Opts.DisableInternalTcpTlsDescr, Opts.InterfacesGroup)]
+		public bool DisableInternalTcpTls { get; set; }
 
-		[ArgDescription(Opts.DisableExternalTlsDescr, Opts.InterfacesGroup)]
-		public bool DisableExternalTls { get; set; }
+		[ArgDescription(Opts.DisableExternalTcpTlsDescr, Opts.InterfacesGroup)]
+		public bool DisableExternalTcpTls { get; set; }
 		
 		[ArgDescription(Opts.AuthorizationTypeDescr, Opts.AuthGroup)]
 		public string AuthorizationType { get; set; }
@@ -378,8 +378,8 @@ namespace EventStore.ClusterNode {
 			CertificatePrivateKeyFile = Opts.CertificatePrivateKeyFileDefault;
 			CertificatePassword = Opts.CertificatePasswordDefault;
 
-			DisableInternalTls = Opts.DisableInternalTlsDefault;
-			DisableExternalTls = Opts.DisableExternalTlsDefault;
+			DisableInternalTcpTls = Opts.DisableInternalTcpTlsDefault;
+			DisableExternalTcpTls = Opts.DisableExternalTcpTlsDefault;
 
 			AuthorizationType = Opts.AuthorizationTypeDefault;
 			AuthorizationConfig = Opts.AuthorizationConfigFileDefault;

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -193,21 +193,21 @@ namespace EventStore.ClusterNode {
 			var quorumSize = GetQuorumSize(options.ClusterSize);
 
 			var httpEndPoint = new IPEndPoint(options.ExtIp, options.HttpPort);
-			var intTcp = options.DisableInternalTls ? new IPEndPoint(options.IntIp, options.IntTcpPort) : null;
-			var intSecTcp = !options.DisableInternalTls ? new IPEndPoint(options.IntIp, options.IntTcpPort) : null;
-			var extTcp = options.EnableExternalTCP && options.DisableExternalTls
+			var intTcp = options.DisableInternalTcpTls ? new IPEndPoint(options.IntIp, options.IntTcpPort) : null;
+			var intSecTcp = !options.DisableInternalTcpTls ? new IPEndPoint(options.IntIp, options.IntTcpPort) : null;
+			var extTcp = options.EnableExternalTCP && options.DisableExternalTcpTls
 				? new IPEndPoint(options.ExtIp, options.ExtTcpPort)
 				: null;
-			var extSecTcp = options.EnableExternalTCP && !options.DisableExternalTls
+			var extSecTcp = options.EnableExternalTCP && !options.DisableExternalTcpTls
 				? new IPEndPoint(options.ExtIp, options.ExtTcpPort)
 				: null;
 
-			var intTcpPortAdvertiseAs = options.DisableInternalTls ? options.IntTcpPortAdvertiseAs : 0;
-			var intSecTcpPortAdvertiseAs = !options.DisableInternalTls ? options.IntTcpPortAdvertiseAs : 0;
-			var extTcpPortAdvertiseAs = options.EnableExternalTCP && options.DisableExternalTls
+			var intTcpPortAdvertiseAs = options.DisableInternalTcpTls ? options.IntTcpPortAdvertiseAs : 0;
+			var intSecTcpPortAdvertiseAs = !options.DisableInternalTcpTls ? options.IntTcpPortAdvertiseAs : 0;
+			var extTcpPortAdvertiseAs = options.EnableExternalTCP && options.DisableExternalTcpTls
 				? options.ExtTcpPortAdvertiseAs
 				: 0;
-			var extSecTcpPortAdvertiseAs = options.EnableExternalTCP && !options.DisableExternalTls
+			var extSecTcpPortAdvertiseAs = options.EnableExternalTCP && !options.DisableExternalTcpTls
 				? options.ExtTcpPortAdvertiseAs
 				: 0;
 
@@ -322,10 +322,10 @@ namespace EventStore.ClusterNode {
 				builder.WithUnsafeIgnoreHardDelete();
 			if (options.UnsafeDisableFlushToDisk)
 				builder.WithUnsafeDisableFlushToDisk();
-			if (options.DisableInternalTls)
-				builder.DisableInternalTls();
-			if (options.DisableExternalTls)
-				builder.DisableExternalTls();
+			if (options.DisableInternalTcpTls)
+				builder.DisableInternalTcpTls();
+			if (options.DisableExternalTcpTls)
+				builder.DisableExternalTcpTls();
 			if (options.EnableExternalTCP)
 				builder.EnableExternalTCP();
 			if (options.DisableAdminUi)

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_default_settings.cs
@@ -29,8 +29,8 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building {
 
 		[Test]
 		public void should_use_tls() {
-			Assert.IsFalse(_settings.DisableInternalTls);
-			Assert.IsFalse(_settings.DisableExternalTls);
+			Assert.IsFalse(_settings.DisableInternalTcpTls);
+			Assert.IsFalse(_settings.DisableExternalTcpTls);
 		}
 
 		[Test]
@@ -107,8 +107,8 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building {
 
 		[Test]
 		public void should_use_tls() {
-			Assert.IsFalse(_settings.DisableInternalTls);
-			Assert.IsFalse(_settings.DisableExternalTls);
+			Assert.IsFalse(_settings.DisableInternalTcpTls);
+			Assert.IsFalse(_settings.DisableExternalTcpTls);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_secure_tcp.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/when_building/with_secure_tcp.cs
@@ -25,8 +25,8 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building {
 
 		[Test]
 		public void should_set_tls_to_enabled() {
-			Assert.IsFalse(_settings.DisableInternalTls);
-			Assert.IsFalse(_settings.DisableExternalTls);
+			Assert.IsFalse(_settings.DisableInternalTcpTls);
+			Assert.IsFalse(_settings.DisableExternalTcpTls);
 		}
 
 		[Test]
@@ -74,8 +74,8 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests.when_building {
 
 		[Test]
 		public void should_set_tls_to_enabled() {
-			Assert.IsFalse(_settings.DisableInternalTls);
-			Assert.IsFalse(_settings.DisableExternalTls);
+			Assert.IsFalse(_settings.DisableInternalTcpTls);
+			Assert.IsFalse(_settings.DisableExternalTcpTls);
 		}
 
 		[Test]

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -41,8 +41,8 @@ namespace EventStore.Core.Cluster.Settings {
 
 		public readonly int NodePriority;
 
-		public readonly bool DisableInternalTls;
-		public readonly bool DisableExternalTls;
+		public readonly bool DisableInternalTcpTls;
+		public readonly bool DisableExternalTcpTls;
 		public readonly bool EnableExternalTCP;
 
 		public readonly TimeSpan StatsPeriod;
@@ -114,8 +114,8 @@ namespace EventStore.Core.Cluster.Settings {
 			TimeSpan prepareTimeout,
 			TimeSpan commitTimeout,
 			TimeSpan writeTimeout,
-			bool disableInternalTls,
-			bool disableExternalTls,
+			bool disableInternalTcpTls,
+			bool disableExternalTcpTls,
 			TimeSpan statsPeriod,
 			StatsStorage statsStorage,
 			int nodePriority,
@@ -221,8 +221,8 @@ namespace EventStore.Core.Cluster.Settings {
 			CommitTimeout = commitTimeout;
 			WriteTimeout = writeTimeout;
 
-			DisableInternalTls = disableInternalTls;
-			DisableExternalTls = disableExternalTls;
+			DisableInternalTcpTls = disableInternalTcpTls;
+			DisableExternalTcpTls = disableExternalTcpTls;
 			EnableExternalTCP = enableExternalTCP;
 
 			StatsPeriod = statsPeriod;
@@ -290,7 +290,7 @@ namespace EventStore.Core.Cluster.Settings {
 			$"PrepareAckCount: {PrepareAckCount}\n" + $"CommitAckCount: {CommitAckCount}\n" +
 			$"PrepareTimeout: {PrepareTimeout}\n" + $"CommitTimeout: {CommitTimeout}\n" +
 			$"WriteTimeout: {WriteTimeout}\n" +
-			$"DisableInternalTls: {DisableInternalTls}\n" + $"DisableExternalTls: {DisableExternalTls}\n" +
+			$"DisableInternalTls: {DisableInternalTcpTls}\n" + $"DisableExternalTls: {DisableExternalTcpTls}\n" +
 			$"StatsPeriod: {StatsPeriod}\n" + $"StatsStorage: {StatsStorage}\n" +
 			$"AuthenticationProviderFactory Type: {AuthenticationProviderFactory.GetType()}\n" +
 			$"AuthorizationProviderFactory  Type: {AuthorizationProviderFactory.GetType()}\n" +

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -290,7 +290,7 @@ namespace EventStore.Core.Cluster.Settings {
 			$"PrepareAckCount: {PrepareAckCount}\n" + $"CommitAckCount: {CommitAckCount}\n" +
 			$"PrepareTimeout: {PrepareTimeout}\n" + $"CommitTimeout: {CommitTimeout}\n" +
 			$"WriteTimeout: {WriteTimeout}\n" +
-			$"DisableInternalTls: {DisableInternalTcpTls}\n" + $"DisableExternalTls: {DisableExternalTcpTls}\n" +
+			$"DisableInternalTcpTls: {DisableInternalTcpTls}\n" + $"DisableExternalTcpTls: {DisableExternalTcpTls}\n" +
 			$"StatsPeriod: {StatsPeriod}\n" + $"StatsStorage: {StatsStorage}\n" +
 			$"AuthenticationProviderFactory Type: {AuthenticationProviderFactory.GetType()}\n" +
 			$"AuthorizationProviderFactory  Type: {AuthorizationProviderFactory.GetType()}\n" +

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -665,7 +665,7 @@ namespace EventStore.Core {
 					_authenticationProvider, AuthorizationGateway,
 					_vNodeSettings.GossipAdvertiseInfo.InternalTcp ?? _vNodeSettings.GossipAdvertiseInfo.InternalSecureTcp,
 					_vNodeSettings.ReadOnlyReplica,
-					!vNodeSettings.DisableInternalTls, _internalServerCertificateValidator,
+					!vNodeSettings.DisableInternalTcpTls, _internalServerCertificateValidator,
 					_certificate,
 					vNodeSettings.IntTcpHeartbeatTimeout, vNodeSettings.ExtTcpHeartbeatInterval,
 					vNodeSettings.WriteTimeout);

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -306,11 +306,11 @@ namespace EventStore.Core.Util {
 		public const string PrepareCountDescr = "The number of nodes which must acknowledge prepares.";
 		public const int PrepareCountDefault = -1;
 
-		public const string DisableInternalTlsDescr = "Whether to disable secure internal communication.";
-		public const bool DisableInternalTlsDefault = false;
+		public const string DisableInternalTcpTlsDescr = "Whether to disable secure internal tcp communication.";
+		public const bool DisableInternalTcpTlsDefault = false;
 		
-		public const string DisableExternalTlsDescr = "Whether to disable secure external communication.";
-		public const bool DisableExternalTlsDefault = false;
+		public const string DisableExternalTcpTlsDescr = "Whether to disable secure external tcp communication.";
+		public const bool DisableExternalTcpTlsDefault = false;
 
 		public const string EnableExternalTCPDescr = "Whether to enable external TCP communication";
 		public const bool EnableExternalTCPDefault = false;

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -71,8 +71,8 @@ namespace EventStore.Core {
 		protected int _nodePriority;
 
 		protected bool _enableExternalTCP;
-		protected bool _disableInternalTls;
-		protected bool _disableExternalTls;
+		protected bool _disableInternalTcpTls;
+		protected bool _disableExternalTcpTls;
 
 		protected TimeSpan _statsPeriod;
 		protected StatsStorage _statsStorage;
@@ -187,8 +187,8 @@ namespace EventStore.Core {
 
 			_nodePriority = Opts.NodePriorityDefault;
 
-			_disableInternalTls = Opts.DisableInternalTlsDefault;
-			_disableExternalTls = Opts.DisableExternalTlsDefault;
+			_disableInternalTcpTls = Opts.DisableInternalTcpTlsDefault;
+			_disableExternalTcpTls = Opts.DisableExternalTcpTlsDefault;
 			_enableExternalTCP = Opts.EnableExternalTCPDefault;
 
 			_statsPeriod = TimeSpan.FromSeconds(Opts.StatsPeriodDefault);
@@ -506,19 +506,20 @@ namespace EventStore.Core {
 		}
 
 		/// <summary>
-		/// Sets that TLS should be disabled on internal connections
+		/// Sets that TLS should be disabled on internal tcp connections
 		/// </summary>
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-		public VNodeBuilder DisableInternalTls() {
-			_disableInternalTls = true;
+		public VNodeBuilder DisableInternalTcpTls() {
+			_disableInternalTcpTls = true;
 			return this;
 		}
 
-		/// Sets that TLS should be disabled on external connections
+		/// <summary>
+		/// Sets that TLS should be disabled on external tcp connections
 		/// </summary>
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
-		public VNodeBuilder DisableExternalTls() {
-			_disableExternalTls = true;
+		public VNodeBuilder DisableExternalTcpTls() {
+			_disableExternalTcpTls = true;
 			return this;
 		}
 
@@ -1425,8 +1426,8 @@ namespace EventStore.Core {
 				_prepareTimeout,
 				_commitTimeout,
 				_writeTimeout,
-				_disableInternalTls,
-				_disableExternalTls,
+				_disableInternalTcpTls,
+				_disableExternalTcpTls,
 				_statsPeriod,
 				_statsStorage,
 				_nodePriority,


### PR DESCRIPTION
Changed: Change options that refers to disabling tls to explicitly refer to disabling tcp tls.