### PR TITLE
Add ability to reload certificates by sending SIGHUP signal or by triggering /admin/reloadconfig endpoint

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 	<!-- Transitive dependencies to help in packaging -->
 	<ItemGroup>
-		<PackageReference Include="EventStore.Plugins" Version="20.6.0" />
+		<PackageReference Include="EventStore.Plugins" Version="20.6.1-preview1" />
 		<PackageReference Include="Google.Protobuf" Version="3.12.3" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.29.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.30.0">

--- a/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionSslTests.cs
+++ b/src/EventStore.ClientAPI.Tests/Transport.Tcp/TcpConnectionSslTests.cs
@@ -53,7 +53,7 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 
 				var serverSocket = listeningSocket.Accept();
 				var serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
-					(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, GetCertificate(), delegate { return (true, null); }, false);
+					(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, GetCertificate, delegate { return (true, null); }, false);
 
 				mre.Wait(TimeSpan.FromSeconds(3));
 				try {
@@ -115,7 +115,7 @@ namespace EventStore.ClientAPI.Tests.Services.Transport.Tcp {
 					serverSocket = listeningSocket.Accept();
 					clientTcpConnection.Close("Intentional close");
 					serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
-						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, GetCertificate(), delegate { return (true, null); }, false);
+						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, GetCertificate, delegate { return (true, null); }, false);
 
 					mre.Wait(TimeSpan.FromSeconds(10));
 					SpinWait.SpinUntil(() => serverTcpConnection.IsClosed, TimeSpan.FromSeconds(10));

--- a/src/EventStore.ClientAPIAcceptanceTests/cluster/EventStoreClientAPIClusterFixture.cs
+++ b/src/EventStore.ClientAPIAcceptanceTests/cluster/EventStoreClientAPIClusterFixture.cs
@@ -55,7 +55,7 @@ namespace EventStore.ClientAPI.Tests {
 									ClientCertificateMode = ClientCertificateMode.AllowCertificate,
 									ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => {
 										var (isValid, error) =
-											ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(certificate, chain, sslPolicyErrors, rootCertificates);
+											ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(certificate, chain, sslPolicyErrors, () => rootCertificates);
 										if (!isValid && error != null) {
 											Log.Error("Client certificate validation error: {e}", error);
 										}

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -399,12 +399,12 @@ namespace EventStore.ClusterNode {
 
 			if (requireCertificates) {
 				if (!string.IsNullOrWhiteSpace(options.CertificateStoreLocation)) {
-					var location = GetCertificateStoreLocation(options.CertificateStoreLocation);
-					var name = GetCertificateStoreName(options.CertificateStoreName);
+					var location = CertificateLoader.GetCertificateStoreLocation(options.CertificateStoreLocation);
+					var name = CertificateLoader.GetCertificateStoreName(options.CertificateStoreName);
 					builder.WithServerCertificateFromStore(location, name, options.CertificateSubjectName,
 						options.CertificateThumbprint);
 				} else if (!string.IsNullOrWhiteSpace(options.CertificateStoreName)) {
-					var name = GetCertificateStoreName(options.CertificateStoreName);
+					var name = CertificateLoader.GetCertificateStoreName(options.CertificateStoreName);
 					builder.WithServerCertificateFromStore(name, options.CertificateSubjectName,
 						options.CertificateThumbprint);
 				} else if (options.CertificateFile.IsNotEmptyString()) {

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -187,7 +187,7 @@ namespace EventStore.ClusterNode {
 			var enabledNodeSubsystems = runProjections >= ProjectionType.System
 				? new[] {NodeSubsystems.Projections}
 				: new NodeSubsystems[0];
-			Node = BuildNode(opts);
+			Node = BuildNode(opts, LoadConfig);
 
 			RegisterWebControllers(enabledNodeSubsystems, opts);
 		}
@@ -205,7 +205,7 @@ namespace EventStore.ClusterNode {
 			return clusterSize / 2 + 1;
 		}
 
-		private static ClusterVNode BuildNode(ClusterNodeOptions options) {
+		private static ClusterVNode BuildNode(ClusterNodeOptions options, Func<ClusterNodeOptions> loadConfigFunc) {
 			var quorumSize = GetQuorumSize(options.ClusterSize);
 
 			var httpEndPoint = new IPEndPoint(options.ExtIp, options.HttpPort);
@@ -244,6 +244,8 @@ namespace EventStore.ClusterNode {
 			} else {
 				builder = ClusterVNodeBuilder.AsSingleNode();
 			}
+
+			builder.WithLoadConfigFunction(loadConfigFunc);
 
 			if (options.MemDb) {
 				builder = builder.RunInMemory();

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -64,7 +64,9 @@ namespace EventStore.ClusterNode {
 										listenOptions.Use(next => new ClearTextHttpMultiplexingMiddleware(next).OnConnectAsync);
 									} else {
 										listenOptions.UseHttps(new HttpsConnectionAdapterOptions {
-											ServerCertificate = hostedService.Node.Certificate,
+											ServerCertificateSelector = delegate {
+												return hostedService.Node.CertificateSelector();
+											},
 											ClientCertificateMode = ClientCertificateMode.AllowCertificate,
 											ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => {
 												var (isValid, error) =

--- a/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
+++ b/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
@@ -304,6 +304,7 @@ namespace EventStore.Core.Tests.Authorization {
 				yield return CreateOperation(Operations.Node.Information.Subsystems);
 
 				yield return CreateOperation(Operations.Node.Shutdown);
+				yield return CreateOperation(Operations.Node.ReloadConfiguration);
 				yield return CreateOperation(Operations.Node.Scavenge.Start);
 				yield return CreateOperation(Operations.Node.Scavenge.Stop);
 				yield return CreateOperation(Operations.Node.MergeIndexes);

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -173,7 +173,7 @@ namespace EventStore.Core.Tests.Helpers {
 								ClientCertificateMode = ClientCertificateMode.AllowCertificate,
 								ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => {
 									var (isValid, error) =
-										ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(certificate, chain, sslPolicyErrors, trustedRootCertificates);
+										ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(certificate, chain, sslPolicyErrors, () => trustedRootCertificates);
 									if (!isValid && error != null) {
 										Log.Error("Client certificate validation error: {e}", error);
 									}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -112,7 +112,8 @@ namespace EventStore.Core.Tests.Helpers {
 				useHttps ? new X509Certificate2Collection(ssl_connections.GetRootCertificate()) : null;
 
 			var singleVNodeSettings = new ClusterVNodeSettings(
-				Guid.NewGuid(), debugIndex, InternalTcpEndPoint, InternalTcpSecEndPoint, ExternalTcpEndPoint,
+				Guid.NewGuid(), debugIndex, () => new ClusterNodeOptions(),
+				InternalTcpEndPoint, InternalTcpSecEndPoint, ExternalTcpEndPoint,
 				ExternalTcpSecEndPoint, HttpEndPoint,
 				new Data.GossipAdvertiseInfo(
 					InternalTcpEndPoint.ToDnsEndPoint(),

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -32,6 +32,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var trustedRootCertificate = useHttps ? ssl_connections.GetRootCertificate() : null;
 
 			var vnode = new ClusterVNodeSettings(Guid.NewGuid(), 0,
+				() => new ClusterNodeOptions(),
 				GetLoopbackForPort(tcpIntPort), null,
 				GetLoopbackForPort(tcpExtPort), null,
 				GetLoopbackForPort(httpPort),

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
@@ -51,7 +51,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 
 				var serverSocket = listeningSocket.Accept();
 				var serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
-					(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, ssl_connections.GetServerCertificate(),
+					(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, ssl_connections.GetServerCertificate,
 					delegate { return (true, null); }, false);
 
 				mre.Wait(TimeSpan.FromSeconds(3));
@@ -118,7 +118,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 					serverSocket = listeningSocket.Accept();
 					clientTcpConnection.Close("Intentional close");
 					serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
-						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, ssl_connections.GetServerCertificate(),delegate { return (true, null); }, false);
+						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, ssl_connections.GetServerCertificate,delegate { return (true, null); }, false);
 
 					mre.Wait(TimeSpan.FromSeconds(10));
 					SpinWait.SpinUntil(() => serverTcpConnection.IsClosed, TimeSpan.FromSeconds(10));

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 
 			var listener = new TcpServerListener(serverEndPoint);
 			listener.StartListening((endPoint, socket) => {
-				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, cert,delegate { return (true, null); },
+				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, () => cert,delegate { return (true, null); },
 					verbose: true);
 				ssl.ConnectionClosed += (x, y) => done.Set();
 				if (ssl.IsClosed)

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
@@ -69,7 +69,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 
 			var listener = new TcpServerListener(serverEndPoint);
 			listener.StartListening((endPoint, socket) => {
-				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, serverCertificate,
+				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, () => serverCertificate,
 					(cert, chain, err) => validateClientCertificate ? ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(cert, chain, err, rootCertificates) : (true, null),
 					verbose: true);
 				ssl.ConnectionClosed += (x, y) => done.Set();

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
@@ -100,7 +100,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				serverEndPoint.GetHost(),
 				serverEndPoint,
 				(cert, chain, err) => validateServerCertificate ? ClusterVNode.ValidateServerCertificateWithTrustedRootCerts(cert, chain, err, rootCertificates) : (true, null),
-				new X509CertificateCollection{clientCertificate},
+				() => new X509CertificateCollection{clientCertificate},
 				new TcpClientConnector(),
 				TcpConnectionManager.ConnectionTimeout,
 				conn => {

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
@@ -70,7 +70,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			var listener = new TcpServerListener(serverEndPoint);
 			listener.StartListening((endPoint, socket) => {
 				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, () => serverCertificate,
-					(cert, chain, err) => validateClientCertificate ? ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(cert, chain, err, rootCertificates) : (true, null),
+					(cert, chain, err) => validateClientCertificate ? ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(cert, chain, err, () => rootCertificates) : (true, null),
 					verbose: true);
 				ssl.ConnectionClosed += (x, y) => done.Set();
 				if (ssl.IsClosed)
@@ -99,7 +99,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				Guid.NewGuid(),
 				serverEndPoint.GetHost(),
 				serverEndPoint,
-				(cert, chain, err) => validateServerCertificate ? ClusterVNode.ValidateServerCertificateWithTrustedRootCerts(cert, chain, err, rootCertificates) : (true, null),
+				(cert, chain, err) => validateServerCertificate ? ClusterVNode.ValidateServerCertificateWithTrustedRootCerts(cert, chain, err, () => rootCertificates) : (true, null),
 				() => new X509CertificateCollection{clientCertificate},
 				new TcpClientConnector(),
 				TcpConnectionManager.ConnectionTimeout,

--- a/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
@@ -57,6 +57,7 @@ namespace EventStore.Core.Authorization {
 			policy.Add(Operations.Node.Gossip.Update, isSystem);
 
 			policy.AddMatchAnyAssertion(Operations.Node.Shutdown, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.ReloadConfiguration, Grant.Allow, OperationsOrAdmins);
 			policy.AddMatchAnyAssertion(Operations.Node.MergeIndexes, Grant.Allow, OperationsOrAdmins);
 			policy.AddMatchAnyAssertion(Operations.Node.SetPriority, Grant.Allow, OperationsOrAdmins);
 			policy.AddMatchAnyAssertion(Operations.Node.Resign, Grant.Allow, OperationsOrAdmins);

--- a/src/EventStore.Core/CertificateLoader.cs
+++ b/src/EventStore.Core/CertificateLoader.cs
@@ -1,0 +1,123 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EventStore.Core {
+	public static class CertificateLoader {
+		public static X509Certificate2 FromStore(StoreLocation storeLocation, StoreName storeName,
+			string certificateSubjectName, string certificateThumbprint) {
+			var store = new X509Store(storeName, storeLocation);
+			return GetCertificateFromStore(store, certificateSubjectName, certificateThumbprint);
+		}
+
+		public static X509Certificate2 FromStore(StoreName storeName, string certificateSubjectName,
+        	string certificateThumbprint) {
+        	var store = new X509Store(storeName);
+        	return GetCertificateFromStore(store, certificateSubjectName, certificateThumbprint);
+		}
+
+		public static X509Certificate2 FromFile(
+			string certificatePath,
+			string privateKeyPath,
+			string password) {
+
+			if (string.IsNullOrEmpty(privateKeyPath)) {
+				X509Certificate2 certificate;
+
+				try {
+					certificate = new X509Certificate2(certificatePath, password);
+				} catch (CryptographicException exc) {
+					throw new AggregateException("Error loading certificate file. Please verify that the correct password has been provided via the `CertificatePassword` option.", exc);
+				}
+
+				if (!certificate.HasPrivateKey) {
+					throw new Exception("Expect certificate to contain a private key. " +
+					                    "Please either provide a certificate that contains one or set the private key" +
+					                    " via the `CertificatePrivateKeyFile` option.");
+				}
+				return certificate;
+			}
+
+			var privateKey = Convert.FromBase64String(string.Join(string.Empty, File.ReadAllLines(privateKeyPath)
+				.Skip(1)
+				.SkipLast(1)));
+
+			using var rsa = RSA.Create();
+			rsa.ImportRSAPrivateKey(new ReadOnlySpan<byte>(privateKey), out _);
+
+			using var publicCertificate = new X509Certificate2(certificatePath, password);
+			using var publicWithPrivate = publicCertificate.CopyWithPrivateKey(rsa);
+
+			return new X509Certificate2(publicWithPrivate.Export(X509ContentType.Pfx));
+		}
+
+		private static X509Certificate2 GetCertificateFromStore(X509Store store, string certificateSubjectName,
+			string certificateThumbprint) {
+			try {
+				store.Open(OpenFlags.OpenExistingOnly);
+			} catch (Exception exc) {
+				throw new Exception(
+					string.Format("Could not open certificate store '{0}' in location {1}'.", store.Name,
+						store.Location), exc);
+			}
+
+			if (!string.IsNullOrWhiteSpace(certificateThumbprint)) {
+				var certificates = store.Certificates.Find(X509FindType.FindByThumbprint, certificateThumbprint, true);
+				if (certificates.Count == 0)
+					throw new Exception(string.Format("Could not find valid certificate with thumbprint '{0}'.",
+						certificateThumbprint));
+
+				//Can this even happen?
+				if (certificates.Count > 1)
+					throw new Exception(string.Format("Could not determine a unique certificate from thumbprint '{0}'.",
+						certificateThumbprint));
+
+				return certificates[0];
+			}
+
+			if (!string.IsNullOrWhiteSpace(certificateSubjectName)) {
+				var certificates =
+					store.Certificates.Find(X509FindType.FindBySubjectName, certificateSubjectName, true);
+				if (certificates.Count == 0)
+					throw new Exception(string.Format("Could not find valid certificate with subject name '{0}'.",
+						certificateSubjectName));
+
+				//Can this even happen?
+				if (certificates.Count > 1)
+					throw new Exception(string.Format(
+						"Could not determine a unique certificate from subject name '{0}'.", certificateSubjectName));
+
+				return certificates[0];
+			}
+
+			throw new ArgumentException(
+				"No thumbprint or subject name was specified for a certificate, but a certificate store was specified.");
+		}
+
+		public static X509Certificate2Collection LoadCertificateCollection(string path) {
+			var certCollection = new X509Certificate2Collection();
+			var files = Directory.GetFiles(path);
+			var acceptedExtensions = new[] {".crt", ".cert", ".cer", ".pem", ".der"};
+			foreach (var file in files) {
+				var fileInfo = new FileInfo(file);
+				var extension = fileInfo.Extension;
+				if (acceptedExtensions.Contains(extension)) {
+					try {
+						var cert = new X509Certificate2(File.ReadAllBytes(file));
+						certCollection.Add(cert);
+						//_log.Information("Trusted root certificate file loaded: {file}", fileInfo.Name);
+					} catch (Exception exc) {
+						throw new AggregateException($"Error loading trusted root certificate file: {file}", exc);
+					}
+				}
+			}
+
+			if (certCollection.Count == 0)
+				throw new Exception($"No trusted root certificates were loaded from: {path}");
+
+			return certCollection;
+		}
+	}
+}

--- a/src/EventStore.Core/CertificateLoader.cs
+++ b/src/EventStore.Core/CertificateLoader.cs
@@ -107,5 +107,17 @@ namespace EventStore.Core {
 				}
 			}
 		}
+
+		public static StoreLocation GetCertificateStoreLocation(string certificateStoreLocation) {
+			if (!Enum.TryParse(certificateStoreLocation, out StoreLocation location))
+				throw new Exception($"Could not find certificate store location '{certificateStoreLocation}'");
+			return location;
+		}
+
+		public static StoreName GetCertificateStoreName(string certificateStoreName) {
+			if (!Enum.TryParse(certificateStoreName, out StoreName name))
+				throw new Exception($"Could not find certificate store name '{certificateStoreName}'");
+			return name;
+		}
 	}
 }

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Cluster {
 		private readonly IPublisher _bus;
 		internal bool Disposed { get; private set; }
 
-		public EventStoreClusterClient(Uri address, IPublisher bus, Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> serverCertValidator, X509Certificate clientCertificate) {
+		public EventStoreClusterClient(Uri address, IPublisher bus, Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> serverCertValidator, Func<X509Certificate> clientCertificateSelector) {
 			HttpMessageHandler httpMessageHandler = null;
 			if (address.Scheme == Uri.UriSchemeHttps){
 				var socketsHttpHandler = new SocketsHttpHandler {
@@ -31,11 +31,11 @@ namespace EventStore.Core.Cluster {
 
 							return isValid;
 						},
-						ClientCertificates = new X509CertificateCollection()
+						LocalCertificateSelectionCallback = delegate {
+							return clientCertificateSelector();
+						}
 					}
 				};
-				if (clientCertificate != null)
-					socketsHttpHandler.SslOptions.ClientCertificates.Add(clientCertificate);
 
 				httpMessageHandler = socketsHttpHandler;
 			} else if (address.Scheme == Uri.UriSchemeHttp) {

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
+using EventStore.Core.Settings;
 using Grpc.Net.Client;
 using Serilog.Extensions.Logging;
 
@@ -34,7 +35,8 @@ namespace EventStore.Core.Cluster {
 						LocalCertificateSelectionCallback = delegate {
 							return clientCertificateSelector();
 						}
-					}
+					},
+					PooledConnectionLifetime = ESConsts.HttpClientConnectionLifeTime
 				};
 
 				httpMessageHandler = socketsHttpHandler;

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -12,6 +12,7 @@ using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Cluster.Settings {
 	public class ClusterVNodeSettings {
+		public readonly Func<ClusterNodeOptions> LoadConfigFunc;
 		public readonly VNodeInfo NodeInfo;
 		public readonly GossipAdvertiseInfo GossipAdvertiseInfo;
 		public readonly bool EnableTrustedAuth;
@@ -95,6 +96,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly bool UnsafeAllowSurplusNodes;
 
 		public ClusterVNodeSettings(Guid instanceId, int debugIndex,
+			Func<ClusterNodeOptions> loadConfigFunc,
 			IPEndPoint internalTcpEndPoint,
 			IPEndPoint internalSecureTcpEndPoint,
 			IPEndPoint externalTcpEndPoint,
@@ -191,6 +193,7 @@ namespace EventStore.Core.Cluster.Settings {
 				throw new ArgumentException(
 					"Either DNS Discovery must be disabled (and seeds specified), or a cluster DNS name must be provided.");
 
+			LoadConfigFunc = loadConfigFunc;
 			NodeInfo = new VNodeInfo(instanceId, debugIndex,
 				internalTcpEndPoint, internalSecureTcpEndPoint,
 				externalTcpEndPoint, externalSecureTcpEndPoint,

--- a/src/EventStore.Core/ClusterNodeOptions.cs
+++ b/src/EventStore.Core/ClusterNodeOptions.cs
@@ -4,7 +4,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Util;
 using EventStore.Rags;
 
-namespace EventStore.ClusterNode {
+namespace EventStore.Core {
 	public class ClusterNodeOptions : IOptions {
 		[ArgDescription(Opts.ShowHelpDescr, Opts.AppGroup)]
 		public bool Help { get; set; }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -208,7 +208,7 @@ namespace EventStore.Core {
 				(endpoint, publisher) =>
 					new EventStoreClusterClient(
 						new UriBuilder(!_vNodeSettings.DisableHttps ? Uri.UriSchemeHttps : Uri.UriSchemeHttp,
-							endpoint.GetHost(), endpoint.GetPort()).Uri, publisher, _internalServerCertificateValidator, _certificate));
+							endpoint.GetHost(), endpoint.GetPort()).Uri, publisher, _internalServerCertificateValidator, _certificateSelector));
 
 			_mainBus.Subscribe<ClusterClientMessage.CleanCache>(_eventStoreClusterClientCache);
 			_mainBus.Subscribe<SystemMessage.SystemInit>(_eventStoreClusterClientCache);
@@ -482,7 +482,7 @@ namespace EventStore.Core {
 			var atomController = new AtomController(_mainQueue, _workersHandler,
 				vNodeSettings.DisableHTTPCaching, vNodeSettings.WriteTimeout);
 			var gossipController = new GossipController(_mainQueue, _workersHandler,
-				_internalServerCertificateValidator, _certificate);
+				_internalServerCertificateValidator, _certificateSelector);
 			var persistentSubscriptionController =
 				new PersistentSubscriptionController(httpSendService, _mainQueue, _workersHandler);
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -133,8 +133,8 @@ namespace EventStore.Core {
 			get { return _tasks; }
 		}
 
-		public X509Certificate2 Certificate => _certificate;
 		public Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> InternalClientCertificateValidator => _internalClientCertificateValidator;
+		public Func<X509Certificate2> CertificateSelector => _certificateSelector;
 		public bool DisableHttps => _disableHttps;
 
 #if DEBUG

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -680,7 +680,7 @@ namespace EventStore.Core {
 					_vNodeSettings.GossipAdvertiseInfo.InternalTcp ?? _vNodeSettings.GossipAdvertiseInfo.InternalSecureTcp,
 					_vNodeSettings.ReadOnlyReplica,
 					!vNodeSettings.DisableInternalTcpTls, _internalServerCertificateValidator,
-					_certificate,
+					_certificateSelector,
 					vNodeSettings.IntTcpHeartbeatTimeout, vNodeSettings.ExtTcpHeartbeatInterval,
 					vNodeSettings.WriteTimeout);
 				_mainBus.Subscribe<SystemMessage.StateChangeMessage>(replicaService);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -55,7 +55,8 @@ namespace EventStore.Core {
 		IHandle<SystemMessage.StateChangeMessage>,
 		IHandle<SystemMessage.BecomeShuttingDown>,
 		IHandle<SystemMessage.BecomeShutdown>,
-		IHandle<SystemMessage.SystemStart> {
+		IHandle<SystemMessage.SystemStart>,
+		IHandle<ClientMessage.ReloadConfig>{
 		private static readonly ILogger Log = Serilog.Log.ForContext<ClusterVNode>();
 
 		public IQueuedHandler MainQueue {
@@ -221,6 +222,8 @@ namespace EventStore.Core {
 			_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(this);
 			_mainBus.Subscribe<SystemMessage.BecomeShutdown>(this);
 			_mainBus.Subscribe<SystemMessage.SystemStart>(this);
+			_mainBus.Subscribe<ClientMessage.ReloadConfig>(this);
+
 			// MONITORING
 			var monitoringInnerBus = new InMemoryBus("MonitoringInnerBus", watchSlowMsg: false);
 			var monitoringRequestBus = new InMemoryBus("MonitoringRequestBus", watchSlowMsg: false);
@@ -912,6 +915,10 @@ namespace EventStore.Core {
 			}
 
 			return (true, null);
+		}
+
+		public void Handle(ClientMessage.ReloadConfig message) {
+			var config = _vNodeSettings.LoadConfigFunc();
 		}
 
 		public override string ToString() {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -742,6 +742,7 @@ namespace EventStore.Core {
 
 			if (Runtime.IsUnixOrMac) {
 				UnixSignalManager.GetInstance().Subscribe(Signum.SIGHUP, () => {
+					Log.Information("Reloading the node's configuration since the SIGHUP signal has been received.");
 					_mainQueue.Publish(new ClientMessage.ReloadConfig());
 				});
 			}
@@ -940,7 +941,6 @@ namespace EventStore.Core {
 
 			Task.Run(() => {
 				try {
-					Log.Information("Reloading the node's configuration");
 					var options = _vNodeSettings.LoadConfigFunc();
 					ReloadCertificates(options);
 					Log.Information("The node's configuration was successfully reloaded");

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -493,8 +493,7 @@ namespace EventStore.Core {
 			var statController = new StatController(monitoringQueue, _workersHandler);
 			var atomController = new AtomController(_mainQueue, _workersHandler,
 				vNodeSettings.DisableHTTPCaching, vNodeSettings.WriteTimeout);
-			var gossipController = new GossipController(_mainQueue, _workersHandler,
-				_internalServerCertificateValidator, _certificateSelector);
+			var gossipController = new GossipController(_mainQueue, _workersHandler);
 			var persistentSubscriptionController =
 				new PersistentSubscriptionController(httpSendService, _mainQueue, _workersHandler);
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -943,6 +943,7 @@ namespace EventStore.Core {
 					Log.Information("Reloading the node's configuration");
 					var options = _vNodeSettings.LoadConfigFunc();
 					ReloadCertificates(options);
+					Log.Information("The node's configuration was successfully reloaded");
 				} catch (Exception exc) {
 					Log.Error(exc, "An error has occurred while reloading the configuration");
 				} finally {
@@ -982,6 +983,7 @@ namespace EventStore.Core {
 
 			var trustedRootCerts = new X509Certificate2Collection();
 			if (!string.IsNullOrEmpty(options.TrustedRootCertificatesPath)) {
+				Log.Information("Loading trusted root certificates");
 				foreach (var (fileName, cert) in CertificateLoader.LoadAllCertificates(options.TrustedRootCertificatesPath)) {
 					trustedRootCerts.Add(cert);
 					Log.Information("Trusted root certificate file loaded: {file}", fileName);
@@ -993,11 +995,14 @@ namespace EventStore.Core {
 					$"{nameof(options.TrustedRootCertificatesPath)} was not specified in the configuration.");
 			}
 
+			var previousThumbprint = _certificate.Thumbprint;
+			var newThumbprint = certificate.Thumbprint;
+
 			//no need for a lock here since reference assignment is atomic
 			_certificate = certificate;
 			_trustedRootCerts = trustedRootCerts;
 
-			Log.Information("Certificates have been successfully reloaded");
+			Log.Information("Certificate loaded. Previous thumbprint: {previousThumbprint}, New thumbprint: {newThumbprint}", previousThumbprint, newThumbprint);
 		}
 
 		public override string ToString() {

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="EventStore.Plugins" Version="20.6.0" />
+		<PackageReference Include="EventStore.Plugins" Version="20.6.1-preview1" />
 		<PackageReference Include="Google.Protobuf" Version="3.12.3" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.29.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.30.0">

--- a/src/EventStore.Core/EventStoreHostedService.cs
+++ b/src/EventStore.Core/EventStoreHostedService.cs
@@ -23,12 +23,12 @@ namespace EventStore.Core {
 		public bool SkipRun => _skipRun;
 		private readonly bool _skipRun;
 		public TOptions Options { get; }
+		private string[] _args;
 
 		protected EventStoreHostedService(string[] args) {
 			try {
-				Options = EventStoreOptions.Parse<TOptions>(args, Opts.EnvPrefix,
-					Path.Combine(Locations.DefaultConfigurationDirectory, DefaultFiles.DefaultConfigFile),
-					MutateEffectiveOptions);
+				_args = args;
+				Options = LoadConfig();
 				if (Options.Help) {
 					Console.WriteLine("EventStoreDB version {0} ({1}/{2}, {3})",
 						VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp);
@@ -65,6 +65,10 @@ namespace EventStore.Core {
 		protected virtual IEnumerable<OptionSource>
 			MutateEffectiveOptions(IEnumerable<OptionSource> effectiveOptions) =>
 			effectiveOptions;
+
+		public TOptions LoadConfig() => EventStoreOptions.Parse<TOptions>(_args, Opts.EnvPrefix,
+			Path.Combine(Locations.DefaultConfigurationDirectory, DefaultFiles.DefaultConfigFile),
+			MutateEffectiveOptions);
 
 		protected abstract Task StartInternalAsync(CancellationToken cancellationToken);
 		protected abstract Task StopInternalAsync(CancellationToken cancellationToken);

--- a/src/EventStore.Core/EventStoreHostedService.cs
+++ b/src/EventStore.Core/EventStoreHostedService.cs
@@ -110,18 +110,6 @@ namespace EventStore.Core {
 			return msg;
 		}
 
-		protected static StoreLocation GetCertificateStoreLocation(string certificateStoreLocation) {
-			if (!Enum.TryParse(certificateStoreLocation, out StoreLocation location))
-				throw new Exception($"Could not find certificate store location '{certificateStoreLocation}'");
-			return location;
-		}
-
-		protected static StoreName GetCertificateStoreName(string certificateStoreName) {
-			if (!Enum.TryParse(certificateStoreName, out StoreName name))
-				throw new Exception($"Could not find certificate store name '{certificateStoreName}'");
-			return name;
-		}
-
 		Task IHostedService.StartAsync(CancellationToken cancellationToken) =>
 			_skipRun ? Task.CompletedTask : StartInternalAsync(cancellationToken);
 

--- a/src/EventStore.Core/Exceptions/NoCertificatePrivateKeyException.cs
+++ b/src/EventStore.Core/Exceptions/NoCertificatePrivateKeyException.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace EventStore.Core.Exceptions {
+	public class NoCertificatePrivateKeyException : Exception {
+		public NoCertificatePrivateKeyException() : base() {
+		}
+	}
+}

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -43,6 +43,13 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class ReloadConfig : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+		}
+
 		public abstract class WriteRequestMessage : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -11,6 +11,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Histograms;
 using EventStore.Core.Services.Transport.Http;
+using EventStore.Core.Settings;
 using EventStore.Transport.Http;
 using EventStore.Transport.Http.EntityManagement;
 using HttpStatusCode = EventStore.Transport.Http.HttpStatusCode;
@@ -43,7 +44,8 @@ namespace EventStore.Core.Services {
 						}
 						return isValid;
 					}
-				}
+				},
+				PooledConnectionLifetime = ESConsts.HttpClientConnectionLifeTime
 			};
 			_forwardClient = new HttpClient(socketsHttpHandler);
 		}

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.Services.Replication {
 		private readonly bool _isReadOnlyReplica;
 		private readonly bool _useSsl;
 		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _sslServerCertValidator;
-		private readonly X509Certificate _sslClientCertificate;
+		private readonly Func<X509Certificate> _sslClientCertificateSelector;
 		private readonly TimeSpan _heartbeatTimeout;
 		private readonly TimeSpan _heartbeatInterval;
 
@@ -59,7 +59,7 @@ namespace EventStore.Core.Services.Replication {
 			bool isReadOnlyReplica,
 			bool useSsl,
 			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> sslServerCertValidator,
-			X509Certificate sslClientCertificate,
+			Func<X509Certificate> sslClientCertificateSelector,
 			TimeSpan heartbeatTimeout,
 			TimeSpan heartbeatInterval,
 			TimeSpan writeTimeout) {
@@ -82,7 +82,7 @@ namespace EventStore.Core.Services.Replication {
 			_isReadOnlyReplica = isReadOnlyReplica;
 			_useSsl = useSsl;
 			_sslServerCertValidator = sslServerCertValidator;
-			_sslClientCertificate = sslClientCertificate;
+			_sslClientCertificateSelector = sslClientCertificateSelector;
 			_heartbeatTimeout = heartbeatTimeout;
 			_heartbeatInterval = heartbeatInterval;
 
@@ -170,7 +170,10 @@ namespace EventStore.Core.Services.Replication {
 				_connector,
 				_useSsl,
 				_sslServerCertValidator,
-				_sslClientCertificate == null ? null : new X509CertificateCollection {_sslClientCertificate},
+				() => {
+					var cert = _sslClientCertificateSelector();
+					return new X509CertificateCollection{cert};
+				},
 				_networkSendQueue,
 				_authProvider,
 				_authorizationGateway,

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		private readonly IPublisher _networkSendQueue;
 
-		public GossipController(IPublisher publisher, IPublisher networkSendQueue, Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> serverCertValidator, X509Certificate clientCertificate)
+		public GossipController(IPublisher publisher, IPublisher networkSendQueue, Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> serverCertValidator, Func<X509Certificate> clientCertificateSelector)
 			: base(publisher) {
 			_networkSendQueue = networkSendQueue;
 
@@ -38,11 +38,11 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 						}
 						return isValid;
 					},
-					ClientCertificates = new X509CertificateCollection()
+					LocalCertificateSelectionCallback = delegate {
+						return clientCertificateSelector();
+					}
 				}
 			};
-			if(clientCertificate != null)
-				socketsHttpHandler.SslOptions.ClientCertificates.Add(clientCertificate);
 		}
 
 		protected override void SubscribeCore(IHttpService service) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
@@ -25,24 +25,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		private readonly IPublisher _networkSendQueue;
 
-		public GossipController(IPublisher publisher, IPublisher networkSendQueue, Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> serverCertValidator, Func<X509Certificate> clientCertificateSelector)
+		public GossipController(IPublisher publisher, IPublisher networkSendQueue)
 			: base(publisher) {
 			_networkSendQueue = networkSendQueue;
-
-			var socketsHttpHandler = new SocketsHttpHandler {
-				SslOptions = {
-					RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => {
-						var (isValid, error) = serverCertValidator(certificate, chain, errors);
-						if (!isValid && error != null) {
-							Log.Error("Server certificate validation error: {e}", error);
-						}
-						return isValid;
-					},
-					LocalCertificateSelectionCallback = delegate {
-						return clientCertificateSelector();
-					}
-				}
-			};
 		}
 
 		protected override void SubscribeCore(IHttpService service) {

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -132,7 +132,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			TcpClientConnector connector,
 			bool useSsl,
 			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> sslServerCertValidator,
-			X509CertificateCollection sslClientCertificates,
+			Func<X509CertificateCollection> sslClientCertificatesSelector,
 			IPublisher networkSendQueue,
 			IAuthenticationProvider authProvider,
 			AuthorizationGateway authorization,
@@ -172,7 +172,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			RemoteEndPoint = remoteEndPoint;
 			_connection = useSsl
 				? connector.ConnectSslTo(ConnectionId, targetHost, remoteEndPoint.ResolveDnsToIPAddress(), ConnectionTimeout,
-					sslServerCertValidator, sslClientCertificates, OnConnectionEstablished, OnConnectionFailed)
+					sslServerCertValidator, sslClientCertificatesSelector, OnConnectionEstablished, OnConnectionFailed)
 				: connector.ConnectTo(ConnectionId, remoteEndPoint.ResolveDnsToIPAddress(), ConnectionTimeout, OnConnectionEstablished,
 					OnConnectionFailed);
 			_connection.ConnectionClosed += OnConnectionClosed;

--- a/src/EventStore.Core/Settings/ESConsts.cs
+++ b/src/EventStore.Core/Settings/ESConsts.cs
@@ -16,6 +16,7 @@ namespace EventStore.Core.Settings {
 		public const int CachedPrincipalCount = 1000;
 
 		public static readonly TimeSpan HttpTimeout = TimeSpan.FromSeconds(10);
+		public static readonly TimeSpan HttpClientConnectionLifeTime = TimeSpan.FromMinutes(10);
 
 		public const int UnrestrictedPendingSendBytes = 0;
 		public const int MaxConnectionQueueSize = 50000;

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -34,6 +34,7 @@ namespace EventStore.Core {
 	public abstract class VNodeBuilder {
 		// ReSharper disable FieldCanBeMadeReadOnly.Local - as more options are added
 		protected ILogger _log;
+		protected Func<ClusterNodeOptions> _loadConfigFunc;
 
 		protected int _chunkSize;
 		protected string _dbPath;
@@ -1356,6 +1357,7 @@ namespace EventStore.Core {
 
 			_vNodeSettings = new ClusterVNodeSettings(Guid.NewGuid(),
 				0,
+				_loadConfigFunc,
 				_internalTcp,
 				_internalSecureTcp,
 				_externalTcp,
@@ -1579,6 +1581,10 @@ namespace EventStore.Core {
 
 		public void WithUnsafeAllowSurplusNodes() {
 			_unsafeAllowSurplusNodes = true;
+		}
+
+		public void WithLoadConfigFunction(Func<ClusterNodeOptions> loadConfigFunc) {
+			_loadConfigFunc = loadConfigFunc;
 		}
 	}
 }

--- a/src/EventStore.Native/UnixSignalManager/UnixSignalManager.cs
+++ b/src/EventStore.Native/UnixSignalManager/UnixSignalManager.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Mono.Unix;
+using Mono.Unix.Native;
+
+namespace EventStore.Native.UnixSignalManager {
+	public class UnixSignalManager {
+		private static UnixSignalManager _instance;
+
+		private const int MaxUnixSignals = 64; //max internal limit of UnixSignal instances per process
+		private static readonly List<UnixSignal> _handledSignals = new List<UnixSignal>();
+		private static readonly object _handledSignalsLock = new object();
+
+		private readonly Dictionary<Signum, List<Action>> _actions = new Dictionary<Signum, List<Action>>();
+		private volatile bool _stop;
+
+		public static UnixSignalManager GetInstance() => _instance ??= new UnixSignalManager();
+
+		private UnixSignalManager() {
+			new Thread(HandleSignals) {
+				IsBackground = true,
+				Name = "UnixSignalManager"
+			}.Start();
+		}
+		public void Subscribe(Signum signum, Action action) {
+			lock (_handledSignalsLock) {
+				if (_handledSignals.All(x => x.Signum != signum)) {
+					if (_handledSignals.Count >= MaxUnixSignals) {
+						throw new ArgumentException($"Maximum limit of {MaxUnixSignals} reached for number of handled signals.");
+					}
+
+					_handledSignals.Add(new UnixSignal(signum));
+				}
+			}
+
+			if (_actions.TryGetValue(signum, out List<Action> actions)) {
+				actions.Add(action);
+			} else {
+				_actions[signum] = new List<Action> { action };
+			}
+		}
+
+		public static void StopProcessing() {
+			_instance?.Stop();
+		}
+
+		private void Stop() {
+			_stop = true;
+		}
+
+		private void HandleSignals() {
+			const int timeoutMs = 1000;
+
+			while (!_stop) {
+				UnixSignal[] handledSignals;
+				lock (_handledSignalsLock) {
+					handledSignals = _handledSignals.ToArray();
+				}
+
+				var index = UnixSignal.WaitAny(handledSignals, TimeSpan.FromMilliseconds(timeoutMs));
+				if (index == timeoutMs) continue;
+				if (_actions.TryGetValue(handledSignals[index].Signum, out List<Action> actions)) {
+					foreach (var action in actions) {
+						action.Invoke();
+					}
+				}
+				handledSignals[index].Reset();
+			}
+		}
+	}
+}

--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -181,7 +181,7 @@ namespace EventStore.TestClient {
 					endpoint.ResolveDnsToIPAddress(),
 					TcpConnectionManager.ConnectionTimeout,
 					(cert,chain,err) => (err == SslPolicyErrors.None || !ValidateServer, err.ToString()),
-					null,
+					() => null,
 					onConnectionEstablished,
 					onConnectionFailed,
 					verbose: !InteractiveMode);

--- a/src/EventStore.Transport.Tcp/TcpClientConnector.cs
+++ b/src/EventStore.Transport.Tcp/TcpClientConnector.cs
@@ -49,13 +49,13 @@ namespace EventStore.Transport.Tcp {
 			IPEndPoint remoteEndPoint,
 			TimeSpan connectionTimeout,
 			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> sslServerCertValidator,
-			X509CertificateCollection clientCertificates,
+			Func<X509CertificateCollection> clientCertificatesSelector,
 			Action<ITcpConnection> onConnectionEstablished = null,
 			Action<ITcpConnection, SocketError> onConnectionFailed = null,
 			bool verbose = true) {
 			Ensure.NotNull(remoteEndPoint, "remoteEndPoint");
 			return TcpConnectionSsl.CreateConnectingConnection(connectionId, targetHost, remoteEndPoint, sslServerCertValidator,
-				clientCertificates, this, connectionTimeout, onConnectionEstablished, onConnectionFailed, verbose);
+				clientCertificatesSelector, this, connectionTimeout, onConnectionEstablished, onConnectionFailed, verbose);
 		}
 
 		internal void InitConnect(IPEndPoint serverEndPoint,


### PR DESCRIPTION
Added: Ability to reload certificates by triggering the /admin/reloadconfig endpoint or by sending a SIGHUP signal (linux only)


Fixes https://github.com/EventStore/home/issues/199

This PR needs to wait for https://github.com/EventStore/EventStore.Plugins/pull/8 to be merged and EventStore.Plugins 20.6.1 to be published before being merged.

## Expected work flow:
1 - Update certificates on each node one by one. Update the config file if required (e.g if certificate file names/password/paths have changed)
2. Send  a POST request to the /admin/reloadconfig endpoint (with admin/ops privileges) or a SIGHUP signal to the EventStore process (Linux only)

## All steps below are optional to verify if the new certificates are working fine

3 - Wait for at least 10 minutes to see if there are any gossip errors (due to .NET connection pooling, see this commit: 1e472bee6b477009e45bc605be44863d869194b6)
4 - Decrease node priority of current leader node and trigger a leader resignation on the leader node to ensure TCP connections are dropped and new connections are established
5 - Restart all gRPC clients  to ensure new certificates are being used by the client (Adding `PooledConnectionLifetime` to the gRPC client should not require a restart for unary calls but it must be verified if it works with streaming calls as well)
6 - Restart all TCP clients to ensure new certificates are being used