### PR TITLE
[V5] Backport projection fixes

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/v8/when_running_a_projection_emitting_invalid_events.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/v8/when_running_a_projection_emitting_invalid_events.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.v8 {
+	public class when_running_a_v8_projection_emitting_invalid_events : TestFixtureWithJsProjection {
+		protected override void Given() {
+			_projection = @"
+                fromAll().when({$any: 
+                    function(state, event) {
+                        emit('', '', {});
+                    return {};
+                }});
+            ";
+		}
+		
+		[Test, Category("v8")]
+		public void process_event_ignores_emitted_event() {
+			string state;
+			EmittedEventEnvelope[] emittedEvents;
+			_stateHandler.ProcessEvent(
+				"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
+				"metadata",
+				@"{""a"":""b""}", out state, out emittedEvents);
+
+			Assert.IsNull(emittedEvents);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/v8/when_running_a_v8_projection_emitting_invalid_links.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/v8/when_running_a_v8_projection_emitting_invalid_links.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.v8 {
+	public class when_running_a_v8_projection_emitting_invalid_links : TestFixtureWithJsProjection {
+		protected override void Given() {
+			_projection = @"
+                fromAll().when({$any: 
+                    function(state, event) {
+                        event.sequenceNumber = null;
+                    linkTo('output-stream', event);
+                    return {};
+                }});
+            ";
+		}
+		
+		[Test, Category("v8")]
+		public void process_event_ignores_emitted_event() {
+			string state;
+			EmittedEventEnvelope[] emittedEvents;
+			_stateHandler.ProcessEvent(
+				"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
+				"metadata",
+				@"{""a"":""b""}", out state, out emittedEvents);
+
+			Assert.IsNull(emittedEvents);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
@@ -131,7 +131,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 				_readAs = readAs;
 			}
 
-			protected void DeliverEvent(float progress, ResolvedEvent resolvedEvent, TFPos position) {
+			protected void DeliverEvent(float progress, ResolvedEvent resolvedEvent, TFPos position,
+				EventStore.Core.Data.ResolvedEvent pair) {
 				if (resolvedEvent.EventOrLinkTargetPosition <= _reader._lastEventPosition)
 					return;
 				_reader._lastEventPosition = resolvedEvent.EventOrLinkTargetPosition;
@@ -144,7 +145,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					return;
 
 				bool isDeletedStreamEvent = StreamDeletedHelper.IsStreamDeletedEventOrLinkToStreamDeletedEvent(
-					resolvedEvent, out deletedPartitionStreamId);
+					resolvedEvent, pair.ResolveResult, out deletedPartitionStreamId);
 				if (isDeletedStreamEvent) {
 					var deletedPartition = deletedPartitionStreamId;
 
@@ -506,7 +507,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				TFPos position) {
 				//TODO: add event sequence validation for inside the index stream
 				var resolvedEvent = new ResolvedEvent(pair, null);
-				DeliverEvent(progress, resolvedEvent, position);
+				DeliverEvent(progress, resolvedEvent, position, pair);
 			}
 
 			public override bool AreEventsRequested() {
@@ -693,7 +694,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				TFPos position) {
 				var resolvedEvent = new ResolvedEvent(pair, null);
 
-				DeliverEvent(progress, resolvedEvent, position);
+				DeliverEvent(progress, resolvedEvent, position, pair);
 			}
 
 			private void SendIdle() {

--- a/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
@@ -216,7 +216,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				return;
 
 			bool isDeletedStreamEvent =
-				StreamDeletedHelper.IsStreamDeletedEventOrLinkToStreamDeletedEvent(resolvedEvent,
+				StreamDeletedHelper.IsStreamDeletedEventOrLinkToStreamDeletedEvent(resolvedEvent, pair.ResolveResult,
 					out deletedPartitionStreamId);
 
 			if (isDeletedStreamEvent) {

--- a/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
@@ -175,7 +175,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				return;
 
 			bool isDeletedStreamEvent = StreamDeletedHelper.IsStreamDeletedEventOrLinkToStreamDeletedEvent(
-				resolvedEvent, out deletedPartitionStreamId);
+				resolvedEvent, @event.ResolveResult, out deletedPartitionStreamId);
 
 			_publisher.Publish(
 				new ReaderSubscriptionMessage.CommittedEventDistributed(

--- a/src/EventStore.Projections.Core/Services/v8/V8ProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/v8/V8ProjectionStateHandler.cs
@@ -10,6 +10,7 @@ using EventStore.Projections.Core.v8;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Linq;
+using EventStore.Common.Log;
 
 namespace EventStore.Projections.Core.Services.v8 {
 	public class V8ProjectionStateHandler : IProjectionStateHandler {
@@ -18,6 +19,9 @@ namespace EventStore.Projections.Core.Services.v8 {
 		private List<EmittedEventEnvelope> _emittedEvents;
 		private CheckpointTag _eventPosition;
 		private bool _disposed;
+		private static readonly char[] LinkToSeparator = { '@' };
+		private static readonly string LinkType = "$>";
+		private ILogger _logger = LogManager.GetLoggerFor<V8ProjectionStateHandler>();
 
 		public V8ProjectionStateHandler(
 			string preludeName, string querySource, Func<string, Tuple<string, string>> getModuleSource,
@@ -66,6 +70,16 @@ namespace EventStore.Projections.Core.Services.v8 {
 				throw new ArgumentException("Failed to deserialize emitted event JSON", ex);
 			}
 
+			if (!IsValidEvent(emittedEvent)) {
+				_logger.Warn($"Invalid emitted event was ignored: streamId: [{emittedEvent.streamId}], eventType: [{emittedEvent.eventName}], payload: [{emittedEvent.body}]");
+				return;
+			}
+			
+			if (emittedEvent.eventName.Equals(LinkType) && !IsValidLinkEvent(emittedEvent)) {
+				_logger.Warn($"Invalid emitted link event was ignored: streamId: [{emittedEvent.streamId}], eventType: [{emittedEvent.eventName}], payload: [{emittedEvent.body}]");
+				return;
+			}
+			
 			if (_emittedEvents == null)
 				_emittedEvents = new List<EmittedEventEnvelope>();
 			_emittedEvents.Add(
@@ -232,6 +246,16 @@ namespace EventStore.Projections.Core.Services.v8 {
 
 		public IQuerySources GetSourceDefinition() {
 			return GetQuerySourcesDefinition();
+		}
+		
+		private static bool IsValidEvent(EmittedEventJsonContract @event) {
+			return !(@event.eventName.IsEmptyString() || @event.streamId.IsEmptyString() || @event.isJson && @event.body.IsEmptyString());
+		}
+		
+		// This function assumes 'IsValidEvent' was called upfront.
+		private static bool IsValidLinkEvent(EmittedEventJsonContract @event) {
+			var parts = @event.body.Split(LinkToSeparator, 2);
+			return long.TryParse(parts[0], out long _);
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
+++ b/src/EventStore.Projections.Core/Standard/ByCorrelationId.cs
@@ -79,6 +79,9 @@ namespace EventStore.Projections.Core.Standard {
 			newState = null;
 			if (data.EventStreamId != data.PositionStreamId)
 				return false;
+			
+			if (data.Metadata == null)
+				return false;
 
 			JObject metadata = null;
 

--- a/src/EventStore.Projections.Core/Standard/StreamDeletedHelper.cs
+++ b/src/EventStore.Projections.Core/Standard/StreamDeletedHelper.cs
@@ -6,8 +6,14 @@ using ResolvedEvent = EventStore.Projections.Core.Services.Processing.ResolvedEv
 namespace EventStore.Projections.Core.Standard {
 	public static class StreamDeletedHelper {
 		public static bool IsStreamDeletedEventOrLinkToStreamDeletedEvent(ResolvedEvent resolvedEvent,
-			out string deletedPartitionStreamId) {
+			ReadEventResult resolveResult, out string deletedPartitionStreamId) {
 			bool isDeletedStreamEvent;
+			// If the event didn't resolve, we can't rely on it as a deleted event
+			if (resolveResult != ReadEventResult.Success) {
+				deletedPartitionStreamId = null;
+				return false;
+			}
+			
 			if (resolvedEvent.IsLinkToDeletedStreamTombstone) {
 				isDeletedStreamEvent = true;
 				deletedPartitionStreamId = resolvedEvent.EventStreamId;


### PR DESCRIPTION
Fixes https://github.com/EventStore/EventStore/issues/2532

Backports the following PR's:

- Filter out unresolved events when checking for deleted partitions (https://github.com/EventStore/EventStore/pull/2586)
- Ignore invalid link events (https://github.com/EventStore/EventStore/pull/2424)
- Avoid parsing metadata if null in ByCorrelationId (https://github.com/EventStore/EventStore/pull/2430)

Without #2424, the fix in #2586 causes invalid link events containing `undefined@undefined` to be written which causes the projection in question to stop processing altogether.
