### PR TITLE
Experiment with raft terms

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -264,27 +264,32 @@ namespace EventStore.Core.Tests.Helpers {
 			ICheckpoint truncateChk;
 			ICheckpoint replicationCheckpoint = new InMemoryCheckpoint(-1);
 			ICheckpoint indexCheckpoint = new InMemoryCheckpoint(-1);
+			ICheckpoint termCheckpoint;
 			if (inMemDb) {
 				writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
 				chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
 				epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
 				truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
+				termCheckpoint = new InMemoryCheckpoint(Checkpoint.Term, initValue: -1);
 			} else {
 				var writerCheckFilename = Path.Combine(dbPath, Checkpoint.Writer + ".chk");
 				var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
 				var epochCheckFilename = Path.Combine(dbPath, Checkpoint.Epoch + ".chk");
 				var truncateCheckFilename = Path.Combine(dbPath, Checkpoint.Truncate + ".chk");
+				var termCheckFilename = Path.Combine(dbPath, Checkpoint.Term + ".chk");
 				writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
 				chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
 				epochChk = new MemoryMappedFileCheckpoint(
 					epochCheckFilename, Checkpoint.Epoch, cached: true, initValue: -1);
 				truncateChk = new MemoryMappedFileCheckpoint(
 					truncateCheckFilename, Checkpoint.Truncate, cached: true, initValue: -1);
+				termCheckpoint = new MemoryMappedFileCheckpoint(
+					termCheckFilename, Checkpoint.Term, cached: true, initValue: -1);
 			}
 
 			var nodeConfig = new TFChunkDbConfig(
 				dbPath, new VersionedPatternFileNamingStrategy(dbPath, "chunk-"), chunkSize, chunksCacheSize, writerChk,
-				chaserChk, epochChk, truncateChk, replicationCheckpoint, indexCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, inMemDb);
+				chaserChk, epochChk, truncateChk, replicationCheckpoint, indexCheckpoint, termCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, inMemDb);
 			return nodeConfig;
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -18,6 +18,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		private const int LastCommitPosition = -1;
 		private const int WriterCheckpoint = 0;
 		private const int ChaserCheckpoint = 0;
+		private const int TermCheckpoint = -1;
 		private static readonly DateTime InitialDate = new DateTime(2012, 6, 1);
 
 		public ClusterInfo ClusterInfo { get; private set; }
@@ -54,6 +55,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				clusterSettings.ClusterNodesCount,
 				new InMemoryCheckpoint(WriterCheckpoint),
 				new InMemoryCheckpoint(ChaserCheckpoint),
+				new InMemoryCheckpoint(TermCheckpoint),
 				new FakeEpochManager(),
 				() => -1, 0, new FakeTimeProvider());
 			ElectionsService.SubscribeMessages(_bus);

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -53,6 +53,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				MemberInfoFromVNode(_node, _timeProvider.UtcNow, VNodeState.Unknown, true, 0, _epochId, 0), 3,
 				new InMemoryCheckpoint(0),
 				new InMemoryCheckpoint(0),
+				new InMemoryCheckpoint(-1),
 				new FakeEpochManager(), () => 0L, 0, _timeProvider);
 			_sut.SubscribeMessages(_bus);
 		}
@@ -1239,6 +1240,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new Core.Services.ElectionsService(new FakePublisher(), nodeInfo, 3,
 					new InMemoryCheckpoint(0),
 					new InMemoryCheckpoint(0),
+					new InMemoryCheckpoint(-1),
 					new FakeEpochManager(), () => 0L, 0, new FakeTimeProvider());
 			});
 		}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/FakeEpochManager.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/FakeEpochManager.cs
@@ -44,9 +44,30 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			}
 		}
 
-		public EpochRecord GetEpochWithAllEpochs(int epochNumber, bool throwIfNotFound) {
+		public EpochRecord GetNextEpoch(int epochNumber, bool throwIfNotFound) {
 			lock (_epochs) {
-				return GetEpoch(epochNumber, throwIfNotFound);
+				var epochIndex = _epochs.FindIndex(e => e.EpochNumber == epochNumber);
+
+				if (throwIfNotFound && epochIndex < 0) {
+					throw new ArgumentOutOfRangeException(nameof(epochNumber), "Epoch not Found");
+				}
+
+				EpochRecord nextEpoch = null;
+				if (0 <= epochIndex && epochIndex < _epochs.Count - 1) {
+					nextEpoch = _epochs[epochIndex + 1];
+				}
+
+				if (throwIfNotFound && nextEpoch == null) {
+					throw new Exception($"Next Epoch not found after epoch number: {epochNumber}");
+				}
+
+				return nextEpoch;
+			}
+		}
+
+		public EpochRecord GetNextEpochWithAllEpochs(int epochNumber, bool throwIfNotFound) {
+			lock (_epochs) {
+				return GetNextEpoch(epochNumber, throwIfNotFound);
 			}
 		}
 
@@ -54,7 +75,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			throw new NotImplementedException();
 		}
 
-		public void WriteNewEpoch() {
+		public void WriteNewEpoch(int epochNumber) {
 			throw new NotImplementedException();
 		}
 

--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -44,6 +44,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 
 				var writerCheckpoint = new InMemoryCheckpoint();
 				var readerCheckpoint = new InMemoryCheckpoint();
+				var termCheckpoint = new InMemoryCheckpoint();
 				var epochManager = new FakeEpochManager();
 				Func<long> lastCommitPosition = () => -1;
 				var electionsService = new Core.Services.ElectionsService(outputBus,
@@ -51,6 +52,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					3,
 					writerCheckpoint,
 					readerCheckpoint,
+					termCheckpoint,
 					epochManager,
 					() => -1, 0, new FakeTimeProvider());
 				electionsService.SubscribeMessages(inputBus);

--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -139,7 +139,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 0,
-				CommitPositions = new long[] {1, 0, 1},
+				WriterCheckpoints = new long[] {1, 0, 1},
 				NodePriorities = new[] {0, 0, int.MinValue},
 				LastElectedLeader = 2,
 				ResigningLeader = 2
@@ -163,7 +163,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 0,
-				CommitPositions = new long[] {1, 0, 0},
+				WriterCheckpoints = new long[] {1, 0, 0},
 				NodePriorities = new[] {int.MinValue, 0, 0},
 				LastElectedLeader = 0
 			};
@@ -205,7 +205,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 2,
-				CommitPositions = new long[] {1, 0, 1},
+				WriterCheckpoints = new long[] {1, 0, 1},
 				NodePriorities = new[] {int.MinValue, 0, int.MinValue},
 				LastElectedLeader = 0,
 				ResigningLeader = 0

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/ElectionsProgressCondition.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/ElectionsProgressCondition.cs
@@ -32,8 +32,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 			var msg = item.Message as ElectionMessage.ElectionsDone;
 			if (msg != null) {
 				var leader = msg.Leader.HttpEndPoint;
-				ElectionsResults[item.EndPoint] = Tuple.Create(msg.InstalledView, leader);
-				Done = ElectionsResults.Values.Count(x => x.Item1 == msg.InstalledView) >= _majorityCount;
+				ElectionsResults[item.EndPoint] = Tuple.Create(msg.Term, leader);
+				Done = ElectionsResults.Values.Count(x => x.Item1 == msg.Term) >= _majorityCount;
 			}
 		}
 

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
@@ -79,6 +79,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 					InstancesCnt,
 					new InMemoryCheckpoint(),
 					new InMemoryCheckpoint(),
+					new InMemoryCheckpoint(),
 					new FakeEpochManager(),
 					() => -1, 0, new FakeTimeProvider());
 				electionsService.SubscribeMessages(inputBus);

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -504,7 +504,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			);
 
 		protected override Message When() =>
-			new SystemMessage.BecomeLeader(Guid.NewGuid());
+			new SystemMessage.BecomeLeader(Guid.NewGuid(), 0);
 
 		[Test]
 		public void should_update_gossip() {

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -69,7 +69,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				queueStatsManager: new QueueStatsManager());
 
 			Service.Handle(new SystemMessage.SystemStart());
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 
 			ReplicaSubscriptionId = AddSubscription(ReplicaId, true, out ReplicaManager1);
 			ReplicaSubscriptionId2 = AddSubscription(ReplicaId2, true, out ReplicaManager2);
@@ -115,7 +115,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		public abstract void When();
 		protected void BecomeLeader() {
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 		}
 
 		protected void BecomeUnknown() {
@@ -129,9 +129,11 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			ICheckpoint truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
 			ICheckpoint replicationCheckpoint = new InMemoryCheckpoint(-1);
 			ICheckpoint indexCheckpoint = new InMemoryCheckpoint(-1);
+			ICheckpoint termCheckpoint = new InMemoryCheckpoint(Checkpoint.Term, initValue: -1);
+
 			var nodeConfig = new TFChunkDbConfig(
 				PathName, new VersionedPatternFileNamingStrategy(PathName, "chunk-"), 1000, 10000, writerChk,
-				chaserChk, epochChk, truncateChk, replicationCheckpoint, indexCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, true);
+				chaserChk, epochChk, truncateChk, replicationCheckpoint, indexCheckpoint, termCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, true);
 			return nodeConfig;
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/with_clustered_replication_tracking_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/with_clustered_replication_tracking_service.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Replication.ReplicationTracking {
 		public abstract void When();
 		
 		protected void BecomeLeader() {
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 		}
 
 		protected void BecomeUnknown() {

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/with_storage_chaser_service.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/with_storage_chaser_service.cs
@@ -19,6 +19,7 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 		readonly ICheckpoint _truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
 		readonly ICheckpoint _replicationCheckpoint = new InMemoryCheckpoint(-1);
 		readonly ICheckpoint _indexCheckpoint = new InMemoryCheckpoint(-1);
+		readonly ICheckpoint _termCheckpoint = new InMemoryCheckpoint(-1);
 
 		protected InMemoryBus Publisher = new InMemoryBus("publisher");
 		protected StorageChaser Service;
@@ -74,7 +75,7 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 
 			var nodeConfig = new TFChunkDbConfig(
 				PathName, new VersionedPatternFileNamingStrategy(PathName, "chunk-"), 1000, 10000, _writerChk,
-				_chaserChk, _epochChk, _truncateChk, _replicationCheckpoint, _indexCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, true);
+				_chaserChk, _epochChk, _truncateChk, _replicationCheckpoint, _indexCheckpoint, _termCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, true);
 			return nodeConfig;
 		}
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -10,7 +10,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public static TFChunkDbConfig CreateDbConfig(string pathName, long writerCheckpointPosition,
 			long chaserCheckpointPosition = 0,
 			long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000,
-			long maxTruncation = -1) {
+			long maxTruncation = -1, long termCheckpoint = -1) {
 			return new TFChunkDbConfig(pathName,
 				new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
 				chunkSize,
@@ -21,6 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(truncateCheckpoint),
 				new InMemoryCheckpoint(-1), 
 				new InMemoryCheckpoint(-1),
+				new InMemoryCheckpoint(termCheckpoint),
 				Constants.TFChunkInitialReaderCountDefault, 
 				Constants.TFChunkMaxReaderCountDefault,
 				maxTruncation: maxTruncation);
@@ -38,6 +39,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				replicationCheckpoint, 
+				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				Constants.TFChunkInitialReaderCountDefault, 
 				Constants.TFChunkMaxReaderCountDefault);

--- a/src/EventStore.Core/Cluster/LeaderInfo.cs
+++ b/src/EventStore.Core/Cluster/LeaderInfo.cs
@@ -1,0 +1,21 @@
+namespace EventStore.Core.Cluster {
+	public class LeaderInfo : MemberInfo {
+		public readonly int? Term;
+
+		public LeaderInfo(MemberInfo memberInfo, int? term) :
+			base(memberInfo.InstanceId, memberInfo.TimeStamp, memberInfo.State, memberInfo.IsAlive, memberInfo.InternalTcpEndPoint,
+				memberInfo.InternalSecureTcpEndPoint, memberInfo.ExternalTcpEndPoint, memberInfo.ExternalSecureTcpEndPoint,
+				memberInfo.HttpEndPoint, memberInfo.AdvertiseHostToClientAs, memberInfo.AdvertiseHttpPortToClientAs,
+				memberInfo.AdvertiseTcpPortToClientAs, memberInfo.LastCommitPosition, memberInfo.WriterCheckpoint,
+				memberInfo.ChaserCheckpoint, memberInfo.EpochPosition, memberInfo.EpochNumber, memberInfo.EpochId,
+				memberInfo.NodePriority, memberInfo.IsReadOnlyReplica) {
+			Term = term;
+		}
+
+		public override int GetHashCode() {
+			int result = Term?.GetHashCode() ?? 0;
+			result = (result * 397) ^ base.GetHashCode();
+			return result;
+		}
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -311,6 +311,7 @@ namespace EventStore.Core {
 			var epochManager = new EpochManager(_mainQueue,
 				ESConsts.CachedEpochCount,
 				db.Config.EpochCheckpoint,
+				db.Config.TermCheckpoint,
 				writer,
 				initialReaderCount: 1,
 				maxReaderCount: 5,
@@ -736,7 +737,7 @@ namespace EventStore.Core {
 			// ELECTIONS
 			if (!vNodeSettings.NodeInfo.IsReadOnlyReplica) {
 				var electionsService = new ElectionsService(_mainQueue, memberInfo, vNodeSettings.ClusterNodeCount,
-					db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint,
+					db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint, db.Config.TermCheckpoint,
 					epochManager, () => readIndex.LastIndexedPosition, vNodeSettings.NodePriority, _timeProvider);
 				electionsService.SubscribeMessages(_mainBus);
 			}

--- a/src/EventStore.Core/Messages/ElectionMessage.cs
+++ b/src/EventStore.Core/Messages/ElectionMessage.cs
@@ -387,18 +387,18 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public readonly int InstalledView;
+			public readonly int Term;
 			public readonly MemberInfo Leader;
 
-			public ElectionsDone(int installedView, MemberInfo leader) {
-				Ensure.Nonnegative(installedView, "installedView");
+			public ElectionsDone(int term, MemberInfo leader) {
+				Ensure.Nonnegative(term, "term");
 				Ensure.NotNull(leader, "leader");
-				InstalledView = installedView;
+				Term = term;
 				Leader = leader;
 			}
 
 			public override string ToString() {
-				return string.Format("---- ElectionsDone: installedView {0}, leader {1}", InstalledView, Leader);
+				return string.Format("---- ElectionsDone: term {0}, leader {1}", Term, Leader);
 			}
 		}
 	}

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -77,6 +77,11 @@ namespace EventStore.Core.Messages {
 			public override int MsgTypeId {
 				get { return TypeId; }
 			}
+
+			public readonly int EpochNumber;
+			public WriteEpoch(int epochNumber) {
+				EpochNumber = epochNumber;
+			}
 		}
 		
 		public class InitiateLeaderResignation : Message {
@@ -130,7 +135,10 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public BecomeLeader(Guid correlationId) : base(correlationId, VNodeState.Leader) {
+			public readonly int Term;
+
+			public BecomeLeader(Guid correlationId, int term) : base(correlationId, VNodeState.Leader) {
+				Term = term;
 			}
 		}
 

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -260,9 +260,9 @@ namespace EventStore.Core.Services.Replication {
 			if (commonEpoch.EpochNumber == _epochManager.LastEpochNumber)
 				return Math.Min(replicaPosition, leaderCheckpoint);
 
-			var nextEpoch = _epochManager.GetEpoch(commonEpoch.EpochNumber + 1, throwIfNotFound: false);
+			var nextEpoch = _epochManager.GetNextEpoch(commonEpoch.EpochNumber, throwIfNotFound: false);
 			if (nextEpoch == null) {
-				nextEpoch = _epochManager.GetEpochWithAllEpochs(commonEpoch.EpochNumber + 1, throwIfNotFound: false);
+				nextEpoch = _epochManager.GetNextEpochWithAllEpochs(commonEpoch.EpochNumber, throwIfNotFound: false);
 			}
 
 			if (nextEpoch == null) {

--- a/src/EventStore.Core/Services/Storage/EpochManager/IEpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/IEpochManager.cs
@@ -10,10 +10,11 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 		EpochRecord GetLastEpoch();
 		EpochRecord[] GetLastEpochs(int maxCount);
 		EpochRecord GetEpoch(int epochNumber, bool throwIfNotFound);
-		EpochRecord GetEpochWithAllEpochs(int epochNumber, bool throwIfNotFound);
+		EpochRecord GetNextEpoch(int epochNumber, bool throwIfNotFound);
+		EpochRecord GetNextEpochWithAllEpochs(int epochNumber, bool throwIfNotFound);
 		bool IsCorrectEpochAt(long epochPosition, int epochNumber, Guid epochId);
 
-		void WriteNewEpoch();
+		void WriteNewEpoch(int epochNumber);
 		void SetLastEpoch(EpochRecord epoch);
 	}
 }

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -178,7 +178,8 @@ namespace EventStore.Core.Services.Storage {
 			switch (message.State) {
 				case VNodeState.Leader: {
 						_indexWriter.Reset();
-						EpochManager.WriteNewEpoch(); // forces flush
+						var becomeLeaderMessage = (SystemMessage.BecomeLeader)message;
+						EpochManager.WriteNewEpoch(becomeLeaderMessage.Term); // forces flush
 						break;
 					}
 				case VNodeState.ShuttingDown: {
@@ -193,7 +194,7 @@ namespace EventStore.Core.Services.Storage {
 				return;
 			if (_vnodeState != VNodeState.Leader)
 				throw new Exception(string.Format("New Epoch request not in leader state. State: {0}.", _vnodeState));
-			EpochManager.WriteNewEpoch();
+			EpochManager.WriteNewEpoch(message.EpochNumber);
 			PurgeNotProcessedInfo();
 		}
 

--- a/src/EventStore.Core/TransactionLog/Checkpoint/Checkpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/Checkpoint.cs
@@ -6,5 +6,6 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 		public const string Truncate = "truncate";
 		public const string Replication = "replication";
 		public const string Index = "index";
+		public const string Term = "term";
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -13,6 +13,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly ICheckpoint TruncateCheckpoint;
 		public readonly ICheckpoint ReplicationCheckpoint;
 		public readonly ICheckpoint IndexCheckpoint;
+		public readonly ICheckpoint TermCheckpoint;
 		public readonly IFileNamingStrategy FileNamingStrategy;
 		public readonly bool InMemDb;
 		public readonly bool Unbuffered;
@@ -33,6 +34,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			ICheckpoint truncateCheckpoint,
 			ICheckpoint replicationCheckpoint,
 			ICheckpoint indexCheckpoint,
+			ICheckpoint termCheckpoint,
 			int initialReaderCount,
 			int maxReaderCount,
 			bool inMemDb = false,
@@ -51,6 +53,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			Ensure.NotNull(truncateCheckpoint, "truncateCheckpoint");
 			Ensure.NotNull(replicationCheckpoint, "replicationCheckpoint");
 			Ensure.NotNull(indexCheckpoint, "indexCheckpoint");
+			Ensure.NotNull(termCheckpoint, "termCheckpoint");
 			Ensure.Positive(initialReaderCount, "initialReaderCount");
 			Ensure.Positive(maxReaderCount, "maxReaderCount");
 
@@ -63,6 +66,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			TruncateCheckpoint = truncateCheckpoint;
 			ReplicationCheckpoint = replicationCheckpoint;
 			IndexCheckpoint = indexCheckpoint;
+			TermCheckpoint = termCheckpoint;
 			FileNamingStrategy = fileNamingStrategy;
 			InMemDb = inMemDb;
 			Unbuffered = unbuffered;

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1550,6 +1550,7 @@ namespace EventStore.Core {
 			ICheckpoint chaserChk;
 			ICheckpoint epochChk;
 			ICheckpoint truncateChk;
+			ICheckpoint termChk;
 			//todo(clc) : promote these to file backed checkpoints re:project-io
 			ICheckpoint replicationChk = new InMemoryCheckpoint(Checkpoint.Replication, initValue: -1);
 			ICheckpoint indexChk = new InMemoryCheckpoint(Checkpoint.Replication, initValue: -1);
@@ -1558,6 +1559,7 @@ namespace EventStore.Core {
 				chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
 				epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
 				truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
+				termChk = new InMemoryCheckpoint(Checkpoint.Term, initValue: -1);
 			} else {
 				try {
 					if (!Directory.Exists(dbPath)) // mono crashes without this check
@@ -1581,12 +1583,14 @@ namespace EventStore.Core {
 				var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
 				var epochCheckFilename = Path.Combine(dbPath, Checkpoint.Epoch + ".chk");
 				var truncateCheckFilename = Path.Combine(dbPath, Checkpoint.Truncate + ".chk");
+				var termCheckFilename = Path.Combine(dbPath, Checkpoint.Term + ".chk");
 				writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
 				chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
 				epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true,
 					initValue: -1);
 				truncateChk = new MemoryMappedFileCheckpoint(truncateCheckFilename, Checkpoint.Truncate,
 					cached: true, initValue: -1);
+				termChk = new MemoryMappedFileCheckpoint(termCheckFilename, Checkpoint.Term, cached: true, initValue: -1);
 			}
 
 			var cache = cachedChunks >= 0
@@ -1603,6 +1607,7 @@ namespace EventStore.Core {
 				truncateChk,
 				replicationChk,
 				indexChk,
+				termChk,
 				chunkInitialReaderCount,
 				chunkMaxReaderCount,
 				inMemDb,

--- a/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_restarting.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_restarting.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -72,7 +72,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 		protected override void Given() {
 			// Start subsystem
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			 var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -141,7 +141,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -186,7 +186,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			WaitForStartMessage();
 			
@@ -209,7 +209,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -244,7 +244,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;

--- a/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_starting.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_starting.cs
@@ -20,7 +20,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				}));
 			
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 
 			var startMsg = WaitForStartMessage();
 			
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				}));
 			
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 			
 			WaitForStartMessage();
 
@@ -75,7 +75,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -103,7 +103,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -127,7 +127,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		[Test]
 		public void should_allow_starting_the_subsystem_again() {
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 			var startMessage = WaitForStartMessage();
 			
 			Assert.AreNotEqual(_instanceCorrelation, startMessage.InstanceCorrelationId);
@@ -141,7 +141,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -169,7 +169,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -184,7 +184,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 			WaitForStopMessage();
 
 			// Become leader again before subsystem fully stopped
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(), 0));
 
 			Subsystem.Handle(new ProjectionSubsystemMessage.ComponentStopped(
 				ProjectionManager.ServiceName, _instanceCorrelation));


### PR DESCRIPTION
Fixes https://github.com/EventStore/home/issues/263

Paxos `View numbers` and `Epoch numbers` used in EventStore are very similar to `Election Terms` in the raft consensus algorithm.

This PR is an experiment to:
- Treat a paxos `view number` like a `term` since, like with raft, at most one leader can be elected for a certain view number (term)
- Treat an `epoch number` like a `term`. Any data that comes after an epoch record having epoch number X has term X (till the next epoch record).
- Note: This breaks the continuity of epoch numbers but monotonicity of epoch numbers should be preserved (similar to raft terms)
- Persisting the term checkpoint whenever we see a new view ensures that any newly elected leader will have a larger term (epoch number) than the previous leader.
-  In raft, the node having the highest (term, index) is considered to have the latest data. Here, the node with the (highest epoch number, writer checkpoint) can be considered to have the latest data.