### PR TITLE
Proactively send heartbeat requests to the remote party if no data was sent within the last heartbeat interval

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -265,6 +265,8 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			get { return _clientConnectionName; }
 		}
 
+		public long TotalBytesSent { get; }
+
 		public bool IsClosed {
 			get { return false; }
 		}

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -266,6 +266,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 		}
 
 		public long TotalBytesSent { get; }
+		public long TotalBytesReceived { get; }
 
 		public bool IsClosed {
 			get { return false; }

--- a/src/EventStore.Core/Messages/TcpMessage.cs
+++ b/src/EventStore.Core/Messages/TcpMessage.cs
@@ -32,10 +32,12 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public readonly int MessageNumber;
+			public readonly long ReceiveProgressIndicator;
+			public readonly long SendProgressIndicator;
 
-			public Heartbeat(int messageNumber) {
-				MessageNumber = messageNumber;
+			public Heartbeat(long receiveProgressIndicator, long sendProgressIndicator) {
+				ReceiveProgressIndicator = receiveProgressIndicator;
+				SendProgressIndicator = sendProgressIndicator;
 			}
 		}
 
@@ -46,10 +48,10 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public readonly int MessageNumber;
+			public readonly long ReceiveProgressIndicator;
 
-			public HeartbeatTimeout(int messageNumber) {
-				MessageNumber = messageNumber;
+			public HeartbeatTimeout(long receiveProgressIndicator) {
+				ReceiveProgressIndicator = receiveProgressIndicator;
 			}
 		}
 

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -52,7 +52,8 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private readonly IPublisher _publisher;
 		private readonly ITcpDispatcher _dispatcher;
 		private readonly IMessageFramer _framer;
-		private int _messageNumber;
+		private long _receiveProgressIndicator;
+		private long _sendProgressIndicator => _connection?.TotalBytesSent ?? 0L;
 		private int _isClosed;
 		private string _clientConnectionName;
 
@@ -64,6 +65,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private readonly SendToWeakThisEnvelope _weakThisEnvelope;
 		private readonly TimeSpan _heartbeatInterval;
 		private readonly TimeSpan _heartbeatTimeout;
+		private bool _awaitingHeartbeatTimeoutCheck;
 		private readonly int _connectionPendingSendBytesThreshold;
 		private readonly int _connectionQueueSizeThreshold;
 
@@ -120,7 +122,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 				return;
 			}
 
-			ScheduleHeartbeat(0);
+			ScheduleHeartbeat(0L, 0L);
 		}
 
 		public TcpConnectionManager(string connectionName,
@@ -184,7 +186,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			Log.Information("Connection '{connectionName}' ({connectionId:B}) to [{remoteEndPoint}] established.",
 				ConnectionName, ConnectionId, connection.RemoteEndPoint);
 
-			ScheduleHeartbeat(0);
+			ScheduleHeartbeat(0L, 0L);
 
 			var handler = _connectionEstablished;
 			if (handler != null)
@@ -214,7 +216,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		}
 
 		private void OnRawDataReceived(ITcpConnection connection, IEnumerable<ArraySegment<byte>> data) {
-			Interlocked.Increment(ref _messageNumber);
+			Interlocked.Increment(ref _receiveProgressIndicator);
 
 			try {
 				_framer.UnFrameData(data);
@@ -420,30 +422,48 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		public void Handle(TcpMessage.Heartbeat message) {
 			if (IsClosed) return;
 
-			var msgNum = _messageNumber;
-			if (message.MessageNumber != msgNum)
-				ScheduleHeartbeat(msgNum);
-			else {
-				SendPackage(new TcpPackage(TcpCommand.HeartbeatRequestCommand, Guid.NewGuid(), null));
+			var receiveProgressIndicator = _receiveProgressIndicator;
+			var sendProgressIndicator = _sendProgressIndicator;
 
+			/*
+			 * If we have not received any data within the heartbeat interval and we are not waiting for a heartbeat timeout check, then we send a heartbeat request.
+			 */
+			if (message.ReceiveProgressIndicator == receiveProgressIndicator && !_awaitingHeartbeatTimeoutCheck) {
+				SendPackage(new TcpPackage(TcpCommand.HeartbeatRequestCommand, Guid.NewGuid(), null));
+				_awaitingHeartbeatTimeoutCheck = true;
 				_publisher.Publish(TimerMessage.Schedule.Create(_heartbeatTimeout, _weakThisEnvelope,
-					new TcpMessage.HeartbeatTimeout(msgNum)));
+					new TcpMessage.HeartbeatTimeout(receiveProgressIndicator)));
 			}
+			/*
+			 * As a proactive measure, if we have not sent any data to the remote party within the heartbeat interval,
+			 * we also send a heartbeat request just to generate some data for the remote party so that it can clear its heartbeat timeouts.
+			 * This is particularly useful when the remote party's heartbeat request is stuck behind a large (multi-megabyte) TCP message.
+			 */
+			else if (message.SendProgressIndicator == sendProgressIndicator) {
+				SendPackage(new TcpPackage(TcpCommand.HeartbeatRequestCommand, Guid.NewGuid(), null));
+				Log.Verbose(
+					"Connection '{connectionName}{clientConnectionName}' [{remoteEndPoint}, {connectionId:B}] Proactive heartbeat request sent to the remote party since no data was sent during the last heartbeat interval.",
+					ConnectionName, ClientConnectionName.IsEmptyString() ? string.Empty : ":" + ClientConnectionName,
+					_connection.RemoteEndPoint, ConnectionId);
+			}
+
+			//schedule the next heartbeat regardless of whether or not there's an active heartbeat request
+			ScheduleHeartbeat(receiveProgressIndicator, sendProgressIndicator);
 		}
 
 		public void Handle(TcpMessage.HeartbeatTimeout message) {
+			_awaitingHeartbeatTimeoutCheck = false;
 			if (IsClosed) return;
 
-			var msgNum = _messageNumber;
-			if (message.MessageNumber != msgNum)
-				ScheduleHeartbeat(msgNum);
-			else
-				Stop(string.Format("HEARTBEAT TIMEOUT at msgNum {0}", msgNum));
+			var receiveProgressIndicator = _receiveProgressIndicator;
+			var sendProgressIndicator = _sendProgressIndicator;
+			if (message.ReceiveProgressIndicator == receiveProgressIndicator)
+				Stop(string.Format($"HEARTBEAT TIMEOUT at receiveProgressIndicator={receiveProgressIndicator}, sendProgressIndicator={sendProgressIndicator}"));
 		}
 
-		private void ScheduleHeartbeat(int msgNum) {
+		private void ScheduleHeartbeat(long receiveProgressIndicator, long sendProgressIndicator) {
 			_publisher.Publish(TimerMessage.Schedule.Create(_heartbeatInterval, _weakThisEnvelope,
-				new TcpMessage.Heartbeat(msgNum)));
+				new TcpMessage.Heartbeat(receiveProgressIndicator, sendProgressIndicator)));
 		}
 
 		private class SendToWeakThisEnvelope : IEnvelope {

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -52,7 +52,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private readonly IPublisher _publisher;
 		private readonly ITcpDispatcher _dispatcher;
 		private readonly IMessageFramer _framer;
-		private long _receiveProgressIndicator;
+		private long _receiveProgressIndicator => _connection?.TotalBytesReceived ?? 0L;
 		private long _sendProgressIndicator => _connection?.TotalBytesSent ?? 0L;
 		private int _isClosed;
 		private string _clientConnectionName;
@@ -216,8 +216,6 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		}
 
 		private void OnRawDataReceived(ITcpConnection connection, IEnumerable<ArraySegment<byte>> data) {
-			Interlocked.Increment(ref _receiveProgressIndicator);
-
 			try {
 				_framer.UnFrameData(data);
 			} catch (PackageFramingException exc) {

--- a/src/EventStore.Transport.Tcp/ITcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/ITcpConnection.cs
@@ -14,6 +14,7 @@ namespace EventStore.Transport.Tcp {
 		int SendQueueSize { get; }
 		int PendingSendBytes { get; }
 		long TotalBytesSent { get; }
+		long TotalBytesReceived { get; }
 		bool IsClosed { get; }
 
 		void ReceiveAsync(Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> callback);

--- a/src/EventStore.Transport.Tcp/ITcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/ITcpConnection.cs
@@ -13,6 +13,7 @@ namespace EventStore.Transport.Tcp {
 		IPEndPoint LocalEndPoint { get; }
 		int SendQueueSize { get; }
 		int PendingSendBytes { get; }
+		long TotalBytesSent { get; }
 		bool IsClosed { get; }
 
 		void ReceiveAsync(Action<ITcpConnection, IEnumerable<ArraySegment<byte>>> callback);


### PR DESCRIPTION
Fixed: Proactively send heartbeat requests to the remote party if no data was sent within the last heartbeat interval

This is a follow-up PR to #2757

Fixes: https://github.com/eventstore/home/issues/312
Fixes: https://github.com/EventStore/EventStore/issues/2771

## Current way heartbeats work
The way heartbeats currently work between nodes is as follows:
- If we have not *received* any data from the remote party for `heartbeat interval` seconds, we enqueue a `heartbeat request` and schedule a heartbeat timeout message locally (Note that we may have *sent* a lot of data in the mean time)
- This `heartbeat request` is enqueued onto the send queue and when it is dequeued (after possibly a lot of other data), it is sent to the remote party over the TCP connection.
- The remote party receives the `heartbeat request` as raw data, enqueues it on the receive queue, dequeues it (after possibly dequeueing a lot of other data), unframes the raw data into a heartbeat request command, processes it and prepares a `heartbeat response` message which is now enqueued on the remote party's send queue and sent.
- If the local party receives the heartbeat response or any other data sent by the remote party before the heartbeat timeout check is triggered, everything is fine otherwise it results in a `HEARTBEAT TIMEOUT` and the TCP connection is closed by the local party.

## Problem description
The above scenario works fine when a connection is idle (there's not much send and receive traffic) or when we are mostly receiving traffic. However, in the case where we are sending a lot of data but not receiving any (as in #2771), it poses the following problem:
- The `heartbeat request` may need to wait behind a lot of other data on the send queue on the local side before being sent
- The `heartbeat request` may need to wait behind a lot of other data on the receive queue on the remote side before being processed

## Fix description
The fix in this PR works as follows:
Just like before:
- If we have not *received* any data from the remote party for `heartbeat interval` seconds, we enqueue a `heartbeat request` and schedule a heartbeat timeout message locally

But now, also:
- If we have not *sent* any data to the remote party during the last `heartbeat interval` seconds, we proactively enqueue a `heartbeat request` to generate some data on the connection. Note: We do not schedule a heartbeat timeout check locally in this case.

Assumptions for this method to work in an optimal way:
- Heartbeat intervals must match on both nodes (it is usually the case)
- `Heartbeat interval` + `Latency between nodes` must be lower than the `Heartbeat Timeout` - otherwise in the worst case, if we schedule the heartbeat request `Heartbeat interval` milliseconds late, the other node will already trigger the timeout check. Usually `Latency << Heartbeat Interval`, so it can be reduced to `Heartbeat interval < Heartbeat Timeout` and it is the case by default.

## Additional improvements
- Take received data info directly from TCP connection to receive fresh info: a0008ee4eb7ab5175b02f5a5223acf461fdacea9
- Submit up to MaxSendPacketSize bytes to the socket API - otherwise we receive feedback about data sent only after the whole buffer has been sent (which can be multiple megabytes large): b1653035c1f14265e0111ab174bfce787dd600ef