### PR TITLE
Do not print stack trace when invalid configuration is encountered

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -151,12 +151,12 @@ namespace EventStore.ClusterNode {
 
 				_dbLock = new ExclusiveDbLock(absolutePath);
 				if (!_dbLock.Acquire())
-					throw new Exception($"Couldn't acquire exclusive lock on DB at '{dbPath}'.");
+					throw new InvalidConfigurationException($"Couldn't acquire exclusive lock on DB at '{dbPath}'.");
 			}
 
 			_clusterNodeMutex = new ClusterNodeMutex();
 			if (!_clusterNodeMutex.Acquire())
-				throw new Exception($"Couldn't acquire exclusive Cluster Node mutex '{_clusterNodeMutex.MutexName}'.");
+				throw new InvalidConfigurationException($"Couldn't acquire exclusive Cluster Node mutex '{_clusterNodeMutex.MutexName}'.");
 
 			if (!opts.DiscoverViaDns && opts.GossipSeed.Length == 0) {
 				if (opts.ClusterSize == 1) {
@@ -216,7 +216,7 @@ namespace EventStore.ClusterNode {
 			Log.Information("Quorum size set to {quorum}", prepareCount);
 
 			if (options.ReadOnlyReplica && options.ClusterSize <= 1) {
-				throw new Exception(
+				throw new InvalidConfigurationException(
 					"This node cannot be configured as a Read Only Replica as these node types are only supported in a clustered configuration.");
 			}
 
@@ -368,7 +368,7 @@ namespace EventStore.ClusterNode {
 					options.CertificatePrivateKeyFile,
 					options.CertificatePassword);
 			} else if (!options.Dev)
-				throw new Exception("A TLS Certificate is required unless development mode (--dev) is set.");
+				throw new InvalidConfigurationException("A TLS Certificate is required unless development mode (--dev) is set.");
 
 			var authorizationConfig = String.IsNullOrEmpty(options.AuthorizationConfig)
 				? options.Config
@@ -377,7 +377,7 @@ namespace EventStore.ClusterNode {
 			if (!string.IsNullOrEmpty(options.TrustedRootCertificatesPath)) {
 				builder.WithTrustedRootCertificatesPath(options.TrustedRootCertificatesPath);
 			} else {
-				throw new Exception(
+				throw new InvalidConfigurationException(
 					$"{nameof(options.TrustedRootCertificatesPath)} must be specified unless development mode (--dev) is set.");
 			}
 

--- a/src/EventStore.Common/Exceptions/InvalidConfigurationException.cs
+++ b/src/EventStore.Common/Exceptions/InvalidConfigurationException.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace EventStore.Common.Exceptions {
+	public class InvalidConfigurationException : Exception {
+		public InvalidConfigurationException(string message) : base(message) { }
+	}
+}

--- a/src/EventStore.Core/EventStoreHostedService.cs
+++ b/src/EventStore.Core/EventStoreHostedService.cs
@@ -43,12 +43,15 @@ namespace EventStore.Core {
 					Create(Options);
 				}
 			} catch (OptionException exc) {
-				Console.Error.WriteLine("Error while parsing options:");
-				Console.Error.WriteLine(FormatExceptionMessage(exc));
-				Console.Error.WriteLine();
-				Console.Error.WriteLine("Options:");
-				Console.Error.WriteLine(EventStoreOptions.GetUsage<TOptions>());
-				throw;
+				Log.Error("Error while parsing options:");
+				Log.Error(FormatExceptionMessage(exc));
+				Log.Information("Options:");
+				Log.Information(EventStoreOptions.GetUsage<TOptions>());
+				_skipRun = true;
+			} catch (InvalidConfigurationException exc) {
+				Log.Error("Invalid Configuration Encountered");
+				Log.Error(exc.Message);
+				_skipRun = true;
 			}
 		}
 


### PR DESCRIPTION
Changed: Do not print stack traces when an invalid configuration is encountered.

- This improves invalid configuration output and makes it easier to spot what the actual issue is.
- This also ensures that an invalid configuration is seen as a graceful shutdown rather than the server terminating unexpectedly.

**Before:**
```
[ 7648, 1,19:48:22.633,FTL] Host terminated unexpectedly.
EventStore.Common.Exceptions.InvalidConfigurationException: A TLS Certificate is required unless development mode (--dev) is set.
   at EventStore.ClusterNode.ClusterVNodeHostedService.BuildNode(ClusterNodeOptions options) in C:\source\EventStore\src\EventStore.ClusterNode\ClusterVNodeHostedService.cs:line 380
   at EventStore.ClusterNode.ClusterVNodeHostedService.Create(ClusterNodeOptions opts) in C:\source\EventStore\src\EventStore.ClusterNode\ClusterVNodeHostedService.cs:line 174
   at EventStore.Core.EventStoreHostedService`1..ctor(String[] args) in C:\source\EventStore\src\EventStore.Core\EventStoreHostedService.cs:line 43
   at EventStore.ClusterNode.ClusterVNodeHostedService..ctor(String[] args) in C:\source\EventStore\src\EventStore.ClusterNode\ClusterVNodeHostedService.cs:line 34
   at EventStore.ClusterNode.Program.Main(String[] args) in C:\source\EventStore\src\EventStore.ClusterNode\Program.cs:line 20
```

**After:**
```
[ 5436, 1,19:48:48.398,INF] Quorum size set to 1
[ 5436, 1,19:48:48.402,ERR] Invalid Configuration Encountered
[ 5436, 1,19:48:48.402,ERR] A TLS Certificate is required unless development mode (--dev) is set.
```