### PR TITLE
Make Microsoft.NETFramework.ReferenceAssemblies reference private

### DIFF
--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -26,7 +26,7 @@
 		<PackageReference Include="protobuf-net" Version="2.4.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+		<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">


### PR DESCRIPTION
Currently on nuget, `Microsoft.NETFramework.ReferenceAssemblies` dependency is listed explicitly, this is redundant and should be tidied up.

Using `PrivateAssets="All"` will achieve this.  The only question is I am 99% sure that .NET 5.0 SDK automatically includes this dependency (privately) so might be able to just remove this line altogether.