### PR TITLE
Changes GossipOnSingleNode to be on by default

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -110,6 +110,10 @@ namespace EventStore.ClusterNode {
 					$"- The '{nameof(Options.DisableExternalTcpTls)}' option has been deprecated as of version 20.6.1.\n";
 			}
 
+			if(!opts.GossipOnSingleNode)
+				deprecationMessages +=
+					$"- The '{nameof(Options.GossipOnSingleNode)}' option has been deprecated as of version 21.2\n";
+
 			if (deprecationMessages.Any()) {
 				Log.Warning($"DEPRECATED\n{deprecationMessages}");
 			}

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -81,7 +81,7 @@ namespace EventStore.Core.Util {
 		public const string GossipOnSingleNodeDescr =
 			"When enabled tells a single node to run gossip as if it is a cluster";
 
-		public const bool GossipOnSingleNodeDefault = false;
+		public const bool GossipOnSingleNodeDefault = true;
 
 		public const string StatsPeriodDescr = "The number of seconds between statistics gathers.";
 		public const int StatsPeriodDefault = 30;

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1530,7 +1530,7 @@ namespace EventStore.Core {
 
 		private IGossipSeedSource GetGossipSource() {
 			IGossipSeedSource gossipSeedSource;
-			if (_discoverViaDns) {
+			if (_discoverViaDns && _clusterNodeCount > 1) {
 				gossipSeedSource = new DnsGossipSeedSource(_clusterDns, _clusterGossipPort);
 			} else {
 				if ((_gossipSeeds == null || _gossipSeeds.Count == 0) && _clusterNodeCount > 1) {


### PR DESCRIPTION
Changed: GossipOnSingleNode is now on by default and the setting has been deprecated in config

Fixes: https://github.com/EventStore/EventStore/issues/2811