### PR TITLE
Fix regression in TCP connection [v5 backport]

### DIFF
--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -151,7 +151,7 @@ namespace EventStore.Transport.Tcp {
 			try {
 				do {
 					lock (_sendLock) {
-						if (_isSending || _sendQueue.IsEmpty || _sendSocketArgs == null) return;
+						if (_isSending || (_sendQueue.IsEmpty && _memoryStreamOffset >= _memoryStream.Length) || _sendSocketArgs == null) return;
 						if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
 						_isSending = true;
 					}

--- a/src/EventStore.Transport.Tcp/TcpConnection.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnection.cs
@@ -11,7 +11,7 @@ using System.Collections.Concurrent;
 
 namespace EventStore.Transport.Tcp {
 	public class TcpConnection : TcpConnectionBase, ITcpConnection {
-		internal const int MaxSendPacketSize = 64 * 1024;
+		internal const int MaxSendPacketSize = 65535 /*Max IP packet size*/ - 20 /*IP packet header size*/ - 32 /*TCP min header size*/;
 
 		internal static readonly BufferManager BufferManager =
 			new BufferManager(TcpConfiguration.BufferChunksCount, TcpConfiguration.SocketBufferSize);

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -348,7 +348,7 @@ namespace EventStore.Transport.Tcp {
 			try {
 				do {
 					lock (_streamLock) {
-						if (_isSending || _sendQueue.IsEmpty || _sslStream == null || !_isAuthenticated) return;
+						if (_isSending || (_sendQueue.IsEmpty && _memoryStreamOffset >= _memoryStream.Length) || _sslStream == null || !_isAuthenticated) return;
 						if (TcpConnectionMonitor.Default.IsSendBlocked()) return;
 						_isSending = true;
 					}


### PR DESCRIPTION
Backport of https://github.com/EventStore/EventStore/pull/2834 for version 5

The regression is also present on v5-master. 
The fix was tested with both plaintext TCP and TLS.