### PR TITLE
Fix linux/macOS build.sh script for .NET 5.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,26 +3,23 @@
 BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PRODUCTNAME="Event Store Open Source"
 COMPANYNAME="Event Store Ltd"
-COPYRIGHT="Copyright 2019 Event Store Ltd. All rights reserved."
+COPYRIGHT="Copyright 2021 Event Store Ltd. All rights reserved."
 
 
 # ------------ End of configuration -------------
 
 CONFIGURATION="Release"
-RUNTIME="linux-x64"
 BUILD_UI="no"
-NET_FRAMEWORK="netcoreapp3.1"
+NET_FRAMEWORK="net5.0"
 
 function usage() {    
 cat <<EOF
 Usage:
-  $0 [<version=0.0.0.0>] [<configuration=Debug|Release>] [<runtime=linux-x64>] [<build_ui=yes|no>]
+  $0 [<version=0.0.0.0>] [<configuration=Debug|Release>] [<build_ui=yes|no>]
 
 version: EventStore build version. Versions must be complete four part identifiers valid for use on a .NET assembly.
 
 configuration: Build configuration. Valid configurations are: Debug, Release
-
-runtime: Runtime Identifier (linux-x64, ubuntu.18.04-x64, etc)
 
 build_ui: Whether or not to build the EventStore UI. Building the UI requires an installation of Node.js (v8.11.4+)
 
@@ -52,10 +49,9 @@ function checkParams() {
 
     version=$1
     configuration=$2
-    runtime=$3
-    build_ui=$4
+    build_ui=$3
 
-    [[ $# -gt 4 ]] && usage
+    [[ $# -gt 3 ]] && usage
 
     if [[ "$version" == "" ]] ; then
         VERSIONSTRING="0.0.0.0"
@@ -76,13 +72,6 @@ function checkParams() {
             echo "Invalid configuration: $configuration"
             usage
         fi
-    fi
-
-    if [[ "$runtime" == "" ]]; then
-        RUNTIME="linux-x64"
-        echo "Runtime defaulted to linux-64: $RUNTIME"
-    else
-        RUNTIME=$runtime
     fi
 
     if [[ "$build_ui" == "" ]]; then
@@ -171,7 +160,7 @@ function buildUI {
 function buildEventStore {
     patchVersionInfo
     rm -rf bin/
-    dotnet build -c $CONFIGURATION /p:Platform=x64 /p:Version=$VERSIONSTRING --runtime=$RUNTIME --framework=$NET_FRAMEWORK src/EventStore.sln || err
+    dotnet build -c $CONFIGURATION /p:Platform=x64 /p:Version=$VERSIONSTRING --framework=$NET_FRAMEWORK src/EventStore.sln || err
     revertVersionInfo
 }
 
@@ -181,7 +170,7 @@ function exitWithError {
 }
 
 detectOS
-checkParams "$1" "$2" "$3" "$4"
+checkParams "$1" "$2" "$3"
 
 echo "Running from base directory: $BASE_DIR"
 buildUI


### PR DESCRIPTION
Fixed: Linux/macOS build.sh script for .NET 5.0

Note: Runtime identifier parameter has been removed due to: https://github.com/dotnet/sdk/issues/14281