### PR TITLE
Introduce insecure flag to disable TLS on all TCP & HTTP interfaces to eliminate requirement for certificates

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -212,7 +212,10 @@ namespace EventStore.ClusterNode {
 
 		[ArgDescription(Opts.DisableExternalTcpTlsDescr, Opts.InterfacesGroup)]
 		public bool DisableExternalTcpTls { get; set; }
-		
+
+		[ArgDescription(Opts.DisableHttpsDescr, Opts.InterfacesGroup)]
+		public bool DisableHttps { get; set; }
+
 		[ArgDescription(Opts.AuthorizationTypeDescr, Opts.AuthGroup)]
 		public string AuthorizationType { get; set; }
 
@@ -386,6 +389,7 @@ namespace EventStore.ClusterNode {
 
 			DisableInternalTcpTls = Opts.DisableInternalTcpTlsDefault;
 			DisableExternalTcpTls = Opts.DisableExternalTcpTlsDefault;
+			DisableHttps = Opts.DisableHttpsDefault;
 
 			AuthorizationType = Opts.AuthorizationTypeDefault;
 			AuthorizationConfig = Opts.AuthorizationConfigFileDefault;

--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -302,6 +302,9 @@ namespace EventStore.ClusterNode {
 		
 		[ArgDescription(Opts.DevDescr, Opts.AppGroup)]
 		public bool Dev { get; set; }
+
+		[ArgDescription(Opts.InsecureDescr, Opts.AppGroup)]
+		public bool Insecure { get; set; }
 		
 		[ArgDescription(Opts.EnableAtomPubOverHTTPDescr, Opts.InterfacesGroup)]
 		public bool EnableAtomPubOverHTTP { get; set; }
@@ -434,6 +437,7 @@ namespace EventStore.ClusterNode {
 			MaxAppendSize = Opts.MaxAppendSizeDefault;
 
 			Dev = Opts.DevDefault;
+			Insecure = Opts.InsecureDefault;
 		}
 	}
 }

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -399,7 +399,7 @@ namespace EventStore.ClusterNode {
 				message += "\nTLS is enabled on at least one TCP/HTTP interface - a certificate is required to run EventStoreDB.";
 			} else {
 				message += "\nTLS is disabled on all TCP/HTTP interfaces - no certificates are required to run EventStoreDB.";
-				message += "\nWe recommended to enable TLS in PRODUCTION to ensure data security.\n";
+				message += "\nIt is recommended to run with TLS enabled in production.\n";
 			}
 
 			Log.Information(message);

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -44,49 +44,49 @@ namespace EventStore.ClusterNode {
 				    && x.Source == "<DEFAULT>"
 				    && developmentMode) {
 					x.Value = true;
-					x.Source = "Set by 'Development Mode' mode";
+					x.Source = "Set by 'Development' mode";
 				}
 
 				if (x.Name == nameof(ClusterNodeOptions.CertificateFile)
 				    && x.Source == "<DEFAULT>"
 				    && developmentMode) {
 					x.Value = Path.Combine(Locations.DevCertificateDirectory, "server1.pem");
-					x.Source = "Set by 'Development Mode' mode";
+					x.Source = "Set by 'Development' mode";
 				}
 
 				if (x.Name == nameof(ClusterNodeOptions.DisableInternalTcpTls)
 				    && x.Source == "<DEFAULT>"
 				    && insecureMode) {
 					x.Value = true;
-					x.Source =  "Set by 'Insecure Mode' mode";
+					x.Source =  "Set by 'Insecure' mode";
 				}
 
 				if (x.Name == nameof(ClusterNodeOptions.DisableExternalTcpTls)
 				    && x.Source == "<DEFAULT>"
 				    && insecureMode) {
 					x.Value = true;
-					x.Source =  "Set by 'Insecure Mode' mode";
+					x.Source =  "Set by 'Insecure' mode";
 				}
 
 				if (x.Name == nameof(ClusterNodeOptions.CertificatePrivateKeyFile)
 				    && x.Source == "<DEFAULT>"
 				    && developmentMode) {
 					x.Value = Path.Combine(Locations.DevCertificateDirectory, "server1.key");
-					x.Source = "Set by 'Development Mode' mode";
+					x.Source = "Set by 'Development' mode";
 				}
 
 				if (x.Name == nameof(ClusterNodeOptions.TrustedRootCertificatesPath)
 				    && x.Source == "<DEFAULT>"
 				    && developmentMode) {
 					x.Value = Locations.DevCertificateDirectory;
-					x.Source = "Set by 'Development Mode' mode";
+					x.Source = "Set by 'Development' mode";
 				}
 
 				if (x.Name == nameof(ClusterNodeOptions.EnableAtomPubOverHTTP)
 				    && x.Source == "<DEFAULT>"
 				    && developmentMode) {
 					x.Value = true;
-					x.Source = "Set by 'Development Mode' mode";
+					x.Source = "Set by 'Development' mode";
 				}
 
 				return x;

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -36,7 +36,9 @@ namespace EventStore.ClusterNode {
 		protected override IEnumerable<OptionSource>
 			MutateEffectiveOptions(IEnumerable<OptionSource> effectiveOptions) {
 			var developmentOption = effectiveOptions.Single(x => x.Name == nameof(ClusterNodeOptions.Dev));
+			var insecureOption = effectiveOptions.Single(x => x.Name == nameof(ClusterNodeOptions.Insecure));
 			bool.TryParse(developmentOption.Value.ToString(), out bool developmentMode);
+			bool.TryParse(insecureOption.Value.ToString(), out bool insecureMode);
 			return effectiveOptions.Select(x => {
 				if (x.Name == nameof(ClusterNodeOptions.MemDb)
 				    && x.Source == "<DEFAULT>"
@@ -50,6 +52,20 @@ namespace EventStore.ClusterNode {
 				    && developmentMode) {
 					x.Value = Path.Combine(Locations.DevCertificateDirectory, "server1.pem");
 					x.Source = "Set by 'Development Mode' mode";
+				}
+
+				if (x.Name == nameof(ClusterNodeOptions.DisableInternalTcpTls)
+				    && x.Source == "<DEFAULT>"
+				    && insecureMode) {
+					x.Value = true;
+					x.Source =  "Set by 'Insecure Mode' mode";
+				}
+
+				if (x.Name == nameof(ClusterNodeOptions.DisableExternalTcpTls)
+				    && x.Source == "<DEFAULT>"
+				    && insecureMode) {
+					x.Value = true;
+					x.Source =  "Set by 'Insecure Mode' mode";
 				}
 
 				if (x.Name == nameof(ClusterNodeOptions.CertificatePrivateKeyFile)

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -57,18 +58,27 @@ namespace EventStore.ClusterNode {
 				.ConfigureWebHostDefaults(builder =>
 					builder.UseKestrel(server => {
 							server.Listen(hostedService.Options.ExtIp, hostedService.Options.HttpPort,
-								listenOptions => listenOptions.UseHttps(new HttpsConnectionAdapterOptions {
-									ServerCertificate = hostedService.Node.Certificate,
-									ClientCertificateMode = ClientCertificateMode.AllowCertificate,
-									ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => {
-										var (isValid, error) = hostedService.Node.InternalClientCertificateValidator(certificate, chain,
-											sslPolicyErrors);
-										if (!isValid && error != null) {
-											Log.Error("Client certificate validation error: {e}", error);
-										}
-										return isValid;
+								listenOptions => {
+									if (hostedService.Node.DisableHttps) {
+										listenOptions.Protocols = HttpProtocols.Http2;
+									} else {
+										listenOptions.UseHttps(new HttpsConnectionAdapterOptions {
+											ServerCertificate = hostedService.Node.Certificate,
+											ClientCertificateMode = ClientCertificateMode.AllowCertificate,
+											ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => {
+												var (isValid, error) =
+													hostedService.Node.InternalClientCertificateValidator(certificate,
+														chain,
+														sslPolicyErrors);
+												if (!isValid && error != null) {
+													Log.Error("Client certificate validation error: {e}", error);
+												}
+
+												return isValid;
+											}
+										});
 									}
-								}));
+								});
 						})
 						.ConfigureServices(services => hostedService.Node.Startup.ConfigureServices(services))
 						.Configure(hostedService.Node.Startup.Configure));

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
+using EventStore.Core.Services.Transport.Http;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
@@ -60,7 +61,7 @@ namespace EventStore.ClusterNode {
 							server.Listen(hostedService.Options.ExtIp, hostedService.Options.HttpPort,
 								listenOptions => {
 									if (hostedService.Node.DisableHttps) {
-										listenOptions.Protocols = HttpProtocols.Http2;
+										listenOptions.Use(next => new ClearTextHttpMultiplexingMiddleware(next).OnConnectAsync);
 									} else {
 										listenOptions.UseHttps(new HttpsConnectionAdapterOptions {
 											ServerCertificate = hostedService.Node.Certificate,

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Services.Transport.Tcp;
 
 namespace EventStore.Core.Tests.ClientOperations {
 	public abstract class specification_with_bare_vnode : IPublisher, ISubscriber, IDisposable {
@@ -11,6 +12,7 @@ namespace EventStore.Core.Tests.ClientOperations {
 		public void CreateTestNode() {
 			var builder = IntegrationVNodeBuilder
 			.AsSingleNode()
+			.WithServerCertificate(ssl_connections.GetServerCertificate())
 			.RunInMemory();
 
 			_node = builder.Build();

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/VNodeBuilderScenarios.cs
@@ -3,6 +3,7 @@ using EventStore.Core.TransactionLog.Chunks;
 using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
+using EventStore.Core.Tests.Services.Transport.Tcp;
 
 namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 	[TestFixture]
@@ -15,6 +16,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 		[OneTimeSetUp]
 		public virtual void TestFixtureSetUp() {
 			_builder = TestVNodeBuilder.AsSingleNode()
+				.WithServerCertificate(ssl_connections.GetServerCertificate())
 				.RunInMemory();
 			Given();
 			_node = _builder.Build();
@@ -47,6 +49,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 		[OneTimeSetUp]
 		public virtual void TestFixtureSetUp() {
 			_builder = TestVNodeBuilder.AsClusterMember(_clusterSize)
+				.WithServerCertificate(ssl_connections.GetServerCertificate())
 				.RunInMemory();
 			_quorumSize = _clusterSize / 2 + 1;
 			Given();

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -67,7 +67,7 @@ namespace EventStore.Core.Tests.Helpers {
 
 		private TestServer _kestrelTestServer;
 
-		public bool UseHttpsInternally() {
+		private static bool EnableHttps() {
 			return !RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 		}
 
@@ -106,8 +106,10 @@ namespace EventStore.Core.Tests.Helpers {
 			ExternalTcpSecEndPoint = externalTcpSec;
 			HttpEndPoint = httpEndPoint;
 
-			var certificate = ssl_connections.GetServerCertificate();
-			var trustedRootCertificates = new X509Certificate2Collection(ssl_connections.GetRootCertificate());
+			var useHttps = EnableHttps();
+			var certificate = useHttps ? ssl_connections.GetServerCertificate() : null;
+			var trustedRootCertificates =
+				useHttps ? new X509Certificate2Collection(ssl_connections.GetRootCertificate()) : null;
 
 			var singleVNodeSettings = new ClusterVNodeSettings(
 				Guid.NewGuid(), debugIndex, InternalTcpEndPoint, InternalTcpSecEndPoint, ExternalTcpEndPoint,
@@ -139,7 +141,7 @@ namespace EventStore.Core.Tests.Helpers {
 				readOnlyReplica: readOnlyReplica,
 				ptableMaxReaderCount: Constants.PTableMaxReaderCountDefault,
 				enableExternalTCP: true,
-				gossipOverHttps: UseHttpsInternally(),
+				disableHttps: !useHttps,
 				enableAtomPubOverHTTP: true);
 			_isReadOnlyReplica = readOnlyReplica;
 

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 		protected ClientCertificateAuthenticationProvider _provider;
 
 		protected void SetUpProvider() {
-			_provider = new ClientCertificateAuthenticationProvider(Opts.CertificateReservedNodeCommonNameDefault);
+			_provider = new ClientCertificateAuthenticationProvider(false, Opts.CertificateReservedNodeCommonNameDefault);
 		}
 	}
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -173,7 +173,7 @@ namespace EventStore.Core.Cluster.Settings {
 			Ensure.Equal(false, internalTcpEndPoint == null && internalSecureTcpEndPoint == null, "Both internal TCP endpoints are null");
 
 			Ensure.NotNull(httpEndPoint, nameof(httpEndPoint));
-			if (internalSecureTcpEndPoint != null || externalSecureTcpEndPoint != null)
+			if ((clusterNodeCount>1 && internalSecureTcpEndPoint != null) || externalSecureTcpEndPoint != null || !disableHttps)
 				Ensure.NotNull(certificate, "certificate");
 			Ensure.Positive(workerThreads, "workerThreads");
 			Ensure.NotNull(clusterDns, "clusterDns");

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -29,7 +29,6 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool DiscoverViaDns;
 		public readonly string ClusterDns;
 		public readonly EndPoint[] GossipSeeds;
-		public readonly bool GossipOverHttps;
 		public readonly bool EnableHistograms;
 		public readonly TimeSpan MinFlushDelay;
 
@@ -44,6 +43,7 @@ namespace EventStore.Core.Cluster.Settings {
 
 		public readonly bool DisableInternalTcpTls;
 		public readonly bool DisableExternalTcpTls;
+		public readonly bool DisableHttps;
 		public readonly bool EnableExternalTCP;
 
 		public readonly TimeSpan StatsPeriod;
@@ -168,7 +168,7 @@ namespace EventStore.Core.Cluster.Settings {
 			bool unsafeAllowSurplusNodes = false,
 			bool enableExternalTCP = false,
 			bool enableAtomPubOverHTTP = true,
-			bool gossipOverHttps = true) {
+			bool disableHttps = false) {
 			Ensure.NotEmptyGuid(instanceId, "instanceId");
 			Ensure.Equal(false, internalTcpEndPoint == null && internalSecureTcpEndPoint == null, "Both internal TCP endpoints are null");
 
@@ -226,6 +226,7 @@ namespace EventStore.Core.Cluster.Settings {
 
 			DisableInternalTcpTls = disableInternalTcpTls;
 			DisableExternalTcpTls = disableExternalTcpTls;
+			DisableHttps = disableHttps;
 			EnableExternalTCP = enableExternalTCP;
 
 			StatsPeriod = statsPeriod;
@@ -244,7 +245,6 @@ namespace EventStore.Core.Cluster.Settings {
 			GossipInterval = gossipInterval;
 			GossipAllowedTimeDifference = gossipAllowedTimeDifference;
 			GossipTimeout = gossipTimeout;
-			GossipOverHttps = gossipOverHttps;
 			IntTcpHeartbeatTimeout = intTcpHeartbeatTimeout;
 			IntTcpHeartbeatInterval = intTcpHeartbeatInterval;
 			ExtTcpHeartbeatTimeout = extTcpHeartbeatTimeout;
@@ -294,6 +294,7 @@ namespace EventStore.Core.Cluster.Settings {
 			$"PrepareTimeout: {PrepareTimeout}\n" + $"CommitTimeout: {CommitTimeout}\n" +
 			$"WriteTimeout: {WriteTimeout}\n" +
 			$"DisableInternalTcpTls: {DisableInternalTcpTls}\n" + $"DisableExternalTcpTls: {DisableExternalTcpTls}\n" +
+			$"DisableHttps: {DisableHttps}\n" +
 			$"StatsPeriod: {StatsPeriod}\n" + $"StatsStorage: {StatsStorage}\n" +
 			$"AuthenticationProviderFactory Type: {AuthenticationProviderFactory.GetType()}\n" +
 			$"AuthorizationProviderFactory  Type: {AuthorizationProviderFactory.GetType()}\n" +

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -23,6 +23,7 @@
 		</PackageReference>
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
+		<PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
 		<PackageReference Include="System.Linq.Async" Version="4.0.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
@@ -7,13 +7,21 @@ using Microsoft.AspNetCore.Http;
 
 namespace EventStore.Core.Services.Transport.Http.Authentication {
 	public class ClientCertificateAuthenticationProvider : IHttpAuthenticationProvider {
+		private bool _bypassAuthentication;
 		private readonly string _certificateReservedNodeCommonName;
 
-		public ClientCertificateAuthenticationProvider(string certificateReservedNodeCommonName) {
+		public ClientCertificateAuthenticationProvider(bool bypassAuthentication, string certificateReservedNodeCommonName) {
+			_bypassAuthentication = bypassAuthentication;
 			_certificateReservedNodeCommonName = $"CN={certificateReservedNodeCommonName}";
 		}
 
 		public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
+			if (_bypassAuthentication) {
+				request = new HttpAuthenticationRequest(context, "system", "");
+				request.Authenticated(SystemAccounts.System);
+				return true;
+			}
+
 			request = null;
 			var clientCertificate = context.Connection.ClientCertificate;
 			if (clientCertificate is null) return false;

--- a/src/EventStore.Core/Services/Transport/Http/ClearTextHttpMultiplexingMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/ClearTextHttpMultiplexingMiddleware.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Buffers;
+using System.IO.Pipelines;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Connections;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.CSharp.RuntimeBinder;
+
+namespace EventStore.Core.Services.Transport.Http
+{
+    public class ClearTextHttpMultiplexingMiddleware {
+	    private ConnectionDelegate _next;
+	    //HTTP/2 prior knowledge-mode connection preface
+	    private static readonly byte[] _http2Preface = {0x50,0x52,0x49,0x20,0x2a,0x20,0x48,0x54,0x54,0x50,0x2f,0x32,0x2e,0x30,0x0d,0x0a,0x0d,0x0a,0x53,0x4d,0x0d,0x0a,0x0d,0x0a}; //PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n
+
+	    public ClearTextHttpMultiplexingMiddleware(ConnectionDelegate next) {
+		    _next = next;
+	    }
+
+	    private static async Task<bool> HasHttp2Preface(PipeReader input) {
+		    while (true) {
+			    var result = await input.ReadAsync().ConfigureAwait(false);
+			    try {
+				    int pos = 0;
+				    foreach (var x in result.Buffer) {
+					    for (var i = 0; i < x.Span.Length && pos < _http2Preface.Length; i++) {
+						    if (_http2Preface[pos] != x.Span[i]) {
+							    return false;
+						    }
+
+						    pos++;
+					    }
+
+					    if (pos >= _http2Preface.Length) {
+						    return true;
+					    }
+				    }
+
+				    if (result.IsCompleted) return false;
+			    } finally {
+				    input.AdvanceTo(result.Buffer.Start);
+			    }
+		    }
+	    }
+
+	    private static void SetProtocols(object target, HttpProtocols protocols) {
+	        var field = target.GetType().GetField("_protocols", BindingFlags.Instance | BindingFlags.NonPublic);
+	        if (field == null) throw new RuntimeBinderException("Couldn't bind to Kestrel's _protocols field");
+	        field.SetValue(target, protocols);
+        }
+
+        public async Task OnConnectAsync(ConnectionContext context) {
+	        var hasHttp2Preface = await HasHttp2Preface(context.Transport.Input).ConfigureAwait(false);
+	        SetProtocols(_next.Target, hasHttp2Preface ? HttpProtocols.Http2 : HttpProtocols.Http1);
+	        await _next(context).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -309,14 +309,17 @@ namespace EventStore.Core.Util {
 		public const string PrepareCountDescr = "The number of nodes which must acknowledge prepares.";
 		public const int PrepareCountDefault = -1;
 
-		public const string DisableInternalTcpTlsDescr = "Whether to disable secure internal tcp communication.";
+		public const string DisableInternalTcpTlsDescr = "Whether to disable secure internal TCP communication.";
 		public const bool DisableInternalTcpTlsDefault = false;
 		
-		public const string DisableExternalTcpTlsDescr = "Whether to disable secure external tcp communication.";
+		public const string DisableExternalTcpTlsDescr = "Whether to disable secure external TCP communication.";
 		public const bool DisableExternalTcpTlsDefault = false;
 
 		public const string EnableExternalTCPDescr = "Whether to enable external TCP communication";
 		public const bool EnableExternalTCPDefault = false;
+
+		public const string DisableHttpsDescr = "Whether to disable HTTPS on the HTTP interface.";
+		public const bool DisableHttpsDefault = false;
 
 		public const string DiscoverViaDnsDescr = "Whether to use DNS lookup to discover other cluster nodes.";
 		public const bool DiscoverViaDnsDefault = true;
@@ -399,7 +402,8 @@ namespace EventStore.Core.Util {
 		
 		public const string DevDescr = "Enable Development Mode for Event Store.";
 		public const bool DevDefault = false;
-		public const string InsecureDescr = "Disable TLS on all TCP interfaces";
+
+		public const string InsecureDescr = "Disable TLS on all TCP/HTTP interfaces";
 		public const bool InsecureDefault = false;
 	}
 }

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -399,5 +399,7 @@ namespace EventStore.Core.Util {
 		
 		public const string DevDescr = "Enable Development Mode for Event Store.";
 		public const bool DevDefault = false;
+		public const string InsecureDescr = "Disable TLS on all TCP interfaces";
+		public const bool InsecureDefault = false;
 	}
 }

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -75,6 +75,7 @@ namespace EventStore.Core {
 		protected bool _enableExternalTCP;
 		protected bool _disableInternalTcpTls;
 		protected bool _disableExternalTcpTls;
+		protected bool _disableHttps;
 
 		protected TimeSpan _statsPeriod;
 		protected StatsStorage _statsStorage;
@@ -192,6 +193,7 @@ namespace EventStore.Core {
 
 			_disableInternalTcpTls = Opts.DisableInternalTcpTlsDefault;
 			_disableExternalTcpTls = Opts.DisableExternalTcpTlsDefault;
+			_disableHttps = Opts.DisableHttpsDefault;
 			_enableExternalTCP = Opts.EnableExternalTCPDefault;
 
 			_statsPeriod = TimeSpan.FromSeconds(Opts.StatsPeriodDefault);
@@ -532,6 +534,15 @@ namespace EventStore.Core {
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
 		public VNodeBuilder EnableExternalTCP() {
 			_enableExternalTCP = true;
+			return this;
+		}
+
+		/// <summary>
+		/// Disable HTTPS Communication
+		/// </summary>
+		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+		public VNodeBuilder DisableHttps() {
+			_disableHttps = true;
 			return this;
 		}
 
@@ -1492,7 +1503,8 @@ namespace EventStore.Core {
 				_maxAppendSize,
 				_unsafeAllowSurplusNodes,
 				_enableExternalTCP,
-				_enableAtomPubOverHTTP);
+				_enableAtomPubOverHTTP,
+				_disableHttps);
 
 			var infoController = new InfoController(options, new Dictionary<string, bool> {
 				{"projections", _projectionType != ProjectionType.None},


### PR DESCRIPTION
Added: --disable-https flag to disable only HTTPS
Added: --insecure flag to disable TLS on all interfaces (TCP & HTTP) to eliminate requirement for certificates to make it easier to run EventStoreDB

Fixes https://github.com/EventStore/home/issues/197