### PR TITLE
[V5] Use a loop instead of recursion for synchronous Receive- and SendAsync

### DIFF
--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -200,31 +200,54 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		}
 
 		private void StartReceive() {
-			var buffer = new ArraySegment<byte>(new byte[TcpConfiguration.SocketBufferSize]);
-			_receiveSocketArgs.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
+
 			try {
-				NotifyReceiveStarting();
-				bool firedAsync = _receiveSocketArgs.AcceptSocket.ReceiveAsync(_receiveSocketArgs);
-				if (!firedAsync)
-					ProcessReceive(_receiveSocketArgs);
+
+				bool continueReceiveSynchronously = true;
+
+				do {
+
+					var buffer = new ArraySegment<byte>(new byte[TcpConfiguration.SocketBufferSize]);
+					_receiveSocketArgs.SetBuffer(buffer.Array, buffer.Offset, buffer.Count);
+
+					NotifyReceiveStarting();
+					bool firedAsync = _receiveSocketArgs.AcceptSocket.ReceiveAsync(_receiveSocketArgs);
+					if (firedAsync) {
+						continueReceiveSynchronously = false;
+					} else {
+
+						var processReceiveSuccess = ProcessReceive(_receiveSocketArgs);
+
+						if (processReceiveSuccess) {
+							TryDequeueReceivedData();
+						}
+
+						continueReceiveSynchronously = processReceiveSuccess;
+					}
+
+				} while (continueReceiveSynchronously);
+
 			} catch (ObjectDisposedException) {
 				ReturnReceivingSocketArgs();
 			}
 		}
 
 		private void OnReceiveAsyncCompleted(object sender, SocketAsyncEventArgs e) {
-			// No other code should go here.  All handling is the same on async and sync completion.
-			ProcessReceive(e);
+
+			if (ProcessReceive(e)) {
+				StartReceive();
+				TryDequeueReceivedData();
+			}
 		}
 
-		private void ProcessReceive(SocketAsyncEventArgs socketArgs) {
+		private bool ProcessReceive(SocketAsyncEventArgs socketArgs) {
 			// socket closed normally or some error occurred
 			if (socketArgs.BytesTransferred == 0 || socketArgs.SocketError != SocketError.Success) {
 				NotifyReceiveCompleted(0);
 				ReturnReceivingSocketArgs();
 				CloseInternal(socketArgs.SocketError,
 					socketArgs.SocketError != SocketError.Success ? "Socket receive error" : "Socket closed");
-				return;
+				return false;
 			}
 
 			NotifyReceiveCompleted(socketArgs.BytesTransferred);
@@ -241,8 +264,7 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 				socketArgs.SetBuffer(null, 0, 0);
 			}
 
-			StartReceive();
-			TryDequeueReceivedData();
+			return true;
 		}
 
 		private void TryDequeueReceivedData() {

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -134,53 +134,62 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		}
 
 		private void TrySend() {
-			lock (_sendLock) {
-				if (_isSending || _sendQueue.IsEmpty || _sendSocketArgs == null) return;
-				if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
-				_isSending = true;
-			}
-
-			_memoryStream.SetLength(0);
-
-			ArraySegment<byte> sendPiece;
-			while (_sendQueue.TryDequeue(out sendPiece)) {
-				_memoryStream.Write(sendPiece.Array, sendPiece.Offset, sendPiece.Count);
-				if (_memoryStream.Length >= MaxSendPacketSize)
-					break;
-			}
-
-			_sendSocketArgs.SetBuffer(_memoryStream.GetBuffer(), 0, (int)_memoryStream.Length);
-
+			bool continueSendSynchronously = true;
 			try {
-				NotifySendStarting(_sendSocketArgs.Count);
-				var firedAsync = _sendSocketArgs.AcceptSocket.SendAsync(_sendSocketArgs);
-				if (!firedAsync)
-					ProcessSend(_sendSocketArgs);
+				do {
+					lock (_sendLock) {
+						if (_isSending || _sendQueue.IsEmpty || _sendSocketArgs == null) return;
+						if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
+						_isSending = true;
+					}
+
+					_memoryStream.SetLength(0);
+
+					ArraySegment<byte> sendPiece;
+					while (_sendQueue.TryDequeue(out sendPiece)) {
+						_memoryStream.Write(sendPiece.Array, sendPiece.Offset, sendPiece.Count);
+						if (_memoryStream.Length >= MaxSendPacketSize)
+							break;
+					}
+
+					_sendSocketArgs.SetBuffer(_memoryStream.GetBuffer(), 0, (int)_memoryStream.Length);
+
+					NotifySendStarting(_sendSocketArgs.Count);
+					var firedAsync = _sendSocketArgs.AcceptSocket.SendAsync(_sendSocketArgs);
+					if (firedAsync) {
+						continueSendSynchronously = false;
+					} else {
+						continueSendSynchronously = ProcessSend(_sendSocketArgs);
+					}
+				} while (continueSendSynchronously);
 			} catch (ObjectDisposedException) {
 				ReturnSendingSocketArgs();
 			}
 		}
 
 		private void OnSendAsyncCompleted(object sender, SocketAsyncEventArgs e) {
-			// No other code should go here. All handling is the same for sync/async completion.
-			ProcessSend(e);
+			if (ProcessSend(e)) {
+				TrySend();
+			}
 		}
 
-		private void ProcessSend(SocketAsyncEventArgs socketArgs) {
+		private bool ProcessSend(SocketAsyncEventArgs socketArgs) {
 			if (socketArgs.SocketError != SocketError.Success) {
 				NotifySendCompleted(0);
 				ReturnSendingSocketArgs();
 				CloseInternal(socketArgs.SocketError, "Socket send error.");
+				return false;
 			} else {
 				NotifySendCompleted(socketArgs.Count);
-				if (_isClosed)
+				if (_isClosed) {
 					ReturnSendingSocketArgs();
-				else {
+					return false;
+				} else {
 					lock (_sendLock) {
 						_isSending = false;
 					}
 
-					TrySend();
+					return true;
 				}
 			}
 		}

--- a/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.ClientAPI/Transport.Tcp/TcpConnection.cs
@@ -242,10 +242,9 @@ namespace EventStore.ClientAPI.Transport.Tcp {
 		}
 
 		private void OnReceiveAsyncCompleted(object sender, SocketAsyncEventArgs e) {
-
 			if (ProcessReceive(e)) {
-				StartReceive();
 				TryDequeueReceivedData();
+				StartReceive();
 			}
 		}
 

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -146,54 +146,63 @@ namespace EventStore.Transport.Tcp {
 		}
 
 		private void TrySend() {
-			lock (_sendLock) {
-				if (_isSending || _sendQueue.IsEmpty || _sendSocketArgs == null) return;
-				if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
-				_isSending = true;
-			}
-
-			_memoryStream.SetLength(0);
-
-			ArraySegment<byte> sendPiece;
-			while (_sendQueue.TryDequeue(out sendPiece)) {
-				_memoryStream.Write(sendPiece.Array, sendPiece.Offset, sendPiece.Count);
-				if (_memoryStream.Length >= MaxSendPacketSize)
-					break;
-			}
-
-			_sendSocketArgs.SetBuffer(_memoryStream.GetBuffer(), 0, (int)_memoryStream.Length);
-
+			bool continueSendSynchronously = true;
 			try {
-				NotifySendStarting(_sendSocketArgs.Count);
-				var firedAsync = _sendSocketArgs.AcceptSocket.SendAsync(_sendSocketArgs);
-				if (!firedAsync)
-					ProcessSend(_sendSocketArgs);
+				do {
+					lock (_sendLock) {
+						if (_isSending || _sendQueue.IsEmpty || _sendSocketArgs == null) return;
+						if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
+						_isSending = true;
+					}
+
+					_memoryStream.SetLength(0);
+
+					ArraySegment<byte> sendPiece;
+					while (_sendQueue.TryDequeue(out sendPiece)) {
+						_memoryStream.Write(sendPiece.Array, sendPiece.Offset, sendPiece.Count);
+						if (_memoryStream.Length >= MaxSendPacketSize)
+							break;
+					}
+
+					_sendSocketArgs.SetBuffer(_memoryStream.GetBuffer(), 0, (int)_memoryStream.Length);
+
+					NotifySendStarting(_sendSocketArgs.Count);
+					var firedAsync = _sendSocketArgs.AcceptSocket.SendAsync(_sendSocketArgs);
+					if (firedAsync) {
+						continueSendSynchronously = false;
+					} else {
+						continueSendSynchronously = ProcessSend(_sendSocketArgs);
+					}
+				} while (continueSendSynchronously);
 			} catch (ObjectDisposedException) {
 				ReturnSendingSocketArgs();
 			}
 		}
 
 		private void OnSendAsyncCompleted(object sender, SocketAsyncEventArgs e) {
-			// No other code should go here. All handling is the same for sync/async completion.
-			ProcessSend(e);
+			if (ProcessSend(e)) {
+				TrySend();
+			}
 		}
 
-		private void ProcessSend(SocketAsyncEventArgs socketArgs) {
+		private bool ProcessSend(SocketAsyncEventArgs socketArgs) {
 			if (socketArgs.SocketError != SocketError.Success) {
 				NotifySendCompleted(0);
 				ReturnSendingSocketArgs();
 				CloseInternal(socketArgs.SocketError, "Socket send error.");
+				return false;
 			} else {
 				NotifySendCompleted(socketArgs.Count);
 
-				if (_isClosed)
+				if (_isClosed) {
 					ReturnSendingSocketArgs();
-				else {
+					return false;
+				} else {
 					lock (_sendLock) {
 						_isSending = false;
 					}
 
-					TrySend();
+					return true;
 				}
 			}
 		}

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -263,8 +263,8 @@ namespace EventStore.Transport.Tcp {
 
 		private void OnReceiveAsyncCompleted(object sender, SocketAsyncEventArgs e) {
 			if (ProcessReceive(e)) {
-				StartReceive();
 				TryDequeueReceivedData();
+				StartReceive();
 			}
 		}
 


### PR DESCRIPTION
Fixed: Prevent Stackoverflow when accepting too much data over a TCP connection on dotnet core

Fixes: #2559 
Backport of https://github.com/EventStore/EventStore/pull/2560