### PR TITLE
Allow no time limit to how quickly checkpoints can be written for a persistent subscription 

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -742,9 +742,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			}
 		}
 
-		
+		 
 		private TimeSpan ToCheckPointAfterTimeout(int milliseconds) {
-			return milliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(milliseconds);
+
+			if (milliseconds < 0) return TimeSpan.MinValue; else 
+				return milliseconds == 0 ? TimeSpan.MaxValue : TimeSpan.FromMilliseconds(milliseconds);
+
 		}
 
 		private TimeSpan ToMessageTimeout(int milliseconds) {


### PR DESCRIPTION
Added : `CheckPointAfter` can be set to negative value in Persistent Subscription to checkpoint as quickly as possible

## Note  
 `CheckPointAfter` in Persistent Subscription and `CheckPointAfterMs` in Projections have different behaviors by design. Setting `CheckPointAfter` in Persistent Subscription to 0 will result in **maximum** time between checkpoints and setting `CheckPointAfterMs` in Projections to 0 will results in **minimum** time between checkpoints.





---
Fixes : #1696 