### PR TITLE
Require anonymous access for gossip updates and elections when HTTPS is disabled

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 		protected ClientCertificateAuthenticationProvider _provider;
 
 		protected void SetUpProvider() {
-			_provider = new ClientCertificateAuthenticationProvider(false, Opts.CertificateReservedNodeCommonNameDefault);
+			_provider = new ClientCertificateAuthenticationProvider(Opts.CertificateReservedNodeCommonNameDefault);
 		}
 	}
 

--- a/src/EventStore.Core/Authorization/Policy.cs
+++ b/src/EventStore.Core/Authorization/Policy.cs
@@ -42,6 +42,14 @@ namespace EventStore.Core.Authorization {
 			assertions.Insert(~insertAt, assertion);
 		}
 
+		public void Clear(OperationDefinition operation) {
+			if (_sealed)
+				throw new InvalidOperationException("policy has been sealed and no further changes can be made");
+			if (!_assertions.TryGetValue(operation, out var assertions))
+				return;
+			assertions.Clear();
+		}
+
 		public ReadOnlyPolicy AsReadOnly() {
 			_sealed = true;
 			return new ReadOnlyPolicy(Name, _version, ValidFrom,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -454,7 +454,7 @@ namespace EventStore.Core {
 			});
 
 			var httpAuthenticationProviders = new List<IHttpAuthenticationProvider> {
-				new ClientCertificateAuthenticationProvider(_disableHttps, _vNodeSettings.CertificateReservedNodeCommonName),
+				new ClientCertificateAuthenticationProvider(_vNodeSettings.CertificateReservedNodeCommonName),
 				new BasicHttpAuthenticationProvider(_authenticationProvider),
 				new BearerHttpAuthenticationProvider(_authenticationProvider)
 			};

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
@@ -7,21 +7,13 @@ using Microsoft.AspNetCore.Http;
 
 namespace EventStore.Core.Services.Transport.Http.Authentication {
 	public class ClientCertificateAuthenticationProvider : IHttpAuthenticationProvider {
-		private bool _bypassAuthentication;
 		private readonly string _certificateReservedNodeCommonName;
 
-		public ClientCertificateAuthenticationProvider(bool bypassAuthentication, string certificateReservedNodeCommonName) {
-			_bypassAuthentication = bypassAuthentication;
+		public ClientCertificateAuthenticationProvider(string certificateReservedNodeCommonName) {
 			_certificateReservedNodeCommonName = $"CN={certificateReservedNodeCommonName}";
 		}
 
 		public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
-			if (_bypassAuthentication) {
-				request = new HttpAuthenticationRequest(context, "system", "");
-				request.Authenticated(SystemAccounts.System);
-				return true;
-			}
-
 			request = null;
 			var clientCertificate = context.Connection.ClientCertificate;
 			if (clientCertificate is null) return false;


### PR DESCRIPTION
Changed: Instead of always giving system access when running with --insecure (since no client certificate is provided), make gossip/updates policies anonymous when HTTPS is disabled.


Fixes https://github.com/EventStore/home/issues/214