### PR TITLE
Add option to disable client certificates

### DIFF
--- a/src/EventStore.Core/ClusterNodeOptions.cs
+++ b/src/EventStore.Core/ClusterNodeOptions.cs
@@ -196,6 +196,9 @@ namespace EventStore.Core {
 		[ArgDescription(Opts.TrustedRootCertificatesPathDescr, Opts.CertificateGroup)]
 		public string TrustedRootCertificatesPath { get; set; }
 
+		[ArgMask, ArgDescription(Opts.DisableClientCertificateDescr, Opts.CertificateGroup)]
+		public bool DisableClientCertificate { get; set; }
+
 		[ArgDescription(Opts.CertificateFileDescr, Opts.CertificatesFromFileGroup)]
 		public string CertificateFile { get; set; }
 
@@ -394,6 +397,7 @@ namespace EventStore.Core {
 			CertificateThumbprint = Opts.CertificateThumbprintDefault;
 
 			TrustedRootCertificatesPath = Opts.TrustedRootCertificatesPathDefault;
+			DisableClientCertificate = Opts.DisableClientCertificateDefault;
 			CertificateFile = Opts.CertificateFileDefault;
 			CertificatePrivateKeyFile = Opts.CertificatePrivateKeyFileDefault;
 			CertificatePassword = Opts.CertificatePasswordDefault;

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -201,6 +201,9 @@ namespace EventStore.Core.Util {
 		public const string TrustedRootCertificatesPathDescr = "The path to a directory which contains trusted X.509 (.pem, .crt, .cer, .der) root certificate files.";
 		public static readonly string TrustedRootCertificatesPathDefault = string.Empty;
 
+		public const string DisableClientCertificateDescr = "Disables HTTPS client certificate authentication.";
+		public static readonly bool DisableClientCertificateDefault = false;
+
 		//Loading certificates from files
 		public const string CertificateFileDescr = "The path to a PKCS #12 (.p12/.pfx) or an X.509 (.pem, .crt, .cer, .der) certificate file.";
 		public static readonly string CertificateFileDefault = string.Empty;


### PR DESCRIPTION
This adds an option `EVENTSTORE_DISABLE_CLIENT_CERTIFICATE` (boolean) to EventStore. When this option is set to true, the Kestrel option `ClientCertificateMode` will **not** be set to `ClientCertificateMode.AllowCertificate` but instead will default to `ClientCertificateMode.NoCertificate`.

The current implementation will always set this to `ClientCertificateMode.AllowCertificate`. This will result in Google Chrome and curl to automatically send client certificates (esp. when accessed through `localhost`). The client certificate validation will fail within EventStore with the error `The certificate provided by the client failed validation with the following error(s): RemoteCertificateChainErrors (PartialChain)`.

When I configured EventStore for production I constantly hit this error and believed I made a mistake at configuring the server certificate. Event though the error states the client certificate is invalid, it didn't cross my mind that both the browser and curl sending invalid client certificates could be the reason here. And I don't really know how to disable sending client side certificates. Even the `curl -k` option does not work for me and results in `curl: (56) Failure when receiving data from the peer` with the `PartialChain` validation error describe above.

Reading issue #2547, there seem to be quite a few other users confused about this behavior. ([comment](https://github.com/EventStore/EventStore/issues/2547#issuecomment-671036141), [another comment](https://github.com/EventStore/EventStore/issues/2547#issuecomment-698347885)). Due to this it might even be a good idea to disable client certificate authentication by default. However, I opted not to do this in this PR as I don't know what consequences it will bring with it.

Because I can't proceed without this, I have built my own Docker image based in this PR to use as a workaround until this issue is addressed.