### PR TITLE
Remove Cancellation Race Condition

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/Authentication/HttpAuthenticationRequest.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/HttpAuthenticationRequest.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 		}
 
 		private void Cancel() {
-			_tcs.TrySetCanceled(_context.RequestAborted);
+			_tcs.TrySetCanceled();
 			_cancellationRegister.Dispose();
 		}
 


### PR DESCRIPTION
Fixed: removed cancellation race condition

Sometimes, if an http request is cancelled, it is possible to see the following error in the logs:

```
An unhandled exception was thrown by the application.
System.AggregateException: One or more errors occurred. (IFeatureCollection has been disposed.
Object name: 'Collection'.)
 ---> System.ObjectDisposedException: IFeatureCollection has been disposed.
Object name: 'Collection'.
   at Microsoft.AspNetCore.Http.Features.FeatureReferences`1.ThrowContextDisposed()
   at Microsoft.AspNetCore.Http.DefaultHttpContext.get_RequestAborted()
   at EventStore.Core.Services.Transport.Http.Authentication.HttpAuthenticationRequest.Cancel() in /build/src/EventStore.Core/Services/Transport/Http/Authentication/HttpAuthenticationRequest.cs:line 36
   at System.Threading.CancellationToken.<>c.<.cctor>b__26_0(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
   --- End of inner exception stack trace ---
   at System.Threading.CancellationTokenSource.ExecuteCallbackHandlers(Boolean throwOnFirstException)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.CancelRequestAbortedToken()
```

While harmless, it's still better to remove noise from the logs.