### PR TITLE
Correctly handle cases when DefaultCredentials are NotAuthenticated in TCP

### DIFF
--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -311,10 +311,12 @@ namespace EventStore.Core.Services.Transport.Tcp {
 					} else if ((package.Flags & TcpFlags.Authenticated) != 0) {
 						_authProvider.Authenticate(new TcpAuthRequest(this, package));
 					} else if (defaultUser != null) {
-						if (defaultUser.User != null)
+						if (defaultUser.User != null) {
 							UnwrapAndPublishPackage(package, defaultUser.User, defaultUser.Tokens);
-						else
-							_authProvider.Authenticate(new TcpAuthRequest(this, package));
+						} else {
+							// The default credentials aren't authenticated
+							ReplyNotAuthenticated(package.CorrelationId, "Not Authenticated");
+						}
 					} else {
 						UnwrapAndPublishPackage(package, Anonymous, null);
 					}
@@ -512,7 +514,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			}
 
 			public override void NotReady() {
-				_manager.ReplyNotAuthenticated(_correlationId, "Server not yet ready");
+				_manager.ReplyNotReady(_correlationId, "Server not yet ready");
 			}
 		}
 


### PR DESCRIPTION
Fixed: Error on TCP operations after default user fails authentication

Fixes https://github.com/EventStore/home/issues/250

- Respond with `NotAuthenticated` when the default user has failed authentication and no credentials have been passed with the TCP package.
- Respond with `NotHandled.NotReady` when the `NotReady` method is called on the `TcpAuthRequest`.

This fixes the following issue:

The default user has the `User` ClaimsPrincipal set when it passes authentication. However, if it fails this remains null.
This change fixes an error in the following situation:
- The connection is using a default user
- The default user failed authentication, either because the node isn't ready or because the credentials are wrong
- The operation does not provide credentials itself

Originally, the above scenario would cause a null argument error as the package doesn't include any authentication tokens:

```Error while processing package. Error: System.ArgumentNullException: Value cannot be null```