### PR TITLE
Fix Plugin Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,11 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 5.0.x
+    - name: Clear Nuget Cache
+      shell: bash
+      if: matrix.os == 'windows-2019'
+      run: |
+        dotnet nuget locals all --clear
     - name: Compile
       shell: bash
       run: |

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -46,5 +46,6 @@
 	<ItemGroup>
 			<None Remove="FakePlugin\**" />
 			<Compile Remove="FakePlugin\**" />
+			<Content Include="FakePlugin\**" CopyToOutputDirectory="Always" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Core.Tests/PluginLoaderTests.cs
+++ b/src/EventStore.Core.Tests/PluginLoaderTests.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Threading.Tasks;
 using EventStore.ClusterNode;
-using EventStore.Core.TransactionLog.Checkpoint;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests {
@@ -138,10 +137,7 @@ namespace EventStore.Core.Tests {
 				throw new Exception(stdout.Result);
 			}
 		}
-		private static string SourceDirectory =>
-			Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "../../../../.."));
-
-		private static string PluginSourceDirectory => Path.Combine(SourceDirectory, "EventStore.Core.Tests", "FakePlugin");
+		private static string PluginSourceDirectory => Path.Combine(Environment.CurrentDirectory, "FakePlugin");
 
 		private const string BuildConfiguration =
 #if DEBUG


### PR DESCRIPTION
Fixed: failing test

Attempting to resolve where FakePlugin is in src didn't work as `dotnet test` and the resharper test runner don't output to same folder.
