### PR TITLE
Fix regression in TCP connection

### DIFF
--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -151,7 +151,7 @@ namespace EventStore.Transport.Tcp {
 			try {
 				do {
 					lock (_sendLock) {
-						if (_isSending || _sendQueue.IsEmpty || _sendSocketArgs == null) return;
+						if (_isSending || (_sendQueue.IsEmpty && _memoryStreamOffset >= _memoryStream.Length) || _sendSocketArgs == null) return;
 						if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
 						_isSending = true;
 					}

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -11,7 +11,7 @@ using ILogger = Serilog.ILogger;
 
 namespace EventStore.Transport.Tcp {
 	public class TcpConnection : TcpConnectionBase, ITcpConnection {
-		internal const int MaxSendPacketSize = 64 * 1024;
+		internal const int MaxSendPacketSize = 65535 /*Max IP packet size*/ - 20 /*IP packet header size*/ - 32 /*TCP min header size*/;
 
 		internal static readonly BufferManager BufferManager =
 			new BufferManager(TcpConfiguration.BufferChunksCount, TcpConfiguration.SocketBufferSize);

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -345,7 +345,7 @@ namespace EventStore.Transport.Tcp {
 			try {
 				do {
 					lock (_streamLock) {
-						if (_isSending || _sendQueue.IsEmpty || _sslStream == null || !_isAuthenticated) return;
+						if (_isSending || (_sendQueue.IsEmpty && _memoryStreamOffset >= _memoryStream.Length) || _sslStream == null || !_isAuthenticated) return;
 						if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
 						_isSending = true;
 					}


### PR DESCRIPTION
Fixed: Regression in TCP connection introduced by commit: cd2aa67926dd06d48c894888d547d92e0d2b9cc1 from PR: https://github.com/EventStore/EventStore/pull/2772


@arwinneil found a massive slowdown (~20x) in catch up subscription speed with version 21.2.0 (using TCP clients). After investigation, the reason for the regression was due to an early return from `TrySend()` when the queue is empty but there's still data to send in the memory stream

This could also be the cause for the regression seen with v5 / mono in PR #2791 (commit: 7a01a1994c7289df30ad501eded3eb9c638350aa had to be added to improve the transfer speeds)

The PR also prevents packet fragmentation for plaintext TCP in this commit: 315cb2355ad8facd385e1e9fbfbdde7ace015d05 by taking the ip and tcp headers into consideration. (Note: This optimization does not apply to TLS connections since we have no control over the size of the encrypted data and the protocol already breaks the data into chunks of up to 2^14 bytes (16kb))