### PR TITLE
Allow 50 logical TB of log size

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -9,7 +9,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 	public class TFChunkManager : IDisposable {
 		private static readonly ILogger Log = Serilog.Log.ForContext<TFChunkManager>();
 
-		public const int MaxChunksCount = 100000; // that's enough for about 25 Tb of data
+		public const int MaxChunksCount = 200000; 
 
 		public int ChunksCount {
 			get { return _chunksCount; }


### PR DESCRIPTION
Changed: Increased the maximum chunk count to patch issue with 25 logical TB. 

This needs revisiting as part of the log work being done, but this should buy enough time to complete that work and fix this longer term. This will affect memory pressure a little on all instances but also keeps the changes to just this file (naming strategy would be an issue if we just add a 0 to the end.