### PR TITLE
Fix TestClient not exiting after executing --command

### DIFF
--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -33,7 +33,7 @@ namespace EventStore.TestClient {
 
 		private readonly CommandsProcessor _commands = new CommandsProcessor(Log);
 
-		public Client(ClientOptions options) {
+		public Client(ClientOptions options, CancellationTokenSource cancellationTokenSource) {
 			Options = options;
 
 			TcpEndpoint = new DnsEndPoint(options.Host, options.TcpPort);
@@ -44,13 +44,12 @@ namespace EventStore.TestClient {
 
 			InteractiveMode = options.Command.IsEmpty();
 
-			RegisterProcessors();
-
+			RegisterProcessors(cancellationTokenSource);
 		}
 
-		private void RegisterProcessors() {
+		private void RegisterProcessors(CancellationTokenSource cancellationTokenSource) {
 			_commands.Register(new UsageProcessor(_commands), usageProcessor: true);
-			_commands.Register(new ExitProcessor());
+			_commands.Register(new ExitProcessor(cancellationTokenSource));
 
 			_commands.Register(new PingProcessor());
 			_commands.Register(new PingFloodProcessor());

--- a/src/EventStore.TestClient/Commands/ExitProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ExitProcessor.cs
@@ -1,7 +1,14 @@
+using System.Threading;
 using EventStore.Common.Utils;
 
 namespace EventStore.TestClient.Commands {
 	internal class ExitProcessor : ICmdProcessor {
+		private readonly CancellationTokenSource _cancellationTokenSource;
+
+		public ExitProcessor(CancellationTokenSource cancellationTokenSource) {
+			_cancellationTokenSource = cancellationTokenSource;
+		}
+
 		public string Usage {
 			get { return Keyword; }
 		}
@@ -12,7 +19,7 @@ namespace EventStore.TestClient.Commands {
 
 		public bool Execute(CommandProcessorContext context, string[] args) {
 			context.Log.Information("Exiting...");
-			Application.Exit(ExitCode.Success, "Exit processor called.");
+			_cancellationTokenSource.Cancel();
 			return true;
 		}
 	}

--- a/src/EventStore.TestClient/Program.cs
+++ b/src/EventStore.TestClient/Program.cs
@@ -11,7 +11,7 @@ namespace EventStore.TestClient {
 			try {
 				var hostedService = new TestClientHostedService(args);
 				await CreateHostBuilder(hostedService, args)
-					.RunConsoleAsync(options => options.SuppressStatusMessages = true);
+					.RunConsoleAsync(options => options.SuppressStatusMessages = true, hostedService.CancellationToken);
 				return await hostedService.Exited;
 			} catch (Exception ex) {
 				Log.Fatal(ex, "Host terminated unexpectedly.");


### PR DESCRIPTION
Fixed: TestClient not exiting after executing `--command`, which prevents it from being automated in an easy way.