### PR TITLE
[V5] Add logging around cases where the latest stream's prepare could not be read

### DIFF
--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -169,6 +169,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			RecordReadResult result = reader.TryReadAt(logPosition);
 			if (!result.Success)
 				return null;
+
 			if (result.LogRecord.RecordType != LogRecordType.Prepare)
 				throw new Exception(string.Format("Incorrect type of log record {0}, expected Prepare record.",
 					result.LogRecord.RecordType));
@@ -435,7 +436,9 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				return ExpectedVersion.NoStream;
 
 			var rec = ReadPrepareInternal(reader, latestEntry.Position);
-			if (rec == null) throw new Exception("Could not read latest stream's prepare. That should never happen.");
+			if (rec == null)
+				throw new Exception(
+					$"Could not read latest stream's prepare for stream '{streamId}' at position {latestEntry.Position}");
 
 			int count = 0;
 			long startVersion = 0;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkReader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -20,6 +21,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		private long _curPos;
 		private bool _optimizeReadSideCache;
 		private readonly TFChunkReaderExistsAtOptimizer _existsAtOptimizer;
+		private readonly ILogger _log = LogManager.GetLoggerFor<TFChunkReader>();
 
 		public TFChunkReader(TFChunkDb db, ICheckpoint writerCheckpoint, long initialPosition = 0,
 			bool optimizeReadSideCache = false) {
@@ -141,8 +143,12 @@ namespace EventStore.Core.TransactionLog.Chunks {
 
 		private RecordReadResult TryReadAtInternal(long position, int retries) {
 			var writerChk = _writerCheckpoint.Read();
-			if (position >= writerChk)
+			if (position >= writerChk) {
+				_log.Warn(
+					"Attempted to read at position {0}, which is further than writer checkpoint {1}",
+					position, writerChk);
 				return RecordReadResult.Failure;
+			}
 
 			var chunk = _db.Manager.GetChunkFor(position);
 			try {


### PR DESCRIPTION
Backport to v5 of https://github.com/EventStore/EventStore/pull/2613
Related to #2603 