### PR TITLE
Track parked message count

### DIFF
--- a/src/EventStore.ClientAPI/PersistentSubscriptions/PersistentSubscriptionDetails.cs
+++ b/src/EventStore.ClientAPI/PersistentSubscriptions/PersistentSubscriptionDetails.cs
@@ -46,6 +46,11 @@ namespace EventStore.ClientAPI.PersistentSubscriptions {
 		/// Number of items seen since last measurement on this connection (used as the basis for <see cref="AverageItemsPerSecond"/>).
 		/// </summary>
 		public long CountSinceLastMeasurement { get; set; }
+		
+		/// <summary>
+		/// Number of messages that have been parked on this subscription.
+		/// </summary>
+		public long ParkedMessageCount { get; set; }
 
 		/// <summary>
 		/// Last processed target stream version.

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionMessageParkerTests.cs
@@ -1,0 +1,297 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.PersistentSubscription;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.PersistentSubscription {
+	[TestFixture]
+	public class PersistentSubscriptionMessageParkerTests {
+		private static string LinkMetadata =
+			"{\"added\":\"2021-01-19T11:40:46.2592636+01:00\",\"reason\":\"Client explicitly NAK'ed message.\"}";
+
+		private static ResolvedEvent CreateResolvedEvent(long eventNumber, long logPosition) {
+			var record = new EventRecord(eventNumber, logPosition, Guid.NewGuid(), Guid.NewGuid(), 0,
+				0, "foo", ExpectedVersion.Any, DateTime.Now, PrepareFlags.IsCommitted, "test-event",
+				Encoding.UTF8.GetBytes("{\"foo\": \"bar\"}"),
+				new byte[] { });
+			return ResolvedEvent.ForResolvedLink(record, null, 0);
+		}
+
+		public class given_parked_stream_does_not_exist : TestFixtureWithExistingEvents {
+			private PersistentSubscriptionMessageParker _messageParker;
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+			protected override void Given() {
+				base.Given();
+				NoOtherStreams();
+				_messageParker = new PersistentSubscriptionMessageParker(Guid.NewGuid().ToString(), _ioDispatcher);
+			}
+
+			[Test]
+			public async Task should_have_no_parked_messages() {
+				_messageParker.BeginLoadStats(() => {
+					Assert.Zero(_messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+				await _done.Task.WithTimeout();
+			}
+		}
+
+		public class given_parked_messages_and_no_truncate_before : TestFixtureWithExistingEvents {
+			private PersistentSubscriptionMessageParker _messageParker;
+			private string _streamId = Guid.NewGuid().ToString();
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+			protected override void Given() {
+				base.Given();
+				_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "0@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "1@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "2@foo");
+				NoOtherStreams();
+			}
+
+			[Test]
+			public async Task should_have_three_parked_messages() {
+				_messageParker.BeginLoadStats(() => {
+					Assert.AreEqual(3, _messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+				await _done.Task.WithTimeout();
+			}
+		}
+
+		public class given_parked_messages_and_half_are_truncated : TestFixtureWithExistingEvents {
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+			private PersistentSubscriptionMessageParker _messageParker;
+			private string _streamId = Guid.NewGuid().ToString();
+
+			protected override void Given() {
+				base.Given();
+				_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "5@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "6@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "7@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "8@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "9@foo");
+			}
+
+			[Test]
+			public async Task should_have_five_parked_messages() {
+				_messageParker.BeginLoadStats(() => {
+					Assert.AreEqual(5, _messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+				await _done.Task.WithTimeout();
+			}
+		}
+
+		public class given_parked_messages_and_all_are_truncated : TestFixtureWithExistingEvents {
+			private PersistentSubscriptionMessageParker _messageParker;
+			private string _streamId = Guid.NewGuid().ToString();
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+			protected override void Given() {
+				base.Given();
+				_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "0@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "1@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "2@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "3@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "4@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "5@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "6@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "7@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "8@foo");
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "9@foo");
+				DeletedStream(_messageParker.ParkedStreamId);
+			}
+
+			[Test]
+			public async Task should_have_no_parked_messages() {
+				_messageParker.BeginLoadStats(() => {
+					Assert.Zero(_messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+				await _done.Task.WithTimeout();
+			}
+		}
+
+		public class given_a_message_is_parked : TestFixtureWithExistingEvents {
+			private PersistentSubscriptionMessageParker _messageParker;
+			private string _streamId = Guid.NewGuid().ToString();
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+			protected override void Given() {
+				base.Given();
+				_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+				NoOtherStreams();
+				AllWritesSucceed();
+			}
+
+			[Test]
+			public async Task should_have_one_parked_message() {
+				_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) => {
+					Assert.AreEqual(1, _messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+				await _done.Task.WithTimeout();
+			}
+		}
+
+		public class given_messages_are_parked_and_then_replayed : TestFixtureWithExistingEvents {
+			private PersistentSubscriptionMessageParker _messageParker;
+			private string _streamId = Guid.NewGuid().ToString();
+			private TaskCompletionSource<bool> _parked;
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+			protected override void Given() {
+				base.Given();
+
+				AllWritesSucceed();
+
+				_parked = new TaskCompletionSource<bool>();
+				_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+				_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) => {
+					_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", (_, __) => {
+						_parked.SetResult(true);
+					});
+				});
+			}
+
+			[Test]
+			public async Task should_have_no_parked_messages() {
+				await _parked.Task;
+				_messageParker.BeginMarkParkedMessagesReprocessed(2, () => {
+					Assert.Zero(_messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+				await _done.Task.WithTimeout();
+			}
+		}
+
+		public class given_message_parked_after_parked_messages_are_replayed : TestFixtureWithExistingEvents {
+			private PersistentSubscriptionMessageParker _messageParker;
+			private string _streamId = Guid.NewGuid().ToString();
+			private TaskCompletionSource<bool> _replayParked;
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+			protected override void Given() {
+				base.Given();
+
+				AllWritesSucceed();
+
+				_replayParked = new TaskCompletionSource<bool>();
+				_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+				_messageParker.BeginParkMessage(CreateResolvedEvent(0, 0), "testing", (_, __) => {
+					_messageParker.BeginParkMessage(CreateResolvedEvent(1, 100), "testing", (_, __) => {
+						_messageParker.BeginMarkParkedMessagesReprocessed(2, () => {
+							_replayParked.SetResult(true);
+						});
+					});
+				});
+			}
+
+			[Test]
+			public async Task should_have_one_parked_message() {
+				await _replayParked.Task;
+				_messageParker.BeginParkMessage(CreateResolvedEvent(2,200), "testing", (_, __) => {
+					Assert.AreEqual(1, _messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+				await _done.Task.WithTimeout();
+			}
+		}
+
+		public class given_read_backwards_fails_when_getting_stats : TestFixtureWithExistingEvents {
+			private PersistentSubscriptionMessageParker _messageParker;
+			private string _streamId = Guid.NewGuid().ToString();
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+			private TaskCompletionSource<bool> _timerMessageReceived = new TaskCompletionSource<bool>();
+			private IODispatcherDelayedMessage _timerMessage;
+
+			protected override void Given() {
+				base.Given();
+
+				AllReadsTimeOut();
+
+				_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+
+				_bus.Subscribe(new AdHocHandler<TimerMessage.Schedule>(
+					msg => {
+						_timerMessage = msg.ReplyMessage as IODispatcherDelayedMessage;
+						_timerMessageReceived.TrySetResult(true);
+					}));
+			}
+
+			[Test]
+			public async Task should_not_hang() {
+				_messageParker.BeginLoadStats(() => {
+					Assert.Zero(_messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+
+				await _timerMessageReceived.Task.WithTimeout();
+				_ioDispatcher.Handle(_timerMessage);
+
+				await _done.Task.WithTimeout();
+			}
+		}
+
+		public class given_read_forwards_fails_when_getting_stats : TestFixtureWithExistingEvents {
+			private PersistentSubscriptionMessageParker _messageParker;
+			private string _streamId = Guid.NewGuid().ToString();
+			private TaskCompletionSource<bool> _done = new TaskCompletionSource<bool>();
+
+			private TaskCompletionSource<bool> _timerMessagesReceived = new TaskCompletionSource<bool>();
+			private TaskCompletionSource<bool> _readForwardReceived = new TaskCompletionSource<bool>();
+			private List<IODispatcherDelayedMessage> _timerMessages = new List<IODispatcherDelayedMessage>();
+			private Guid _readForwardCorrelationId;
+
+			protected override void Given() {
+				base.Given();
+
+				_messageParker = new PersistentSubscriptionMessageParker(_streamId, _ioDispatcher);
+				ExistingEvent(_messageParker.ParkedStreamId, "$>", LinkMetadata, "0@foo");
+
+				// Disable the forward reader so it times out
+				_bus.Unsubscribe(_ioDispatcher.ForwardReader);
+				_bus.Subscribe(new AdHocHandler<ClientMessage.ReadStreamEventsForward>(msg => {
+					_readForwardCorrelationId = msg.CorrelationId;
+					_readForwardReceived.TrySetResult(true);
+				}));
+				_bus.Subscribe(new AdHocHandler<TimerMessage.Schedule>(
+					msg => {
+						_timerMessages.Add(msg.ReplyMessage as IODispatcherDelayedMessage);
+						if (_timerMessages.Count == 2) _timerMessagesReceived.TrySetResult(true);
+					}));
+			}
+
+			[Test]
+			public async Task should_not_hang() {
+				_messageParker.BeginLoadStats(() => {
+					Assert.AreEqual(1, _messageParker.ParkedMessageCount);
+					_done.TrySetResult(true);
+				});
+
+				await _readForwardReceived.Task.WithTimeout();
+				await _timerMessagesReceived.Task.WithTimeout();
+
+				_ioDispatcher.Handle(_timerMessages.FirstOrDefault(x => x.MessageCorrelationId == _readForwardCorrelationId));
+
+				await _done.Task.WithTimeout();
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -1770,6 +1770,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 		public List<ResolvedEvent> ParkedEvents = new List<ResolvedEvent>();
 		private readonly Action _deleteAction;
 		private long _lastParkedEventNumber = -1;
+		private long _lastTruncateBefore = -1;
 		public int BeginReadEndSequenceCount { get; private set; } = 0;
 
 		public FakeMessageParker() {
@@ -1806,6 +1807,18 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 		public void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed) {
 			_deleteAction?.Invoke();
+		}
+
+		public long ParkedMessageCount {
+			get {
+				return _lastParkedEventNumber == -1 ? 0 :
+					_lastTruncateBefore == -1 ? _lastParkedEventNumber + 1 :
+					_lastParkedEventNumber - _lastTruncateBefore + 1;
+			}
+		}
+
+		public void BeginLoadStats(Action completed) {
+			completed();
 		}
 	}
 

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -123,6 +123,7 @@ namespace EventStore.Core.Messages {
 			public int OutstandingMessagesCount { get; set; }
 			public string NamedConsumerStrategy { get; set; }
 			public int MaxSubscriberCount { get; set; }
+			public long ParkedMessageCount { get; set; }
 		}
 
 		public class ConnectionInfo {

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionMessageParker.cs
@@ -8,5 +8,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		void BeginReadEndSequence(Action<long?> completed);
 		void BeginMarkParkedMessagesReprocessed(long sequence);
 		void BeginDelete(Action<IPersistentSubscriptionMessageParker> completed);
+		long ParkedMessageCount { get; }
+		public void BeginLoadStats(Action completed);
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -112,7 +112,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					Log.Debug("Subscription {subscriptionId}: read checkpoint {checkpoint}", _settings.SubscriptionId,
 						checkpoint.Value);
 					_streamBufferSource.SetResult(new StreamBuffer(_settings.BufferSize, _settings.LiveBufferSize, -1, true));
-					TryReadingNewBatch();
+					_settings.MessageParker.BeginLoadStats(TryReadingNewBatch);
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -71,6 +71,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				});
 			}
 
+			long parkedMessageCount = _settings.MessageParker.ParkedMessageCount;
+
 			return new MonitoringMessage.SubscriptionInfo() {
 				EventStreamId = _parent.EventStreamId,
 				GroupName = _parent.GroupName,
@@ -98,7 +100,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				TotalInFlightMessages = totalInflight,
 				OutstandingMessagesCount = _parent.OutstandingMessageCount,
 				NamedConsumerStrategy = _settings.ConsumerStrategy.Name,
-				MaxSubscriberCount = _settings.MaxSubscriberCount
+				MaxSubscriberCount = _settings.MaxSubscriberCount,
+				ParkedMessageCount = parkedMessageCount
 			};
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -893,9 +893,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 						ResolveLinktos = stat.ResolveLinktos,
 						StartFrom = stat.StartFrom,
 						ExtraStatistics = stat.ExtraStatistics,
-						MaxSubscriberCount = stat.MaxSubscriberCount
+						MaxSubscriberCount = stat.MaxSubscriberCount,
 					},
-					Connections = new List<ConnectionInfo>()
+					Connections = new List<ConnectionInfo>(),
+					ParkedMessageCount = stat.ParkedMessageCount
 				};
 				if (stat.Connections != null) {
 					foreach (var connection in stat.Connections) {
@@ -1020,6 +1021,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			public int TotalInFlightMessages { get; set; }
 			public int OutstandingMessagesCount { get; set; }
 			public List<ConnectionInfo> Connections { get; set; }
+			public long ParkedMessageCount { get; set; }
 		}
 
 		public class ConnectionInfo {


### PR DESCRIPTION
Added: Parked message count is now available on persistent subscription stats

Fixes: https://github.com/EventStore/EventStore/issues/2787
The first and last event in the parked message stream is read after loading the persistent subscription checkpoint. This adds 2 to 3 reads per subscription at startup.

The count is updated every time a message is parked, or when the parked messages are replayed.

The `parkedMessageCount` is available on the `{server}/subscriptions/test-stream/test-group/info` endpoint for the HTTP API, and on the result of `Describe` on the `PersistentSubscriptionsManager` in the TCP client API.
