### PR TITLE
Fix ci.yml following set-env deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,14 +58,14 @@ jobs:
       run: |
         git fetch --prune --unshallow
     - name: Install Dotnet
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
     - name: Calculate Version
       run: |
         dotnet tool restore
         version=$(dotnet tool run minver -- --tag-prefix=oss-v)-${{ matrix.container-runtime }}
-        echo "::set-env name=VERSION::${version}"
+        echo "VERSION=${version}" >> $GITHUB_ENV
     - name: Build
       run: |
         docker build \
@@ -135,7 +135,7 @@ jobs:
       run: |
         git fetch --prune --unshallow
     - name: Install Dotnet
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
     - name: Compile
@@ -180,7 +180,7 @@ jobs:
       run: |
         git fetch --prune --unshallow
     - name: Install Dotnet
-      uses: actions/setup-dotnet@v1.4.0
+      uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
     - name: Pack


### PR DESCRIPTION
Fixed: ci.yml following set-env deprecation


Ref: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

- Use setup-dotnet@v1 (latest stable v1 version) instead of pinned version 1.4.0 in ci.yml (which currently fails due to set-env deprecation)
- Replace set-env VERSION with use of environment file