### PR TITLE
Release the mutex on the correct thread

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -25,7 +25,7 @@ using EventStore.Plugins.Authentication;
 using EventStore.Plugins.Authorization;
 
 namespace EventStore.ClusterNode {
-	internal class ClusterVNodeHostedService : EventStoreHostedService<ClusterNodeOptions> {
+	internal class ClusterVNodeHostedService : EventStoreHostedService<ClusterNodeOptions>, IDisposable {
 		private ExclusiveDbLock _dbLock;
 		private ClusterNodeMutex _clusterNodeMutex;
 
@@ -554,13 +554,15 @@ namespace EventStore.ClusterNode {
 		protected override Task StartInternalAsync(CancellationToken cancellationToken) => Node.StartAsync(false);
 
 		protected override Task StopInternalAsync(CancellationToken cancellationToken) {
+			return Node.StopAsync(cancellationToken: cancellationToken);
+		}
+
+		public void Dispose() {
 			if (_dbLock != null && _dbLock.IsAcquired) {
 				using (_dbLock) {
 					_dbLock.Release();
 				}
 			}
-
-			return Node.StopAsync(cancellationToken: cancellationToken);
 		}
 	}
 }


### PR DESCRIPTION
Fixed: Mutex being released on wrong thread resulting in an annoying log message on shutdown

Fixes #2710 

The mutex is acquired on the Main thread. There isn't really a good way of releasing it on the main thread using an async main function, so the async work is moved into a single block and signals when it is done allowing the release to happen on the main thread. The only other option would be to burn a thread inside the mutex class to do the acquire, and then signal that thread to do the release