### PR TITLE
Add timeout when getting gossip during discovery

### DIFF
--- a/src/EventStore.ClientAPI.Tests/endpoint_discoverer.cs
+++ b/src/EventStore.ClientAPI.Tests/endpoint_discoverer.cs
@@ -6,8 +6,11 @@ using System.Threading.Tasks;
 using EventStore.ClientAPI.Common.Log;
 using EventStore.ClientAPI.Internal;
 using EventStore.ClientAPI.Messages;
+using EventStore.ClientAPI.SystemData;
+using EventStore.ClientAPI.Transport.Http;
 using EventStore.Common.Utils;
 using Xunit;
+using HttpStatusCode = System.Net.HttpStatusCode;
 
 namespace EventStore.ClientAPI.Tests {
 	public class endpoint_discoverer {
@@ -38,26 +41,43 @@ namespace EventStore.ClientAPI.Tests {
 				new[] {new GossipSeed(new IPEndPoint(IPAddress.Any, 2113))}, TimeSpan.FromSeconds(1),
 				nodePreference,
 				new NoCompatibilityMode(),
-				new TestMessageHandler(response.ToJson()));
+				new TestHttpClient(response.ToJson()));
 
 			var result = await sut.DiscoverAsync(new IPEndPoint(IPAddress.Any, 1113));
 			Assert.Equal(1113, EndPointExtensions.GetPort(result.TcpEndPoint));
 		}
 	}
 
-	internal class TestMessageHandler : HttpMessageHandler {
+	internal class TestHttpClient : IHttpClient {
 		private readonly string _response;
-
-		public TestMessageHandler(string response) {
+		public TestHttpClient(string response) {
 			_response = response;
 		}
 
-		protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
-			CancellationToken cancellationToken) {
-			return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+		public void Get(string url, UserCredentials userCredentials, Action<HttpResponse> onSuccess, Action<Exception> onException, string hostHeader = "") {
+			var request = new HttpRequestMessage();
+			request.RequestUri = new Uri(url);
+			request.Method = new System.Net.Http.HttpMethod("GET");
+			onSuccess(new HttpResponse(new HttpResponseMessage(HttpStatusCode.OK) {
 				Content = new StringContent(_response),
 				RequestMessage = request
+			}) {
+				Body = _response
 			});
+		}
+
+		public void Post(string url, string body, string contentType, UserCredentials userCredentials, Action<HttpResponse> onSuccess,
+			Action<Exception> onException) {
+			throw new NotImplementedException();
+		}
+
+		public void Delete(string url, UserCredentials userCredentials, Action<HttpResponse> onSuccess, Action<Exception> onException) {
+			throw new NotImplementedException();
+		}
+
+		public void Put(string url, string body, string contentType, UserCredentials userCredentials, Action<HttpResponse> onSuccess,
+			Action<Exception> onException) {
+			throw new NotImplementedException();
 		}
 	}
 }

--- a/src/EventStore.ClientAPI/EventStoreConnection.cs
+++ b/src/EventStore.ClientAPI/EventStoreConnection.cs
@@ -7,6 +7,7 @@ using System;
 using System.Runtime.ExceptionServices;
 using EventStore.ClientAPI.Messages;
 using EventStore.ClientAPI.SystemData;
+using EventStore.ClientAPI.Transport.Http;
 
 namespace EventStore.ClientAPI {
 	/// <summary>
@@ -192,6 +193,9 @@ namespace EventStore.ClientAPI {
 			Ensure.NotNull(connectionSettings, "connectionSettings");
 			Ensure.NotNull(clusterSettings, "clusterSettings");
 
+			var discoverClient = new HttpAsyncClient(
+				clusterSettings.GossipTimeout,
+				connectionSettings.CustomHttpMessageHandler);
 			var endPointDiscoverer = new ClusterDnsEndPointDiscoverer(connectionSettings.Log,
 				clusterSettings.ClusterDns,
 				clusterSettings.MaxDiscoverAttempts,
@@ -200,8 +204,7 @@ namespace EventStore.ClientAPI {
 				clusterSettings.GossipTimeout,
 				clusterSettings.NodePreference,
 				CompatibilityMode.Create(connectionSettings.CompatibilityMode),
-				connectionSettings.CustomHttpMessageHandler);
-			
+				discoverClient);
 			return new EventStoreNodeConnection(connectionSettings, clusterSettings, endPointDiscoverer,
 				connectionName);
 		}


### PR DESCRIPTION
Fixed: Time out gossip discovery on the TCP client if the task does not complete

Fixes: https://github.com/eventstore/home/issues/360
This prevents the following error during gossip discovery if the task never completes:

```
[06,10:39:47.450,ERROR] Failed to get cluster info from [127.0.0.1:2113]: request failed, error: System.AggregateException: One or more errors occurred. (A task was canceled.) (A task was canceled.) ---> System.Threading.Tasks.T
askCanceledException: A task was canceled.
   --- End of inner exception stack trace ---
---> (Inner Exception #0) System.Threading.Tasks.TaskCanceledException: A task was canceled.<---
```