### PR TITLE
gRPC: Continue reading if IsEndOfStream is still false, even if there's no events

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/ReadStreamsBackwardTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/ReadStreamsBackwardTests.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.ClientAPI;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Core.Tests.ClientAPI;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
+	[TestFixture]
+	public class ReadStreamsBackwardTests {
+		private static ClaimsPrincipal CreateTestUser() {
+			return new ClaimsPrincipal(new ClaimsIdentity(
+				new[] {
+					new Claim(ClaimTypes.Name, "admin"),
+				}, "ES-Test"));
+		}
+
+		private static List<EventData> CreateEvents(int count) {
+			var events = new List<EventData>();
+			for (var i = 0; i < count; i++) {
+				events.Add(new EventData(Guid.NewGuid(), "test", false, new byte[] { }, null));
+			}
+
+			return events;
+		}
+
+		public class when_reading_backward_from_past_the_end_of_the_stream : SpecificationWithMiniNode {
+			private readonly string _streamName = Guid.NewGuid().ToString();
+			private readonly List<Data.ResolvedEvent> _responses = new List<Data.ResolvedEvent>();
+			private const ulong _maxCount = 20;
+
+			protected override async Task Given() {
+				await _conn.AppendToStreamAsync(_streamName, ExpectedVersion.Any, CreateEvents(30));
+			}
+
+			protected override async Task When() {
+				var enumerator = new Enumerators.ReadStreamBackwards(_node.Node.MainQueue, _streamName,
+					StreamRevision.FromInt64(50),
+					_maxCount, false, CreateTestUser(), false, DateTime.Now.AddMinutes(5), e => {
+						Assert.Fail($"Failed to read: {e}");
+						return Task.CompletedTask;
+					}, CancellationToken.None);
+
+				while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+					_responses.Add(enumerator.Current);
+				}
+			}
+
+			[Test]
+			public void should_not_receive_null_events() {
+				Assert.False(_responses.Any(x=> x.Event is null));
+			}
+
+			[Test]
+			public void should_read_a_number_of_events_equal_to_the_max_count() {
+				Assert.AreEqual(_maxCount, _responses.Count);
+			}
+
+			[Test]
+			public void should_read_the_correct_events() {
+				Assert.AreEqual(29, _responses[0].OriginalEventNumber);
+				Assert.AreEqual(10, _responses[^1].OriginalEventNumber);
+			}
+		}
+
+		public class when_reading_backward_from_the_end_of_the_stream : SpecificationWithMiniNode {
+			private readonly string _streamName = Guid.NewGuid().ToString();
+			private readonly List<Data.ResolvedEvent> _responses = new List<Data.ResolvedEvent>();
+			private const ulong _maxCount = 20;
+
+			protected override async Task Given() {
+				await _conn.AppendToStreamAsync(_streamName, ExpectedVersion.Any, CreateEvents(30));
+			}
+
+			protected override async Task When() {
+				var enumerator = new Enumerators.ReadStreamBackwards(_node.Node.MainQueue, _streamName, StreamRevision.End,
+					_maxCount, false, CreateTestUser(), false, DateTime.Now.AddMinutes(5), e => {
+						Assert.Fail($"Failed to read: {e}");
+						return Task.CompletedTask;
+					}, CancellationToken.None);
+
+				while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+					_responses.Add(enumerator.Current);
+				}
+			}
+			
+			[Test]
+			public void should_not_receive_null_events() {
+				Assert.False(_responses.Any(x=> x.Event is null));
+			}
+
+			[Test]
+			public void should_read_a_number_of_events_equal_to_the_max_count() {
+				Assert.AreEqual(_maxCount, _responses.Count);
+			}
+			
+			[Test]
+			public void should_read_the_correct_events() {
+				Assert.AreEqual(29, _responses[0].OriginalEventNumber);
+				Assert.AreEqual(10, _responses[^1].OriginalEventNumber);
+			}
+		}
+		
+		public class when_reading_backward_from_the_start_of_the_stream : SpecificationWithMiniNode {
+			private readonly string _streamName = Guid.NewGuid().ToString();
+			private readonly List<Data.ResolvedEvent> _responses = new List<Data.ResolvedEvent>();
+			private const ulong _maxCount = 20;
+
+			protected override async Task Given() {
+				await _conn.AppendToStreamAsync(_streamName, ExpectedVersion.Any, CreateEvents(30));
+			}
+
+			protected override async Task When() {
+				var enumerator = new Enumerators.ReadStreamBackwards(_node.Node.MainQueue, _streamName, StreamRevision.Start,
+					_maxCount, false, CreateTestUser(), false, DateTime.Now.AddMinutes(5), e => {
+						Assert.Fail($"Failed to read: {e}");
+						return Task.CompletedTask;
+					}, CancellationToken.None);
+
+				while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+					_responses.Add(enumerator.Current);
+				}
+			}
+
+			[Test]
+			public void should_receive_the_first_event() {
+				Assert.AreEqual(1, _responses.Count);
+				Assert.AreEqual(0, _responses[0].OriginalEventNumber);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/ReadStreamsForwardTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/ReadStreamsForwardTests.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.ClientAPI;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Core.Tests.ClientAPI;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
+	[TestFixture]
+	public class ReadStreamsForwardTests {
+		private static ClaimsPrincipal CreateTestUser() {
+			return new ClaimsPrincipal(new ClaimsIdentity(
+				new[] {
+					new Claim(ClaimTypes.Name, "admin"),
+				}, "ES-Test"));
+		}
+
+		private static List<EventData> CreateEvents(int count) {
+			var events = new List<EventData>();
+			for (var i = 0; i < count; i++) {
+				events.Add(new EventData(Guid.NewGuid(), "test", false, new byte[] { }, null));
+			}
+
+			return events;
+		}
+
+		public class when_reading_forward_from_stream_that_has_been_truncated : SpecificationWithMiniNode {
+			private readonly string _streamName = Guid.NewGuid().ToString();
+			private readonly List<Data.ResolvedEvent> _responses = new List<Data.ResolvedEvent>();
+			private const ulong _maxCount = 10;
+
+			protected override async Task Given() {
+				await _conn.AppendToStreamAsync(_streamName, ExpectedVersion.Any, CreateEvents(100));
+				var metadata = StreamMetadata.Build().SetTruncateBefore(81);
+				await _conn.SetStreamMetadataAsync(_streamName, ExpectedVersion.Any, metadata);
+			}
+
+			protected override async Task When() {
+				var enumerator = new Enumerators.ReadStreamForwards(_node.Node.MainQueue, _streamName,
+					StreamRevision.Start,
+					_maxCount, false, CreateTestUser(), false, DateTime.Now.AddMinutes(5), e => {
+						Assert.Fail($"Failed to read: {e}");
+						return Task.CompletedTask;
+					}, CancellationToken.None);
+
+				while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+					_responses.Add(enumerator.Current);
+				}
+			}
+
+			[Test]
+			public void should_not_receive_null_events() {
+				Assert.False(_responses.Any(x => x.Event is null));
+			}
+
+			[Test]
+			public void should_read_a_number_of_events_equal_to_the_max_count() {
+				Assert.AreEqual(_maxCount, _responses.Count);
+			}
+
+			[Test]
+			public void should_start_from_the_truncation_position() {
+				Assert.AreEqual(81, _responses[0].OriginalEventNumber);
+				Assert.AreEqual(90, _responses[^1].OriginalEventNumber);
+			}
+		}
+
+		public class when_reading_forward_from_the_start_of_the_stream : SpecificationWithMiniNode {
+			private readonly string _streamName = Guid.NewGuid().ToString();
+			private readonly List<Data.ResolvedEvent> _responses = new List<Data.ResolvedEvent>();
+			private const ulong _maxCount = 50;
+
+			protected override async Task Given() {
+				await _conn.AppendToStreamAsync(_streamName, ExpectedVersion.Any, CreateEvents(100));
+			}
+
+			protected override async Task When() {
+				var enumerator = new Enumerators.ReadStreamForwards(_node.Node.MainQueue, _streamName,
+					StreamRevision.Start,
+					_maxCount, false, CreateTestUser(), false, DateTime.Now.AddMinutes(5), e => {
+						Assert.Fail($"Failed to read: {e}");
+						return Task.CompletedTask;
+					}, CancellationToken.None);
+
+				while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+					_responses.Add(enumerator.Current);
+				}
+			}
+
+			[Test]
+			public void should_not_receive_null_events() {
+				Assert.False(_responses.Any(x => x.Event is null));
+			}
+
+			[Test]
+			public void should_read_a_number_of_events_equal_to_the_max_count() {
+				Assert.AreEqual(_maxCount, _responses.Count);
+			}
+
+			[Test]
+			public void should_read_the_correct_events() {
+				Assert.AreEqual(50, _responses.Count);
+				Assert.AreEqual(49, _responses[^1].OriginalEventNumber);
+			}
+		}
+
+		public class when_reading_forward_from_stream_with_no_events_after_position : SpecificationWithMiniNode {
+			private readonly string _streamName = Guid.NewGuid().ToString();
+			private readonly List<Data.ResolvedEvent> _responses = new List<Data.ResolvedEvent>();
+			private const ulong _maxCount = 50;
+
+			protected override async Task Given() {
+				await _conn.AppendToStreamAsync(_streamName, ExpectedVersion.Any, CreateEvents(10));
+			}
+
+			protected override async Task When() {
+				var enumerator = new Enumerators.ReadStreamForwards(_node.Node.MainQueue, _streamName,
+					StreamRevision.FromInt64(11),
+					_maxCount, false, CreateTestUser(), false, DateTime.Now.AddMinutes(5), e => {
+						Assert.Fail($"Failed to read: {e}");
+						return Task.CompletedTask;
+					}, CancellationToken.None);
+
+				while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+					_responses.Add(enumerator.Current);
+				}
+			}
+
+			[Test]
+			public void should_not_receive_events() {
+				Assert.IsEmpty(_responses);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
@@ -73,6 +73,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
+				ReadLoop:
 				if (_readCount >= _maxCount || _disposedTokenSource.IsCancellationRequested) {
 					return false;
 				}
@@ -114,7 +115,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					return true;
 				}
 
-				return false;
+				goto ReadLoop;
 
 				void OnMessage(Message message) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
@@ -72,6 +72,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
+				ReadLoop:
 				if (_readCount >= _maxCount || _disposedTokenSource.IsCancellationRequested) {
 					return false;
 				}
@@ -109,7 +110,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					return true;
 				}
 
-				return false;
+				goto ReadLoop;
 
 				void OnMessage(Message message) {
 					if (message is ClientMessage.NotHandled notHandled &&


### PR DESCRIPTION
Fixed: gRPC unable to read events from a truncated stream
Changed: gRPC reads will always try and read maxCount of events if it's not reached the end of the stream.

Fixes https://github.com/EventStore/EventStore/issues/2622

Don't return if the read has returned no events, but it's not at the end of the stream yet.
Add gRPC enumerator tests for reading streams forwards and backwards.

With this change, gRPC reads will always try and read maxCount of events. This includes when the stream has been truncated, or the read is beyond the end of the stream.

#### Reading forwards example:
- Given a stream with 100 events
- Set TruncateBefore to 81
- Read 10 events forwards from position 0

Events 81 to 90 will be returned.

#### Reading backwards example:
- Given a stream with 30 events
- Read 20 events from position 50

Events 29 to 10 will be returned.

