### PR TITLE
Add checkpoint tracking for proposed epochs 

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -261,6 +261,7 @@ namespace EventStore.Core.Tests.Helpers {
 			ICheckpoint writerChk;
 			ICheckpoint chaserChk;
 			ICheckpoint epochChk;
+			ICheckpoint proposalChk;
 			ICheckpoint truncateChk;
 			ICheckpoint replicationCheckpoint = new InMemoryCheckpoint(-1);
 			ICheckpoint indexCheckpoint = new InMemoryCheckpoint(-1);
@@ -268,23 +269,39 @@ namespace EventStore.Core.Tests.Helpers {
 				writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
 				chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
 				epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
+				proposalChk = new InMemoryCheckpoint(Checkpoint.Proposal, initValue: -1);
 				truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
 			} else {
 				var writerCheckFilename = Path.Combine(dbPath, Checkpoint.Writer + ".chk");
 				var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
 				var epochCheckFilename = Path.Combine(dbPath, Checkpoint.Epoch + ".chk");
+				var proposalFilename = Path.Combine(dbPath, Checkpoint.Proposal + ".chk");
 				var truncateCheckFilename = Path.Combine(dbPath, Checkpoint.Truncate + ".chk");
 				writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
 				chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
 				epochChk = new MemoryMappedFileCheckpoint(
 					epochCheckFilename, Checkpoint.Epoch, cached: true, initValue: -1);
+				proposalChk = new MemoryMappedFileCheckpoint(
+					proposalFilename, Checkpoint.Proposal, cached: true, initValue: -1);
 				truncateChk = new MemoryMappedFileCheckpoint(
 					truncateCheckFilename, Checkpoint.Truncate, cached: true, initValue: -1);
 			}
 
 			var nodeConfig = new TFChunkDbConfig(
-				dbPath, new VersionedPatternFileNamingStrategy(dbPath, "chunk-"), chunkSize, chunksCacheSize, writerChk,
-				chaserChk, epochChk, truncateChk, replicationCheckpoint, indexCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, inMemDb);
+				dbPath, 
+				new VersionedPatternFileNamingStrategy(dbPath, "chunk-"), 
+				chunkSize, 
+				chunksCacheSize, 
+				writerChk,
+				chaserChk, 
+				epochChk, 
+				proposalChk, 
+				truncateChk, 
+				replicationCheckpoint, 
+				indexCheckpoint, 
+				Constants.TFChunkInitialReaderCountDefault, 
+				Constants.TFChunkMaxReaderCountDefault, 
+				inMemDb);
 			return nodeConfig;
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -18,6 +18,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		private const int LastCommitPosition = -1;
 		private const int WriterCheckpoint = 0;
 		private const int ChaserCheckpoint = 0;
+		private const int ProposalCheckpoint = -1;
 		private static readonly DateTime InitialDate = new DateTime(2012, 6, 1);
 
 		public ClusterInfo ClusterInfo { get; private set; }
@@ -54,6 +55,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				clusterSettings.ClusterNodesCount,
 				new InMemoryCheckpoint(WriterCheckpoint),
 				new InMemoryCheckpoint(ChaserCheckpoint),
+				new InMemoryCheckpoint(ProposalCheckpoint),
 				new FakeEpochManager(),
 				() => -1, 0, new FakeTimeProvider());
 			ElectionsService.SubscribeMessages(_bus);

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -53,6 +53,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				MemberInfoFromVNode(_node, _timeProvider.UtcNow, VNodeState.Unknown, true, 0, _epochId, 0), 3,
 				new InMemoryCheckpoint(0),
 				new InMemoryCheckpoint(0),
+				new InMemoryCheckpoint(-1),
 				new FakeEpochManager(), () => 0L, 0, _timeProvider);
 			_sut.SubscribeMessages(_bus);
 		}
@@ -827,7 +828,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				_nodeThree.HttpEndPoint, 0, 0, 0, _epochId, Guid.Empty, 0, 0, 0, 0));
 
 			var expected = new Message[] {
-				new ElectionMessage.ElectionsDone(0,
+				new ElectionMessage.ElectionsDone(0,0,
 					MemberInfo.ForVNode(
 						_nodeThree.InstanceId, _timeProvider.UtcNow, VNodeState.Unknown, true,
 						_nodeThree.InternalTcp,
@@ -967,7 +968,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				proposalMessage.LeaderId, proposalMessage.LeaderHttpEndPoint, 0));
 
 			var expected = new Message[] {
-				new ElectionMessage.ElectionsDone(0,
+				new ElectionMessage.ElectionsDone(0,0,
 					MemberInfo.ForVNode(
 						_nodeTwo.InstanceId, _timeProvider.UtcNow, VNodeState.Unknown, true,
 						_nodeTwo.InternalTcp,
@@ -1186,7 +1187,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				proposalMessage.LeaderId, proposalMessage.LeaderHttpEndPoint, 3));
 
 			var expected = new Message[] {
-				new ElectionMessage.ElectionsDone(3,
+				new ElectionMessage.ElectionsDone(3,1,
 					MemberInfo.ForVNode(
 						_nodeTwo.InstanceId, _timeProvider.UtcNow, VNodeState.Unknown, true,
 						_nodeTwo.InternalTcp,
@@ -1239,6 +1240,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new Core.Services.ElectionsService(new FakePublisher(), nodeInfo, 3,
 					new InMemoryCheckpoint(0),
 					new InMemoryCheckpoint(0),
+					new InMemoryCheckpoint(-1),
 					new FakeEpochManager(), () => 0L, 0, new FakeTimeProvider());
 			});
 		}
@@ -1266,7 +1268,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		[Test]
 		public void previous_leader_should_be_elected() {
 			var expected = new Message[] {
-				new ElectionMessage.ElectionsDone(0,
+				new ElectionMessage.ElectionsDone(0,0,
 					MemberInfo.ForVNode(
 						_nodeThree.InstanceId, _timeProvider.UtcNow, VNodeState.Unknown, true,
 						_nodeThree.InternalTcp,
@@ -1355,7 +1357,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			[Test]
 			public void previous_leader_should_not_be_elected() {
 				var expected = new Message[] {
-					new ElectionMessage.ElectionsDone(0,
+					new ElectionMessage.ElectionsDone(0,0,
 						MemberInfo.ForVNode(
 							_nodeTwo.InstanceId, _timeProvider.UtcNow, VNodeState.Unknown, true,
 							_nodeTwo.InternalTcp,
@@ -1388,7 +1390,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			[Test]
 			public void previous_leader_should_not_be_elected() {
 				var expected = new Message[] {
-					new ElectionMessage.ElectionsDone(0,
+					new ElectionMessage.ElectionsDone(0,0,
 						MemberInfo.ForVNode(
 							_nodeTwo.InstanceId, _timeProvider.UtcNow, VNodeState.Unknown, true,
 							_nodeTwo.InternalTcp,
@@ -1439,7 +1441,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			[Test]
 			public void previous_leader_should_not_be_elected() {
 				var expected = new Message[] {
-					new ElectionMessage.ElectionsDone(0,
+					new ElectionMessage.ElectionsDone(0,0,
 						MemberInfo.ForVNode(
 							_nodeTwo.InstanceId, _timeProvider.UtcNow, VNodeState.Unknown, true,
 							_nodeTwo.InternalTcp,
@@ -1472,7 +1474,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			[Test]
 			public void previous_leader_should_not_be_elected() {
 				var expected = new Message[] {
-					new ElectionMessage.ElectionsDone(0,
+					new ElectionMessage.ElectionsDone(0,0,
 						MemberInfo.ForVNode(
 							_nodeTwo.InstanceId, _timeProvider.UtcNow, VNodeState.Unknown, true,
 							_nodeTwo.InternalTcp,

--- a/src/EventStore.Core.Tests/Services/ElectionsService/FakeEpochManager.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/FakeEpochManager.cs
@@ -35,30 +35,34 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			}
 		}
 
-		public EpochRecord GetEpoch(int epochNumber, bool throwIfNotFound) {
+		public EpochRecord GetEpochAfter(int epochNumber, bool throwIfNotFound) {
 			lock (_epochs) {
 				var epoch = _epochs.FirstOrDefault(e => e.EpochNumber == epochNumber);
+				if (epoch != null) {
+					var index = _epochs.IndexOf(epoch);
+					epoch = null;
+					if (index + 1 < _epochs.Count) {
+						epoch = _epochs[index + 1];
+					}
+				}
+
 				if (throwIfNotFound && epoch == null)
 					throw new ArgumentOutOfRangeException(nameof(epochNumber), "Epoch not Found");
 				return epoch;
 			}
 		}
 
-		public EpochRecord GetEpochWithAllEpochs(int epochNumber, bool throwIfNotFound) {
-			lock (_epochs) {
-				return GetEpoch(epochNumber, throwIfNotFound);
-			}
-		}
+		
 
 		public bool IsCorrectEpochAt(long epochPosition, int epochNumber, Guid epochId) {
 			throw new NotImplementedException();
 		}
-
-		public void WriteNewEpoch() {
+		
+		public void WriteNewEpoch(int epochNumber) {
 			throw new NotImplementedException();
 		}
 
-		public void SetLastEpoch(EpochRecord epoch) {
+		public void CacheEpoch(EpochRecord epoch) {
 			lock (_epochs) {
 				_epochs.Add(epoch);
 			}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
@@ -79,6 +79,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 					InstancesCnt,
 					new InMemoryCheckpoint(),
 					new InMemoryCheckpoint(),
+					new InMemoryCheckpoint(-1),
 					new FakeEpochManager(),
 					() => -1, 0, new FakeTimeProvider());
 				electionsService.SubscribeMessages(inputBus);

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -504,7 +504,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			);
 
 		protected override Message When() =>
-			new SystemMessage.BecomeLeader(Guid.NewGuid());
+			new SystemMessage.BecomeLeader(Guid.NewGuid(),0);
 
 		[Test]
 		public void should_update_gossip() {
@@ -811,7 +811,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			);
 
 		protected override Message When() =>
-			new ElectionMessage.ElectionsDone(0,
+			new ElectionMessage.ElectionsDone(0,0,
 				MemberInfoForVNode(_nodeTwo, _timeProvider.UtcNow, nodeState: VNodeState.Leader));
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Net;
 using System.Threading.Tasks;
 using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Bus;
@@ -69,7 +68,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				queueStatsManager: new QueueStatsManager());
 
 			Service.Handle(new SystemMessage.SystemStart());
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			ReplicaSubscriptionId = AddSubscription(ReplicaId, true, out ReplicaManager1);
 			ReplicaSubscriptionId2 = AddSubscription(ReplicaId2, true, out ReplicaManager2);
@@ -115,7 +114,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		public abstract void When();
 		protected void BecomeLeader() {
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 		}
 
 		protected void BecomeUnknown() {
@@ -126,12 +125,25 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			ICheckpoint writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
 			ICheckpoint chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
 			ICheckpoint epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
+			ICheckpoint proposalChk = new InMemoryCheckpoint(Checkpoint.Proposal, initValue: -1);
 			ICheckpoint truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
 			ICheckpoint replicationCheckpoint = new InMemoryCheckpoint(-1);
 			ICheckpoint indexCheckpoint = new InMemoryCheckpoint(-1);
 			var nodeConfig = new TFChunkDbConfig(
-				PathName, new VersionedPatternFileNamingStrategy(PathName, "chunk-"), 1000, 10000, writerChk,
-				chaserChk, epochChk, truncateChk, replicationCheckpoint, indexCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, true);
+				PathName, 
+				new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
+				1000,
+				10000,
+				writerChk,
+				chaserChk,
+				epochChk,
+				proposalChk,
+				truncateChk,
+				replicationCheckpoint,
+				indexCheckpoint,
+				Constants.TFChunkInitialReaderCountDefault,
+				Constants.TFChunkMaxReaderCountDefault,
+				true);
 			return nodeConfig;
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/with_clustered_replication_tracking_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/with_clustered_replication_tracking_service.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Replication.ReplicationTracking {
 		public abstract void When();
 		
 		protected void BecomeLeader() {
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 		}
 
 		protected void BecomeUnknown() {

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/with_storage_chaser_service.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/with_storage_chaser_service.cs
@@ -16,6 +16,7 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 		readonly ICheckpoint _writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
 		readonly ICheckpoint _chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
 		readonly ICheckpoint _epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
+		readonly ICheckpoint _proposalChk = new InMemoryCheckpoint(Checkpoint.Proposal, initValue: -1);
 		readonly ICheckpoint _truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
 		readonly ICheckpoint _replicationCheckpoint = new InMemoryCheckpoint(-1);
 		readonly ICheckpoint _indexCheckpoint = new InMemoryCheckpoint(-1);
@@ -73,8 +74,20 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 		private TFChunkDbConfig CreateDbConfig() {
 
 			var nodeConfig = new TFChunkDbConfig(
-				PathName, new VersionedPatternFileNamingStrategy(PathName, "chunk-"), 1000, 10000, _writerChk,
-				_chaserChk, _epochChk, _truncateChk, _replicationCheckpoint, _indexCheckpoint, Constants.TFChunkInitialReaderCountDefault, Constants.TFChunkMaxReaderCountDefault, true);
+				PathName, 
+				new VersionedPatternFileNamingStrategy(PathName, "chunk-"), 
+				1000, 
+				10000, 
+				_writerChk,
+				_chaserChk, 
+				_epochChk,
+				_proposalChk,
+				_truncateChk,
+				_replicationCheckpoint,
+				_indexCheckpoint,
+				Constants.TFChunkInitialReaderCountDefault,
+				Constants.TFChunkMaxReaderCountDefault,
+				true);
 			return nodeConfig;
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using EventStore.Core.Services.Storage.EpochManager;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using System.Threading;
+
+namespace EventStore.Core.Tests.Services.Storage {
+	[TestFixture]
+	public sealed class when_having_TFLog_with_existing_epochs : SpecificationWithDirectoryPerTestFixture, IDisposable {
+		private TFChunkDb _db;
+		private EpochManager _epochManager;
+		private LinkedList<EpochRecord> _cache;
+		private TFChunkReader _reader;
+		private TFChunkWriter _writer;
+		private IBus _mainBus;
+		private readonly Guid _instanceId = Guid.NewGuid();
+		private readonly List<Message> _published = new List<Message>();
+		private List<EpochRecord> _epochs;
+		private static int GetNextEpoch() {
+			return (int)Interlocked.Increment(ref _currentEpoch);
+		}
+		private static long _currentEpoch = -1;
+		private EpochManager GetManager() {
+			return new EpochManager(_mainBus,
+				10,
+				_db.Config.EpochCheckpoint,
+				_writer,
+				initialReaderCount: 1,
+				maxReaderCount: 5,
+				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
+					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				_instanceId);
+		}
+		private LinkedList<EpochRecord> GetCache(EpochManager manager) {
+			return (LinkedList<EpochRecord>)typeof(EpochManager).GetField("_epochs", BindingFlags.NonPublic | BindingFlags.Instance)
+				.GetValue(_epochManager);
+		}
+		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
+			long pos = _writer.Checkpoint.ReadNonFlushed();
+			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
+			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
+				SystemRecordSerialization.Json, epoch.AsSerialized());
+			_writer.Write(rec, out _);
+			_writer.Flush();
+			return epoch;
+		}
+		[OneTimeSetUp]
+		public override async Task TestFixtureSetUp() {
+			await base.TestFixtureSetUp();
+			_mainBus = new InMemoryBus(nameof(when_having_an_epoch_manager_and_empty_tf_log));
+			_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
+			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
+			_db.Open();
+			_reader = new TFChunkReader(_db, _db.Config.WriterCheckpoint);
+			_writer = new TFChunkWriter(_db);
+
+			_epochManager = GetManager();
+			_epochManager.Init();
+			_cache = GetCache(_epochManager);
+			Assert.NotNull(_cache);
+			Assert.That(_cache.Count == 0);
+			_epochs = new List<EpochRecord>();
+			var lastPos = 0L;
+			for (int i = 0; i < 30; i++) {
+				var epoch = WriteEpoch(GetNextEpoch(), lastPos, _instanceId);
+				_epochs.Add(epoch);
+				lastPos = epoch.EpochPosition;
+			}
+		}
+
+		[OneTimeTearDown]
+		public override async Task TestFixtureTearDown() {
+			this.Dispose();
+			await base.TestFixtureTearDown();
+		}
+		// epoch manager is stateful with TFLog, 
+		// and TFLog is expesive to build fresh for each test
+		// and the tests depend on previous state in the epoch manager
+		// so this test will run through the test cases 
+		// in order
+		[Test]
+		public void can_add_epochs_to_cache() {
+
+			Assert.That(_cache.Count == 0);
+			//add fist epoch to empty cache
+			_epochManager.AddEpochToCache(_epochs[3]);
+
+			Assert.That(_cache.Count == 4);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[0].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[3].EpochNumber);
+
+			//add new last epoch
+			_epochManager.AddEpochToCache(_epochs[4]);
+
+			Assert.That(_cache.Count == 5);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[0].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[4].EpochNumber);
+
+			//idempotent add
+			_epochManager.AddEpochToCache(_epochs[1]);
+			_epochManager.AddEpochToCache(_epochs[2]);
+			_epochManager.AddEpochToCache(_epochs[3]);
+
+			Assert.That(_cache.Count == 5);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[0].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[4].EpochNumber);
+
+			//add new skip 1 last epoch
+			_epochManager.AddEpochToCache(_epochs[6]);
+
+			Assert.That(_cache.Count == 7);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[0].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[6].EpochNumber);
+
+			//add new skip 5 last epoch
+			_epochManager.AddEpochToCache(_epochs[11]);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[2].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[11].EpochNumber);
+
+			//add last rolls cache
+			_epochManager.AddEpochToCache(_epochs[12]);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[3].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[12].EpochNumber);
+
+
+			//add epoch before cache
+			_epochManager.AddEpochToCache(_epochs[1]);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[3].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[12].EpochNumber);
+
+			//add idempotent first epoch
+			_epochManager.AddEpochToCache(_epochs[2]);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[3].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[12].EpochNumber);
+
+			//add idempotent last epoch
+			_epochManager.AddEpochToCache(_epochs[12]);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[3].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[12].EpochNumber);
+
+			//add disjunct skip epoch
+			_epochManager.AddEpochToCache(_epochs[24]);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[15].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[24].EpochNumber);
+
+			
+			//cannot get epoch ahead of last cached on master
+			var nextEpoch = _epochManager.GetEpochAfter(_epochs[24].EpochNumber, false);
+			Assert.Null(nextEpoch);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[15].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[24].EpochNumber);
+
+			//cannot get epoch ahead of cache on master
+			nextEpoch = _epochManager.GetEpochAfter(_epochs[25].EpochNumber, false);
+			Assert.Null(nextEpoch);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[15].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[24].EpochNumber);
+						
+			//can get next  in cache			
+			nextEpoch = _epochManager.GetEpochAfter(_epochs[20].EpochNumber, false);
+			
+			Assert.That(nextEpoch.EpochPosition == _epochs[21].EpochPosition);
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[15].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[24].EpochNumber);
+			
+			//can get next from first			
+			nextEpoch = _epochManager.GetEpochAfter(_epochs[15].EpochNumber, false);
+			
+			Assert.That(nextEpoch.EpochPosition == _epochs[16].EpochPosition);
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[15].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[24].EpochNumber);
+			
+			//can get next epoch from just before cache 
+			nextEpoch = _epochManager.GetEpochAfter(_epochs[14].EpochNumber, false);
+			
+			Assert.That(nextEpoch.EpochPosition == _epochs[15].EpochPosition);
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[15].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[24].EpochNumber);
+
+			//can get next epoch from before cache 
+			nextEpoch = _epochManager.GetEpochAfter(_epochs[10].EpochNumber, false);
+			
+			Assert.That(nextEpoch.EpochPosition == _epochs[11].EpochPosition);
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[15].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[24].EpochNumber);
+
+			//can get next epoch from 0 epoch
+			nextEpoch = _epochManager.GetEpochAfter(_epochs[0].EpochNumber, false);
+			
+			Assert.That(nextEpoch.EpochPosition == _epochs[1].EpochPosition);
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[15].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[24].EpochNumber);
+
+
+			//can add last epoch in log
+			_epochManager.AddEpochToCache(_epochs[29]);
+
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[20].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[29].EpochNumber);
+
+		}
+		public void Dispose() {
+			//epochManager?.Dispose();
+			//reader?.Dispose();
+			_writer?.Dispose();
+			_db?.Close();
+			_db?.Dispose();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
@@ -1,0 +1,144 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using EventStore.Core.Services.Storage.EpochManager;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using System.Threading;
+
+namespace EventStore.Core.Tests.Services.Storage {
+	[TestFixture]
+	public sealed class when_having_an_epoch_manager_and_empty_tf_log : SpecificationWithDirectoryPerTestFixture, IDisposable {
+		private TFChunkDb _db;
+		private EpochManager _epochManager;
+		private LinkedList<EpochRecord> _cache;
+		private TFChunkReader _reader;
+		private TFChunkWriter _writer;
+		private IBus _mainBus;
+		private readonly Guid _instanceId = Guid.NewGuid();
+		private readonly List<Message> _published = new List<Message>();
+		private static int GetNextEpoch() {
+			return (int)Interlocked.Increment(ref _currentEpoch);
+		}
+		private static long _currentEpoch = -1;
+		private EpochManager GetManager() {
+			return new EpochManager(_mainBus,
+				10,
+				_db.Config.EpochCheckpoint,
+				_writer,
+				initialReaderCount: 1,
+				maxReaderCount: 5,
+				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
+					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				_instanceId);
+		}
+		private LinkedList<EpochRecord> GetCache(EpochManager manager) {
+			return (LinkedList<EpochRecord>)typeof(EpochManager).GetField("_epochs", BindingFlags.NonPublic | BindingFlags.Instance)
+				.GetValue(_epochManager);
+		}
+		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
+			long pos = _writer.Checkpoint.ReadNonFlushed();
+			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
+			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
+				SystemRecordSerialization.Json, epoch.AsSerialized());
+			_writer.Write(rec, out _);
+			_writer.Flush();
+			return epoch;
+		}
+		[OneTimeSetUp]
+		public override async Task TestFixtureSetUp() {
+			await base.TestFixtureSetUp();
+			_mainBus = new InMemoryBus(nameof(when_having_an_epoch_manager_and_empty_tf_log));
+			_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
+			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
+			_db.Open();
+			_reader = new TFChunkReader(_db, _db.Config.WriterCheckpoint);
+			_writer = new TFChunkWriter(_db);
+
+			_epochManager = GetManager();
+			_epochManager.Init();
+			_cache = GetCache(_epochManager);
+			Assert.NotNull(_cache);
+		}
+
+		[OneTimeTearDown]
+		public override async Task TestFixtureTearDown() {
+			this.Dispose();
+			await base.TestFixtureTearDown();
+		}
+		// epoch manager is stateful with TFLog, 
+		// and TFLog is expesive to build fresh for each test
+		// and the tests depend on previous state in the epoch manager
+		// so this test will run through the test cases 
+		// in order
+		[Test]
+		public void can_write_epochs() {
+
+			//can write first epoch
+			_published.Clear();
+			var beforeWrite = DateTime.UtcNow;
+			_epochManager.WriteNewEpoch(GetNextEpoch());
+			Assert.That(_published.Count == 1);
+			var epochWritten = _published[0] as SystemMessage.EpochWritten;
+			Assert.NotNull(epochWritten);
+			Assert.That(epochWritten.Epoch.EpochNumber == 0);
+			Assert.That(epochWritten.Epoch.PrevEpochPosition == -1);
+			Assert.That(epochWritten.Epoch.EpochPosition == 0);
+			Assert.That(epochWritten.Epoch.LeaderInstanceId == _instanceId);
+			Assert.That(epochWritten.Epoch.TimeStamp < DateTime.UtcNow);
+			Assert.That(epochWritten.Epoch.TimeStamp >= beforeWrite);
+			_published.Clear();
+
+			// will_cache_epochs_written() {
+			
+			for (int i = 0; i < 4; i++) {
+				_epochManager.WriteNewEpoch(GetNextEpoch());
+			}
+			Assert.That(_cache.Count == 5);
+			Assert.That(_cache.First.Value.EpochNumber == 0);
+			Assert.That(_cache.Last.Value.EpochNumber == 4);
+			var epochs = new List<int>();
+			var epoch = _cache.First;
+			while (epoch != null) {
+				epochs.Add(epoch.Value.EpochNumber);
+				epoch = epoch.Next;
+			}
+			CollectionAssert.IsOrdered(epochs);
+
+			// can_write_more_epochs_than_cache_size
+			
+			for (int i = 0; i < 16; i++) {
+				_epochManager.WriteNewEpoch(GetNextEpoch());
+			}
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == 11);
+			Assert.That(_cache.Last.Value.EpochNumber == 20);			
+			epochs = new List<int>();
+			epoch = _cache.First;
+			while (epoch != null) {
+				epochs.Add(epoch.Value.EpochNumber);
+				epoch = epoch.Next;
+			}
+			CollectionAssert.IsOrdered(epochs);
+		}
+
+		public void Dispose() {
+			//epochManager?.Dispose();
+			//reader?.Dispose();
+			_writer?.Dispose();
+			_db?.Close();
+			_db?.Dispose();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs - Copy.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs - Copy.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using EventStore.Core.Services.Storage.EpochManager;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using System.Threading;
+
+namespace EventStore.Core.Tests.Services.Storage {
+	[TestFixture]
+	public sealed class when_starting_having_TFLog_with_existing_epochs : SpecificationWithDirectoryPerTestFixture, IDisposable {
+		private TFChunkDb _db;
+		private EpochManager _epochManager;
+		private LinkedList<EpochRecord> _cache;
+		private TFChunkReader _reader;
+		private TFChunkWriter _writer;
+		private IBus _mainBus;
+		private readonly Guid _instanceId = Guid.NewGuid();
+		private readonly List<Message> _published = new List<Message>();
+		private List<EpochRecord> _epochs;
+		private static int GetNextEpoch() {
+			return (int)Interlocked.Increment(ref _currentEpoch);
+		}
+		private static long _currentEpoch = -1;
+		private EpochManager GetManager() {
+			return new EpochManager(_mainBus,
+				10,
+				_db.Config.EpochCheckpoint,
+				_writer,
+				initialReaderCount: 1,
+				maxReaderCount: 5,
+				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
+					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				_instanceId);
+		}
+		private LinkedList<EpochRecord> GetCache(EpochManager manager) {
+			return (LinkedList<EpochRecord>)typeof(EpochManager).GetField("_epochs", BindingFlags.NonPublic | BindingFlags.Instance)
+				.GetValue(_epochManager);
+		}
+		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
+			long pos = _writer.Checkpoint.ReadNonFlushed();
+			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
+			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
+				SystemRecordSerialization.Json, epoch.AsSerialized());
+			_writer.Write(rec, out _);
+			_writer.Flush();
+			return epoch;
+		}
+		[OneTimeSetUp]
+		public override async Task TestFixtureSetUp() {
+			await base.TestFixtureSetUp();
+			_mainBus = new InMemoryBus(nameof(when_having_an_epoch_manager_and_empty_tf_log));
+			_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
+			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
+			_db.Open();
+			_reader = new TFChunkReader(_db, _db.Config.WriterCheckpoint);
+			_writer = new TFChunkWriter(_db);			
+			_epochs = new List<EpochRecord>();
+			var lastPos = 0L;
+			for (int i = 0; i < 30; i++) {
+				var epoch = WriteEpoch(GetNextEpoch(), lastPos, _instanceId);
+				_epochs.Add(epoch);
+				lastPos = epoch.EpochPosition;
+			}
+		}
+
+		[OneTimeTearDown]
+		public override async Task TestFixtureTearDown() {
+			this.Dispose();
+			await base.TestFixtureTearDown();
+		}
+		
+		[Test]
+		public void starting_epoch_manager_loads_epochs() {
+
+			_epochManager = GetManager();
+			_epochManager.Init();
+			_cache = GetCache(_epochManager);
+			Assert.NotNull(_cache);
+			
+			Assert.That(_cache.Count == 10);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[20].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[29].EpochNumber);
+
+		}
+		[Test]
+		public void starting_epoch_manager_with_cache_larger_than_epoch_count_loads_all_epochs() {
+
+			_epochManager = new EpochManager(_mainBus,
+				1000,
+				_db.Config.EpochCheckpoint,
+				_writer,
+				initialReaderCount: 1,
+				maxReaderCount: 5,
+				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
+					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				_instanceId);
+			_epochManager.Init();
+			_cache = GetCache(_epochManager);
+			Assert.NotNull(_cache);
+			
+			Assert.That(_cache.Count == 30);
+			Assert.That(_cache.First.Value.EpochNumber == _epochs[0].EpochNumber);
+			Assert.That(_cache.Last.Value.EpochNumber == _epochs[29].EpochNumber);
+
+		}
+		public void Dispose() {
+			//epochManager?.Dispose();
+			//reader?.Dispose();
+			_writer?.Dispose();
+			_db?.Close();
+			_db?.Dispose();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_no_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_no_epochs.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using EventStore.Core.Services.Storage.EpochManager;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using System.Threading;
+
+namespace EventStore.Core.Tests.Services.Storage {
+	[TestFixture]
+	public sealed class when_starting_having_TFLog_with_no_epochs : SpecificationWithDirectoryPerTestFixture, IDisposable {
+		private TFChunkDb _db;
+		private EpochManager _epochManager;
+		private LinkedList<EpochRecord> _cache;
+		private TFChunkReader _reader;
+		private TFChunkWriter _writer;
+		private IBus _mainBus;
+		private readonly Guid _instanceId = Guid.NewGuid();
+		private readonly List<Message> _published = new List<Message>();
+		
+		private static int GetNextEpoch() {
+			return (int)Interlocked.Increment(ref _currentEpoch);
+		}
+		private static long _currentEpoch = -1;
+		private EpochManager GetManager() {
+			return new EpochManager(_mainBus,
+				10,
+				_db.Config.EpochCheckpoint,
+				_writer,
+				initialReaderCount: 1,
+				maxReaderCount: 5,
+				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
+					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				_instanceId);
+		}
+		private LinkedList<EpochRecord> GetCache(EpochManager manager) {
+			return (LinkedList<EpochRecord>)typeof(EpochManager).GetField("_epochs", BindingFlags.NonPublic | BindingFlags.Instance)
+				.GetValue(_epochManager);
+		}
+		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
+			long pos = _writer.Checkpoint.ReadNonFlushed();
+			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
+			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
+				SystemRecordSerialization.Json, epoch.AsSerialized());
+			_writer.Write(rec, out _);
+			_writer.Flush();
+			return epoch;
+		}
+		[OneTimeSetUp]
+		public override async Task TestFixtureSetUp() {
+			await base.TestFixtureSetUp();
+			_mainBus = new InMemoryBus(nameof(when_having_an_epoch_manager_and_empty_tf_log));
+			_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
+			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
+			_db.Open();
+			_reader = new TFChunkReader(_db, _db.Config.WriterCheckpoint);
+			_writer = new TFChunkWriter(_db);			
+			
+		}
+
+		[OneTimeTearDown]
+		public override async Task TestFixtureTearDown() {
+			this.Dispose();
+			await base.TestFixtureTearDown();
+		}
+		
+		[Test]
+		public void starting_epoch_manager_loads_without_epochs() {
+
+			_epochManager = GetManager();
+			_epochManager.Init();
+			_cache = GetCache(_epochManager);
+			Assert.NotNull(_cache);
+			
+			Assert.That(_cache.Count == 0);
+			Assert.That(_cache?.First?.Value == null);
+			Assert.That(_cache?.Last?.Value == null);
+			Assert.That(_epochManager.LastEpochNumber == -1);
+			_epochManager.WriteNewEpoch(0);
+			Assert.That(_cache.Count == 1);
+			Assert.That(_cache.First.Value.EpochNumber == 0);
+			Assert.That(_cache.Last.Value.EpochNumber == 0);
+			Assert.That(_epochManager.LastEpochNumber == 0);
+
+		}
+		
+		public void Dispose() {
+			//epochManager?.Dispose();
+			//reader?.Dispose();
+			_writer?.Dispose();
+			_db?.Close();
+			_db?.Dispose();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				DbRes.Db.Close();
 			}
 
-			var dbConfig = TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 1024 * 1024);
+			var dbConfig = TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 1024 * 1024);
 			var dbHelper = new TFChunkDbCreationHelper(dbConfig);
 
 			DbRes = dbHelper.Chunk(records).CreateDb();

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			var dbConfig = TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 1024 * 1024);
+			var dbConfig = TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 1024 * 1024);
 			var dbCreationHelper = new TFChunkDbCreationHelper(dbConfig);
 
 			DbRes = CreateDb(dbCreationHelper);

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			var dbConfig = TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 1024 * 1024);
+			var dbConfig = TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 1024 * 1024);
 			var dbCreationHelper = new TFChunkDbCreationHelper(dbConfig);
 
 			_dbResult = dbCreationHelper

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			var dbConfig = TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 1024 * 1024);
+			var dbConfig = TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 1024 * 1024);
 			var dbCreationHelper = new TFChunkDbCreationHelper(dbConfig);
 			_dbResult = CreateDb(dbCreationHelper);
 			_keptRecords = KeptRecords(_dbResult);

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -7,10 +7,27 @@ using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog {
 	public static class TFChunkHelper {
-		public static TFChunkDbConfig CreateDbConfig(string pathName, long writerCheckpointPosition,
-			long chaserCheckpointPosition = 0,
-			long epochCheckpointPosition = -1, long truncateCheckpoint = -1, int chunkSize = 10000,
-			long maxTruncation = -1) {
+		public static TFChunkDbConfig CreateDbConfig(
+			string pathName,
+			long writerCheckpointPosition) {
+			return CreateDbConfigEx(pathName, writerCheckpointPosition,0,-1,-1,-1,10000,-1);
+		}
+		public static TFChunkDbConfig CreateSizedDbConfig(
+			string pathName,
+			long writerCheckpointPosition,
+			int chunkSize) {
+			return CreateDbConfigEx(pathName, writerCheckpointPosition,0,-1,-1,-1,chunkSize,-1);
+		}
+		public static TFChunkDbConfig CreateDbConfigEx(
+			string pathName, 
+			long writerCheckpointPosition,
+			long chaserCheckpointPosition,// Default 0
+			long epochCheckpointPosition ,// Default -1
+			long proposalCheckpointPosition ,// Default -1
+			long truncateCheckpoint ,// Default -1
+			int chunkSize ,// Default 10000
+			long maxTruncation // Default -1
+			) {
 			return new TFChunkDbConfig(pathName,
 				new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
 				chunkSize,
@@ -18,6 +35,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				new InMemoryCheckpoint(writerCheckpointPosition),
 				new InMemoryCheckpoint(chaserCheckpointPosition),
 				new InMemoryCheckpoint(epochCheckpointPosition),
+				new InMemoryCheckpoint(proposalCheckpointPosition),
 				new InMemoryCheckpoint(truncateCheckpoint),
 				new InMemoryCheckpoint(-1), 
 				new InMemoryCheckpoint(-1),
@@ -26,15 +44,21 @@ namespace EventStore.Core.Tests.TransactionLog {
 				maxTruncation: maxTruncation);
 		}
 
-		public static TFChunkDbConfig CreateDbConfig(string pathName, ICheckpoint writerCheckpoint,
-			ICheckpoint chaserCheckpoint, int chunkSize = 10000, ICheckpoint replicationCheckpoint = null) {
+		public static TFChunkDbConfig CreateDbConfig(
+			string pathName, 
+			ICheckpoint writerCheckpoint,
+			ICheckpoint chaserCheckpoint, 
+			int chunkSize = 10000, 
+			ICheckpoint replicationCheckpoint = null) {
 			if (replicationCheckpoint == null) replicationCheckpoint = new InMemoryCheckpoint(-1);
-			return new TFChunkDbConfig(pathName,
+			return new TFChunkDbConfig(
+				pathName,
 				new VersionedPatternFileNamingStrategy(pathName, "chunk-"),
 				chunkSize,
 				0,
 				writerCheckpoint,
 				chaserCheckpoint,
+				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				new InMemoryCheckpoint(-1),
 				replicationCheckpoint, 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_against_max_truncation_config.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 			await base.TestFixtureSetUp();
 
 			// writer checkpoint = 5500, truncate to 0, max truncation = 1000
-			_config = TFChunkHelper.CreateDbConfig(PathName, 5500, 5500, 5500, 0, 1000, maxTruncation: 1000);
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 5500, 5500, 5500, -1, 0, 1000, maxTruncation: 1000);
 
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_config = TFChunkHelper.CreateDbConfig(PathName, 1711, 5500, 5500, 1111, 1000);
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 1711, 5500, 5500, -1, 1111, 1000, -1);
 
 			var rnd = new Random();
 			_file1Contents = new byte[_config.ChunkSize];

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
@@ -16,7 +16,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_config = TFChunkHelper.CreateDbConfig(PathName, 11111, 5500, 5500, 5757, 1000);
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 11111, 5500, 5500, -1,5757, 1000, -1);
 
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_ongoing_chunk.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_config = TFChunkHelper.CreateDbConfig(PathName, 1711, 5500, 5500, 1111, 1000);
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 1711, 5500, 5500, -1, 1111, 1000, -1);
 
 			var rnd = new Random();
 			_file1Contents = new byte[_config.ChunkSize];

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_right_at_the_end_of_multichunk.cs
@@ -16,7 +16,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_config = TFChunkHelper.CreateDbConfig(PathName, 13500, 5500, 5500, 11000, 1000);
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 13500, 5500, 5500, -1, 11000, 1000, -1);
 
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_to_the_very_beginning_of_db.cs
@@ -16,7 +16,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_config = TFChunkHelper.CreateDbConfig(PathName, 11111, 5500, 5500, 0, 1000);
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 11111, 5500, 5500, -1,0, 1000, -1);
 
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
@@ -49,7 +49,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void does_not_allow_not_completed_not_last_chunks() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 4000, chunkSize: 1000);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 4000, chunkSize: 1000);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateOngoingChunk(config, 1, GetFilePathFor("chunk-000001.000000"));
@@ -157,7 +157,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void when_a_chaser_checksum_is_ahead_of_writer_checksum_throws_corrupt_database_exception() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 0, 11);
+			var config = TFChunkHelper.CreateDbConfigEx(PathName, 0, 11,-1,-1,-1,1000,-1);
 			using (var db = new TFChunkDb(config)) {
 				Assert.That(() => db.Open(verifyHash: false),
 					Throws.Exception.InstanceOf<CorruptDatabaseException>()
@@ -167,7 +167,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void when_an_epoch_checksum_is_ahead_of_writer_checksum_throws_corrupt_database_exception() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 0, 0, 11);
+			var config = TFChunkHelper.CreateDbConfigEx(PathName, 0, 0, 11,-1,-1,1000,-1);
 			using (var db = new TFChunkDb(config)) {
 				Assert.That(() => db.Open(verifyHash: false),
 					Throws.Exception.InstanceOf<CorruptDatabaseException>()
@@ -206,7 +206,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void allows_checkpoint_to_point_into_the_middle_of_completed_chunk_when_enough_actual_data_in_chunk() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 1500, chunkSize: 1000);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 1500, chunkSize: 1000);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"), actualDataSize: 500);
@@ -235,7 +235,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void does_not_allow_checkpoint_to_point_into_the_middle_of_scavenged_chunk() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 1500, chunkSize: 1000);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 1500, chunkSize: 1000);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"), isScavenged: true,
@@ -252,7 +252,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			File.Create(GetFilePathFor("foo")).Close();
 			File.Create(GetFilePathFor("bla")).Close();
 
-			var config = TFChunkHelper.CreateDbConfig(PathName, 350, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 350, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000002"));
@@ -277,7 +277,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void when_checkpoint_is_on_boundary_of_chunk_last_chunk_is_preserved() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"));
@@ -295,7 +295,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		[Test]
 		public void
 			when_checkpoint_is_on_boundary_of_new_chunk_last_chunk_is_preserved_and_excessive_versions_are_removed_if_present() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"));
@@ -314,7 +314,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		[Test]
 		public void
 			when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_not_present_but_should_be_created() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"));
@@ -331,7 +331,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_present() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"));
@@ -349,7 +349,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_no_exception_is_thrown() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"),
@@ -368,7 +368,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		[Test, Ignore("Not valid test now after disabling size validation on ongoing TFChunk ")]
 		public void
 			when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_but_not_completed_exception_is_thrown() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateOngoingChunk(config, 1, GetFilePathFor("chunk-000001.000001"),
@@ -382,7 +382,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void temporary_files_are_removed() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 150, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 150, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateOngoingChunk(config, 1, GetFilePathFor("chunk-000001.000001"));

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db_with_multi_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db_with_multi_chunks.cs
@@ -78,7 +78,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			File.Create(GetFilePathFor("foo")).Close();
 			File.Create(GetFilePathFor("bla")).Close();
 
-			var config = TFChunkHelper.CreateDbConfig(PathName, 350, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 350, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000002"));
@@ -103,7 +103,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		[Test]
 		public void
 			when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_not_present_but_should_be_created() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
 
@@ -118,7 +118,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_present() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 200, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateOngoingChunk(config, 2, GetFilePathFor("chunk-000002.000001"));
@@ -134,7 +134,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void when_checkpoint_is_on_boundary_of_new_chunk_and_last_chunk_is_truncated_no_exception_is_thrown() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 300, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 300, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateMultiChunk(config, 1, 2, GetFilePathFor("chunk-000001.000001"), physicalSize: 50,
@@ -152,7 +152,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void does_not_allow_checkpoint_to_point_into_the_middle_of_multichunk_chunk() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 1500, chunkSize: 1000);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 1500, chunkSize: 1000);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateMultiChunk(config, 1, 10, GetFilePathFor("chunk-000001.000001"));
@@ -165,7 +165,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 
 		[Test]
 		public void allows_last_chunk_to_be_multichunk_when_checkpoint_point_at_the_start_of_next_chunk() {
-			var config = TFChunkHelper.CreateDbConfig(PathName, 4000, chunkSize: 1000);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 4000, chunkSize: 1000);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateMultiChunk(config, 1, 3, GetFilePathFor("chunk-000001.000001"));

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 16 * 1024));
+			_db = new TFChunkDb(TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 16 * 1024));
 			_db.Open();
 
 			var chunk = _db.Manager.GetChunkFor(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
-			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 4096));
+			_db = new TFChunkDb(TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 4096));
 			_db.Open();
 
 			var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 4096));
+			_db = new TFChunkDb(TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 4096));
 			_db.Open();
 
 			var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 4096));
+			_db = new TFChunkDb(TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 4096));
 			_db.Open();
 
 			var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			await base.TestFixtureSetUp();
 
 			_db = new TFChunkDb(
-				TFChunkHelper.CreateDbConfig(PathName, 0, chunkSize: 4096));
+				TFChunkHelper.CreateSizedDbConfig(PathName, 0, chunkSize: 4096));
 			_db.Open();
 
 			var chunk = _db.Manager.GetChunk(0);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -735,9 +735,17 @@ namespace EventStore.Core {
 
 			// ELECTIONS
 			if (!vNodeSettings.NodeInfo.IsReadOnlyReplica) {
-				var electionsService = new ElectionsService(_mainQueue, memberInfo, vNodeSettings.ClusterNodeCount,
-					db.Config.WriterCheckpoint, db.Config.ChaserCheckpoint,
-					epochManager, () => readIndex.LastIndexedPosition, vNodeSettings.NodePriority, _timeProvider);
+				var electionsService = new ElectionsService(
+					_mainQueue, 
+					memberInfo, 
+					vNodeSettings.ClusterNodeCount,
+					db.Config.WriterCheckpoint, 
+					db.Config.ChaserCheckpoint,
+					db.Config.ProposalCheckpoint,
+					epochManager,
+					() => readIndex.LastIndexedPosition, 
+					vNodeSettings.NodePriority,
+					_timeProvider);
 				electionsService.SubscribeMessages(_mainBus);
 			}
 

--- a/src/EventStore.Core/Messages/ElectionMessage.cs
+++ b/src/EventStore.Core/Messages/ElectionMessage.cs
@@ -320,7 +320,7 @@ namespace EventStore.Core.Messages {
 					ServerId, ServerHttpEndPoint, LeaderId, LeaderHttpEndPoint, View);
 			}
 		}
-		
+
 		public class LeaderIsResigning : Message {
 			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
 
@@ -346,7 +346,7 @@ namespace EventStore.Core.Messages {
 				return $"---- LeaderIsResigning: serverId {LeaderId}";
 			}
 		}
-		
+
 		public class LeaderIsResigningOk : Message {
 			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
 
@@ -358,7 +358,7 @@ namespace EventStore.Core.Messages {
 			public readonly EndPoint LeaderHttpEndPoint;
 			public readonly Guid ServerId;
 			public readonly EndPoint ServerHttpEndPoint;
-			
+
 			public LeaderIsResigningOk(ElectionMessageDto.LeaderIsResigningOkDto dto) {
 				LeaderId = dto.LeaderId;
 				LeaderHttpEndPoint = new IPEndPoint(IPAddress.Parse(dto.LeaderHttpAddress),
@@ -388,17 +388,19 @@ namespace EventStore.Core.Messages {
 			}
 
 			public readonly int InstalledView;
+			public readonly int ProposalNumber;
 			public readonly MemberInfo Leader;
 
-			public ElectionsDone(int installedView, MemberInfo leader) {
+			public ElectionsDone(int installedView, int proposalNumber, MemberInfo leader) {
 				Ensure.Nonnegative(installedView, "installedView");
 				Ensure.NotNull(leader, "leader");
 				InstalledView = installedView;
 				Leader = leader;
+				ProposalNumber = proposalNumber;
 			}
 
 			public override string ToString() {
-				return string.Format("---- ElectionsDone: installedView {0}, leader {1}", InstalledView, Leader);
+				return $"---- ElectionsDone: installedView {InstalledView}, proposal number {ProposalNumber}, leader {Leader}";
 			}
 		}
 	}

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -73,12 +73,17 @@ namespace EventStore.Core.Messages {
 
 		public class WriteEpoch : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
-
 			public override int MsgTypeId {
 				get { return TypeId; }
 			}
+			public readonly int EpochNumber;
+			public WriteEpoch(int epochNumber) {
+				EpochNumber = epochNumber;
+			}
+
+
 		}
-		
+
 		public class InitiateLeaderResignation : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 
@@ -86,7 +91,7 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 		}
-		
+
 		public class RequestQueueDrained : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 
@@ -130,7 +135,10 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public BecomeLeader(Guid correlationId) : base(correlationId, VNodeState.Leader) {
+			public readonly int EpochNumber;
+
+			public BecomeLeader(Guid correlationId, int epochNumber) : base(correlationId, VNodeState.Leader) {
+				EpochNumber = epochNumber;
 			}
 		}
 
@@ -269,7 +277,7 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public BecomeReadOnlyLeaderless (Guid correlationId)
+			public BecomeReadOnlyLeaderless(Guid correlationId)
 				: base(correlationId, VNodeState.ReadOnlyLeaderless) {
 			}
 		}
@@ -334,7 +342,7 @@ namespace EventStore.Core.Messages {
 			public readonly Guid ConnectionId;
 			public readonly Guid? SubscriptionId;
 
-			public VNodeConnectionLost(EndPoint vNodeEndPoint, Guid connectionId, Guid? subscriptionId=null) {
+			public VNodeConnectionLost(EndPoint vNodeEndPoint, Guid connectionId, Guid? subscriptionId = null) {
 				Ensure.NotNull(vNodeEndPoint, "vNodeEndPoint");
 				Ensure.NotEmptyGuid(connectionId, "connectionId");
 

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -255,15 +255,13 @@ namespace EventStore.Core.Services.Replication {
 
 			// if afterCommonEpoch is present, logPosition > afterCommonEpoch.EpochPosition,
 			// so safe position is definitely the start of afterCommonEpoch
-			var replicaPosition = afterCommonEpoch == null ? logPosition : afterCommonEpoch.EpochPosition;
+			var replicaPosition = afterCommonEpoch?.EpochPosition ?? logPosition;
 
 			if (commonEpoch.EpochNumber == _epochManager.LastEpochNumber)
 				return Math.Min(replicaPosition, leaderCheckpoint);
 
-			var nextEpoch = _epochManager.GetEpoch(commonEpoch.EpochNumber + 1, throwIfNotFound: false);
-			if (nextEpoch == null) {
-				nextEpoch = _epochManager.GetEpochWithAllEpochs(commonEpoch.EpochNumber + 1, throwIfNotFound: false);
-			}
+			// common epoch number is older than the last epoch
+			var nextEpoch = _epochManager.GetEpochAfter(commonEpoch.EpochNumber , false);
 
 			if (nextEpoch == null) {
 				var msg = string.Format(

--- a/src/EventStore.Core/Services/Storage/EpochManager/IEpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/IEpochManager.cs
@@ -9,11 +9,9 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 
 		EpochRecord GetLastEpoch();
 		EpochRecord[] GetLastEpochs(int maxCount);
-		EpochRecord GetEpoch(int epochNumber, bool throwIfNotFound);
-		EpochRecord GetEpochWithAllEpochs(int epochNumber, bool throwIfNotFound);
+		EpochRecord GetEpochAfter(int epochNumber, bool throwIfNotFound);
 		bool IsCorrectEpochAt(long epochPosition, int epochNumber, Guid epochId);
-
-		void WriteNewEpoch();
-		void SetLastEpoch(EpochRecord epoch);
+		void WriteNewEpoch(int epochNumber);
+		void CacheEpoch(EpochRecord epoch);
 	}
 }

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -252,10 +252,10 @@ namespace EventStore.Core.Services.Storage {
 			if (record.SystemRecordType == SystemRecordType.Epoch) {
 				// Epoch record is written to TF, but possibly is not added to EpochManager
 				// as we could be in Follower/Clone mode. We try to add epoch to EpochManager
-				// every time we encounter EpochRecord while chasing. SetLastEpoch call is idempotent,
+				// every time we encounter EpochRecord while chasing. CacheEpoch call is idempotent,
 				// but does integrity checks.
 				var epoch = record.GetEpochRecord();
-				_epochManager.SetLastEpoch(epoch);
+				_epochManager.CacheEpoch(epoch);
 			}
 		}
 

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -178,7 +178,7 @@ namespace EventStore.Core.Services.Storage {
 			switch (message.State) {
 				case VNodeState.Leader: {
 						_indexWriter.Reset();
-						EpochManager.WriteNewEpoch(); // forces flush
+						EpochManager.WriteNewEpoch(((SystemMessage.BecomeLeader)message).EpochNumber);
 						break;
 					}
 				case VNodeState.ShuttingDown: {
@@ -189,11 +189,12 @@ namespace EventStore.Core.Services.Storage {
 		}
 
 		void IHandle<SystemMessage.WriteEpoch>.Handle(SystemMessage.WriteEpoch message) {
+			//Ensure we write a new epoch when being re-elected master even if there is no state change
 			if (_vnodeState == VNodeState.PreLeader)
 				return;
 			if (_vnodeState != VNodeState.Leader)
 				throw new Exception(string.Format("New Epoch request not in leader state. State: {0}.", _vnodeState));
-			EpochManager.WriteNewEpoch();
+			EpochManager.WriteNewEpoch(message.EpochNumber);
 			PurgeNotProcessedInfo();
 		}
 

--- a/src/EventStore.Core/TransactionLog/Checkpoint/Checkpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/Checkpoint.cs
@@ -3,6 +3,7 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 		public const string Writer = "writer";
 		public const string Chaser = "chaser";
 		public const string Epoch = "epoch";
+		public const string Proposal = "proposal";
 		public const string Truncate = "truncate";
 		public const string Replication = "replication";
 		public const string Index = "index";

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -286,12 +286,12 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		}
 
 		public void Close() {
-			if (Manager != null)
-				Manager.Dispose();
+			Manager?.Dispose();
 			Config.WriterCheckpoint.Close();
 			Config.ChaserCheckpoint.Close();
 			Config.EpochCheckpoint.Close();
 			Config.TruncateCheckpoint.Close();
+			Config.ProposalCheckpoint.Close();
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -10,6 +10,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly ICheckpoint WriterCheckpoint;
 		public readonly ICheckpoint ChaserCheckpoint;
 		public readonly ICheckpoint EpochCheckpoint;
+		public readonly ICheckpoint ProposalCheckpoint;
 		public readonly ICheckpoint TruncateCheckpoint;
 		public readonly ICheckpoint ReplicationCheckpoint;
 		public readonly ICheckpoint IndexCheckpoint;
@@ -30,6 +31,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			ICheckpoint writerCheckpoint,
 			ICheckpoint chaserCheckpoint,
 			ICheckpoint epochCheckpoint,
+			ICheckpoint proposalCheckpoint,
 			ICheckpoint truncateCheckpoint,
 			ICheckpoint replicationCheckpoint,
 			ICheckpoint indexCheckpoint,
@@ -48,6 +50,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
 			Ensure.NotNull(chaserCheckpoint, "chaserCheckpoint");
 			Ensure.NotNull(epochCheckpoint, "epochCheckpoint");
+			Ensure.NotNull(proposalCheckpoint, "proposalCheckpoint");
 			Ensure.NotNull(truncateCheckpoint, "truncateCheckpoint");
 			Ensure.NotNull(replicationCheckpoint, "replicationCheckpoint");
 			Ensure.NotNull(indexCheckpoint, "indexCheckpoint");
@@ -60,6 +63,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			WriterCheckpoint = writerCheckpoint;
 			ChaserCheckpoint = chaserCheckpoint;
 			EpochCheckpoint = epochCheckpoint;
+			ProposalCheckpoint = proposalCheckpoint;
 			TruncateCheckpoint = truncateCheckpoint;
 			ReplicationCheckpoint = replicationCheckpoint;
 			IndexCheckpoint = indexCheckpoint;

--- a/src/EventStore.Core/TransactionLog/LogRecords/EpochRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/EpochRecord.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 		}
 	}
 
-	public class EpochRecord {
+	public class EpochRecord: IComparable {
 		public readonly long EpochPosition;
 		public readonly int EpochNumber;
 		public readonly Guid EpochId;
@@ -56,6 +56,13 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 				PrevEpochPosition,
 				TimeStamp,
 				LeaderInstanceId);
+		}
+
+		public int CompareTo(object obj) {
+			if (obj == null) return 1;
+			EpochRecord other = obj as EpochRecord;
+			if(other == null) throw new ArgumentException("Object is not a Epoch Record");
+			return EpochNumber.CompareTo(other.EpochNumber);
 		}
 
 		internal class EpochRecordDto {

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1549,6 +1549,7 @@ namespace EventStore.Core {
 			ICheckpoint writerChk;
 			ICheckpoint chaserChk;
 			ICheckpoint epochChk;
+			ICheckpoint proposalChk;
 			ICheckpoint truncateChk;
 			//todo(clc) : promote these to file backed checkpoints re:project-io
 			ICheckpoint replicationChk = new InMemoryCheckpoint(Checkpoint.Replication, initValue: -1);
@@ -1557,6 +1558,7 @@ namespace EventStore.Core {
 				writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
 				chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
 				epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
+				proposalChk = new InMemoryCheckpoint(Checkpoint.Proposal, initValue: -1);
 				truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
 			} else {
 				try {
@@ -1580,10 +1582,13 @@ namespace EventStore.Core {
 				var writerCheckFilename = Path.Combine(dbPath, Checkpoint.Writer + ".chk");
 				var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
 				var epochCheckFilename = Path.Combine(dbPath, Checkpoint.Epoch + ".chk");
+				var proposalCheckFilename = Path.Combine(dbPath, Checkpoint.Proposal + ".chk");
 				var truncateCheckFilename = Path.Combine(dbPath, Checkpoint.Truncate + ".chk");
 				writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
 				chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
 				epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true,
+					initValue: -1);
+				proposalChk = new MemoryMappedFileCheckpoint(proposalCheckFilename, Checkpoint.Proposal, cached: true,
 					initValue: -1);
 				truncateChk = new MemoryMappedFileCheckpoint(truncateCheckFilename, Checkpoint.Truncate,
 					cached: true, initValue: -1);
@@ -1600,6 +1605,7 @@ namespace EventStore.Core {
 				writerChk,
 				chaserChk,
 				epochChk,
+				proposalChk,
 				truncateChk,
 				replicationChk,
 				indexChk,

--- a/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_restarting.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_restarting.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -72,7 +72,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 		protected override void Given() {
 			// Start subsystem
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			 var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -141,7 +141,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -186,7 +186,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			WaitForStartMessage();
 			
@@ -209,7 +209,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -244,7 +244,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;

--- a/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_starting.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_starting.cs
@@ -20,7 +20,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				}));
 			
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				}));
 			
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 			
 			WaitForStartMessage();
 
@@ -75,7 +75,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -103,7 +103,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -127,7 +127,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		[Test]
 		public void should_allow_starting_the_subsystem_again() {
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 			var startMessage = WaitForStartMessage();
 			
 			Assert.AreNotEqual(_instanceCorrelation, startMessage.InstanceCorrelationId);
@@ -141,7 +141,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -169,7 +169,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -184,7 +184,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 			WaitForStopMessage();
 
 			// Become leader again before subsystem fully stopped
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
 
 			Subsystem.Handle(new ProjectionSubsystemMessage.ComponentStopped(
 				ProjectionManager.ServiceName, _instanceCorrelation));


### PR DESCRIPTION
Fixed: EventStore/home#263

Add checkpoint based tracking of proposed epoch numbers on each node in addition to the epoch records in the replicated Log.

Close edge case for isolated deposed leaders being preferred in elections due to subsequent quorums being able to form with a lower epoch number in the case replication is disrupted during a series of election cycles.

More complete fix than #2742 as theoretically possible further edge cases are also closed.
Aligns with paxos terminology better than #2741 

Note: The required pre-condition is not possible in a cluster with an active quorum in version 20.6 and higher, although it can occur in the rarer case of two nodes forming a quorum.
