### PR TITLE
Decline benchmark on PR from forked repositories

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,9 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request Benchmark
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'Benchmark') }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'Benchmark') && github.event.repository.fork == "false" }}
         run: |
           curl -X POST "https://api.github.com/repos/EventStore/grpc-tcp-benchmark/dispatches" \
           -H 'Accept: application/vnd.github.everest-preview+json' \
           -u ${{ secrets.GH_PAT }} \
-          --data '{"event_type": "benchmark_deployment", "client_payload": {"pr_no":  ${{ github.event.number }} }}'
+          --data '{"event_type": "benchmark_deployment", "client_payload": {"pr_no":  ${{ github.event.number }}, actor : ${{ github.actor }} }}'
+           
+      - name: Benchmark is not available on forked repos.
+        if: ${{ github.event.repository.fork == "true" }}
+        run: echo "Benchmark is not available on forked repos." && exit 1


### PR DESCRIPTION
GitHub secrets are not available with Actions that run PR from forked repositories, which causes Benchmark Request Action to fail. 

This workflow updates declines benchmark requests on PR from forked repositories and gives a failure message accordingly, instead of `curl` just failing ungracefully.

---

Pull Request Webhook Payload for ref : https://developer.github.com/webhooks/event-payloads/#pull_request