### PR TITLE
Entrypoint.sh now passes along arguments  [eventstore-docker#78]

### DIFF
--- a/scripts/docker/entrypoint.sh
+++ b/scripts/docker/entrypoint.sh
@@ -6,4 +6,4 @@ then
     export EVENTSTORE_INT_IP=`ip addr show eth0|grep -E '(\/[0-9][0-9])'|awk '/inet / {print $2}'|sed -e 's/\/.*//'`
 fi
 
-exec eventstored
+exec eventstored "$@"


### PR DESCRIPTION
## Originally opened by @kaancfidan at [eventstore-docker#78](https://github.com/EventStore/eventstore-docker/pull/78)

> I have uploaded this version of the image to my own docker registry as [kaancfidan/eventstore](https://hub.docker.com/repository/docker/kaancfidan/eventstore).
> 
> To see the fix in action, you may:
> - Create the container:
> ```bash
> docker run -it --rm -p 2113:2113 -p 1113:1113 kaancfidan/eventstore --run-projections=all --start-standard-projections=true
> ```
> 
> - Browse to http://localhost:2113/web/index.html#/projections
> 
> **Expected behavior:**
> All system projections should be **Running**.
> 

Co-Authored-By: Kaan C. Fidan <kaancfidan@gmail.com>
[See original thread](https://github.com/EventStore/eventstore-docker/pull/78)

---
Fixes : #2654 