### PR TITLE
Introduce low latency heartbeats by relying on TCP ACKs

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -265,6 +265,8 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			get { return _clientConnectionName; }
 		}
 
+		public long TotalAcknowledgedBytes { get; }
+
 		public bool IsClosed {
 			get { return false; }
 		}

--- a/src/EventStore.Core/Messages/TcpMessage.cs
+++ b/src/EventStore.Core/Messages/TcpMessage.cs
@@ -32,9 +32,9 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public readonly int MessageNumber;
+			public readonly long MessageNumber;
 
-			public Heartbeat(int messageNumber) {
+			public Heartbeat(long messageNumber) {
 				MessageNumber = messageNumber;
 			}
 		}
@@ -46,9 +46,9 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public readonly int MessageNumber;
+			public readonly long MessageNumber;
 
-			public HeartbeatTimeout(int messageNumber) {
+			public HeartbeatTimeout(long messageNumber) {
 				MessageNumber = messageNumber;
 			}
 		}

--- a/src/EventStore.Transport.Tcp/ITcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/ITcpConnection.cs
@@ -13,6 +13,7 @@ namespace EventStore.Transport.Tcp {
 		IPEndPoint LocalEndPoint { get; }
 		int SendQueueSize { get; }
 		int PendingSendBytes { get; }
+		long TotalAcknowledgedBytes { get; }
 		bool IsClosed { get; }
 
 		void ReceiveAsync(Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> callback);

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -66,6 +66,8 @@ namespace EventStore.Transport.Tcp {
 			get { return _sendQueue.Count; }
 		}
 
+		public long TotalAcknowledgedBytes => TotalBytesSent + TotalBytesReceived;
+
 		public string ClientConnectionName {
 			get { return _clientConnectionName; }
 		}

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -85,6 +85,7 @@ namespace EventStore.Transport.Tcp {
 
 		private readonly Queue<ReceivedData> _receiveQueue = new Queue<ReceivedData>();
 		private readonly MemoryStream _memoryStream = new MemoryStream();
+		private long _memoryStreamOffset = 0L;
 
 		private readonly object _receivingLock = new object();
 		private readonly object _sendLock = new object();
@@ -157,16 +158,22 @@ namespace EventStore.Transport.Tcp {
 						_isSending = true;
 					}
 
-					_memoryStream.SetLength(0);
+					if (_memoryStreamOffset >= _memoryStream.Length) {
+						_memoryStream.SetLength(0);
+						_memoryStreamOffset = 0L;
 
-					ArraySegment<byte> sendPiece;
-					while (_sendQueue.TryDequeue(out sendPiece)) {
-						_memoryStream.Write(sendPiece.Array, sendPiece.Offset, sendPiece.Count);
-						if (_memoryStream.Length >= MaxSendPacketSize)
-							break;
+						ArraySegment<byte> sendPiece;
+						while (_sendQueue.TryDequeue(out sendPiece)) {
+							_memoryStream.Write(sendPiece.Array, sendPiece.Offset, sendPiece.Count);
+							if (_memoryStream.Length >= MaxSendPacketSize)
+								break;
+						}
 					}
 
-					_sendSocketArgs.SetBuffer(_memoryStream.GetBuffer(), 0, (int)_memoryStream.Length);
+					int sendingBytes = Math.Min((int)_memoryStream.Length - (int) _memoryStreamOffset, MaxSendPacketSize);
+
+					_sendSocketArgs.SetBuffer(_memoryStream.GetBuffer(), (int) _memoryStreamOffset, sendingBytes);
+					_memoryStreamOffset += sendingBytes;
 
 					NotifySendStarting(_sendSocketArgs.Count);
 					var firedAsync = _sendSocketArgs.AcceptSocket.SendAsync(_sendSocketArgs);

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -83,6 +83,7 @@ namespace EventStore.Transport.Tcp {
 			_receiveQueue = new ConcurrentQueueWrapper<ReceivedData>();
 
 		private readonly MemoryStream _memoryStream = new MemoryStream();
+		private long _memoryStreamOffset = 0L;
 
 		private readonly object _streamLock = new object();
 		private readonly object _closeLock = new object();
@@ -351,19 +352,23 @@ namespace EventStore.Transport.Tcp {
 						_isSending = true;
 					}
 
-					_memoryStream.SetLength(0);
+					if (_memoryStreamOffset >= _memoryStream.Length) {
+						_memoryStream.SetLength(0);
+						_memoryStreamOffset = 0L;
 
-					ArraySegment<byte> sendPiece;
-					while (_sendQueue.TryDequeue(out sendPiece)) {
-						_memoryStream.Write(sendPiece.Array, sendPiece.Offset, sendPiece.Count);
-						if (_memoryStream.Length >= TcpConnection.MaxSendPacketSize)
-							break;
+						ArraySegment<byte> sendPiece;
+						while (_sendQueue.TryDequeue(out sendPiece)) {
+							_memoryStream.Write(sendPiece.Array, sendPiece.Offset, sendPiece.Count);
+							if (_memoryStream.Length >= TcpConnection.MaxSendPacketSize)
+								break;
+						}
 					}
 
-					_sendingBytes = (int)_memoryStream.Length;
+					_sendingBytes = Math.Min((int)_memoryStream.Length - (int) _memoryStreamOffset, TcpConnection.MaxSendPacketSize);
 
 					NotifySendStarting(_sendingBytes);
-					var result = _sslStream.BeginWrite(_memoryStream.GetBuffer(), 0, _sendingBytes, OnEndWrite, null);
+					var result = _sslStream.BeginWrite(_memoryStream.GetBuffer(), (int)_memoryStreamOffset, _sendingBytes, OnEndWrite, null);
+					_memoryStreamOffset += _sendingBytes;
 					continueSendSynchronously = result.CompletedSynchronously;
 					if (continueSendSynchronously) {
 						EndWrite(result);

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -64,6 +64,8 @@ namespace EventStore.Transport.Tcp {
 			get { return _sendQueue.Count; }
 		}
 
+		public long TotalAcknowledgedBytes => TotalBytesSent + TotalBytesReceived;
+
 		public string ClientConnectionName {
 			get { return _clientConnectionName; }
 		}


### PR DESCRIPTION
Added: Introduce low latency TCP heartbeats by relying on TCP ACKs instead of waiting for the remote party to process heartbeat requests

Fixes: https://github.com/eventstore/home/issues/312

The way heartbeats currently work between nodes is as follows:
- If we have not *received* any data from the remote party for `heartbeat interval` seconds, we enqueue a `heartbeat request` and schedule a heartbeat timeout message locally (Note that we may have *sent* a lot of data in the mean time)
- This `heartbeat request` is enqueued onto the send queue and when it is dequeued (after possibly a lot of other data), it is sent to the remote party over the TCP connection.
- The remote party receives the `heartbeat request` as raw data, enqueues it on the receive queue, dequeues it (after possibly dequeueing a lot of other data), unframes the raw data into a heartbeat request command, processes it and prepares a `heartbeat response` message which is now enqueued on the remote party's send queue and sent.
- If the local party receives the heartbeat response or any other data sent by the remote party before the heartbeat timeout check is triggered, everything is fine otherwise it results in a `HEARTBEAT TIMEOUT` and the TCP connection is closed by the local party.

The above scenario works fine when a connection is idle (there's not much send and receive traffic) or when we are mostly receiving traffic. However, in the case where we are sending a lot of data but not receiving much (e.g on leader nodes), it poses the following problem:
- The `heartbeat request` may need to wait behind a lot of other data on the send queue on the local side before being sent
- The `heartbeat request` may need to wait behind a lot of other data on the receive queue on the remote side before being processed


This PR changes the way heartbeats work by relying on TCP ACKs to determine if the remote party is alive:
- As soon as we have successfully *sent* any data to the remote party, be it the `heartbeat request` or any other data, it implies that we must have received a TCP ACK message from the remote party and we can consider that the remote party is alive.
- Note: We no longer even need to send a heartbeat response for node to node communication but it's been left there for backwards compatibility + it is needed for TCP clients.
- This has been implemented by adding a `TotalAcknowledgedBytes` property on `ITcpConnection` which is equal to `TotalBytesSent` + `TotalBytesReceived` on the TCP connection. If this value changes between a heartbeat request and the heartbeat timeout check, it implies that the node is alive.