### PR TITLE
Allow external clients (e.g UI) to discover supported authentication methods

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 	<!-- Transitive dependencies to help in packaging -->
 	<ItemGroup>
-		<PackageReference Include="EventStore.Plugins" Version="20.6.1-preview2" />
+		<PackageReference Include="EventStore.Plugins" Version="20.6.1-preview3" />
 		<PackageReference Include="Google.Protobuf" Version="3.12.3" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.29.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.30.0">

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
@@ -20,11 +20,11 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 		public void Authenticate(AuthenticationRequest authenticationRequest) {
 			authenticationRequest.Authenticated(new ClaimsPrincipal(new ClaimsIdentity(new []{new Claim(ClaimTypes.Name, authenticationRequest.Name), })));
 		}
-		public string GetName() => "test";
+		public string Name => "test";
 		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
 		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
 			//nothing to do
 		}
-		public IEnumerable<AuthenticationSchemes> GetSupportedAuthenticationSchemes() => null;
+		public IReadOnlyList<string> GetSupportedAuthenticationSchemes() => null;
 	}
 }

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
@@ -25,6 +25,8 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
 			//nothing to do
 		}
-		public IReadOnlyList<string> GetSupportedAuthenticationSchemes() => null;
+		public IReadOnlyList<string> GetSupportedAuthenticationSchemes() => new []{
+			"Basic"
+		};
 	}
 }

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
@@ -25,5 +25,6 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
 			//nothing to do
 		}
+		public IEnumerable<AuthenticationSchemes> GetSupportedAuthenticationSchemes() => null;
 	}
 }

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using EventStore.Plugins.Authentication;
@@ -18,5 +19,7 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 		public void Authenticate(AuthenticationRequest authenticationRequest) {
 			authenticationRequest.Authenticated(new ClaimsPrincipal(new ClaimsIdentity(new []{new Claim(ClaimTypes.Name, authenticationRequest.Name), })));
 		}
+		public string GetName() => "test";
+		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
 	}
 }

--- a/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core.Tests/Common/VNodeBuilderTests/TestAuthenticationProviderFactory.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Routing;
 using Serilog;
 
 namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
@@ -21,5 +22,8 @@ namespace EventStore.Core.Tests.Common.VNodeBuilderTests {
 		}
 		public string GetName() => "test";
 		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
+		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
+			//nothing to do
+		}
 	}
 }

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -159,7 +159,8 @@ namespace EventStore.Core.Tests.Helpers {
 				HttpEndPoint);
 
 			Node = new ClusterVNode(Db, singleVNodeSettings,
-				infoController: new InfoController(null, new Dictionary<string, bool>()), subsystems: subsystems,
+				infoControllerBuilder: new InfoControllerBuilder()
+				, subsystems: subsystems,
 				gossipSeedSource: new KnownEndpointGossipSeedSource(gossipSeeds));
 			Node.HttpService.SetupController(new TestController(Node.MainQueue));
 

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -61,6 +61,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 			_server = new TestServer(
 				new WebHostBuilder()
 					.UseStartup(new ClusterVNodeStartup(Array.Empty<ISubsystem>(), queue, _bus, _multiQueuedHandler,
+						new TestAuthenticationProvider(),
 						new IHttpAuthenticationProvider[] {
 							new BasicHttpAuthenticationProvider(new TestAuthenticationProvider()),
 							new AnonymousHttpAuthenticationProvider(),

--- a/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
@@ -11,6 +11,7 @@ using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Routing;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Authentication.InternalAuthentication {
@@ -58,6 +59,10 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 		}
 		public string GetName() => "internal";
 		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
+
+		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
+			//nothing to do
+		}
 
 		private void ReadUserDataCompleted(ClientMessage.ReadStreamEventsBackwardCompleted completed,
 			AuthenticationRequest authenticationRequest) {

--- a/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
@@ -57,16 +57,16 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 					m => ReadUserDataCompleted(m, authenticationRequest));
 			}
 		}
-		public string GetName() => "internal";
+		public string Name => "internal";
 		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
 
 		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
 			//nothing to do
 		}
 
-		public IEnumerable<AuthenticationSchemes> GetSupportedAuthenticationSchemes() {
+		public IReadOnlyList<string> GetSupportedAuthenticationSchemes() {
 			return new [] {
-				AuthenticationSchemes.Basic
+				"Basic"
 			};
 		}
 

--- a/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
@@ -64,6 +64,12 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 			//nothing to do
 		}
 
+		public IEnumerable<AuthenticationSchemes> GetSupportedAuthenticationSchemes() {
+			return new [] {
+				AuthenticationSchemes.Basic
+			};
+		}
+
 		private void ReadUserDataCompleted(ClientMessage.ReadStreamEventsBackwardCompleted completed,
 			AuthenticationRequest authenticationRequest) {
 			try {

--- a/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
@@ -56,6 +56,8 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 					m => ReadUserDataCompleted(m, authenticationRequest));
 			}
 		}
+		public string GetName() => "internal";
+		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
 
 		private void ReadUserDataCompleted(ClientMessage.ReadStreamEventsBackwardCompleted completed,
 			AuthenticationRequest authenticationRequest) {

--- a/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
@@ -13,6 +13,13 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
 			//nothing to do
 		}
+
+		public IEnumerable<AuthenticationSchemes> GetSupportedAuthenticationSchemes() {
+			return new [] {
+				AuthenticationSchemes.Insecure
+			};
+		}
+
 		public Task Initialize() => Task.CompletedTask;
 	}
 }

--- a/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
@@ -8,15 +8,15 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 	public class PassthroughAuthenticationProvider : IAuthenticationProvider {
 		public void Authenticate(AuthenticationRequest authenticationRequest) =>
 			authenticationRequest.Authenticated(SystemAccounts.System);
-		public string GetName() => "insecure";
+		public string Name => "insecure";
 		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
 		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
 			//nothing to do
 		}
 
-		public IEnumerable<AuthenticationSchemes> GetSupportedAuthenticationSchemes() {
+		public IReadOnlyList<string> GetSupportedAuthenticationSchemes() {
 			return new [] {
-				AuthenticationSchemes.Insecure
+				"Insecure"
 			};
 		}
 

--- a/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Plugins.Authentication;
@@ -6,6 +7,8 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 	public class PassthroughAuthenticationProvider : IAuthenticationProvider {
 		public void Authenticate(AuthenticationRequest authenticationRequest) =>
 			authenticationRequest.Authenticated(SystemAccounts.System);
+		public string GetName() => "insecure";
+		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
 		public Task Initialize() => Task.CompletedTask;
 	}
 }

--- a/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/PassthroughAuthentication/PassthroughAuthenticationProvider.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Plugins.Authentication;
+using Microsoft.AspNetCore.Routing;
 
 namespace EventStore.Core.Authentication.InternalAuthentication {
 	public class PassthroughAuthenticationProvider : IAuthenticationProvider {
@@ -9,6 +10,9 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 			authenticationRequest.Authenticated(SystemAccounts.System);
 		public string GetName() => "insecure";
 		public IEnumerable<KeyValuePair<string, string>> GetPublicProperties() => null;
+		public void ConfigureEndpoints(IEndpointRouteBuilder endpointRouteBuilder) {
+			//nothing to do
+		}
 		public Task Initialize() => Task.CompletedTask;
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -474,20 +474,20 @@ namespace EventStore.Core {
 
 			var httpAuthenticationProviders = new List<IHttpAuthenticationProvider>();
 
-			foreach (var authenticationScheme in _authenticationProvider.GetSupportedAuthenticationSchemes() ?? Enumerable.Empty<AuthenticationSchemes>()) {
+			foreach (var authenticationScheme in _authenticationProvider.GetSupportedAuthenticationSchemes() ?? Enumerable.Empty<string>()) {
 				switch (authenticationScheme)
 				{
-					case AuthenticationSchemes.Basic:
+					case "Basic":
 						httpAuthenticationProviders.Add(new BasicHttpAuthenticationProvider(_authenticationProvider));
 						break;
-					case AuthenticationSchemes.Bearer:
+					case "Bearer":
 						httpAuthenticationProviders.Add(new BearerHttpAuthenticationProvider(_authenticationProvider));
 						break;
-					case AuthenticationSchemes.Insecure:
+					case "Insecure":
 						httpAuthenticationProviders.Add(new PassthroughHttpAuthenticationProvider(_authenticationProvider));
 						break;
 					default:
-						Log.Error($"Unsupported Authentication Scheme: {authenticationScheme}");
+						Log.Warning($"Unsupported Authentication Scheme: {authenticationScheme}");
 						break;
 				}
 			}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -780,7 +780,7 @@ namespace EventStore.Core {
 				}
 			}
 
-			_startup = new ClusterVNodeStartup(_subsystems, _mainQueue, _mainBus, _workersHandler, httpAuthenticationProviders, _authorizationProvider, _readIndex,
+			_startup = new ClusterVNodeStartup(_subsystems, _mainQueue, _mainBus, _workersHandler, _authenticationProvider, httpAuthenticationProviders, _authorizationProvider, _readIndex,
 				_vNodeSettings.MaxAppendSize, _httpService);
 			_mainBus.Subscribe<SystemMessage.SystemReady>(_startup);
 			_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_startup);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -160,7 +160,7 @@ namespace EventStore.Core {
 		public ClusterVNode(TFChunkDb db,
 			ClusterVNodeSettings vNodeSettings,
 			IGossipSeedSource gossipSeedSource,
-			InfoController infoController,
+			InfoControllerBuilder infoControllerBuilder,
 			params ISubsystem[] subsystems) {
 			Ensure.NotNull(db, "db");
 			Ensure.NotNull(vNodeSettings, "vNodeSettings");
@@ -491,8 +491,6 @@ namespace EventStore.Core {
 				};
 			}
 
-			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(infoController);
-
 			var adminController = new AdminController(_mainQueue, _workersHandler);
 			var pingController = new PingController();
 			var histogramController = new HistogramController();
@@ -502,6 +500,11 @@ namespace EventStore.Core {
 			var gossipController = new GossipController(_mainQueue, _workersHandler);
 			var persistentSubscriptionController =
 				new PersistentSubscriptionController(httpSendService, _mainQueue, _workersHandler);
+			var infoController = infoControllerBuilder
+				.WithAuthenticationProvider(_authenticationProvider)
+				.Build();
+
+			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(infoController);
 
 			_httpService.SetupController(persistentSubscriptionController);
 			if (vNodeSettings.AdminOnPublic)

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -492,6 +492,10 @@ namespace EventStore.Core {
 				}
 			}
 
+			if (!httpAuthenticationProviders.Any()) {
+				throw new InvalidConfigurationException($"The server does not support any authentication scheme supported by the '{_authenticationProvider.Name}' authentication provider.");
+			}
+
 			if (!_disableHttps) {
 				//transport-level authentication providers
 				httpAuthenticationProviders.Add(

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -134,6 +134,7 @@ namespace EventStore.Core {
 				.Aggregate(services
 						.AddRouting()
 						.AddSingleton(_httpAuthenticationProviders)
+						.AddSingleton(_authenticationProvider)
 						.AddSingleton(_authorizationProvider)
 						.AddSingleton<AuthenticationMiddleware>()
 						.AddSingleton<AuthorizationMiddleware>()

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="EventStore.Plugins" Version="20.6.1-preview2" />
+		<PackageReference Include="EventStore.Plugins" Version="20.6.1-preview3" />
 		<PackageReference Include="Google.Protobuf" Version="3.12.3" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.29.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.30.0">

--- a/src/EventStore.Core/Services/Transport/Http/AuthenticationMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AuthenticationMiddleware.cs
@@ -1,23 +1,26 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
-using EventStore.Core.Bus;
 using EventStore.Core.Services.Transport.Http.Authentication;
-using EventStore.Core.Services.Transport.Http.Messages;
+using EventStore.Plugins.Authentication;
 using EventStore.Transport.Http;
 using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 
 namespace EventStore.Core.Services.Transport.Http {
 	public class AuthenticationMiddleware : IMiddleware {
-		private readonly IReadOnlyList<IHttpAuthenticationProvider> _authenticationProviders;
+		private readonly IAuthenticationProvider _authenticationProvider;
+		private readonly IReadOnlyList<IHttpAuthenticationProvider> _httpAuthenticationProviders;
 
-		public AuthenticationMiddleware(IReadOnlyList<IHttpAuthenticationProvider> authenticationProviders) {
-			_authenticationProviders = authenticationProviders;
+		public AuthenticationMiddleware(IReadOnlyList<IHttpAuthenticationProvider> httpAuthenticationProviders, IAuthenticationProvider authenticationProvider) {
+			_httpAuthenticationProviders = httpAuthenticationProviders;
+			_authenticationProvider = authenticationProvider;
 		}
 
 		public async Task InvokeAsync(HttpContext context, RequestDelegate next) {
-			for (int i = 0; i < _authenticationProviders.Count; i++) {
-				if (_authenticationProviders[i].Authenticate(context, out var authenticationRequest)) {
+			for (int i = 0; i < _httpAuthenticationProviders.Count; i++) {
+				if (_httpAuthenticationProviders[i].Authenticate(context, out var authenticationRequest)) {
 					if (await authenticationRequest.AuthenticateAsync().ConfigureAwait(false)) {
 						await next(context).ConfigureAwait(false);
 						return;
@@ -28,6 +31,15 @@ namespace EventStore.Core.Services.Transport.Http {
 			}
 
 			context.Response.StatusCode = HttpStatusCode.Unauthorized;
+			var authSchemes = _authenticationProvider.GetSupportedAuthenticationSchemes();
+			if (authSchemes != null && authSchemes.Any()) {
+				//add "X-" in front to prevent any default browser behaviour e.g Basic Auth popups
+				context.Response.Headers.Add("WWW-Authenticate", $"X-{authSchemes.First()} realm=\"ESDB\"");
+				var properties = _authenticationProvider.GetPublicProperties();
+				if (properties != null && properties.Any()) {
+					await context.Response.WriteAsync(JsonConvert.SerializeObject(properties)).ConfigureAwait(false);
+				}
+			}
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -10,6 +10,7 @@ using EventStore.Transport.Http.EntityManagement;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
+using EventStore.Plugins.Authentication;
 using EventStore.Plugins.Authorization;
 using ILogger = Serilog.ILogger;
 
@@ -21,11 +22,13 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		private readonly IOptions _options;
 		private readonly IDictionary<string, bool> _features;
+		private readonly IAuthenticationProvider _authenticationProvider;
 		private VNodeState _currentState;
 
-		public InfoController(IOptions options, IDictionary<string, bool> features) {
+		public InfoController(IOptions options, IDictionary<string, bool> features, IAuthenticationProvider authenticationProvider) {
 			_options = options;
 			_features = features;
+			_authenticationProvider = authenticationProvider;
 		}
 
 		public void Subscribe(IHttpService service) {
@@ -46,12 +49,23 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					ESVersion = VersionInfo.Version,
 					State = _currentState.ToString().ToLower(),
 					Features = _features,
+					Authentication = GetAuthenticationInfo()
 				}),
 				HttpStatusCode.OK,
 				"OK",
 				entity.ResponseCodec.ContentType,
 				null,
 				e => Log.Error(e, "Error while writing HTTP response (info)"));
+		}
+
+		private Dictionary<string, object> GetAuthenticationInfo() {
+			if (_authenticationProvider == null)
+				return null;
+
+			return new Dictionary<string, object>(){
+				{ "type", _authenticationProvider.GetName() },
+				{ "properties", _authenticationProvider.GetPublicProperties() }
+			};
 		}
 
 		private void OnGetOptions(HttpEntityManager entity, UriTemplateMatch match) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				return null;
 
 			return new Dictionary<string, object>(){
-				{ "type", _authenticationProvider.GetName() },
+				{ "type", _authenticationProvider.Name },
 				{ "properties", _authenticationProvider.GetPublicProperties() }
 			};
 		}

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoControllerBuilder.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoControllerBuilder.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using EventStore.Common.Options;
+using EventStore.Plugins.Authentication;
+
+namespace EventStore.Core.Services.Transport.Http.Controllers {
+	public class InfoControllerBuilder {
+		private IOptions _options;
+		private IDictionary<string, bool> _features;
+		private IAuthenticationProvider _authenticationProvider;
+
+		public InfoControllerBuilder WithOptions(IOptions options) {
+			_options = options;
+			return this;
+
+		}
+
+		public InfoControllerBuilder WithFeatures(IDictionary<string, bool> features) {
+			_features = features;
+			return this;
+		}
+
+		public InfoControllerBuilder WithAuthenticationProvider(IAuthenticationProvider authenticationProvider) {
+			_authenticationProvider = authenticationProvider;
+			return this;
+		}
+
+		public InfoController Build() {
+			return new InfoController(_options, _features, _authenticationProvider);
+		}
+	}
+}

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1434,11 +1434,13 @@ namespace EventStore.Core {
 				_enableAtomPubOverHTTP,
 				_disableHttps);
 
-			var infoController = new InfoController(options, new Dictionary<string, bool> {
-				{"projections", _projectionType != ProjectionType.None},
-				{"userManagement", _authenticationProviderIsInternal},
-				{"atomPub", _enableAtomPubOverHTTP}
-			});
+			var infoControllerBuilder = new InfoControllerBuilder()
+				.WithOptions(options)
+				.WithFeatures(new Dictionary<string, bool> {
+					{"projections", _projectionType != ProjectionType.None},
+					{"userManagement", _authenticationProviderIsInternal},
+					{"atomPub", _enableAtomPubOverHTTP}
+				});
 
 			var writerCheckpoint = _db.Config.WriterCheckpoint.Read();
 			var chaserCheckpoint = _db.Config.ChaserCheckpoint.Read();
@@ -1456,7 +1458,7 @@ namespace EventStore.Core {
 			_log.Information("{description,-25} {truncateCheckpoint} (0x{truncateCheckpoint:X})", "TRUNCATE CHECKPOINT:",
 				truncateCheckpoint, truncateCheckpoint);
 
-			return new ClusterVNode(_db, _vNodeSettings, GetGossipSource(), infoController, _subsystems.ToArray());
+			return new ClusterVNode(_db, _vNodeSettings, GetGossipSource(), infoControllerBuilder, _subsystems.ToArray());
 		}
 
 		private int ComputePTableMaxReaderCount(int ptableInitialReaderCount, int readerThreadsCount) {


### PR DESCRIPTION
Added: Allow external clients to discover supported authentication methods

Related to: https://github.com/EventStore/EventStore.UI/issues/265
This PR adds an `authentication` property to the JSON response of `/info` to allow external clients (e.g UI) to discover supported authentication methods (insecure, internal, oauth, ldaps)

The PR also adds the `WWW-Authenticate` header to 401 responses but with an `X-` in front of the authentication scheme to prevent default browser behaviour (like basic auth popups)

Note: It requires EventStore.Plugins 20.6.1-preview3 to be published (https://github.com/EventStore/EventStore.Plugins/pull/10)