### PR TITLE
Expose option for stream info cache capacity

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -268,7 +268,8 @@ namespace EventStore.ClusterNode {
 				.WithMaxAutoMergeIndexLevel(options.MaxAutoMergeIndexLevel)
 				.WithMaxTruncation(options.MaxTruncation)
 				.WithMaxAppendSize(options.MaxAppendSize)
-				.WithEnableAtomPubOverHTTP(options.EnableAtomPubOverHTTP);
+				.WithEnableAtomPubOverHTTP(options.EnableAtomPubOverHTTP)
+				.WithStreamInfoCacheCapacity(options.StreamInfoCacheCapacity);
 
 			if (options.GossipSeed.Length > 0)
 				builder.WithGossipSeeds(options.GossipSeed);

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -141,6 +141,7 @@ namespace EventStore.Core.Tests.Helpers {
 				connectionQueueSizeThreshold: Opts.ConnectionQueueSizeThresholdDefault,
 				readOnlyReplica: readOnlyReplica,
 				ptableMaxReaderCount: Constants.PTableMaxReaderCountDefault,
+				streamInfoCacheCapacity: Opts.StreamInfoCacheCapacityDefault,
 				enableExternalTCP: true,
 				disableHttps: !useHttps,
 				enableAtomPubOverHTTP: true);

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -59,6 +59,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				false, false,
 				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ConnectionQueueSizeThresholdDefault,
 				Constants.PTableMaxReaderCountDefault,
+				Opts.StreamInfoCacheCapacityDefault,
 				readOnlyReplica: isReadOnlyReplica,
 				disableHttps: !useHttps);
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -78,6 +78,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly int IndexCacheDepth;
 		public readonly byte IndexBitnessVersion;
 		public readonly bool OptimizeIndexMerge;
+		public readonly int StreamInfoCacheCapacity;
 
 		public readonly string Index;
 		public readonly int ReaderThreadsCount;
@@ -147,6 +148,7 @@ namespace EventStore.Core.Cluster.Settings {
 			int connectionPendingSendBytesThreshold,
 			int connectionQueueSizeThreshold,
 			int ptableMaxReaderCount,
+			int streamInfoCacheCapacity,
 			string index = null, bool enableHistograms = false,
 			bool skipIndexVerify = false,
 			int indexCacheDepth = 16,
@@ -279,6 +281,7 @@ namespace EventStore.Core.Cluster.Settings {
 			PTableMaxReaderCount = ptableMaxReaderCount;
 			UnsafeAllowSurplusNodes = unsafeAllowSurplusNodes;
 			MaxTruncation = maxTruncation;
+			StreamInfoCacheCapacity = streamInfoCacheCapacity;
 		}
 
 		public override string ToString() =>
@@ -313,6 +316,7 @@ namespace EventStore.Core.Cluster.Settings {
 			$"ReadOnlyReplica: {ReadOnlyReplica}\n" +
 			$"UnsafeAllowSurplusNodes: {UnsafeAllowSurplusNodes}\n" +
 			$"DeadMemberRemovalPeriod: {DeadMemberRemovalPeriod}\n" +
-			$"MaxTruncation: {MaxTruncation}\n";
+			$"MaxTruncation: {MaxTruncation}\n" +
+			$"StreamInfoCacheCapacity: {StreamInfoCacheCapacity}\n";
 	}
 }

--- a/src/EventStore.Core/ClusterNodeOptions.cs
+++ b/src/EventStore.Core/ClusterNodeOptions.cs
@@ -93,6 +93,9 @@ namespace EventStore.Core {
 		[ArgDescription(Opts.ConnectionQueueSizeThresholdDescr, Opts.InterfacesGroup)]
 		public int ConnectionQueueSizeThreshold { get; set; }
 
+		[ArgDescription(Opts.StreamInfoCacheCapacityDescr, Opts.AppGroup)]
+		public int StreamInfoCacheCapacity { get; set; }
+
 		[ArgDescription(Opts.ClusterSizeDescr, Opts.ClusterGroup)]
 		public int ClusterSize { get; set; }
 
@@ -443,6 +446,8 @@ namespace EventStore.Core {
 			ConnectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
 			ConnectionQueueSizeThreshold = Opts.ConnectionQueueSizeThresholdDefault;
 			ChunkInitialReaderCount = Opts.ChunkInitialReaderCountDefault;
+
+			StreamInfoCacheCapacity = Opts.StreamInfoCacheCapacityDefault;
 
 			MaxAutoMergeIndexLevel = Opts.MaxAutoMergeIndexLevelDefault;
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -299,7 +299,7 @@ namespace EventStore.Core {
 			var readIndex = new ReadIndex(_mainQueue,
 				readerPool,
 				tableIndex,
-				ESConsts.StreamInfoCacheCapacity,
+				vNodeSettings.StreamInfoCacheCapacity,
 				ESConsts.PerformAdditionlCommitChecks,
 				ESConsts.MetaStreamMaxCount,
 				vNodeSettings.HashCollisionReadLimit,

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -73,6 +73,11 @@ namespace EventStore.Core.Util {
 
 		public const int ConnectionQueueSizeThresholdDefault = 50000;
 
+		public const string StreamInfoCacheCapacityDescr =
+			"The maximum number of entries to keep in the stream info cache.";
+
+		public const int StreamInfoCacheCapacityDefault = 100000;
+
 		public const string GossipOnSingleNodeDescr =
 			"When enabled tells a single node to run gossip as if it is a cluster";
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -103,6 +103,7 @@ namespace EventStore.Core {
 		protected TimeSpan _extTcpHeartbeatInterval;
 		protected int _connectionPendingSendBytesThreshold;
 		protected int _connectionQueueSizeThreshold;
+		protected int _streamInfoCacheCapacity;
 
 		protected bool _skipVerifyDbHashes;
 		protected int _maxMemtableSize;
@@ -229,6 +230,7 @@ namespace EventStore.Core {
 			_extTcpHeartbeatTimeout = TimeSpan.FromMilliseconds(Opts.ExtTcpHeartbeatTimeoutDefault);
 			_connectionPendingSendBytesThreshold = Opts.ConnectionPendingSendBytesThresholdDefault;
 			_connectionQueueSizeThreshold = Opts.ConnectionQueueSizeThresholdDefault;
+			_streamInfoCacheCapacity = Opts.StreamInfoCacheCapacityDefault;
 
 			_skipVerifyDbHashes = Opts.SkipDbVerifyDefault;
 			_maxMemtableSize = Opts.MaxMemtableSizeDefault;
@@ -813,6 +815,16 @@ namespace EventStore.Core {
 		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
 		public VNodeBuilder WithConnectionQueueSizeThreshold(int connectionQueueSizeThreshold) {
 			_connectionQueueSizeThreshold = connectionQueueSizeThreshold;
+			return this;
+		}
+
+		/// <summary>
+		/// Sets the maximum number of entries to keep in the stream info cache.
+		/// </summary>
+		/// <param name="streamInfoCacheCapacity"></param>
+		/// <returns></returns>
+		public VNodeBuilder WithStreamInfoCacheCapacity(int streamInfoCacheCapacity) {
+			_streamInfoCacheCapacity = streamInfoCacheCapacity;
 			return this;
 		}
 
@@ -1442,6 +1454,7 @@ namespace EventStore.Core {
 				_connectionPendingSendBytesThreshold,
 				_connectionQueueSizeThreshold,
 				ComputePTableMaxReaderCount(ESConsts.PTableInitialReaderCount, _readerThreadsCount),
+				_streamInfoCacheCapacity,
 				_index,
 				_enableHistograms,
 				_skipIndexVerify,


### PR DESCRIPTION
Added: --stream-info-cache-capacity option to allow setting the cache capacity of the ReadIndex.

Fixes https://github.com/EventStore/home/issues/338