### PR TITLE
Auto compatibility mode

### DIFF
--- a/src/EventStore.ClientAPI.Tests/endpoint_discoverer.cs
+++ b/src/EventStore.ClientAPI.Tests/endpoint_discoverer.cs
@@ -36,8 +36,8 @@ namespace EventStore.ClientAPI.Tests {
 
 			var sut = new ClusterDnsEndPointDiscoverer(new ConsoleLogger(), "dns", 1, 1111,
 				new[] {new GossipSeed(new IPEndPoint(IPAddress.Any, 2113))}, TimeSpan.FromSeconds(1),
-				nodePreference, false,
-				false,
+				nodePreference,
+				new NoCompatibilityMode(),
 				new TestMessageHandler(response.ToJson()));
 
 			var result = await sut.DiscoverAsync(new IPEndPoint(IPAddress.Any, 1113));

--- a/src/EventStore.ClientAPI/CompatibilityMode.cs
+++ b/src/EventStore.ClientAPI/CompatibilityMode.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace EventStore.ClientAPI {
+	/// <summary>
+	/// Compatibility mode factory.
+	/// </summary>
+	public static class CompatibilityMode {
+		/// <summary>
+		/// Creates a compatibility mode handler. If the string parameter is null or empty, the client will not run any
+		/// compatibility mode.
+		/// </summary>
+		public static ICompatibilityMode Create(string compatibilityModeStr) {
+			if (String.IsNullOrEmpty(compatibilityModeStr)) {
+				return new NoCompatibilityMode();
+			}
+
+			return new StringCompatibilityMode(compatibilityModeStr);
+		}
+	}
+}

--- a/src/EventStore.ClientAPI/ConnectionSettings.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettings.cs
@@ -131,12 +131,6 @@ namespace EventStore.ClientAPI {
 		public readonly int MaxDiscoverAttempts;
 
 		/// <summary>
-		/// If true, use non-TLS for discover:// URIs
-		/// Useful for backwards compatibility with v5 clusters
-		/// </summary>
-		public bool LegacyGossipDiscovery;
-
-		/// <summary>
 		/// The well-known endpoint on which cluster nodes are running.
 		/// </summary>
 		public readonly int GossipPort;
@@ -162,9 +156,9 @@ namespace EventStore.ClientAPI {
 		public readonly TimeSpan ClientConnectionTimeout;
 
 		/// <summary>
-		/// If true, switch the client into EventStoreDB Version 5 compatibility mode.
+		/// Switch the client into a specific EventStoreDB version compatibility mode.
 		/// </summary>
-		public readonly bool EnableVersion5Compability;
+		public readonly string CompatibilityMode;
 
 		internal ConnectionSettings(ILogger log,
 			bool verboseLogging,
@@ -187,11 +181,10 @@ namespace EventStore.ClientAPI {
 			string clusterDns,
 			GossipSeed[] gossipSeeds,
 			int maxDiscoverAttempts,
-			bool legacyGossipDiscovery,
 			int gossipPort,
 			TimeSpan gossipTimeout,
 			NodePreference nodePreference,
-			bool enableVersion5Compability,
+			string compatibilityMode,
 			HttpMessageHandler customHttpMessageHandler) {
 
 			Ensure.NotNull(log, "log");
@@ -233,11 +226,10 @@ namespace EventStore.ClientAPI {
 			ClusterDns = clusterDns;
 			GossipSeeds = gossipSeeds;
 			MaxDiscoverAttempts = maxDiscoverAttempts;
-			LegacyGossipDiscovery = legacyGossipDiscovery;
 			GossipPort = gossipPort;
 			GossipTimeout = gossipTimeout;
 			NodePreference = nodePreference;
-			EnableVersion5Compability = enableVersion5Compability;
+			CompatibilityMode = compatibilityMode;
 			CustomHttpMessageHandler = customHttpMessageHandler;
 		}
 	}

--- a/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
+++ b/src/EventStore.ClientAPI/ConnectionSettingsBuilder.cs
@@ -41,7 +41,7 @@ namespace EventStore.ClientAPI {
 		private TimeSpan _gossipTimeout = TimeSpan.FromSeconds(1);
 		private GossipSeed[] _gossipSeeds;
 		private NodePreference _nodePreference = NodePreference.Leader;
-		private bool _enableVersion5Compability;
+		private string _compatibilityMode = "";
 		private HttpMessageHandler _customHttpMessageHandler;
 
 		internal ConnectionSettingsBuilder() {
@@ -453,11 +453,11 @@ namespace EventStore.ClientAPI {
 		}
 
 		/// <summary>
-		/// Specifies if the client should run in Version 5 compability mode.
+		/// Specifies if the client should run in a specific version compatibility mode.
 		/// </summary>
 		/// <returns>A <see cref="ConnectionSettingsBuilder"/> for further configuration.</returns>
-		public ConnectionSettingsBuilder SetVersion5Compability(bool value) {
-			_enableVersion5Compability = value;
+		public ConnectionSettingsBuilder SetCompatibilityMode(string value) {
+			_compatibilityMode = value;
 			return this;
 		}
 
@@ -497,11 +497,10 @@ namespace EventStore.ClientAPI {
 				_clusterDns,
 				_gossipSeeds,
 				_maxDiscoverAttempts,
-				_legacyGossipDiscovery,
 				_httpPort,
 				_gossipTimeout,
 				_nodePreference,
-				_enableVersion5Compability,
+				_compatibilityMode,
 				_customHttpMessageHandler);
 		}
 	}

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -101,9 +101,8 @@ namespace EventStore.ClientAPI {
 						connectionSettings.HeartbeatInterval, connectionSettings.HeartbeatTimeout,
 						connectionSettings.ClientConnectionTimeout, connectionSettings.ClusterDns,
 						connectionSettings.GossipSeeds, connectionSettings.MaxDiscoverAttempts,
-						connectionSettings.LegacyGossipDiscovery,
 						connectionSettings.GossipPort, connectionSettings.GossipTimeout,
-						connectionSettings.NodePreference, connectionSettings.EnableVersion5Compability, connectionSettings.CustomHttpMessageHandler);
+						connectionSettings.NodePreference, connectionSettings.CompatibilityMode, connectionSettings.CustomHttpMessageHandler);
 				}
 
 				if (scheme == "discover") {
@@ -200,8 +199,7 @@ namespace EventStore.ClientAPI {
 				clusterSettings.GossipSeeds,
 				clusterSettings.GossipTimeout,
 				clusterSettings.NodePreference,
-				connectionSettings.LegacyGossipDiscovery,
-				connectionSettings.EnableVersion5Compability,
+				CompatibilityMode.Create(connectionSettings.CompatibilityMode),
 				connectionSettings.CustomHttpMessageHandler);
 
 			return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,

--- a/src/EventStore.ClientAPI/GossipSeed.cs
+++ b/src/EventStore.ClientAPI/GossipSeed.cs
@@ -21,13 +21,20 @@ namespace EventStore.ClientAPI {
 		public readonly bool SeedOverTls;
 
 		/// <summary>
+		/// If Gossip should be requested with no "Host" header to be compatible with v5 clusters.
+		/// </summary>
+		public readonly bool V5HostHeader;
+
+		/// <summary>
 		/// Creates a new <see cref="GossipSeed" />.
 		/// </summary>
 		/// <param name="endPoint">The <see cref="EndPoint"/> for the HTTP endpoint of the gossip seed. The standard port is 2113.</param>
 		/// <param name="seedOverTls">Specifies that eventstore should use https when connecting to gossip</param>
-		public GossipSeed(EndPoint endPoint, bool seedOverTls = true) {
+		/// <param name="v5HostHeader">Specifies that eventstore should request gossip with no "Host" header to be compatible with v5 clusters.</param>
+		public GossipSeed(EndPoint endPoint, bool seedOverTls = true, bool v5HostHeader = false) {
 			EndPoint = endPoint;
 			SeedOverTls = seedOverTls;
+			V5HostHeader = v5HostHeader;
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/ICompatibilityMode.cs
+++ b/src/EventStore.ClientAPI/ICompatibilityMode.cs
@@ -1,0 +1,11 @@
+namespace EventStore.ClientAPI {
+	/// <summary>
+	/// Compatibility mode abstraction.
+	/// </summary>
+	public interface ICompatibilityMode {
+		/// <summary>
+		/// Is EventStoreDB Version 5 compatibility mode enabled.
+		/// </summary>
+		public bool IsVersion5CompatibilityModeEnabled();
+	}
+}

--- a/src/EventStore.ClientAPI/ICompatibilityMode.cs
+++ b/src/EventStore.ClientAPI/ICompatibilityMode.cs
@@ -7,5 +7,6 @@ namespace EventStore.ClientAPI {
 		/// Is EventStoreDB Version 5 compatibility mode enabled.
 		/// </summary>
 		public bool IsVersion5CompatibilityModeEnabled();
+		public bool IsAutoCompatibilityModeEnabled();
 	}
 }

--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -23,7 +23,7 @@ namespace EventStore.ClientAPI.Internal {
 		private readonly TimeSpan _gossipTimeout;
 
 		private readonly NodePreference _nodePreference;
-		private readonly bool _legacyGossipDiscovery;
+		private readonly ICompatibilityMode _compatibilityMode;
 
 		public ClusterDnsEndPointDiscoverer(ILogger log,
 			string clusterDns,
@@ -32,8 +32,7 @@ namespace EventStore.ClientAPI.Internal {
 			GossipSeed[] gossipSeeds,
 			TimeSpan gossipTimeout,
 			NodePreference nodePreference,
-			bool legacyGossipDiscovery,
-			bool enableVersion5Compability,
+			ICompatibilityMode compatibilityMode,
 			HttpMessageHandler httpMessageHandler = null) {
 			Ensure.NotNull(log, "log");
 
@@ -44,9 +43,9 @@ namespace EventStore.ClientAPI.Internal {
 			_maxDiscoverAttempts = maxDiscoverAttempts;
 			_gossipSeeds = gossipSeeds;
 			_gossipTimeout = gossipTimeout;
-			_client = new HttpAsyncClient(_gossipTimeout, httpMessageHandler, enableVersion5Compability);
+			_compatibilityMode = compatibilityMode;
+			_client = new HttpAsyncClient(_gossipTimeout, httpMessageHandler, _compatibilityMode);
 			_nodePreference = nodePreference;
-			_legacyGossipDiscovery = legacyGossipDiscovery;
 		}
 
 		public Task<NodeEndPoints> DiscoverAsync(EndPoint failedTcpEndPoint) {
@@ -103,7 +102,7 @@ namespace EventStore.ClientAPI.Internal {
 			//_log.Debug("ClusterDnsEndPointDiscoverer: GetGossipCandidatesFromDns");
 			var endpoints = _gossipSeeds != null && _gossipSeeds.Length > 0
 				? _gossipSeeds
-				: new[] {new GossipSeed(_clusterDns, !_legacyGossipDiscovery)};
+				: new[] {new GossipSeed(_clusterDns, !_compatibilityMode.IsVersion5CompatibilityModeEnabled())};
 
 			RandomShuffle(endpoints, 0, endpoints.Length - 1);
 			return endpoints;

--- a/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
+++ b/src/EventStore.ClientAPI/Internal/ClusterDnsEndPointDiscoverer.cs
@@ -19,7 +19,7 @@ namespace EventStore.ClientAPI.Internal {
 		private readonly GossipSeed[] _gossipSeeds;
 
 		private readonly IHttpClient _client;
-		private ClusterMessages.MemberInfoDto[] _oldGossip;
+		private Tuple<ClusterMessages.MemberInfoDto[], GossipSeed> _oldGossip;
 		private readonly TimeSpan _gossipTimeout;
 
 		private readonly NodePreference _nodePreference;
@@ -44,7 +44,7 @@ namespace EventStore.ClientAPI.Internal {
 			_gossipSeeds = gossipSeeds;
 			_gossipTimeout = gossipTimeout;
 			_compatibilityMode = compatibilityMode;
-			_client = new HttpAsyncClient(_gossipTimeout, httpMessageHandler, _compatibilityMode);
+			_client = new HttpAsyncClient(_gossipTimeout, httpMessageHandler);
 			_nodePreference = nodePreference;
 		}
 
@@ -81,8 +81,8 @@ namespace EventStore.ClientAPI.Internal {
 		private NodeEndPoints? DiscoverEndPoint(EndPoint failedEndPoint) {
 			var oldGossip = Interlocked.Exchange(ref _oldGossip, null);
 			var gossipCandidates = oldGossip != null
-				? GetGossipCandidatesFromOldGossip(oldGossip, failedEndPoint)
-				: GetGossipCandidatesFromDns();
+				? GetGossipCandidatesFromOldGossip(oldGossip.Item1, oldGossip.Item2, failedEndPoint)
+				: GetGossipCandidatesFromConfig();
 			for (int i = 0; i < gossipCandidates.Length; ++i) {
 				var gossip = TryGetGossipFrom(gossipCandidates[i]);
 				if (gossip == null || gossip.Members == null || gossip.Members.Length == 0)
@@ -90,7 +90,7 @@ namespace EventStore.ClientAPI.Internal {
 
 				var bestNode = TryDetermineBestNode(gossip.Members, _nodePreference);
 				if (bestNode != null) {
-					_oldGossip = gossip.Members;
+					_oldGossip = Tuple.Create(gossip.Members, gossipCandidates[i]);
 					return bestNode;
 				}
 			}
@@ -98,37 +98,57 @@ namespace EventStore.ClientAPI.Internal {
 			return null;
 		}
 
-		private GossipSeed[] GetGossipCandidatesFromDns() {
+		private GossipSeed[] GetGossipCandidatesFromConfig() {
 			//_log.Debug("ClusterDnsEndPointDiscoverer: GetGossipCandidatesFromDns");
-			var endpoints = _gossipSeeds != null && _gossipSeeds.Length > 0
-				? _gossipSeeds
-				: new[] {new GossipSeed(_clusterDns, !_compatibilityMode.IsVersion5CompatibilityModeEnabled())};
+			var endpoints = _gossipSeeds;
 
-			RandomShuffle(endpoints, 0, endpoints.Length - 1);
+			if ((endpoints?.Length ?? 0) == 0) {
+				if (_compatibilityMode.IsAutoCompatibilityModeEnabled()) {
+					endpoints = new[] {
+						new GossipSeed(_clusterDns, seedOverTls: true, v5HostHeader: false), // Try HTTPS gossip first (v20 defaults)
+						new GossipSeed(_clusterDns, seedOverTls: false, v5HostHeader: true) // Then HTTP gossip (v5 defaults)
+					};
+				} else if (_compatibilityMode.IsVersion5CompatibilityModeEnabled()) {
+					// if v5 compatibility mode is enabled, then use v5 defaults
+					endpoints = new[] {
+						new GossipSeed(_clusterDns, seedOverTls: false, v5HostHeader: true)
+					};
+				} else {
+					// Use only v20 defaults 
+					endpoints = new[] {
+						new GossipSeed(_clusterDns, seedOverTls: true, v5HostHeader: false)
+					};
+				}
+			} else {
+				RandomShuffle(endpoints, 0, endpoints.Length - 1);
+			}
+
 			return endpoints;
 		}
 
 		private GossipSeed[] GetGossipCandidatesFromOldGossip(IEnumerable<ClusterMessages.MemberInfoDto> oldGossip,
+			GossipSeed discoveredFrom,
 			EndPoint failedTcpEndPoint) {
 			var gossipCandidates = failedTcpEndPoint == null
 				? oldGossip.ToArray()
 				: oldGossip.Where(x => !(x.ExternalTcpPort == failedTcpEndPoint.GetPort()
-				                         && x.ExternalTcpIp.Equals(failedTcpEndPoint.GetHost())))
+										 && x.ExternalTcpIp.Equals(failedTcpEndPoint.GetHost())))
 					.ToArray();
-			return ArrangeGossipCandidates(gossipCandidates);
+			return ArrangeGossipCandidates(gossipCandidates, discoveredFrom);
 		}
 
-		private GossipSeed[] ArrangeGossipCandidates(ClusterMessages.MemberInfoDto[] members) {
+		private GossipSeed[] ArrangeGossipCandidates(ClusterMessages.MemberInfoDto[] members, GossipSeed discoveredFrom) {
+			// We assume that if the members are discovered via a non-TLS endpoint, the members will also be non-TLS.  Same for v5 header stuff.
 			var result = new GossipSeed[members.Length];
 			int i = -1;
 			int j = members.Length;
 			for (int k = 0; k < members.Length; ++k) {
 				if (members[k].State == ClusterMessages.VNodeState.Manager)
 					result[--j] = new GossipSeed(new DnsEndPoint(members[k].HttpAddress,
-						members[k].HttpPort));
+						members[k].HttpPort), discoveredFrom.SeedOverTls, discoveredFrom.V5HostHeader);
 				else
 					result[++i] = new GossipSeed(new DnsEndPoint(members[k].HttpAddress,
-						members[k].HttpPort));
+						members[k].HttpPort), discoveredFrom.SeedOverTls, discoveredFrom.V5HostHeader);
 			}
 
 			RandomShuffle(result, 0, i); // shuffle nodes
@@ -162,30 +182,36 @@ namespace EventStore.ClientAPI.Internal {
 				url,
 				null,
 				response => {
-					if (response.HttpStatusCode != HttpStatusCode.OK) {
-						_log.Info("[{0}] responded with {1} ({2})", endPoint, response.HttpStatusCode,
-							response.StatusDescription);
-						completed.Set();
-						return;
-					}
-
 					try {
-						result = response.Body.ParseJson<ClusterMessages.ClusterInfoDto>();
-						//_log.Debug("ClusterDnsEndPointDiscoverer: Got gossip from [{0}]:\n{1}.", endPoint, string.Join("\n", result.Members.Select(x => x.ToString())));
-					} catch (Exception e) {
-						if (e is AggregateException ae)
-							e = ae.Flatten();
-						_log.Error("Failed to get cluster info from [{0}]: deserialization error: {1}.", endPoint, e);
-					}
+						if (response.HttpStatusCode != HttpStatusCode.OK) {
+							_log.Info("[{0}] responded with {1} ({2})", endPoint, response.HttpStatusCode,
+								response.StatusDescription);
+							return;
+						}
 
-					completed.Set();
+						try {
+							result = response.Body.ParseJson<ClusterMessages.ClusterInfoDto>();
+							//_log.Debug("ClusterDnsEndPointDiscoverer: Got gossip from [{0}]:\n{1}.", endPoint, string.Join("\n", result.Members.Select(x => x.ToString())));
+						} catch (Exception e) {
+							if (e is AggregateException ae)
+								e = ae.Flatten();
+							_log.Error("Failed to get cluster info from [{0}]: deserialization error: {1}.", endPoint, e);
+						}
+					} finally {
+						completed.Set();
+					}
 				},
 				e => {
-					if (e is AggregateException ae)
-						e = ae.Flatten();
-					_log.Error("Failed to get cluster info from [{0}]: request failed, error: {1}.", endPoint, e);
-					completed.Set();
-				}, endPoint.EndPoint.GetHost());
+					try {
+						if (e is AggregateException ae)
+							e = ae.Flatten();
+						_log.Error("Failed to get cluster info from [{0}]: request failed, error: {1}.", endPoint, e);
+					} finally {
+						completed.Set();
+					}
+				},
+				// https://github.com/EventStore/EventStore/pull/2744#pullrequestreview-562358658
+				endPoint.V5HostHeader ? "" : endPoint.EndPoint.GetHost());
 
 			completed.Wait();
 			return result;
@@ -228,7 +254,7 @@ namespace EventStore.ClientAPI.Internal {
 						.ToArray(); // OrderBy is a stable sort and only affects order of matching entries
 					RandomShuffle(nodes, 0,
 						nodes.Count(nodeEntry => nodeEntry.State == ClusterMessages.VNodeState.Follower ||
-						                         nodeEntry.State == ClusterMessages.VNodeState.Slave) - 1);
+												 nodeEntry.State == ClusterMessages.VNodeState.Slave) - 1);
 					break;
 				case NodePreference.ReadOnlyReplica:
 					nodes = nodes.OrderBy(nodeEntry => !IsReadOnlyReplicaState(nodeEntry.State))
@@ -256,7 +282,7 @@ namespace EventStore.ClientAPI.Internal {
 
 		private bool IsReadOnlyReplicaState(ClusterMessages.VNodeState state) {
 			return state == ClusterMessages.VNodeState.ReadOnlyLeaderless
-			       || state == ClusterMessages.VNodeState.ReadOnlyReplica;
+				   || state == ClusterMessages.VNodeState.ReadOnlyReplica;
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/NoCompatibilityMode.cs
+++ b/src/EventStore.ClientAPI/NoCompatibilityMode.cs
@@ -1,0 +1,13 @@
+namespace EventStore.ClientAPI {
+	/// <summary>
+	/// Disables all compatibility mode.
+	/// </summary>
+	public class NoCompatibilityMode: ICompatibilityMode {
+		/// <summary>
+		/// Is EventStoreDB Version 5 compatibility mode enabled.
+		/// </summary>
+		public bool IsVersion5CompatibilityModeEnabled() {
+			return false;
+		}
+	}
+}

--- a/src/EventStore.ClientAPI/NoCompatibilityMode.cs
+++ b/src/EventStore.ClientAPI/NoCompatibilityMode.cs
@@ -2,7 +2,11 @@ namespace EventStore.ClientAPI {
 	/// <summary>
 	/// Disables all compatibility mode.
 	/// </summary>
-	public class NoCompatibilityMode: ICompatibilityMode {
+	public class NoCompatibilityMode : ICompatibilityMode {
+		public bool IsAutoCompatibilityModeEnabled() {
+			return false;
+		}
+
 		/// <summary>
 		/// Is EventStoreDB Version 5 compatibility mode enabled.
 		/// </summary>

--- a/src/EventStore.ClientAPI/StringCompatibilityMode.cs
+++ b/src/EventStore.ClientAPI/StringCompatibilityMode.cs
@@ -6,28 +6,33 @@ namespace EventStore.ClientAPI {
 	/// Parses a version string following that format X[.Y[.Z]]
 	/// </summary>
 	public class StringCompatibilityMode : ICompatibilityMode {
-	private readonly int _majorNum;
+		private readonly int? _majorNum;
+		private readonly bool _auto;
 
-	/// <summary>
-	/// Constructs a <see cref="StringCompatibilityMode"/>.
-	/// </summary>
-	/// <param name="compatibilityModeStr"></param>
-	public StringCompatibilityMode(string compatibilityModeStr) {
-		Ensure.NotNullOrEmpty(compatibilityModeStr, "compatibilityModeStr");
-		var splits = compatibilityModeStr.Split('.');
+		/// <summary>
+		/// Constructs a <see cref="StringCompatibilityMode"/>.
+		/// </summary>
+		/// <param name="compatibilityModeStr"></param>
+		public StringCompatibilityMode(string compatibilityModeStr) {
+			Ensure.NotNullOrEmpty(compatibilityModeStr, "compatibilityModeStr");
+			var splits = compatibilityModeStr.Split('.');
 
-		if (!int.TryParse(splits[0], out var majNum)) {
-			throw new ArgumentException($"Invalid compability version string {compatibilityModeStr}");
+			if (int.TryParse(splits[0], out var majNum)) {
+				_majorNum = majNum;
+			} else if (compatibilityModeStr.Trim().ToLowerInvariant() == "auto") {
+				_auto = true;
+			}
 		}
 
-		_majorNum = majNum;
-	}
+		public bool IsAutoCompatibilityModeEnabled() {
+			return _auto;
+		}
 
-	/// <summary>
-	/// Is EventStoreDB Version 5 compatibility mode enabled.
-	/// </summary>
-	public bool IsVersion5CompatibilityModeEnabled() {
-		return _majorNum == 5;
-	}
+		/// <summary>
+		/// Is EventStoreDB Version 5 compatibility mode enabled.
+		/// </summary>
+		public bool IsVersion5CompatibilityModeEnabled() {
+			return _majorNum == 5;
+		}
 	}
 }

--- a/src/EventStore.ClientAPI/StringCompatibilityMode.cs
+++ b/src/EventStore.ClientAPI/StringCompatibilityMode.cs
@@ -1,0 +1,33 @@
+using System;
+using EventStore.ClientAPI.Common.Utils;
+
+namespace EventStore.ClientAPI {
+	/// <summary>
+	/// Parses a version string following that format X[.Y[.Z]]
+	/// </summary>
+	public class StringCompatibilityMode : ICompatibilityMode {
+	private readonly int _majorNum;
+
+	/// <summary>
+	/// Constructs a <see cref="StringCompatibilityMode"/>.
+	/// </summary>
+	/// <param name="compatibilityModeStr"></param>
+	public StringCompatibilityMode(string compatibilityModeStr) {
+		Ensure.NotNullOrEmpty(compatibilityModeStr, "compatibilityModeStr");
+		var splits = compatibilityModeStr.Split('.');
+
+		if (!int.TryParse(splits[0], out var majNum)) {
+			throw new ArgumentException($"Invalid compability version string {compatibilityModeStr}");
+		}
+
+		_majorNum = majNum;
+	}
+
+	/// <summary>
+	/// Is EventStoreDB Version 5 compatibility mode enabled.
+	/// </summary>
+	public bool IsVersion5CompatibilityModeEnabled() {
+		return _majorNum == 5;
+	}
+	}
+}

--- a/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
@@ -15,7 +15,7 @@ namespace EventStore.ClientAPI.Transport.Http {
 	public class HttpAsyncClient : IHttpClient {
 		private static readonly UTF8Encoding UTF8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 		private HttpClient _client;
-		private readonly bool _enableVersion5Compability;
+		private readonly ICompatibilityMode _compatibilityMode;
 
 		static HttpAsyncClient() {
 			ServicePointManager.MaxServicePointIdleTime = 10000;
@@ -27,11 +27,11 @@ namespace EventStore.ClientAPI.Transport.Http {
 		/// </summary>
 		/// <param name="timeout"></param>
 		/// <param name="clientHandler"></param>
-		/// <param name="enableVersion5Compability"></param>
-		public HttpAsyncClient(TimeSpan timeout, HttpMessageHandler clientHandler = null, bool enableVersion5Compability = false) {
+		/// <param name="compatibilityMode"></param>
+		public HttpAsyncClient(TimeSpan timeout, HttpMessageHandler clientHandler = null, ICompatibilityMode compatibilityMode = null) {
 			_client = clientHandler == null ? new HttpClient() : new HttpClient(clientHandler);
 			_client.Timeout = timeout;
-			_enableVersion5Compability = enableVersion5Compability;
+			_compatibilityMode = compatibilityMode ?? new NoCompatibilityMode();
 		}
 
 		/// <inheritdoc />
@@ -88,7 +88,7 @@ namespace EventStore.ClientAPI.Transport.Http {
 			if (userCredentials != null)
 				AddAuthenticationHeader(request, userCredentials);
 			
-			if (_enableVersion5Compability)
+			if (_compatibilityMode.IsVersion5CompatibilityModeEnabled())
 				hostHeader = "";
 
 			if (!string.IsNullOrWhiteSpace(hostHeader))

--- a/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
+++ b/src/EventStore.ClientAPI/Transport.Http/HttpAsyncClient.cs
@@ -15,7 +15,6 @@ namespace EventStore.ClientAPI.Transport.Http {
 	public class HttpAsyncClient : IHttpClient {
 		private static readonly UTF8Encoding UTF8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 		private HttpClient _client;
-		private readonly ICompatibilityMode _compatibilityMode;
 
 		static HttpAsyncClient() {
 			ServicePointManager.MaxServicePointIdleTime = 10000;
@@ -28,10 +27,9 @@ namespace EventStore.ClientAPI.Transport.Http {
 		/// <param name="timeout"></param>
 		/// <param name="clientHandler"></param>
 		/// <param name="compatibilityMode"></param>
-		public HttpAsyncClient(TimeSpan timeout, HttpMessageHandler clientHandler = null, ICompatibilityMode compatibilityMode = null) {
+		public HttpAsyncClient(TimeSpan timeout, HttpMessageHandler clientHandler = null) {
 			_client = clientHandler == null ? new HttpClient() : new HttpClient(clientHandler);
 			_client.Timeout = timeout;
-			_compatibilityMode = compatibilityMode ?? new NoCompatibilityMode();
 		}
 
 		/// <inheritdoc />
@@ -88,9 +86,6 @@ namespace EventStore.ClientAPI.Transport.Http {
 			if (userCredentials != null)
 				AddAuthenticationHeader(request, userCredentials);
 			
-			if (_compatibilityMode.IsVersion5CompatibilityModeEnabled())
-				hostHeader = "";
-
 			if (!string.IsNullOrWhiteSpace(hostHeader))
 				request.Headers.Host = hostHeader;
 


### PR DESCRIPTION
This PR is based on the `compatibility-mode` branch that is currently inflight to solve https://github.com/EventStore/EventStore/issues/2801

I aimed for fairly minimal changes here and have tested:

`ConnectTo=discover://localhost:2111;CompatibilityMode=Auto` 

Successfully against a V5 non-TLS and V20 TLS cluster with *no connection string changes*.  

**How it works**

If auto compatibility mode is enabled, it will default to two gossip seeds (first one for v20 TLS, second one for v5 non-TLS).  It will perform a gossip request for those seeds in that order (we want to prioritise v20 clusters here).  This means no pre-flight check is necessary to discover the version of the cluster.

Note: I also fixed a bug here whereby v5 clusters would never get a successful discover during an initial reconnect (e.g. if a disconnect happened, on the reconnect, it tries to use `_oldGossip` which would have defaulted to `seedOverTls = true` which would never work).  Thankfully this never really showed itself given the next attempt would work as it goes back to the configured discover process (e.g. same logic as initial connect discovery)