### PR TITLE
Preauthorize gossip & election routes with system access when HTTPS is disabled

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 		protected ClientCertificateAuthenticationProvider _provider;
 
 		protected void SetUpProvider() {
-			_provider = new ClientCertificateAuthenticationProvider(false, Opts.CertificateReservedNodeCommonNameDefault);
+			_provider = new ClientCertificateAuthenticationProvider(Opts.CertificateReservedNodeCommonNameDefault);
 		}
 	}
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -454,7 +454,7 @@ namespace EventStore.Core {
 			});
 
 			var httpAuthenticationProviders = new List<IHttpAuthenticationProvider> {
-				new ClientCertificateAuthenticationProvider(_disableHttps, _vNodeSettings.CertificateReservedNodeCommonName),
+				new ClientCertificateAuthenticationProvider(_vNodeSettings.CertificateReservedNodeCommonName),
 				new BasicHttpAuthenticationProvider(_authenticationProvider),
 				new BearerHttpAuthenticationProvider(_authenticationProvider)
 			};

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -454,10 +454,17 @@ namespace EventStore.Core {
 			});
 
 			var httpAuthenticationProviders = new List<IHttpAuthenticationProvider> {
-				new ClientCertificateAuthenticationProvider(_vNodeSettings.CertificateReservedNodeCommonName),
 				new BasicHttpAuthenticationProvider(_authenticationProvider),
 				new BearerHttpAuthenticationProvider(_authenticationProvider)
 			};
+
+			if (!_disableHttps) {
+				httpAuthenticationProviders.Add(
+					new ClientCertificateAuthenticationProvider(_vNodeSettings.CertificateReservedNodeCommonName));
+			} else {
+				httpAuthenticationProviders.Add(new GossipAndElectionsAuthenticationProvider());
+			}
+
 			if (vNodeSettings.EnableTrustedAuth)
 				httpAuthenticationProviders.Add(new TrustedHttpAuthenticationProvider());
 			httpAuthenticationProviders.Add(new AnonymousHttpAuthenticationProvider());

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
@@ -7,21 +7,13 @@ using Microsoft.AspNetCore.Http;
 
 namespace EventStore.Core.Services.Transport.Http.Authentication {
 	public class ClientCertificateAuthenticationProvider : IHttpAuthenticationProvider {
-		private bool _bypassAuthentication;
 		private readonly string _certificateReservedNodeCommonName;
 
-		public ClientCertificateAuthenticationProvider(bool bypassAuthentication, string certificateReservedNodeCommonName) {
-			_bypassAuthentication = bypassAuthentication;
+		public ClientCertificateAuthenticationProvider(string certificateReservedNodeCommonName) {
 			_certificateReservedNodeCommonName = $"CN={certificateReservedNodeCommonName}";
 		}
 
 		public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
-			if (_bypassAuthentication) {
-				request = new HttpAuthenticationRequest(context, "system", "");
-				request.Authenticated(SystemAccounts.System);
-				return true;
-			}
-
 			request = null;
 			var clientCertificate = context.Connection.ClientCertificate;
 			if (clientCertificate is null) return false;

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/GossipAndElectionsAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/GossipAndElectionsAuthenticationProvider.cs
@@ -1,0 +1,25 @@
+﻿using EventStore.Core.Services.UserManagement;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace EventStore.Core.Services.Transport.Http.Authentication {
+	public class GossipAndElectionsAuthenticationProvider : IHttpAuthenticationProvider {
+		private readonly MediaTypeHeaderValue _gRPCHeader = new MediaTypeHeaderValue("application/grpc");
+		private readonly PathString _gossipPath = new PathString("/event_store.cluster.Gossip");
+		private readonly PathString _electionsPath = new PathString("/event_store.cluster.Elections");
+
+		public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
+			request = null;
+			if (!(context.Request.GetTypedHeaders().ContentType?.IsSubsetOf(_gRPCHeader)).GetValueOrDefault(false))
+				return false;
+
+			if (!context.Request.Path.StartsWithSegments(_gossipPath) &&
+			    !context.Request.Path.StartsWithSegments(_electionsPath))
+				return false;
+
+			request = new HttpAuthenticationRequest(context, "system", "");
+			request.Authenticated(SystemAccounts.System);
+			return true;
+		}
+	}
+}


### PR DESCRIPTION
Changed: Instead of always giving system access over HTTP when running with --insecure (since no client certificate is provided), only pre-authorize the gossip and election routes with system access


Fixes: https://github.com/EventStore/home/issues/214