### PR TITLE
 Increase max chunks count until better implementation is available

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -9,7 +9,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 	public class TFChunkManager : IDisposable {
 		private static readonly ILogger Log = Serilog.Log.ForContext<TFChunkManager>();
 
-		public const int MaxChunksCount = 100000; // that's enough for about 25 Tb of data
+		public const int MaxChunksCount = 200000; 
 
 		public int ChunksCount {
 			get { return _chunksCount; }


### PR DESCRIPTION
Changed: Increased the maximum chunk count to patch issue with 25 logical TB.

Backports https://github.com/EventStore/EventStore/pull/2822 to v20.10.2.
Fixes https://github.com/EventStore/home/issues/406