### PR TITLE
Add a DtoExtension method to parse TcpClientMessageDto.Filter into ReaderIndex.EventFilter

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
+++ b/src/EventStore.ClientAPI.Embedded/EventStoreEmbeddedNodeConnection.cs
@@ -412,7 +412,7 @@ namespace EventStore.ClientAPI.Embedded {
 					new ClientMessage.FilteredReadAllEventsForward(corrId, corrId, envelope,
 						position.CommitPosition,
 						position.PreparePosition, maxCount, resolveLinkTos, false, maxSearchWindow, null,
-						EventFilter.Get(serverFilter), user));
+						serverFilter.ToEventFilter(), user));
 			return await source.Task.ConfigureAwait(false);
 		}
 
@@ -462,7 +462,7 @@ namespace EventStore.ClientAPI.Embedded {
 					new ClientMessage.FilteredReadAllEventsBackward(corrId, corrId, envelope,
 						position.CommitPosition,
 						position.PreparePosition, maxCount, resolveLinkTos, false, maxSearchWindow, null,
-						EventFilter.Get(serverFilter), user));
+						serverFilter.ToEventFilter(), user));
 			return await source.Task.ConfigureAwait(false);
 		}
 

--- a/src/EventStore.ClientAPI.Embedded/FilteredEmbeddedSubscription.cs
+++ b/src/EventStore.ClientAPI.Embedded/FilteredEmbeddedSubscription.cs
@@ -57,7 +57,7 @@ namespace EventStore.ClientAPI.Embedded {
 					StreamId,
 					_resolveLinkTos,
 					user,
-					EventFilter.Get(_filter),
+					_filter.ToEventFilter(),
 					_checkpointInterval));
 		}
 

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
-using EventStore.Core.Data;
-using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLogV2.Data;
-using EventStore.Core.Util;
-using static EventStore.Core.Messages.TcpClientMessageDto.Filter;
 
 namespace EventStore.Core.Tests.Services.Storage.AllReader {
 	public class when_reading_all_with_filtering : ReadIndexTestScenario {
@@ -28,10 +24,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 
 		[Test]
 		public void should_read_only_events_forward_with_event_type_prefix() {
-			var filter = new TcpClientMessageDto.Filter(
-				FilterContext.EventType,
-				FilterType.Prefix, new[] {"event-type"});
-			var eventFilter = filter.ToEventFilter();
+			var eventFilter = EventFilter.EventType.Prefixes("event-type");
 
 			var result = ReadIndex.ReadAllEventsForwardFiltered(_forwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(2, result.Records.Count);
@@ -39,10 +32,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 
 		[Test]
 		public void should_read_only_events_forward_with_event_type_regex() {
-			var filter = new TcpClientMessageDto.Filter(
-				FilterContext.EventType,
-				FilterType.Regex, new[] {@"^.*other-event.*$"});
-			var eventFilter = filter.ToEventFilter();
+			var eventFilter = EventFilter.EventType.Regex(@"^.*other-event.*$");
 
 			var result = ReadIndex.ReadAllEventsForwardFiltered(_forwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(2, result.Records.Count);
@@ -50,10 +40,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 
 		[Test]
 		public void should_read_only_events_forward_with_stream_id_prefix() {
-			var filter = new TcpClientMessageDto.Filter(
-				FilterContext.StreamId,
-				FilterType.Prefix, new[] {"ES2"});
-			var eventFilter = filter.ToEventFilter();
+			var eventFilter = EventFilter.StreamName.Prefixes("ES2");
 
 			var result = ReadIndex.ReadAllEventsForwardFiltered(_forwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(1, result.Records.Count);
@@ -61,10 +48,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 
 		[Test]
 		public void should_read_only_events_forward_with_stream_id_regex() {
-			var filter = new TcpClientMessageDto.Filter(
-				FilterContext.StreamId,
-				FilterType.Regex, new[] {@"^.*ES2.*$"});
-			var eventFilter = filter.ToEventFilter();
+			var eventFilter = EventFilter.StreamName.Regex(@"^.*ES2.*$");
 
 			var result = ReadIndex.ReadAllEventsForwardFiltered(_forwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(1, result.Records.Count);
@@ -72,10 +56,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 
 		[Test]
 		public void should_read_only_events_backward_with_event_type_prefix() {
-			var filter = new TcpClientMessageDto.Filter(
-				FilterContext.EventType,
-				FilterType.Prefix, new[] {"event-type"});
-			var eventFilter = filter.ToEventFilter();
+			var eventFilter = EventFilter.EventType.Prefixes("event-type");
 
 			var result = ReadIndex.ReadAllEventsBackwardFiltered(_backwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(2, result.Records.Count);
@@ -83,10 +64,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 
 		[Test]
 		public void should_read_only_events_backward_with_event_type_regex() {
-			var filter = new TcpClientMessageDto.Filter(
-				FilterContext.EventType,
-				FilterType.Regex, new[] {@"^.*other-event.*$"});
-			var eventFilter = filter.ToEventFilter();
+			var eventFilter = EventFilter.EventType.Regex(@"^.*other-event.*$");
 
 			var result = ReadIndex.ReadAllEventsBackwardFiltered(_backwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(2, result.Records.Count);
@@ -94,10 +72,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 
 		[Test]
 		public void should_read_only_events_backward_with_stream_id_prefix() {
-			var filter = new TcpClientMessageDto.Filter(
-				FilterContext.StreamId,
-				FilterType.Prefix, new[] {"ES2"});
-			var eventFilter = filter.ToEventFilter();
+			var eventFilter = EventFilter.StreamName.Prefixes("ES2");
 
 			var result = ReadIndex.ReadAllEventsBackwardFiltered(_backwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(1, result.Records.Count);
@@ -105,10 +80,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 
 		[Test]
 		public void should_read_only_events_backward_with_stream_id_regex() {
-			var filter = new TcpClientMessageDto.Filter(
-				FilterContext.StreamId,
-				FilterType.Regex, new[] {@"^.*ES2.*$"});
-			var eventFilter = filter.ToEventFilter();
+			var eventFilter = EventFilter.StreamName.Regex(@"^.*ES2.*$");
 
 			var result = ReadIndex.ReadAllEventsBackwardFiltered(_backwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(1, result.Records.Count);

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			var filter = new TcpClientMessageDto.Filter(
 				FilterContext.EventType,
 				FilterType.Prefix, new[] {"event-type"});
-			var eventFilter = EventFilter.Get(filter);
+			var eventFilter = filter.ToEventFilter();
 
 			var result = ReadIndex.ReadAllEventsForwardFiltered(_forwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(2, result.Records.Count);
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			var filter = new TcpClientMessageDto.Filter(
 				FilterContext.EventType,
 				FilterType.Regex, new[] {@"^.*other-event.*$"});
-			var eventFilter = EventFilter.Get(filter);
+			var eventFilter = filter.ToEventFilter();
 
 			var result = ReadIndex.ReadAllEventsForwardFiltered(_forwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(2, result.Records.Count);
@@ -53,7 +53,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			var filter = new TcpClientMessageDto.Filter(
 				FilterContext.StreamId,
 				FilterType.Prefix, new[] {"ES2"});
-			var eventFilter = EventFilter.Get(filter);
+			var eventFilter = filter.ToEventFilter();
 
 			var result = ReadIndex.ReadAllEventsForwardFiltered(_forwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(1, result.Records.Count);
@@ -64,7 +64,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			var filter = new TcpClientMessageDto.Filter(
 				FilterContext.StreamId,
 				FilterType.Regex, new[] {@"^.*ES2.*$"});
-			var eventFilter = EventFilter.Get(filter);
+			var eventFilter = filter.ToEventFilter();
 
 			var result = ReadIndex.ReadAllEventsForwardFiltered(_forwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(1, result.Records.Count);
@@ -75,7 +75,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			var filter = new TcpClientMessageDto.Filter(
 				FilterContext.EventType,
 				FilterType.Prefix, new[] {"event-type"});
-			var eventFilter = EventFilter.Get(filter);
+			var eventFilter = filter.ToEventFilter();
 
 			var result = ReadIndex.ReadAllEventsBackwardFiltered(_backwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(2, result.Records.Count);
@@ -86,7 +86,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			var filter = new TcpClientMessageDto.Filter(
 				FilterContext.EventType,
 				FilterType.Regex, new[] {@"^.*other-event.*$"});
-			var eventFilter = EventFilter.Get(filter);
+			var eventFilter = filter.ToEventFilter();
 
 			var result = ReadIndex.ReadAllEventsBackwardFiltered(_backwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(2, result.Records.Count);
@@ -97,7 +97,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			var filter = new TcpClientMessageDto.Filter(
 				FilterContext.StreamId,
 				FilterType.Prefix, new[] {"ES2"});
-			var eventFilter = EventFilter.Get(filter);
+			var eventFilter = filter.ToEventFilter();
 
 			var result = ReadIndex.ReadAllEventsBackwardFiltered(_backwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(1, result.Records.Count);
@@ -108,7 +108,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			var filter = new TcpClientMessageDto.Filter(
 				FilterContext.StreamId,
 				FilterType.Regex, new[] {@"^.*ES2.*$"});
-			var eventFilter = EventFilter.Get(filter);
+			var eventFilter = filter.ToEventFilter();
 
 			var result = ReadIndex.ReadAllEventsBackwardFiltered(_backwardReadPos, 10, 10, eventFilter);
 			Assert.AreEqual(1, result.Records.Count);

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -233,7 +233,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			var dto = package.Data.Deserialize<TcpClientMessageDto.FilteredReadAllEvents>();
 			if (dto == null) return null;
 
-			IEventFilter eventFilter = EventFilter.Get(dto.Filter);
+			IEventFilter eventFilter = dto.Filter.ToEventFilter();
 
 			int maxSearchWindow = dto.MaxCount;
 			if (dto.MaxSearchWindow.HasValue) {
@@ -269,7 +269,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			var dto = package.Data.Deserialize<TcpClientMessageDto.FilteredReadAllEvents>();
 			if (dto == null) return null;
 
-			IEventFilter eventFilter = EventFilter.Get(dto.Filter);
+			IEventFilter eventFilter = dto.Filter.ToEventFilter();
 
 			int maxSearchWindow = dto.MaxCount;
 			if (dto.MaxSearchWindow.HasValue) {
@@ -308,7 +308,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			var dto = package.Data.Deserialize<TcpClientMessageDto.FilteredSubscribeToStream>();
 			if (dto == null) return null;
 
-			IEventFilter eventFilter = EventFilter.Get(dto.Filter);
+			IEventFilter eventFilter = dto.Filter.ToEventFilter();
 
 			return new ClientMessage.FilteredSubscribeToStream(Guid.NewGuid(), package.CorrelationId, envelope,
 				connection.ConnectionId, dto.EventStreamId, dto.ResolveLinkTos, user, eventFilter,


### PR DESCRIPTION
Added: A DtoExtension method to parse TcpClientMessageDto.Filter into ReaderIndex.EventFilter

Related to https://github.com/EventStore/home/issues/248

Remove references to Tcp Dtos from `EventFilter`.
This allows the `EventFilter` classes to be moved into the Storage project without depending on types in Core.

Remove TcpClientMessageDtos from filter tests.
The ClientAPI and Http tests already cover parsing the `TcpClientMessageDtos` to Storage `EventFilter`s