### PR TITLE
stop referencing container that does not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         registry: https://docker.pkg.github.com
     - name: Docker Push CI
       uses: jen20/action-docker-build@v1
-      if: github.event_name == 'push' && matrix.container-runtime == 'bionic'
+      if: github.event_name == 'push' && matrix.container-runtime == 'focal'
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changed: Ci container now based on `focal` build