### PR TITLE
Don't resolve DNS entries to IPs from GossipSeeds

### DIFF
--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -172,7 +172,7 @@ namespace EventStore.ClientAPI.Internal {
 
 			var url = endPoint.EndPoint.ToHttpUrl(
 				endPoint.SeedOverTls ? EndpointExtensions.HTTPS_SCHEMA : EndpointExtensions.HTTP_SCHEMA,
-				"/gossip?format=json", true);
+				"/gossip?format=json");
 			_client.Get(
 				url,
 				null,


### PR DESCRIPTION
Not sure what the thinking is here as it seems *very* deliberate but I'll put this here as an RFC.

There are numerous configurations that mean you might want to use TLS (without IP SANs) on your gossip seed addresses.

This fixes #2718 in the v20.6 client