### PR TITLE
Make --insecure work with .NET 5.0

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -33,9 +33,9 @@
 	<!-- Transitive dependencies to help in packaging -->
 	<ItemGroup>
 		<PackageReference Include="EventStore.Plugins" Version="20.6.1" />
-		<PackageReference Include="Google.Protobuf" Version="3.12.3" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.29.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.30.0">
+		<PackageReference Include="Google.Protobuf" Version="3.14.0" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.34.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
+++ b/src/EventStore.Core.Tests/Http/HttpProtocols/clear_text_http_multiplexing_middleware.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Transport.Http;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Http.HttpProtocols {
+
+	public class Startup : IStartup{
+		public IServiceProvider ConfigureServices(IServiceCollection services) {
+			return services.AddRouting().BuildServiceProvider();
+		}
+
+		public void Configure(IApplicationBuilder app) {
+			app.UseRouter(router => {
+				router.MapGet("/test", async context => {
+					await context.Response.WriteAsync("hello");
+				});
+			});
+		}
+	}
+
+	[TestFixture]
+	public class clear_text_http_multiplexing_middleware {
+		private IWebHost _host;
+		private string _endpoint;
+
+		[SetUp]
+		public void SetUp() {
+			_host = new WebHostBuilder()
+				.UseKestrel(server => {
+					server.Listen(IPAddress.Loopback, 0, listenOptions => {
+						listenOptions.Use(next => new ClearTextHttpMultiplexingMiddleware(next).OnConnectAsync);
+					});
+				})
+				.UseStartup(new Startup())
+				.Build();
+
+			_host.Start();
+			_endpoint = _host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.Single();
+		}
+
+		[TearDown]
+		public Task Teardown() {
+			_host?.Dispose();
+			return Task.CompletedTask;
+		}
+
+		[Test]
+		public async Task http1_request() {
+			using var client = new HttpClient();
+			var request = new HttpRequestMessage(HttpMethod.Get, _endpoint + "/test");
+			var result = await client.SendAsync(request);
+			Assert.AreEqual(new Version(1,1), result.Version);
+			Assert.AreEqual("hello", await result.Content.ReadAsStringAsync());
+		}
+
+		[Test]
+		public async Task http2_request() {
+			using var client = new HttpClient();
+			var request = new HttpRequestMessage(HttpMethod.Get, _endpoint + "/test") {
+				Version = new Version(2, 0),
+				VersionPolicy = HttpVersionPolicy.RequestVersionExact
+			};
+
+			var result = await client.SendAsync(request);
+			Assert.AreEqual(new Version(2,0), result.Version);
+			Assert.AreEqual("hello", await result.Content.ReadAsStringAsync());
+		}
+
+	}
+}

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.cs
@@ -41,7 +41,6 @@ namespace EventStore.Core.Cluster {
 
 				httpMessageHandler = socketsHttpHandler;
 			} else if (address.Scheme == Uri.UriSchemeHttp) {
-				AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
 				httpMessageHandler = new SocketsHttpHandler();
 			}
 

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -15,9 +15,9 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="EventStore.Plugins" Version="20.6.1" />
-		<PackageReference Include="Google.Protobuf" Version="3.12.3" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.29.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.30.0">
+		<PackageReference Include="Google.Protobuf" Version="3.14.0" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.34.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Core/Services/Transport/Http/ClearTextHttpMultiplexingMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/ClearTextHttpMultiplexingMiddleware.cs
@@ -45,8 +45,8 @@ namespace EventStore.Core.Services.Transport.Http
 	    }
 
 	    private static void SetProtocols(object target, HttpProtocols protocols) {
-	        var field = target.GetType().GetField("_protocols", BindingFlags.Instance | BindingFlags.NonPublic);
-	        if (field == null) throw new RuntimeBinderException("Couldn't bind to Kestrel's _protocols field");
+	        var field = target.GetType().GetField("_endpointDefaultProtocols", BindingFlags.Instance | BindingFlags.NonPublic);
+	        if (field == null) throw new RuntimeBinderException("Couldn't bind to Kestrel's _endpointDefaultProtocols field");
 	        field.SetValue(target, protocols);
         }
 


### PR DESCRIPTION
Fixed: --insecure has stopped working after targeting .NET 5.0

Fixes https://github.com/EventStore/EventStore/issues/2778

Changes made:
- renamed `_protocols` to `_endpointDefaultProtocols` (see https://github.com/dotnet/aspnetcore/blob/master/src/Servers/Kestrel/Core/src/Middleware/HttpConnectionMiddleware.cs#L16)
- upgraded gRPC dependencies since `AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);` no longer works with current gRPC dependencies and .NET 5.0 (see https://github.com/dotnet/core/issues/5265)
- removed `AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);`  from EventStoreClusterClient