### PR TITLE
Add gRPC client to EventStore.TestClient

### DIFF
--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -1,154 +1,14 @@
 using System;
 using System.Net;
-using System.Net.Security;
-using System.Net.Sockets;
 using System.Threading;
-using EventStore.BufferManagement;
 using EventStore.Common.Utils;
-using EventStore.Core.Services.Transport.Tcp;
 using EventStore.TestClient.Commands;
 using EventStore.TestClient.Commands.DvuBasic;
-using EventStore.Transport.Tcp;
-using EventStore.Transport.Tcp.Formatting;
-using EventStore.Transport.Tcp.Framing;
 using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
 using ILogger = Serilog.ILogger;
 #pragma warning disable 1591
 
 namespace EventStore.TestClient {
-	public class TcpTestClient {
-		private readonly BufferManager _bufferManager =
-			new BufferManager(TcpConfiguration.BufferChunksCount, TcpConfiguration.SocketBufferSize);
-		private readonly TcpClientConnector _connector = new TcpClientConnector();
-
-		private readonly bool _validateServer;
-		private readonly bool _useSsl;
-		private readonly ILogger _log;
-		private readonly bool _interactiveMode;
-		public readonly EndPoint TcpEndpoint;
-		public readonly ClientOptions Options;
-
-		public TcpTestClient(ClientOptions options, bool interactiveMode, ILogger log) {
-			_interactiveMode = interactiveMode;
-			_log = log;
-			_useSsl = options.UseTls;
-			TcpEndpoint = new DnsEndPoint(options.Host, options.TcpPort);
-			_validateServer = options.TlsValidateServer;
-			Options = options;
-		}
-
-		public Connection CreateTcpConnection(CommandProcessorContext context,
-			Action<Connection, TcpPackage> handlePackage,
-			Action<Connection> connectionEstablished = null,
-			Action<Connection, SocketError> connectionClosed = null,
-			bool failContextOnError = true,
-			IPEndPoint tcpEndPoint = null) {
-			var connectionCreatedEvent = new ManualResetEventSlim(false);
-			Connection typedConnection = null;
-
-			Action<ITcpConnection> onConnectionEstablished = conn => {
-				// we execute callback on ThreadPool because on FreeBSD it can be called synchronously
-				// causing deadlock
-				ThreadPool.QueueUserWorkItem(_ => {
-					if (!_interactiveMode)
-						_log.Information(
-							"TcpTypedConnection: connected to [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}].",
-							conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId);
-					if (connectionEstablished != null) {
-						if (!connectionCreatedEvent.Wait(10000))
-							throw new Exception("TcpTypedConnection: creation took too long!");
-						connectionEstablished(typedConnection);
-					}
-				});
-			};
-			Action<ITcpConnection, SocketError> onConnectionFailed = (conn, error) => {
-				_log.Error(
-					"TcpTypedConnection: connection to [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}] failed. Error: {e}.",
-					conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId, error);
-
-				if (connectionClosed != null)
-					connectionClosed(null, error);
-
-				if (failContextOnError)
-					context.Fail(reason: string.Format("Socket connection failed with error {0}.", error));
-			};
-
-			var endpoint = tcpEndPoint ?? TcpEndpoint;
-			ITcpConnection connection;
-			if (_useSsl) {
-				connection = _connector.ConnectSslTo(
-					Guid.NewGuid(),
-					endpoint.GetHost(),
-					endpoint.ResolveDnsToIPAddress(),
-					TcpConnectionManager.ConnectionTimeout,
-					(cert,chain,err) => (err == SslPolicyErrors.None || !_validateServer, err.ToString()),
-					() => null,
-					onConnectionEstablished,
-					onConnectionFailed,
-					verbose: !_interactiveMode);
-			} else {
-				connection = _connector.ConnectTo(
-					Guid.NewGuid(),
-					endpoint.ResolveDnsToIPAddress(),
-					TcpConnectionManager.ConnectionTimeout,
-					onConnectionEstablished,
-					onConnectionFailed,
-					verbose: !_interactiveMode);
-			}
-
-			typedConnection = new Connection(connection, new RawMessageFormatter(_bufferManager),
-				new LengthPrefixMessageFramer());
-			typedConnection.ConnectionClosed +=
-				(conn, error) => {
-					if (!_interactiveMode || error != SocketError.Success) {
-						_log.Information(
-							"TcpTypedConnection: connection [{remoteEndPoint}, L{localEndPoint}] was closed {status}",
-							conn.RemoteEndPoint, conn.LocalEndPoint,
-							error == SocketError.Success ? "cleanly." : "with error: " + error + ".");
-					}
-
-					if (connectionClosed != null)
-						connectionClosed(conn, error);
-					else
-						_log.Information("connectionClosed callback was null");
-				};
-			connectionCreatedEvent.Set();
-
-			typedConnection.ReceiveAsync(
-				(conn, pkg) => {
-					var package = new TcpPackage();
-					bool validPackage = false;
-					try {
-						package = TcpPackage.FromArraySegment(new ArraySegment<byte>(pkg));
-						validPackage = true;
-
-						if (package.Command == TcpCommand.HeartbeatRequestCommand) {
-							var resp = new TcpPackage(TcpCommand.HeartbeatResponseCommand, Guid.NewGuid(), null);
-							conn.EnqueueSend(resp.AsByteArray());
-							return;
-						}
-
-						handlePackage(conn, package);
-					} catch (Exception ex) {
-						_log.Information(ex,
-							"TcpTypedConnection: [{remoteEndPoint}, L{localEndPoint}] ERROR for {package}. Connection will be closed.",
-							conn.RemoteEndPoint, conn.LocalEndPoint,
-							validPackage ? package.Command as object : "<invalid package>");
-						conn.Close(ex.Message);
-
-						if (failContextOnError)
-							context.Fail(ex);
-					}
-				});
-
-			return typedConnection;
-		}
-		
-	}
-
-	public class GrpcTestClient {
-	}
-
 	public class Client {
 		private static readonly ILogger Log = Serilog.Log.ForContext<Client>();
 
@@ -173,6 +33,7 @@ namespace EventStore.TestClient {
 			InteractiveMode = options.Command.IsEmpty();
 
 			_tcpTestClient = new TcpTestClient(options, interactiveMode, Log);
+			_grpcTestClient = new GrpcTestClient(options, Log);
 			RegisterProcessors(cancellationTokenSource);
 		}
 
@@ -213,6 +74,9 @@ namespace EventStore.TestClient {
 			_commands.Register(new TcpSanitazationCheckProcessor());
 
 			_commands.Register(new SubscriptionStressTestProcessor());
+			
+			// gRPC
+			_commands.Register(new GrpcCommands.WriteFloodProcessor());
 		}
 
 		public int Run() {

--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -16,6 +16,139 @@ using ILogger = Serilog.ILogger;
 #pragma warning disable 1591
 
 namespace EventStore.TestClient {
+	public class TcpTestClient {
+		private readonly BufferManager _bufferManager =
+			new BufferManager(TcpConfiguration.BufferChunksCount, TcpConfiguration.SocketBufferSize);
+		private readonly TcpClientConnector _connector = new TcpClientConnector();
+
+		private readonly bool _validateServer;
+		private readonly bool _useSsl;
+		private readonly ILogger _log;
+		private readonly bool _interactiveMode;
+		public readonly EndPoint TcpEndpoint;
+		public readonly ClientOptions Options;
+
+		public TcpTestClient(ClientOptions options, bool interactiveMode, ILogger log) {
+			_interactiveMode = interactiveMode;
+			_log = log;
+			_useSsl = options.UseTls;
+			TcpEndpoint = new DnsEndPoint(options.Host, options.TcpPort);
+			_validateServer = options.TlsValidateServer;
+			Options = options;
+		}
+
+		public Connection CreateTcpConnection(CommandProcessorContext context,
+			Action<Connection, TcpPackage> handlePackage,
+			Action<Connection> connectionEstablished = null,
+			Action<Connection, SocketError> connectionClosed = null,
+			bool failContextOnError = true,
+			IPEndPoint tcpEndPoint = null) {
+			var connectionCreatedEvent = new ManualResetEventSlim(false);
+			Connection typedConnection = null;
+
+			Action<ITcpConnection> onConnectionEstablished = conn => {
+				// we execute callback on ThreadPool because on FreeBSD it can be called synchronously
+				// causing deadlock
+				ThreadPool.QueueUserWorkItem(_ => {
+					if (!_interactiveMode)
+						_log.Information(
+							"TcpTypedConnection: connected to [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}].",
+							conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId);
+					if (connectionEstablished != null) {
+						if (!connectionCreatedEvent.Wait(10000))
+							throw new Exception("TcpTypedConnection: creation took too long!");
+						connectionEstablished(typedConnection);
+					}
+				});
+			};
+			Action<ITcpConnection, SocketError> onConnectionFailed = (conn, error) => {
+				_log.Error(
+					"TcpTypedConnection: connection to [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}] failed. Error: {e}.",
+					conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId, error);
+
+				if (connectionClosed != null)
+					connectionClosed(null, error);
+
+				if (failContextOnError)
+					context.Fail(reason: string.Format("Socket connection failed with error {0}.", error));
+			};
+
+			var endpoint = tcpEndPoint ?? TcpEndpoint;
+			ITcpConnection connection;
+			if (_useSsl) {
+				connection = _connector.ConnectSslTo(
+					Guid.NewGuid(),
+					endpoint.GetHost(),
+					endpoint.ResolveDnsToIPAddress(),
+					TcpConnectionManager.ConnectionTimeout,
+					(cert,chain,err) => (err == SslPolicyErrors.None || !_validateServer, err.ToString()),
+					() => null,
+					onConnectionEstablished,
+					onConnectionFailed,
+					verbose: !_interactiveMode);
+			} else {
+				connection = _connector.ConnectTo(
+					Guid.NewGuid(),
+					endpoint.ResolveDnsToIPAddress(),
+					TcpConnectionManager.ConnectionTimeout,
+					onConnectionEstablished,
+					onConnectionFailed,
+					verbose: !_interactiveMode);
+			}
+
+			typedConnection = new Connection(connection, new RawMessageFormatter(_bufferManager),
+				new LengthPrefixMessageFramer());
+			typedConnection.ConnectionClosed +=
+				(conn, error) => {
+					if (!_interactiveMode || error != SocketError.Success) {
+						_log.Information(
+							"TcpTypedConnection: connection [{remoteEndPoint}, L{localEndPoint}] was closed {status}",
+							conn.RemoteEndPoint, conn.LocalEndPoint,
+							error == SocketError.Success ? "cleanly." : "with error: " + error + ".");
+					}
+
+					if (connectionClosed != null)
+						connectionClosed(conn, error);
+					else
+						_log.Information("connectionClosed callback was null");
+				};
+			connectionCreatedEvent.Set();
+
+			typedConnection.ReceiveAsync(
+				(conn, pkg) => {
+					var package = new TcpPackage();
+					bool validPackage = false;
+					try {
+						package = TcpPackage.FromArraySegment(new ArraySegment<byte>(pkg));
+						validPackage = true;
+
+						if (package.Command == TcpCommand.HeartbeatRequestCommand) {
+							var resp = new TcpPackage(TcpCommand.HeartbeatResponseCommand, Guid.NewGuid(), null);
+							conn.EnqueueSend(resp.AsByteArray());
+							return;
+						}
+
+						handlePackage(conn, package);
+					} catch (Exception ex) {
+						_log.Information(ex,
+							"TcpTypedConnection: [{remoteEndPoint}, L{localEndPoint}] ERROR for {package}. Connection will be closed.",
+							conn.RemoteEndPoint, conn.LocalEndPoint,
+							validPackage ? package.Command as object : "<invalid package>");
+						conn.Close(ex.Message);
+
+						if (failContextOnError)
+							context.Fail(ex);
+					}
+				});
+
+			return typedConnection;
+		}
+		
+	}
+
+	public class GrpcTestClient {
+	}
+
 	public class Client {
 		private static readonly ILogger Log = Serilog.Log.ForContext<Client>();
 
@@ -23,28 +156,23 @@ namespace EventStore.TestClient {
 
 		public readonly ClientOptions Options;
 		public readonly EndPoint TcpEndpoint;
-		public readonly EndPoint HttpEndpoint;
-		public readonly bool UseSsl;
-		public readonly bool ValidateServer;
 
-		private readonly BufferManager _bufferManager =
-			new BufferManager(TcpConfiguration.BufferChunksCount, TcpConfiguration.SocketBufferSize);
-
-		private readonly TcpClientConnector _connector = new TcpClientConnector();
+		public readonly TcpTestClient _tcpTestClient;
+		public readonly GrpcTestClient _grpcTestClient;
 
 		private readonly CommandsProcessor _commands = new CommandsProcessor(Log);
 
 		public Client(ClientOptions options, CancellationTokenSource cancellationTokenSource) {
 			Options = options;
+			
+			var interactiveMode = options.Command.IsEmpty();
+			var tcpEndpoint = new DnsEndPoint(options.Host, options.TcpPort);
+			var httpEndpoint = new DnsEndPoint(options.Host, options.HttpPort);
 
-			TcpEndpoint = new DnsEndPoint(options.Host, options.TcpPort);
-			HttpEndpoint = new DnsEndPoint(options.Host, options.HttpPort);
-
-			UseSsl = options.UseTls;
-			ValidateServer = options.TlsValidateServer;
-
+			TcpEndpoint = tcpEndpoint;
 			InteractiveMode = options.Command.IsEmpty();
 
+			_tcpTestClient = new TcpTestClient(options, interactiveMode, Log);
 			RegisterProcessors(cancellationTokenSource);
 		}
 
@@ -125,7 +253,7 @@ namespace EventStore.TestClient {
 		private int Execute(string[] args) {
 			Log.Information("Processing command: {command}.", string.Join(" ", args));
 
-			var context = new CommandProcessorContext(this, Log, new ManualResetEventSlim(true));
+			var context = new CommandProcessorContext(_tcpTestClient, _grpcTestClient, Options.Timeout, Log, new ManualResetEventSlim(true));
 
 			int exitCode;
 			if (_commands.TryProcess(context, args, out exitCode)) {
@@ -134,113 +262,6 @@ namespace EventStore.TestClient {
 			}
 
 			return exitCode;
-		}
-
-		public Connection CreateTcpConnection(CommandProcessorContext context,
-			Action<Connection, TcpPackage> handlePackage,
-			Action<Connection> connectionEstablished = null,
-			Action<Connection, SocketError> connectionClosed = null,
-			bool failContextOnError = true,
-			IPEndPoint tcpEndPoint = null) {
-			var connectionCreatedEvent = new ManualResetEventSlim(false);
-			Connection typedConnection = null;
-
-			Action<ITcpConnection> onConnectionEstablished = conn => {
-				// we execute callback on ThreadPool because on FreeBSD it can be called synchronously
-				// causing deadlock
-				ThreadPool.QueueUserWorkItem(_ => {
-					if (!InteractiveMode)
-						Log.Information(
-							"TcpTypedConnection: connected to [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}].",
-							conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId);
-					if (connectionEstablished != null) {
-						if (!connectionCreatedEvent.Wait(10000))
-							throw new Exception("TcpTypedConnection: creation took too long!");
-						connectionEstablished(typedConnection);
-					}
-				});
-			};
-			Action<ITcpConnection, SocketError> onConnectionFailed = (conn, error) => {
-				Log.Error(
-					"TcpTypedConnection: connection to [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}] failed. Error: {e}.",
-					conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId, error);
-
-				if (connectionClosed != null)
-					connectionClosed(null, error);
-
-				if (failContextOnError)
-					context.Fail(reason: string.Format("Socket connection failed with error {0}.", error));
-			};
-
-			var endpoint = tcpEndPoint ?? TcpEndpoint;
-			ITcpConnection connection;
-			if (UseSsl) {
-				connection = _connector.ConnectSslTo(
-					Guid.NewGuid(),
-					endpoint.GetHost(),
-					endpoint.ResolveDnsToIPAddress(),
-					TcpConnectionManager.ConnectionTimeout,
-					(cert,chain,err) => (err == SslPolicyErrors.None || !ValidateServer, err.ToString()),
-					() => null,
-					onConnectionEstablished,
-					onConnectionFailed,
-					verbose: !InteractiveMode);
-			} else {
-				connection = _connector.ConnectTo(
-					Guid.NewGuid(),
-					endpoint.ResolveDnsToIPAddress(),
-					TcpConnectionManager.ConnectionTimeout,
-					onConnectionEstablished,
-					onConnectionFailed,
-					verbose: !InteractiveMode);
-			}
-
-			typedConnection = new Connection(connection, new RawMessageFormatter(_bufferManager),
-				new LengthPrefixMessageFramer());
-			typedConnection.ConnectionClosed +=
-				(conn, error) => {
-					if (!InteractiveMode || error != SocketError.Success) {
-						Log.Information(
-							"TcpTypedConnection: connection [{remoteEndPoint}, L{localEndPoint}] was closed {status}",
-							conn.RemoteEndPoint, conn.LocalEndPoint,
-							error == SocketError.Success ? "cleanly." : "with error: " + error + ".");
-					}
-
-					if (connectionClosed != null)
-						connectionClosed(conn, error);
-					else
-						Log.Information("connectionClosed callback was null");
-				};
-			connectionCreatedEvent.Set();
-
-			typedConnection.ReceiveAsync(
-				(conn, pkg) => {
-					var package = new TcpPackage();
-					bool validPackage = false;
-					try {
-						package = TcpPackage.FromArraySegment(new ArraySegment<byte>(pkg));
-						validPackage = true;
-
-						if (package.Command == TcpCommand.HeartbeatRequestCommand) {
-							var resp = new TcpPackage(TcpCommand.HeartbeatResponseCommand, Guid.NewGuid(), null);
-							conn.EnqueueSend(resp.AsByteArray());
-							return;
-						}
-
-						handlePackage(conn, package);
-					} catch (Exception ex) {
-						Log.Information(ex,
-							"TcpTypedConnection: [{remoteEndPoint}, L{localEndPoint}] ERROR for {package}. Connection will be closed.",
-							conn.RemoteEndPoint, conn.LocalEndPoint,
-							validPackage ? package.Command as object : "<invalid package>");
-						conn.Close(ex.Message);
-
-						if (failContextOnError)
-							context.Fail(ex);
-					}
-				});
-
-			return typedConnection;
 		}
 	}
 }

--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -1,5 +1,6 @@
 using System;
-using System.Net;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.TestClient.Commands;
@@ -15,7 +16,6 @@ namespace EventStore.TestClient {
 		public readonly bool InteractiveMode;
 
 		public readonly ClientOptions Options;
-		public readonly EndPoint TcpEndpoint;
 
 		public readonly TcpTestClient _tcpTestClient;
 		public readonly GrpcTestClient _grpcTestClient;
@@ -26,10 +26,7 @@ namespace EventStore.TestClient {
 			Options = options;
 			
 			var interactiveMode = options.Command.IsEmpty();
-			var tcpEndpoint = new DnsEndPoint(options.Host, options.TcpPort);
-			var httpEndpoint = new DnsEndPoint(options.Host, options.HttpPort);
 
-			TcpEndpoint = tcpEndpoint;
 			InteractiveMode = options.Command.IsEmpty();
 
 			_tcpTestClient = new TcpTestClient(options, interactiveMode, Log);
@@ -79,6 +76,12 @@ namespace EventStore.TestClient {
 			_commands.Register(new GrpcCommands.WriteFloodProcessor());
 		}
 
+		public string GetCommandList() {
+			var sb = new StringBuilder();
+			_commands.RegisteredProcessors.Select(x => x.Usage.ToUpper()).ToList().ForEach(s => sb.AppendLine(s));
+			return sb.ToString();
+		}
+
 		public int Run() {
 			if (!InteractiveMode) {
 				var args = ParseCommandLine(Options.Command[0]);
@@ -87,6 +90,7 @@ namespace EventStore.TestClient {
 
 			new Thread(() => {
 				Thread.Sleep(100);
+				Console.WriteLine(GetCommandList());
 				Console.Write(">>> ");
 
 				string line;

--- a/src/EventStore.TestClient/ClientOptions.cs
+++ b/src/EventStore.TestClient/ClientOptions.cs
@@ -26,6 +26,9 @@ namespace EventStore.TestClient {
 		public bool UseTls { get; init; }
 		public bool TlsValidateServer { get; init; }
 
+		[ArgDescription("A connection string to connect to a node/cluster. Used by gRPC only.")]
+		public string ConnectionString { get; set; }
+
 		public ClientOptions() {
 			Command = Array.Empty<string>();
 			Host = IPAddress.Loopback.ToString();
@@ -38,6 +41,7 @@ namespace EventStore.TestClient {
 			Reconnect = true;
 			UseTls = false;
 			TlsValidateServer = false;
+			ConnectionString = string.Empty;
 		}
 
 		public override string ToString() {

--- a/src/EventStore.TestClient/ClientOptions.cs
+++ b/src/EventStore.TestClient/ClientOptions.cs
@@ -26,7 +26,6 @@ namespace EventStore.TestClient {
 		public bool UseTls { get; init; }
 		public bool TlsValidateServer { get; init; }
 
-		[ArgDescription("A connection string to connect to a node/cluster. Used by gRPC only.")]
 		public string ConnectionString { get; set; }
 
 		public ClientOptions() {

--- a/src/EventStore.TestClient/CommandProcessorContext.cs
+++ b/src/EventStore.TestClient/CommandProcessorContext.cs
@@ -19,15 +19,19 @@ namespace EventStore.TestClient {
 		/// </summary>
 		public readonly Serilog.ILogger Log;
 
-		public readonly Client Client;
+		public readonly TcpTestClient _tcpTestClient;
+		public readonly GrpcTestClient _grpcTestClient;
 
 		private readonly ManualResetEventSlim _doneEvent;
 		private int _completed;
+		private int _timeout;
 
-		public CommandProcessorContext(Client client, ILogger log, ManualResetEventSlim doneEvent) {
-			Client = client;
+		public CommandProcessorContext(TcpTestClient tcpTestClient, GrpcTestClient grpcTestClient, int timeout, ILogger log, ManualResetEventSlim doneEvent) {
+			_tcpTestClient = tcpTestClient;
+			_grpcTestClient = grpcTestClient;
 			Log = log;
 			_doneEvent = doneEvent;
+			_timeout = timeout;
 		}
 
 		public void Completed(int exitCode = (int)Common.Utils.ExitCode.Success, Exception error = null,
@@ -55,10 +59,10 @@ namespace EventStore.TestClient {
 		}
 
 		public void WaitForCompletion() {
-			if (Client.Options.Timeout < 0)
+			if (_timeout < 0)
 				_doneEvent.Wait();
 			else {
-				if (!_doneEvent.Wait(Client.Options.Timeout * 1000))
+				if (!_doneEvent.Wait(_timeout * 1000))
 					throw new TimeoutException("Command didn't finished within timeout.");
 			}
 		}

--- a/src/EventStore.TestClient/Commands/DeleteProcessor.cs
+++ b/src/EventStore.TestClient/Commands/DeleteProcessor.cs
@@ -28,7 +28,7 @@ namespace EventStore.TestClient.Commands {
 
 			context.IsAsync();
 			var sw = new Stopwatch();
-			context.Client.CreateTcpConnection(
+			context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => {
 					context.Log.Information(

--- a/src/EventStore.TestClient/Commands/DvuBasic/DvuBasicProcessor.cs
+++ b/src/EventStore.TestClient/Commands/DvuBasic/DvuBasicProcessor.cs
@@ -248,13 +248,13 @@ namespace EventStore.TestClient.Commands.DvuBasic {
 			Action<TcpTypedConnection<byte[]>> established = _ => { };
 			Action<TcpTypedConnection<byte[]>, SocketError> closed = null;
 			closed = (_, __) => {
-				if (!context.Client.Options.Reconnect) return;
+				if (!context._tcpTestClient.Options.Reconnect) return;
 				Thread.Sleep(TimeSpan.FromSeconds(1));
 				connection =
-					context.Client.CreateTcpConnection(context, packageHandler, cn => iteration.Set(), closed, false);
+					context._tcpTestClient.CreateTcpConnection(context, packageHandler, cn => iteration.Set(), closed, false);
 			};
 
-			connection = context.Client.CreateTcpConnection(context, packageHandler, established, closed, false);
+			connection = context._tcpTestClient.CreateTcpConnection(context, packageHandler, established, closed, false);
 
 			for (var i = 0; i < requests; ++i) {
 				streamIdx = NextStreamForWriting(rnd, writerIdx);
@@ -280,7 +280,7 @@ namespace EventStore.TestClient.Commands.DvuBasic {
 			status.ReportWritesProgress(writerIdx, sent, prepareTimeouts, commitTimeouts, forwardTimeouts,
 				wrongExpectedVersion, streamsDeleted, failed, requests);
 			status.FinilizeStatus(writerIdx, failed != sent);
-			context.Client.Options.Reconnect = false;
+			context._tcpTestClient.Options.Reconnect = false;
 			connection.Close();
 			finish.Set();
 		}
@@ -329,13 +329,13 @@ namespace EventStore.TestClient.Commands.DvuBasic {
 			Action<TcpTypedConnection<byte[]>> established = _ => { };
 			Action<TcpTypedConnection<byte[]>, SocketError> closed = null;
 			closed = (_, __) => {
-				if (!context.Client.Options.Reconnect) return;
+				if (!context._tcpTestClient.Options.Reconnect) return;
 				Thread.Sleep(TimeSpan.FromSeconds(1));
 				connection =
-					context.Client.CreateTcpConnection(context, packageReceived, cn => iteration.Set(), closed, false);
+					context._tcpTestClient.CreateTcpConnection(context, packageReceived, cn => iteration.Set(), closed, false);
 			};
 
-			connection = context.Client.CreateTcpConnection(context, packageReceived, established, closed, false);
+			connection = context._tcpTestClient.CreateTcpConnection(context, packageReceived, established, closed, false);
 
 			while (!_stopReading) {
 				streamIdx = NextStreamForReading(rnd, readerIdx);
@@ -359,7 +359,7 @@ namespace EventStore.TestClient.Commands.DvuBasic {
 
 			status.ReportReadsProgress(readerIdx, successes, fails);
 			status.FinilizeStatus(readerIdx, fails == 0);
-			context.Client.Options.Reconnect = false;
+			context._tcpTestClient.Options.Reconnect = false;
 			connection.Close();
 			finishedEvent.Set();
 		}

--- a/src/EventStore.TestClient/Commands/MultiWriteFloodWaiting.cs
+++ b/src/EventStore.TestClient/Commands/MultiWriteFloodWaiting.cs
@@ -58,7 +58,7 @@ namespace EventStore.TestClient.Commands {
 				var count = requestsCnt / clientsCnt + ((i == clientsCnt - 1) ? requestsCnt % clientsCnt : 0);
 				var localDoneEvent = new AutoResetEvent(false);
 				var eventStreamId = "es" + Guid.NewGuid();
-				var client = context.Client.CreateTcpConnection(
+				var client = context._tcpTestClient.CreateTcpConnection(
 					context,
 					(conn, pkg) => {
 						if (pkg.Command != TcpCommand.WriteEventsCompleted) {

--- a/src/EventStore.TestClient/Commands/MultiWriteProcessor.cs
+++ b/src/EventStore.TestClient/Commands/MultiWriteProcessor.cs
@@ -37,7 +37,7 @@ namespace EventStore.TestClient.Commands {
 
 			context.IsAsync();
 			var sw = new Stopwatch();
-			context.Client.CreateTcpConnection(
+			context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => {
 					context.Log.Information("[{remoteEndPoint}, L{localEndPoint}]: Writing...", conn.RemoteEndPoint,

--- a/src/EventStore.TestClient/Commands/PingFloodProcessor.cs
+++ b/src/EventStore.TestClient/Commands/PingFloodProcessor.cs
@@ -47,7 +47,7 @@ namespace EventStore.TestClient.Commands {
 				var count = requestsCnt / clientsCnt + ((i == clientsCnt - 1) ? requestsCnt % clientsCnt : 0);
 				long received = 0;
 				long sent = 0;
-				var client = context.Client.CreateTcpConnection(
+				var client = context._tcpTestClient.CreateTcpConnection(
 					context,
 					(conn, msg) => {
 						Interlocked.Increment(ref received);
@@ -68,7 +68,7 @@ namespace EventStore.TestClient.Commands {
 
 						var localSent = Interlocked.Increment(ref sent);
 						while (localSent - Interlocked.Read(ref received) >
-						       context.Client.Options.PingWindow / clientsCnt) {
+						       context._tcpTestClient.Options.PingWindow / clientsCnt) {
 							Thread.Sleep(1);
 						}
 					}

--- a/src/EventStore.TestClient/Commands/PingFloodWaitingProcessor.cs
+++ b/src/EventStore.TestClient/Commands/PingFloodWaitingProcessor.cs
@@ -43,7 +43,7 @@ namespace EventStore.TestClient.Commands {
 			long all = 0;
 			for (int i = 0; i < clientsCnt; i++) {
 				var autoResetEvent = new AutoResetEvent(false);
-				var client = context.Client.CreateTcpConnection(
+				var client = context._tcpTestClient.CreateTcpConnection(
 					context,
 					(_, __) => {
 						Interlocked.Increment(ref all);

--- a/src/EventStore.TestClient/Commands/PingProcessor.cs
+++ b/src/EventStore.TestClient/Commands/PingProcessor.cs
@@ -14,12 +14,12 @@ namespace EventStore.TestClient.Commands {
 		public bool Execute(CommandProcessorContext context, string[] args) {
 			context.IsAsync();
 
-			context.Client.CreateTcpConnection(
+			context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => {
 					var package = new TcpPackage(TcpCommand.Ping, Guid.NewGuid(), null);
-					context.Log.Information("[{ip}:{tcpPort}]: PING...", context.Client.Options.Host,
-						context.Client.Options.TcpPort);
+					context.Log.Information("[{ip}:{tcpPort}]: PING...", context._tcpTestClient.Options.Host,
+						context._tcpTestClient.Options.TcpPort);
 					conn.EnqueueSend(package.AsByteArray());
 				},
 				handlePackage: (conn, pkg) => {
@@ -28,8 +28,8 @@ namespace EventStore.TestClient.Commands {
 						return;
 					}
 
-					context.Log.Information("[{ip}:{tcpPort}]: PONG!", context.Client.Options.Host,
-						context.Client.Options.TcpPort);
+					context.Log.Information("[{ip}:{tcpPort}]: PONG!", context._tcpTestClient.Options.Host,
+						context._tcpTestClient.Options.TcpPort);
 					context.Success();
 					conn.Close();
 				},

--- a/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
@@ -56,7 +56,7 @@ namespace EventStore.TestClient.Commands {
 			var tcpCommand = forward ? TcpCommand.ReadAllEventsForward : TcpCommand.ReadAllEventsBackward;
 			var tcpCommandToReceive = forward ? TcpCommand.ReadAllEventsForwardCompleted : TcpCommand.ReadAllEventsBackwardCompleted;
 
-			context.Client.CreateTcpConnection(
+			context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => {
 					context.Log.Information("[{remoteEndPoint}, L{localEndPoint}]: Reading all {readDirection}...",

--- a/src/EventStore.TestClient/Commands/ReadFloodProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadFloodProcessor.cs
@@ -58,7 +58,7 @@ namespace EventStore.TestClient.Commands {
 				var count = requestsCnt / clientsCnt + ((i == clientsCnt - 1) ? requestsCnt % clientsCnt : 0);
 				long received = 0;
 				long sent = 0;
-				var client = context.Client.CreateTcpConnection(
+				var client = context._tcpTestClient.CreateTcpConnection(
 					context,
 					(conn, pkg) => {
 						if (pkg.Command != TcpCommand.ReadEventCompleted) {
@@ -101,7 +101,7 @@ namespace EventStore.TestClient.Commands {
 
 						var localSent = Interlocked.Increment(ref sent);
 						while (localSent - Interlocked.Read(ref received) >
-						       context.Client.Options.ReadWindow / clientsCnt) {
+						       context._tcpTestClient.Options.ReadWindow / clientsCnt) {
 							Thread.Sleep(1);
 						}
 					}

--- a/src/EventStore.TestClient/Commands/ReadProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadProcessor.cs
@@ -34,7 +34,7 @@ namespace EventStore.TestClient.Commands {
 			context.IsAsync();
 
 			var sw = new Stopwatch();
-			context.Client.CreateTcpConnection(
+			context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => {
 					context.Log.Information("[{remoteEndPoint}, L{localEndPoint}]: Reading...", conn.RemoteEndPoint,

--- a/src/EventStore.TestClient/Commands/RunTestScenariosProcessor.cs
+++ b/src/EventStore.TestClient/Commands/RunTestScenariosProcessor.cs
@@ -238,7 +238,7 @@ namespace EventStore.TestClient.Commands {
 				};
 				Action<TcpTypedConnection<byte[]>, SocketError> closed = (_, __) => sent.Set();
 
-				context.Client.CreateTcpConnection(context, handlePackage, established, closed, false, tcpEndPoint);
+				context._tcpTestClient.CreateTcpConnection(context, handlePackage, established, closed, false, tcpEndPoint);
 				if (!sent.WaitOne(timeoutMilliseconds))
 					throw new ApplicationException("Connection to server was not closed in time.");
 			};

--- a/src/EventStore.TestClient/Commands/ScavengeProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ScavengeProcessor.cs
@@ -16,7 +16,7 @@ namespace EventStore.TestClient.Commands {
 			var package = new TcpPackage(TcpCommand.ScavengeDatabase, Guid.NewGuid(), null);
 			context.Log.Information("Sending SCAVENGE request...");
 
-			var connection = context.Client.CreateTcpConnection(
+			var connection = context._tcpTestClient.CreateTcpConnection(
 				context,
 				(conn, pkg) => { },
 				null,

--- a/src/EventStore.TestClient/Commands/SubscribeToStreamProcessor.cs
+++ b/src/EventStore.TestClient/Commands/SubscribeToStreamProcessor.cs
@@ -20,7 +20,7 @@ namespace EventStore.TestClient.Commands {
 
 			var streamByCorrId = new Dictionary<Guid, string>();
 
-			var connection = context.Client.CreateTcpConnection(
+			var connection = context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => { },
 				handlePackage: (conn, pkg) => {

--- a/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
+++ b/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
@@ -30,7 +30,7 @@ namespace EventStore.TestClient.Commands {
 					.UseCustomLogger(new ClientApiLoggerBridge(context.Log))
 					.FailOnNoServerResponse()
 				/*.EnableVerboseLogging()*/,
-				new Uri($"tcp://{context.Client.TcpEndpoint.GetHost()}:{context.Client.TcpEndpoint.GetPort()}"));
+				new Uri($"tcp://{context._tcpTestClient.TcpEndpoint.GetHost()}:{context._tcpTestClient.TcpEndpoint.GetPort()}"));
 			conn.ConnectAsync().Wait();
 
 			long appearedCnt = 0;

--- a/src/EventStore.TestClient/Commands/TcpSanitazationCheckProcessor.cs
+++ b/src/EventStore.TestClient/Commands/TcpSanitazationCheckProcessor.cs
@@ -58,7 +58,7 @@ namespace EventStore.TestClient.Commands {
 				else
 					Console.WriteLine("{0} Starting step {1} (RANDOM BYTES) {0}", new string('#', 20), step);
 
-				var connection = context.Client.CreateTcpConnection(
+				var connection = context._tcpTestClient.CreateTcpConnection(
 					context,
 					(conn, package) => {
 						if (package.Command != TcpCommand.BadRequest)
@@ -89,13 +89,13 @@ namespace EventStore.TestClient.Commands {
 
 			Log.Information("Now sending raw bytes...");
 			try {
-				SendRaw(context.Client.TcpEndpoint, BitConverter.GetBytes(int.MaxValue));
-				SendRaw(context.Client.TcpEndpoint, BitConverter.GetBytes(int.MinValue));
+				SendRaw(context._tcpTestClient.TcpEndpoint, BitConverter.GetBytes(int.MaxValue));
+				SendRaw(context._tcpTestClient.TcpEndpoint, BitConverter.GetBytes(int.MinValue));
 
-				SendRaw(context.Client.TcpEndpoint, BitConverter.GetBytes(double.MinValue));
-				SendRaw(context.Client.TcpEndpoint, BitConverter.GetBytes(double.MinValue));
+				SendRaw(context._tcpTestClient.TcpEndpoint, BitConverter.GetBytes(double.MinValue));
+				SendRaw(context._tcpTestClient.TcpEndpoint, BitConverter.GetBytes(double.MinValue));
 
-				SendRaw(context.Client.TcpEndpoint, BitConverter.GetBytes(new Random().NextDouble()));
+				SendRaw(context._tcpTestClient.TcpEndpoint, BitConverter.GetBytes(new Random().NextDouble()));
 			} catch (Exception e) {
 				context.Fail(e, "Raw bytes sent failed");
 				return false;

--- a/src/EventStore.TestClient/Commands/TransactionWriteProcessor.cs
+++ b/src/EventStore.TestClient/Commands/TransactionWriteProcessor.cs
@@ -37,7 +37,7 @@ namespace EventStore.TestClient.Commands {
 			var stage = Stage.AcquiringTransactionId;
 			long transactionId = -1;
 			var writtenEvents = 0;
-			context.Client.CreateTcpConnection(
+			context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => {
 					context.Log.Information("[{remoteEndPoint}, L{localEndPoint}]: Starting transaction...",

--- a/src/EventStore.TestClient/Commands/WriteFloodClientApiProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodClientApiProcessor.cs
@@ -66,11 +66,11 @@ namespace EventStore.TestClient.Commands {
 					.LimitReconnectionsTo(10)
 					.LimitRetriesForOperationTo(10)
 					.LimitOperationsQueueTo(10000)
-					.LimitConcurrentOperationsTo(context.Client.Options.WriteWindow / clientsCnt)
+					.LimitConcurrentOperationsTo(context._tcpTestClient.Options.WriteWindow / clientsCnt)
 					.FailOnNoServerResponse();
 
 				var client = EventStoreConnection.Create(settings,
-					new Uri($"tcp://{context.Client.TcpEndpoint.GetHost()}:{context.Client.TcpEndpoint.GetPort()}"));
+					new Uri($"tcp://{context._tcpTestClient.TcpEndpoint.GetHost()}:{context._tcpTestClient.TcpEndpoint.GetPort()}"));
 				clients.Add(client);
 
 				threads.Add(new Thread(_ => {

--- a/src/EventStore.TestClient/Commands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodProcessor.cs
@@ -75,7 +75,7 @@ namespace EventStore.TestClient.Commands {
 				long sent = 0;
 				long received = 0;
 				var rnd = new Random();
-				var client = context.Client.CreateTcpConnection(
+				var client = context._tcpTestClient.CreateTcpConnection(
 					context,
 					(conn, pkg) => {
 						if (pkg.Command != TcpCommand.WriteEventsCompleted) {
@@ -161,7 +161,7 @@ namespace EventStore.TestClient.Commands {
 
 						var localSent = Interlocked.Increment(ref sent);
 						while (localSent - Interlocked.Read(ref received) >
-						       context.Client.Options.WriteWindow / clientsCnt) {
+						       context._tcpTestClient.Options.WriteWindow / clientsCnt) {
 							Thread.Sleep(1);
 						}
 					}

--- a/src/EventStore.TestClient/Commands/WriteFloodWaitingProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodWaitingProcessor.cs
@@ -57,7 +57,7 @@ namespace EventStore.TestClient.Commands {
 				var autoEvent = new AutoResetEvent(false);
 				var eventStreamId = "es" + Guid.NewGuid();
 				var received = 0;
-				var client = context.Client.CreateTcpConnection(
+				var client = context._tcpTestClient.CreateTcpConnection(
 					context,
 					(conn, pkg) => {
 						if (pkg.Command != TcpCommand.WriteEventsCompleted) {

--- a/src/EventStore.TestClient/Commands/WriteJsonProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteJsonProcessor.cs
@@ -53,7 +53,7 @@ namespace EventStore.TestClient.Commands {
 			var sw = new Stopwatch();
 			bool dataReceived = false;
 
-			context.Client.CreateTcpConnection(
+			context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => {
 					context.Log.Information("[{remoteEndPoint}, L{localEndPoint}]: Writing...", conn.RemoteEndPoint,

--- a/src/EventStore.TestClient/Commands/WriteLongTermProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteLongTermProcessor.cs
@@ -79,7 +79,7 @@ namespace EventStore.TestClient.Commands {
 			for (int i = 0; i < clientsCnt; i++) {
 				var esId = eventStreamId ?? "Stream-" + Thread.CurrentThread.ManagedThreadId % 3;
 
-				var client = context.Client.CreateTcpConnection(
+				var client = context._tcpTestClient.CreateTcpConnection(
 					context,
 					(conn, pkg) => {
 						if (pkg.Command != TcpCommand.WriteEventsCompleted) {
@@ -169,7 +169,7 @@ namespace EventStore.TestClient.Commands {
 						Thread.Sleep(sleepTime);
 						sentCount -= 1;
 
-						while (sent - received > context.Client.Options.WriteWindow / clientsCnt) {
+						while (sent - received > context._tcpTestClient.Options.WriteWindow / clientsCnt) {
 							Thread.Sleep(1);
 						}
 					}

--- a/src/EventStore.TestClient/Commands/WriteProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteProcessor.cs
@@ -43,7 +43,7 @@ namespace EventStore.TestClient.Commands {
 
 			context.IsAsync();
 			var sw = new Stopwatch();
-			context.Client.CreateTcpConnection(
+			context._tcpTestClient.CreateTcpConnection(
 				context,
 				connectionEstablished: conn => {
 					context.Log.Information("[{remoteEndPoint}, L{localEndPoint}]: Writing...", conn.RemoteEndPoint,

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -8,8 +8,9 @@
 				<Platforms>x64</Platforms>
 		</PropertyGroup>
 		<ItemGroup>
-				<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1"/>
+				<PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
 				<PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20574.7" />
+				<PackageReference Include="EventStore.Client.Grpc.Streams" Version="21.2.0" />
 		</ItemGroup>
 		<ItemGroup>
 				<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -12,12 +12,12 @@
 				<PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20574.7" />
 		</ItemGroup>
 		<ItemGroup>
-				<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj"/>
-				<ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj"/>
-				<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj"/>
-				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj"/>
-				<ProjectReference Include="..\EventStore.Transport.Http\EventStore.Transport.Http.csproj"/>
-				<ProjectReference Include="..\EventStore.Transport.Tcp\EventStore.Transport.Tcp.csproj"/>
+				<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />
+				<ProjectReference Include="..\EventStore.ClientAPI\EventStore.ClientAPI.csproj" />
+				<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
+				<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
+				<ProjectReference Include="..\EventStore.Transport.Http\EventStore.Transport.Http.csproj" />
+				<ProjectReference Include="..\EventStore.Transport.Tcp\EventStore.Transport.Tcp.csproj" />
 		</ItemGroup>
 		<ItemGroup>
 				<None Include="..\EventStore.Common\Log\logconfig.json">

--- a/src/EventStore.TestClient/GrpcCommands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/GrpcCommands/WriteFloodProcessor.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.TestClient.Commands;
+
+namespace EventStore.TestClient.GrpcCommands {
+	internal class WriteFloodProcessor : ICmdProcessor {
+		private static readonly UTF8Encoding UTF8NoBom = new UTF8Encoding(false);
+
+		public string Usage {
+			get { return "WRFLGRPC [<clients> <requests> [<streams-cnt> [<size>] [<batchsize>]]]"; }
+		}
+
+		public string Keyword {
+			get { return "WRFLGRPC"; }
+		}
+
+		public bool Execute(CommandProcessorContext context, string[] args) {
+			int clientsCnt = 1;
+			long requestsCnt = 5000;
+			int streamsCnt = 1000;
+			int size = 256;
+			int batchSize = 1;
+			if (args.Length > 0)
+			{
+			    if (args.Length < 2 || args.Length > 5)
+			        return false;
+			
+			    try
+			    {
+			        clientsCnt = int.Parse(args[0]);
+			        requestsCnt = long.Parse(args[1]);
+			        if (args.Length >= 3)
+			            streamsCnt = int.Parse(args[2]);
+			        if (args.Length >= 4)
+			            size = int.Parse(args[3]);
+			        if (args.Length >= 5)
+			            batchSize = int.Parse(args[4]);
+			    }
+			    catch
+			    {
+			        return false;
+			    }
+			}
+			
+			var monitor = new RequestMonitor();
+			try {
+				var task = WriteFlood(context, clientsCnt, requestsCnt, streamsCnt, size, batchSize, monitor);
+				task.Wait();
+			} catch (Exception ex) {
+				context.Fail(ex);
+			}
+
+			return true;
+		}
+
+		private async Task WriteFlood(CommandProcessorContext context, int clientsCnt, long requestsCnt, int streamsCnt,
+			int size, int batchSize, RequestMonitor monitor) {
+			context.IsAsync();
+
+			long succ = 0;
+			long last = 0;
+			long fail = 0;
+			long prepTimeout = 0;
+			long commitTimeout = 0;
+			long forwardTimeout = 0;
+			long wrongExpVersion = 0;
+			long streamDeleted = 0;
+			long all = 0;
+			long interval = 100000;
+			long currentInterval = 0;
+
+			var streams = Enumerable.Range(0, streamsCnt).Select(x => Guid.NewGuid().ToString()).ToArray();
+			var start = new TaskCompletionSource();
+			var sw2 = new Stopwatch();
+			var capacity = 2000 / clientsCnt;
+			var clientTasks = new List<Task>();
+			for (int i = 0; i < clientsCnt; i++) {
+				var count = requestsCnt / clientsCnt + ((i == clientsCnt - 1) ? requestsCnt % clientsCnt : 0);
+
+				var client = context._grpcTestClient.CreateGrpcClient();
+				clientTasks.Add(RunClient(client, count));
+			}
+
+			async Task RunClient(EventStoreClient client, long count) {
+				var rnd = new Random();
+				List<Task> pending = new List<Task>(capacity);
+				await start.Task;
+				for (int j = 0; j < count; ++j) {
+
+					var events = new EventData[batchSize];
+					for (int q = 0; q < batchSize; q++) {
+						events[q] = new EventData(Uuid.FromGuid(Guid.NewGuid()),
+							"TakeSomeSpaceEvent",
+							UTF8NoBom.GetBytes(
+								"{ \"DATA\" : \"" + new string('*', size) + "\"}"),
+							UTF8NoBom.GetBytes(
+								"{ \"METADATA\" : \"" + new string('$', 100) + "\"}"));
+					}
+
+					var corrid = Guid.NewGuid();
+					monitor.StartOperation(corrid);
+
+					pending.Add(client.AppendToStreamAsync(streams[rnd.Next(streamsCnt)], StreamState.Any, events)
+						.ContinueWith(t => {
+							if (t.IsCompletedSuccessfully) Interlocked.Increment(ref succ);
+							else {
+								if (Interlocked.Increment(ref fail) % 1000 == 0)
+									Console.Write('#');
+							}
+							var localAll = Interlocked.Add(ref all, batchSize);
+							if (localAll - currentInterval > interval) {
+								var localInterval = Interlocked.Exchange(ref currentInterval, localAll);
+								var elapsed = sw2.Elapsed;
+								sw2.Restart();
+								context.Log.Information(
+									"\nDONE TOTAL {writes} WRITES IN {elapsed} ({rate:0.0}/s) [S:{success}, F:{failures} (WEV:{wrongExpectedVersion}, P:{prepareTimeout}, C:{commitTimeout}, F:{forwardTimeout}, D:{streamDeleted})].",
+									localAll, elapsed, 1000.0 * (localAll - localInterval) / elapsed.TotalMilliseconds,
+									succ, fail,
+									wrongExpVersion, prepTimeout, commitTimeout, forwardTimeout, streamDeleted);
+							}
+
+							monitor.EndOperation(corrid);
+						}));
+					if (pending.Count == capacity) {
+						await Task.WhenAny(pending).ConfigureAwait(false);
+
+						while (pending.Count > 0 && Task.WhenAny(pending).IsCompleted) {
+							pending.RemoveAll(x => x.IsCompleted);
+							if (succ - last > 1000) {
+								Console.Write(".");
+								last = succ;
+							}
+						}
+					}
+				}
+
+				if (pending.Count > 0) await Task.WhenAll(pending);
+			}
+
+			var sw = Stopwatch.StartNew();
+			sw2.Start();
+			start.SetResult();
+			await Task.WhenAll(clientTasks);
+			sw.Stop();
+
+			context.Log.Information(
+				"Completed. Successes: {success}, failures: {failures} (WRONG VERSION: {wrongExpectedVersion}, P: {prepareTimeout}, C: {commitTimeout}, F: {forwardTimeout}, D: {streamDeleted})",
+				succ, fail,
+				wrongExpVersion, prepTimeout, commitTimeout, forwardTimeout, streamDeleted);
+
+			var reqPerSec = (all + 0.0) / sw.ElapsedMilliseconds * 1000;
+			context.Log.Information("{requests} requests completed in {elapsed}ms ({rate:0.00} reqs per sec).", all,
+				sw.ElapsedMilliseconds, reqPerSec);
+
+			PerfUtils.LogData(
+				Keyword,
+				PerfUtils.Row(PerfUtils.Col("clientsCnt", clientsCnt),
+					PerfUtils.Col("requestsCnt", requestsCnt),
+					PerfUtils.Col("ElapsedMilliseconds", sw.ElapsedMilliseconds)),
+				PerfUtils.Row(PerfUtils.Col("successes", succ), PerfUtils.Col("failures", fail)));
+
+			var failuresRate = (int)(100 * fail / (fail + succ));
+			PerfUtils.LogTeamCityGraphData(string.Format("{0}-{1}-{2}-reqPerSec", Keyword, clientsCnt, requestsCnt),
+				(int)reqPerSec);
+			PerfUtils.LogTeamCityGraphData(
+				string.Format("{0}-{1}-{2}-failureSuccessRate", Keyword, clientsCnt, requestsCnt), failuresRate);
+			PerfUtils.LogTeamCityGraphData(
+				string.Format("{0}-c{1}-r{2}-st{3}-s{4}-reqPerSec", Keyword, clientsCnt, requestsCnt, streamsCnt, size),
+				(int)reqPerSec);
+			PerfUtils.LogTeamCityGraphData(
+				string.Format("{0}-c{1}-r{2}-st{3}-s{4}-failureSuccessRate", Keyword, clientsCnt, requestsCnt,
+					streamsCnt, size), failuresRate);
+			monitor.GetMeasurementDetails();
+			if (Interlocked.Read(ref succ) != requestsCnt)
+				context.Fail(reason: "There were errors or not all requests completed.");
+			else
+				context.Success();
+		}
+	}
+}

--- a/src/EventStore.TestClient/GrpcCommands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/GrpcCommands/WriteFloodProcessor.cs
@@ -13,7 +13,7 @@ namespace EventStore.TestClient.GrpcCommands {
 		private static readonly UTF8Encoding UTF8NoBom = new UTF8Encoding(false);
 
 		public string Usage {
-			get { return "WRFLGRPC [<clients> <requests> [<streams-cnt> [<size>] [<batchsize>] <streamNamePrefix>]]"; }
+			get { return "WRFLGRPC [<clients> <requests> [<streams-cnt> [<size> [<batchsize> [<stream-prefix>]]]]]"; }
 		}
 
 		public string Keyword {

--- a/src/EventStore.TestClient/GrpcTestClient.cs
+++ b/src/EventStore.TestClient/GrpcTestClient.cs
@@ -1,0 +1,24 @@
+﻿using EventStore.Client;
+using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.TestClient {
+	public class GrpcTestClient {
+		private ClientOptions _options;
+		private ILogger _log;
+
+		public GrpcTestClient(ClientOptions options, ILogger log) {
+			_options = options;
+			_log = log;
+		}
+
+		public EventStoreClient CreateGrpcClient() {
+			var connectionString = string.IsNullOrWhiteSpace(_options.ConnectionString)
+				? $"esdb://{_options.Host}:{_options.HttpPort}?tls={_options.UseTls}&tlsVerifyCert={_options.TlsValidateServer}"
+				: _options.ConnectionString;
+			_log.Debug("Creating gRPC client with connection string '{connectionString}'.", connectionString);
+			var settings = EventStoreClientSettings.Create(connectionString);
+			return new EventStoreClient(settings);
+		}
+	}
+}

--- a/src/EventStore.TestClient/GrpcTestClient.cs
+++ b/src/EventStore.TestClient/GrpcTestClient.cs
@@ -3,15 +3,27 @@ using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.TestClient {
+	/// <summary>
+	/// The dotnet gRPC client used by the TestClient commands that have the 'grpc' suffix
+	/// </summary>
 	public class GrpcTestClient {
 		private ClientOptions _options;
 		private ILogger _log;
 
+		/// <summary>
+		/// Creates a dotnet gRPC Test Client for a command
+		/// </summary>
+		/// <param name="options">The ClientOptions for the TestClient.</param>
+		/// <param name="log"></param>
 		public GrpcTestClient(ClientOptions options, ILogger log) {
 			_options = options;
 			_log = log;
 		}
 
+		/// <summary>
+		/// Creates a gRPC client for the command to use for its tests
+		/// </summary>
+		/// <returns></returns>
 		public EventStoreClient CreateGrpcClient() {
 			var connectionString = string.IsNullOrWhiteSpace(_options.ConnectionString)
 				? $"esdb://{_options.Host}:{_options.HttpPort}?tls={_options.UseTls}&tlsVerifyCert={_options.TlsValidateServer}"

--- a/src/EventStore.TestClient/Program.cs
+++ b/src/EventStore.TestClient/Program.cs
@@ -29,11 +29,12 @@ namespace EventStore.TestClient {
 		/// <param name="reconnect"></param>
 		/// <param name="useTls"></param>
 		/// <param name="tlsValidateServer"></param>
+		/// <param name="connectionString">A connection string to connect to a node/cluster. Used by gRPC only.</param>
 		/// <returns></returns>
 		public static async Task<int> Main(bool version = false, FileInfo? log = null, bool whatIf = false,
 			string[]? command = null, string host = "localhost", int tcpPort = 1113, int httpPort = 2113,
 			int timeout = Timeout.Infinite, int readWindow = 2000, int writeWindow = 2000, int pingWindow = 2000,
-			bool reconnect = true, bool useTls = false, bool tlsValidateServer = false) {
+			bool reconnect = true, bool useTls = false, bool tlsValidateServer = false, string connectionString = "") {
 			Log.Logger = EventStoreLoggerConfiguration.ConsoleLog;
 
 			try {

--- a/src/EventStore.TestClient/TcpTestClient.cs
+++ b/src/EventStore.TestClient/TcpTestClient.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Threading;
+using EventStore.BufferManagement;
+using EventStore.Common.Utils;
+using EventStore.Core.Services.Transport.Tcp;
+using EventStore.Transport.Tcp;
+using EventStore.Transport.Tcp.Formatting;
+using EventStore.Transport.Tcp.Framing;
+using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.TestClient {
+	public class TcpTestClient {
+		private readonly BufferManager _bufferManager =
+			new BufferManager(TcpConfiguration.BufferChunksCount, TcpConfiguration.SocketBufferSize);
+
+		private readonly TcpClientConnector _connector = new TcpClientConnector();
+
+		private readonly bool _validateServer;
+		private readonly bool _useSsl;
+		private readonly ILogger _log;
+		private readonly bool _interactiveMode;
+		public readonly EndPoint TcpEndpoint;
+		public readonly ClientOptions Options;
+
+		public TcpTestClient(ClientOptions options, bool interactiveMode, ILogger log) {
+			_interactiveMode = interactiveMode;
+			_log = log;
+			_useSsl = options.UseTls;
+			TcpEndpoint = new DnsEndPoint(options.Host, options.TcpPort);
+			_validateServer = options.TlsValidateServer;
+			Options = options;
+		}
+
+		public Connection CreateTcpConnection(CommandProcessorContext context,
+			Action<Connection, TcpPackage> handlePackage,
+			Action<Connection> connectionEstablished = null,
+			Action<Connection, SocketError> connectionClosed = null,
+			bool failContextOnError = true,
+			IPEndPoint tcpEndPoint = null) {
+			var connectionCreatedEvent = new ManualResetEventSlim(false);
+			Connection typedConnection = null;
+
+			Action<ITcpConnection> onConnectionEstablished = conn => {
+				// we execute callback on ThreadPool because on FreeBSD it can be called synchronously
+				// causing deadlock
+				ThreadPool.QueueUserWorkItem(_ => {
+					if (!_interactiveMode)
+						_log.Information(
+							"TcpTypedConnection: connected to [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}].",
+							conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId);
+					if (connectionEstablished != null) {
+						if (!connectionCreatedEvent.Wait(10000))
+							throw new Exception("TcpTypedConnection: creation took too long!");
+						connectionEstablished(typedConnection);
+					}
+				});
+			};
+			Action<ITcpConnection, SocketError> onConnectionFailed = (conn, error) => {
+				_log.Error(
+					"TcpTypedConnection: connection to [{remoteEndPoint}, L{localEndPoint}, {connectionId:B}] failed. Error: {e}.",
+					conn.RemoteEndPoint, conn.LocalEndPoint, conn.ConnectionId, error);
+
+				if (connectionClosed != null)
+					connectionClosed(null, error);
+
+				if (failContextOnError)
+					context.Fail(reason: string.Format("Socket connection failed with error {0}.", error));
+			};
+
+			var endpoint = tcpEndPoint ?? TcpEndpoint;
+			ITcpConnection connection;
+			if (_useSsl) {
+				connection = _connector.ConnectSslTo(
+					Guid.NewGuid(),
+					endpoint.GetHost(),
+					endpoint.ResolveDnsToIPAddress(),
+					TcpConnectionManager.ConnectionTimeout,
+					(cert, chain, err) => (err == SslPolicyErrors.None || !_validateServer, err.ToString()),
+					() => null,
+					onConnectionEstablished,
+					onConnectionFailed,
+					verbose: !_interactiveMode);
+			} else {
+				connection = _connector.ConnectTo(
+					Guid.NewGuid(),
+					endpoint.ResolveDnsToIPAddress(),
+					TcpConnectionManager.ConnectionTimeout,
+					onConnectionEstablished,
+					onConnectionFailed,
+					verbose: !_interactiveMode);
+			}
+
+			typedConnection = new Connection(connection, new RawMessageFormatter(_bufferManager),
+				new LengthPrefixMessageFramer());
+			typedConnection.ConnectionClosed +=
+				(conn, error) => {
+					if (!_interactiveMode || error != SocketError.Success) {
+						_log.Information(
+							"TcpTypedConnection: connection [{remoteEndPoint}, L{localEndPoint}] was closed {status}",
+							conn.RemoteEndPoint, conn.LocalEndPoint,
+							error == SocketError.Success ? "cleanly." : "with error: " + error + ".");
+					}
+
+					if (connectionClosed != null)
+						connectionClosed(conn, error);
+					else
+						_log.Information("connectionClosed callback was null");
+				};
+			connectionCreatedEvent.Set();
+
+			typedConnection.ReceiveAsync(
+				(conn, pkg) => {
+					var package = new TcpPackage();
+					bool validPackage = false;
+					try {
+						package = TcpPackage.FromArraySegment(new ArraySegment<byte>(pkg));
+						validPackage = true;
+
+						if (package.Command == TcpCommand.HeartbeatRequestCommand) {
+							var resp = new TcpPackage(TcpCommand.HeartbeatResponseCommand, Guid.NewGuid(), null);
+							conn.EnqueueSend(resp.AsByteArray());
+							return;
+						}
+
+						handlePackage(conn, package);
+					} catch (Exception ex) {
+						_log.Information(ex,
+							"TcpTypedConnection: [{remoteEndPoint}, L{localEndPoint}] ERROR for {package}. Connection will be closed.",
+							conn.RemoteEndPoint, conn.LocalEndPoint,
+							validPackage ? package.Command as object : "<invalid package>");
+						conn.Close(ex.Message);
+
+						if (failContextOnError)
+							context.Fail(ex);
+					}
+				});
+
+			return typedConnection;
+		}
+	}
+}

--- a/src/EventStore.TestClient/TcpTestClient.cs
+++ b/src/EventStore.TestClient/TcpTestClient.cs
@@ -13,6 +13,9 @@ using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.TestClient {
+	/// <summary>
+	/// The Raw TCP client used by the TestClient commands that don't have a client suffix.
+	/// </summary>
 	public class TcpTestClient {
 		private readonly BufferManager _bufferManager =
 			new BufferManager(TcpConfiguration.BufferChunksCount, TcpConfiguration.SocketBufferSize);
@@ -23,9 +26,21 @@ namespace EventStore.TestClient {
 		private readonly bool _useSsl;
 		private readonly ILogger _log;
 		private readonly bool _interactiveMode;
+		/// <summary>
+		/// The TCP EndPoint for the Event Store server.
+		/// </summary>
 		public readonly EndPoint TcpEndpoint;
+		/// <summary>
+		/// The ClientOptions for the TestClient.
+		/// </summary>
 		public readonly ClientOptions Options;
 
+		/// <summary>
+		/// Creates a Raw Tcp Test Client for a command
+		/// </summary>
+		/// <param name="options">The ClientOptions for the TestClient.</param>
+		/// <param name="interactiveMode">Whether the TestClient is in interactive mode.</param>
+		/// <param name="log"></param>
 		public TcpTestClient(ClientOptions options, bool interactiveMode, ILogger log) {
 			_interactiveMode = interactiveMode;
 			_log = log;
@@ -35,6 +50,17 @@ namespace EventStore.TestClient {
 			Options = options;
 		}
 
+		/// <summary>
+		/// Creates a connection for the command to use for its tests
+		/// </summary>
+		/// <param name="context">The context for this command</param>
+		/// <param name="handlePackage"></param>
+		/// <param name="connectionEstablished"></param>
+		/// <param name="connectionClosed"></param>
+		/// <param name="failContextOnError"></param>
+		/// <param name="tcpEndPoint"></param>
+		/// <returns></returns>
+		/// <exception cref="Exception"></exception>
 		public Connection CreateTcpConnection(CommandProcessorContext context,
 			Action<Connection, TcpPackage> handlePackage,
 			Action<Connection> connectionEstablished = null,


### PR DESCRIPTION
Added: gRPC client to EventStore.TestClient

- Split out `TcpTestClient` and `GrpcTestClient`
- Add `WRFLGRPC` command to perform a write flood against gRPC
- Print out usage on startup
- Add `--connection-string` option to specify gRPC connection string
- Make it possible to set stream prefix when running write flood for gRPC

Example command to run a gRPC write flood:

```
wrflgrpc 10 100000 1000 256 1 foo
```