### PR TITLE
Handle clusters with only secure tcp endpoints during reconnect

### DIFF
--- a/src/EventStore.ClientAPI/Messages/ClientMessagesExtensions.cs
+++ b/src/EventStore.ClientAPI/Messages/ClientMessagesExtensions.cs
@@ -8,7 +8,11 @@ namespace EventStore.ClientAPI.Messages {
 		public partial class NotHandled {
 			public partial class MasterInfo {
 				public IPEndPoint ExternalTcpEndPoint {
-					get { return new IPEndPoint(IPAddress.Parse(ExternalTcpAddress), ExternalTcpPort); }
+					get {
+						return ExternalTcpAddress == null
+							? null
+							: new IPEndPoint(IPAddress.Parse(ExternalTcpAddress), ExternalTcpPort);
+					}
 				}
 
 				public IPEndPoint ExternalSecureTcpEndPoint {

--- a/src/EventStore.ClientAPI/SystemData/InspectionResult.cs
+++ b/src/EventStore.ClientAPI/SystemData/InspectionResult.cs
@@ -11,8 +11,11 @@ namespace EventStore.ClientAPI.SystemData {
 
 		public InspectionResult(InspectionDecision decision, string description, IPEndPoint tcpEndPoint = null,
 			IPEndPoint secureTcpEndPoint = null) {
-			if (decision == InspectionDecision.Reconnect)
-				Ensure.NotNull(tcpEndPoint, "tcpEndPoint");
+			if (decision == InspectionDecision.Reconnect) {
+				if (tcpEndPoint == null && secureTcpEndPoint == null) {
+					throw new ArgumentException("tcpEndPoint and secureTcpEndPoint cannot both be null");
+				}
+			}
 			else {
 				if (tcpEndPoint != null)
 					throw new ArgumentException(string.Format("tcpEndPoint is not null for decision {0}.", decision));


### PR DESCRIPTION
When sent a reconnect message from a 20.6 cluster (and presumably also from a v5 cluster with `DisableInsecureTcp` enabled, but I've not tested that), `ExternalTcpAddress` is `null` in the message's master info. This allows either `tcpEndPoint` or `secureTcpEndPoint` to be null in the reconnect message, but not both. 

Related to #2646 