### PR TITLE
Improving help output by removing alternate argument format

### DIFF
--- a/src/EventStore.Core/EventStoreHostedService.cs
+++ b/src/EventStore.Core/EventStoreHostedService.cs
@@ -30,7 +30,9 @@ namespace EventStore.Core {
 					Path.Combine(Locations.DefaultConfigurationDirectory, DefaultFiles.DefaultConfigFile),
 					MutateEffectiveOptions);
 				if (Options.Help) {
-					Console.WriteLine("Options:");
+					Console.WriteLine("EventStore version {0} ({1}/{2}, {3})",
+						VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp);
+					Console.WriteLine();
 					Console.WriteLine(EventStoreOptions.GetUsage<TOptions>());
 					_skipRun = true;
 				} else if (Options.Version) {

--- a/src/EventStore.Core/EventStoreHostedService.cs
+++ b/src/EventStore.Core/EventStoreHostedService.cs
@@ -30,13 +30,13 @@ namespace EventStore.Core {
 					Path.Combine(Locations.DefaultConfigurationDirectory, DefaultFiles.DefaultConfigFile),
 					MutateEffectiveOptions);
 				if (Options.Help) {
-					Console.WriteLine("EventStore version {0} ({1}/{2}, {3})",
+					Console.WriteLine("EventStoreDB version {0} ({1}/{2}, {3})",
 						VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp);
 					Console.WriteLine();
 					Console.WriteLine(EventStoreOptions.GetUsage<TOptions>());
 					_skipRun = true;
 				} else if (Options.Version) {
-					Console.WriteLine("EventStore version {0} ({1}/{2}, {3})",
+					Console.WriteLine("EventStoreDB version {0} ({1}/{2}, {3})",
 						VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp);
 					_skipRun = true;
 				} else {

--- a/src/EventStore.Rags/ArgUsage.cs
+++ b/src/EventStore.Rags/ArgUsage.cs
@@ -74,181 +74,45 @@ namespace EventStore.Rags {
 
 			ConsoleString ret = new ConsoleString();
 
-			ret += new ConsoleString("Usage: " + exeName, ConsoleColor.Cyan);
+			ret += new ConsoleString("Usage: " + exeName + " [arguments]");
 
-			ret.AppendUsingCurrentFormat(" options\n\n");
+			ret += Environment.NewLine;
 
 			ret += GetOptionsUsage(typeof(T).GetProperties(), false);
 
-			ret += "\n";
+			ret += Environment.NewLine;
 
 			return ret;
 		}
 
 		private static ConsoleString GetOptionsUsage(IEnumerable<PropertyInfo> opts, bool ignoreActionProperties) {
-			if (opts.Count() == 0) {
+			if (!opts.Any()) {
 				return new ConsoleString("There are no options");
 			}
 
 			var usageInfos = opts.Select(o => new ArgumentUsageInfo(o));
 
-			List<ConsoleString> columnHeaders = new List<ConsoleString>() {
-				new ConsoleString("OPTION", ConsoleColor.Yellow),
-				new ConsoleString("DESCRIPTION", ConsoleColor.Yellow),
-			};
+			var ret = new ConsoleString();
 
-			List<List<ConsoleString>> rows = new List<List<ConsoleString>>();
-			string currentGroup = String.Empty;
-			foreach (ArgumentUsageInfo usageInfo in usageInfos.OrderBy(x => x.Group)) {
-				if (currentGroup != usageInfo.Group && !String.IsNullOrEmpty(usageInfo.Group)) {
+			var currentGroup = string.Empty;
+
+			var longestArg = usageInfos.Select(u => u.Name)
+				.Aggregate("", (max, cur) => max.Length > cur.Length ? max : cur);
+
+			foreach (var usageInfo in usageInfos.OrderBy(x => x.Group)) {
+				if (currentGroup != usageInfo.Group && !string.IsNullOrEmpty(usageInfo.Group)) {
 					currentGroup = usageInfo.Group;
-					rows.Add(new List<ConsoleString>() {ConsoleString.Empty, ConsoleString.Empty, ConsoleString.Empty});
-					rows.Add(new List<ConsoleString>() {
-						new ConsoleString(currentGroup),
-						ConsoleString.Empty,
-						ConsoleString.Empty
-					});
+					ret += $"{Environment.NewLine}{currentGroup}:{Environment.NewLine}";
 				}
 
-				var descriptionString = new ConsoleString(usageInfo.Description);
+				ret += string.Format("  -{0,-" + (longestArg.Length + 2) + "}{1}", usageInfo.Name,
+					usageInfo.Description);
 
-				var aliases = usageInfo.Aliases.OrderBy(a => a.Length).ToList();
-				var maxInlineAliasLength = 8;
-				string inlineAliasInfo = "";
-
-				int aliasIndex;
-				for (aliasIndex = 0; aliasIndex < aliases.Count; aliasIndex++) {
-					var proposedInlineAliases = inlineAliasInfo == string.Empty
-						? aliases[aliasIndex]
-						: inlineAliasInfo + ", " + aliases[aliasIndex];
-					if (proposedInlineAliases.Length <= maxInlineAliasLength) {
-						inlineAliasInfo = proposedInlineAliases;
-					} else {
-						break;
-					}
+				if (usageInfo.PossibleValues.Any()) {
+					ret += $" ({string.Join(", ", usageInfo.PossibleValues)})";
 				}
 
-				if (inlineAliasInfo != string.Empty) inlineAliasInfo = " (" + inlineAliasInfo + ")";
-
-				rows.Add(new List<ConsoleString>() {
-					new ConsoleString("") + ("-" + usageInfo.Name + inlineAliasInfo),
-					descriptionString,
-				});
-
-				for (int i = aliasIndex; i < aliases.Count; i++) {
-					rows.Add(new List<ConsoleString>() {
-						new ConsoleString("  " + aliases[i]),
-						ConsoleString.Empty,
-					});
-				}
-
-				foreach (var possibleValue in usageInfo.PossibleValues) {
-					rows.Add(new List<ConsoleString>() {
-						ConsoleString.Empty,
-						new ConsoleString("  " + possibleValue),
-					});
-				}
-			}
-
-			return FormatAsTable(columnHeaders, rows, "   ");
-		}
-
-		private static ConsoleString FormatAsTable(List<ConsoleString> columns, List<List<ConsoleString>> rows,
-			string rowPrefix = "") {
-			if (Environment.OSVersion.Platform == PlatformID.Win32NT) {
-				return FormatAsTableWindows(columns, rows, rowPrefix);
-			} else {
-				return FormatAsTableUnix(columns, rows, rowPrefix);
-			}
-		}
-
-		private static ConsoleString FormatAsTableWindows(List<ConsoleString> columns, List<List<ConsoleString>> rows,
-			string rowPrefix = "") {
-			if (rows.Count == 0) return new ConsoleString();
-
-			Dictionary<int, int> maximums = new Dictionary<int, int>();
-
-			for (int i = 0; i < columns.Count; i++) {
-				maximums.Add(i, columns[i].Length);
-			}
-
-			for (int i = 0; i < columns.Count; i++) {
-				foreach (var row in rows) {
-					maximums[i] = Math.Max(maximums[i], row[i].Length);
-				}
-			}
-
-			ConsoleString ret = new ConsoleString();
-			int buffer = 3;
-
-			ret += rowPrefix;
-			for (int i = 0; i < columns.Count; i++) {
-				var val = columns[i];
-				while (val.Length < maximums[i] + buffer) val += " ";
-				ret += val;
-			}
-
-			ret += "\n";
-
-			foreach (var row in rows) {
-				ret += rowPrefix;
-				for (int i = 0; i < columns.Count; i++) {
-					var val = row[i];
-					while (val.Length < maximums[i] + buffer) val += " ";
-
-					ret += val;
-				}
-
-				ret += "\n";
-			}
-
-			return ret;
-		}
-
-		private static ConsoleString FormatAsTableUnix(List<ConsoleString> columns, List<List<ConsoleString>> rows,
-			string rowPrefix = "") {
-			if (rows.Count == 0) return new ConsoleString();
-
-			Dictionary<int, int> maximums = new Dictionary<int, int>();
-
-			int optionDescriptionWidth = 41;
-			int standardColumnWidth = 80;
-
-			List<int> columnWidths = new List<int>();
-
-			for (int i = 0; i < columns.Count; i++) {
-				columnWidths.Add(i == 0 ? optionDescriptionWidth : standardColumnWidth - optionDescriptionWidth);
-				maximums.Add(i, columns[i].Length);
-			}
-
-			for (int i = 0; i < columns.Count; i++) {
-				foreach (var row in rows) {
-					maximums[i] = columnWidths[i];
-				}
-			}
-
-			ConsoleString ret = new ConsoleString();
-			int buffer = 3;
-
-			ret += rowPrefix;
-			for (int i = 0; i < columns.Count; i++) {
-				var val = columns[i];
-				while (val.Length < maximums[i] + buffer) val += " ";
-				ret += val;
-			}
-
-			ret += "\n";
-
-			foreach (var row in rows) {
-				ret += rowPrefix;
-				for (int i = 0; i < columns.Count; i++) {
-					var val = row[i];
-					while (val.Length < maximums[i] + buffer) val += " ";
-
-					ret += val;
-				}
-
-				ret += "\n";
+				ret += Environment.NewLine;
 			}
 
 			return ret;


### PR DESCRIPTION
Fixed: Improved output of CLI help

felt the help output was a bit difficult to read so tried to simplify it from:

![image](https://user-images.githubusercontent.com/2362687/86128760-b379e080-bad9-11ea-9b07-3dc3b6145edc.png)

to

![image](https://user-images.githubusercontent.com/2362687/86128659-91805e00-bad9-11ea-91e4-468974219247.png)

