### PR TITLE
Connection string: SkipCertificateValidation=true instead of CustomHttpClient=SkipCertificateValidation [v5 TCP client]

### DIFF
--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -37,7 +37,12 @@ namespace EventStore.ClientAPI {
 		/// <summary>
 		/// Allows overriding the HTTPClient <see cref="IHttpClient"/>
 		/// </summary>
-		public IHttpClient CustomHttpClient;
+		public IHttpClient CustomHttpClient { get; set; }
+
+		/// <summary>
+		/// Whether to skip the certificate verification for TLS connections
+		/// </summary>
+		public bool SkipCertificateValidation;
 
 		/// <summary>
 		/// Whether to use excessive logging of <see cref="EventStoreConnection"/> internal logic.

--- a/src/EventStore.ClientAPI/ConnectionString.cs
+++ b/src/EventStore.ClientAPI/ConnectionString.cs
@@ -84,22 +84,6 @@ namespace EventStore.ClientAPI {
 									x), ex);
 						}
 					}
-				},
-				{
-					typeof(IHttpClient), x => {
-#if NET452
-						throw new Exception("Setting the value of IHttpClient in the connection string is not supported in .NET 4.5.2");
-#elif NET46
-						throw new Exception("Setting the value of IHttpClient in the connection string is not supported in .NET 4.6");
-#else
-						if (x.Trim().Equals("SkipCertificateValidation")) {
-							return new HttpAsyncClient(TimeSpan.FromMilliseconds(1000), new HttpClientHandler {
-								ServerCertificateCustomValidationCallback = delegate { return true; }
-							});
-						}
-						throw new Exception("The only supported value for IHttpClient is: SkipCertificateValidation");
-#endif
-					}
 				}
 			};
 		}

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
       <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -210,7 +210,8 @@ namespace EventStore.ClientAPI {
 				clusterSettings.GossipSeeds,
 				clusterSettings.GossipTimeout,
 				clusterSettings.NodePreference,
-				connectionSettings.CustomHttpClient);
+				connectionSettings.CustomHttpClient,
+				connectionSettings.SkipCertificateValidation);
 
 			return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
 				connectionName);

--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -8,6 +8,7 @@ using EventStore.ClientAPI.Exceptions;
 using EventStore.ClientAPI.Messages;
 using EventStore.ClientAPI.Transport.Http;
 using System.Linq;
+using System.Net.Http;
 using HttpStatusCode = EventStore.ClientAPI.Transport.Http.HttpStatusCode;
 
 namespace EventStore.ClientAPI.Internal {
@@ -31,7 +32,8 @@ namespace EventStore.ClientAPI.Internal {
 			GossipSeed[] gossipSeeds,
 			TimeSpan gossipTimeout,
 			NodePreference nodePreference,
-			IHttpClient client = null) {
+			IHttpClient client,
+			bool skipCertificateValidation) {
 			Ensure.NotNull(log, "log");
 
 			_log = log;
@@ -40,7 +42,19 @@ namespace EventStore.ClientAPI.Internal {
 			_managerExternalHttpPort = managerExternalHttpPort;
 			_gossipSeeds = gossipSeeds;
 			_gossipTimeout = gossipTimeout;
-			_client = client ?? new HttpAsyncClient(_gossipTimeout);
+			HttpClientHandler handler = null;
+			if (skipCertificateValidation) {
+#if NET452 || NET46
+				handler = new WebRequestHandler {
+					ServerCertificateValidationCallback = delegate { return true; }
+				};
+#else
+				handler = new HttpClientHandler {
+					ServerCertificateCustomValidationCallback = delegate { return true; }
+				};
+#endif
+			}
+			_client = client ?? new HttpAsyncClient(_gossipTimeout, handler);
 			_nodePreference = nodePreference;
 		}
 


### PR DESCRIPTION
Changed: Allow user to specify SkipCertificateValidation=true instead of CustomHttpClient=SkipCertificateValidation in connection string


Fixes #2584 

If a custom http client has been specified by the user, it will take precedence over the SkipCertificateValidation flag.