### PR TITLE
Remove development mode

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -34,36 +34,6 @@ namespace EventStore.ClusterNode {
 		public ClusterVNodeHostedService(string[] args) : base(args) {
 		}
 
-		protected override IEnumerable<OptionSource>
-			MutateEffectiveOptions(IEnumerable<OptionSource> effectiveOptions) {
-			var developmentOption = effectiveOptions.Single(x => x.Name == nameof(ClusterNodeOptions.Dev));
-			bool.TryParse(developmentOption.Value.ToString(), out bool developmentMode);
-			return effectiveOptions.Select(x => {
-				if (x.Name == nameof(ClusterNodeOptions.DisableInternalTcpTls)
-				    && x.Source == "<DEFAULT>"
-				    && developmentMode) {
-					x.Value = true;
-					x.Source =  "Set by 'Development' mode";
-				}
-
-				if (x.Name == nameof(ClusterNodeOptions.DisableExternalTcpTls)
-				    && x.Source == "<DEFAULT>"
-				    && developmentMode) {
-					x.Value = true;
-					x.Source =  "Set by 'Development' mode";
-				}
-
-				if (x.Name == nameof(ClusterNodeOptions.EnableAtomPubOverHTTP)
-				    && x.Source == "<DEFAULT>"
-				    && developmentMode) {
-					x.Value = true;
-					x.Source = "Set by 'Development' mode";
-				}
-
-				return x;
-			});
-		}
-
 		protected override string GetLogsDirectory(ClusterNodeOptions options) => options.Log;
 
 		protected override string GetComponentName(ClusterNodeOptions options) =>
@@ -107,16 +77,7 @@ namespace EventStore.ClusterNode {
 		protected override void Create(ClusterNodeOptions opts) {
 			var dbPath = opts.Db;
 
-			if (opts.Dev) {
-				Log.Warning(
-					"\n========================================================================================================\n" +
-					"DEVELOPMENT MODE IS ON. THIS MODE IS *NOT* INTENDED FOR PRODUCTION USE.\n" +
-					"WHEN IN DEVELOPMENT MODE EVENTSTOREDB WILL\n" +
-					" - DISABLE TLS ON ALL TCP INTERFACES.\n" +
-					" - ENABLE THE ATOMPUB PROTOCOL OVER HTTP.\n" +
-					"========================================================================================================\n");
-			}
-			else if (opts.Insecure) {
+			if (opts.Insecure) {
 				Log.Warning(
 					"\n========================================================================================================\n" +
 					"INSECURE MODE IS ON. THIS MODE IS *NOT* RECOMMENDED FOR PRODUCTION USE.\n" +

--- a/src/EventStore.Core/ClusterNodeOptions.cs
+++ b/src/EventStore.Core/ClusterNodeOptions.cs
@@ -312,9 +312,6 @@ namespace EventStore.Core {
 		[ArgDescription(Opts.MaxAppendSizeDecr, Opts.AppGroup)]
 		public int MaxAppendSize { get; set; }
 		
-		[ArgDescription(Opts.DevDescr, Opts.AppGroup)]
-		public bool Dev { get; set; }
-
 		[ArgDescription(Opts.InsecureDescr, Opts.AppGroup)]
 		public bool Insecure { get; set; }
 		
@@ -453,7 +450,6 @@ namespace EventStore.Core {
 			MaxTruncation = Opts.MaxTruncationDefault;
 			MaxAppendSize = Opts.MaxAppendSizeDefault;
 
-			Dev = Opts.DevDefault;
 			Insecure = Opts.InsecureDefault;
 		}
 	}

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -408,9 +408,6 @@ namespace EventStore.Core.Util {
 			"When truncate.chk is set, the database will be truncated on startup. This is a safety check to ensure large amounts of data truncation does not happen accidentally. This value should be set in the low 10,000s for allow for standard cluster recovery operations. -1 is no max.";
 		public static readonly long MaxTruncationDefault = 256 * 1024 * 1024;
 		
-		public const string DevDescr = "Enable Development Mode for Event Store.";
-		public const bool DevDefault = false;
-
 		public const string InsecureDescr = "Disable Authentication, Authorization and TLS on all TCP/HTTP interfaces";
 		public const bool InsecureDefault = false;
 	}


### PR DESCRIPTION
Removed: Development mode

Fixes: https://github.com/EventStore/home/issues/228

With the introduction of `--insecure` and instructions for setting up a cluster in docker, `--dev` doesn't serve much purpose.