### PR TITLE
Enable v5 client cluster connectivity tests

### DIFF
--- a/src/EventStore.ClientAPI.v5.Tests/EventStore.ClientAPI.v5.Tests.csproj
+++ b/src/EventStore.ClientAPI.v5.Tests/EventStore.ClientAPI.v5.Tests.csproj
@@ -8,7 +8,7 @@
 		<DefineConstants>CLIENT_API_V5</DefineConstants>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="EventStore.Client" Version="5.0.8" />
+		<PackageReference Include="EventStore.Client" Version="5.0.9" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">

--- a/src/EventStore.ClientAPI.v5.Tests/EventStoreClientAPIClusterFixture.Tcp.cs
+++ b/src/EventStore.ClientAPI.v5.Tests/EventStoreClientAPIClusterFixture.Tcp.cs
@@ -31,14 +31,17 @@ namespace EventStore.ClientAPI.Tests {
 			var settings = configureSettings ?? DefaultConfigureSettingsForConnectionString;
 			var host = useDnsEndPoint ? "localhost" : IPAddress.Loopback.ToString();
 
-			if (useSsl) settings += "UseSslConnection=true;";
+			if (useSsl) settings += $"UseSslConnection=true;ValidateServer=false;TargetHost={host};";
+			else settings += "UseSslConnection=false;";
 
 			var gossipSeeds = GetGossipSeedEndPointsExceptFor(-1, false).Cast<IPEndPoint>().ToArray();
 			var gossipSeedsString = "";
 			for(var i=0;i<gossipSeeds.Length;i++) {
 				if (i > 0) gossipSeedsString += ",";
-				gossipSeedsString += host + ":" + gossipSeeds[i].Port;
+				gossipSeedsString += (useSsl?"https://":"") + host + ":" + gossipSeeds[i].Port;
 			}
+
+			settings += "CustomHttpClient=SkipCertificateValidation;";
 
 			var connectionString = $"GossipSeeds={gossipSeedsString};{settings}";
 			return EventStoreConnection.Create(connectionString);

--- a/src/EventStore.ClientAPI.v5.Tests/EventStoreClientAPIClusterFixture.Tcp.cs
+++ b/src/EventStore.ClientAPI.v5.Tests/EventStoreClientAPIClusterFixture.Tcp.cs
@@ -41,7 +41,7 @@ namespace EventStore.ClientAPI.Tests {
 				gossipSeedsString += (useSsl?"https://":"") + host + ":" + gossipSeeds[i].Port;
 			}
 
-			settings += "CustomHttpClient=SkipCertificateValidation;";
+			settings += "SkipCertificateValidation=true;";
 
 			var connectionString = $"GossipSeeds={gossipSeedsString};{settings}";
 			return EventStoreConnection.Create(connectionString);

--- a/src/EventStore.ClientAPIAcceptanceTests/cluster/connect_to_cluster.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/cluster/connect_to_cluster.cs
@@ -15,8 +15,6 @@ namespace EventStore.ClientAPI.Tests {
 		 * and XUnit does not support parametrized test fixtures so that we can start up the server with only insecure TCP
 		 */
 
-		/*These tests do not work for v5 yet*/
-		#if !CLIENT_API_V5
 		[Fact]
 		public async Task can_connect_to_tls_ip_endpoint_gossip_seed() {
 			var streamName = $"{GetStreamName()}";
@@ -59,6 +57,5 @@ namespace EventStore.ClientAPI.Tests {
 				await connection.AppendToStreamAsync(streamName, ExpectedVersion.Any, _fixture.CreateTestEvents());
 			Assert.True(writeResult.LogPosition.PreparePosition > 0);
 		}
-		#endif
 	}
 }


### PR DESCRIPTION
Changed: Enable v5 client cluster connectivity acceptance tests


Following PR #2553, cluster connectivity tests can be enabled for the v5 client. This PR needs to wait for `EventStore.Client` 5.0.9 to be published to nuget before being merged.