### PR TITLE
Add action to trigger client release

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -1,0 +1,20 @@
+name: Initiate Client Release
+ 
+on:
+  push:
+    tags:
+      - "dotnet-client-v*"
+ 
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF:25}
+      - name: Perform Release 
+        run: |
+          curl -X POST https://api.github.com/repos/EventStore/TrainStation/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.GH_PAT }} \
+          --data '{"event_type": "client-release", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "version": "${{ steps.get_version.outputs.version }}" }}'


### PR DESCRIPTION
This action triggers the `client-release` dispatch when the repo is tagged with `dotnet-client-v{version}`