### PR TITLE
Prioritize leader selection in elections by replication checkpoint.

### DIFF
--- a/src/EventStore.ClientAPI/Messages/ClusterMessages.cs
+++ b/src/EventStore.ClientAPI/Messages/ClusterMessages.cs
@@ -42,6 +42,7 @@ namespace EventStore.ClientAPI.Messages {
 			public long LastCommitPosition { get; set; }
 			public long WriterCheckpoint { get; set; }
 			public long ChaserCheckpoint { get; set; }
+			public long ReplicationCheckpoint { get; set; }
 
 			public long EpochPosition { get; set; }
 			public int EpochNumber { get; set; }
@@ -56,14 +57,14 @@ namespace EventStore.ClientAPI.Messages {
 						HttpAddress, HttpPort,
 						TimeStamp);
 				return string.Format(
-					"VND {0:B} <{1}> [{2}, {3}:{4}, {5}, {6}:{7}, {8}, {9}:{10}] {11}/{12}/{13}/E{14}@{15}:{16:B} | {17:yyyy-MM-dd HH:mm:ss.fff}",
+					"VND {0:B} <{1}> [{2}, {3}:{4}, {5}, {6}:{7}, {8}, {9}:{10}] {11}/{12}/{13}/R{14}/E{15}@{16}:{17:B} | {18:yyyy-MM-dd HH:mm:ss.fff}",
 					InstanceId, IsAlive ? "LIVE" : "DEAD", State,
 					InternalTcpIp, InternalTcpPort,
 					InternalSecureTcpPort > 0 ? string.Format("{0}:{1}", InternalTcpIp, InternalSecureTcpPort) : "n/a",
 					ExternalTcpIp, ExternalTcpPort,
 					ExternalSecureTcpPort > 0 ? string.Format("{0}:{1}", ExternalTcpIp, ExternalSecureTcpPort) : "n/a",
 					HttpAddress, HttpPort,
-					LastCommitPosition, WriterCheckpoint, ChaserCheckpoint,
+					LastCommitPosition, WriterCheckpoint, ChaserCheckpoint, ReplicationCheckpoint,
 					EpochNumber, EpochPosition, EpochId,
 					TimeStamp);
 			}

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -35,6 +35,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 		protected TFChunkWriter Writer;
 		protected ICheckpoint WriterCheckpoint;
 		protected ICheckpoint ChaserCheckpoint;
+		protected ICheckpoint ReplicationCheckpoint;
 		protected IODispatcher IODispatcher;
 		protected InMemoryBus Bus;
 
@@ -57,11 +58,13 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 
 			var writerCheckFilename = Path.Combine(dbPath, Checkpoint.Writer + ".chk");
 			var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
+			var replicationCheckFilename = Path.Combine(dbPath, Checkpoint.Replication + ".chk");
 
 			WriterCheckpoint = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
 			ChaserCheckpoint = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
+			ReplicationCheckpoint = new MemoryMappedFileCheckpoint(replicationCheckFilename, Checkpoint.Replication, cached: true);
 
-			Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(dbPath, WriterCheckpoint, ChaserCheckpoint, TFConsts.ChunkSize));
+			Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(dbPath, WriterCheckpoint, ChaserCheckpoint, TFConsts.ChunkSize, ReplicationCheckpoint));
 			Db.Open();
 
 			// create DB
@@ -74,6 +77,8 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 			WriterCheckpoint.Flush();
 			ChaserCheckpoint.Write(WriterCheckpoint.Read());
 			ChaserCheckpoint.Flush();
+			ReplicationCheckpoint.Write(WriterCheckpoint.Read());
+			ReplicationCheckpoint.Flush();
 			Db.Close();
 
 			// start node with our created DB

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -47,4 +47,35 @@
 			<None Remove="FakePlugin\**" />
 			<Compile Remove="FakePlugin\**" />
 	</ItemGroup>
+	<ItemGroup>
+	  <Compile Remove="Services\ElectionsService\ElectionServiceUnit.cs" />
+	  <Compile Remove="Services\ElectionsService\ElectionsServiceTests.cs" />
+	  <Compile Remove="Services\ElectionsService\no_quorum_cases.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\ElectionParams.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\ElectionsInstance.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\ElectionsLogger.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\ElectionsProgressCondition.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\ElectionsSafetyCondition.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_3_nodes_full_gossip_no_http_loss_no_dup.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_3_nodes_full_gossip_some_http_loss_some_dup.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_4_nodes_full_gossip_no_http_loss_no_dup.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_4_nodes_full_gossip_some_http_loss_some_dup.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_4_nodes_full_gossip_some_http_loss_some_dup_rndseed_20676840.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_5_nodes_full_gossip_no_http_loss_no_dup.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_5_nodes_full_gossip_some_http_loss_some_dup.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_5_nodes_with_1_known_when_started_and_set_full_imediately.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\elections_service_5_nodes_with_1_known_when_started_and_set_to_full_later.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\GossipUpdateParams.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\InnerBusMessagesProcessor.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\RandomizedElectionsAndGossipTestCase.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\RandomizedElectionsTestCase.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\SendOverGrpcBlockingProcessor.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\SendOverGrpcProcessor.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\SeqHelpers.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\TimerMessageProcessor.cs" />
+	  <Compile Remove="Services\ElectionsService\Randomized\UpdateGossipProcessor.cs" />
+	</ItemGroup>
+	<ItemGroup>
+	  <Folder Include="Services\ElectionsService\Randomized\" />
+	</ItemGroup>
 </Project>

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -64,7 +64,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 		[SetUp]
 		public void Setup() {
 			SUT = new NodeGossipService(_bus, _gossipSeedSource, MemberInfoForVNode(_currentNode, DateTime.UtcNow),
-				new InMemoryCheckpoint(0), new InMemoryCheckpoint(0), new FakeEpochManager(), () => 0L, 0,
+				new InMemoryCheckpoint(0), new InMemoryCheckpoint(0),new InMemoryCheckpoint(0), new FakeEpochManager(), () => 0L, 0,
 				_gossipInterval, _allowedTimeDifference, _gossipTimeout, _deadMemberRemovalPeriod, _timeProvider, _getNodeToGossipTo);
 
 			foreach (var message in Given()) {
@@ -103,7 +103,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			return MemberInfo.ForVNode(nodeInfo.InstanceId, utcNow, nodeState, true,
 				nodeInfo.InternalTcp, nodeInfo.InternalSecureTcp, nodeInfo.ExternalTcp,
 				nodeInfo.ExternalSecureTcp, nodeInfo.HttpEndPoint, null, 0, 0,
-				0, writerCheckpoint ?? 0, 0, -1, epochNumber ?? -1, Guid.Empty, nodePriority ?? 0, false);
+				0, writerCheckpoint ?? 0, 0, 0, -1, epochNumber ?? -1, Guid.Empty, nodePriority ?? 0, false);
 		}
 
 		/// <summary>
@@ -852,7 +852,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			var ipEndpoint = new IPEndPoint(IPAddress.Loopback, identifier);
 			return MemberInfo.ForVNode(Guid.NewGuid(), timeStamp, VNodeState.Initializing, isAlive,
 				ipEndpoint, ipEndpoint, ipEndpoint, ipEndpoint, ipEndpoint, null, 0, 0,
-				0, 0, 0, -1, -1, Guid.Empty, 0, false);
+				0, 0, 0, 0,-1, -1, Guid.Empty, 0, false);
 		}
 
 		[Test]
@@ -899,7 +899,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			var ipEndpoint = new IPEndPoint(IPAddress.Loopback, identifier);
 			return MemberInfo.ForVNode(Guid.NewGuid(), timeStamp, VNodeState.Initializing, isAlive,
 				ipEndpoint, ipEndpoint, ipEndpoint, ipEndpoint, ipEndpoint, null, 0, 0,
-				0, 0, 0, -1, -1, Guid.Empty, 0, false);
+				0, 0, 0,0, -1, -1, Guid.Empty, 0, false);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		protected TFChunkWriter Writer;
 		protected ICheckpoint WriterCheckpoint;
 		protected ICheckpoint ChaserCheckpoint;
+		protected ICheckpoint ReplicationCheckpoint;
 
 		private TFChunkScavenger _scavenger;
 		private bool _scavenge;
@@ -53,9 +54,9 @@ namespace EventStore.Core.Tests.Services.Storage {
 
 			WriterCheckpoint = new InMemoryCheckpoint(0);
 			ChaserCheckpoint = new InMemoryCheckpoint(0);
+			ReplicationCheckpoint = new InMemoryCheckpoint(0);
 
-			Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, WriterCheckpoint, ChaserCheckpoint,
-				replicationCheckpoint: new InMemoryCheckpoint(-1)));
+			Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, WriterCheckpoint, ChaserCheckpoint, replicationCheckpoint: ReplicationCheckpoint));
 
 			Db.Open();
 			// create db
@@ -68,6 +69,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 			WriterCheckpoint.Flush();
 			ChaserCheckpoint.Write(WriterCheckpoint.Read());
 			ChaserCheckpoint.Flush();
+			ReplicationCheckpoint.Write(WriterCheckpoint.Read());
+			ReplicationCheckpoint.Flush();
 
 			var readers = new ObjectPool<ITransactionFileReader>("Readers", 2, 5,
 				() => new TFChunkReader(Db, Db.Config.WriterCheckpoint));

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -46,6 +46,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 			DbRes.Db.Config.WriterCheckpoint.Flush();
 			DbRes.Db.Config.ChaserCheckpoint.Write(DbRes.Db.Config.WriterCheckpoint.Read());
 			DbRes.Db.Config.ChaserCheckpoint.Flush();
+			DbRes.Db.Config.ReplicationCheckpoint.Write(DbRes.Db.Config.WriterCheckpoint.Read());
+			DbRes.Db.Config.ReplicationCheckpoint.Flush();
 
 			var readers = new ObjectPool<ITransactionFileReader>(
 				"Readers", 2, 2, () => new TFChunkReader(DbRes.Db, DbRes.Db.Config.WriterCheckpoint));

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -44,6 +44,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 			DbRes.Db.Config.WriterCheckpoint.Flush();
 			DbRes.Db.Config.ChaserCheckpoint.Write(DbRes.Db.Config.WriterCheckpoint.Read());
 			DbRes.Db.Config.ChaserCheckpoint.Flush();
+			DbRes.Db.Config.ReplicationCheckpoint.Write(DbRes.Db.Config.WriterCheckpoint.Read());
+			DbRes.Db.Config.ReplicationCheckpoint.Flush();
 
 			var readers = new ObjectPool<ITransactionFileReader>(
 				"Readers", 2, 2, () => new TFChunkReader(DbRes.Db, DbRes.Db.Config.WriterCheckpoint));

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
@@ -31,6 +31,8 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 			_dbResult.Db.Config.WriterCheckpoint.Flush();
 			_dbResult.Db.Config.ChaserCheckpoint.Write(_dbResult.Db.Config.WriterCheckpoint.Read());
 			_dbResult.Db.Config.ChaserCheckpoint.Flush();
+			_dbResult.Db.Config.ReplicationCheckpoint.Write(_dbResult.Db.Config.WriterCheckpoint.Read());
+			_dbResult.Db.Config.ReplicationCheckpoint.Flush();
 
 			Log = new FakeTFScavengerLog();
 			FakeTableIndex = new FakeTableIndex();

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -46,6 +46,8 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 			_dbResult.Db.Config.WriterCheckpoint.Flush();
 			_dbResult.Db.Config.ChaserCheckpoint.Write(_dbResult.Db.Config.WriterCheckpoint.Read());
 			_dbResult.Db.Config.ChaserCheckpoint.Flush();
+			_dbResult.Db.Config.ReplicationCheckpoint.Write(_dbResult.Db.Config.WriterCheckpoint.Read());
+			_dbResult.Db.Config.ReplicationCheckpoint.Flush();
 
 			var indexPath = Path.Combine(PathName, "index");
 			var readerPool = new ObjectPool<ITransactionFileReader>(

--- a/src/EventStore.Core/Cluster/ClientClusterInfo.cs
+++ b/src/EventStore.Core/Cluster/ClientClusterInfo.cs
@@ -45,6 +45,7 @@ namespace EventStore.Core.Cluster {
 			public long LastCommitPosition { get; set; }
 			public long WriterCheckpoint { get; set; }
 			public long ChaserCheckpoint { get; set; }
+			public long ReplicationCheckpoint { get; set; }
 
 			public long EpochPosition { get; set; }
 			public int EpochNumber { get; set; }
@@ -91,6 +92,7 @@ namespace EventStore.Core.Cluster {
 				LastCommitPosition = member.LastCommitPosition;
 				WriterCheckpoint = member.WriterCheckpoint;
 				ChaserCheckpoint = member.ChaserCheckpoint;
+				ReplicationCheckpoint = member.ReplicationCheckpoint;
 
 				EpochPosition = member.EpochPosition;
 				EpochNumber = member.EpochNumber;
@@ -106,7 +108,7 @@ namespace EventStore.Core.Cluster {
 					$"InternalTcpIp: {InternalTcpIp}, InternalTcpPort: {InternalTcpPort}, InternalSecureTcpPort: {InternalSecureTcpPort}, " +
 					$"ExternalTcpIp: {ExternalTcpIp}, ExternalTcpPort: {ExternalTcpPort}, ExternalSecureTcpPort: {ExternalSecureTcpPort}, " +
 					$"HttpEndPointIp: {HttpEndPointIp}, HttpEndPointPort: {HttpEndPointPort}, " +
-					$"LastCommitPosition: {LastCommitPosition}, WriterCheckpoint: {WriterCheckpoint}, ChaserCheckpoint: {ChaserCheckpoint}, " +
+					$"LastCommitPosition: {LastCommitPosition}, WriterCheckpoint: {WriterCheckpoint}, ChaserCheckpoint: {ChaserCheckpoint}, ReplicationCheckpoint: {ReplicationCheckpoint}, " +
 					$"EpochPosition: {EpochPosition}, EpochNumber: {EpochNumber}, EpochId: {EpochId:B}, NodePriority: {NodePriority}, " +
 					$"IsReadOnlyReplica: {IsReadOnlyReplica}";
 			}

--- a/src/EventStore.Core/Cluster/ClusterInfo.cs
+++ b/src/EventStore.Core/Cluster/ClusterInfo.cs
@@ -61,7 +61,7 @@ namespace EventStore.Core.Cluster {
 						: null,
 					new DnsEndPoint(x.HttpEndPoint.Address, (int)x.HttpEndPoint.Port),
 					x.AdvertiseHostToClientAs, (int)x.AdvertiseHttpPortToClientAs, (int)x.AdvertiseTcpPortToClientAs,
-					x.LastCommitPosition, x.WriterCheckpoint, x.ChaserCheckpoint,
+					x.LastCommitPosition, x.WriterCheckpoint, x.ChaserCheckpoint, x.ReplicationCheckpoint,
 					x.EpochPosition, x.EpochNumber, Uuid.FromDto(x.EpochId).ToGuid(), x.NodePriority,
 					x.IsReadOnlyReplica
 				)).ToArray();
@@ -97,6 +97,7 @@ namespace EventStore.Core.Cluster {
 				LastCommitPosition = x.LastCommitPosition,
 				WriterCheckpoint = x.WriterCheckpoint,
 				ChaserCheckpoint = x.ChaserCheckpoint,
+				ReplicationCheckpoint = x.ReplicationCheckpoint,
 				EpochPosition = x.EpochPosition,
 				EpochNumber = x.EpochNumber,
 				EpochId = Uuid.FromGuid(x.EpochId).ToDto(),

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.Elections.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.Elections.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Cluster {
 			SendPrepareOkAsync(prepareOk.View, prepareOk.ServerId, prepareOk.ServerHttpEndPoint, prepareOk.EpochNumber,
 					prepareOk.EpochPosition, prepareOk.EpochId, prepareOk.EpochLeaderInstanceId, prepareOk.LastCommitPosition,
 					prepareOk.WriterCheckpoint,
-					prepareOk.ChaserCheckpoint, prepareOk.NodePriority, prepareOk.ClusterInfo, deadline)
+					prepareOk.ChaserCheckpoint, prepareOk.ReplicationCheckpoint,prepareOk.NodePriority, prepareOk.ClusterInfo, deadline)
 				.ContinueWith(r => {
 					if (r.Exception != null) {
 						Log.Information(r.Exception, "Prepare OK Send Failed to {Server}",
@@ -54,7 +54,7 @@ namespace EventStore.Core.Cluster {
 			SendProposalAsync(proposal.ServerId, proposal.ServerHttpEndPoint, proposal.LeaderId,
 					proposal.LeaderHttpEndPoint,
 					proposal.View, proposal.EpochNumber, proposal.EpochPosition, proposal.EpochId,proposal.EpochLeaderInstanceId,
-					proposal.LastCommitPosition, proposal.WriterCheckpoint, proposal.ChaserCheckpoint,
+					proposal.LastCommitPosition, proposal.WriterCheckpoint, proposal.ChaserCheckpoint,proposal.ReplicationCheckpoint,
 					proposal.NodePriority,
 					deadline)
 				.ContinueWith(r => {
@@ -124,7 +124,7 @@ namespace EventStore.Core.Cluster {
 		}
 
 		private async Task SendPrepareOkAsync(int view, Guid serverId, EndPoint serverHttpEndPoint, int epochNumber,
-			long epochPosition, Guid epochId, Guid epochLeaderInstanceId, long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint,
+			long epochPosition, Guid epochId, Guid epochLeaderInstanceId, long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint,long replicationCheckpoint,
 			int nodePriority, ClusterInfo clusterInfo, DateTime deadline) {
 			var request = new PrepareOkRequest {
 				View = view,
@@ -137,6 +137,7 @@ namespace EventStore.Core.Cluster {
 				LastCommitPosition = lastCommitPosition,
 				WriterCheckpoint = writerCheckpoint,
 				ChaserCheckpoint = chaserCheckpoint,
+				ReplicationCheckpoint = replicationCheckpoint,
 				NodePriority = nodePriority,
 				ClusterInfo = ClusterInfo.ToGrpcClusterInfo(clusterInfo)
 			};
@@ -145,7 +146,7 @@ namespace EventStore.Core.Cluster {
 
 		private async Task SendProposalAsync(Guid serverId, EndPoint serverHttpEndPoint, Guid leaderId,
 			EndPoint leaderHttp, int view, int epochNumber, long epochPosition, Guid epochId, Guid epochLeaderInstanceId,
-			long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint, int nodePriority,
+			long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint, long replicationCheckpoint, int nodePriority,
 			DateTime deadline) {
 			var request = new ProposalRequest {
 				ServerId = Uuid.FromGuid(serverId).ToDto(),
@@ -160,6 +161,7 @@ namespace EventStore.Core.Cluster {
 				LastCommitPosition = lastCommitPosition,
 				WriterCheckpoint = writerCheckpoint,
 				ChaserCheckpoint = chaserCheckpoint,
+				ReplicationCheckpoint = replicationCheckpoint,
 				NodePriority = nodePriority
 			};
 			await _electionsClient.ProposalAsync(request, deadline: deadline.ToUniversalTime());

--- a/src/EventStore.Core/Cluster/MemberInfo.cs
+++ b/src/EventStore.Core/Cluster/MemberInfo.cs
@@ -25,6 +25,7 @@ namespace EventStore.Core.Cluster {
 		public readonly long LastCommitPosition;
 		public readonly long WriterCheckpoint;
 		public readonly long ChaserCheckpoint;
+		public readonly long ReplicationCheckpoint;
 		public readonly long EpochPosition;
 		public readonly int EpochNumber;
 		public readonly Guid EpochId;
@@ -37,7 +38,7 @@ namespace EventStore.Core.Cluster {
 			return new MemberInfo(instanceId, timeStamp, VNodeState.Manager, isAlive,
 				httpEndPoint, null, httpEndPoint, null,
 				httpEndPoint, null, 0, 0,
-				-1, -1, -1, -1, -1, Guid.Empty, 0, false);
+				-1, -1, -1, -1, -1, -1, Guid.Empty, 0, false);
 		}
 
 		public static MemberInfo ForVNode(Guid instanceId,
@@ -55,6 +56,7 @@ namespace EventStore.Core.Cluster {
 			long lastCommitPosition,
 			long writerCheckpoint,
 			long chaserCheckpoint,
+			long replicationCheckpoint,
 			long epochPosition,
 			int epochNumber,
 			Guid epochId,
@@ -66,7 +68,7 @@ namespace EventStore.Core.Cluster {
 				internalTcpEndPoint, internalSecureTcpEndPoint,
 				externalTcpEndPoint, externalSecureTcpEndPoint,
 				httpEndPoint, advertiseHostToClientAs, advertiseHttpPortToClientAs, advertiseTcpPortToClientAs,
-				lastCommitPosition, writerCheckpoint, chaserCheckpoint,
+				lastCommitPosition, writerCheckpoint, chaserCheckpoint, replicationCheckpoint,
 				epochPosition, epochNumber, epochId, nodePriority, isReadOnlyReplica);
 		}
 		
@@ -90,14 +92,14 @@ namespace EventStore.Core.Cluster {
 				internalTcpEndPoint, internalSecureTcpEndPoint,
 				externalTcpEndPoint, externalSecureTcpEndPoint,
 				httpEndPoint, advertiseHostToClientAs, advertiseHttpPortToClientAs, advertiseTcpPortToClientAs,
-				-1, -1, -1, -1, -1, Guid.Empty, nodePriority, isReadOnlyReplica);
+				-1, -1, -1, -1, -1, -1, Guid.Empty, nodePriority, isReadOnlyReplica);
 		}
 
 		internal MemberInfo(Guid instanceId, DateTime timeStamp, VNodeState state, bool isAlive,
 			EndPoint internalTcpEndPoint, EndPoint internalSecureTcpEndPoint,
 			EndPoint externalTcpEndPoint, EndPoint externalSecureTcpEndPoint,
 			EndPoint httpEndPoint, string advertiseHostToClientAs, int advertiseHttpPortToClientAs, int advertiseTcpPortToClientAs,
-			long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint,
+			long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint, long replicationCheckpoint,
 			long epochPosition, int epochNumber, Guid epochId, int nodePriority, bool isReadOnlyReplica) {
 			Ensure.Equal(false, internalTcpEndPoint == null && internalSecureTcpEndPoint == null, "Both internal TCP endpoints are null");
 			Ensure.NotNull(httpEndPoint, nameof(httpEndPoint));
@@ -120,6 +122,7 @@ namespace EventStore.Core.Cluster {
 			LastCommitPosition = lastCommitPosition;
 			WriterCheckpoint = writerCheckpoint;
 			ChaserCheckpoint = chaserCheckpoint;
+			ReplicationCheckpoint = replicationCheckpoint;
 
 			EpochPosition = epochPosition;
 			EpochNumber = epochNumber;
@@ -149,6 +152,7 @@ namespace EventStore.Core.Cluster {
 			LastCommitPosition = dto.LastCommitPosition;
 			WriterCheckpoint = dto.WriterCheckpoint;
 			ChaserCheckpoint = dto.ChaserCheckpoint;
+			ReplicationCheckpoint = dto.ReplicationCheckpoint;
 			EpochPosition = dto.EpochPosition;
 			EpochNumber = dto.EpochNumber;
 			EpochId = dto.EpochId;
@@ -171,6 +175,7 @@ namespace EventStore.Core.Cluster {
 			long? lastCommitPosition = null,
 			long? writerCheckpoint = null,
 			long? chaserCheckpoint = null,
+			long? replicationCheckpoint = null,
 			EpochRecord epoch = null,
 			int? nodePriority = null) {
 			return new MemberInfo(InstanceId,
@@ -188,6 +193,7 @@ namespace EventStore.Core.Cluster {
 				lastCommitPosition ?? LastCommitPosition,
 				writerCheckpoint ?? WriterCheckpoint,
 				chaserCheckpoint ?? ChaserCheckpoint,
+				replicationCheckpoint ?? ReplicationCheckpoint,
 				epoch != null ? epoch.EpochPosition : EpochPosition,
 				epoch != null ? epoch.EpochNumber : EpochNumber,
 				epoch != null ? epoch.EpochId : EpochId,
@@ -206,7 +212,7 @@ namespace EventStore.Core.Cluster {
 				$"{(ExternalTcpEndPoint == null ? "n/a" : ExternalTcpEndPoint.ToString())}, " +
 				$"{(ExternalSecureTcpEndPoint == null ? "n/a" : ExternalSecureTcpEndPoint.ToString())}, " +
 				$"{HttpEndPoint}, (ADVERTISED: HTTP:{AdvertiseHostToClientAs}:{AdvertiseHttpPortToClientAs}, TCP:{AdvertiseHostToClientAs}:{AdvertiseTcpPortToClientAs})] " +
-				$"{LastCommitPosition}/{WriterCheckpoint}/{ChaserCheckpoint}/E{EpochNumber}@{EpochPosition}:{EpochId:B} | {TimeStamp:yyyy-MM-dd HH:mm:ss.fff}";
+				$"{LastCommitPosition}/{WriterCheckpoint}/{ChaserCheckpoint}/{ReplicationCheckpoint}/E{EpochNumber}@{EpochPosition}:{EpochId:B} | {TimeStamp:yyyy-MM-dd HH:mm:ss.fff}";
 		}
 
 		public bool Equals(MemberInfo other) {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -736,7 +736,7 @@ namespace EventStore.Core {
 			// ELECTIONS
 			if (!vNodeSettings.NodeInfo.IsReadOnlyReplica) {
 				var electionsService = new ElectionsService(_mainQueue, memberInfo, vNodeSettings.ClusterNodeCount,
-					db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint,
+					db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint, db.Config.ReplicationCheckpoint,
 					epochManager, () => readIndex.LastIndexedPosition, vNodeSettings.NodePriority, _timeProvider);
 				electionsService.SubscribeMessages(_mainBus);
 			}
@@ -745,7 +745,7 @@ namespace EventStore.Core {
 				// GOSSIP
 
 				var gossip = new NodeGossipService(_mainQueue, gossipSeedSource, memberInfo, db.Config.WriterCheckpoint,
-					db.Config.ChaserCheckpoint, epochManager, () => readIndex.LastIndexedPosition,
+					db.Config.ChaserCheckpoint,db.Config.ReplicationCheckpoint, epochManager, () => readIndex.LastIndexedPosition,
 					vNodeSettings.NodePriority, vNodeSettings.GossipInterval, vNodeSettings.GossipAllowedTimeDifference,
 					vNodeSettings.GossipTimeout,
 					vNodeSettings.DeadMemberRemovalPeriod,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -263,11 +263,12 @@ namespace EventStore.Core {
 			var truncPos = db.Config.TruncateCheckpoint.Read();
 			var writerCheckpoint = db.Config.WriterCheckpoint.Read();
 			var chaserCheckpoint = db.Config.ChaserCheckpoint.Read();
+			var replicationCheckpoint = db.Config.ReplicationCheckpoint.Read();
 			var epochCheckpoint = db.Config.EpochCheckpoint.Read();
 			if (truncPos != -1) {
 				Log.Information(
-					"Truncate checkpoint is present. Truncate: {truncatePosition} (0x{truncatePosition:X}), Writer: {writerCheckpoint} (0x{writerCheckpoint:X}), Chaser: {chaserCheckpoint} (0x{chaserCheckpoint:X}), Epoch: {epochCheckpoint} (0x{epochCheckpoint:X})",
-					truncPos, truncPos, writerCheckpoint, writerCheckpoint, chaserCheckpoint, chaserCheckpoint,
+					"Truncate checkpoint is present. Truncate: {truncatePosition} (0x{truncatePosition:X}), Writer: {writerCheckpoint} (0x{writerCheckpoint:X}), Chaser: {chaserCheckpoint} (0x{chaserCheckpoint:X}), Replication: {replicationCheckpoint} (0x{replicationCheckpoint:X}), Epoch: {epochCheckpoint} (0x{epochCheckpoint:X})",
+					truncPos, truncPos, writerCheckpoint, writerCheckpoint, chaserCheckpoint, chaserCheckpoint, replicationCheckpoint, replicationCheckpoint,
 					epochCheckpoint, epochCheckpoint);
 				var truncator = new TFChunkDbTruncator(db.Config);
 				truncator.TruncateDb(truncPos);

--- a/src/EventStore.Core/Messages/ElectionMessage.cs
+++ b/src/EventStore.Core/Messages/ElectionMessage.cs
@@ -254,8 +254,8 @@ namespace EventStore.Core.Messages {
 				EpochLeaderInstanceId = epochLeaderInstanceId;
 				LastCommitPosition = lastCommitPosition;
 				WriterCheckpoint = writerCheckpoint;
-				ReplicationCheckpoint = replicationCheckpoint;
 				ChaserCheckpoint = chaserCheckpoint;
+				ReplicationCheckpoint = replicationCheckpoint;
 				NodePriority = nodePriority;
 			}
 

--- a/src/EventStore.Core/Messages/ElectionMessage.cs
+++ b/src/EventStore.Core/Messages/ElectionMessage.cs
@@ -159,6 +159,7 @@ namespace EventStore.Core.Messages {
 			public readonly long LastCommitPosition;
 			public readonly long WriterCheckpoint;
 			public readonly long ChaserCheckpoint;
+			public readonly long ReplicationCheckpoint;
 			public readonly int NodePriority;
 			public readonly ClusterInfo ClusterInfo;
 
@@ -172,6 +173,7 @@ namespace EventStore.Core.Messages {
 				long lastCommitPosition,
 				long writerCheckpoint,
 				long chaserCheckpoint,
+				long replicationCheckpoint,
 				int nodePriority,
 				ClusterInfo clusterInfo) {
 				View = view;
@@ -184,6 +186,7 @@ namespace EventStore.Core.Messages {
 				LastCommitPosition = lastCommitPosition;
 				WriterCheckpoint = writerCheckpoint;
 				ChaserCheckpoint = chaserCheckpoint;
+				ReplicationCheckpoint = replicationCheckpoint;
 				NodePriority = nodePriority;
 				ClusterInfo = clusterInfo;
 			}
@@ -200,6 +203,7 @@ namespace EventStore.Core.Messages {
 				LastCommitPosition = dto.LastCommitPosition;
 				WriterCheckpoint = dto.WriterCheckpoint;
 				ChaserCheckpoint = dto.ChaserCheckpoint;
+				ReplicationCheckpoint = dto.ReplicationCheckpoint;
 				NodePriority = dto.NodePriority;
 				ClusterInfo = dto.ClusterInfo;
 			}
@@ -207,9 +211,9 @@ namespace EventStore.Core.Messages {
 			public override string ToString() {
 				return string.Format(
 					"---- PrepareOk: view {0}, serverId {1}, serverHttp {2}, epochNumber {3}, " +
-					"epochPosition {4}, epochId {5}, epochLeaderInstanceId {6:B}, lastCommitPosition {7}, writerCheckpoint {8}, chaserCheckpoint {9}, nodePriority: {10}, clusterInfo: {11}",
+					"epochPosition {4}, epochId {5}, epochLeaderInstanceId {6:B}, lastCommitPosition {7}, writerCheckpoint {8}, chaserCheckpoint {9}, replicationCheckpoint {10}, nodePriority: {11}, clusterInfo: {12}",
 					View, ServerId, ServerHttpEndPoint, EpochNumber,
-					EpochPosition, EpochId, EpochLeaderInstanceId, LastCommitPosition, WriterCheckpoint, ChaserCheckpoint, NodePriority, ClusterInfo);
+					EpochPosition, EpochId, EpochLeaderInstanceId, LastCommitPosition, WriterCheckpoint, ChaserCheckpoint, ReplicationCheckpoint, NodePriority, ClusterInfo);
 			}
 		}
 
@@ -233,11 +237,12 @@ namespace EventStore.Core.Messages {
 			public readonly long LastCommitPosition;
 			public readonly long WriterCheckpoint;
 			public readonly long ChaserCheckpoint;
+			public readonly long ReplicationCheckpoint;
 			public readonly int NodePriority;
 
 			public Proposal(Guid serverId, EndPoint serverHttpEndPoint, Guid leaderId, EndPoint leaderHttpEndPoint,
 				int view, int epochNumber, long epochPosition, Guid epochId, Guid epochLeaderInstanceId,
-				long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint, int nodePriority) {
+				long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint, long replicationCheckpoint, int nodePriority) {
 				ServerId = serverId;
 				ServerHttpEndPoint = serverHttpEndPoint;
 				LeaderId = leaderId;
@@ -249,6 +254,7 @@ namespace EventStore.Core.Messages {
 				EpochLeaderInstanceId = epochLeaderInstanceId;
 				LastCommitPosition = lastCommitPosition;
 				WriterCheckpoint = writerCheckpoint;
+				ReplicationCheckpoint = replicationCheckpoint;
 				ChaserCheckpoint = chaserCheckpoint;
 				NodePriority = nodePriority;
 			}
@@ -268,15 +274,16 @@ namespace EventStore.Core.Messages {
 				LastCommitPosition = dto.LastCommitPosition;
 				WriterCheckpoint = dto.WriterCheckpoint;
 				ChaserCheckpoint = dto.ChaserCheckpoint;
+				ReplicationCheckpoint = dto.ReplicationCheckpoint;
 				NodePriority = dto.NodePriority;
 			}
 
 			public override string ToString() {
 				return string.Format(
 					"---- Proposal: serverId {0}, serverHttp {1}, leaderId {2}, leaderHttp {3}, "
-					+ "view {4}, lastCommitCheckpoint {5}, writerCheckpoint {6}, chaserCheckpoint {7}, epoch {8}@{9}:{10:B} (L={11:B}), NodePriority {12}",
+					+ "view {4}, lastCommitCheckpoint {5}, writerCheckpoint {6}, chaserCheckpoint {7}, replicationCheckpoint {8}, epoch {9}@{10}:{11:B} (L={12:B}), NodePriority {13}",
 					ServerId, ServerHttpEndPoint, LeaderId, LeaderHttpEndPoint,
-					View, LastCommitPosition, WriterCheckpoint, ChaserCheckpoint,
+					View, LastCommitPosition, WriterCheckpoint, ChaserCheckpoint, ReplicationCheckpoint,
 					EpochNumber, EpochPosition, EpochId, EpochLeaderInstanceId, NodePriority);
 			}
 		}

--- a/src/EventStore.Core/Messages/ElectionMessageDtos.cs
+++ b/src/EventStore.Core/Messages/ElectionMessageDtos.cs
@@ -75,6 +75,7 @@ namespace EventStore.Core.Messages {
 			public long LastCommitPosition { get; set; }
 			public long WriterCheckpoint { get; set; }
 			public long ChaserCheckpoint { get; set; }
+			public long ReplicationCheckpoint { get; set; }
 
 			public int NodePriority { get; set; }
 			public ClusterInfo ClusterInfo { get; set; }
@@ -96,6 +97,7 @@ namespace EventStore.Core.Messages {
 				LastCommitPosition = message.LastCommitPosition;
 				WriterCheckpoint = message.WriterCheckpoint;
 				ChaserCheckpoint = message.ChaserCheckpoint;
+				ReplicationCheckpoint = message.ReplicationCheckpoint;
 
 				NodePriority = message.NodePriority;
 				ClusterInfo = message.ClusterInfo;
@@ -117,6 +119,7 @@ namespace EventStore.Core.Messages {
 			public long LastCommitPosition { get; set; }
 			public long WriterCheckpoint { get; set; }
 			public long ChaserCheckpoint { get; set; }
+			public long ReplicationCheckpoint { get; set; }
 			public int EpochNumber { get; set; }
 			public long EpochPosition { get; set; }
 			public Guid EpochId { get; set; }
@@ -143,6 +146,7 @@ namespace EventStore.Core.Messages {
 				LastCommitPosition = message.LastCommitPosition;
 				WriterCheckpoint = message.WriterCheckpoint;
 				ChaserCheckpoint = message.ChaserCheckpoint;
+				ReplicationCheckpoint = message.ReplicationCheckpoint;
 				NodePriority = message.NodePriority;
 			}
 		}

--- a/src/EventStore.Core/Messages/MemberInfoDto.cs
+++ b/src/EventStore.Core/Messages/MemberInfoDto.cs
@@ -28,6 +28,7 @@ namespace EventStore.Core.Messages {
 		public long LastCommitPosition { get; set; }
 		public long WriterCheckpoint { get; set; }
 		public long ChaserCheckpoint { get; set; }
+		public long ReplicationCheckpoint { get; set; }
 
 		public long EpochPosition { get; set; }
 		public int EpochNumber { get; set; }
@@ -65,6 +66,7 @@ namespace EventStore.Core.Messages {
 			LastCommitPosition = member.LastCommitPosition;
 			WriterCheckpoint = member.WriterCheckpoint;
 			ChaserCheckpoint = member.ChaserCheckpoint;
+			ReplicationCheckpoint = member.ReplicationCheckpoint;
 
 			EpochPosition = member.EpochPosition;
 			EpochNumber = member.EpochNumber;
@@ -82,7 +84,7 @@ namespace EventStore.Core.Messages {
 				$"HttpEndPointIp: {HttpEndPointIp}, HttpEndPointPort: {HttpEndPointPort}, " +
 				$"{nameof(AdvertiseHostToClientAs)}: {AdvertiseHostToClientAs}, {nameof(AdvertiseHttpPortToClientAs)}: {AdvertiseHttpPortToClientAs}, " +
 				$"{nameof(AdvertiseTcpPortToClientAs)}: {AdvertiseTcpPortToClientAs}, " +
-				$"LastCommitPosition: {LastCommitPosition}, WriterCheckpoint: {WriterCheckpoint}, ChaserCheckpoint: {ChaserCheckpoint}, " +
+				$"LastCommitPosition: {LastCommitPosition}, WriterCheckpoint: {WriterCheckpoint}, ChaserCheckpoint: {ChaserCheckpoint}, ReplicationCheckpoint: {ReplicationCheckpoint}," +
 				$"EpochPosition: {EpochPosition}, EpochNumber: {EpochNumber}, EpochId: {EpochId:B}, NodePriority: {NodePriority}, " +
 				$"IsReadOnlyReplica: {IsReadOnlyReplica}";
 		}

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -382,7 +382,7 @@ namespace EventStore.Core.Services {
 
 			Log.Information("ELECTIONS: (V={view}) PREPARE_OK FROM {nodeInfo}.", msg.View,
 				FormatNodeInfo(msg.ServerHttpEndPoint, msg.ServerId,
-					msg.LastCommitPosition, msg.WriterCheckpoint, msg.ChaserCheckpoint,
+					msg.LastCommitPosition, msg.WriterCheckpoint, msg.ChaserCheckpoint,msg.ReplicationCheckpoint,
 					msg.EpochNumber, msg.EpochPosition, msg.EpochId, msg.EpochLeaderInstanceId, msg.NodePriority));
 
 			if (!_prepareOkReceived.ContainsKey(msg.ServerId)) {
@@ -544,6 +544,8 @@ namespace EventStore.Core.Services {
 		}
 
 		private static bool IsCandidateGoodEnough(LeaderCandidate candidate, LeaderCandidate ownInfo) {
+			if (candidate.ReplicationCheckpoint != ownInfo.ReplicationCheckpoint)
+				return candidate.ReplicationCheckpoint > ownInfo.ReplicationCheckpoint;
 			if (candidate.EpochNumber != ownInfo.EpochNumber)
 				return candidate.EpochNumber > ownInfo.EpochNumber;
 			if (candidate.LastCommitPosition != ownInfo.LastCommitPosition)
@@ -647,16 +649,16 @@ namespace EventStore.Core.Services {
 		
 		private static string FormatNodeInfo(LeaderCandidate candidate) {
 			return FormatNodeInfo(candidate.HttpEndPoint, candidate.InstanceId,
-				candidate.LastCommitPosition, candidate.WriterCheckpoint, candidate.ChaserCheckpoint,
+				candidate.LastCommitPosition, candidate.WriterCheckpoint, candidate.ChaserCheckpoint,candidate.ReplicationCheckpoint,
 				candidate.EpochNumber, candidate.EpochPosition, candidate.EpochId, candidate.EpochLeaderInstanceId, candidate.NodePriority);
 		}
 
 		private static string FormatNodeInfo(EndPoint serverEndPoint, Guid serverId,
-			long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint,
+			long lastCommitPosition, long writerCheckpoint, long chaserCheckpoint, long replicationCheckpoint,
 			int epochNumber, long epochPosition, Guid epochId, Guid epochLeaderInstanceId, int priority) {
-			return string.Format("[{0},{1:B}](L={2},W={3},C={4},E{5}@{6}:{7:B} (L={8:B}),Priority={9})",
+			return string.Format("[{0},{1:B}](L={2},W={3},C={4},R={5},E{6}@{7}:{8:B} (L={9:B}),Priority={10})",
 				serverEndPoint, serverId,
-				lastCommitPosition, writerCheckpoint, chaserCheckpoint,
+				lastCommitPosition, writerCheckpoint, chaserCheckpoint, replicationCheckpoint,
 				epochNumber, epochPosition, epochId, epochLeaderInstanceId, priority);
 		}
 

--- a/src/EventStore.Core/Services/Gossip/NodeGossipService.cs
+++ b/src/EventStore.Core/Services/Gossip/NodeGossipService.cs
@@ -12,6 +12,7 @@ namespace EventStore.Core.Services.Gossip {
 	public class NodeGossipService : GossipServiceBase, IHandle<GossipMessage.UpdateNodePriority> {
 		private readonly ICheckpoint _writerCheckpoint;
 		private readonly ICheckpoint _chaserCheckpoint;
+		private readonly ICheckpoint _replicationCheckpoint;
 		private readonly IEpochManager _epochManager;
 		private readonly Func<long> _getLastCommitPosition;
 		private int _nodePriority;
@@ -22,6 +23,7 @@ namespace EventStore.Core.Services.Gossip {
 			MemberInfo memberInfo,
 			ICheckpoint writerCheckpoint,
 			ICheckpoint chaserCheckpoint,
+			ICheckpoint replicationCheckpoint,
 			IEpochManager epochManager,
 			Func<long> getLastCommitPosition,
 			int nodePriority,
@@ -39,6 +41,7 @@ namespace EventStore.Core.Services.Gossip {
 
 			_writerCheckpoint = writerCheckpoint;
 			_chaserCheckpoint = chaserCheckpoint;
+			_replicationCheckpoint = replicationCheckpoint;
 			_epochManager = epochManager;
 			_getLastCommitPosition = getLastCommitPosition;
 			_nodePriority = nodePriority;
@@ -63,6 +66,7 @@ namespace EventStore.Core.Services.Gossip {
 				_getLastCommitPosition(),
 				_writerCheckpoint.Read(),
 				_chaserCheckpoint.Read(),
+				_replicationCheckpoint.Read(),
 				lastEpoch == null ? -1 : lastEpoch.EpochPosition,
 				lastEpoch == null ? -1 : lastEpoch.EpochNumber,
 				lastEpoch == null ? Guid.Empty : lastEpoch.EpochId,

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Elections.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Elections.cs
@@ -81,6 +81,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 				request.LastCommitPosition,
 				request.WriterCheckpoint,
 				request.ChaserCheckpoint,
+				request.ReplicationCheckpoint,
 				request.NodePriority,
 				ClusterInfo.FromGrpcClusterInfo(request.ClusterInfo)));
 			return EmptyResult;
@@ -104,6 +105,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 				request.LastCommitPosition,
 				request.WriterCheckpoint,
 				request.ChaserCheckpoint,
+				request.ReplicationCheckpoint,
 				request.NodePriority));
 			return EmptyResult;
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -290,6 +290,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				Manager.Dispose();
 			Config.WriterCheckpoint.Close();
 			Config.ChaserCheckpoint.Close();
+			Config.ReplicationCheckpoint.Close();
+			Config.IndexCheckpoint.Close();
 			Config.EpochCheckpoint.Close();
 			Config.TruncateCheckpoint.Close();
 		}

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1478,6 +1478,8 @@ namespace EventStore.Core {
 
 			var writerCheckpoint = _db.Config.WriterCheckpoint.Read();
 			var chaserCheckpoint = _db.Config.ChaserCheckpoint.Read();
+			var replicationCheckpoint = _db.Config.ReplicationCheckpoint.Read();
+			var indexCheckpoint = _db.Config.IndexCheckpoint.Read();
 			var epochCheckpoint = _db.Config.EpochCheckpoint.Read();
 			var truncateCheckpoint = _db.Config.TruncateCheckpoint.Read();
 
@@ -1487,6 +1489,10 @@ namespace EventStore.Core {
 				writerCheckpoint, writerCheckpoint);
 			_log.Information("{description,-25} {chaserCheckpoint} (0x{chaserCheckpoint:X})", "CHASER CHECKPOINT:",
 				chaserCheckpoint, chaserCheckpoint);
+			_log.Information($"{{description,-25}} {replicationCheckpoint} (0x{{replicationCheckpoint:X}})", "REPLICATION CHECKPOINT:",
+				replicationCheckpoint, replicationCheckpoint);
+			_log.Information($"{{description,-25}} {indexCheckpoint} (0x{{indexCheckpoint:X}})", "INDEX CHECKPOINT:",
+				indexCheckpoint, indexCheckpoint);
 			_log.Information("{description,-25} {epochCheckpoint} (0x{epochCheckpoint:X})", "EPOCH CHECKPOINT:",
 				epochCheckpoint, epochCheckpoint);
 			_log.Information("{description,-25} {truncateCheckpoint} (0x{truncateCheckpoint:X})", "TRUNCATE CHECKPOINT:",

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1550,14 +1550,16 @@ namespace EventStore.Core {
 			ICheckpoint chaserChk;
 			ICheckpoint epochChk;
 			ICheckpoint truncateChk;
-			//todo(clc) : promote these to file backed checkpoints re:project-io
-			ICheckpoint replicationChk = new InMemoryCheckpoint(Checkpoint.Replication, initValue: -1);
-			ICheckpoint indexChk = new InMemoryCheckpoint(Checkpoint.Replication, initValue: -1);
+			ICheckpoint replicationChk;
+			ICheckpoint indexChk;
 			if (inMemDb) {
 				writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
 				chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
 				epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
 				truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
+				replicationChk = new InMemoryCheckpoint(Checkpoint.Replication, initValue: -1);
+				indexChk = new InMemoryCheckpoint(Checkpoint.Replication, initValue: -1);
+
 			} else {
 				try {
 					if (!Directory.Exists(dbPath)) // mono crashes without this check
@@ -1581,12 +1583,14 @@ namespace EventStore.Core {
 				var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
 				var epochCheckFilename = Path.Combine(dbPath, Checkpoint.Epoch + ".chk");
 				var truncateCheckFilename = Path.Combine(dbPath, Checkpoint.Truncate + ".chk");
+				var replicationCheckFilename = Path.Combine(dbPath, Checkpoint.Replication + ".chk");
+				var indexCheckFilename = Path.Combine(dbPath, Checkpoint.Index + ".chk");
 				writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
 				chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
-				epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true,
-					initValue: -1);
-				truncateChk = new MemoryMappedFileCheckpoint(truncateCheckFilename, Checkpoint.Truncate,
-					cached: true, initValue: -1);
+				epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true, initValue: -1);
+				truncateChk = new MemoryMappedFileCheckpoint(truncateCheckFilename, Checkpoint.Truncate, cached: true, initValue: -1);
+				replicationChk = new MemoryMappedFileCheckpoint(replicationCheckFilename, Checkpoint.Epoch, cached: true, initValue: -1);
+				indexChk = new MemoryMappedFileCheckpoint(indexCheckFilename, Checkpoint.Epoch, cached: true, initValue: -1);
 			}
 
 			var cache = cachedChunks >= 0

--- a/src/Protos/Grpc/cluster.proto
+++ b/src/Protos/Grpc/cluster.proto
@@ -55,8 +55,9 @@ message PrepareOkRequest {
 	int64 last_commit_position = 8;
 	int64 writer_checkpoint = 9;
 	int64 chaser_checkpoint = 10;
+	int64 replication_checkpoint = 13;
 	int32 node_priority = 11;
-	ClusterInfo cluster_info = 12;
+	ClusterInfo cluster_info = 12;	
 }
 
 message ProposalRequest {
@@ -73,6 +74,8 @@ message ProposalRequest {
 	int64 writer_checkpoint = 11;
 	int64 chaser_checkpoint = 12;
 	int32 node_priority = 13;
+
+	int64 replication_checkpoint = 14;
 }
 
 message AcceptRequest {
@@ -136,6 +139,7 @@ message MemberInfo {
     int64 last_commit_position = 10;
     int64 writer_checkpoint = 11;
 	int64 chaser_checkpoint = 12;
+	int64 replication_checkpoint = 21;
     int64 epoch_position = 13;
     int32 epoch_number = 14;
     event_store.client.shared.UUID epoch_id = 15;


### PR DESCRIPTION
Fixed: EventStore/home#263

Close edge case for isolated deposed leaders being preferred in elections due to an artificially high epoch count.
The prioritizing by replication checkpoint correctly identifies the instance with the most current client acknowledge data.
Note: The required pre-condition is not possible in a cluster with an active quorum in version 20.6 and higher, although it can occur in the rarer case of two nodes forming a quorum.