### PR TITLE
Fix quotes in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request Benchmark
-        if: ${{ contains(github.event.pull_request.labels.*.name, 'Benchmark') && github.event.repository.fork == "false" }}
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'Benchmark') && github.event.repository.fork == 'false' }}
         run: |
           curl -X POST "https://api.github.com/repos/EventStore/grpc-tcp-benchmark/dispatches" \
           -H 'Accept: application/vnd.github.everest-preview+json' \
@@ -18,5 +18,5 @@ jobs:
           --data '{"event_type": "benchmark_deployment", "client_payload": {"pr_no":  ${{ github.event.number }}, actor : ${{ github.actor }} }}'
            
       - name: Benchmark is not available on forked repos.
-        if: ${{ github.event.repository.fork == "true" }}
+        if: ${{ github.event.repository.fork == 'true' }}
         run: echo "Benchmark is not available on forked repos." && exit 1


### PR DESCRIPTION
Fix improper use of  `"` indead of `'` for strings in benchmark.yml which caused Action to fail.

E.g :  https://github.com/EventStore/EventStore/actions/runs/170983087

