### PR TITLE
Prioritize leader selection in elections by Commit Checkpoint

### DIFF
--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -119,110 +119,148 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 0,
-				NodePriorities = new[] {3, 2, 1}
+				NodePriorities = new[] { 3, 2, 1 }
 			};
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 1,
-				NodePriorities = new[] {0, 0, int.MinValue},
-				LastElectedLeader = 2,
+				NodePriorities = new[] { 0, 0, int.MinValue },
+				LastElectedLeader =  new int?[] { 2, 2, 2 },
 				ResigningLeader = 2
 			};
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 0,
-				NodePriorities = new[] {int.MinValue, int.MinValue, int.MinValue},
-				LastElectedLeader = 0,
+				NodePriorities = new[] { int.MinValue, int.MinValue, int.MinValue },
+				LastElectedLeader = new int?[] { 0, 0, 0 },
 			};
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 0,
-				CommitPositions = new long[] {1, 0, 1},
-				NodePriorities = new[] {0, 0, int.MinValue},
-				LastElectedLeader = 2,
+				CommitPositions = new long[] { 1, 0, 1 },
+				NodePriorities = new[] { 0, 0, int.MinValue },
+				LastElectedLeader =  new int?[] { 2, 2, 2 },
 				ResigningLeader = 2
 			};
-			
+
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 1,
-				WriterCheckpoints = new long[] {0, 1, 1},
-				NodePriorities = new[] {0, 0, int.MinValue},
-				LastElectedLeader = 2,
-				ResigningLeader = 2
-			};
-			
-			yield return new TestCase {
-				ExpectedLeaderCandidateNode = 0,
-				ChaserCheckpoints = new long[] {1, 0, 1},
-				NodePriorities = new[] {0, 0, int.MinValue},
-				LastElectedLeader = 2,
+				WriterCheckpoints = new long[] { 0, 1, 1 },
+				NodePriorities = new[] { 0, 0, int.MinValue },
+				LastElectedLeader =  new int?[] { 2, 2, 2 },
 				ResigningLeader = 2
 			};
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 0,
-				CommitPositions = new long[] {1, 0, 0},
-				NodePriorities = new[] {int.MinValue, 0, 0},
-				LastElectedLeader = 0
+				ChaserCheckpoints = new long[] { 1, 0, 1 },
+				NodePriorities = new[] { 0, 0, int.MinValue },
+				LastElectedLeader =  new int?[] { 2, 2, 2 },
+				ResigningLeader = 2
 			};
-			
+
+			yield return new TestCase {
+				ExpectedLeaderCandidateNode = 0,
+				CommitPositions = new long[] { 1, 0, 0 },
+				NodePriorities = new[] { int.MinValue, 0, 0 },
+				LastElectedLeader = new int?[] { 0, 0, 0 },
+			};
+
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 1,
-				WriterCheckpoints = new long[] {0, 1, 0},
-				NodePriorities = new[] {0, int.MinValue, 0},
-				LastElectedLeader = 1
+				WriterCheckpoints = new long[] { 0, 1, 0 },
+				NodePriorities = new[] { 0, int.MinValue, 0 },
+				LastElectedLeader =  new int?[] { 1, 1, 1 },
 			};
-			
+
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 2,
-				ChaserCheckpoints = new long[] {0, 0, 1},
-				NodePriorities = new[] {0, 0, int.MinValue},
-				LastElectedLeader = 2
+				ChaserCheckpoints = new long[] { 0, 0, 1 },
+				NodePriorities = new[] { 0, 0, int.MinValue },
+				LastElectedLeader =  new int?[] { 2, 2, 2 }
 			};
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 0,
-				NodePriorities = new[] {0, int.MinValue, int.MinValue},
-				LastElectedLeader = 1,
+				NodePriorities = new[] { 0, int.MinValue, int.MinValue },
+				LastElectedLeader = new int?[] { 1, 1, 1 },
 				ResigningLeader = 1
 			};
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 1,
-				NodePriorities = new[] {int.MinValue, 0, int.MinValue},
-				LastElectedLeader = 0,
+				NodePriorities = new[] { int.MinValue, 0, int.MinValue },
+				LastElectedLeader = new int?[] { 0, 0, 0 },
 				ResigningLeader = 0
 			};
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 2,
-				NodePriorities = new[] {int.MinValue, int.MinValue, 0},
-				LastElectedLeader = 1,
+				NodePriorities = new[] { int.MinValue, int.MinValue, 0 },
+				LastElectedLeader = new int?[] { 1, 1, 1 },
 				ResigningLeader = 1
 			};
 
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 2,
-				CommitPositions = new long[] {1, 0, 1},
-				NodePriorities = new[] {int.MinValue, 0, int.MinValue},
-				LastElectedLeader = 0,
+				CommitPositions = new long[] { 1, 0, 1 },
+				NodePriorities = new[] { int.MinValue, 0, int.MinValue },
+				LastElectedLeader = new int?[] { 0, 0, 0 },
 				ResigningLeader = 0
 			};
-			
+
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 2,
-				WriterCheckpoints = new long[] {1, 0, 1},
-				NodePriorities = new[] {int.MinValue, 0, int.MinValue},
-				LastElectedLeader = 0,
+				WriterCheckpoints = new long[] { 1, 0, 1 },
+				NodePriorities = new[] { int.MinValue, 0, int.MinValue },
+				LastElectedLeader = new int?[] { 0, 0, 0 },
 				ResigningLeader = 0
 			};
-			
+
 			yield return new TestCase {
 				ExpectedLeaderCandidateNode = 2,
-				ChaserCheckpoints = new long[] {1, 0, 1},
-				NodePriorities = new[] {int.MinValue, 0, int.MinValue},
-				LastElectedLeader = 0,
+				ChaserCheckpoints = new long[] { 1, 0, 1 },
+				NodePriorities = new[] { int.MinValue, 0, int.MinValue },
+				LastElectedLeader = new int?[] { 0, 0, 0 },
 				ResigningLeader = 0
+			};
+			yield return new TestCase {
+				ExpectedLeaderCandidateNode = 2,
+				CommitPositions = new long[] { 0, 0, 5 },
+				NodePriorities = new[] { 0, 0, 1 },
+				LastElectedLeader =  new int?[] { 0, 2, 2 },
+				EpochNumbers = new[] { 10, 5, 5 }
+			};
+			yield return new TestCase {
+				ExpectedLeaderCandidateNode = 2,
+				CommitPositions = new long[] { 0, 0, 5 },
+				NodePriorities = new[] { 0, 0, 1 },
+				LastElectedLeader =  new int?[] { 0, 2, 2 },
+				EpochNumbers = new[] { 5, 5, 5 }
+			};
+			yield return new TestCase {
+				ExpectedLeaderCandidateNode = 2,
+				CommitPositions = new long[] { 0, 5, 5 },
+				NodePriorities = new[] { 0, 0, 1 },
+				LastElectedLeader = new int?[] { 0, 2, 2 },
+				EpochNumbers = new[] { 10, 5, 5 },
+				WriterCheckpoints = new[] { 10L, 5, 5 },
+			};
+			yield return new TestCase {
+				ExpectedLeaderCandidateNode = 1,
+				CommitPositions = new long[] { 0, 5, 5 },
+				NodePriorities = new[] { 0, 0, 1 },
+				LastElectedLeader = new int?[] { 0, 1, 1 },
+				EpochNumbers = new[] { 10, 5, 5 },
+				WriterCheckpoints = new[] { 10L, 5, 5 },
+			};
+			yield return new TestCase {
+				ExpectedLeaderCandidateNode = 2,
+				CommitPositions = new long[] { 0, 5, 5 },
+				NodePriorities = new[] { 0, 0, 0 },
+				LastElectedLeader = new int?[] { 0, 2, 2 },
+				EpochNumbers = new[] { 10, 5, 5 },
+				WriterCheckpoints = new[] { 10L, 5, 5 },
 			};
 		}
 
@@ -235,33 +273,34 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			Func<int, long> writerCheckpoint = i => tc.WriterCheckpoints[i];
 			Func<int, long> chaserCheckpoint = i => tc.ChaserCheckpoints[i];
 			Func<int, int> nodePriority = i => tc.NodePriorities[i];
+			Func<int, int> epochNumber = i => tc.EpochNumbers[i];
 
 			for (int index = 0; index < 3; index++) {
 				members[index] = CreateMemberInfo(index, epochId, lastCommitPosition, writerCheckpoint,
-					chaserCheckpoint, nodePriority);
+					chaserCheckpoint, nodePriority, epochNumber);
 			}
 
 			var clusterInfo = new ClusterInfo(members);
-			var previousLeaderId = tc.LastElectedLeader.HasValue ? IdForNode(tc.LastElectedLeader.Value) : Guid.Empty;
+			Func<int, Guid> previousLeaderId = i => !tc.LastElectedLeader[i].HasValue ? Guid.Empty : IdForNode(tc.LastElectedLeader[i].Value);
 
 			for (int index = 0; index < 3; index++) {
 				var prepareOk = CreatePrepareOk(index, epochId, lastCommitPosition, writerCheckpoint, chaserCheckpoint,
-					nodePriority, previousLeaderId, clusterInfo);
+					nodePriority, epochNumber, previousLeaderId, clusterInfo);
 				prepareOks.Add(prepareOk.ServerId, prepareOk);
 			}
 
-			var lastElectedLeader = tc.LastElectedLeader.HasValue
-				? (Guid?)IdForNode(tc.LastElectedLeader.Value)
-				: null;
+			//var lastElectedLeader = tc.LastElectedLeader.HasValue
+			//	? (Guid?)IdForNode(tc.LastElectedLeader.Value)
+			//	: null;
 			var resigningLeadership = tc.ResigningLeader.HasValue
 				? (Guid?)IdForNode(tc.ResigningLeader.Value)
 				: null;
 			var mc = SUT.GetBestLeaderCandidate(prepareOks, members, resigningLeadership, 0);
 
-			Assert.AreEqual(IdForNode(tc.ExpectedLeaderCandidateNode), mc.InstanceId);
+			Assert.AreEqual(IdForNode(tc.ExpectedLeaderCandidateNode), mc.InstanceId, $"Expected node {tc.ExpectedLeaderCandidateNode} got node {Array.FindIndex(members, 0, m => m.InstanceId == mc.InstanceId) + 1 }");
 
 			var ownInfo = CreateLeaderCandidate(1, epochId, lastCommitPosition, writerCheckpoint, chaserCheckpoint,
-				nodePriority, previousLeaderId);
+				nodePriority, epochNumber, previousLeaderId);
 
 			var isLegit = SUT.IsLegitimateLeader(1, EndpointForNode(tc.ProposingNode),
 				IdForNode(tc.ProposingNode), mc, members, null, members[0].InstanceId,
@@ -276,11 +315,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			Func<int, long> writerCheckpoint,
 			Func<int, long> chaserCheckpoint,
 			Func<int, int> nodePriority,
-			Guid previousLeaderId,
+			Func<int, int> epochNumber,
+			Func<int, Guid> previousLeaderId,
 			ClusterInfo clusterInfo) {
 			var id = IdForNode(i);
 			var ep = EndpointForNode(i);
-			return new ElectionMessage.PrepareOk(1, id, ep, 1, 1, epochId, previousLeaderId, lastCommitPosition(i), writerCheckpoint(i),
+			return new ElectionMessage.PrepareOk(1, id, ep, epochNumber(i), 1, epochId, previousLeaderId(i), lastCommitPosition(i), writerCheckpoint(i),
 				chaserCheckpoint(i), nodePriority(i), clusterInfo);
 		}
 
@@ -289,21 +329,24 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			Func<int, long> writerCheckpoint,
 			Func<int, long> chaserCheckpoint,
 			Func<int, int> nodePriority,
-			Guid previousLeaderId) {
+			Func<int, int> epochNumber,
+			Func<int, Guid> previousLeaderId) {
 			var id = IdForNode(i);
 			var ep = EndpointForNode(i);
-			return new SUT.LeaderCandidate(id, ep, 1, 1, epochId, previousLeaderId, lastCommitPosition(i), writerCheckpoint(i),
+			return new SUT.LeaderCandidate(id, ep, epochNumber(i), 1, epochId, previousLeaderId(i), lastCommitPosition(i), writerCheckpoint(i),
 				chaserCheckpoint(i), nodePriority(i));
 		}
 
 		static MemberInfo CreateMemberInfo(int i, Guid epochId, Func<int, long> lastCommitPosition,
 			Func<int, long> writerCheckpoint,
 			Func<int, long> chaserCheckpoint,
-			Func<int, int> nodePriority) {
+			Func<int, int> nodePriority,
+			Func<int, int> epochNumber
+			) {
 			var id = IdForNode(i);
 			var ep = EndpointForNode(i);
 			return MemberInfo.ForVNode(id, DateTime.Now, VNodeState.Follower, true, ep, ep, ep, ep, ep, null, 0, 0,
-				lastCommitPosition(i), writerCheckpoint(i), chaserCheckpoint(i), 1, 1, epochId, nodePriority(i), false);
+				lastCommitPosition(i), writerCheckpoint(i), chaserCheckpoint(i), 1, epochNumber(i), epochId, nodePriority(i), false);
 		}
 
 		private static IPEndPoint EndpointForNode(int i) {
@@ -322,42 +365,63 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			public int ExpectedLeaderCandidateNode { get; set; }
 			public int? ResigningLeader { get; set; }
 			public int ProposingNode { get; set; }
-			public int? LastElectedLeader { get; set; }
-			public long[] CommitPositions { get; set; } = {1L, 1, 1};
-			public long[] WriterCheckpoints { get; set; } = {1L, 1, 1};
-			public long[] ChaserCheckpoints { get; set; } = {1L, 1, 1};
-			public int[] NodePriorities { get; set; } = {1, 1, 1};
+			public int?[] LastElectedLeader { get; set; } = { null, null, null };
+			public long[] CommitPositions { get; set; } = { 1L, 1, 1 };
+			public long[] WriterCheckpoints { get; set; } = { 1L, 1, 1 };
+			public long[] ChaserCheckpoints { get; set; } = { 1L, 1, 1 };
+			public int[] NodePriorities { get; set; } = { 1, 1, 1 };
+			public int[] EpochNumbers { get; set; } = { -1, -1, -1 };
 
-			private static string GenerateName(int expectedLeaderCandidateNode, long[] commitPositions,
+			private static string GenerateName(int expectedLeaderCandidateNode, int?[] previousLeader, long[] commitPositions,
 				long[] writerCheckpoints,
-				long[] chaserCheckpoints, int[] nodePriorities) {
+				long[] chaserCheckpoints, int[] nodePriorities, int[] epochNumbers) {
 				var nameBuilder = new StringBuilder();
 				if (commitPositions != null) {
-					if (nameBuilder.Length == 0) nameBuilder.Append("Nodes with ");
-					else nameBuilder.Append(" and");
+					if (nameBuilder.Length == 0)
+						nameBuilder.Append("Nodes with ");
+					else
+						nameBuilder.Append(" and");
+					nameBuilder.AppendFormat("previous Leader number ( {0} )", string.Join(",",
+						previousLeader.Where(x => x != 1).Select((x, i) => $"{i} : cp {x}")));
+				}
+				if (commitPositions != null) {
+					if (nameBuilder.Length == 0)
+						nameBuilder.Append("Nodes with ");
+					else
+						nameBuilder.Append(" and");
 					nameBuilder.AppendFormat("commit positions ( {0} )", string.Join(",",
 						commitPositions.Where(x => x != 1).Select((x, i) => $"{i} : cp {x}")));
 				}
-
 				if (writerCheckpoints != null) {
-					if (nameBuilder.Length == 0) nameBuilder.Append("Nodes with ");
-					else nameBuilder.Append(" and ");
+					if (nameBuilder.Length == 0)
+						nameBuilder.Append("Nodes with ");
+					else
+						nameBuilder.Append(" and ");
 					nameBuilder.AppendFormat("writer checkpoints ( {0} )", string.Join(",",
 						writerCheckpoints.Where(x => x != 1).Select((x, i) => $"{i} : wcp {x}")));
 				}
 
 				if (chaserCheckpoints != null) {
-					if (nameBuilder.Length == 0) nameBuilder.Append("Nodes with ");
-					else nameBuilder.Append(" and ");
+					if (nameBuilder.Length == 0)
+						nameBuilder.Append("Nodes with ");
+					else
+						nameBuilder.Append(" and ");
 					nameBuilder.AppendFormat("chaser checkpoints ( {0} )", string.Join(",",
 						chaserCheckpoints.Where(x => x != 1).Select((x, i) => $"{i} : ccp {x}")));
 				}
 
 				if (nodePriorities != null) {
-					if (nameBuilder.Length == 0) nameBuilder.Append("Nodes with ");
-					else nameBuilder.Append(" and ");
+					if (nameBuilder.Length == 0)
+						nameBuilder.Append("Nodes with ");
+					else
+						nameBuilder.Append(" and ");
 					nameBuilder.AppendFormat("node priorities ( {0} )", string.Join(",",
 						nodePriorities.Where(x => x != 0).Select((x, i) => $"{i} : np {x}")));
+				}
+				if (epochNumbers != null) {
+					nameBuilder.Append(nameBuilder.Length == 0 ? "Nodes with " : " and ");
+					nameBuilder.AppendFormat("epoch numbers ( {0} )", string.Join(",",
+						epochNumbers.Where(x => x != 0).Select((x, i) => $"{i} : en {x}")));
 				}
 
 				if (nameBuilder.Length == 0)
@@ -368,8 +432,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			}
 
 			public override string ToString() {
-				return GenerateName(ExpectedLeaderCandidateNode, CommitPositions, WriterCheckpoints, ChaserCheckpoints,
-					NodePriorities);
+				return GenerateName(ExpectedLeaderCandidateNode, LastElectedLeader, CommitPositions, WriterCheckpoints, ChaserCheckpoints,
+					NodePriorities, EpochNumbers);
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -423,9 +423,10 @@ namespace EventStore.Core.Services {
 
 		public static LeaderCandidate GetBestLeaderCandidate(Dictionary<Guid, ElectionMessage.PrepareOk> received,
 			MemberInfo[] servers, Guid? resigningLeaderInstanceId, int lastAttemptedView) {
+			
 			var best = received.Values
-				.OrderByDescending(x => x.EpochNumber)
-				.ThenByDescending(x => x.LastCommitPosition)
+				.OrderByDescending(x => x.LastCommitPosition)
+				.ThenByDescending(x => x.EpochNumber)
 				.ThenByDescending(x => x.WriterCheckpoint)
 				.ThenByDescending(x => x.ChaserCheckpoint)
 				.ThenByDescending(x => x.NodePriority)


### PR DESCRIPTION
Fixed: EventStore/home#263

Close edge case for isolated deposed leaders being preferred in elections due to an artificially high epoch count.

The prioritizing by commit checkpoint correctly identifies the instance with the most current client acknowledge data.

The tests have been enhanced to add support for `epoch number` and differing `last leader` values. This allows recreating the exact scenarios with differing epochs and the disagreement on the last known quorum leader that occurs when isolated nodes rejoin.

Note: The required pre-condition is not possible in a cluster with an active quorum in version 20.6 and higher, although it can occur in the rarer case of two nodes forming a quorum.

Note  this approach also avoids the performance impact of persisting the replication checkpoint