### PR TITLE
[v5] Expose option for stream info cache capacity

### DIFF
--- a/src/EventStore.ClusterNode/ClusterNodeOptions.cs
+++ b/src/EventStore.ClusterNode/ClusterNodeOptions.cs
@@ -101,6 +101,9 @@ namespace EventStore.ClusterNode {
 		
 		[ArgDescription(Opts.ConnectionQueueSizeThresholdDescr, Opts.InterfacesGroup)]
 		public int ConnectionQueueSizeThreshold { get; set; }
+		
+		[ArgDescription(Opts.StreamInfoCacheCapacityDescr, Opts.AppGroup)]
+		public int StreamInfoCacheCapacity { get; set; }
 
 		[ArgDescription(Opts.ForceDescr, Opts.AppGroup)]
 		public bool Force { get; set; }
@@ -439,6 +442,7 @@ namespace EventStore.ClusterNode {
 			ConnectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
 			ConnectionQueueSizeThreshold = Opts.ConnectionQueueSizeThresholdDefault;
 			ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
+			StreamInfoCacheCapacity = Opts.StreamInfoCacheCapacityDefault;
 
 			MaxAutoMergeIndexLevel = Opts.MaxAutoMergeIndexLevelDefault;
 

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -234,7 +234,8 @@ namespace EventStore.ClusterNode {
 				.WithConnectionQueueSizeThreshold(options.ConnectionQueueSizeThreshold)
 				.WithChunkInitialReaderCount(options.ChunkInitialReaderCount)
 				.WithInitializationThreads(options.InitializationThreads)
-				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel);
+				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel)
+				.WithStreamInfoCacheCapacity(options.StreamInfoCacheCapacity);
 
 			if (options.GossipSeed.Length > 0)
 				builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -105,7 +105,8 @@ namespace EventStore.Core.Tests.Helpers {
 				startStandardProjections: false, disableHTTPCaching: false, logHttpRequests: false,
 				connectionPendingSendBytesThreshold: Opts.ConnectionPendingSendBytesThresholdDefault,
 				connectionQueueSizeThreshold: Opts.ConnectionQueueSizeThresholdDefault,
-				chunkInitialReaderCount: Opts.ChunkInitialReaderCountDefault);
+				chunkInitialReaderCount: Opts.ChunkInitialReaderCountDefault,
+				streamInfoCacheCapacity: Opts.StreamInfoCacheCapacityDefault);
 
 			Log.Info(
 				"\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				TimeSpan.FromSeconds(10), true, Opts.MaxMemtableSizeDefault, Opts.HashCollisionReadLimitDefault, false,
 				false, false,
 				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ConnectionQueueSizeThresholdDefault,
-				Opts.ChunkInitialReaderCountDefault);
+				Opts.ChunkInitialReaderCountDefault, Opts.StreamInfoCacheCapacityDefault);
 
 			return vnode;
 		}

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -62,6 +62,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly TimeSpan ExtTcpHeartbeatInterval;
 		public readonly int ConnectionPendingSendBytesThreshold;
 		public readonly int ConnectionQueueSizeThreshold;
+		public readonly int StreamInfoCacheCapacity;
 		public readonly bool UnsafeIgnoreHardDeletes;
 		public readonly bool VerifyDbHash;
 		public readonly int MaxMemtableEntryCount;
@@ -137,6 +138,7 @@ namespace EventStore.Core.Cluster.Settings {
 			int connectionPendingSendBytesThreshold,
 			int connectionQueueSizeThreshold,
 			int chunkInitialReaderCount,
+			int streamInfoCacheCapacity,
 			string index = null, bool enableHistograms = false,
 			bool skipIndexVerify = false,
 			int indexCacheDepth = 16,
@@ -258,6 +260,7 @@ namespace EventStore.Core.Cluster.Settings {
 			MaxAutoMergeIndexLevel = maxAutoMergeIndexLevel;
 			FaultOutOfOrderProjections = faultOutOfOrderProjections;
 			StructuredLog = structuredLog;
+			StreamInfoCacheCapacity = streamInfoCacheCapacity;
 		}
 
 		public override string ToString() {
@@ -302,7 +305,8 @@ namespace EventStore.Core.Cluster.Settings {
 			                     + "ReduceFileCachePressure: {38}\n"
 			                     + "InitializationThreads: {39}\n"
 			                     + "StructuredLog: {40}\n"
-								 + "DisableFirstLevelHttpAuthorization: {41}\n",
+								 + "DisableFirstLevelHttpAuthorization: {41}\n"
+								 + "StreamInfoCacheCapacity: {42}\n",
 				NodeInfo.InstanceId,
 				NodeInfo.InternalTcp, NodeInfo.InternalSecureTcp,
 				NodeInfo.ExternalTcp, NodeInfo.ExternalSecureTcp,
@@ -322,7 +326,7 @@ namespace EventStore.Core.Cluster.Settings {
 				EnableHistograms, DisableHTTPCaching, Index, ScavengeHistoryMaxAge,
 				ConnectionPendingSendBytesThreshold, ChunkInitialReaderCount,
 				ReduceFileCachePressure, InitializationThreads, StructuredLog,
-				DisableFirstLevelHttpAuthorization);
+				DisableFirstLevelHttpAuthorization, StreamInfoCacheCapacity);
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -224,7 +224,7 @@ namespace EventStore.Core {
 			var readIndex = new ReadIndex(_mainQueue,
 				readerPool,
 				tableIndex,
-				ESConsts.StreamInfoCacheCapacity,
+				vNodeSettings.StreamInfoCacheCapacity,
 				Application.IsDefined(Application.AdditionalCommitChecks),
 				Application.IsDefined(Application.InfiniteMetastreams) ? int.MaxValue : 1,
 				vNodeSettings.HashCollisionReadLimit,

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -69,9 +69,14 @@ namespace EventStore.Core.Util {
 		public const int IntTcpHeartbeatIntervalDefault = 700;
 
 		public const string ConnectionPendingSendBytesThresholdDescr =
-			"The maximum number of pending send bytes allowed before a connection is closed.";
-
+    			"The maximum number of pending send bytes allowed before a connection is closed.";
+    
 		public const int ConnectionPendingSendBytesThresholdDefault = 10 * 1024 * 1024;
+            
+		public const string StreamInfoCacheCapacityDescr =
+			"The maximum number of entries to keep in the stream info cache.";
+
+		public const int StreamInfoCacheCapacityDefault = 100000;
 		
 		public const string ConnectionQueueSizeThresholdDescr =
 			"The maximum number of pending connection operations allowed before a connection is closed.";

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -93,6 +93,7 @@ namespace EventStore.Core {
 		protected TimeSpan _extTcpHeartbeatInterval;
 		protected int _connectionPendingSendBytesThreshold;
 		protected int _connectionQueueSizeThreshold;
+		protected int _streamInfoCacheCapacity;
 
 		protected bool _skipVerifyDbHashes;
 		protected int _maxMemtableSize;
@@ -205,6 +206,7 @@ namespace EventStore.Core {
 			_extTcpHeartbeatTimeout = TimeSpan.FromMilliseconds(Opts.ExtTcpHeartbeatTimeoutDefault);
 			_connectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
 			_connectionQueueSizeThreshold = Opts.ConnectionQueueSizeThresholdDefault;
+			_streamInfoCacheCapacity = Opts.StreamInfoCacheCapacityDefault;
 
 			_skipVerifyDbHashes = Opts.SkipDbVerifyDefault;
 			_maxMemtableSize = Opts.MaxMemtableSizeDefault;
@@ -755,6 +757,16 @@ namespace EventStore.Core {
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
 		public VNodeBuilder WithConnectionQueueSizeThreshold(int connectionQueueSizeThreshold) {
 			_connectionQueueSizeThreshold = connectionQueueSizeThreshold;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the maximum number of entries to keep in the stream info cache.
+		/// </summary>
+		/// <param name="streamInfoCacheCapacity"></param>
+		/// <returns></returns>
+		public VNodeBuilder WithStreamInfoCacheCapacity(int streamInfoCacheCapacity) {
+			_streamInfoCacheCapacity = streamInfoCacheCapacity;
 			return this;
 		}
 
@@ -1399,6 +1411,7 @@ namespace EventStore.Core {
 				_connectionPendingSendBytesThreshold,
 				_connectionQueueSizeThreshold,
 				_chunkInitialReaderCount,
+				_streamInfoCacheCapacity,
 				_index,
 				_enableHistograms,
 				_skipIndexVerify,


### PR DESCRIPTION
Adds option `--stream-info-cache-capacity` to allow setting the cache capacity of the ReadIndex.