### PR TITLE
Fix performance counter error message on linux / macOS

### DIFF
--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -33,6 +33,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />
+		<ProjectReference Include="..\EventStore.Common.Utils\EventStore.Common.Utils.csproj" />
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Native\EventStore.Native.csproj" />
 		<ProjectReference Include="..\EventStore.Rags\EventStore.Rags.csproj" />

--- a/src/EventStore.Core/Services/Monitoring/Utils/PerfCounterHelper.cs
+++ b/src/EventStore.Core/Services/Monitoring/Utils/PerfCounterHelper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using EventStore.Common.Utils;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services.Monitoring.Utils {
@@ -19,6 +20,10 @@ namespace EventStore.Core.Services.Monitoring.Utils {
 		}
 
 		private PerformanceCounter CreatePerfCounter(string category, string counter, string instance = null) {
+			if(!Runtime.IsWindows){
+				return null;
+			}
+
 			try {
 				return string.IsNullOrEmpty(instance)
 					? new PerformanceCounter(category, counter)


### PR DESCRIPTION
Fixed: Performance counter error message on linux / macOS


Fixes: https://github.com/EventStore/home/issues/332

Create CPU & memory performance counters on Windows only since on Linux & macOS use the [HostStat.NET](https://www.nuget.org/packages/HostStat.NET/) library
