### PR TITLE
Check retries on messages when connection is lost

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -1468,6 +1468,10 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			// Message 2 should be retried on client 1 as it wasn't acked.
 			Assert.AreEqual(2, client1Envelope.Replies.Count);
 			Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+			// Retry count should have increased
+			Assert.AreEqual(1,
+				((ClientMessage.PersistentSubscriptionStreamEventAppeared)client1Envelope.Replies.Last()).RetryCount);
 		}
 
 		[Test]
@@ -1507,6 +1511,10 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			// Message 2 should be retried on client 1 as it wasn't acked.
 			Assert.AreEqual(2, client1Envelope.Replies.Count);
 			Assert.AreEqual(1, client2Envelope.Replies.Count);
+
+			// Retry count should have increased
+			Assert.AreEqual(1,
+				((ClientMessage.PersistentSubscriptionStreamEventAppeared)client1Envelope.Replies.Last()).RetryCount);
 		}
 	}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionClientCollection.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			return _consumerStrategy.PushMessageToClient(ev, retryCount);
 		}
 
-		public IEnumerable<ResolvedEvent> RemoveClientByConnectionId(Guid connectionId) {
+		public IEnumerable<OutstandingMessage> RemoveClientByConnectionId(Guid connectionId) {
 			var clients = _hash.Values.Where(x => x.ConnectionId == connectionId).ToList();
 			return clients.SelectMany(client => RemoveClientByCorrelationId(client.CorrelationId, false));
 		}
@@ -39,9 +39,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			}
 		}
 
-		public IEnumerable<ResolvedEvent> RemoveClientByCorrelationId(Guid correlationId, bool sendDropNotification) {
+		public IEnumerable<OutstandingMessage> RemoveClientByCorrelationId(Guid correlationId, bool sendDropNotification) {
 			PersistentSubscriptionClient client;
-			if (!_hash.TryGetValue(correlationId, out client)) return new ResolvedEvent[0];
+			if (!_hash.TryGetValue(correlationId, out client)) return new OutstandingMessage[0];
 			_hash.Remove(client.CorrelationId);
 			_consumerStrategy.ClientRemoved(client);
 			if (sendDropNotification) {


### PR DESCRIPTION
Fixed: Track retry count for persistent subscription messages after a client has lost connection.

Fixes: https://github.com/EventStore/EventStore/issues/2748

- Track the number of times a message has been retried by a client
- Get the retry count from disconnected clients when getting the events
- Check the retry counts and possibly park messages when retrying messages after a client is disconnected