### PR TITLE
Ability to load (or reload) default log level from EventStore config file

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -15,6 +15,7 @@ using EventStore.Core.PluginModel;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Services.Transport.Http.Controllers;
 using System.Threading.Tasks;
+using EventStore.Common.Log;
 using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Authorization;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
@@ -97,6 +98,13 @@ namespace EventStore.ClusterNode {
 
 		protected override string GetComponentName(ClusterNodeOptions options) =>
 			$"{options.ExtIp}-{options.HttpPort}-cluster-node";
+
+		protected override void Init(ClusterNodeOptions options) {
+			base.Init(options);
+			if (options.LogLevel != LogLevel.Default) {
+				EventStoreLoggerConfiguration.AdjustMinimumLogLevel(options.LogLevel);
+			}
+		}
 
 		protected override void PreInit(ClusterNodeOptions options) {
 			base.PreInit(options);

--- a/src/EventStore.Common/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Common/Log/EventStoreLoggerConfiguration.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using EventStore.Common.Options;
 using EventStore.Common.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.FileProviders;

--- a/src/EventStore.Common/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Common/Log/EventStoreLoggerConfiguration.cs
@@ -24,6 +24,8 @@ namespace EventStore.Common.Log {
 		private static readonly Func<LogEvent, bool> RegularStats = Matching.FromSource("REGULAR-STATS-LOGGER");
 
 		private static int Initialized;
+		private static LoggingLevelSwitch _defaultLogLevelSwitch;
+		private static object _defaultLogLevelSwitchLock = new object();
 
 		private readonly string _logsDirectory;
 		private readonly string _componentName;
@@ -75,6 +77,25 @@ namespace EventStore.Common.Log {
 			Serilog.Debugging.SelfLog.Disable();
 		}
 
+		public static bool AdjustMinimumLogLevel(LogLevel logLevel) {
+			lock (_defaultLogLevelSwitchLock) {
+				if (_defaultLogLevelSwitch == null) {
+					throw new InvalidOperationException($"The logger configuration has not yet been initialized.");
+				}
+
+				if (Enum.TryParse<LogEventLevel>(logLevel.ToString(), out var serilogLogLevel)) {
+					if (serilogLogLevel != _defaultLogLevelSwitch.MinimumLevel) {
+						_defaultLogLevelSwitch.MinimumLevel = serilogLogLevel;
+						return true;
+					}
+
+					return false;
+				} else {
+					throw new ArgumentException($"'{logLevel}' is not a valid log level.");
+				}
+			}
+		}
+
 		private static LoggerConfiguration FromConfiguration(IConfiguration configuration) =>
 			new LoggerConfiguration().ReadFrom.Configuration(configuration);
 
@@ -101,14 +122,15 @@ namespace EventStore.Common.Log {
 
 			var loglevelSection = logLevelConfigurationRoot.GetSection("Logging").GetSection("LogLevel");
 			var defaultLogLevelSection = loglevelSection.GetSection("Default");
-			var defaultLevelSwitch = new LoggingLevelSwitch {
-				MinimumLevel = LogEventLevel.Verbose
-			};
-
-			ApplyLogLevel(defaultLogLevelSection, defaultLevelSwitch);
+			lock (_defaultLogLevelSwitchLock) {
+				_defaultLogLevelSwitch = new LoggingLevelSwitch {
+					MinimumLevel = LogEventLevel.Verbose
+				};
+				ApplyLogLevel(defaultLogLevelSection, _defaultLogLevelSwitch);
+			}
 
 			var loggerConfiguration = StandardLoggerConfiguration
-				.MinimumLevel.ControlledBy(defaultLevelSwitch)
+				.MinimumLevel.ControlledBy(_defaultLogLevelSwitch)
 				.WriteTo.Async(AsyncSink);
 
 			foreach (var namedLogLevelSection in loglevelSection.GetChildren().Where(x => x.Key != "Default")) {

--- a/src/EventStore.Common/Options/LogLevel.cs
+++ b/src/EventStore.Common/Options/LogLevel.cs
@@ -1,0 +1,11 @@
+namespace EventStore.Common.Options {
+	public enum LogLevel {
+		Default = 0,
+		Verbose = 1,
+		Debug = 2,
+		Information = 3,
+		Warning = 4,
+		Error = 5,
+		Fatal = 6
+	}
+}

--- a/src/EventStore.Core/ClusterNodeOptions.cs
+++ b/src/EventStore.Core/ClusterNodeOptions.cs
@@ -15,6 +15,9 @@ namespace EventStore.Core {
 		[ArgDescription(Opts.LogsDescr, Opts.AppGroup)]
 		public string Log { get; set; }
 
+		[ArgDescription(Opts.LogLevelDescr, Opts.AppGroup)]
+		public LogLevel LogLevel { get; set; }
+
 		[ArgDescription(Opts.ConfigsDescr, Opts.AppGroup)]
 		public string Config { get; set; }
 
@@ -320,6 +323,7 @@ namespace EventStore.Core {
 			Help = Opts.ShowHelpDefault;
 			Version = Opts.ShowVersionDefault;
 			Log = Locations.DefaultLogDirectory;
+			LogLevel = Opts.LogLevelDefault;
 			WhatIf = Opts.WhatIfDefault;
 
 			IntIp = Opts.InternalIpDefault;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -39,6 +39,7 @@ using EventStore.Core.Services.Histograms;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using System.Threading.Tasks;
 using EventStore.Common.Exceptions;
+using EventStore.Common.Log;
 using EventStore.Core.Authorization;
 using EventStore.Core.Cluster;
 using EventStore.Native.UnixSignalManager;

--- a/src/EventStore.Core/EventStoreHostedService.cs
+++ b/src/EventStore.Core/EventStoreHostedService.cs
@@ -76,7 +76,7 @@ namespace EventStore.Core {
 		protected virtual void PreInit(TOptions options) {
 		}
 
-		private void Init(TOptions options) {
+		protected virtual void Init(TOptions options) {
 			var projName = Assembly.GetEntryAssembly().GetName().Name.Replace(".", " - ");
 			var componentName = GetComponentName(options);
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -39,6 +39,8 @@ namespace EventStore.Core.Util {
 		public const bool DisableHttpCachingDefault = false;
 
 		public const string LogsDescr = "Path where to keep log files.";
+		public const string LogLevelDescr = "Sets the minimum log level. For more granular settings, please edit logconfig.json.";
+		public const LogLevel LogLevelDefault = LogLevel.Default;
 
 		public const string ConfigsDescr = "Configuration files.";
 		public static readonly string[] ConfigsDefault = new string[0];


### PR DESCRIPTION
Added: Ability to load (or reload) default log level from EventStore config file


Fixes: #2598 
Note: This PR merges into `certificate-rolling` branch so that it's retarged to master once #2590 is merged.

This PR adds a `LogLevel` configuration option.
Supported values: Default, Verbose, Debug, Information, Warning, Error, Fatal

- Prior to this PR, log levels could already be adjusted dynamically by editing logconfig.json file (located under ` /usr/share/eventstore/` on linux). The change takes effect almost immediately.
- logconfig.json allows editing the log levels for different namespaces: `Grpc`, `System`, `Microsoft` and there's a special one called `Default` for remaining namespaces
- This PR adds a `LogLevel` option to the EventStore configuration to control the `Default` log level.
- The log level can be dynamically reloaded (only if specified in config file) by triggering the /admin/reloadconfig endpoint or sending a SIGHUP signal.
- The option can be specified on the command line (--log-level), environment variable (EVENTSTORE_LOG_LEVEL) or config file (LogLevel). Only config files support dynamic reloading since if the log level is specified on command line/env var they will take precedence over the config file. However, editing logconfig.json directly will still work dynamically even if log level option has been specified on command line/env var.