### PR TITLE
Prevent a checkpoint from being emitted at same position twice

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_different_event_filters.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projection_subscription/when_handling_events_with_different_event_filters.cs
@@ -21,12 +21,8 @@ namespace EventStore.Projections.Core.Tests.Services.projection_subscription {
 	[TestFixture("good-stream", "good-event-type", "good-stream", "bad-event-type", true, false)]
 	[TestFixture("good-stream", "good-event-type", "good-stream", "bad-event-type", false, true)]
 	[TestFixture("good-stream", "good-event-type", "good-stream", "bad-event-type", false, false)]
-	[TestFixture("good-stream", "good-event-type", "bad-stream", "good-event-type", true, true)]
-	[TestFixture("good-stream", "good-event-type", "bad-stream", "good-event-type", true, false)]
 	[TestFixture("good-stream", "good-event-type", "bad-stream", "good-event-type", false, true)]
 	[TestFixture("good-stream", "good-event-type", "bad-stream", "good-event-type", false, false)]
-	[TestFixture("good-stream", "good-event-type", "bad-stream", "bad-event-type", true, true)]
-	[TestFixture("good-stream", "good-event-type", "bad-stream", "bad-event-type", true, false)]
 	[TestFixture("good-stream", "good-event-type", "bad-stream", "bad-event-type", false, true)]
 	[TestFixture("good-stream", "good-event-type", "bad-stream", "bad-event-type", false, false)]
 	public class


### PR DESCRIPTION
Fixed: Prevent a projection checkpoint from being emitted at same position twice

Fix regression introduced due to https://github.com/EventStore/EventStore/pull/2809 and discovered by @timothycoleman 

Co-Authored-By: @hayley-jean 
Fixes: https://github.com/EventStore/home/issues/386