### PR TITLE
Fix memory/disk space issues during large cascading index merges / index rebuilds (especially when index cache depth is high)

### DIFF
--- a/src/EventStore.Core.Tests/DataStructures/unmanaged_memory_append_only_list_should.cs
+++ b/src/EventStore.Core.Tests/DataStructures/unmanaged_memory_append_only_list_should.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using EventStore.Core.DataStructures;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.DataStructures {
+	[TestFixture(1)]
+	[TestFixture(2)]
+	[TestFixture(10)]
+	[TestFixture(13)]
+	[TestFixture(100)]
+	public class unmanaged_memory_append_only_list_should {
+		private UnmanagedMemoryAppendOnlyList<int> _list;
+		private readonly int _maxCapacity;
+
+		public unmanaged_memory_append_only_list_should(int maxCapacity) {
+			_maxCapacity = maxCapacity;
+		}
+
+		[SetUp]
+		public void SetUp() {
+			_list = new UnmanagedMemoryAppendOnlyList<int>(_maxCapacity);
+		}
+
+		[TearDown]
+		public void TearDown() {
+			_list?.Dispose();
+		}
+
+		[Test]
+		public void correctly_add_items() {
+			Assert.AreEqual(0, _list.Count);
+
+			for (int i = 1; i <= _maxCapacity; i++) {
+				_list.Add(i);
+				Assert.AreEqual(i, _list.Count);
+			}
+
+			for (int i = 0; i < _maxCapacity; i++) {
+				Assert.AreEqual(i + 1, _list[i]);
+			}
+		}
+
+		[Test]
+		public void correctly_clear_items() {
+			Assert.AreEqual(0, _list.Count);
+
+			//add _maxCapacity items with values 1.._maxCapacity
+			for (int i = 1; i <= _maxCapacity; i++) {
+				_list.Add(i);
+				Assert.AreEqual(i, _list.Count);
+			}
+
+			//clear the list
+			_list.Clear();
+			Assert.AreEqual(0, _list.Count);
+
+			//we should not be able to access any item at indexes 0.._maxCapacity-1
+			for (int i = 0; i < _maxCapacity; i++) {
+				Assert.Throws<IndexOutOfRangeException>(() => {
+					var unused = _list[i];
+				});
+			}
+
+			//add _maxCapacity items with values -1..-_maxCapacity
+			for (int i = 1; i <= _maxCapacity; i++) {
+				_list.Add(-i);
+				Assert.AreEqual(i, _list.Count);
+			}
+
+			//verify that the new items have been correctly added
+			for (int i = 0; i < _maxCapacity; i++) {
+				Assert.AreEqual(-(i + 1), _list[i]);
+			}
+		}
+
+		[Test]
+		public void throw_max_capacity_reached_exception_if_list_is_full() {
+			for (int i = 1; i <= _maxCapacity; i++) {
+				_list.Add(0);
+			}
+
+			Assert.Throws<MaxCapacityReachedException>(() => {
+				_list.Add(0);
+			});
+		}
+
+		[Test]
+		public void throw_index_out_of_range_exception_when_accessing_out_of_bounds_index() {
+			int unused;
+			Assert.Throws<IndexOutOfRangeException>(() => {
+				unused = _list[-1];
+			});
+
+			Assert.Throws<IndexOutOfRangeException>(() => {
+				unused = _list[-2];
+			});
+
+			for (int i = 0; i < _maxCapacity; i++) {
+				Assert.Throws<IndexOutOfRangeException>(() => {
+					unused = _list[i];
+				});
+				_list.Add(0);
+
+				Assert.DoesNotThrow(() => {
+					unused = _list[i];
+				});
+			}
+
+			Assert.Throws<IndexOutOfRangeException>(() => {
+				unused = _list[_maxCapacity];
+			});
+
+			Assert.Throws<IndexOutOfRangeException>(() => {
+				unused = _list[_maxCapacity + 1];
+			});
+		}
+	}
+
+	public class unmanaged_memory_append_only_list_with_non_positive_capacity_should {
+		[Test]
+		public void throw_argument_exception() {
+			Assert.Throws<ArgumentException>(() => {
+				var unused = new UnmanagedMemoryAppendOnlyList<int>(0);
+			});
+
+			Assert.Throws<ArgumentException>(() => {
+				var unused = new UnmanagedMemoryAppendOnlyList<int>(-1);
+			});
+
+			Assert.Throws<ArgumentException>(() => {
+				var unused = new UnmanagedMemoryAppendOnlyList<int>(-2);
+			});
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/DataStructures/unmanaged_memory_append_only_list_should.cs
+++ b/src/EventStore.Core.Tests/DataStructures/unmanaged_memory_append_only_list_should.cs
@@ -41,6 +41,20 @@ namespace EventStore.Core.Tests.DataStructures {
 		}
 
 		[Test]
+		public void return_correct_count_and_items_with_as_span() {
+			Assert.AreEqual(0, _list.AsSpan().Length);
+
+			for (int i = 1; i <= _maxCapacity; i++) {
+				_list.Add(i);
+				var span = _list.AsSpan();
+				Assert.AreEqual(i,span.Length);
+				for (int j = 0; j < i; j++) {
+					Assert.AreEqual(j+1, span[j]);
+				}
+			}
+		}
+
+		[Test]
 		public void correctly_clear_items() {
 			Assert.AreEqual(0, _list.Count);
 

--- a/src/EventStore.Core.Tests/DataStructures/unmanaged_memory_append_only_list_should.cs
+++ b/src/EventStore.Core.Tests/DataStructures/unmanaged_memory_append_only_list_should.cs
@@ -114,6 +114,24 @@ namespace EventStore.Core.Tests.DataStructures {
 				unused = _list[_maxCapacity + 1];
 			});
 		}
+
+		[Test]
+		public void be_passed_by_reference() {
+			Assert.AreEqual(0, _list.Count);
+			Add(_list, 5);
+			Assert.AreEqual(1, _list.Count);
+			Assert.AreEqual(5, _list[0]);
+			Clear(_list);
+			Assert.AreEqual(0, _list.Count);
+		}
+
+		private static void Add(IAppendOnlyList<int> list, int value) {
+			list.Add(value);
+		}
+
+		private static void Clear(IAppendOnlyList<int> list) {
+			list.Clear();
+		}
 	}
 
 	public class unmanaged_memory_append_only_list_with_non_positive_capacity_should {

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/rolling_manual_only_merges.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/rolling_manual_only_merges.cs
@@ -14,17 +14,13 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 		[Test]
 		public void alternating_table_dumps_and_manual_merges_should_merge_correctly() {
 			AddTables(1);
-			var (level, table) = _result.MergedMap.GetTableForManualMerge();
-			Assert.Null(table); //if there is only one table it shouldn't be merged
 			Assert.AreEqual(1, _result.MergedMap.InOrder().Count());
 			for (int i = 0; i < 100; i++) {
 				AddTables(1);
 				Assert.AreEqual(2, _result.MergedMap.InOrder().Count());
 
-				(level, table) = _result.MergedMap.GetTableForManualMerge();
-				_result = _result.MergedMap.AddPTable(table, _result.MergedMap.PrepareCheckpoint,
-					_result.MergedMap.CommitCheckpoint, UpgradeHash, ExistsAt, RecordExistsAt, _fileNameProvider,
-					_ptableVersion, level, 16, false);
+				_result = _result.MergedMap.TryManualMerge(UpgradeHash, ExistsAt, RecordExistsAt, _fileNameProvider,
+					_ptableVersion, 16, false);
 				_result.ToDelete.ForEach(x => x.MarkForDestruction());
 				Assert.AreEqual(1, _result.MergedMap.InOrder().Count());
 			}

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_auto_merge_level_is_zero.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_auto_merge_level_is_zero.cs
@@ -14,9 +14,9 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 		[Test]
 		public void manual_merge_should_merge_all_tables() {
 			AddTables(11);
-			var (level, table) = _result.MergedMap.GetTableForManualMerge();
-			_result = _result.MergedMap.AddPTable(table, -1, -1, UpgradeHash, ExistsAt, RecordExistsAt,
-				_fileNameProvider, _ptableVersion, level);
+			_result = _result.MergedMap.TryManualMerge(
+				UpgradeHash, ExistsAt, RecordExistsAt,
+				_fileNameProvider, _ptableVersion);
 			Assert.AreEqual(1, _result.MergedMap.InOrder().Count());
 		}
 	}

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_reduced.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_reduced.cs
@@ -17,12 +17,9 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 			_result.MergedMap.Dispose(TimeSpan.FromMilliseconds(100));
 			_map.Dispose(TimeSpan.FromMilliseconds(100));
 			_map = IndexMapTestFactory.FromFile(filename, maxAutoMergeLevel: 3);
-			var (level, table) = _map.GetTableForManualMerge();
-			Assert.Greater(level, _maxAutoMergeLevel);
-			_result = _map.AddPTable(table, _result.MergedMap.PrepareCheckpoint, _result.MergedMap.CommitCheckpoint,
+			_result = _map.TryManualMerge(
 				UpgradeHash, ExistsAt,
 				RecordExistsAt, _fileNameProvider, _ptableVersion,
-				level: level,
 				skipIndexVerify: _skipIndexVerify);
 			Assert.AreEqual(2, _result.MergedMap.InOrder().Count());
 		}

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_set.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_max_auto_merge_level_is_set.cs
@@ -38,15 +38,14 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 			if (_result != null)
 				first = _result.MergedMap;
 			var pTable = PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
-			_result = first.AddPTable(pTable,
-				10, 20, UpgradeHash, ExistsAt, RecordExistsAt, _fileNameProvider, _ptableVersion,
-				0, 0, skipIndexVerify: _skipIndexVerify);
+			_result = first.AddAndMergePTable(pTable,
+				10, 20, UpgradeHash, ExistsAt, RecordExistsAt, _fileNameProvider, _ptableVersion,0, skipIndexVerify: _skipIndexVerify);
 			for (int i = 3; i <= count * 2; i += 2) {
 				pTable = PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
-				_result = _result.MergedMap.AddPTable(
+				_result = _result.MergedMap.AddAndMergePTable(
 					pTable,
 					i * 10, (i + 1) * 10, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
-					_fileNameProvider, _ptableVersion, 0, 0, skipIndexVerify: _skipIndexVerify);
+					_fileNameProvider, _ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 				_result.ToDelete.ForEach(x => x.MarkForDestruction());
 			}
 		}

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_multiple_tables_higher_than_manual_merge_level.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_multiple_tables_higher_than_manual_merge_level.cs
@@ -17,13 +17,9 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 
 		[Test]
 		public void tables_should_be_merged() {
-			var (level, table) = _map.GetTableForManualMerge();
-			Assert.NotNull(table);
-
-			_result = _map.AddPTable(table, _result.MergedMap.PrepareCheckpoint, _result.MergedMap.CommitCheckpoint,
+			_result = _map.TryManualMerge(
 				UpgradeHash, ExistsAt,
 				RecordExistsAt, _fileNameProvider, _ptableVersion,
-				level: level,
 				skipIndexVerify: _skipIndexVerify);
 			Assert.AreEqual(1, _result.MergedMap.InOrder().Count());
 		}

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_no_tables_are_eligible_for_manual_merge.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_no_tables_are_eligible_for_manual_merge.cs
@@ -8,25 +8,26 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 			base.Setup();
 			AddTables(8);
 			Assert.AreEqual(2, _result.MergedMap.InOrder().Count());
-			var (level, table) = _result.MergedMap.GetTableForManualMerge();
-			Assert.NotNull(table);
 
-			_result = _result.MergedMap.AddPTable(table, _result.MergedMap.PrepareCheckpoint,
-				_result.MergedMap.CommitCheckpoint, UpgradeHash, ExistsAt,
+			_result = _result.MergedMap.TryManualMerge(
+				UpgradeHash, ExistsAt,
 				RecordExistsAt, _fileNameProvider, _ptableVersion,
-				level: level,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		}
 
 		[Test]
-		public void should_not_return_table_for_merge() {
+		public void should_not_manually_merge_any_table() {
 			Assert.AreEqual(1, _result.MergedMap.InOrder().Count());
 			AddTables(3); //adding 3 tables will cause an auto merge, but not enough to give us tables for manual merge
-			var (level, table) = _result.MergedMap.GetTableForManualMerge();
-			Assert.Null(table);
-
 			Assert.AreEqual(3, _result.MergedMap.InOrder().Count());
+
+			_result = _result.MergedMap.TryManualMerge(
+				UpgradeHash, ExistsAt,
+				RecordExistsAt, _fileNameProvider, _ptableVersion,
+				skipIndexVerify: _skipIndexVerify);
+
+			Assert.False(_result.HasMergedAny);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_no_tables_have_yet_reached_maximum_automerge_level.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_no_tables_have_yet_reached_maximum_automerge_level.cs
@@ -5,12 +5,17 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 	public class when_no_tables_have_yet_reached_maximum_automerge_level : when_max_auto_merge_level_is_set {
 		[Test]
-		public void should_not_return_table_for_merge() {
+		public void should_not_manually_merge_any_table() {
 			AddTables(3);
 			Assert.AreEqual(2, _result.MergedMap.InOrder().Count());
-			var (level, table) = _result.MergedMap.GetTableForManualMerge();
-			Assert.AreEqual(1, level);
-			Assert.Null(table);
+			var result = _result.MergedMap.TryManualMerge(
+				UpgradeHash,
+				ExistsAt,
+				RecordExistsAt,
+				_fileNameProvider,
+				_ptableVersion,
+				skipIndexVerify: _skipIndexVerify);
+			Assert.False(result.HasMergedAny);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_only_one_table_file_higher_than_manual_merge_level.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_only_one_table_file_higher_than_manual_merge_level.cs
@@ -19,9 +19,16 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 		}
 
 		[Test]
-		public void no_table_should_be_available_for_merge() {
-			var (_, table) = _map.GetTableForManualMerge();
-			Assert.Null(table);
+		public void no_table_should_manually_merged() {
+			var result = _map.TryMergeOneLevel(
+				UpgradeHash,
+				ExistsAt,
+				RecordExistsAt,
+				_fileNameProvider,
+				_ptableVersion,
+				skipIndexVerify: _skipIndexVerify
+				);
+			Assert.False(result.HasMergedAny);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_tables_available_for_manual_merge.cs
+++ b/src/EventStore.Core.Tests/Index/AutoMergeLevelTests/when_tables_available_for_manual_merge.cs
@@ -8,12 +8,8 @@ namespace EventStore.Core.Tests.Index.AutoMergeLevelTests {
 		public void should_merge_pending_tables_at_max_auto_merge_level() {
 			AddTables(100);
 			Assert.AreEqual(25, _result.MergedMap.InOrder().Count());
-			var (level, table) = _result.MergedMap.GetTableForManualMerge();
-			Assert.Greater(level, 2);
-			_result = _result.MergedMap.AddPTable(table, _result.MergedMap.PrepareCheckpoint,
-				_result.MergedMap.CommitCheckpoint, UpgradeHash, ExistsAt,
+			_result = _result.MergedMap.TryManualMerge(UpgradeHash, ExistsAt,
 				RecordExistsAt, _fileNameProvider, _ptableVersion,
-				level: level,
 				skipIndexVerify: _skipIndexVerify);
 			Assert.AreEqual(1, _result.MergedMap.InOrder().Count());
 		}

--- a/src/EventStore.Core.Tests/Index/IndexMapExtensions.cs
+++ b/src/EventStore.Core.Tests/Index/IndexMapExtensions.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using EventStore.Core.Index;
+
+namespace EventStore.Core.Tests.Index {
+	public static class IndexMapExtensions {
+		public static MergeResult AddAndMergePTable(
+			this IndexMap indexMap,
+			PTable tableToAdd,
+			int prepareCheckpoint,
+			int commitCheckpoint,
+			Func<string, ulong, ulong> upgradeHash,
+			Func<IndexEntry, bool> existsAt,
+			Func<IndexEntry, Tuple<string, bool>> recordExistsAt,
+			IIndexFilenameProvider filenameProvider,
+			byte version,
+			int indexCacheDepth = 16,
+			bool skipIndexVerify = false) {
+
+			var addResult = indexMap.AddPTable(tableToAdd, prepareCheckpoint, commitCheckpoint);
+			if (addResult.CanMergeAny) {
+				var toDelete = new List<PTable>();
+				MergeResult mergeResult;
+				IndexMap curMap = addResult.NewMap;
+				do {
+					mergeResult = curMap.TryMergeOneLevel(
+						upgradeHash,
+						existsAt,
+						recordExistsAt,
+						filenameProvider,
+						version,
+						indexCacheDepth,
+						skipIndexVerify
+					);
+
+					curMap = mergeResult.MergedMap;
+					toDelete.AddRange(mergeResult.ToDelete);
+				} while (mergeResult.CanMergeAny);
+
+				return new MergeResult(curMap, toDelete, true, false);
+			}
+			return new MergeResult(addResult.NewMap, new List<PTable>(), false, false);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_four_tables_per_level_causes_merge.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_four_tables_per_level_causes_merge.cs
@@ -37,41 +37,40 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_mergeFile = GetTempFilePath();
 			_filename = GetTempFilePath();
 
-			_map = IndexMapTestFactory.FromFile(_filename, maxTablesPerLevel: 4);
+			_map = IndexMapTestFactory.FromFile(_filename, maxTablesPerLevel: 4, maxAutoMergeLevel:_maxAutoMergeIndexLevel);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 1, 0);
 
-			_result = _map.AddPTable(
+			_result = _map.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 1, 2,
 				(streamId, hash) => hash,
 				_ => true,
 				_ => new System.Tuple<string, bool>("", true),
 				new GuidFilenameProvider(PathName),
 				_ptableVersion,
-				_maxAutoMergeIndexLevel,
 				0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 3, 4,
 				(streamId, hash) => hash,
 				_ => true, _ => new System.Tuple<string, bool>("", true), new GuidFilenameProvider(PathName),
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 4, 5,
 				(streamId, hash) => hash,
 				_ => true, _ => new System.Tuple<string, bool>("", true), new GuidFilenameProvider(PathName),
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 1,
 				(streamId, hash) => hash,
 				_ => true, _ => new System.Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile),
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_two_tables_per_level_causes_double_merge.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_four_items_to_empty_index_map_with_two_tables_per_level_causes_double_merge.cs
@@ -38,33 +38,32 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_mergeFile = GetTempFilePath();
 			_filename = GetTempFilePath();
 
-			_map = IndexMapTestFactory.FromFile(_filename, maxTablesPerLevel: 2);
+			_map = IndexMapTestFactory.FromFile(_filename, maxTablesPerLevel: 2, maxAutoMergeLevel: _maxAutoMergeIndexLevel);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 1, 0);
 
-			_result = _map.AddPTable(
+			_result = _map.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				10, 20, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
-				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0,
+				new GuidFilenameProvider(PathName), _ptableVersion, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				20, 30, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
-				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0,
+				new GuidFilenameProvider(PathName), _ptableVersion, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				30, 40, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
-				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0,
+				new GuidFilenameProvider(PathName), _ptableVersion, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				50, 60, (streamId, hash) => hash, _ => true, _ => new Tuple<string, bool>("", true),
-				new FakeFilenameProvider(_mergeFile + ".firstmerge", _mergeFile), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				new FakeFilenameProvider(_mergeFile + ".firstmerge", _mergeFile), _ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_item_to_empty_index_map.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_item_to_empty_index_map.cs
@@ -36,13 +36,12 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_tablename = GetTempFilePath();
 			_mergeFile = GetFilePathFor("mergefile");
 
-			_map = IndexMapTestFactory.FromFile(_filename);
+			_map = IndexMapTestFactory.FromFile(_filename, maxAutoMergeLevel: _maxAutoMergeIndexLevel);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 1, 0);
 			var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
-			_result = _map.AddPTable(table, 7, 11, (streamId, hash) => hash, _ => true,
-				_ => new System.Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+			_result = _map.AddAndMergePTable(table, 7, 11, (streamId, hash) => hash, _ => true,
+				_ => new System.Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			table.MarkForDestruction();
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_sixteen_items_to_empty_index_map_with_four_tables_per_level_causes_double_merge.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_sixteen_items_to_empty_index_map_with_four_tables_per_level_causes_double_merge.cs
@@ -40,89 +40,89 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_finalmergefile = GetTempFilePath();
 			_finalmergefile2 = GetTempFilePath();
 
-			_map = IndexMapTestFactory.FromFile(_filename);
+			_map = IndexMapTestFactory.FromFile(_filename, maxAutoMergeLevel: _maxAutoMergeIndexLevel);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 1, 0);
 			var guidFilename = new GuidFilenameProvider(PathName);
-			_result = _map.AddPTable(
+			_result = _map.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 0, 0,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true), guidFilename,
-				_ptableVersion, _maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify);
+				_ptableVersion, 0, skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify), 1, 2,
 				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true),
-				new FakeFilenameProvider(_finalmergefile, _finalmergefile2), _ptableVersion, 4, 0,
+				new FakeFilenameProvider(_finalmergefile, _finalmergefile2), _ptableVersion, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		}

--- a/src/EventStore.Core.Tests/Index/IndexV1/adding_two_items_to_empty_index_map_with_two_tables_per_level_causes_merge.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/adding_two_items_to_empty_index_map_with_two_tables_per_level_causes_merge.cs
@@ -37,20 +37,20 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_filename = GetTempFilePath();
 			_mergeFile = GetTempFilePath();
 
-			_map = IndexMapTestFactory.FromFile(_filename, maxTablesPerLevel: 2);
+			_map = IndexMapTestFactory.FromFile(_filename, maxTablesPerLevel: 2, maxAutoMergeLevel: _maxAutoMergeIndexLevel);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 1, 0);
 
-			_result = _map.AddPTable(
+			_result = _map.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				123, 321, (streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true),
-				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0,
+				new GuidFilenameProvider(PathName), _ptableVersion, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
-			_result = _result.MergedMap.AddPTable(
+			_result = _result.MergedMap.AddAndMergePTable(
 				PTable.FromMemtable(memtable, GetTempFilePath(), Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify),
 				100, 400, (streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true),
-				new FakeFilenameProvider(_mergeFile), _ptableVersion, _maxAutoMergeIndexLevel, 0,
+				new FakeFilenameProvider(_mergeFile), _ptableVersion, 0,
 				skipIndexVerify: _skipIndexVerify);
 			_result.ToDelete.ForEach(x => x.MarkForDestruction());
 		}

--- a/src/EventStore.Core.Tests/Index/IndexV1/index_map_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/index_map_should.cs
@@ -19,7 +19,6 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		private IndexMap _emptyIndexMap;
 		private PTable _ptable;
 		protected byte _ptableVersion = PTableVersions.IndexV1;
-		private int _maxAutoMergeIndexLevel = 4;
 
 		public index_map_should(byte version) {
 			_ptableVersion = version;
@@ -47,16 +46,12 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 
 		[Test]
 		public void not_allow_negative_prepare_checkpoint_when_adding_ptable() {
-			Assert.Throws<ArgumentOutOfRangeException>(() => _emptyIndexMap.AddPTable(_ptable, -1, 0,
-				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true),
-				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0));
+			Assert.Throws<ArgumentOutOfRangeException>(() => _emptyIndexMap.AddPTable(_ptable, -1, 0));
 		}
 
 		[Test]
 		public void not_allow_negative_commit_checkpoint_when_adding_ptable() {
-			Assert.Throws<ArgumentOutOfRangeException>(() => _emptyIndexMap.AddPTable(_ptable, 0, -1,
-				(streamId, hash) => hash, _ => true, _ => new System.Tuple<string, bool>("", true),
-				new GuidFilenameProvider(PathName), _ptableVersion, _maxAutoMergeIndexLevel, 0));
+			Assert.Throws<ArgumentOutOfRangeException>(() => _emptyIndexMap.AddPTable(_ptable, 0, -1));
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Index/IndexV1/index_map_should_detect_corruption.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/index_map_should_detect_corruption.cs
@@ -35,15 +35,14 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			_indexMapFileName = GetFilePathFor("index.map");
 			_ptableFileName = GetFilePathFor("ptable");
 
-			var indexMap = IndexMapTestFactory.FromFile(_indexMapFileName, maxTablesPerLevel: 2);
+			var indexMap = IndexMapTestFactory.FromFile(_indexMapFileName, maxTablesPerLevel: 2, maxAutoMergeLevel: _maxAutoMergeIndexLevel);
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 0, 0);
 			memtable.Add(1, 1, 100);
 			_ptable = PTable.FromMemtable(memtable, _ptableFileName, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault, skipIndexVerify: _skipIndexVerify);
 
-			indexMap = indexMap.AddPTable(_ptable, 0, 0, (streamId, hash) => hash, _ => true,
-				_ => new Tuple<string, bool>("", true), new GuidFilenameProvider(PathName), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0, skipIndexVerify: _skipIndexVerify).MergedMap;
+			indexMap = indexMap.AddAndMergePTable(_ptable, 0, 0, (streamId, hash) => hash, _ => true,
+				_ => new Tuple<string, bool>("", true), new GuidFilenameProvider(PathName), _ptableVersion, 0, skipIndexVerify: _skipIndexVerify).MergedMap;
 			indexMap.SaveToFile(_indexMapFileName);
 		}
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/ptable_midpoint_cache_should.cs
@@ -52,21 +52,21 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			return ptable;
 		}
 
-		private void ValidateCache(PTable.Midpoint[] cache, int count, int depth) {
+		private void ValidateCache(ReadOnlySpan<PTable.Midpoint> cache, int count, int depth) {
 			if (count == 0 || depth == 0) {
-				Assert.IsNull(cache);
+				Assert.True(cache.IsEmpty);
 				return;
 			}
 
 			if (count == 1) {
-				Assert.IsNotNull(cache);
+				Assert.False(cache.IsEmpty);
 				Assert.AreEqual(2, cache.Length);
 				Assert.AreEqual(0, cache[0].ItemIndex);
 				Assert.AreEqual(0, cache[1].ItemIndex);
 				return;
 			}
 
-			Assert.IsNotNull(cache);
+			Assert.False(cache.IsEmpty);
 			Assert.AreEqual(Math.Min(count, 1 << depth), cache.Length);
 
 			Assert.AreEqual(0, cache[0].ItemIndex);

--- a/src/EventStore.Core.Tests/Index/IndexV1/saving_index_with_single_item_to_a_file.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/saving_index_with_single_item_to_a_file.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 2, 7);
 			var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
-			_result = _map.AddPTable(table, 7, 11, (streamId, hash) => hash, _ => true,
+			_result = _map.AddAndMergePTable(table, 7, 11, (streamId, hash) => hash, _ => true,
 				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
 			_result.MergedMap.SaveToFile(_filename);
 			_result.ToDelete.ForEach(x => x.Dispose());

--- a/src/EventStore.Core.Tests/Index/IndexV1/saving_index_with_six_items_to_a_file.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/saving_index_with_six_items_to_a_file.cs
@@ -18,7 +18,6 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		private IndexMap _map;
 		private MergeResult _result;
 		protected byte _ptableVersion = PTableVersions.IndexV1;
-		private int _maxAutoMergeIndexLevel = 4;
 
 		public saving_index_with_six_items_to_a_file(byte version) {
 			_ptableVersion = version;
@@ -36,24 +35,18 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var memtable = new HashListMemTable(_ptableVersion, maxSize: 10);
 			memtable.Add(0, 2, 123);
 			var table = PTable.FromMemtable(memtable, _tablename, Constants.PTableInitialReaderCount, Constants.PTableMaxReaderCountDefault);
-			_result = _map.AddPTable(table, 0, 0, (streamId, hash) => hash, _ => true,
-				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0);
-			_result = _result.MergedMap.AddPTable(table, 0, 0, (streamId, hash) => hash, _ => true,
-				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0);
-			_result = _result.MergedMap.AddPTable(table, 0, 0, (streamId, hash) => hash, _ => true,
-				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0);
-			var merged = _result.MergedMap.AddPTable(table, 0, 0, (streamId, hash) => hash, _ => true,
-				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0);
-			_result = merged.MergedMap.AddPTable(table, 0, 0, (streamId, hash) => hash, _ => true,
-				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0);
-			_result = _result.MergedMap.AddPTable(table, 7, 11, (streamId, hash) => hash, _ => true,
-				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion,
-				_maxAutoMergeIndexLevel, 0);
+			_result = _map.AddAndMergePTable(table, 0, 0, (streamId, hash) => hash, _ => true,
+				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
+			_result = _result.MergedMap.AddAndMergePTable(table, 0, 0, (streamId, hash) => hash, _ => true,
+				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
+			_result = _result.MergedMap.AddAndMergePTable(table, 0, 0, (streamId, hash) => hash, _ => true,
+				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
+			var merged = _result.MergedMap.AddAndMergePTable(table, 0, 0, (streamId, hash) => hash, _ => true,
+				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
+			_result = merged.MergedMap.AddAndMergePTable(table, 0, 0, (streamId, hash) => hash, _ => true,
+				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
+			_result = _result.MergedMap.AddAndMergePTable(table, 7, 11, (streamId, hash) => hash, _ => true,
+				_ => new Tuple<string, bool>("", true), new FakeFilenameProvider(_mergeFile), _ptableVersion, 0);
 			_result.MergedMap.SaveToFile(_filename);
 
 			table.Dispose();

--- a/src/EventStore.Core.Tests/Index/IndexV4/when_merging_ptables_with_entries_to_nonexisting_record.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV4/when_merging_ptables_with_entries_to_nonexisting_record.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 
 		[Test]
 		public void the_correct_midpoints_are_cached() {
-			PTable.Midpoint[] midpoints = _newtable.GetMidPoints();
+			var midpoints = _newtable.GetMidPoints();
 			var requiredMidpoints = PTable.GetRequiredMidpointCountCached(_newtable.Count, _ptableVersion);
 
 			Assert.AreEqual(requiredMidpoints, midpoints.Length);

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_fails.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_fails.cs
@@ -26,20 +26,11 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			_indexDir = PathName;
 
 			var fakeReader = new TFReaderLease(new FakeIndexReader());
-			int readerCount = 0;
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
 			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
-				() => {
-					readerCount++;
-					if (readerCount < 4) // One for each table add.
-					{
-						return fakeReader;
-					}
-
-					throw new Exception("Expected exception");
-				},
+				() => throw new Exception("Expected exception") /* throw an exception when the first PTable scavenge starts and tries to acquire a reader */,
 				PTableVersions.IndexV4,
 				5, Constants.PTableMaxReaderCountDefault,
 				maxSizeForMemory: 2,

--- a/src/EventStore.Core/DataStructures/UnmanagedMemoryAppendOnlyList.cs
+++ b/src/EventStore.Core/DataStructures/UnmanagedMemoryAppendOnlyList.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace EventStore.Core.DataStructures {
+
+	public interface IAppendOnlyList<in T> {
+		void Add(T item);
+		void Clear();
+		int Count { get; }
+	}
+
+	public sealed class UnmanagedMemoryAppendOnlyList<T> : IAppendOnlyList<T>, IDisposable {
+		private readonly int _maxCapacity;
+		private readonly IntPtr _dataPtr;
+
+		private int _count;
+		private bool _disposed;
+
+		public UnmanagedMemoryAppendOnlyList(int maxCapacity) {
+			if (maxCapacity <= 0) {
+				throw new ArgumentException("maxCapacity must be positive");
+			}
+
+			_maxCapacity = maxCapacity;
+			_count = 0;
+			_dataPtr = IntPtr.Zero;
+			_dataPtr = Marshal.AllocHGlobal(new IntPtr((long)_maxCapacity * Marshal.SizeOf(typeof(T))));
+		}
+
+		~UnmanagedMemoryAppendOnlyList() => Dispose(false);
+
+		public void Add(T item) {
+			if (_count >= _maxCapacity)
+				throw new MaxCapacityReachedException();
+
+			unsafe
+			{
+				new Span<T>(_dataPtr.ToPointer(), _maxCapacity) {
+					[_count] = item
+				};
+			}
+			_count++;
+		}
+
+		public void Clear() {
+			_count = 0;
+		}
+
+		public int Count => _count;
+
+		public T this[int index] {
+			get {
+				if (index < 0 || index >= _count) {
+					throw new IndexOutOfRangeException();
+				}
+
+				unsafe
+				{
+					return new ReadOnlySpan<T>(_dataPtr.ToPointer(), _maxCapacity)[index];
+				}
+			}
+		}
+
+		public void Dispose() {
+			Dispose(true);
+		}
+
+		private void Dispose(bool disposing) {
+			if (_disposed) {
+				return;
+			}
+
+			if (disposing) {
+				//dispose any managed objects here
+			}
+
+			if (_dataPtr != IntPtr.Zero) {
+				Marshal.FreeHGlobal(_dataPtr);
+			}
+
+			_disposed = true;
+		}
+	}
+
+	public class MaxCapacityReachedException : Exception {
+		public MaxCapacityReachedException() : base("Max capacity reached") {
+		}
+	}
+}

--- a/src/EventStore.Core/DataStructures/UnmanagedMemoryAppendOnlyList.cs
+++ b/src/EventStore.Core/DataStructures/UnmanagedMemoryAppendOnlyList.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.DataStructures {
 
 		public UnmanagedMemoryAppendOnlyList(int maxCapacity) {
 			if (maxCapacity <= 0) {
-				throw new ArgumentException("maxCapacity must be positive");
+				throw new ArgumentException($"{nameof(maxCapacity)} must be positive");
 			}
 
 			_maxCapacity = maxCapacity;

--- a/src/EventStore.Core/DataStructures/UnmanagedMemoryAppendOnlyList.cs
+++ b/src/EventStore.Core/DataStructures/UnmanagedMemoryAppendOnlyList.cs
@@ -63,6 +63,7 @@ namespace EventStore.Core.DataStructures {
 
 		public void Dispose() {
 			Dispose(true);
+			GC.SuppressFinalize(this);
 		}
 
 		private void Dispose(bool disposing) {

--- a/src/EventStore.Core/DataStructures/UnmanagedMemoryAppendOnlyList.cs
+++ b/src/EventStore.Core/DataStructures/UnmanagedMemoryAppendOnlyList.cs
@@ -55,6 +55,14 @@ namespace EventStore.Core.DataStructures {
 		}
 
 		public int Count => _count;
+		public ReadOnlySpan<T> AsSpan() {
+			if (_dataPtr == IntPtr.Zero)
+				return ReadOnlySpan<T>.Empty;
+
+			unsafe {
+				return new ReadOnlySpan<T>(_dataPtr.ToPointer(), _maxCapacity).Slice(0, _count);
+			}
+		}
 
 		public T this[int index] {
 			get {

--- a/src/EventStore.Core/Index/AddResult.cs
+++ b/src/EventStore.Core/Index/AddResult.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+
+namespace EventStore.Core.Index {
+	public class AddResult {
+		public readonly IndexMap NewMap;
+		public readonly bool CanMergeAny;
+
+		public AddResult(IndexMap newMap, bool canMergeAny) {
+			NewMap = newMap;
+			CanMergeAny = canMergeAny;
+		}
+	}
+}

--- a/src/EventStore.Core/Index/IndexMap.cs
+++ b/src/EventStore.Core/Index/IndexMap.cs
@@ -372,30 +372,6 @@ namespace EventStore.Core.Index {
 			}
 		}
 
-		public Tuple<int, PTable> GetTableForManualMerge() {
-			//we have more than one entry at the max level
-			//or we have at least one entry at the max level and tables at a level above it
-			// or we have any tables > max level
-			var tablesExistAtMaxLevelOrAbove = _map.Count > _maxTableLevelsForAutomaticMerge
-			                                   && _map[_maxTableLevelsForAutomaticMerge] != null;
-			bool moreThanOneEntryAtMaxLevel = tablesExistAtMaxLevelOrAbove
-			                                  && _map[_maxTableLevelsForAutomaticMerge].Count > 1;
-			bool atLeastOneEntryAtMaxLevelAndOneAboveIt =
-				tablesExistAtMaxLevelOrAbove && _map[_maxTableLevelsForAutomaticMerge].Count == 1
-				                             && _map.Count > _maxTableLevelsForAutomaticMerge + 1
-				                             && _map.Skip(_maxTableLevelsForAutomaticMerge).Any(x => x.Count > 0);
-			bool moreThanOneEntryAboveMaxLevel = tablesExistAtMaxLevelOrAbove &&
-			                                     _map.Skip(_maxTableLevelsForAutomaticMerge).Any(x => x.Count > 1) ||
-			                                     _map.Skip(_maxTableLevelsForAutomaticMerge).Count(x => x.Count > 0) >
-			                                     1;
-			if (moreThanOneEntryAtMaxLevel || atLeastOneEntryAtMaxLevelAndOneAboveIt || moreThanOneEntryAboveMaxLevel) {
-				//we don't actually care which table we return here as manual merge will actually just iterate over anything above the max merge level
-				return Tuple.Create(_map.Count, _map[_map.Count - 1].FirstOrDefault());
-			}
-
-			return Tuple.Create(_map.Count - 1, default(PTable));
-		}
-
 		public AddResult AddPTable(PTable tableToAdd,
 			long prepareCheckpoint,
 			long commitCheckpoint) {

--- a/src/EventStore.Core/Index/IndexMap.cs
+++ b/src/EventStore.Core/Index/IndexMap.cs
@@ -447,7 +447,7 @@ namespace EventStore.Core.Index {
 
 			var tables = CopyFrom(_map);
 
-			if (tables.Count < _maxTableLevelsForAutomaticMerge) {
+			if (tables.Count <= _maxTableLevelsForAutomaticMerge) {
 				return new MergeResult(this, new List<PTable>(), false, false);
 			}
 

--- a/src/EventStore.Core/Index/IndexMap.cs
+++ b/src/EventStore.Core/Index/IndexMap.cs
@@ -396,69 +396,58 @@ namespace EventStore.Core.Index {
 			return Tuple.Create(_map.Count - 1, default(PTable));
 		}
 
-		public MergeResult AddPTable(PTable tableToAdd,
+		public AddResult AddPTable(PTable tableToAdd,
 			long prepareCheckpoint,
-			long commitCheckpoint,
-			Func<string, ulong, ulong> upgradeHash,
-			Func<IndexEntry, bool> existsAt,
-			Func<IndexEntry, Tuple<string, bool>> recordExistsAt,
-			IIndexFilenameProvider filenameProvider,
-			byte version,
-			int level,
-			int indexCacheDepth = 16,
-			bool skipIndexVerify = false) {
-			bool isManual;
-			//if (_maxTableLevelsForAutomaticMerge == 0)
-			//{
-			//    //when we are not auto merging at all, a manual merge will only be triggered if
-			//    //there are entries in the index map. the table it passes is always the first table
-			//    //at the maximum automerge level, so we only need to hit the first table and see if it
-			//    //matches, otherwise it must be an an add of a memtable.
-			//    //although we are not automatically merging, the automerge process is also responsible
-			//    //for writing out the memtable that just got persisted so we want to call auto merge still
-			//    isManual = _map.Count != 0 && _map[0].FirstOrDefault() == tableToAdd;
-			//}
-			//else
-			//{
-			isManual = level > _maxTableLevelsForAutomaticMerge;
-			//}
-
-			if (isManual) {
-				//For manual merge, we are never adding any extra entries, just merging existing files, so the index p/c checkpoint won't change
-				return AddPTableForManualMerge(PrepareCheckpoint, CommitCheckpoint, upgradeHash, existsAt,
-					recordExistsAt,
-					filenameProvider, version, indexCacheDepth, skipIndexVerify);
-			}
-
-			return AddPTableForAutomaticMerge(tableToAdd, prepareCheckpoint, commitCheckpoint, upgradeHash,
-				existsAt, recordExistsAt, filenameProvider, version, indexCacheDepth, skipIndexVerify);
-		}
-
-		public MergeResult AddPTableForAutomaticMerge(PTable tableToAdd,
-			long prepareCheckpoint,
-			long commitCheckpoint,
-			Func<string, ulong, ulong> upgradeHash,
-			Func<IndexEntry, bool> existsAt,
-			Func<IndexEntry, Tuple<string, bool>> recordExistsAt,
-			IIndexFilenameProvider filenameProvider,
-			byte version,
-			int indexCacheDepth = 16,
-			bool skipIndexVerify = false) {
+			long commitCheckpoint) {
+			Ensure.NotNull(tableToAdd, "tableToAdd");
 			Ensure.Nonnegative(prepareCheckpoint, "prepareCheckpoint");
 			Ensure.Nonnegative(commitCheckpoint, "commitCheckpoint");
 
 			var tables = CopyFrom(_map);
 			AddTableToTables(tables, 0, tableToAdd);
 
+			var indexMap = new IndexMap(Version, tables, prepareCheckpoint, commitCheckpoint, _maxTablesPerLevel,
+				_maxTableLevelsForAutomaticMerge, _pTableMaxReaderCount);
+
+			var canMergeAny = false;
+			var maxTableLevelsToMerge = Math.Min(tables.Count, _maxTableLevelsForAutomaticMerge);
+			for (int level = 0; level < maxTableLevelsToMerge; level++) {
+				if (tables[level].Count >= _maxTablesPerLevel) {
+					canMergeAny = true;
+					break;
+				}
+			}
+
+			return new AddResult(indexMap, canMergeAny);
+		}
+
+		public MergeResult TryMergeOneLevel(
+			Func<string, ulong, ulong> upgradeHash,
+			Func<IndexEntry, bool> existsAt,
+			Func<IndexEntry, Tuple<string, bool>> recordExistsAt,
+			IIndexFilenameProvider filenameProvider,
+			byte version,
+			int indexCacheDepth = 16,
+			bool skipIndexVerify = false) {
+
+			var tables = CopyFrom(_map);
+
+			var hasMergedAny = false;
+			var canMergeAny = false;
 			var toDelete = new List<PTable>();
 			var maxTableLevelsToMerge = Math.Min(tables.Count, _maxTableLevelsForAutomaticMerge);
 			for (int level = 0; level < maxTableLevelsToMerge; level++) {
 				if (tables[level].Count >= _maxTablesPerLevel) {
+					if (hasMergedAny) {
+						canMergeAny = true;
+						break;
+					}
 					var filename = filenameProvider.GetFilenameNewTable();
 					PTable mergedTable = PTable.MergeTo(tables[level], filename, upgradeHash, existsAt, recordExistsAt,
 						version,
 						ESConsts.PTableInitialReaderCount, _pTableMaxReaderCount,
 						indexCacheDepth, skipIndexVerify);
+					hasMergedAny = true;
 
 					AddTableToTables(tables, level + 1, mergedTable);
 					toDelete.AddRange(tables[level]);
@@ -466,13 +455,12 @@ namespace EventStore.Core.Index {
 				}
 			}
 
-			var indexMap = new IndexMap(Version, tables, prepareCheckpoint, commitCheckpoint, _maxTablesPerLevel,
+			var indexMap = new IndexMap(Version, tables, PrepareCheckpoint, CommitCheckpoint, _maxTablesPerLevel,
 				_maxTableLevelsForAutomaticMerge, _pTableMaxReaderCount);
-			return new MergeResult(indexMap, toDelete);
+			return new MergeResult(indexMap, toDelete, hasMergedAny, canMergeAny);
 		}
 
-		public MergeResult AddPTableForManualMerge(long prepareCheckpoint,
-			long commitCheckpoint,
+		public MergeResult TryManualMerge(
 			Func<string, ulong, ulong> upgradeHash,
 			Func<IndexEntry, bool> existsAt,
 			Func<IndexEntry, Tuple<string, bool>> recordExistsAt,
@@ -480,19 +468,17 @@ namespace EventStore.Core.Index {
 			byte version,
 			int indexCacheDepth = 16,
 			bool skipIndexVerify = false) {
-			Ensure.Nonnegative(prepareCheckpoint, "prepareCheckpoint");
-			Ensure.Nonnegative(commitCheckpoint, "commitCheckpoint");
 
 			var tables = CopyFrom(_map);
 
 			if (tables.Count < _maxTableLevelsForAutomaticMerge) {
-				return new MergeResult(this, new List<PTable>());
+				return new MergeResult(this, new List<PTable>(), false, false);
 			}
 
 			var toDelete = new List<PTable>();
 			var tablesToMerge = tables.Skip(_maxTableLevelsForAutomaticMerge).SelectMany(a => a).ToList();
 			if (tablesToMerge.Count == 1)
-				return new MergeResult(this, new List<PTable>());
+				return new MergeResult(this, new List<PTable>(), false, false);
 
 			var filename = filenameProvider.GetFilenameNewTable();
 			PTable mergedTable = PTable.MergeTo(tablesToMerge, filename, upgradeHash, existsAt, recordExistsAt,
@@ -507,9 +493,9 @@ namespace EventStore.Core.Index {
 			AddTableToTables(tables, _maxTableLevelsForAutomaticMerge + 1, mergedTable);
 			toDelete.AddRange(tablesToMerge);
 
-			var indexMap = new IndexMap(Version, tables, prepareCheckpoint, commitCheckpoint, _maxTablesPerLevel,
+			var indexMap = new IndexMap(Version, tables, PrepareCheckpoint, CommitCheckpoint, _maxTablesPerLevel,
 				_maxTableLevelsForAutomaticMerge, _pTableMaxReaderCount);
-			return new MergeResult(indexMap, toDelete);
+			return new MergeResult(indexMap, toDelete, true, false);
 		}
 
 		public ScavengeResult Scavenge(Guid toScavenge, CancellationToken ct,

--- a/src/EventStore.Core/Index/MergeResult.cs
+++ b/src/EventStore.Core/Index/MergeResult.cs
@@ -4,10 +4,14 @@ namespace EventStore.Core.Index {
 	public class MergeResult {
 		public readonly IndexMap MergedMap;
 		public readonly List<PTable> ToDelete;
+		public readonly bool HasMergedAny;
+		public readonly bool CanMergeAny;
 
-		public MergeResult(IndexMap mergedMap, List<PTable> toDelete) {
+		public MergeResult(IndexMap mergedMap, List<PTable> toDelete, bool hasMergedAny, bool canMergeAny) {
 			MergedMap = mergedMap;
 			ToDelete = toDelete;
+			HasMergedAny = hasMergedAny;
+			CanMergeAny = canMergeAny;
 		}
 	}
 }

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -374,6 +374,8 @@ namespace EventStore.Core.Index {
 
 					return (midpointsPtr, midpointsCount);
 				}
+			} catch (PossibleToHandleOutOfMemoryException) {
+				throw;
 			} catch {
 				Dispose();
 				throw;

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -771,6 +771,7 @@ namespace EventStore.Core.Index {
 				File.Delete(_filename);
 			_destroyEvent.Set();
 			Dispose(true);
+			GC.SuppressFinalize(this);
 		}
 
 		public void WaitForDisposal(int timeout) {

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -119,6 +119,16 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 							(result.RecordPostPosition - startPosition) * 100.0 / (buildToPosition - startPosition));
 						lastTime = DateTime.UtcNow;
 					}
+
+					if (processed % 1000000 == 0) {
+						if (_tableIndex.IsBackgroundTaskRunning) {
+							Log.Debug("Pausing ReadIndex Rebuild due to ongoing index merges.");
+							while (_tableIndex.IsBackgroundTaskRunning) {
+								Thread.Sleep(1000);
+							}
+							Log.Debug("Resuming ReadIndex Rebuild.");
+						}
+					}
 				}
 
 				Log.Debug("ReadIndex rebuilding done: total processed {processed} records, time elapsed: {elapsed}.",

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -76,6 +76,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			_indexRebuild = true;
 			using (var reader = _backend.BorrowReader()) {
 				var startPosition = Math.Max(0, _persistedCommitPos);
+				var fullRebuild = startPosition == 0;
 				reader.Reposition(startPosition);
 
 				var commitedPrepares = new List<PrepareLogRecord>();
@@ -120,7 +121,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 						lastTime = DateTime.UtcNow;
 					}
 
-					if (processed % 1000000 == 0) {
+					if (fullRebuild && processed % 1000000 == 0) {
 						if (_tableIndex.IsBackgroundTaskRunning) {
 							Log.Debug("Pausing ReadIndex Rebuild due to ongoing index merges.");
 							while (_tableIndex.IsBackgroundTaskRunning) {


### PR DESCRIPTION
Fixed: Memory/disk space issues during large cascading index merges (especially when index cache depth is high)

Thanks to @slav for his assistance with this issue!

This PR fixes multiple memory/disk issues with the indexes:
- During cascading index merges, immediately dispose merged PTables instead of waiting for all the cascading merges to complete. This helps save a lot of memory taken by midpoints (especially when the index cache depth is high) and disk space since the merged PTables can be deleted immediately. Before the PR, around (2 x size of all current PTables on disk) free disk space was required for a cascading merge but now only (1 x size of largest PTable in the cascading merge) free disk space is required.
- Keep midpoints in unmanaged memory and immediately release the memory used by the midpoints when the PTable is disposed.
- Keep midpoints in unmanaged memory instead of List<Midpoint> (which takes excessive memory, particularly when internally doubling the array size) when merging PTables and immediately release the memory when the merge has completed.
- Prevent MemTables from piling up when large index merges are taking place during full index rebuilds by pausing the index rebuild and waiting until the merge has completed.

The following is the rationale behind using unmanaged memory for the midpoints:
- With a high index cache depth, the midpoints would often go to the Large Object Heap and thus they would rarely be garbage collected. From the user-perspective, it would be unclear whether a memory leak is present or whether the midpoints are just waiting to be garbage collected. Thus unmanaged memory gives us much more predictable behaviour.