### PR TITLE
Filter out unresolved events when checking for deleted partitions

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
@@ -131,7 +131,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 				_readAs = readAs;
 			}
 
-			protected void DeliverEvent(float progress, ResolvedEvent resolvedEvent, TFPos position) {
+			protected void DeliverEvent(float progress, ResolvedEvent resolvedEvent, TFPos position,
+				EventStore.Core.Data.ResolvedEvent pair) {
 				if (resolvedEvent.EventOrLinkTargetPosition <= _reader._lastEventPosition)
 					return;
 				_reader._lastEventPosition = resolvedEvent.EventOrLinkTargetPosition;
@@ -144,7 +145,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					return;
 
 				bool isDeletedStreamEvent = StreamDeletedHelper.IsStreamDeletedEventOrLinkToStreamDeletedEvent(
-					resolvedEvent, out deletedPartitionStreamId);
+					resolvedEvent, pair.ResolveResult, out deletedPartitionStreamId);
 				if (isDeletedStreamEvent) {
 					var deletedPartition = deletedPartitionStreamId;
 
@@ -506,7 +507,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				TFPos position) {
 				//TODO: add event sequence validation for inside the index stream
 				var resolvedEvent = new ResolvedEvent(pair, null);
-				DeliverEvent(progress, resolvedEvent, position);
+				DeliverEvent(progress, resolvedEvent, position, pair);
 			}
 
 			public override bool AreEventsRequested() {
@@ -686,7 +687,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				TFPos position) {
 				var resolvedEvent = new ResolvedEvent(pair, null);
 
-				DeliverEvent(progress, resolvedEvent, position);
+				DeliverEvent(progress, resolvedEvent, position, pair);
 			}
 
 			private void SendIdle() {

--- a/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
@@ -216,7 +216,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				return;
 
 			bool isDeletedStreamEvent =
-				StreamDeletedHelper.IsStreamDeletedEventOrLinkToStreamDeletedEvent(resolvedEvent,
+				StreamDeletedHelper.IsStreamDeletedEventOrLinkToStreamDeletedEvent(resolvedEvent, pair.ResolveResult,
 					out deletedPartitionStreamId);
 
 			if (isDeletedStreamEvent) {

--- a/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
@@ -175,7 +175,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				return;
 
 			bool isDeletedStreamEvent = StreamDeletedHelper.IsStreamDeletedEventOrLinkToStreamDeletedEvent(
-				resolvedEvent, out deletedPartitionStreamId);
+				resolvedEvent, @event.ResolveResult, out deletedPartitionStreamId);
 
 			_publisher.Publish(
 				new ReaderSubscriptionMessage.CommittedEventDistributed(

--- a/src/EventStore.Projections.Core/Standard/StreamDeletedHelper.cs
+++ b/src/EventStore.Projections.Core/Standard/StreamDeletedHelper.cs
@@ -7,8 +7,14 @@ using ResolvedEvent = EventStore.Projections.Core.Services.Processing.ResolvedEv
 namespace EventStore.Projections.Core.Standard {
 	public static class StreamDeletedHelper {
 		public static bool IsStreamDeletedEventOrLinkToStreamDeletedEvent(ResolvedEvent resolvedEvent,
-			out string deletedPartitionStreamId) {
+			ReadEventResult resolveResult, out string deletedPartitionStreamId) {
 			bool isDeletedStreamEvent;
+			// If the event didn't resolve, we can't rely on it as a deleted event
+			if (resolveResult != ReadEventResult.Success) {
+				deletedPartitionStreamId = null;
+				return false;
+			}
+			
 			if (resolvedEvent.IsLinkToDeletedStreamTombstone) {
 				isDeletedStreamEvent = true;
 				deletedPartitionStreamId = resolvedEvent.EventStreamId;


### PR DESCRIPTION
Changed: Don't treat unresolved links as deleted linkTo events when checking for deleted partitions in projections.

Fixes #2532 

If multiple deleted events for the same stream are written quickly, it's possible for the projection to process a deleted link event that couldn't be resolved. This can result in the projection processing the event twice, once as a committed event and once as a partition deleted event. See the issue for details on how/why this happens.

This PR changes the check for whether to publish an `EventReaderPartitionDeleted` message to also check if the link is resolved.
Because the partition deleted messages don't get emitted this change should be backwards compatible.