### PR TITLE
Do not connect to PreReadOnlyReplica nodes

### DIFF
--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -211,7 +211,16 @@ namespace EventStore.ClientAPI.Internal {
 			var notAllowedStates = new[] {
 				ClusterMessages.VNodeState.Manager,
 				ClusterMessages.VNodeState.ShuttingDown,
-				ClusterMessages.VNodeState.Shutdown
+				ClusterMessages.VNodeState.Manager,
+				ClusterMessages.VNodeState.Shutdown,
+				ClusterMessages.VNodeState.Unknown,
+				ClusterMessages.VNodeState.Initializing,
+				ClusterMessages.VNodeState.CatchingUp,
+				ClusterMessages.VNodeState.ShuttingDown,
+				ClusterMessages.VNodeState.PreLeader,
+				ClusterMessages.VNodeState.PreReplica,
+				ClusterMessages.VNodeState.PreReadOnlyReplica,
+				ClusterMessages.VNodeState.Clone
 			};
 
 			var nodes = members.Where(x => x.IsAlive)

--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -262,7 +262,6 @@ namespace EventStore.ClientAPI.Internal {
 
 		private bool IsReadOnlyReplicaState(ClusterMessages.VNodeState state) {
 			return state == ClusterMessages.VNodeState.ReadOnlyLeaderless
-			       || state == ClusterMessages.VNodeState.PreReadOnlyReplica
 			       || state == ClusterMessages.VNodeState.ReadOnlyReplica;
 		}
 	}


### PR DESCRIPTION
I encountered an issue where clients would connect to read only replicas which had not yet caught up. This PR will prevent the endpoint discovered from prioritizing such nodes, and [match behavior](https://github.com/EventStore/EventStore-Client-Dotnet/blob/dc6d7dc3941a3c614a5b33aa619eb9306698dc48/src/EventStore.Client/GossipBasedEndpointDiscoverer.cs#L197) with the gRPC client