### PR TITLE
Update startup logs

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -96,29 +96,34 @@ namespace EventStore.ClusterNode {
 				$"\tEnabled\t: {opts.EnableAtomPubOverHTTP}\n" +
 				$"\tPort\t: {opts.HttpPort}\n");
 
+			var deprecationMessages = string.Empty;
+			
 			if (opts.EnableAtomPubOverHTTP) {
-				Log.Warning(
-					"\n DEPRECATION WARNING: AtomPub over HTTP Interface has been deprecated as of version 20.6.0. It is recommended to use gRPC instead.\n");
+				deprecationMessages +=
+					"- AtomPub over HTTP Interface has been deprecated as of version 20.6.0. It is recommended to use gRPC instead.\n";
 			}
 
 			if (opts.DisableInternalTcpTls) {
-				Log.Warning(
-					$"\n DEPRECATION WARNING: The '{nameof(Options.DisableInternalTcpTls)}' option has been deprecated as of version 20.6.1 and currently has no effect. "
-					+ $"Please use the '{nameof(Options.Insecure)}' option instead.\n");
+				deprecationMessages +=
+					$"- The '{nameof(Options.DisableInternalTcpTls)}' option has been deprecated as of version 20.6.1 and currently has no effect. "
+					+ $"Please use the '{nameof(Options.Insecure)}' option instead.\n";
 			}
 
 			if (opts.EnableExternalTCP) {
-				Log.Warning(
-					"\n DEPRECATION WARNING: The Legacy TCP Client Interface has been deprecated as of version 20.6.0. "
+				deprecationMessages +=
+					"- The Legacy TCP Client Interface has been deprecated as of version 20.6.0. "
 					+ $"The External TCP Interface can be re-enabled with the '{nameof(Options.EnableExternalTCP)}' option. "
-					+ "It is recommended to use gRPC instead.\n");
+					+ "It is recommended to use gRPC instead.\n";
 			}
 
 			if (opts.DisableExternalTcpTls) {
-				Log.Warning(
-					$"\n DEPRECATION WARNING: The '{nameof(Options.DisableExternalTcpTls)}' option has been deprecated as of version 20.6.1.\n");
+				deprecationMessages +=
+					$"- The '{nameof(Options.DisableExternalTcpTls)}' option has been deprecated as of version 20.6.1.\n";
 			}
 
+			if (deprecationMessages.Any()) {
+				Log.Warning($"DEPRECATED\n{deprecationMessages}");
+			}
 
 			if (!opts.MemDb) {
 				var absolutePath = Path.GetFullPath(dbPath);

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -79,16 +79,14 @@ namespace EventStore.ClusterNode {
 
 			if (opts.Insecure) {
 				Log.Warning(
-					"\n========================================================================================================\n" +
+					"\n==============================================================================================================\n" +
 					"INSECURE MODE IS ON. THIS MODE IS *NOT* RECOMMENDED FOR PRODUCTION USE.\n" +
-					"WHEN IN INSECURE MODE EVENTSTOREDB WILL\n" +
-					" - DISABLE ALL AUTHENTICATION AND AUTHORIZATION.\n" +
-					" - DISABLE TLS ON ALL TCP AND HTTP INTERFACES.\n" +
-					"========================================================================================================\n");
+					"INSECURE MODE WILL DISABLE ALL AUTHENTICATION, AUTHORIZATION AND TRANSPORT SECURITY FOR ALL CLIENTS AND NODES.\n" +
+					"==============================================================================================================\n");
 			}
 
 			var deprecationMessages = string.Empty;
-			
+
 			if (opts.EnableAtomPubOverHTTP) {
 				deprecationMessages +=
 					"- AtomPub over HTTP Interface has been deprecated as of version 20.6.0. It is recommended to use gRPC instead.\n";


### PR DESCRIPTION
Changed: Updated startup logs to be more clear about security and interfaces.

This is an attempt to simplify the startup logs regarding the security and deprecation warnings.
There are 3 commits, and each could be taken individually depending on if we want to take any of these changes.

1. **Join the deprecation warnings into a single log**
    This cleans up some of the noise where previously we printed out every deprecation warning with a duplicate message.

Original:

```
[ 3864, 1,13:53:37.863,WRN]
 DEPRECATION WARNING: AtomPub over HTTP Interface has been deprecated as of version 20.6.0. It is recommended to use gRPC instead.

[ 3864, 1,13:53:37.863,WRN]
 DEPRECATION WARNING: The Legacy TCP Client Interface has been deprecated as of version 20.6.0. The External TCP Interface can be re-enabled with the 'EnableExternalTCP' option. It is recommended to use gRPC instead.
```

Updated:

```
[ 4484, 1,13:56:30.669,WRN] DEPRECATED
- AtomPub over HTTP Interface has been deprecated as of version 20.6.0. It is recommended to use gRPC instead.
- The Legacy TCP Client Interface has been deprecated as of version 20.6.0. The External TCP Interface can be re-enabled with the 'EnableExternalTCP' option. It is recommended to use gRPC instead.
```

2. **Show a single warning about auth and tls rather than listing interfaces**
    The original idea of printing out the interfaces was to make it obvious whether they were enabled or not, but this should be easily discovered from the config and deprecation warnings. With the exception of TLS on external TCP, TLS and auth is also enabled for all interfaces or none of them, so showing the configuration per interface might not be as useful.

Original (Secure with only certificates configured):

```
[19992, 1,13:52:09.320,INF]
INTERFACES
External TCP (Protobuf)
        Enabled : False
        Port    : 1113
HTTP (AtomPub)
        Enabled : False
        Port    : 2113

[19992, 1,13:52:09.334,INF] Quorum size set to 1
[19992, 1,13:52:09.337,INF]
SECURITY
HTTP (gRPC / Admin UI)
        TLS enabled     : True
        Authentication/Authorization enabled    : True

TLS is enabled on at least one TCP/HTTP interface - a certificate is required to run EventStoreDB.
```

Original (Insecure with no other options):

```
[ 8156, 1,13:51:39.020,WRN]
========================================================================================================
INSECURE MODE IS ON. THIS MODE IS *NOT* RECOMMENDED FOR PRODUCTION USE.
WHEN IN INSECURE MODE EVENTSTOREDB WILL
 - DISABLE ALL AUTHENTICATION AND AUTHORIZATION.
 - DISABLE TLS ON ALL TCP AND HTTP INTERFACES.
========================================================================================================

[ 8156, 1,13:51:39.020,INF]
INTERFACES
External TCP (Protobuf)
        Enabled : False
        Port    : 1113
HTTP (AtomPub)
        Enabled : False
        Port    : 2113

[ 8156, 1,13:51:39.047,INF] Quorum size set to 1
[ 8156, 1,13:51:39.050,INF]
SECURITY
HTTP (gRPC / Admin UI)
        TLS enabled     : False
        Authentication/Authorization enabled    : False

TLS is disabled on all TCP/HTTP interfaces - no certificates are required to run EventStoreDB.
It is recommended to run with TLS enabled in production.
```

Updated (Secure with only certificates configured):

```
[20840, 1,13:56:59.813,INF] Quorum size set to 1
[20840, 1,13:56:59.815,INF] TLS is enabled on at least one TCP/HTTP interface - a certificate is required to run EventStoreDB.
```

Updated (Insecure with no other options):

```
[22500, 1,13:55:20.484,WRN]
==============================================================================================================
INSECURE MODE IS ON. THIS MODE IS *NOT* RECOMMENDED FOR PRODUCTION USE.
INSECURE MODE WILL DISABLE ALL AUTHENTICATION, AUTHORIZATION AND TRANSPORT SECURITY FOR ALL CLIENTS AND NODES.
==============================================================================================================

[22500, 1,13:55:20.507,INF] Quorum size set to 1
[22500, 1,13:55:20.509,WRN] Authentication and Authorization is disabled on all TCP/HTTP interfaces. It is recommended to run with Authentication and Authorization enabled in production
[22500, 1,13:55:20.509,WRN] TLS is disabled on all TCP/HTTP interfaces - no certificates are required to run EventStoreDB. It is recommended to run with TLS enabled in production.
```
