### PR TITLE
Filter out invalid json events from projections

### DIFF
--- a/src/EventStore.Common/Utils/Json.cs
+++ b/src/EventStore.Common/Utils/Json.cs
@@ -70,9 +70,9 @@ namespace EventStore.Common.Utils {
 			});
 		}
 
-		public static bool IsValidJson(this byte[] value) {
+		public static bool IsValidJson(this string value) {
 			try {
-				JToken.Parse(Helper.UTF8NoBom.GetString(value));
+				JToken.Parse(value);
 			} catch {
 				return false;
 			}

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -100,7 +100,7 @@ namespace EventStore.Core.Tests.Helpers {
 					_fakePosition, Guid.NewGuid(), Guid.NewGuid(), _fakePosition, 0, streamId, list.Count - 1,
 					_timeProvider.UtcNow,
 					PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd | (isJson ? PrepareFlags.IsJson : 0),
-					eventType, Helper.UTF8NoBom.GetBytes(eventData),
+					eventType, eventData is null ? null : Helper.UTF8NoBom.GetBytes(eventData),
 					eventMetadata == null ? new byte[0] : Helper.UTF8NoBom.GetBytes(eventMetadata)));
 			list.Add(eventRecord);
 			var eventPosition = new TFPos(_fakePosition + 50, _fakePosition);

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/TestFixtureWithCoreProjection.cs
@@ -79,13 +79,13 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 		protected ProjectionProcessingStrategy CreateProjectionProcessingStrategy() {
 			return new ContinuousProjectionProcessingStrategy(
 				_projectionName, _version, _stateHandler, _projectionConfig, _stateHandler.GetSourceDefinition(), null,
-				_subscriptionDispatcher);
+				_subscriptionDispatcher, true);
 		}
 
 		protected ProjectionProcessingStrategy CreateQueryProcessingStrategy() {
 			return new QueryProcessingStrategy(
 				_projectionName, _version, _stateHandler, _projectionConfig, _stateHandler.GetSourceDefinition(), null,
-				_subscriptionDispatcher);
+				_subscriptionDispatcher, true);
 		}
 
 		protected virtual ProjectionConfig GivenProjectionConfig() {

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_creating_a_projection.cs
@@ -45,7 +45,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					projectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),
@@ -71,7 +72,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					projectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),
@@ -95,7 +97,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					_defaultProjectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),
@@ -119,7 +122,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					_defaultProjectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),
@@ -143,7 +147,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					_defaultProjectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),
@@ -167,7 +172,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					_defaultProjectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					null,
 					Guid.NewGuid(),
@@ -190,7 +196,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 				_defaultProjectionConfig,
 				projectionStateHandler.GetSourceDefinition(),
 				null,
-				_subscriptionDispatcher).Create(
+				_subscriptionDispatcher,
+				true).Create(
 				Guid.NewGuid(),
 				new FakePublisher(),
 				Guid.NewGuid(),
@@ -213,7 +220,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					_defaultProjectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),
@@ -237,7 +245,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					_defaultProjectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),
@@ -263,7 +272,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					projectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),
@@ -287,7 +297,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 					_defaultProjectionConfig,
 					projectionStateHandler.GetSourceDefinition(),
 					null,
-					_subscriptionDispatcher).Create(
+					_subscriptionDispatcher,
+					true).Create(
 					Guid.NewGuid(),
 					new FakePublisher(),
 					Guid.NewGuid(),

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -58,7 +58,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 			var version = new ProjectionVersion(1, 0, 0);
 			var projectionProcessingStrategy = new ContinuousProjectionProcessingStrategy(
 				"projection", version, projectionStateHandler, _projectionConfig,
-				projectionStateHandler.GetSourceDefinition(), null, _subscriptionDispatcher);
+				projectionStateHandler.GetSourceDefinition(), null, _subscriptionDispatcher, true);
 			_coreProjection = projectionProcessingStrategy.Create(
 				Guid.NewGuid(),
 				_bus,

--- a/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_service/when_a_subscribed_projection_handler_throws.cs
@@ -16,7 +16,7 @@ namespace EventStore.Projections.Core.Tests.Services.core_service {
 			_readerService.Handle(
 				new ReaderSubscriptionManagement.Subscribe(
 					projectionCorrelationId, CheckpointTag.FromPosition(0, 0, 0), readerStrategy,
-					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
+					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null, true)));
 			_readerService.Handle(
 				ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
 					readerStrategy.EventReaderId, new TFPos(20, 10), "throws", 10, false, Guid.NewGuid(),

--- a/src/EventStore.Projections.Core.Tests/Services/core_service/when_unsubscribing_a_subscribed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_service/when_unsubscribing_a_subscribed_projection.cs
@@ -21,11 +21,11 @@ namespace EventStore.Projections.Core.Tests.Services.core_service {
 			_readerService.Handle(
 				new ReaderSubscriptionManagement.Subscribe(
 					_projectionCorrelationId, CheckpointTag.FromPosition(0, 0, 0), CreateReaderStrategy(),
-					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
+					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null, enableContentTypeValidation: true)));
 			_readerService.Handle(
 				new ReaderSubscriptionManagement.Subscribe(
 					_projectionCorrelationId2, CheckpointTag.FromPosition(0, 0, 0), CreateReaderStrategy(),
-					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null)));
+					new ReaderSubscriptionOptions(1000, 2000, 10000, false, stopAfterNEvents: null, enableContentTypeValidation: true)));
 			// when
 			_readerService.Handle(new ReaderSubscriptionManagement.Unsubscribe(_projectionCorrelationId));
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_including_links.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_including_links.cs
@@ -49,7 +49,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.all_streams_wi
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: true,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null,
+					enableContentTypeValidation: true);
 			}
 
 			protected override IEnumerable<WhenStep> When() {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_not_including_links.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/all_streams_with_links_event_reader/when_not_including_links.cs
@@ -49,7 +49,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.all_streams_wi
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: true,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null,
+					enableContentTypeValidation: true);
 			}
 
 			protected override IEnumerable<WhenStep> When() {

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/index_checkpoint.cs
@@ -48,7 +48,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: false,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null,
+					enableContentTypeValidation: true);
 			}
 
 			protected abstract void GivenInitialIndexState();

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_one_event_type_has_been_never_emitted.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_one_event_type_has_been_never_emitted.cs
@@ -54,7 +54,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: false,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null,
+					enableContentTypeValidation: true);
 			}
 
 			protected abstract void GivenInitialIndexState();

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_reordering_happens_in_event_by_type_index.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/event_by_type_index_reader/catching_up/when_reordering_happens_in_event_by_type_index.cs
@@ -50,7 +50,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.event_by_type_
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: false,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null,
+					enableContentTypeValidation: true);
 			}
 
 			protected abstract void GivenInitialIndexState();

--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/reordering.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/multi_stream_reader/reordering.cs
@@ -23,8 +23,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 			protected override void Given() {
 				base.Given();
 				AllWritesSucceed();
-				ExistingEvent("stream-a", "type1", "{}", "{Data: 1}");
-				ExistingEvent("stream-b", "type1", "{}", "{Data: 2}");
+				ExistingEvent("stream-a", "type1", "{}", "{\"Data\": 1}");
+				ExistingEvent("stream-b", "type1", "{}", "{\"Data\": 2}");
 
 				GivenOtherEvents();
 
@@ -45,7 +45,8 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.multi_stream_r
 				_readerSubscriptionOptions = new ReaderSubscriptionOptions(
 					checkpointUnhandledBytesThreshold: 10000, checkpointProcessedEventsThreshold: 100,
 					checkpointAfterMs: 10000, stopOnEof: false,
-					stopAfterNEvents: null);
+					stopAfterNEvents: null,
+					enableContentTypeValidation: false);
 			}
 
 			protected abstract void GivenOtherEvents();

--- a/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/TestFixtureWithEventReorderingProjectionSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/TestFixtureWithEventReorderingProjectionSubscription.cs
@@ -32,7 +32,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 				_readerStrategy,
 				_timeProvider,
 				_checkpointUnhandledBytesThreshold, _checkpointProcessedEventsThreshold, _checkpointAfterMs,
-				_processingLagMs);
+				_processingLagMs,
+				false,
+				null,
+				false);
 		}
 	}
 }

--- a/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/when_creating_projection_subscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reordering_projection_subscription/when_creating_projection_subscription.cs
@@ -19,7 +19,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 				1000,
 				2000,
 				10000,
-				500);
+				500,
+				false,
+				null,
+				false);
 		}
 
 		[Test]
@@ -34,7 +37,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 					1000,
 					2000,
 					10000,
-					500);
+					500,
+					false,
+					null,
+					false);
 			});
 		}
 
@@ -50,7 +56,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 					1000,
 					2000,
 					10000,
-					500);
+					500,
+					false,
+					null,
+					false);
 			});
 		}
 
@@ -66,7 +75,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reordering_projection
 					1000,
 					2000,
 					10000,
-					500);
+					500,
+					false,
+					null,
+					false);
 			});
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projection_core_service/when_stopping_the_projection_core_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_core_service/when_stopping_the_projection_core_service.cs
@@ -40,7 +40,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
 				_projectionId, _workerId, "test-projection", 
 				new ProjectionVersion(), ProjectionConfig.GetTest(),
-				"JS", "fromStream('$user-admin').outputState()"));
+				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 		}
 
@@ -75,7 +75,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
 				_projectionId, _workerId, "test-projection", 
 				new ProjectionVersion(), ProjectionConfig.GetTest(),
-				"JS", "fromStream('$user-admin').outputState()"));
+				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCoreTimeout(_stopCorrelationId));
 		}
@@ -103,7 +103,7 @@ namespace EventStore.Projections.Core.Tests.Services.projection_core_service {
 			_service.Handle(new CoreProjectionManagementMessage.CreateAndPrepare(
 				_projectionId, _workerId, "test-projection", 
 				new ProjectionVersion(), ProjectionConfig.GetTest(),
-				"JS", "fromStream('$user-admin').outputState()"));
+				"JS", "fromStream('$user-admin').outputState()", true));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCore(_stopCorrelationId));
 			_service.Handle(new ProjectionCoreServiceMessage.StopCoreTimeout(Guid.NewGuid()));
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/TestFixtureWithProjectionSubscription.cs
@@ -68,7 +68,10 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 				_timeProvider,
 				_checkpointUnhandledBytesThreshold,
 				_checkpointProcessedEventsThreshold,
-				_checkpointAfterMs);
+				_checkpointAfterMs,
+				false,
+				null,
+				false);
 		}
 
 		protected virtual void Given() {

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_creating_projection_subscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_creating_projection_subscription.cs
@@ -19,7 +19,10 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 				new FakeTimeProvider(),
 				1000,
 				2000,
-				10000);
+				10000,
+				false,
+				null,
+				false);
 		}
 
 		[Test]
@@ -34,7 +37,10 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					new FakeTimeProvider(),
 					1000,
 					2000,
-					10000);
+					10000,
+					false,
+					null,
+					false);
 			});
 		}
 
@@ -50,7 +56,10 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					new FakeTimeProvider(),
 					1000,
 					2000,
-					10000);
+					10000,
+					false,
+					null,
+					false);
 			});
 		}
 
@@ -66,7 +75,10 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 					null,
 					1000,
 					2000,
-					10000);
+					10000,
+					false,
+					null,
+					false);
 			});
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_content_type_validation.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_content_type_validation.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Text;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
+	public class when_handling_events_with_content_type_validation {
+		[TestFixture]
+		public class given_json_events_and_content_type_validation_enabled : TestFixtureWithProjectionSubscription {
+			protected override void When() {
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(100, 100), "test-stream", 0, false, Guid.NewGuid(),
+						"null-json", true, null, null));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+						"invalid-json", true, Encoding.UTF8.GetBytes("{foo:bar}"), new byte[0]));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(300, 300), "test-stream", 2, false, Guid.NewGuid(),
+						"valid-json", true, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+			}
+
+			protected override IReaderSubscription CreateProjectionSubscription() {
+				return new ReaderSubscription(
+					"Test Subscription",
+					_bus,
+					_projectionCorrelationId,
+					_readerStrategy.PositionTagger.MakeZeroCheckpointTag(),
+					_readerStrategy,
+					_timeProvider,
+					_checkpointUnhandledBytesThreshold,
+					_checkpointProcessedEventsThreshold,
+					_checkpointAfterMs,
+					false,
+					null,
+					true);
+			}
+
+			[Test]
+			public void only_the_valid_json_is_handled() {
+				Assert.AreEqual(1, _eventHandler.HandledMessages.Count);
+				Assert.AreEqual("valid-json", _eventHandler.HandledMessages[0].Data.EventType);
+			}
+		}
+
+		[TestFixture]
+		public class given_non_json_events_and_content_type_validation_enabled : TestFixtureWithProjectionSubscription {
+			protected override void When() {
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(100, 100), "test-stream", 0, false, Guid.NewGuid(),
+						"null-event", false, null, null));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+						"plain-text", false, Encoding.UTF8.GetBytes("foo bar"), new byte[0]));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(300, 300), "test-stream", 2, false, Guid.NewGuid(),
+						"valid-json", false, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+			}
+
+			protected override IReaderSubscription CreateProjectionSubscription() {
+				return new ReaderSubscription(
+					"Test Subscription",
+					_bus,
+					_projectionCorrelationId,
+					_readerStrategy.PositionTagger.MakeZeroCheckpointTag(),
+					_readerStrategy,
+					_timeProvider,
+					_checkpointUnhandledBytesThreshold,
+					_checkpointProcessedEventsThreshold,
+					_checkpointAfterMs,
+					false,
+					null,
+					true);
+			}
+
+			[Test]
+			public void all_events_are_handled() {
+				Assert.AreEqual(3, _eventHandler.HandledMessages.Count);
+			}
+		}
+
+		[TestFixture]
+		public class given_json_and_non_json_events_and_content_type_validation_disabled : TestFixtureWithProjectionSubscription {
+			protected override void When() {
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(100, 100), "test-stream", 0, false, Guid.NewGuid(),
+						"null-json", true, null, null));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(200, 200), "test-stream", 1, false, Guid.NewGuid(),
+						"invalid-json", true, Encoding.UTF8.GetBytes("{foo:bar}"), new byte[0]));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(300, 300), "test-stream", 2, false, Guid.NewGuid(),
+						"valid-json", true, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(400, 400), "test-stream", 3, false, Guid.NewGuid(),
+						"null-event", false, null, null));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(500, 500), "test-stream", 4, false, Guid.NewGuid(),
+						"plain-text", false, Encoding.UTF8.GetBytes("foo bar"), new byte[0]));
+				_subscription.Handle(
+					ReaderSubscriptionMessage.CommittedEventDistributed.Sample(
+						Guid.NewGuid(), new TFPos(600, 600), "test-stream", 5, false, Guid.NewGuid(),
+						"valid-json", false, Encoding.UTF8.GetBytes("{\"foo\":\"bar\"}"), new byte[0]));
+			}
+
+			protected override IReaderSubscription CreateProjectionSubscription() {
+				return new ReaderSubscription(
+					"Test Subscription",
+					_bus,
+					_projectionCorrelationId,
+					_readerStrategy.PositionTagger.MakeZeroCheckpointTag(),
+					_readerStrategy,
+					_timeProvider,
+					_checkpointUnhandledBytesThreshold,
+					_checkpointProcessedEventsThreshold,
+					_checkpointAfterMs,
+					false,
+					null,
+					false);
+			}
+
+			[Test]
+			public void all_events_are_handled() {
+				Assert.AreEqual(6, _eventHandler.HandledMessages.Count);
+			}
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithJsProjection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithJsProjection.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 	public abstract class TestFixtureWithJsProjection {
-		private ProjectionStateHandlerFactory _stateHandlerFactory;
+		protected ProjectionStateHandlerFactory _stateHandlerFactory;
 		protected IProjectionStateHandler _stateHandler;
 		protected List<string> _logged;
 		protected string _projection;
@@ -22,13 +22,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			Given();
 			_logged = new List<string>();
 			_stateHandlerFactory = new ProjectionStateHandlerFactory();
-			_stateHandler = _stateHandlerFactory.Create(
-				"JS", _projection, logger: (s, _) => {
-					if (s.StartsWith("P:"))
-						Console.WriteLine(s);
-					else
-						_logged.Add(s);
-				}); // skip prelude debug output
+			_stateHandler = CreateStateHandler();
 			_source = _stateHandler.GetSourceDefinition();
 
 			if (_state != null)
@@ -39,6 +33,16 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			if (_sharedState != null)
 				_stateHandler.LoadShared(_sharedState);
 			When();
+		}
+
+		protected virtual IProjectionStateHandler CreateStateHandler() {
+			return _stateHandlerFactory.Create(
+				"JS", _projection, true, logger: (s, _) => {
+					if (s.StartsWith("P:"))
+						Console.WriteLine(s);
+					else
+						_logged.Add(s);
+				}); // skip prelude debug output
 		}
 
 		protected virtual void When() {

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_existing_projection_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/managed_projection/when_loading_existing_projection_state.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using EventStore.Common.Utils;
+using EventStore.Core.Bus;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Services.TimeService;
+using EventStore.Core.Util;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Management;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.core_projection;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.projections_manager.managed_projection {
+	[TestFixture]
+	public class when_loading_existing_projection_state_with_no_projection_subsystem_version : TestFixtureWithExistingEvents {
+		private new ITimeProvider _timeProvider;
+		private string _projectionName = Guid.NewGuid().ToString();
+
+		private ManagedProjection _mp;
+
+		protected override void Given() {
+			var persistedState = new ManagedProjection.PersistedState {
+					Enabled = true,
+					HandlerType = "JS",
+					Query = @"log(1);", 
+					Mode = ProjectionMode.Continuous,
+					EmitEnabled = true,
+					CheckpointsDisabled = true,
+					Epoch = -1,
+					Version = -1,
+					RunAs = SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous)
+			};
+			ExistingEvent(ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName,
+				ProjectionEventTypes.ProjectionUpdated, "", persistedState.ToJson());
+
+			_timeProvider = new FakeTimeProvider();
+			_mp = new ManagedProjection(
+				Guid.NewGuid(),
+				Guid.NewGuid(),
+				1,
+				"name",
+				true,
+				null,
+				_streamDispatcher,
+				_writeDispatcher,
+				_readDispatcher,
+				_bus,
+				_timeProvider, new RequestResponseDispatcher
+					<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
+						_bus,
+						v => v.CorrelationId,
+						v => v.CorrelationId,
+						new PublishEnvelope(_bus)), new RequestResponseDispatcher
+					<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
+						_bus,
+						v => v.CorrelationId,
+						v => v.CorrelationId,
+						new PublishEnvelope(_bus)),
+				_ioDispatcher,
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+		}
+
+		[Test]
+		public void content_type_validation_is_disabled() {
+			_mp.InitializeExisting(_projectionName);
+			Assert.False(_mp.EnableContentTypeValidation);
+		}
+	}
+
+	[TestFixture]
+	public class when_loading_existing_projection_state_with_projection_subsystem_version : TestFixtureWithExistingEvents {
+		private new ITimeProvider _timeProvider;
+		private string _projectionName = Guid.NewGuid().ToString();
+
+		private ManagedProjection _mp;
+
+		protected override void Given() {
+			var persistedState = new ManagedProjection.PersistedState {
+				Enabled = true,
+				HandlerType = "JS",
+				Query = @"log(1);", 
+				Mode = ProjectionMode.Continuous,
+				EmitEnabled = true,
+				CheckpointsDisabled = true,
+				Epoch = -1,
+				Version = -1,
+				RunAs = SerializedRunAs.SerializePrincipal(ProjectionManagementMessage.RunAs.Anonymous),
+				ProjectionSubsystemVersion = 4
+			};
+			ExistingEvent(ProjectionNamesBuilder.ProjectionsStreamPrefix + _projectionName,
+				ProjectionEventTypes.ProjectionUpdated, "", persistedState.ToJson());
+
+			_timeProvider = new FakeTimeProvider();
+			_mp = new ManagedProjection(
+				Guid.NewGuid(),
+				Guid.NewGuid(),
+				1,
+				"name",
+				true,
+				null,
+				_streamDispatcher,
+				_writeDispatcher,
+				_readDispatcher,
+				_bus,
+				_timeProvider, new RequestResponseDispatcher
+					<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>(
+						_bus,
+						v => v.CorrelationId,
+						v => v.CorrelationId,
+						new PublishEnvelope(_bus)), new RequestResponseDispatcher
+					<CoreProjectionManagementMessage.GetResult, CoreProjectionStatusMessage.ResultReport>(
+						_bus,
+						v => v.CorrelationId,
+						v => v.CorrelationId,
+						new PublishEnvelope(_bus)),
+				_ioDispatcher,
+				TimeSpan.FromMinutes(Opts.ProjectionsQueryExpiryDefault));
+		}
+
+		[Test]
+		public void content_type_validation_is_enabled() {
+			_mp.InitializeExisting(_projectionName);
+			Assert.True(_mp.EnableContentTypeValidation);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/v8/when_compiling_v8_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/v8/when_compiling_v8_projection.cs
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.v8 {
 				_logged = new List<string>();
 				_stateHandlerFactory = new ProjectionStateHandlerFactory();
 				_stateHandler = _stateHandlerFactory.Create(
-					"JS", _projection, logger: (s, _) => {
+					"JS", _projection, true, logger: (s, _) => {
 						if (!s.StartsWith("P:")) _logged.Add(s);
 						else _logDelegate(s);
 					}); // skip prelude debug output

--- a/src/EventStore.Projections.Core.Tests/Services/v8/when_creating_v8_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/v8/when_creating_v8_projection.cs
@@ -30,14 +30,14 @@ namespace EventStore.Projections.Core.Tests.Services.v8 {
 
 		[Test, Category("v8")]
 		public void it_can_be_created() {
-			using (_stateHandlerFactory.Create("JS", @"")) {
+			using (_stateHandlerFactory.Create("JS", @"", true)) {
 			}
 		}
 
 		[Test, Category("v8")]
 		public void it_can_log_messages() {
 			string m = null;
-			using (_stateHandlerFactory.Create("JS", @"log(""Message1"");", logger: (s, _) => m = s)) {
+			using (_stateHandlerFactory.Create("JS", @"log(""Message1"");", true, logger: (s, _) => m = s)) {
 			}
 
 			Assert.AreEqual("Message1", m);
@@ -46,7 +46,7 @@ namespace EventStore.Projections.Core.Tests.Services.v8 {
 		[Test, Category("v8")]
 		public void js_syntax_errors_are_reported() {
 			try {
-				using (_stateHandlerFactory.Create("JS", @"log(1;", logger: (s, _) => { })) {
+				using (_stateHandlerFactory.Create("JS", @"log(1;", true, logger: (s, _) => { })) {
 				}
 			} catch (Exception ex) {
 				Assert.IsInstanceOf<Js1Exception>(ex);
@@ -57,7 +57,7 @@ namespace EventStore.Projections.Core.Tests.Services.v8 {
 		[Test, Category("v8")]
 		public void js_exceptions_errors_are_reported() {
 			try {
-				using (_stateHandlerFactory.Create("JS", @"throw 123;", logger: (s, _) => { })) {
+				using (_stateHandlerFactory.Create("JS", @"throw 123;", true, logger: (s, _) => { })) {
 				}
 			} catch (Exception ex) {
 				Assert.IsInstanceOf<Js1Exception>(ex);
@@ -73,6 +73,7 @@ namespace EventStore.Projections.Core.Tests.Services.v8 {
                                 var i = 0;
                                 while (true) i++;
                     ",
+					true,
 					logger: (s, _) => { },
 					cancelCallbackFactory: (timeout, action) => ThreadPool.QueueUserWorkItem(state => {
 						Console.WriteLine("Calling a callback in " + timeout + "ms");
@@ -100,6 +101,7 @@ namespace EventStore.Projections.Core.Tests.Services.v8 {
                             }
                         });
                     ",
+					true,
 					logger: Console.WriteLine,
 					cancelCallbackFactory: (timeout, action) => ThreadPool.QueueUserWorkItem(state => {
 						Console.WriteLine("Calling a callback in " + timeout + "ms");
@@ -137,6 +139,7 @@ namespace EventStore.Projections.Core.Tests.Services.v8 {
                                 while (true) i++;
                         });
                     ",
+					true,
 					logger: Console.WriteLine,
 					cancelCallbackFactory: (timeout, action) => ThreadPool.QueueUserWorkItem(state => {
 						Console.WriteLine("Calling a callback in " + timeout + "ms");
@@ -173,7 +176,7 @@ namespace EventStore.Projections.Core.Tests.Services.v8 {
                             while (true) i++;
                         }
                     });
-                ", logger: Console.WriteLine,
+                ", true, logger: Console.WriteLine,
 						cancelCallbackFactory: (timeout, action) => ThreadPool.QueueUserWorkItem(
 							state => {
 								Console.WriteLine("Calling a callback in " + timeout + "ms");

--- a/src/EventStore.Projections.Core.Tests/Services/v8/when_running_with_content_type_validation.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/v8/when_running_with_content_type_validation.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Services.Processing;
+using EventStore.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.v8 {
+	public class when_running_with_content_type_validation {
+		[TestFixture]
+		public class when_running_with_content_type_validation_enabled : TestFixtureWithJsProjection {
+			protected override void Given() {
+				_projection = @"
+                fromAll().when({$any: 
+                    function(state, event) {
+                    linkTo('output-stream' + event.sequenceNumber, event);
+                    return {};
+                }});
+            ";
+			}
+
+			protected override IProjectionStateHandler CreateStateHandler() {
+				return _stateHandlerFactory.Create(
+					"JS", _projection, 
+					enableContentTypeValidation: true, logger: (s, _) => {
+						if (s.StartsWith("P:"))
+							Console.WriteLine(s);
+						else
+							_logged.Add(s);
+					}); // skip prelude debug output
+			}
+
+			[Test, Category("v8")]
+			public void process_null_json_event_does_not_emit() {
+				string state = null;
+				EmittedEventEnvelope[] emittedEvents = null;
+
+				var result = _stateHandler.ProcessEvent(
+					"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
+					"metadata",
+					null, out state, out emittedEvents, isJson: true);
+
+				Assert.IsNull(emittedEvents);
+			}
+
+			[Test, Category("v8")]
+			public void process_null_non_json_event_does_emit() {
+				string state = null;
+				EmittedEventEnvelope[] emittedEvents = null;
+
+				var result = _stateHandler.ProcessEvent(
+					"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
+					"metadata",
+					null, out state, out emittedEvents, isJson: false);
+
+				Assert.IsNotNull(emittedEvents);
+				Assert.AreEqual(1, emittedEvents.Length);
+			}
+		}
+
+		[TestFixture]
+		public class when_running_with_content_type_validation_disabled : TestFixtureWithJsProjection {
+			protected override void Given() {
+				_projection = @"
+                fromAll().when({$any: 
+                    function(state, event) {
+                    linkTo('output-stream' + event.sequenceNumber, event);
+                    return {};
+                }});
+            ";
+			}
+
+			protected override IProjectionStateHandler CreateStateHandler() {
+				return _stateHandlerFactory.Create(
+					"JS", _projection, 
+					enableContentTypeValidation: false, logger: (s, _) => {
+						if (s.StartsWith("P:"))
+							Console.WriteLine(s);
+						else
+							_logged.Add(s);
+					}); // skip prelude debug output
+			}
+
+			[Test, Category("v8")]
+			public void process_null_json_event_does_not_emit() {
+				string state = null;
+				EmittedEventEnvelope[] emittedEvents = null;
+
+				var result = _stateHandler.ProcessEvent(
+					"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
+					"metadata",
+					null, out state, out emittedEvents, isJson: true);
+
+				Assert.IsNull(emittedEvents);
+			}
+
+			[Test, Category("v8")]
+			public void process_null_non_json_event_does_not_emit() {
+				string state = null;
+				EmittedEventEnvelope[] emittedEvents = null;
+
+				var result = _stateHandler.ProcessEvent(
+					"", CheckpointTag.FromPosition(0, 20, 10), "stream1", "type1", "category", Guid.NewGuid(), 0,
+					"metadata",
+					null, out state, out emittedEvents, isJson: false);
+
+				Assert.IsNull(emittedEvents);
+			}
+		}
+	}
+}
+

--- a/src/EventStore.Projections.Core/EventReaders/Feeds/FeedReader.cs
+++ b/src/EventStore.Projections.Core/EventReaders/Feeds/FeedReader.cs
@@ -85,7 +85,9 @@ namespace EventStore.Projections.Core.EventReaders.Feeds {
 				checkpointAfterMs: 10000,
 				checkpointProcessedEventsThreshold: null,
 				stopOnEof: true,
-				stopAfterNEvents: _maxEvents);
+				stopAfterNEvents: _maxEvents,
+				// The projection must be stopped for debugging, so will enable content type validation automatically
+				enableContentTypeValidation: true);
 
 			_subscriptionId =
 				_subscriptionDispatcher.PublishSubscribe(

--- a/src/EventStore.Projections.Core/Messages/CoreProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/CoreProjectionManagementMessage.cs
@@ -117,6 +117,7 @@ namespace EventStore.Projections.Core.Messages {
 			private readonly string _query;
 			private readonly string _name;
 			private readonly ProjectionVersion _version;
+			private readonly bool _enableContentTypeValidation;
 
 			public CreateAndPrepare(
 				Guid projectionId,
@@ -125,13 +126,15 @@ namespace EventStore.Projections.Core.Messages {
 				ProjectionVersion version,
 				ProjectionConfig config,
 				string handlerType,
-				string query)
+				string query,
+				bool enableContentTypeValidation)
 				: base(projectionId, workerId) {
 				_name = name;
 				_version = version;
 				_config = config;
 				_handlerType = handlerType;
 				_query = query;
+				_enableContentTypeValidation = enableContentTypeValidation;
 			}
 
 			public ProjectionConfig Config {
@@ -153,6 +156,10 @@ namespace EventStore.Projections.Core.Messages {
 			public string Query {
 				get { return _query; }
 			}
+
+			public bool EnableContentTypeValidation {
+				get { return _enableContentTypeValidation; }
+			}
 		}
 
 		public class CreatePrepared : CoreProjectionManagementControlMessage {
@@ -168,6 +175,7 @@ namespace EventStore.Projections.Core.Messages {
 			private readonly string _query;
 			private readonly string _name;
 			private readonly ProjectionVersion _version;
+			private readonly bool _enableContentTypeValidation;
 
 			public CreatePrepared(
 				Guid projectionId,
@@ -177,7 +185,8 @@ namespace EventStore.Projections.Core.Messages {
 				ProjectionConfig config,
 				QuerySourcesDefinition sourceDefinition,
 				string handlerType,
-				string query)
+				string query,
+				bool enableContentTypeValidation)
 				: base(projectionId, workerId) {
 				if (name == null) throw new ArgumentNullException("name");
 				if (config == null) throw new ArgumentNullException("config");
@@ -190,6 +199,7 @@ namespace EventStore.Projections.Core.Messages {
 				_sourceDefinition = sourceDefinition;
 				_handlerType = handlerType;
 				_query = query;
+				_enableContentTypeValidation = enableContentTypeValidation;
 			}
 
 			public ProjectionConfig Config {
@@ -214,6 +224,10 @@ namespace EventStore.Projections.Core.Messages {
 
 			public string Query {
 				get { return _query; }
+			}
+
+			public bool EnableContentTypeValidation {
+				get { return _enableContentTypeValidation; }
 			}
 		}
 

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -40,7 +40,8 @@ namespace EventStore.Projections.Core {
 		private readonly bool _startStandardProjections;
 		private readonly TimeSpan _projectionsQueryExpiry;
 		private readonly ILogger _logger = Serilog.Log.ForContext<ProjectionsSubsystem>();
-		public const int VERSION = 3;
+		public const int VERSION = 4;
+		public const int CONTENT_TYPE_VALIDATION_VERSION = 4;
 
 		private IQueuedHandler _leaderInputQueue;
 		private readonly InMemoryBus _leaderMainBus;

--- a/src/EventStore.Projections.Core/Services/IProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/IProjectionStateHandler.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Services {
 		/// </summary>
 		/// <returns>true - if event was processed (new state must be returned) </returns>
 		bool ProcessEvent(
-			string partition, CheckpointTag eventPosition, string category, ResolvedEvent data, out string newState,
+			string partition, CheckpointTag eventPosition, string category, ResolvedEvent @event, out string newState,
 			out string newSharedState, out EmittedEventEnvelope[] emittedEvents);
 
 		/// <summary>
@@ -35,11 +35,11 @@ namespace EventStore.Projections.Core.Services {
 		/// </summary>
 		/// <param name="partition"></param>
 		/// <param name="createPosition"></param>
-		/// <param name="data"></param>
+		/// <param name="event"></param>
 		/// <param name="emittedEvents"></param>
 		/// <returns>true - if notification was processed (new state must be returned)</returns>
 		bool ProcessPartitionCreated(
-			string partition, CheckpointTag createPosition, ResolvedEvent data,
+			string partition, CheckpointTag createPosition, ResolvedEvent @event,
 			out EmittedEventEnvelope[] emittedEvents);
 
 		/// <summary>

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -1171,7 +1171,8 @@ namespace EventStore.Projections.Core.Services.Management {
 						MaxAllowedWritesInFlight = ProjectionConsts.MaxAllowedWritesInFlight,
 						Epoch = -1,
 						Version = version,
-						RunAs = _enableRunAs ? SerializedRunAs.SerializePrincipal(_runAs) : null
+						RunAs = _enableRunAs ? SerializedRunAs.SerializePrincipal(_runAs) : null,
+						ProjectionSubsystemVersion = ProjectionsSubsystem.VERSION
 					},
 					_replyEnvelope);
 			}

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionStateHandlerFactory.cs
@@ -5,7 +5,9 @@ using System.Linq;
 namespace EventStore.Projections.Core.Services.Management {
 	public class ProjectionStateHandlerFactory {
 		public IProjectionStateHandler Create(
-			string factoryType, string source, Action<int, Action> cancelCallbackFactory = null,
+			string factoryType, string source,
+			bool enableContentTypeValidation,
+			Action<int, Action> cancelCallbackFactory = null,
 			Action<string, object[]> logger = null) {
 			var colonPos = factoryType.IndexOf(':');
 			string kind = null;
@@ -20,7 +22,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			IProjectionStateHandler result;
 			switch (kind.ToLowerInvariant()) {
 				case "js":
-					result = new DefaultV8ProjectionStateHandler(source, logger, cancelCallbackFactory);
+					result = new DefaultV8ProjectionStateHandler(source, logger, cancelCallbackFactory, enableContentTypeValidation);
 					break;
 				case "native":
 					var type = Type.GetType(rest);

--- a/src/EventStore.Projections.Core/Services/Processing/ContinuousProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ContinuousProjectionProcessingStrategy.cs
@@ -9,10 +9,10 @@ namespace EventStore.Projections.Core.Services.Processing {
 		public ContinuousProjectionProcessingStrategy(
 			string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 			ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-			ReaderSubscriptionDispatcher subscriptionDispatcher)
+			ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
 			: base(
 				name, projectionVersion, stateHandler, projectionConfig, sourceDefinition, logger,
-				subscriptionDispatcher) {
+				subscriptionDispatcher, enableContentTypeValidation) {
 		}
 
 		public override bool GetStopOnEof() {

--- a/src/EventStore.Projections.Core/Services/Processing/DefaultProjectionProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/DefaultProjectionProcessingStrategy.cs
@@ -11,15 +11,17 @@ namespace EventStore.Projections.Core.Services.Processing {
 		protected readonly IQuerySources _sourceDefinition;
 		private readonly ReaderSubscriptionDispatcher _subscriptionDispatcher;
 		private readonly bool _isBiState;
+		protected readonly bool _enableContentTypeValidation;
 
 		protected EventReaderBasedProjectionProcessingStrategy(
 			string name, ProjectionVersion projectionVersion, ProjectionConfig projectionConfig,
-			IQuerySources sourceDefinition, Serilog.ILogger logger, ReaderSubscriptionDispatcher subscriptionDispatcher)
+			IQuerySources sourceDefinition, Serilog.ILogger logger, ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
 			: base(name, projectionVersion, logger) {
 			_projectionConfig = projectionConfig;
 			_sourceDefinition = sourceDefinition;
 			_subscriptionDispatcher = subscriptionDispatcher;
 			_isBiState = sourceDefinition.IsBiState;
+			_enableContentTypeValidation = enableContentTypeValidation;
 		}
 
 		public override sealed IProjectionProcessingPhase[] CreateProcessingPhases(
@@ -167,8 +169,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 		protected DefaultProjectionProcessingStrategy(
 			string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 			ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-			ReaderSubscriptionDispatcher subscriptionDispatcher)
-			: base(name, projectionVersion, projectionConfig, sourceDefinition, logger, subscriptionDispatcher) {
+			ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
+			: base(name, projectionVersion, projectionConfig, sourceDefinition, logger, subscriptionDispatcher, enableContentTypeValidation) {
 			_stateHandler = stateHandler;
 		}
 
@@ -210,7 +212,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 				this.GetStopOnEof(),
 				_sourceDefinition.IsBiState,
 				orderedPartitionProcessing: orderedPartitionProcessing,
-				emittedStreamsTracker: emittedStreamsTracker);
+				emittedStreamsTracker: emittedStreamsTracker,
+				enableContentTypeValidation: _enableContentTypeValidation);
 		}
 
 		protected virtual StatePartitionSelector CreateStatePartitionSelector() {

--- a/src/EventStore.Projections.Core/Services/Processing/EventFilter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventFilter.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using EventStore.Common.Utils;
 
 namespace EventStore.Projections.Core.Services.Processing {
 	public abstract class EventFilter {
@@ -25,6 +26,14 @@ namespace EventStore.Projections.Core.Services.Processing {
 			return (PassesSource(resolvedFromLinkTo, eventStreamId, eventName))
 			       && ((_allEvents || _events != null && _events.Contains(eventName))
 			           && (!isStreamDeletedEvent || _includeDeletedStreamEvents));
+		}
+
+		public bool PassesValidation(bool isJson, string data) {
+			if (!isJson) return true;
+			if (data is null) {
+				return false;
+			}
+			return data.IsValidJson();
 		}
 
 		protected abstract bool DeletedNotificationPasses(string positionStreamId);

--- a/src/EventStore.Projections.Core/Services/Processing/EventProcessingProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventProcessingProjectionProcessingPhase.cs
@@ -44,7 +44,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 			bool stopOnEof,
 			bool isBiState,
 			bool orderedPartitionProcessing,
-			IEmittedStreamsTracker emittedStreamsTracker)
+			IEmittedStreamsTracker emittedStreamsTracker,
+			bool enableContentTypeValidation)
 			: base(
 				publisher,
 				inputQueue,
@@ -64,7 +65,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 				stopOnEof,
 				orderedPartitionProcessing,
 				isBiState,
-				emittedStreamsTracker) {
+				emittedStreamsTracker,
+				enableContentTypeValidation) {
 			_projectionStateHandler = projectionStateHandler;
 			_definesStateTransform = definesStateTransform;
 			_statePartitionSelector = statePartitionSelector;

--- a/src/EventStore.Projections.Core/Services/Processing/EventReorderingReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReorderingReaderSubscription.cs
@@ -22,8 +22,9 @@ namespace EventStore.Projections.Core.Services.Processing {
 			int? checkpointProcessedEventsThreshold,
 			int checkpointAfterMs,
 			int processingLagMs,
-			bool stopOnEof = false,
-			int? stopAfterNEvents = null)
+			bool stopOnEof,
+			int? stopAfterNEvents,
+			bool enableContentTypeValidation)
 			: base(
 				publisher,
 				subscriptionId,
@@ -34,7 +35,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 				checkpointProcessedEventsThreshold,
 				checkpointAfterMs,
 				stopOnEof,
-				stopAfterNEvents) {
+				stopAfterNEvents,
+				enableContentTypeValidation) {
 			_processingLagMs = processingLagMs;
 		}
 

--- a/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventSubscriptionBasedProjectionProcessingPhase.cs
@@ -43,6 +43,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		protected readonly bool _stopOnEof;
 		private readonly bool _isBiState;
 		protected readonly IEmittedStreamsTracker _emittedStreamsTracker;
+		protected readonly bool _enableContentTypeValidation;
 
 		private readonly Action _updateStatistics;
 
@@ -65,7 +66,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 			bool stopOnEof,
 			bool orderedPartitionProcessing,
 			bool isBiState,
-			IEmittedStreamsTracker emittedStreamsTracker) {
+			IEmittedStreamsTracker emittedStreamsTracker,
+			bool enableContentTypeValidation) {
 			_publisher = publisher;
 			_inputQueue = inputQueue;
 			_coreProjection = coreProjection;
@@ -90,6 +92,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			_progressResultWriter = new ProgressResultWriter(this, _resultWriter);
 			_inutQueueEnvelope = new PublishEnvelope(_inputQueue);
 			_emittedStreamsTracker = emittedStreamsTracker;
+			_enableContentTypeValidation = enableContentTypeValidation;
 		}
 
 		public void UnlockAndForgetBefore(CheckpointTag checkpointTag) {
@@ -275,7 +278,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			return new ReaderSubscriptionOptions(
 				_projectionConfig.CheckpointUnhandledBytesThreshold, _projectionConfig.CheckpointHandledThreshold,
 				_projectionConfig.CheckpointAfterMs,
-				_stopOnEof, stopAfterNEvents: null);
+				_stopOnEof, stopAfterNEvents: null, _enableContentTypeValidation);
 		}
 
 		protected void SubscribeReaders(CheckpointTag checkpointTag) {

--- a/src/EventStore.Projections.Core/Services/Processing/ProcessingStrategySelector.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProcessingStrategySelector.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			ProjectionNamesBuilder namesBuilder,
 			IQuerySources sourceDefinition,
 			ProjectionConfig projectionConfig,
-			IProjectionStateHandler stateHandler, string handlerType, string query) {
+			IProjectionStateHandler stateHandler, string handlerType, string query, bool enableContentTypeValidation) {
 
 			return projectionConfig.StopOnEof
 				? (ProjectionProcessingStrategy)
@@ -28,7 +28,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					projectionConfig,
 					sourceDefinition,
 					_logger,
-					_subscriptionDispatcher)
+					_subscriptionDispatcher,
+					enableContentTypeValidation)
 				: new ContinuousProjectionProcessingStrategy(
 					name,
 					projectionVersion,
@@ -36,7 +37,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					projectionConfig,
 					sourceDefinition,
 					_logger,
-					_subscriptionDispatcher);
+					_subscriptionDispatcher,
+					enableContentTypeValidation);
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ProjectionCoreService.cs
@@ -148,7 +148,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					_timeoutScheduler,
 					_logger,
 					message.HandlerType,
-					message.Query);
+					message.Query,
+					message.EnableContentTypeValidation);
 
 				string name = message.Name;
 				var sourceDefinition = ProjectionSourceDefinition.From(stateHandler.GetSourceDefinition());
@@ -165,7 +166,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					projectionConfig,
 					stateHandler,
 					message.HandlerType,
-					message.Query);
+					message.Query,
+					message.EnableContentTypeValidation);
 
 				CreateCoreProjection(message.ProjectionId, projectionConfig.RunAs, projectionProcessingStrategy);
 				_publisher.Publish(
@@ -193,7 +195,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					projectionConfig,
 					null,
 					message.HandlerType,
-					message.Query);
+					message.Query,
+					message.EnableContentTypeValidation);
 
 				CreateCoreProjection(message.ProjectionId, projectionConfig.RunAs, projectionProcessingStrategy);
 				_publisher.Publish(
@@ -293,10 +296,12 @@ namespace EventStore.Projections.Core.Services.Processing {
 			ISingletonTimeoutScheduler singletonTimeoutScheduler,
 			ILogger logger,
 			string handlerType,
-			string query) {
+			string query,
+			bool enableContentTypeValidation) {
 			var stateHandler = new ProjectionStateHandlerFactory().Create(
 				handlerType,
 				query,
+				enableContentTypeValidation,
 				logger: logger.Verbose,
 				cancelCallbackFactory:
 				singletonTimeoutScheduler == null ? (Action<int, Action>)null : singletonTimeoutScheduler.Schedule);

--- a/src/EventStore.Projections.Core/Services/Processing/QueryProcessingStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/QueryProcessingStrategy.cs
@@ -10,10 +10,10 @@ namespace EventStore.Projections.Core.Services.Processing {
 		public QueryProcessingStrategy(
 			string name, ProjectionVersion projectionVersion, IProjectionStateHandler stateHandler,
 			ProjectionConfig projectionConfig, IQuerySources sourceDefinition, ILogger logger,
-			ReaderSubscriptionDispatcher subscriptionDispatcher)
+			ReaderSubscriptionDispatcher subscriptionDispatcher, bool enableContentTypeValidation)
 			: base(
 				name, projectionVersion, stateHandler, projectionConfig, sourceDefinition, logger,
-				subscriptionDispatcher) {
+				subscriptionDispatcher, enableContentTypeValidation) {
 		}
 
 		public override bool GetStopOnEof() {

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderStrategy.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderStrategy.cs
@@ -148,7 +148,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					readerSubscriptionOptions.CheckpointAfterMs,
 					_processingLag,
 					readerSubscriptionOptions.StopOnEof,
-					readerSubscriptionOptions.StopAfterNEvents);
+					readerSubscriptionOptions.StopAfterNEvents,
+					readerSubscriptionOptions.EnableContentTypeValidation);
 			else
 				return new ReaderSubscription(
 					_tag,
@@ -161,7 +162,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					readerSubscriptionOptions.CheckpointProcessedEventsThreshold,
 					readerSubscriptionOptions.CheckpointAfterMs,
 					readerSubscriptionOptions.StopOnEof,
-					readerSubscriptionOptions.StopAfterNEvents);
+					readerSubscriptionOptions.StopAfterNEvents,
+					readerSubscriptionOptions.EnableContentTypeValidation);
 		}
 
 		public IEventReader CreatePausedEventReader(

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
@@ -15,8 +15,9 @@ namespace EventStore.Projections.Core.Services.Processing {
 			long? checkpointUnhandledBytesThreshold,
 			int? checkpointProcessedEventsThreshold,
 			int checkpointAfterMs,
-			bool stopOnEof = false,
-			int? stopAfterNEvents = null)
+			bool stopOnEof,
+			int? stopAfterNEvents,
+			bool enableContentTypeValidation)
 			: base(
 				publisher,
 				subscriptionId,
@@ -27,7 +28,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 				checkpointProcessedEventsThreshold,
 				checkpointAfterMs,
 				stopOnEof,
-				stopAfterNEvents) {
+				stopAfterNEvents,
+				enableContentTypeValidation) {
 			_tag = tag;
 		}
 

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionOptions.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionOptions.cs
@@ -5,15 +5,17 @@ namespace EventStore.Projections.Core.Services.Processing {
 		private readonly int _checkpointAfterMs;
 		private readonly bool _stopOnEof;
 		private readonly int? _stopAfterNEvents;
+		private readonly bool _enableContentTypeValidation;
 
 		public ReaderSubscriptionOptions(
 			long checkpointUnhandledBytesThreshold, int? checkpointProcessedEventsThreshold, int checkpointAfterMs,
-			bool stopOnEof, int? stopAfterNEvents) {
+			bool stopOnEof, int? stopAfterNEvents, bool enableContentTypeValidation) {
 			_checkpointUnhandledBytesThreshold = checkpointUnhandledBytesThreshold;
 			_checkpointProcessedEventsThreshold = checkpointProcessedEventsThreshold;
 			_checkpointAfterMs = checkpointAfterMs;
 			_stopOnEof = stopOnEof;
 			_stopAfterNEvents = stopAfterNEvents;
+			_enableContentTypeValidation = enableContentTypeValidation;
 		}
 
 		public long CheckpointUnhandledBytesThreshold {
@@ -34,6 +36,10 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		public int? StopAfterNEvents {
 			get { return _stopAfterNEvents; }
+		}
+
+		public bool EnableContentTypeValidation {
+			get { return _enableContentTypeValidation; }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/v8/DefaultV8ProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/v8/DefaultV8ProjectionStateHandler.cs
@@ -6,8 +6,8 @@ using System.Reflection;
 namespace EventStore.Projections.Core.Services.v8 {
 	public class DefaultV8ProjectionStateHandler : V8ProjectionStateHandler {
 		public DefaultV8ProjectionStateHandler(
-			string query, Action<string, object[]> logger, Action<int, Action> cancelCallbackFactory)
-			: base("1Prelude", query, GetModuleSource, logger, cancelCallbackFactory) {
+			string query, Action<string, object[]> logger, Action<int, Action> cancelCallbackFactory, bool enableContentTypeValidation)
+			: base("1Prelude", query, GetModuleSource, logger, cancelCallbackFactory, enableContentTypeValidation) {
 		}
 
 		public static Tuple<string, string> GetModuleSource(string name) {


### PR DESCRIPTION
Added: Content Type Validation to projections which will allow projections to only handle valid json events if isJson is set to true

Enforce the following rules on events being passed to projections going forwards:
- If `IsJson=true` the event must have non-null valid json data
- If `IsJson`=false the event may have null data
- Metadata may always be null

These rules are applied to projections created/updated in projection subsystem version 4 or greater.
This won't immediately affect all projections and a running projection must first be stopped or reset before it will be affected by these changes.

Additional changes:

- Bump the projection subsystem version to v4.
- Add `ProjectionSubsystemVersion` to persistent state. This allows us to determine if a projection was created on this version of the projection subsystem. If the version is empty, then the above rules are not applied.
- Add Content Type Validation to reader subscription.
- Filter out invalid json events in the event filter.
- Convert null data to empty string for non-json events in the v8 handler.
