### PR TITLE
Change minver prefix for tcp clients

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -5,6 +5,7 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
 		<Platforms>x64</Platforms>
+		<MinVerTagPrefix>dotnet-client-v</MinVerTagPrefix>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>EventStore.Client.Embedded</PackageId>

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -5,6 +5,7 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<LangVersion>latest</LangVersion>
 		<Platforms>x64</Platforms>
+		<MinVerTagPrefix>dotnet-client-v</MinVerTagPrefix>
 	</PropertyGroup>
 	<PropertyGroup>
 		<PackageId>EventStore.Client</PackageId>


### PR DESCRIPTION
changed: minver prefix for tcp clients

This allows us to build the correct client version based on the `dotnet-client-v{version}` tag.