### PR TITLE
Better scavenge stat events

### DIFF
--- a/src/EventStore.Core.Tests/Services/Replication/FakeTfChunkLogManager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/FakeTfChunkLogManager.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Services.Replication {
 		public string ScavengeId { get; }
 		public long SpaceSaved { get; }
 
-		public void ScavengeStarted() {
+		public void ScavengeStarted(bool alwaysKeepScavenged, bool mergeChunks, int startFromChunk, int threads) {
 		}
 
 		public void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved) {

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/FakeTFScavengerLog.cs
@@ -8,6 +8,10 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 
 		public long SpaceSaved { get; } = 0;
 
+		public bool AlwaysKeepScavenged { get; private set; }
+		public bool MergeChunks { get; private set; }
+		public int StartFromChunk { get; private set; }
+		public int Threads { get; private set; }
 		public bool Started { get; private set; }
 
 		public bool Completed { get; private set; }
@@ -23,7 +27,11 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 		public IList<ScavengedLog> Merged { get; } = new List<ScavengedLog>();
 		public IList<IndexScavengedLog> ScavengedIndices { get; } = new List<IndexScavengedLog>();
 
-		public void ScavengeStarted() {
+		public void ScavengeStarted(bool alwaysKeepScavenged, bool mergeChunks, int startFromChunk, int threads) {
+			AlwaysKeepScavenged = alwaysKeepScavenged;
+			MergeChunks = mergeChunks;
+			StartFromChunk = startFromChunk;
+			Threads = threads;
 			Started = true;
 			StartedCallback?.Invoke(this, EventArgs.Empty);
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/ITFChunkScavengerLog.cs
@@ -7,7 +7,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 
 		long SpaceSaved { get; }
 
-		void ScavengeStarted();
+		void ScavengeStarted(bool alwaysKeepScavenged, bool mergeChunks, int startFromChunk, int threads);
 
 		void ChunksScavenged(int chunkStartNumber, int chunkEndNumber, TimeSpan elapsed, long spaceSaved);
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -85,7 +85,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				ScavengeResult result = ScavengeResult.Success;
 				string error = null;
 				try {
-					_scavengerLog.ScavengeStarted();
+					_scavengerLog.ScavengeStarted(alwaysKeepScavenged, mergeChunks, startFromChunk, _threads);
 
 					ScavengeInternal(alwaysKeepScavenged, mergeChunks, startFromChunk, ct);
 


### PR DESCRIPTION
- Add useful stats to scavenge start / stop events (e.g. the starting chunk#, the "max" chunk# it reached, thread count etc)
- Collect stats on incomplete scavenges to ensure scavenge completed event is fully rebuilt/populated when node is shutdown mid-scavenge.