### PR TITLE
Generalize TF and Index in preparation for LogV3

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -21,6 +21,7 @@ using EventStore.Plugins.Authorization;
 using EventStore.Projections.Core;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using EventStore.Core.LogAbstraction;
 
 namespace EventStore.ClusterNode {
 	internal class ClusterVNodeHostedService : IHostedService, IDisposable {
@@ -67,7 +68,8 @@ namespace EventStore.ClusterNode {
 
 			var plugInContainer = FindPlugins();
 
-			Node = new ClusterVNode(_options, GetAuthenticationProviderFactory(), GetAuthorizationProviderFactory(),
+			var logFormat = LogFormatAbstractor.V2;
+			Node = new ClusterVNode<string>(_options, logFormat, GetAuthenticationProviderFactory(), GetAuthorizationProviderFactory(),
 				GetPersistentSubscriptionConsumerStrategyFactories());
 
 			var runProjections = _options.Projections.RunProjections;

--- a/src/EventStore.Common/Utils/Ensure.cs
+++ b/src/EventStore.Common/Utils/Ensure.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 
 namespace EventStore.Common.Utils {
+	public interface IValidator<T> {
+		void Validate(T t);
+	}
+
 	public static class Ensure {
 		public static void NotNull<T>(T argument, string argumentName) where T : class {
 			if (argument == null)
@@ -53,6 +57,10 @@ namespace EventStore.Common.Utils {
 			if (expected != actual)
 				throw new ArgumentException(string.Format("{0} expected value: {1}, actual value: {2}", argumentName,
 					expected, actual));
+		}
+
+		public static void Valid<T>(T t, IValidator<T> validator) {
+			validator?.Validate(t);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -20,7 +20,10 @@ using System.IO;
 using System.Threading.Tasks;
 
 namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
-	public abstract class MiniNodeWithExistingRecords : SpecificationWithDirectoryPerTestFixture {
+	public abstract class MiniNodeWithExistingRecords : MiniNodeWithExistingRecords<string> {
+	}
+
+	public abstract class MiniNodeWithExistingRecords<TStreamId> : SpecificationWithDirectoryPerTestFixture {
 		private readonly TcpType _tcpType = TcpType.Ssl;
 		protected MiniNode Node;
 
@@ -28,8 +31,8 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 		protected readonly long MetastreamMaxCount = 1;
 		protected readonly bool PerformAdditionalCommitChecks = true;
 		protected readonly byte IndexBitnessVersion = Opts.IndexBitnessVersionDefault;
-		protected TableIndex TableIndex;
-		protected IReadIndex ReadIndex;
+		protected TableIndex<TStreamId> TableIndex;
+		protected IReadIndex<TStreamId> ReadIndex;
 
 		protected TFChunkDb Db;
 		protected TFChunkWriter Writer;
@@ -98,13 +101,17 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 		public abstract void WriteTestScenario();
 		public abstract Task Given();
 
-		protected EventRecord WriteSingleEvent(string eventStreamId,
+		protected EventRecord WriteSingleEvent(TStreamId eventStreamId,
 			long eventNumber,
 			string data,
 			DateTime? timestamp = null,
 			Guid eventId = default(Guid),
 			string eventType = "some-type") {
-			var prepare = LogRecord.SingleWrite(WriterCheckpoint.ReadNonFlushed(),
+
+			var logFormat = LogFormatHelper<TStreamId>.LogFormat;
+			var prepare = LogRecord.SingleWrite(
+				logFormat.RecordFactory,
+				WriterCheckpoint.ReadNonFlushed(),
 				eventId == default(Guid) ? Guid.NewGuid() : eventId,
 				Guid.NewGuid(),
 				eventStreamId,
@@ -119,7 +126,8 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 				eventNumber);
 			Assert.IsTrue(Writer.Write(commit, out pos));
 
-			var eventRecord = new EventRecord(eventNumber, prepare);
+			var streamName = logFormat.StreamNamesFactory.Create().LookupName(prepare.EventStreamId);
+			var eventRecord = new EventRecord(eventNumber, prepare, streamName);
 			return eventRecord;
 		}
 	}

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -6,6 +6,7 @@ using EventStore.Core.Authentication;
 using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Services.Transport.Tcp;
 
@@ -14,10 +15,11 @@ namespace EventStore.Core.Tests.ClientOperations {
 		private ClusterVNode _node;
 		private readonly List<IDisposable> _disposables = new List<IDisposable>();
 		public void CreateTestNode() {
-			_node = new ClusterVNode(new ClusterVNodeOptions()
+			_node = new ClusterVNode<string>(new ClusterVNodeOptions()
 					.RunInMemory()
 					.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 						ssl_connections.GetServerCertificate()),
+				LogFormatAbstractor.V2,
 				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)));
 			_node.StartAsync(true).Wait();

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using EventStore.Core.Authentication;
 using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Authorization;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Tests.Services.Transport.Tcp;
 using NUnit.Framework;
 
@@ -19,7 +20,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 					.RunInMemory()
 					.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 						ssl_connections.GetServerCertificate()));
-			_node = new ClusterVNode(_options,
+			_node = new ClusterVNode<string>(_options, LogFormatAbstractor.V2,
 				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)));
 			_node.Start();
@@ -48,7 +49,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 				.RunInMemory()
 				.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 					ssl_connections.GetServerCertificate()));
-			_node = new ClusterVNode(_options,
+			_node = new ClusterVNode<string>(_options, LogFormatAbstractor.V2,
 				new AuthenticationProviderFactory(_ => new InternalAuthenticationProviderFactory(_)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)));
 			_node.Start();

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_cluster_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_cluster_node_and_custom_settings.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using EventStore.Common.Utils;
+using EventStore.Core.LogAbstraction;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
@@ -37,7 +38,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
 				}
 			}.RunInMemory();
 			try {
-				_ = new ClusterVNode(_options);
+				_ = new ClusterVNode<string>(_options, LogFormatAbstractor.V2);
 			} catch (Exception e) {
 				_caughtException = e;
 			}

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_secure_tcp.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_secure_tcp.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Tests.Services.Transport.Tcp;
 using NUnit.Framework;
 
@@ -104,7 +105,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
 				.WithInternalSecureTcpOn(internalSecTcp)
 				.WithExternalSecureTcpOn(externalSecTcp);
 			try {
-				_ = new ClusterVNode(_options);
+				_ = new ClusterVNode<string>(_options, LogFormatAbstractor.V2);
 			} catch (Exception ex) {
 				_caughtException = ex;
 			}

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/IODispatcherTestHelpers.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/IODispatcherTestHelpers.cs
@@ -3,6 +3,7 @@ using System.Text;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
 using EventStore.Core.Bus;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.TransactionLog.LogRecords;
 using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
 
@@ -10,7 +11,8 @@ namespace EventStore.Core.Tests.Helpers.IODispatcherTests {
 	public static class IODispatcherTestHelpers {
 		public static ResolvedEvent[] CreateResolvedEvent(string streamId, string eventType, string data,
 			string metadata = "", long eventNumber = 0) {
-			var record = new EventRecord(eventNumber, LogRecord.Prepare(0, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+			var recordFactory = LogFormatAbstractor.V2.RecordFactory;
+			var record = new EventRecord(eventNumber, LogRecord.Prepare(recordFactory, 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				streamId, eventNumber, PrepareFlags.None, eventType, Encoding.UTF8.GetBytes(data),
 				Encoding.UTF8.GetBytes(metadata)));
 			return new ResolvedEvent[] {

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -12,6 +12,7 @@ using EventStore.Core.Authentication;
 using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Authorization;
 using EventStore.Core.Bus;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Monitoring;
 using EventStore.Core.Tests.Http;
@@ -167,7 +168,7 @@ namespace EventStore.Core.Tests.Helpers {
 				ExternalTcpEndPoint, "ExHTTP ENDPOINT:",
 				HttpEndPoint);
 
-			Node = new ClusterVNode(options, new AuthenticationProviderFactory(components =>
+			Node = new ClusterVNode<string>(options, LogFormatAbstractor.V2, new AuthenticationProviderFactory(components =>
 					new InternalAuthenticationProviderFactory(components)),
 				new AuthorizationProviderFactory(components =>
 					new LegacyAuthorizationProviderFactory(components.MainQueue)),
@@ -185,7 +186,7 @@ namespace EventStore.Core.Tests.Helpers {
 								ClientCertificateMode = ClientCertificateMode.AllowCertificate,
 								ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => {
 									var (isValid, error) =
-										ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(certificate, chain, sslPolicyErrors, () => trustedRootCertificates);
+										ClusterVNode<string>.ValidateClientCertificateWithTrustedRootCerts(certificate, chain, sslPolicyErrors, () => trustedRootCertificates);
 									if (!isValid && error != null) {
 										Log.Error("Client certificate validation error: {e}", error);
 									}

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -20,6 +20,7 @@ using EventStore.Core.Messages;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.TestHost;
 using ILogger = Serilog.ILogger;
+using EventStore.Core.LogAbstraction;
 
 namespace EventStore.Core.Tests.Helpers {
 	public class MiniNode {
@@ -143,7 +144,7 @@ namespace EventStore.Core.Tests.Helpers {
 				"TCP ENDPOINT:", TcpEndPoint,
 				"HTTP ENDPOINT:", HttpEndPoint);
 
-			Node = new ClusterVNode(options,
+			Node = new ClusterVNode<string>(options, LogFormatAbstractor.V2,
 				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)));
 			Db = Node.Db;

--- a/src/EventStore.Core.Tests/IIndexReaderExtensions.cs
+++ b/src/EventStore.Core.Tests/IIndexReaderExtensions.cs
@@ -1,0 +1,14 @@
+﻿using EventStore.Core.Services.Storage.ReaderIndex;
+
+namespace EventStore.Core.Tests {
+	public static class IIndexReaderExtensions {
+		public static IndexReadEventResult ReadEvent(this IIndexReader<string> index, string streamName, long eventNumber) =>
+			index.ReadEvent(streamName, streamName, eventNumber);
+
+		public static IndexReadStreamResult ReadStreamEventsBackward(this IIndexReader<string> index, string streamName, long fromEventNumber, int maxCount) =>
+			index.ReadStreamEventsBackward(streamName, streamName, fromEventNumber, maxCount);
+
+		public static IndexReadStreamResult ReadStreamEventsForward(this IIndexReader<string> index, string streamName, long fromEventNumber, int maxCount) =>
+			index.ReadStreamEventsForward(streamName, streamName, fromEventNumber, maxCount);
+	}
+}

--- a/src/EventStore.Core.Tests/IReadIndexExtensions.cs
+++ b/src/EventStore.Core.Tests/IReadIndexExtensions.cs
@@ -1,0 +1,14 @@
+﻿using EventStore.Core.Services.Storage.ReaderIndex;
+
+namespace EventStore.Core.Tests {
+	public static class IReadIndexExtensions {
+		public static IndexReadEventResult ReadEvent(this IReadIndex<string> index, string streamName, long eventNumber) =>
+			index.ReadEvent(streamName, streamName, eventNumber);
+
+		public static IndexReadStreamResult ReadStreamEventsBackward(this IReadIndex<string> index, string streamName, long fromEventNumber, int maxCount) =>
+			index.ReadStreamEventsBackward(streamName, streamName, fromEventNumber, maxCount);
+
+		public static IndexReadStreamResult ReadStreamEventsForward(this IReadIndex<string> index, string streamName, long fromEventNumber, int maxCount) =>
+			index.ReadStreamEventsForward(streamName, streamName, fromEventNumber, maxCount);
+	}
+}

--- a/src/EventStore.Core.Tests/Index/FakeIndexHasher.cs
+++ b/src/EventStore.Core.Tests/Index/FakeIndexHasher.cs
@@ -2,7 +2,7 @@
 using System;
 
 namespace EventStore.Core.Tests.Index {
-	public class FakeIndexHasher : IHasher {
+	public class FakeIndexHasher : IHasher<string> {
 		public uint Hash(byte[] data) {
 			return (uint)data.Length;
 		}

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_on_range_query.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_on_range_query.cs
@@ -15,9 +15,9 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 	[TestFixture(PTableVersions.IndexV4, false)]
 	[TestFixture(PTableVersions.IndexV4, true)]
 	public class table_index_on_range_query : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		protected byte _ptableVersion = PTableVersions.IndexV1;
 		private bool _skipIndexVerify;
 
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(PathName, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(PathName, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(version: _ptableVersion, maxSize: 40),
 				() => { throw new InvalidOperationException(); },
 				_ptableVersion,

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_on_try_get_one_value_query.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_on_try_get_one_value_query.cs
@@ -16,9 +16,9 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 	[TestFixture(PTableVersions.IndexV4, false)]
 	[TestFixture(PTableVersions.IndexV4, true)]
 	public class table_index_on_try_get_one_value_query : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		protected byte _ptableVersion = PTableVersions.IndexV1;
 		private bool _skipIndexVerify;
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var fakeReader = new TFReaderLease(new FakeTfReader());
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(_ptableVersion, maxSize: 10),
 				() => fakeReader,
 				_ptableVersion,

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_should.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 	[TestFixture(PTableVersions.IndexV4, false)]
 	[TestFixture(PTableVersions.IndexV4, true)]
 	public class table_index_should : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
+		private TableIndex<string> _tableIndex;
 		protected byte _ptableVersion = PTableVersions.IndexV1;
 		private bool _skipIndexVerify;
 
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			await base.TestFixtureSetUp();
 			var lowHasher = new XXHashUnsafe();
 			var highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(PathName, lowHasher, highHasher,
+			_tableIndex = new TableIndex<string>(PathName, lowHasher, highHasher, "",
 				() => new HashListMemTable(_ptableVersion, maxSize: 20),
 				() => { throw new InvalidOperationException(); },
 				_ptableVersion,

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_with_corrupt_index_entries_should.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_with_corrupt_index_entries_should.cs
@@ -13,7 +13,7 @@ using EventStore.Core.Exceptions;
 namespace EventStore.Core.Tests.Index.IndexV1 {
 	[TestFixture]
 	public class table_index_with_corrupt_index_entries_should : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
+		private TableIndex<string> _tableIndex;
 		private IndexMap _indexMap;
 		public const string StreamName = "stream";
 		public const int NumIndexEntries = 512;
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var highHasher = new Murmur3AUnsafe();
 			var fakeReader = new TFReaderLease(new FakeIndexReader());
 
-			_tableIndex = new TableIndex(PathName, lowHasher, highHasher,
+			_tableIndex = new TableIndex<string>(PathName, lowHasher, highHasher, "",
 				() => new HashListMemTable(version, maxSize: NumIndexEntries),
 				() => fakeReader,
 				version,
@@ -65,7 +65,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			}
 
 			//load table index again
-			_tableIndex = new TableIndex(PathName, lowHasher, highHasher,
+			_tableIndex = new TableIndex<string>(PathName, lowHasher, highHasher, "",
 				() => new HashListMemTable(version, maxSize: NumIndexEntries),
 				() => fakeReader,
 				version,

--- a/src/EventStore.Core.Tests/Index/IndexV1/table_index_with_two_ptables_and_memtable_on_range_query.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/table_index_with_two_ptables_and_memtable_on_range_query.cs
@@ -17,9 +17,9 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 	[TestFixture(PTableVersions.IndexV4, false), Category("LongRunning")]
 	[TestFixture(PTableVersions.IndexV4, true), Category("LongRunning")]
 	public class table_index_with_two_ptables_and_memtable_on_range_query : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		protected byte _ptableVersion = PTableVersions.IndexV1;
 		private bool _skipIndexVerify;
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			var fakeReader = new TFReaderLease(new FakeIndexReader());
 			_lowHasher = new FakeIndexHasher();
 			_highHasher = new FakeIndexHasher();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(_ptableVersion, maxSize: 10),
 				() => fakeReader,
 				_ptableVersion,

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_merging_four_ptables.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_merging_four_ptables.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 		private readonly List<PTable> _tables = new List<PTable>();
 		private PTable _newtable;
 		protected byte _ptableVersion = PTableVersions.IndexV1;
-		private IHasher hasher;
+		private IHasher<string> hasher;
 
 		private bool _skipIndexVerify;
 

--- a/src/EventStore.Core.Tests/Index/IndexV1/when_merging_ptables.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_merging_ptables.cs
@@ -215,7 +215,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			SpecificationWithDirectoryPerTestFixture {
 		private readonly List<string> _files = new List<string>();
 		private readonly List<PTable> _tables = new List<PTable>();
-		private IHasher hasher;
+		private IHasher<string> hasher;
 
 		private PTable _newtable;
 		private bool _skipIndexVerify;
@@ -290,7 +290,7 @@ namespace EventStore.Core.Tests.Index.IndexV1 {
 			SpecificationWithDirectoryPerTestFixture {
 		private readonly List<string> _files = new List<string>();
 		private readonly List<PTable> _tables = new List<PTable>();
-		private IHasher hasher;
+		private IHasher<string> hasher;
 
 		private PTable _newtable;
 		private bool _skipIndexVerify;

--- a/src/EventStore.Core.Tests/Index/IndexV2/table_index_hash_collision_when_upgrading_to_64bit.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/table_index_hash_collision_when_upgrading_to_64bit.cs
@@ -14,9 +14,9 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 	[TestFixture(0, 10)]
 	[TestFixture(10, 10)]
 	public class table_index_hash_collision_when_upgrading_to_64bit : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		protected byte _ptableVersion;
 		private int _extraStreamHashesAtBeginning;
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 			var fakeReader = new TFReaderLease(new FakeIndexReader());
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV1, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV1,
@@ -64,7 +64,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 
 			_tableIndex.Close(false);
 
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(_ptableVersion, maxSize: 5),
 				() => fakeReader,
 				_ptableVersion,

--- a/src/EventStore.Core.Tests/Index/IndexV2/table_index_when_merging_upgrading_to_64bit_if_entry_doesnt_exist_drops_entry_and_carries_on.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/table_index_when_merging_upgrading_to_64bit_if_entry_doesnt_exist_drops_entry_and_carries_on.cs
@@ -14,9 +14,9 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 	public class
 		table_index_when_merging_upgrading_to_64bit_if_single_stream_entry_doesnt_exist_drops_entry_and_carries_on :
 			SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		protected byte _ptableVersion;
 
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 			var fakeReader = new TFReaderLease(new FakeIndexReader2());
 			_lowHasher = new ByLengthHasher();
 			_highHasher = new ByLengthHasher();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV1, maxSize: 3),
 				() => fakeReader,
 				PTableVersions.IndexV1,
@@ -53,7 +53,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 
 			_tableIndex.Close(false);
 
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(_ptableVersion, maxSize: 3),
 				() => fakeReader,
 				_ptableVersion,

--- a/src/EventStore.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
@@ -10,9 +10,9 @@ using EventStore.Core.TransactionLog.LogRecords;
 namespace EventStore.Core.Tests.Index.IndexV3 {
 	[TestFixture, Category("LongRunning")]
 	public class when_upgrading_index_to_64bit_stream_version : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		protected byte _ptableVersion;
 
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Index.IndexV3 {
 			var fakeReader = new TFReaderLease(new FakeIndexReader());
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV2, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV2,
@@ -45,7 +45,7 @@ namespace EventStore.Core.Tests.Index.IndexV3 {
 
 			_tableIndex.Close(false);
 
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(_ptableVersion, maxSize: 5),
 				() => fakeReader,
 				_ptableVersion,

--- a/src/EventStore.Core.Tests/Index/IndexV4/when_merging_ptables_vx_to_v4.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV4/when_merging_ptables_vx_to_v4.cs
@@ -143,7 +143,7 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 	public class when_merging_to_ptable_v4_with_deleted_entries_from_v1 : SpecificationWithDirectoryPerTestFixture {
 		private readonly List<string> _files = new List<string>();
 		private readonly List<PTable> _tables = new List<PTable>();
-		private IHasher hasher;
+		private IHasher<string> hasher;
 		private string _newtableFile;
 
 		private PTable _newtable;
@@ -256,7 +256,7 @@ namespace EventStore.Core.Tests.Index.IndexV4 {
 	public class when_merging_to_ptable_v4_with_deleted_entries : SpecificationWithDirectoryPerTestFixture {
 		private readonly List<string> _files = new List<string>();
 		private readonly List<PTable> _tables = new List<PTable>();
-		private IHasher hasher;
+		private IHasher<string> hasher;
 		private string _newtableFile;
 
 		private PTable _newtable;

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index.cs
@@ -13,9 +13,9 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 	[TestFixture(false)]
 	[TestFixture(true)]
 	class when_scavenging_a_table_index : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		private FakeTFScavengerLog _log;
 		private static readonly long[] Deleted = { 200, 300, 500 };
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
@@ -58,7 +58,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			// Check it's loadable.
 			_tableIndex.Close(false);
 
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_and_another_table_is_completed_during.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_and_another_table_is_completed_during.cs
@@ -14,9 +14,9 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 	[TestFixture]
 	class
 		when_scavenging_a_table_index_and_another_table_is_completed_during : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		private FakeTFScavengerLog _log;
 
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
@@ -70,7 +70,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			// Check it's loadable.
 			_tableIndex.Close(false);
 
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_scavenging_table.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_scavenging_table.cs
@@ -12,9 +12,9 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Index.Scavenge {
 	[TestFixture]
 	class when_scavenging_a_table_index_cancelled_while_scavenging_table : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		private FakeTFScavengerLog _log;
 
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
@@ -58,7 +58,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			// Check it's loadable still.
 			_tableIndex.Close(false);
 
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_waiting_for_lock.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_cancelled_while_waiting_for_lock.cs
@@ -12,9 +12,9 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Index.Scavenge {
 	[TestFixture]
 	class when_scavenging_a_table_index_cancelled_while_waiting_for_lock : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		private FakeTFScavengerLog _log;
 
@@ -27,7 +27,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			var fakeReader = new TFReaderLease(new FakeIndexReader());
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,
@@ -54,7 +54,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			// Check it's loadable still.
 			_tableIndex.Close(false);
 
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_fails.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_table_index_fails.cs
@@ -13,9 +13,9 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Index.Scavenge {
 	[TestFixture]
 	class when_scavenging_a_table_index_fails : SpecificationWithDirectoryPerTestFixture {
-		private TableIndex _tableIndex;
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private TableIndex<string> _tableIndex;
+		private IHasher<string> _lowHasher;
+		private IHasher<string> _highHasher;
 		private string _indexDir;
 		private FakeTFScavengerLog _log;
 
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			var fakeReader = new TFReaderLease(new FakeIndexReader());
 			_lowHasher = new XXHashUnsafe();
 			_highHasher = new Murmur3AUnsafe();
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => throw new Exception("Expected exception") /* throw an exception when the first PTable scavenge starts and tries to acquire a reader */,
 				PTableVersions.IndexV4,
@@ -51,7 +51,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 			// Check it's loadable still.
 			_tableIndex.Close(false);
 
-			_tableIndex = new TableIndex(_indexDir, _lowHasher, _highHasher,
+			_tableIndex = new TableIndex<string>(_indexDir, _lowHasher, _highHasher, "",
 				() => new HashListMemTable(PTableVersions.IndexV4, maxSize: 5),
 				() => fakeReader,
 				PTableVersions.IndexV4,

--- a/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_v1_index.cs
+++ b/src/EventStore.Core.Tests/Index/Scavenge/when_scavenging_a_v1_index.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.Index.Scavenge {
 	[TestFixture(PTableVersions.IndexV4, false)]
 	[TestFixture(PTableVersions.IndexV4, true)]
 	public class when_scavenging_a_v1_index : SpecificationWithDirectoryPerTestFixture {
-		private IHasher hasher;
+		private IHasher<string> hasher;
 
 		private PTable _newtable;
 		private readonly byte _newVersion;

--- a/src/EventStore.Core.Tests/LogFormatHelper.cs
+++ b/src/EventStore.Core.Tests/LogFormatHelper.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using EventStore.Core.LogAbstraction;
+
+namespace EventStore.Core.Tests {
+	// thing that can choose between a V2 or V3 implementation according to the
+	// TStreamId type parameter. Handy for tests; don't write anything like this in the main code.
+	internal static class LogFormatHelper<TStreamId> {
+		public static T WhenV2<T>(object v2) =>
+			typeof(TStreamId) == typeof(string) ? (T)v2 : throw new NotImplementedException();
+
+		public static T Choose<T>(object v2, object v3) =>
+			typeof(TStreamId) == typeof(string) ? (T)v2 : (T)v3;
+
+		public static LogFormatAbstractor<TStreamId> LogFormat { get; } =
+			WhenV2<LogFormatAbstractor<TStreamId>>(LogFormatAbstractor.V2);
+	}
+}
+		

--- a/src/EventStore.Core.Tests/Services/IndexCommitter/when_constructing_index_committer_service.cs
+++ b/src/EventStore.Core.Tests/Services/IndexCommitter/when_constructing_index_committer_service.cs
@@ -14,41 +14,41 @@ namespace EventStore.Core.Tests.Services.IndexCommitter {
 		protected ICheckpoint ReplicationCheckpoint = new InMemoryCheckpoint(0);
 		protected ICheckpoint WriterCheckpoint = new InMemoryCheckpoint(0);
 		protected InMemoryBus Publisher = new InMemoryBus("publisher");
-		protected FakeIndexCommitter IndexCommitter = new FakeIndexCommitter();
-		protected ITableIndex TableIndex = new FakeTableIndex();
+		protected FakeIndexCommitter<string> IndexCommitter = new FakeIndexCommitter<string>();
+		protected ITableIndex TableIndex = new FakeTableIndex<string>();
 		private readonly QueueStatsManager _queueStatsManager = new QueueStatsManager();
 
 		[Test]
 		public void null_index_committer_throws_argument_null_exception() {
-			Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(null, Publisher,
+			Assert.Throws<ArgumentNullException>(() => new IndexCommitterService<string>(null, Publisher,
 				 WriterCheckpoint, ReplicationCheckpoint, CommitCount, TableIndex, _queueStatsManager));
 		}
 
 		[Test]
 		public void null_publisher_throws_argument_null_exception() {
-			Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(IndexCommitter, null,
+			Assert.Throws<ArgumentNullException>(() => new IndexCommitterService<string>(IndexCommitter, null,
 				 WriterCheckpoint, ReplicationCheckpoint, CommitCount, TableIndex, _queueStatsManager));
 		}
 
 		[Test]
 		public void null_writer_checkpoint_throws_argument_null_exception() {
-			Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(IndexCommitter, Publisher,
+			Assert.Throws<ArgumentNullException>(() => new IndexCommitterService<string>(IndexCommitter, Publisher,
 				 null, ReplicationCheckpoint, CommitCount, TableIndex, _queueStatsManager));
 		}
 		[Test]
 		public void null_replication_checkpoint_throws_argument_null_exception() {
-			Assert.Throws<ArgumentNullException>(() => new IndexCommitterService(IndexCommitter, Publisher,
+			Assert.Throws<ArgumentNullException>(() => new IndexCommitterService<string>(IndexCommitter, Publisher,
 				 WriterCheckpoint, null, CommitCount, TableIndex, _queueStatsManager));
 		}
 		[Test]
 		public void commit_count_of_zero_throws_argument_out_of_range_exception() {
-			Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(IndexCommitter, Publisher,
+			Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService<string>(IndexCommitter, Publisher,
 				 WriterCheckpoint, ReplicationCheckpoint, 0, TableIndex, _queueStatsManager));
 		}
 
 		[Test]
 		public void negative_commit_count_throws_argument_out_of_range_exception() {
-			Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService(IndexCommitter, Publisher,
+			Assert.Throws<ArgumentOutOfRangeException>(() => new IndexCommitterService<string>(IndexCommitter, Publisher,
 				 WriterCheckpoint, ReplicationCheckpoint, -1, TableIndex, _queueStatsManager));
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/Storage/ByLengthHasher.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ByLengthHasher.cs
@@ -2,7 +2,7 @@ using System;
 using EventStore.Core.Index.Hashes;
 
 namespace EventStore.Core.Tests.Services.Storage {
-	public class ByLengthHasher : IHasher {
+	public class ByLengthHasher : IHasher<string> {
 		public uint Hash(string s) {
 			return (uint)s.Length;
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/with_storage_chaser_service.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/with_storage_chaser_service.cs
@@ -12,7 +12,10 @@ using EventStore.Core.TransactionLog.FileNamingStrategy;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Storage.Chaser {
-	public abstract class with_storage_chaser_service : SpecificationWithDirectoryPerTestFixture {
+	public abstract class with_storage_chaser_service : with_storage_chaser_service<string> {
+	}
+
+	public abstract class with_storage_chaser_service<TStreamId> : SpecificationWithDirectoryPerTestFixture {
 		readonly ICheckpoint _writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
 		readonly ICheckpoint _chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
 		readonly ICheckpoint _epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
@@ -22,8 +25,8 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 		readonly ICheckpoint _indexCheckpoint = new InMemoryCheckpoint(-1);
 
 		protected InMemoryBus Publisher = new InMemoryBus("publisher");
-		protected StorageChaser Service;
-		protected FakeIndexCommitterService IndexCommitter;
+		protected StorageChaser<TStreamId> Service;
+		protected FakeIndexCommitterService<TStreamId> IndexCommitter;
 		protected IEpochManager EpochManager;
 		protected TFChunkDb Db;
 		protected TFChunkChaser Chaser;
@@ -42,10 +45,10 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 			Writer = new TFChunkWriter(Db);
 			Writer.Open();
 
-			IndexCommitter = new FakeIndexCommitterService();
+			IndexCommitter = new FakeIndexCommitterService<TStreamId>();
 			EpochManager = new FakeEpochManager();
 
-			Service = new StorageChaser(
+			Service = new StorageChaser<TStreamId>(
 				Publisher,
 				_writerChk,
 				Chaser,

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_and_committing_one.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_and_committing_one.cs
@@ -5,9 +5,9 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 	[TestFixture]
 	public class when_writing_few_prepares_and_committing_one : ReadIndexTestScenario {
-		private PrepareLogRecord _prepare0;
-		private PrepareLogRecord _prepare1;
-		private PrepareLogRecord _prepare2;
+		private IPrepareLogRecord _prepare0;
+		private IPrepareLogRecord _prepare1;
+		private IPrepareLogRecord _prepare2;
 
 		protected override void WriteTestScenario() {
 			_prepare0 = WritePrepare("ES", expectedVersion: -1);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs
@@ -6,9 +6,9 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 	[TestFixture]
 	public class
 		when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them : ReadIndexTestScenario {
-		private PrepareLogRecord _prepare0;
-		private PrepareLogRecord _prepare1;
-		private PrepareLogRecord _prepare2;
+		private IPrepareLogRecord _prepare0;
+		private IPrepareLogRecord _prepare1;
+		private IPrepareLogRecord _prepare2;
 
 		protected override void WriteTestScenario() {
 			_prepare0 = WritePrepare("ES", expectedVersion: -1);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs
@@ -5,9 +5,9 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 	[TestFixture]
 	public class when_writing_few_prepares_with_same_expected_version_and_not_committing_them : ReadIndexTestScenario {
-		private PrepareLogRecord _prepare0;
-		private PrepareLogRecord _prepare1;
-		private PrepareLogRecord _prepare2;
+		private IPrepareLogRecord _prepare0;
+		private IPrepareLogRecord _prepare1;
+		private IPrepareLogRecord _prepare2;
 
 		protected override void WriteTestScenario() {
 			_prepare0 = WritePrepare("ES", -1);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs
@@ -5,11 +5,11 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 	[TestFixture]
 	public class when_writing_prepares_in_wrong_order_and_committing_in_right_order : ReadIndexTestScenario {
-		private PrepareLogRecord _prepare0;
-		private PrepareLogRecord _prepare1;
-		private PrepareLogRecord _prepare2;
-		private PrepareLogRecord _prepare3;
-		private PrepareLogRecord _prepare4;
+		private IPrepareLogRecord _prepare0;
+		private IPrepareLogRecord _prepare1;
+		private IPrepareLogRecord _prepare2;
+		private IPrepareLogRecord _prepare3;
+		private IPrepareLogRecord _prepare4;
 
 		protected override void WriteTestScenario() {
 			_prepare0 = WritePrepare("ES", expectedVersion: -1);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_single_prepare.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_single_prepare.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 	[TestFixture]
 	public class when_writing_single_prepare : ReadIndexTestScenario {
-		private PrepareLogRecord _prepare;
+		private IPrepareLogRecord _prepare;
 
 		protected override void WriteTestScenario() {
 			_prepare = WritePrepare("ES", -1);

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_hard_deleting_stream_with_log_version_0.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_hard_deleting_stream_with_log_version_0.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 		[Test]
 		public void should_change_expected_version_to_deleted_event_number_when_reading() {
 			var chunk = Db.Manager.GetChunk(0);
-			var chunkRecords = new List<LogRecord>();
+			var chunkRecords = new List<ILogRecord>();
 			RecordReadResult result = chunk.TryReadFirst();
 			while (result.Success) {
 				chunkRecords.Add(result.LogRecord);

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_delete_prepare_but_no_commit_read_index_should.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_delete_prepare_but_no_commit_read_index_should.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 		protected override void WriteTestScenario() {
 			_event0 = WriteSingleEvent("ES", 0, "bla1");
 
-			var prepare = LogRecord.DeleteTombstone(WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(),
+			var prepare = LogRecord.DeleteTombstone(_recordFactory, WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(),
 				"ES", 1);
 			long pos;
 			Assert.IsTrue(Writer.Write(prepare, out pos));

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_few_prepares_on_same_event_number_and_commiting_delete_on_this_version_read_index_should.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_few_prepares_on_same_event_number_and_commiting_delete_on_this_version_read_index_should.cs
@@ -16,7 +16,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 		protected override void WriteTestScenario() {
 			long pos;
 
-			var prepare1 = LogRecord.SingleWrite(WriterCheckpoint.ReadNonFlushed(), // prepare1
+			var prepare1 = LogRecord.SingleWrite(_recordFactory, WriterCheckpoint.ReadNonFlushed(), // prepare1
 				Guid.NewGuid(),
 				Guid.NewGuid(),
 				"ES",
@@ -27,7 +27,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 				DateTime.UtcNow);
 			Assert.IsTrue(Writer.Write(prepare1, out pos));
 
-			var prepare2 = LogRecord.SingleWrite(WriterCheckpoint.ReadNonFlushed(), // prepare2
+			var prepare2 = LogRecord.SingleWrite(_recordFactory, WriterCheckpoint.ReadNonFlushed(), // prepare2
 				Guid.NewGuid(),
 				Guid.NewGuid(),
 				"ES",
@@ -39,12 +39,12 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 			Assert.IsTrue(Writer.Write(prepare2, out pos));
 
 
-			var deletePrepare = LogRecord.DeleteTombstone(WriterCheckpoint.ReadNonFlushed(), // delete prepare
+			var deletePrepare = LogRecord.DeleteTombstone(_recordFactory, WriterCheckpoint.ReadNonFlushed(), // delete prepare
 				Guid.NewGuid(), Guid.NewGuid(), "ES", -1);
 			_deleteTombstone = new EventRecord(EventNumber.DeletedStream, deletePrepare);
 			Assert.IsTrue(Writer.Write(deletePrepare, out pos));
 
-			var prepare3 = LogRecord.SingleWrite(WriterCheckpoint.ReadNonFlushed(), // prepare3
+			var prepare3 = LogRecord.SingleWrite(_recordFactory, WriterCheckpoint.ReadNonFlushed(), // prepare3
 				Guid.NewGuid(),
 				Guid.NewGuid(),
 				"ES",

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
+using EventStore.Core.LogV2;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.TransactionLog;
@@ -42,6 +43,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				new LogV2RecordFactory(),
 				_instanceId);
 		}
 		private LinkedList<EpochRecord> GetCache(EpochManager manager) {

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
+using EventStore.Core.LogV2;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.TransactionLog;
@@ -41,6 +42,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				new LogV2RecordFactory(),
 				_instanceId);
 		}
 		private LinkedList<EpochRecord> GetCache(EpochManager manager) {

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs - Copy.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs - Copy.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
+using EventStore.Core.LogV2;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.TransactionLog;
@@ -42,6 +43,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				new LogV2RecordFactory(),
 				_instanceId);
 		}
 		private LinkedList<EpochRecord> GetCache(EpochManager manager) {
@@ -105,6 +107,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				new LogV2RecordFactory(),
 				_instanceId);
 			_epochManager.Init();
 			_cache = GetCache(_epochManager);

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_no_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_no_epochs.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
+using EventStore.Core.LogV2;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.TransactionLog;
@@ -42,6 +43,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				new LogV2RecordFactory(),
 				_instanceId);
 		}
 		private LinkedList<EpochRecord> GetCache(EpochManager manager) {

--- a/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTFReader.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTFReader.cs
@@ -5,7 +5,7 @@ using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.Tests.Services.Storage {
 	public class FakeInMemoryTfReader : ITransactionFileReader {
-		private Dictionary<long, LogRecord> _records = new Dictionary<long, LogRecord>();
+		private Dictionary<long, ILogRecord> _records = new Dictionary<long, ILogRecord>();
 		private long _curPosition = 0;
 		private int _recordOffset;
 
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			_recordOffset = recordOffset;
 		}
 
-		public void AddRecord(LogRecord record, long position){
+		public void AddRecord(ILogRecord record, long position){
 			_records.Add(position, record);
 		}
 

--- a/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
@@ -5,25 +5,24 @@ using System.Threading.Tasks;
 using EventStore.Core.Index;
 
 namespace EventStore.Core.Tests.Services.Storage {
-	public class FakeInMemoryTableIndex : ITableIndex
-	{
+	public class FakeInMemoryTableIndex<TStreamId> : ITableIndex<TStreamId> {
 		public long CommitCheckpoint => throw new NotImplementedException();
 
 		public long PrepareCheckpoint => throw new NotImplementedException();
 
 		public bool IsBackgroundTaskRunning => throw new NotImplementedException();
 
-		private Dictionary<string, List<IndexKey> > _indexEntries = new Dictionary<string, List<IndexKey> >();
-		public void Add(long commitPos, string streamId, long version, long position)
+		private Dictionary<TStreamId, List<IndexKey<TStreamId>> > _indexEntries = new Dictionary<TStreamId, List<IndexKey<TStreamId>> >();
+		public void Add(long commitPos, TStreamId streamId, long version, long position)
 		{
 			throw new NotImplementedException();
 		}
 
-		public void AddEntries(long commitPos, IList<IndexKey> entries)
+		public void AddEntries(long commitPos, IList<IndexKey<TStreamId>> entries)
 		{
 			foreach(var entry in entries){
 				if(!_indexEntries.ContainsKey(entry.StreamId))
-					_indexEntries[entry.StreamId] = new List<IndexKey>();
+					_indexEntries[entry.StreamId] = new List<IndexKey<TStreamId>>();
 				_indexEntries[entry.StreamId].Add(entry);
 			}
 		}
@@ -32,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		{
 		}
 
-		public IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null)
+		public IEnumerable<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion, int? limit = null)
 		{
 			var entries = new List<IndexEntry>();
 			if(_indexEntries.ContainsKey(streamId)){
@@ -58,7 +57,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			throw new NotImplementedException();
 		}
 
-		public bool TryGetLatestEntry(string streamId, out IndexEntry entry)
+		public bool TryGetLatestEntry(TStreamId streamId, out IndexEntry entry)
 		{
 			if(_indexEntries.ContainsKey(streamId)){
 				var entries = _indexEntries[streamId];
@@ -72,12 +71,12 @@ namespace EventStore.Core.Tests.Services.Storage {
 			}
 		}
 
-		public bool TryGetOldestEntry(string streamId, out IndexEntry entry)
+		public bool TryGetOldestEntry(TStreamId streamId, out IndexEntry entry)
 		{
 			throw new NotImplementedException();
 		}
 
-		public bool TryGetOneValue(string streamId, long version, out long position)
+		public bool TryGetOneValue(TStreamId streamId, long version, out long position)
 		{
 			throw new NotImplementedException();
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/FakeIndexCommitterService.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeIndexCommitterService.cs
@@ -7,9 +7,9 @@ using EventStore.Core.Services.Storage;
 using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.Tests.Services.Storage {
-	public class FakeIndexCommitterService : IIndexCommitterService {
+	public class FakeIndexCommitterService<TStreamId> : IIndexCommitterService<TStreamId> {
 		public Dictionary<Guid, Transaction> Transactions = new Dictionary<Guid, Transaction>();
-		public List<LogRecord> Records = new List<LogRecord>();
+		public List<ILogRecord> Records = new List<ILogRecord>();
 		public long PostPosition;
 		public void AddPendingCommit(CommitLogRecord commit, long postPosition) {
 			if (commit == null)
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			PostPosition = postPosition;
 		}
 
-		public void AddPendingPrepare(PrepareLogRecord[] prepares, long postPosition) {
+		public void AddPendingPrepare(IPrepareLogRecord<TStreamId>[] prepares, long postPosition) {
 			if (prepares == null)
 				throw new InvalidOperationException("Cannot commit a null transaction");
 			if (prepares.Length <= 0)
@@ -53,17 +53,17 @@ namespace EventStore.Core.Tests.Services.Storage {
 			public Guid Id { get; }
 			public bool IsCommitted => Commit != null;
 			public CommitLogRecord Commit { get; private set; }
-			public ReadOnlyCollection<PrepareLogRecord> Prepares => _prepares.AsReadOnly();
-			private List<PrepareLogRecord> _prepares = new List<PrepareLogRecord>();
+			public ReadOnlyCollection<IPrepareLogRecord<TStreamId>> Prepares => _prepares.AsReadOnly();
+			private List<IPrepareLogRecord<TStreamId>> _prepares = new List<IPrepareLogRecord<TStreamId>>();
 
-			public Transaction(Guid id, ICollection<PrepareLogRecord> prepares = null) {
+			public Transaction(Guid id, ICollection<IPrepareLogRecord<TStreamId>> prepares = null) {
 				Id = id;
 				if (prepares != null) { AddPrepares(prepares); }
 			}
 			public void CommitTransaction(CommitLogRecord commit) {
 				Commit = commit;
 			}
-			public void AddPrepares(ICollection<PrepareLogRecord> prepares) {
+			public void AddPrepares(ICollection<IPrepareLogRecord<TStreamId>> prepares) {
 				if (IsCommitted) { throw new InvalidOperationException("Cannot add data to a committed transation"); }
 				_prepares.AddRange(prepares);
 			}

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using EventStore.Core.Index;
 
 namespace EventStore.Core.Tests.Services.Storage {
-	public class FakeTableIndex : ITableIndex {
+	public class FakeTableIndex<TStreamId> : ITableIndex<TStreamId> {
 		internal static readonly IndexEntry InvalidIndexEntry = new IndexEntry(0, -1, -1);
 		public int ScavengeCount { get; private set; }
 
@@ -23,30 +23,30 @@ namespace EventStore.Core.Tests.Services.Storage {
 		public void Close(bool removeFiles = true) {
 		}
 
-		public void Add(long commitPos, string streamId, long version, long position) {
+		public void Add(long commitPos, TStreamId streamId, long version, long position) {
 			throw new NotImplementedException();
 		}
 
-		public void AddEntries(long commitPos, IList<IndexKey> entries) {
+		public void AddEntries(long commitPos, IList<IndexKey<TStreamId>> entries) {
 			throw new NotImplementedException();
 		}
 
-		public bool TryGetOneValue(string streamId, long version, out long position) {
+		public bool TryGetOneValue(TStreamId streamId, long version, out long position) {
 			position = -1;
 			return false;
 		}
 
-		public bool TryGetLatestEntry(string streamId, out IndexEntry entry) {
+		public bool TryGetLatestEntry(TStreamId streamId, out IndexEntry entry) {
 			entry = InvalidIndexEntry;
 			return false;
 		}
 
-		public bool TryGetOldestEntry(string streamId, out IndexEntry entry) {
+		public bool TryGetOldestEntry(TStreamId streamId, out IndexEntry entry) {
 			entry = InvalidIndexEntry;
 			return false;
 		}
 
-		public IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion,
+		public IEnumerable<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion,
 			int? limit = null) {
 			yield break;
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_deleting_single_stream_spanning_through_2_chunks_in_2nd_chunk__in_db_with_3_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_deleting_single_stream_spanning_through_2_chunks_in_2nd_chunk__in_db_with_3_chunks.cs
@@ -9,7 +9,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 	public class
 		when_deleting_single_stream_spanning_through_2_chunks_in_2nd_chunk_in_db_with_3_chunks : ReadIndexTestScenario {
 		private EventRecord _event7;
-		private PrepareLogRecord _event7prepare;
+		private IPrepareLogRecord<string> _event7prepare;
 		private CommitLogRecord _event7commit;
 
 		private EventRecord _event9;

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
@@ -6,18 +6,18 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 	[TestFixture]
 	public class when_having_commit_spanning_multiple_chunks : ReadIndexTestScenario {
-		private List<LogRecord> _survivors;
-		private List<LogRecord> _scavenged;
+		private List<ILogRecord> _survivors;
+		private List<ILogRecord> _scavenged;
 
 		protected override void WriteTestScenario() {
-			_survivors = new List<LogRecord>();
-			_scavenged = new List<LogRecord>();
+			_survivors = new List<ILogRecord>();
+			_scavenged = new List<ILogRecord>();
 
 			var transPos = WriterCheckpoint.ReadNonFlushed();
 
 			for (int i = 0; i < 10; ++i) {
 				long tmp;
-				var r = LogRecord.Prepare(WriterCheckpoint.ReadNonFlushed(),
+				var r = LogRecord.Prepare(_recordFactory, WriterCheckpoint.ReadNonFlushed(),
 					Guid.NewGuid(),
 					Guid.NewGuid(),
 					transPos,

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				new[] {
 					dbResult.Recs[0][0],

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
@@ -55,7 +55,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		[Test]
 		public void should_have_updated_deleted_stream_event_number() {
 			var chunk = Db.Manager.GetChunk(0);
-			var chunkRecords = new List<LogRecord>();
+			var chunkRecords = new List<ILogRecord>();
 			RecordReadResult result = chunk.TryReadFirst();
 			while (result.Success) {
 				chunkRecords.Add(result.LogRecord);
@@ -72,7 +72,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		[Test]
 		public void the_log_records_are_still_version_0() {
 			var chunk = Db.Manager.GetChunk(0);
-			var chunkRecords = new List<LogRecord>();
+			var chunkRecords = new List<ILogRecord>();
 			RecordReadResult result = chunk.TryReadFirst();
 			while (result.Success) {
 				chunkRecords.Add(result.LogRecord);

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
@@ -101,7 +101,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		public void the_log_records_are_still_version_0_in_first_chunk() {
 			var chunk = Db.Manager.GetChunk(0);
 
-			var chunkRecords = new List<LogRecord>();
+			var chunkRecords = new List<ILogRecord>();
 			RecordReadResult result = chunk.TryReadFirst();
 			while (result.Success) {
 				chunkRecords.Add(result.LogRecord);
@@ -116,7 +116,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		public void the_log_records_are_unchanged_in_second_chunk() {
 			var chunk = Db.Manager.GetChunk(1);
 
-			var chunkRecords = new List<LogRecord>();
+			var chunkRecords = new List<ILogRecord>();
 			RecordReadResult result = chunk.TryReadFirst();
 			while (result.Success) {
 				chunkRecords.Add(result.LogRecord);

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_and_all_events_and_metaevents_are_in_one_chunk.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_and_all_events_and_metaevents_are_in_one_chunk.cs
@@ -23,8 +23,8 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
-			return new[] {new LogRecord[0]};
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
+			return new[] {new ILogRecord[0]};
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_but_some_events_are_in_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_but_some_events_are_in_multiple_chunks.cs
@@ -20,9 +20,9 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
-				new LogRecord[0],
+				new ILogRecord[0],
 				new[] {
 					dbResult.Recs[1][0],
 					dbResult.Recs[1][1],

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_but_some_metaevents_are_in_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_but_some_metaevents_are_in_multiple_chunks.cs
@@ -22,9 +22,9 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
-				new LogRecord[0],
+				new ILogRecord[0],
 				new[] {
 					dbResult.Recs[1][2],
 					dbResult.Recs[1][3],

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_with_log_version_0_but_some_events_are_in_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_and_temp_with_log_version_0_but_some_events_are_in_multiple_chunks.cs
@@ -27,9 +27,9 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
-				new LogRecord[0],
+				new ILogRecord[0],
 				new[] {
 					dbResult.Recs[1][0],
 					dbResult.Recs[1][1],

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_with_log_record_version_0.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_with_log_record_version_0.cs
@@ -25,8 +25,8 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
-			return new[] {new LogRecord[0]};
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
+			return new[] {new ILogRecord[0]};
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_stream_is_softdeleted_with_mixed_log_record_version_0_and_version_1.cs
@@ -35,7 +35,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				new[] {
 					dbResult.Recs[0][2],

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_writing_delete_prepare_without_commit_on_stream_spanning_through_2_chunks_in_db_with_2_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_writing_delete_prepare_without_commit_on_stream_spanning_through_2_chunks_in_db_with_2_chunks.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		protected override void WriteTestScenario() {
 			_event0 = WriteSingleEvent("ES", 0, "bla1");
 
-			var prepare = LogRecord.DeleteTombstone(WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(),
+			var prepare = LogRecord.DeleteTombstone(_recordFactory, WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(),
 				"ES", 2);
 			long pos;
 			Assert.IsTrue(Writer.Write(prepare, out pos));

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -15,11 +15,17 @@ using EventStore.Core.Util;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Storage {
+	public abstract class SimpleDbTestScenario : SimpleDbTestScenario<string> {
+		protected SimpleDbTestScenario(int maxEntriesInMemTable = 20, long metastreamMaxCount = 1) 
+			: base(maxEntriesInMemTable, metastreamMaxCount) {
+		}
+	}
+
 	[TestFixture]
-	public abstract class SimpleDbTestScenario : SpecificationWithDirectoryPerTestFixture {
+	public abstract class SimpleDbTestScenario<TStreamId> : SpecificationWithDirectoryPerTestFixture {
 		protected readonly int MaxEntriesInMemTable;
-		protected TableIndex TableIndex;
-		protected IReadIndex ReadIndex;
+		protected TableIndex<TStreamId> TableIndex;
+		protected IReadIndex<TStreamId> ReadIndex;
 
 		protected DbResult DbRes;
 
@@ -45,12 +51,14 @@ namespace EventStore.Core.Tests.Services.Storage {
 			DbRes.Db.Config.ChaserCheckpoint.Write(DbRes.Db.Config.WriterCheckpoint.Read());
 			DbRes.Db.Config.ChaserCheckpoint.Flush();
 
+			var logFormat = LogFormatHelper<TStreamId>.LogFormat;
 			var readers = new ObjectPool<ITransactionFileReader>(
 				"Readers", 2, 2, () => new TFChunkReader(DbRes.Db, DbRes.Db.Config.WriterCheckpoint));
 
-			var lowHasher = new XXHashUnsafe();
-			var highHasher = new Murmur3AUnsafe();
-			TableIndex = new TableIndex(GetFilePathFor("index"), lowHasher, highHasher,
+			var lowHasher = logFormat.LowHasher;
+			var highHasher = logFormat.HighHasher;
+			var emptyStreamId = logFormat.EmptyStreamId;
+			TableIndex = new TableIndex<TStreamId>(GetFilePathFor("index"), lowHasher, highHasher, emptyStreamId,
 				() => new HashListMemTable(PTableVersions.IndexV2, MaxEntriesInMemTable * 2),
 				() => new TFReaderLease(readers),
 				PTableVersions.IndexV2,
@@ -58,9 +66,15 @@ namespace EventStore.Core.Tests.Services.Storage {
 				Constants.PTableMaxReaderCountDefault,
 				MaxEntriesInMemTable);
 
-			ReadIndex = new ReadIndex(new NoopPublisher(),
+			ReadIndex = new ReadIndex<TStreamId>(new NoopPublisher(),
 				readers,
 				TableIndex,
+				logFormat.StreamIds,
+				logFormat.StreamNamesFactory,
+				logFormat.SystemStreams,
+				logFormat.EmptyStreamId,
+				logFormat.StreamIdValidator,
+				logFormat.StreamIdSizer,
 				0,
 				additionalCommitChecks: true,
 				metastreamMaxCount: _metastreamMaxCount,
@@ -69,7 +83,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				replicationCheckpoint: DbRes.Db.Config.ReplicationCheckpoint,
 				indexCheckpoint: DbRes.Db.Config.IndexCheckpoint);
 
-			((ReadIndex)ReadIndex).IndexCommitter.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
+			((ReadIndex<TStreamId>)ReadIndex).IndexCommitter.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
 		}
 
 		public override Task TestFixtureTearDown() {

--- a/src/EventStore.Core.Tests/Services/Storage/Transactions/when_having_two_intermingled_transactions_and_some_uncommited_prepares_in_the_end_read_index_should.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Transactions/when_having_two_intermingled_transactions_and_some_uncommited_prepares_in_the_end_read_index_should.cs
@@ -42,13 +42,13 @@ namespace EventStore.Core.Tests.Services.Storage.Transactions {
 			_t1CommitPos = WriteCommit(t1.CorrelationId, t1.TransactionPosition, t1.EventStreamId, _p1.EventNumber);
 
 			_pos6 = Db.Config.WriterCheckpoint.ReadNonFlushed();
-			var r6 = LogRecord.Prepare(_pos6, Guid.NewGuid(), Guid.NewGuid(), _pos6, 0, "t1", -1,
+			var r6 = LogRecord.Prepare(_recordFactory, _pos6, Guid.NewGuid(), Guid.NewGuid(), _pos6, 0, "t1", -1,
 				PrepareFlags.SingleWrite, "et", LogRecord.NoData, LogRecord.NoData);
 			Writer.Write(r6, out _pos7);
-			var r7 = LogRecord.Prepare(_pos7, Guid.NewGuid(), Guid.NewGuid(), _pos7, 0, "t1", -1,
+			var r7 = LogRecord.Prepare(_recordFactory, _pos7, Guid.NewGuid(), Guid.NewGuid(), _pos7, 0, "t1", -1,
 				PrepareFlags.SingleWrite, "et", LogRecord.NoData, LogRecord.NoData);
 			Writer.Write(r7, out _pos8);
-			var r8 = LogRecord.Prepare(_pos8, Guid.NewGuid(), Guid.NewGuid(), _pos8, 0, "t1", -1,
+			var r8 = LogRecord.Prepare(_recordFactory, _pos8, Guid.NewGuid(), Guid.NewGuid(), _pos8, 0, "t1", -1,
 				PrepareFlags.SingleWrite, "et", LogRecord.NoData, LogRecord.NoData);
 			long pos9;
 			Writer.Write(r8, out pos9);

--- a/src/EventStore.Core.Tests/Services/Storage/Transactions/when_having_two_intermingled_transactions_and_some_uncommited_prepares_spanning_few_chunks_read_index_should.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Transactions/when_having_two_intermingled_transactions_and_some_uncommited_prepares_spanning_few_chunks_read_index_should.cs
@@ -42,13 +42,13 @@ namespace EventStore.Core.Tests.Services.Storage.Transactions {
 			_t1CommitPos = WriteCommit(t1.CorrelationId, t1.TransactionPosition, t1.EventStreamId, _p1.EventNumber);
 
 			_pos6 = Db.Config.WriterCheckpoint.ReadNonFlushed();
-			var r6 = LogRecord.Prepare(_pos6, Guid.NewGuid(), Guid.NewGuid(), _pos6, 0, "t1", -1,
+			var r6 = LogRecord.Prepare(_recordFactory, _pos6, Guid.NewGuid(), Guid.NewGuid(), _pos6, 0, "t1", -1,
 				PrepareFlags.SingleWrite, "et", LogRecord.NoData, LogRecord.NoData);
 			Writer.Write(r6, out _pos7);
-			var r7 = LogRecord.Prepare(_pos7, Guid.NewGuid(), Guid.NewGuid(), _pos7, 0, "t1", -1,
+			var r7 = LogRecord.Prepare(_recordFactory, _pos7, Guid.NewGuid(), Guid.NewGuid(), _pos7, 0, "t1", -1,
 				PrepareFlags.SingleWrite, "et", LogRecord.NoData, LogRecord.NoData);
 			Writer.Write(r7, out _pos8);
-			var r8 = LogRecord.Prepare(_pos8, Guid.NewGuid(), Guid.NewGuid(), _pos8, 0, "t1", -1,
+			var r8 = LogRecord.Prepare(_recordFactory, _pos8, Guid.NewGuid(), Guid.NewGuid(), _pos8, 0, "t1", -1,
 				PrepareFlags.SingleWrite, "et", LogRecord.NoData, LogRecord.NoData);
 			long pos9;
 			Writer.Write(r8, out pos9);

--- a/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.DataStructures;
 using EventStore.Core.Index;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -15,14 +17,19 @@ namespace EventStore.Core.Tests.Services.Storage {
 	public abstract class WriteEventsToIndexScenario {
 		protected InMemoryBus _publisher;
 		protected ITransactionFileReader _tfReader;
-		protected ITableIndex _tableIndex;
-		protected IIndexBackend _indexBackend;
-		protected IIndexReader _indexReader;
-		protected IIndexWriter _indexWriter;
-		protected IIndexCommitter _indexCommitter;
+		protected ITableIndex<string> _tableIndex;
+		protected IIndexBackend<string> _indexBackend;
+		protected IStreamIdLookup<string> _streamIds;
+		protected IStreamNameLookup<string> _streamNames;
+		protected ISystemStreamLookup<string> _systemStreams;
+		protected IValidator<string> _validator;
+		protected ISizer<string> _sizer;
+		protected IIndexReader<string> _indexReader;
+		protected IIndexWriter<string> _indexWriter;
+		protected IIndexCommitter<string> _indexCommitter;
 		protected ObjectPool<ITransactionFileReader> _readerPool;
 		protected const int RecordOffset = 1000;
-		public IList<PrepareLogRecord> CreatePrepareLogRecord(string stream, int expectedVersion, string eventType, Guid eventId, long transactionPosition){
+		public IList<IPrepareLogRecord<string>> CreatePrepareLogRecord(string stream, int expectedVersion, string eventType, Guid eventId, long transactionPosition){
 			return new PrepareLogRecord[]{
 				new PrepareLogRecord (
 					transactionPosition,
@@ -41,7 +48,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			};
 		}
 
-		public IList<PrepareLogRecord> CreatePrepareLogRecords(string stream, int expectedVersion, IList<string> eventTypes, IList<Guid> eventIds, long transactionPosition){
+		public IList<IPrepareLogRecord<string>> CreatePrepareLogRecords(string stream, int expectedVersion, IList<string> eventTypes, IList<Guid> eventIds, long transactionPosition){
 			if(eventIds.Count != eventTypes.Count)
 				throw new Exception("eventType and eventIds length mismatch!");
 			if(eventIds.Count == 0)
@@ -51,7 +58,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 
 			var numEvents = eventTypes.Count;
 
-			var prepares = new List<PrepareLogRecord>();
+			var prepares = new List<IPrepareLogRecord<string>>();
 			for(var i=0;i<numEvents;i++){
 				PrepareFlags flags = PrepareFlags.Data | PrepareFlags.IsCommitted;
 				if(i==0) flags |= PrepareFlags.TransactionBegin;
@@ -82,7 +89,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			return new CommitLogRecord (logPosition, Guid.NewGuid(), transactionPosition, DateTime.Now, 0);
 		}
 
-		public void WriteToDB(IList<PrepareLogRecord> prepares){
+		public void WriteToDB(IList<IPrepareLogRecord<string>> prepares){
 			foreach(var prepare in prepares){
 				((FakeInMemoryTfReader)_tfReader).AddRecord(prepare, prepare.LogPosition);
 			}
@@ -92,7 +99,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			((FakeInMemoryTfReader)_tfReader).AddRecord(commit, commit.LogPosition);
 		}
 
-		public void PreCommitToIndex(IList<PrepareLogRecord> prepares){
+		public void PreCommitToIndex(IList<IPrepareLogRecord<string>> prepares){
 			_indexWriter.PreCommit(prepares);
 		}
 
@@ -100,7 +107,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			_indexWriter.PreCommit(commitLogRecord);
 		}
 
-		public void CommitToIndex(IList<PrepareLogRecord> prepares){
+		public void CommitToIndex(IList<IPrepareLogRecord<string>> prepares){
 			_indexCommitter.Commit(prepares, false, false);
 		}
 
@@ -114,14 +121,21 @@ namespace EventStore.Core.Tests.Services.Storage {
 		public virtual void TestFixtureSetUp() {
 			_publisher = new InMemoryBus("publisher");
 			_tfReader = new FakeInMemoryTfReader(RecordOffset);
-			_tableIndex = new FakeInMemoryTableIndex();
+			_tableIndex = new FakeInMemoryTableIndex<string>();
 			_readerPool = new ObjectPool<ITransactionFileReader>(
 				"ReadIndex readers pool", 5, 100,
 				() => _tfReader);
-			_indexBackend = new IndexBackend(_readerPool, 100000, 100000);
-			_indexReader = new IndexReader(_indexBackend, _tableIndex, new StreamMetadata(maxCount: 100000), 100, false);
-			_indexWriter = new IndexWriter(_indexBackend, _indexReader);
-			_indexCommitter = new Core.Services.Storage.ReaderIndex.IndexCommitter(_publisher, _indexBackend, _indexReader, _tableIndex, new InMemoryCheckpoint(-1),  false);
+			_indexBackend = new IndexBackend<string>(_readerPool, 100000, 100000);
+			var logFormat = LogFormatAbstractor.V2;
+			_streamIds = logFormat.StreamIds;
+			_streamNames = logFormat.StreamNamesFactory.Create();
+			_systemStreams = logFormat.SystemStreams;
+			_validator = logFormat.StreamIdValidator;
+			var emptyStreamId = logFormat.EmptyStreamId;
+			_sizer = logFormat.StreamIdSizer;
+			_indexReader = new IndexReader<string>(_indexBackend, _tableIndex, _systemStreams, _validator, new StreamMetadata(maxCount: 100000), 100, false);
+			_indexWriter = new IndexWriter<string>(_indexBackend, _indexReader, _streamIds, _streamNames, _systemStreams, emptyStreamId, _sizer);
+			_indexCommitter = new Core.Services.Storage.ReaderIndex.IndexCommitter<string>(_publisher, _indexBackend, _indexReader, _tableIndex, _streamNames, _systemStreams, new InMemoryCheckpoint(-1),  false);
 
 			WriteEvents();
 		}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -60,12 +60,12 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 			bootstrap?.Invoke(_service);
 			_server = new TestServer(
 				new WebHostBuilder()
-					.UseStartup(new ClusterVNodeStartup(Array.Empty<ISubsystem>(), queue, _bus, _multiQueuedHandler,
+					.UseStartup(new ClusterVNodeStartup<string>(Array.Empty<ISubsystem>(), queue, _bus, _multiQueuedHandler,
 						new TestAuthenticationProvider(),
 						new IHttpAuthenticationProvider[] {
 							new BasicHttpAuthenticationProvider(new TestAuthenticationProvider()),
 							new AnonymousHttpAuthenticationProvider(),
-						}, new TestAuthorizationProvider(), new FakeReadIndex(_ => false), 1024 * 1024, _service)));
+						}, new TestAuthorizationProvider(), new FakeReadIndex<string>(_ => false), 1024 * 1024, _service)));
 			_httpMessageHandler = _server.CreateHandler();
 			_client = new HttpAsyncClient(_timeout, _httpMessageHandler);
 			

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -10,6 +10,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using System.Text;
 using EventStore.Core.Authentication.InternalAuthentication;
+using EventStore.Core.LogV2;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services;
@@ -489,11 +490,11 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 
 		private EventRecord CreateDeletedEventRecord() {
 			return new EventRecord(long.MaxValue,
-				LogRecord.DeleteTombstone(0, Guid.NewGuid(), Guid.NewGuid(), "test-stream", long.MaxValue));
+				LogRecord.DeleteTombstone(new LogV2RecordFactory(), 0, Guid.NewGuid(), Guid.NewGuid(), "test-stream", long.MaxValue));
 		}
 
 		private EventRecord CreateLinkEventRecord() {
-			return new EventRecord(0, LogRecord.Prepare(100, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+			return new EventRecord(0, LogRecord.Prepare(new LogV2RecordFactory(), 100, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				"link-stream", -1, PrepareFlags.SingleWrite | PrepareFlags.Data, SystemEventTypes.LinkTo,
 				Encoding.UTF8.GetBytes(string.Format("{0}@test-stream", long.MaxValue)), new byte[0]));
 		}

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
@@ -70,7 +70,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			var listener = new TcpServerListener(serverEndPoint);
 			listener.StartListening((endPoint, socket) => {
 				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, () => serverCertificate,
-					(cert, chain, err) => validateClientCertificate ? ClusterVNode.ValidateClientCertificateWithTrustedRootCerts(cert, chain, err, () => rootCertificates) : (true, null),
+					(cert, chain, err) => validateClientCertificate ? ClusterVNode<string>.ValidateClientCertificateWithTrustedRootCerts(cert, chain, err, () => rootCertificates) : (true, null),
 					verbose: true);
 				ssl.ConnectionClosed += (x, y) => done.Set();
 				if (ssl.IsClosed)
@@ -99,7 +99,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				Guid.NewGuid(),
 				serverEndPoint.GetHost(),
 				serverEndPoint,
-				(cert, chain, err) => validateServerCertificate ? ClusterVNode.ValidateServerCertificateWithTrustedRootCerts(cert, chain, err, () => rootCertificates) : (true, null),
+				(cert, chain, err) => validateServerCertificate ? ClusterVNode<string>.ValidateServerCertificateWithTrustedRootCerts(cert, chain, err, () => rootCertificates) : (true, null),
 				() => new X509CertificateCollection{clientCertificate},
 				new TcpClientConnector(),
 				TcpConnectionManager.ConnectionTimeout,

--- a/src/EventStore.Core.Tests/TransactionLog/FakeReadIndex.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/FakeReadIndex.cs
@@ -4,24 +4,28 @@ using System.Security.Claims;
 using EventStore.ClientAPI.Common;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Util;
 
 namespace EventStore.Core.Tests.TransactionLog {
-	internal class FakeReadIndex : IReadIndex {
+	internal class FakeReadIndex<TStreamId> : IReadIndex<TStreamId> {
+		private readonly ISystemStreamLookup<TStreamId> _systemStreams =
+			LogFormatHelper<TStreamId>.LogFormat.SystemStreams;
+
 		public long LastIndexedPosition {
 			get { throw new NotImplementedException(); }
 		}
 		
-		public IIndexWriter IndexWriter {
+		public IIndexWriter<TStreamId> IndexWriter {
 			get { throw new NotImplementedException(); }
 		}
 
-		private readonly Func<string, bool> _isStreamDeleted;
+		private readonly Func<TStreamId, bool> _isStreamDeleted;
 
-		public FakeReadIndex(Func<string, bool> isStreamDeleted) {
+		public FakeReadIndex(Func<TStreamId, bool> isStreamDeleted) {
 			Ensure.NotNull(isStreamDeleted, "isStreamDeleted");
 			_isStreamDeleted = isStreamDeleted;
 		}
@@ -34,7 +38,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			throw new NotImplementedException();
 		}
 
-		public void Commit(IList<PrepareLogRecord> commitedPrepares) {
+		public void Commit(IList<IPrepareLogRecord<TStreamId>> commitedPrepares) {
 			throw new NotImplementedException();
 		}
 
@@ -42,15 +46,15 @@ namespace EventStore.Core.Tests.TransactionLog {
 			throw new NotImplementedException();
 		}
 
-		public IndexReadEventResult ReadEvent(string streamId, long eventNumber) {
+		public IndexReadEventResult ReadEvent(string streamName, TStreamId streamId, long eventNumber) {
 			throw new NotImplementedException();
 		}
 
-		public IndexReadStreamResult ReadStreamEventsBackward(string streamId, long fromEventNumber, int maxCount) {
+		public IndexReadStreamResult ReadStreamEventsBackward(string streamName, TStreamId streamId, long fromEventNumber, int maxCount) {
 			throw new NotImplementedException();
 		}
 
-		public IndexReadStreamResult ReadStreamEventsForward(string streamId, long fromEventNumber, int maxCount) {
+		public IndexReadStreamResult ReadStreamEventsForward(string streamName, TStreamId streamId, long fromEventNumber, int maxCount) {
 			throw new NotImplementedException();
 		}
 
@@ -72,29 +76,37 @@ namespace EventStore.Core.Tests.TransactionLog {
 			throw new NotImplementedException();
 		}
 
-		public bool IsStreamDeleted(string streamId) {
+		public bool IsStreamDeleted(TStreamId streamId) {
 			return _isStreamDeleted(streamId);
 		}
 
-		public long GetStreamLastEventNumber(string streamId) {
-			if (SystemStreams.IsMetastream(streamId))
-				return GetStreamLastEventNumber(SystemStreams.OriginalStreamOf(streamId));
+		public long GetStreamLastEventNumber(TStreamId streamId) {
+			if (_systemStreams.IsMetaStream(streamId))
+				return GetStreamLastEventNumber(_systemStreams.OriginalStreamOf(streamId));
 			return _isStreamDeleted(streamId) ? EventNumber.DeletedStream : 1000000;
 		}
 
-		public StorageMessage.EffectiveAcl GetEffectiveAcl(string streamId) {
+		public StorageMessage.EffectiveAcl GetEffectiveAcl(TStreamId streamId) {
 			throw new NotImplementedException();
 		}
 
-		public string GetEventStreamIdByTransactionId(long transactionId) {
+		public TStreamId GetEventStreamIdByTransactionId(long transactionId) {
 			throw new NotImplementedException();
 		}
 
-		public StreamAccess CheckStreamAccess(string streamId, StreamAccessType streamAccessType, ClaimsPrincipal user) {
+		public StreamAccess CheckStreamAccess(TStreamId streamId, StreamAccessType streamAccessType, ClaimsPrincipal user) {
 			throw new NotImplementedException();
 		}
 
-		public StreamMetadata GetStreamMetadata(string streamId) {
+		public StreamMetadata GetStreamMetadata(TStreamId streamId) {
+			throw new NotImplementedException();
+		}
+
+		public TStreamId GetStreamId(string streamName) {
+			throw new NotImplementedException();
+		}
+
+		public string GetStreamName(TStreamId streamId) {
 			throw new NotImplementedException();
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_deleted_stream_with_a_lot_of_data_is_scavenged.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_deleted_stream_with_a_lot_of_data_is_scavenged.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new[] {8, 9}.Contains(i)).ToArray(),
 			};
@@ -56,7 +56,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new int[] { }.Contains(i)).ToArray(),
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_deleted_stream_with_explicit_transaction_is_scavenged.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_deleted_stream_with_explicit_transaction_is_scavenged.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new[] {7, 8}.Contains(i)).ToArray(),
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_deleted_stream_with_metadata_is_scavenged.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_deleted_stream_with_metadata_is_scavenged.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => i >= 3).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_nothing_to_scavenge.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_nothing_to_scavenge.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return dbResult.Recs;
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_both_max_age_and_max_count_with_stricted_max_age_specified.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_both_max_age_and_max_count_with_stricted_max_age_specified.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new[] {0, 1, 11, 12, 13, 14}.Contains(i)).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_both_max_age_and_max_count_with_stricted_max_count_specified.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_both_max_age_and_max_count_with_stricted_max_count_specified.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new[] {0, 1, 11, 12, 13, 14}.Contains(i)).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_max_age_specified.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_max_age_specified.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new[] {0, 1, 11, 12, 13, 14}.Contains(i)).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_max_count_specified.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_max_count_specified.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new[] {0, 1, 11, 12, 13, 14}.Contains(i)).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_start_from_specified.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_start_from_specified.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new[] {0, 1, 11, 12, 13, 14}.Contains(i)).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_strict_max_age_leaving_no_events_in_stream.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_having_stream_with_strict_max_age_leaving_no_events_in_stream.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => new[] {0, 1, 7, 8}.Contains(i)).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_metastream_is_scavenged_and_read_index_is_set_to_keep_just_last_metaevent.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_metastream_is_scavenged_and_read_index_is_set_to_keep_just_last_metaevent.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => i >= 3).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_metastream_is_scavenged_and_read_index_is_set_to_keep_last_3_metaevents.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_metastream_is_scavenged_and_read_index_is_set_to_keep_last_3_metaevents.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				dbResult.Recs[0].Where((x, i) => i >= 2).ToArray()
 			};

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_stream_is_deleted.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_stream_is_deleted.cs
@@ -14,9 +14,9 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
-				new LogRecord[0],
+				new ILogRecord[0],
 				dbResult.Recs[1]
 			};
 		}
@@ -41,10 +41,10 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
-				new LogRecord[0],
-				new LogRecord[0]
+				new ILogRecord[0],
+				new ILogRecord[0]
 			};
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_stream_is_deleted_and_bulk_transaction_spans_chunks_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_stream_is_deleted_and_bulk_transaction_spans_chunks_boundary.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				new[] {dbResult.Recs[0][2]}, // first prepare in commit that is in different chunk
 				dbResult.Recs[1].Where((x, i) => i >= 3).ToArray(),

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_stream_is_deleted_and_explicit_transaction_spans_chunks_boundary.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_stream_is_deleted_and_explicit_transaction_spans_chunks_boundary.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 				.CreateDb();
 		}
 
-		protected override LogRecord[][] KeptRecords(DbResult dbResult) {
+		protected override ILogRecord[][] KeptRecords(DbResult dbResult) {
 			return new[] {
 				new[] {dbResult.Recs[0][2]},
 				new[] {dbResult.Recs[1][6]}, // commit

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateScenario.cs
@@ -4,7 +4,13 @@ using EventStore.Core.Tests.Services.Storage;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core.Tests.TransactionLog.Truncation {
-	public abstract class TruncateScenario : ReadIndexTestScenario {
+	public abstract class TruncateScenario : TruncateScenario<string> {
+		protected TruncateScenario(int maxEntriesInMemTable = 100, int metastreamMaxCount = 1)
+			: base(maxEntriesInMemTable, metastreamMaxCount) {
+		}
+	}
+
+	public abstract class TruncateScenario<TStreamId> : ReadIndexTestScenario<TStreamId> {
 		protected TFChunkDbTruncator Truncator;
 		protected long TruncateCheckpoint = long.MinValue;
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			var chaser = new TFChunkChaser(db, writerchk, new InMemoryCheckpoint(), false);
 			chaser.Open();
 
-			LogRecord record;
+			ILogRecord record;
 			Assert.IsFalse(chaser.TryReadNext(out record));
 
 			chaser.Close();
@@ -44,7 +44,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			var chaser = new TFChunkChaser(db, writerchk, chaserchk, false);
 			chaser.Open();
 
-			LogRecord record;
+			ILogRecord record;
 			Assert.IsFalse(chaser.TryReadNext(out record));
 			Assert.AreEqual(12, chaserchk.Read());
 
@@ -86,7 +86,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			var chaser = new TFChunkChaser(db, writerchk, chaserchk, false);
 			chaser.Open();
 
-			LogRecord record;
+			ILogRecord record;
 			var recordRead = chaser.TryReadNext(out record);
 			chaser.Close();
 
@@ -129,7 +129,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			var reader = new TFChunkChaser(db, writerchk, chaserchk, false);
 			reader.Open();
 
-			LogRecord record;
+			ILogRecord record;
 			var readRecord = reader.TryReadNext(out record);
 			reader.Close();
 
@@ -170,7 +170,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			var chaser = new TFChunkChaser(db, writerchk, chaserchk, false);
 			chaser.Open();
 
-			LogRecord record;
+			ILogRecord record;
 			var readRecord = chaser.TryReadNext(out record);
 			chaser.Close();
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.LogV2;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Services.Storage;
 using EventStore.Core.Tests.Fakes;
@@ -23,7 +25,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		private TFChunkDb _db;
 		private TFChunk _scavengedChunk;
 		private int _originalFileSize;
-		private PrepareLogRecord _p1, _p2, _p3;
+		private IPrepareLogRecord _p1, _p2, _p3;
 		private CommitLogRecord _c1, _c2, _c3;
 		private RecordWriteResult _res1, _res2, _res3;
 		private RecordWriteResult _cres1, _cres2, _cres3;
@@ -36,14 +38,14 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var chunk = _db.Manager.GetChunkFor(0);
 
-			_p1 = LogRecord.SingleWrite(0, Guid.NewGuid(), Guid.NewGuid(), "es-to-scavenge", ExpectedVersion.Any, "et1",
+			_p1 = LogRecord.SingleWrite(new LogV2RecordFactory(), 0, Guid.NewGuid(), Guid.NewGuid(), "es-to-scavenge", ExpectedVersion.Any, "et1",
 				new byte[2048], new byte[] { 5, 7 });
 			_res1 = chunk.TryAppend(_p1);
 
 			_c1 = LogRecord.Commit(_res1.NewPosition, Guid.NewGuid(), _p1.LogPosition, 0);
 			_cres1 = chunk.TryAppend(_c1);
 
-			_p2 = LogRecord.SingleWrite(_cres1.NewPosition,
+			_p2 = LogRecord.SingleWrite(new LogV2RecordFactory(), _cres1.NewPosition,
 				Guid.NewGuid(), Guid.NewGuid(), "es-to-scavenge", ExpectedVersion.Any, "et1",
 				new byte[2048], new byte[] { 5, 7 });
 			_res2 = chunk.TryAppend(_p2);
@@ -51,7 +53,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_c2 = LogRecord.Commit(_res2.NewPosition, Guid.NewGuid(), _p2.LogPosition, 1);
 			_cres2 = chunk.TryAppend(_c2);
 
-			_p3 = LogRecord.SingleWrite(_cres2.NewPosition,
+			_p3 = LogRecord.SingleWrite(new LogV2RecordFactory(), _cres2.NewPosition,
 				Guid.NewGuid(), Guid.NewGuid(), "es-to-scavenge", ExpectedVersion.Any, "et1",
 				new byte[2048], new byte[] { 5, 7 });
 			_res3 = chunk.TryAppend(_p3);
@@ -67,8 +69,9 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_db.Config.ChaserCheckpoint.Write(chunk.ChunkHeader.ChunkEndPosition);
 			_db.Config.ChaserCheckpoint.Flush();
 
-			var scavenger = new TFChunkScavenger(_db, new FakeTFScavengerLog(), new FakeTableIndex(),
-				new FakeReadIndex(x => x == "es-to-scavenge"));
+			var scavenger = new TFChunkScavenger<string>(_db, new FakeTFScavengerLog(), new FakeTableIndex<string>(),
+				new FakeReadIndex<string>(x => x == "es-to-scavenge"),
+				LogFormatAbstractor.V2.SystemStreams);
 			await scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);
 
 			_scavengedChunk = _db.Manager.GetChunk(0);
@@ -136,7 +139,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void sequencial_read_returns_no_records() {
-			var records = new List<LogRecord>();
+			var records = new List<ILogRecord>();
 			RecordReadResult res = _scavengedChunk.TryReadFirst();
 			while (res.Success) {
 				records.Add(res.LogRecord);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
+using EventStore.Core.LogV2;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
@@ -14,7 +15,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		private const int RecordsCount = 8;
 
 		private TFChunkDb _db;
-		private LogRecord[] _records;
+		private ILogRecord[] _records;
 		private RecordWriteResult[] _results;
 
 		public override async Task TestFixtureSetUp() {
@@ -24,7 +25,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var chunk = _db.Manager.GetChunk(0);
 
-			_records = new LogRecord[RecordsCount];
+			_records = new ILogRecord[RecordsCount];
 			_results = new RecordWriteResult[RecordsCount];
 
 			var pos = 0;
@@ -35,7 +36,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 					chunk = _db.Manager.AddNewChunk();
 				}
 
-				_records[i] = LogRecord.SingleWrite(pos,
+				_records[i] = LogRecord.SingleWrite(new LogV2RecordFactory(), pos,
 					Guid.NewGuid(), Guid.NewGuid(), "es1", ExpectedVersion.Any, "et1",
 					new byte[1200], new byte[] { 5, 7 });
 				_results[i] = chunk.TryAppend(_records[i]);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_an_empty_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_an_empty_chunked_transaction_log.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using EventStore.Core.LogV2;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -37,7 +38,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			Assert.IsFalse(reader.TryReadNext().Success);
 
-			var rec = LogRecord.SingleWrite(0, Guid.NewGuid(), Guid.NewGuid(), "ES", -1, "ET", new byte[] {7}, null);
+			var rec = LogRecord.SingleWrite(new LogV2RecordFactory(), 0, Guid.NewGuid(), Guid.NewGuid(), "ES", -1, "ET", new byte[] {7}, null);
 			long tmp;
 			Assert.IsTrue(writer.Write(rec, out tmp));
 			writer.Flush();

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_logical_bytes_bulk_from_a_chunk.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Core.LogV2;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
@@ -69,7 +70,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void if_asked_for_more_than_buffer_size_will_only_read_buffer_size() {
 			var chunk = TFChunkHelper.CreateNewChunk(GetFilePathFor("file1"), 3000);
 
-			var rec = LogRecord.Prepare(0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "ES", -1, PrepareFlags.None, "ET",
+			var rec = LogRecord.Prepare(new LogV2RecordFactory(), 0, Guid.NewGuid(), Guid.NewGuid(), 0, 0, "ES", -1, PrepareFlags.None, "ET",
 				new byte[2000], null);
 			Assert.IsTrue(chunk.TryAppend(rec).Success, "Record was not appended");
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
+using EventStore.Core.LogV2;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -15,7 +16,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		private const int RecordsCount = 8;
 
 		private TFChunkDb _db;
-		private LogRecord[] _records;
+		private ILogRecord[] _records;
 		private RecordWriteResult[] _results;
 
 		public override async Task TestFixtureSetUp() {
@@ -26,7 +27,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var chunk = _db.Manager.GetChunk(0);
 
-			_records = new LogRecord[RecordsCount];
+			_records = new ILogRecord[RecordsCount];
 			_results = new RecordWriteResult[RecordsCount];
 
 			var pos = 0;
@@ -37,7 +38,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 					chunk = _db.Manager.AddNewChunk();
 				}
 
-				_records[i] = LogRecord.SingleWrite(pos,
+				_records[i] = LogRecord.SingleWrite(new LogV2RecordFactory(), pos,
 					Guid.NewGuid(), Guid.NewGuid(), "es1", ExpectedVersion.Any, "et1",
 					new byte[1200], new byte[] { 5, 7 });
 				_results[i] = chunk.TryAppend(_records[i]);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
+using EventStore.Core.LogV2;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -15,7 +16,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		private const int RecordsCount = 3;
 
 		private TFChunkDb _db;
-		private LogRecord[] _records;
+		private ILogRecord[] _records;
 		private RecordWriteResult[] _results;
 
 		public override async Task TestFixtureSetUp() {
@@ -26,11 +27,11 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var chunk = _db.Manager.GetChunk(0);
 
-			_records = new LogRecord[RecordsCount];
+			_records = new ILogRecord[RecordsCount];
 			_results = new RecordWriteResult[RecordsCount];
 
 			for (int i = 0; i < _records.Length; ++i) {
-				_records[i] = LogRecord.SingleWrite(i == 0 ? 0 : _results[i - 1].NewPosition,
+				_records[i] = LogRecord.SingleWrite(new LogV2RecordFactory(), i == 0 ? 0 : _results[i - 1].NewPosition,
 					Guid.NewGuid(), Guid.NewGuid(), "es1", ExpectedVersion.Any, "et1",
 					new byte[] { 0, 1, 2 }, new byte[] { 5, 7 });
 				_results[i] = chunk.TryAppend(_records[i]);

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
+using EventStore.Core.LogV2;
 using EventStore.Core.Tests.TransactionLog;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -16,7 +17,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		private const int RecordsCount = 3;
 
 		private TFChunkDb _db;
-		private LogRecord[] _records;
+		private ILogRecord[] _records;
 		private RecordWriteResult[] _results;
 
 		public override async Task TestFixtureSetUp() {
@@ -28,11 +29,12 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var chunk = _db.Manager.GetChunk(0);
 
-			_records = new LogRecord[RecordsCount];
+			_records = new ILogRecord[RecordsCount];
 			_results = new RecordWriteResult[RecordsCount];
 
 			for (int i = 0; i < _records.Length - 1; ++i) {
 				_records[i] = LogRecord.SingleWrite(
+					new LogV2RecordFactory(),
 					i == 0 ? 0 : _results[i - 1].NewPosition,
 					Guid.NewGuid(),
 					Guid.NewGuid(),
@@ -45,6 +47,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			}
 
 			_records[_records.Length - 1] = LogRecord.Prepare(
+				new LogV2RecordFactory(),
 				_results[_records.Length - 1 - 1].NewPosition,
 				Guid.NewGuid(),
 				Guid.NewGuid(),

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
@@ -44,7 +44,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void the_data_is_written() {
 			using (var reader = new TFChunkChaser(_db, _writerCheckpoint, _db.Config.ChaserCheckpoint, false)) {
 				reader.Open();
-				LogRecord r;
+				ILogRecord r;
 				Assert.IsTrue(reader.TryReadNext(out r));
 
 				Assert.True(r is CommitLogRecord);

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
@@ -53,7 +53,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			//TODO MAKE THIS ACTUALLY ASSERT OFF THE FILE AND READER FROM KNOWN FILE
 			using (var reader = new TFChunkChaser(_db, _writerCheckpoint, _db.Config.ChaserCheckpoint, false)) {
 				reader.Open();
-				LogRecord r;
+				ILogRecord r;
 				Assert.IsTrue(reader.TryReadNext(out r));
 
 				Assert.True(r is PrepareLogRecord);

--- a/src/EventStore.Core/Data/EventRecord.cs
+++ b/src/EventStore.Core/Data/EventRecord.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Data {
 		public readonly ReadOnlyMemory<byte> Data;
 		public readonly ReadOnlyMemory<byte> Metadata;
 
-		public EventRecord(long eventNumber, PrepareLogRecord prepare) {
+		public EventRecord(long eventNumber, IPrepareLogRecord prepare, string eventStreamName) {
 			Ensure.Nonnegative(eventNumber, "eventNumber");
 
 			EventNumber = eventNumber;
@@ -33,7 +33,7 @@ namespace EventStore.Core.Data {
 			EventId = prepare.EventId;
 			TransactionPosition = prepare.TransactionPosition;
 			TransactionOffset = prepare.TransactionOffset;
-			EventStreamId = prepare.EventStreamId;
+			EventStreamId = eventStreamName;
 			ExpectedVersion = prepare.ExpectedVersion;
 			TimeStamp = prepare.TimeStamp;
 
@@ -43,6 +43,11 @@ namespace EventStore.Core.Data {
 			Metadata = prepare.Metadata;
 		}
 
+		// called from tests only
+		public EventRecord(long eventNumber, IPrepareLogRecord<string> prepare) : this(eventNumber, prepare, prepare.EventStreamId) {
+		}
+
+		// called from tests only
 		public EventRecord(long eventNumber,
 			long logPosition,
 			Guid correlationId,

--- a/src/EventStore.Core/Index/Hashes/IHasher.cs
+++ b/src/EventStore.Core/Index/Hashes/IHasher.cs
@@ -1,7 +1,10 @@
 namespace EventStore.Core.Index.Hashes {
 	public interface IHasher {
-		uint Hash(string s);
 		uint Hash(byte[] data);
 		uint Hash(byte[] data, int offset, uint len, uint seed);
+	}
+
+	public interface IHasher<TStreamId> : IHasher {
+		uint Hash(TStreamId s);
 	}
 }

--- a/src/EventStore.Core/Index/Hashes/Murmur2Unsafe.cs
+++ b/src/EventStore.Core/Index/Hashes/Murmur2Unsafe.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 
 namespace EventStore.Core.Index.Hashes {
-	public class Murmur2Unsafe : IHasher {
+	public class Murmur2Unsafe : IHasher<string> {
 		private const uint Seed = 0xc58f1a7b;
 
 		private const UInt32 m = 0x5bd1e995;

--- a/src/EventStore.Core/Index/Hashes/Murmur3AUnsafe.cs
+++ b/src/EventStore.Core/Index/Hashes/Murmur3AUnsafe.cs
@@ -1,7 +1,7 @@
 using System;
 
 namespace EventStore.Core.Index.Hashes {
-	public class Murmur3AUnsafe : IHasher {
+	public class Murmur3AUnsafe : IHasher<string> {
 		private const uint Seed = 0xc58f1a7b;
 
 		private const UInt32 c1 = 0xcc9e2d51;

--- a/src/EventStore.Core/Index/Hashes/XXHashUnsafe.cs
+++ b/src/EventStore.Core/Index/Hashes/XXHashUnsafe.cs
@@ -1,7 +1,7 @@
 using System;
 
 namespace EventStore.Core.Index.Hashes {
-	public class XXHashUnsafe : IHasher {
+	public class XXHashUnsafe : IHasher<string> {
 		private const uint Seed = 0xc58f1a7b;
 
 		private const uint PRIME1 = 2654435761U;

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -9,18 +9,19 @@ namespace EventStore.Core.Index {
 
 		void Initialize(long chaserCheckpoint);
 		void Close(bool removeFiles = true);
-
-		void Add(long commitPos, string streamId, long version, long position);
-		void AddEntries(long commitPos, IList<IndexKey> entries);
-
-		bool TryGetOneValue(string streamId, long version, out long position);
-		bool TryGetLatestEntry(string streamId, out IndexEntry entry);
-		bool TryGetOldestEntry(string streamId, out IndexEntry entry);
-
-		IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null);
-
 		void Scavenge(IIndexScavengerLog log, CancellationToken ct);
 		Task MergeIndexes();
 		bool IsBackgroundTaskRunning { get; }
+	}
+
+	public interface ITableIndex<TStreamId> : ITableIndex {
+		void Add(long commitPos, TStreamId streamId, long version, long position);
+		void AddEntries(long commitPos, IList<IndexKey<TStreamId>> entries);
+
+		bool TryGetOneValue(TStreamId streamId, long version, out long position);
+		bool TryGetLatestEntry(TStreamId streamId, out IndexEntry entry);
+		bool TryGetOldestEntry(TStreamId streamId, out IndexEntry entry);
+
+		IEnumerable<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion, int? limit = null);
 	}
 }

--- a/src/EventStore.Core/Index/IndexKey.cs
+++ b/src/EventStore.Core/Index/IndexKey.cs
@@ -1,14 +1,14 @@
 ﻿namespace EventStore.Core.Index {
-	public struct IndexKey {
-		public string StreamId;
+	public struct IndexKey<TStreamId> {
+		public TStreamId StreamId;
 		public long Version;
 		public long Position;
 		public ulong Hash;
 
-		public IndexKey(string streamId, long version, long position) : this(streamId, version, position, 0) {
+		public IndexKey(TStreamId streamId, long version, long position) : this(streamId, version, position, 0) {
 		}
 
-		public IndexKey(string streamId, long version, long position, ulong hash) {
+		public IndexKey(TStreamId streamId, long version, long position, ulong hash) {
 			StreamId = streamId;
 			Version = version;
 			Position = position;

--- a/src/EventStore.Core/Index/IndexMap.cs
+++ b/src/EventStore.Core/Index/IndexMap.cs
@@ -397,10 +397,10 @@ namespace EventStore.Core.Index {
 			return new AddResult(indexMap, canMergeAny);
 		}
 
-		public MergeResult TryMergeOneLevel(
-			Func<string, ulong, ulong> upgradeHash,
+		public MergeResult TryMergeOneLevel<TStreamId>(
+			Func<TStreamId, ulong, ulong> upgradeHash,
 			Func<IndexEntry, bool> existsAt,
-			Func<IndexEntry, Tuple<string, bool>> recordExistsAt,
+			Func<IndexEntry, Tuple<TStreamId, bool>> recordExistsAt,
 			IIndexFilenameProvider filenameProvider,
 			byte version,
 			int indexCacheDepth = 16,
@@ -436,10 +436,10 @@ namespace EventStore.Core.Index {
 			return new MergeResult(indexMap, toDelete, hasMergedAny, canMergeAny);
 		}
 
-		public MergeResult TryManualMerge(
-			Func<string, ulong, ulong> upgradeHash,
+		public MergeResult TryManualMerge<TStreamId>(
+			Func<TStreamId, ulong, ulong> upgradeHash,
 			Func<IndexEntry, bool> existsAt,
-			Func<IndexEntry, Tuple<string, bool>> recordExistsAt,
+			Func<IndexEntry, Tuple<TStreamId, bool>> recordExistsAt,
 			IIndexFilenameProvider filenameProvider,
 			byte version,
 			int indexCacheDepth = 16,
@@ -474,10 +474,10 @@ namespace EventStore.Core.Index {
 			return new MergeResult(indexMap, toDelete, true, false);
 		}
 
-		public ScavengeResult Scavenge(Guid toScavenge, CancellationToken ct,
-			Func<string, ulong, ulong> upgradeHash,
+		public ScavengeResult Scavenge<TStreamId>(Guid toScavenge, CancellationToken ct,
+			Func<TStreamId, ulong, ulong> upgradeHash,
 			Func<IndexEntry, bool> existsAt,
-			Func<IndexEntry, Tuple<string, bool>> recordExistsAt,
+			Func<IndexEntry, Tuple<TStreamId, bool>> recordExistsAt,
 			IIndexFilenameProvider filenameProvider,
 			byte version,
 			int indexCacheDepth = 16,

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -15,14 +15,18 @@ using EventStore.Core.Settings;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.Chunks;
 using ILogger = Serilog.ILogger;
+using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.Index {
-	public class TableIndex : ITableIndex {
-		public const string IndexMapFilename = "indexmap";
-		private const int MaxMemoryTables = 1;
-
-		private static readonly ILogger Log = Serilog.Log.ForContext<TableIndex>();
+	public abstract class TableIndex {
 		internal static readonly IndexEntry InvalidIndexEntry = new IndexEntry(0, -1, -1);
+		public const string IndexMapFilename = "indexmap";
+		public const string ForceIndexVerifyFilename = ".forceverify";
+		protected static readonly ILogger Log = Serilog.Log.ForContext<TableIndex>();
+	}
+
+	public class TableIndex<TStreamId> : TableIndex, ITableIndex<TStreamId> {
+		private const int MaxMemoryTables = 1;
 
 		public long CommitCheckpoint {
 			get { return Interlocked.Read(ref _commitCheckpoint); }
@@ -57,17 +61,18 @@ namespace EventStore.Core.Index {
 		private volatile bool _backgroundRunning;
 		private readonly ManualResetEventSlim _backgroundRunningEvent = new ManualResetEventSlim(true);
 
-		private IHasher _lowHasher;
-		private IHasher _highHasher;
+		private IHasher<TStreamId> _lowHasher;
+		private IHasher<TStreamId> _highHasher;
+		private readonly TStreamId _emptyStreamId;
 
 		private bool _initialized;
-		public const string ForceIndexVerifyFilename = ".forceverify";
 		private readonly int _maxAutoMergeIndexLevel;
 		private readonly int _pTableMaxReaderCount;
 
 		public TableIndex(string directory,
-			IHasher lowHasher,
-			IHasher highHasher,
+			IHasher<TStreamId> lowHasher,
+			IHasher<TStreamId> highHasher,
+			TStreamId emptyStreamId,
 			Func<IMemTable> memTableFactory,
 			Func<TFReaderLease> tfReaderFactory,
 			byte ptableVersion,
@@ -109,6 +114,7 @@ namespace EventStore.Core.Index {
 
 			_lowHasher = lowHasher;
 			_highHasher = highHasher;
+			_emptyStreamId = emptyStreamId;
 
 			_maxAutoMergeIndexLevel = maxAutoMergeIndexLevel;
 			_pTableMaxReaderCount = pTableMaxReaderCount;
@@ -203,7 +209,7 @@ namespace EventStore.Core.Index {
 				Directory.CreateDirectory(directory);
 		}
 
-		public void Add(long commitPos, string streamId, long version, long position) {
+		public void Add(long commitPos, TStreamId streamId, long version, long position) {
 			Ensure.Nonnegative(commitPos, "commitPos");
 			Ensure.Nonnegative(version, "version");
 			Ensure.Nonnegative(position, "position");
@@ -211,7 +217,7 @@ namespace EventStore.Core.Index {
 			AddEntries(commitPos, new[] {CreateIndexKey(streamId, version, position)});
 		}
 
-		public void AddEntries(long commitPos, IList<IndexKey> entries) {
+		public void AddEntries(long commitPos, IList<IndexKey<TStreamId>> entries) {
 			//should only be called on a single thread.
 			var table = (IMemTable)_awaitingMemTables[0].Table; // always a memtable
 
@@ -461,14 +467,14 @@ namespace EventStore.Core.Index {
 			}
 		}
 
-		private static Tuple<string, bool> ReadEntry(TFReaderLease reader, long position) {
+		private Tuple<TStreamId, bool> ReadEntry(TFReaderLease reader, long position) {
 			RecordReadResult result = reader.TryReadAt(position);
 			if (!result.Success)
-				return new Tuple<string, bool>(String.Empty, false);
-			if (result.LogRecord.RecordType != TransactionLog.LogRecords.LogRecordType.Prepare)
+				return new Tuple<TStreamId, bool>(_emptyStreamId, false);
+			if (result.LogRecord.RecordType != LogRecordType.Prepare)
 				throw new Exception(string.Format("Incorrect type of log record {0}, expected Prepare record.",
 					result.LogRecord.RecordType));
-			return new Tuple<string, bool>(((TransactionLog.LogRecords.PrepareLogRecord)result.LogRecord).EventStreamId,
+			return new Tuple<TStreamId, bool>(((IPrepareLogRecord<TStreamId>)result.LogRecord).EventStreamId,
 				true);
 		}
 
@@ -506,7 +512,7 @@ namespace EventStore.Core.Index {
 			}
 		}
 
-		public bool TryGetOneValue(string streamId, long version, out long position) {
+		public bool TryGetOneValue(TStreamId streamId, long version, out long position) {
 			ulong stream = CreateHash(streamId);
 			int counter = 0;
 			while (counter < 5) {
@@ -544,7 +550,7 @@ namespace EventStore.Core.Index {
 			return false;
 		}
 
-		public bool TryGetLatestEntry(string streamId, out IndexEntry entry) {
+		public bool TryGetLatestEntry(TStreamId streamId, out IndexEntry entry) {
 			ulong stream = CreateHash(streamId);
 			var counter = 0;
 			while (counter < 5) {
@@ -579,7 +585,7 @@ namespace EventStore.Core.Index {
 			return false;
 		}
 
-		public bool TryGetOldestEntry(string streamId, out IndexEntry entry) {
+		public bool TryGetOldestEntry(TStreamId streamId, out IndexEntry entry) {
 			ulong stream = CreateHash(streamId);
 			var counter = 0;
 			while (counter < 5) {
@@ -614,7 +620,7 @@ namespace EventStore.Core.Index {
 			return false;
 		}
 
-		public IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion,
+		public IEnumerable<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion,
 			int? limit = null) {
 			ulong hash = CreateHash(streamId);
 			var counter = 0;
@@ -713,21 +719,21 @@ namespace EventStore.Core.Index {
 			_indexMap.InOrder().ToList().ForEach(x => x.WaitForDisposal(TimeSpan.FromMilliseconds(5000)));
 		}
 
-		private IndexEntry CreateIndexEntry(IndexKey key) {
+		private IndexEntry CreateIndexEntry(IndexKey<TStreamId> key) {
 			key = CreateIndexKey(key.StreamId, key.Version, key.Position);
 			return new IndexEntry(key.Hash, key.Version, key.Position);
 		}
 
-		private ulong UpgradeHash(string streamId, ulong lowHash) {
+		private ulong UpgradeHash(TStreamId streamId, ulong lowHash) {
 			return lowHash << 32 | _highHasher.Hash(streamId);
 		}
 
-		private ulong CreateHash(string streamId) {
+		private ulong CreateHash(TStreamId streamId) {
 			return (ulong)_lowHasher.Hash(streamId) << 32 | _highHasher.Hash(streamId);
 		}
 
-		private IndexKey CreateIndexKey(string streamId, long version, long position) {
-			return new IndexKey(streamId, version, position, CreateHash(streamId));
+		private IndexKey<TStreamId> CreateIndexKey(TStreamId streamId, long version, long position) {
+			return new IndexKey<TStreamId>(streamId, version, position, CreateHash(streamId));
 		}
 
 		private class TableItem {

--- a/src/EventStore.Core/LogAbstraction/IRecordFactory.cs
+++ b/src/EventStore.Core/LogAbstraction/IRecordFactory.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.LogAbstraction {
+	public interface IRecordFactory {
+		ISystemLogRecord CreateEpoch(EpochRecord epoch);
+	}
+
+	public interface IRecordFactory<TStreamId> : IRecordFactory {
+		IPrepareLogRecord<TStreamId> CreatePrepare(
+			long logPosition,
+			Guid correlationId,
+			Guid eventId,
+			long transactionPosition,
+			int transactionOffset,
+			TStreamId eventStreamId,
+			long expectedVersion,
+			DateTime timeStamp,
+			PrepareFlags flags,
+			string eventType,
+			ReadOnlyMemory<byte> data,
+			ReadOnlyMemory<byte> metadata);
+
+		IPrepareLogRecord<TStreamId> CopyForRetry(
+			IPrepareLogRecord<TStreamId> prepare,
+			long logPosition,
+			long transactionPosition) {
+
+			var result = CreatePrepare(
+				logPosition: logPosition,
+				correlationId: prepare.CorrelationId,
+				eventId: prepare.EventId,
+				transactionPosition: transactionPosition,
+				transactionOffset: prepare.TransactionOffset,
+				eventStreamId: prepare.EventStreamId,
+				expectedVersion: prepare.ExpectedVersion,
+				timeStamp: prepare.TimeStamp,
+				flags: prepare.Flags,
+				eventType: prepare.EventType,
+				data: prepare.Data,
+				metadata: prepare.Metadata);
+			return result;
+		}
+	}
+}

--- a/src/EventStore.Core/LogAbstraction/ISizer.cs
+++ b/src/EventStore.Core/LogAbstraction/ISizer.cs
@@ -1,0 +1,5 @@
+﻿namespace EventStore.Core.LogAbstraction {
+	public interface ISizer<T> {
+		int GetSizeInBytes(T t);
+	}
+}

--- a/src/EventStore.Core/LogAbstraction/IStreamIdLookup.cs
+++ b/src/EventStore.Core/LogAbstraction/IStreamIdLookup.cs
@@ -1,0 +1,5 @@
+﻿namespace EventStore.Core.LogAbstraction {
+	public interface IStreamIdLookup<TStreamId> {
+		TStreamId LookupId(string streamName);
+	}
+}

--- a/src/EventStore.Core/LogAbstraction/IStreamNameIndex.cs
+++ b/src/EventStore.Core/LogAbstraction/IStreamNameIndex.cs
@@ -1,0 +1,5 @@
+﻿namespace EventStore.Core.LogAbstraction {
+	public interface IStreamNameIndex<TStreamId> {
+		bool GetOrAddId(string streamName, out TStreamId streamId);
+	}
+}

--- a/src/EventStore.Core/LogAbstraction/IStreamNameLookup.cs
+++ b/src/EventStore.Core/LogAbstraction/IStreamNameLookup.cs
@@ -1,0 +1,5 @@
+﻿namespace EventStore.Core.LogAbstraction {
+	public interface IStreamNameLookup<TStreamId> {
+		string LookupName(TStreamId streamId);
+	}
+}

--- a/src/EventStore.Core/LogAbstraction/IStreamNameLookupFactory.cs
+++ b/src/EventStore.Core/LogAbstraction/IStreamNameLookupFactory.cs
@@ -1,0 +1,5 @@
+﻿namespace EventStore.Core.LogAbstraction {
+	public interface IStreamNameLookupFactory<T> {
+		IStreamNameLookup<T> Create(object input = null);
+	}
+}

--- a/src/EventStore.Core/LogAbstraction/ISystemStreamLookup.cs
+++ b/src/EventStore.Core/LogAbstraction/ISystemStreamLookup.cs
@@ -1,0 +1,11 @@
+﻿namespace EventStore.Core.LogAbstraction {
+	public interface ISystemStreamLookup<TStreamId> {
+		TStreamId AllStream { get; }
+		TStreamId SettingsStream { get; }
+
+		bool IsMetaStream(TStreamId streamId);
+		bool IsSystemStream(TStreamId streamId);
+		TStreamId MetaStreamOf(TStreamId streamId);
+		TStreamId OriginalStreamOf(TStreamId streamId);
+	}
+}

--- a/src/EventStore.Core/LogAbstraction/LogFormatAbstractor.cs
+++ b/src/EventStore.Core/LogAbstraction/LogFormatAbstractor.cs
@@ -1,0 +1,62 @@
+﻿using EventStore.Common.Utils;
+using EventStore.Core.Index.Hashes;
+using EventStore.Core.LogV2;
+using EventStore.Core.Services.Storage.ReaderIndex;
+
+namespace EventStore.Core.LogAbstraction {
+	public class LogFormatAbstractor {
+		public static LogFormatAbstractor<string> V2 { get; }
+
+		static LogFormatAbstractor() {
+			var streamNameIndex = new LogV2StreamNameIndex();
+			V2 = new LogFormatAbstractor<string>(
+				new XXHashUnsafe(),
+				new Murmur3AUnsafe(),
+				streamNameIndex,
+				streamNameIndex,
+				new StreamNameLookupSingletonFactory<string>(streamNameIndex),
+				new LogV2SystemStreams(),
+				new LogV2StreamIdValidator(),
+				string.Empty,
+				new LogV2Sizer(),
+				new LogV2RecordFactory());
+		}
+	}
+
+	public class LogFormatAbstractor<TStreamId> : LogFormatAbstractor {
+		public LogFormatAbstractor(
+			IHasher<TStreamId> lowHasher,
+			IHasher<TStreamId> highHasher,
+			IStreamNameIndex<TStreamId> streamNameIndex,
+			IStreamIdLookup<TStreamId> streamIds,
+			IStreamNameLookupFactory<TStreamId> streamNamesFactory,
+			ISystemStreamLookup<TStreamId> systemStreams,
+			IValidator<TStreamId> streamIdValidator,
+			TStreamId emptyStreamId,
+			ISizer<TStreamId> streamIdSizer,
+			IRecordFactory<TStreamId> recordFactory) {
+
+			LowHasher = lowHasher;
+			HighHasher = highHasher;
+			StreamNameIndex = streamNameIndex;
+			StreamIds = streamIds;
+			StreamNamesFactory = streamNamesFactory;
+			SystemStreams = systemStreams;
+			StreamIdValidator = streamIdValidator;
+			EmptyStreamId = emptyStreamId;
+			StreamIdSizer = streamIdSizer;
+			RecordFactory = recordFactory;
+		}
+
+		public IHasher<TStreamId> LowHasher { get; }
+		public IHasher<TStreamId> HighHasher { get; }
+		public IStreamNameIndex<TStreamId> StreamNameIndex { get; }
+		public IStreamIdLookup<TStreamId> StreamIds { get; }
+		public IStreamNameLookupFactory<TStreamId> StreamNamesFactory { get; }
+		public ISystemStreamLookup<TStreamId> SystemStreams { get; }
+		public IValidator<TStreamId> StreamIdValidator { get; }
+		public TStreamId EmptyStreamId { get; }
+		public ISizer<TStreamId> StreamIdSizer { get; }
+		public IRecordFactory<TStreamId> RecordFactory { get; }
+	}
+}

--- a/src/EventStore.Core/LogAbstraction/StreamNameLookupSingletonFactory.cs
+++ b/src/EventStore.Core/LogAbstraction/StreamNameLookupSingletonFactory.cs
@@ -1,0 +1,13 @@
+﻿namespace EventStore.Core.LogAbstraction {
+	public class StreamNameLookupSingletonFactory<TStreamId> : IStreamNameLookupFactory<TStreamId> {
+		private readonly IStreamNameLookup<TStreamId> _streamIdToName;
+
+		public StreamNameLookupSingletonFactory(IStreamNameLookup<TStreamId> streamIdToName) {
+			_streamIdToName = streamIdToName;
+		}
+
+		public IStreamNameLookup<TStreamId> Create(object input = null) {
+			return _streamIdToName;
+		}
+	}
+}

--- a/src/EventStore.Core/LogV2/LogV2RecordFactory.cs
+++ b/src/EventStore.Core/LogV2/LogV2RecordFactory.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.LogV2 {
+	public class LogV2RecordFactory : IRecordFactory<string> {
+		public LogV2RecordFactory() {
+		}
+
+		public ISystemLogRecord CreateEpoch(EpochRecord epoch) {
+			var result = new SystemLogRecord(
+				logPosition: epoch.EpochPosition,
+				timeStamp: epoch.TimeStamp,
+				systemRecordType: SystemRecordType.Epoch,
+				systemRecordSerialization: SystemRecordSerialization.Json,
+				data: epoch.AsSerialized());
+			return result;
+		}
+
+		public IPrepareLogRecord<string> CreatePrepare(
+			long logPosition,
+			Guid correlationId,
+			Guid eventId,
+			long transactionPosition,
+			int transactionOffset,
+			string eventStreamId,
+			long expectedVersion,
+			DateTime timeStamp,
+			PrepareFlags flags,
+			string eventType,
+			ReadOnlyMemory<byte> data,
+			ReadOnlyMemory<byte> metadata) {
+
+			var result = new PrepareLogRecord(
+				logPosition: logPosition,
+				correlationId: correlationId,
+				eventId: eventId,
+				transactionPosition: transactionPosition,
+				transactionOffset: transactionOffset,
+				eventStreamId: eventStreamId,
+				expectedVersion: expectedVersion,
+				timeStamp: timeStamp,
+				flags: flags,
+				eventType: eventType,
+				data: data,
+				metadata: metadata);
+			return result;
+		}
+	}
+}

--- a/src/EventStore.Core/LogV2/LogV2Sizer.cs
+++ b/src/EventStore.Core/LogV2/LogV2Sizer.cs
@@ -1,0 +1,7 @@
+﻿using EventStore.Core.LogAbstraction;
+
+namespace EventStore.Core.LogV2 {
+	public class LogV2Sizer : ISizer<string> {
+		public int GetSizeInBytes(string t) => 2 * t.Length;
+	}
+}

--- a/src/EventStore.Core/LogV2/LogV2StreamIdValidator.cs
+++ b/src/EventStore.Core/LogV2/LogV2StreamIdValidator.cs
@@ -1,0 +1,12 @@
+﻿using EventStore.Common.Utils;
+
+namespace EventStore.Core.LogV2 {
+	public class LogV2StreamIdValidator : IValidator<string> {
+		public LogV2StreamIdValidator() {
+		}
+
+		public void Validate(string streamId) {
+			Ensure.NotNullOrEmpty(streamId, "streamId");
+		}
+	}
+}

--- a/src/EventStore.Core/LogV2/LogV2StreamNameIndex.cs
+++ b/src/EventStore.Core/LogV2/LogV2StreamNameIndex.cs
@@ -1,0 +1,20 @@
+﻿using EventStore.Core.LogAbstraction;
+
+namespace EventStore.Core.LogV2 {
+	public class LogV2StreamNameIndex :
+		IStreamNameIndex<string>,
+		IStreamIdLookup<string>,
+		IStreamNameLookup<string> {
+
+		public LogV2StreamNameIndex() {
+		}
+
+		public bool GetOrAddId(string streamName, out string streamId) {
+			streamId = streamName;
+			return true;
+		}
+
+		public string LookupId(string streamName) => streamName;
+		public string LookupName(string streamId) => streamId;
+	}
+}

--- a/src/EventStore.Core/LogV2/LogV2SystemStreams.cs
+++ b/src/EventStore.Core/LogV2/LogV2SystemStreams.cs
@@ -1,0 +1,17 @@
+﻿using EventStore.Core.LogAbstraction;
+using EventStore.Core.Services;
+
+namespace EventStore.Core.LogV2 {
+	public class LogV2SystemStreams : ISystemStreamLookup<string> {
+		public LogV2SystemStreams() {
+		}
+
+		public string AllStream { get; } = SystemStreams.AllStream;
+		public string SettingsStream { get; } = SystemStreams.SettingsStream;
+
+		public bool IsMetaStream(string streamId) => SystemStreams.IsMetastream(streamId);
+		public bool IsSystemStream(string streamId) => SystemStreams.IsSystemStream(streamId);
+		public string MetaStreamOf(string streamId) => SystemStreams.MetastreamOf(streamId);
+		public string OriginalStreamOf(string streamId) => SystemStreams.OriginalStreamOf(streamId);
+	}
+}

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -5,6 +5,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Replication;
 using EventStore.Core.Services.Storage;
@@ -16,7 +17,10 @@ using EventStore.Core.TransactionLog.LogRecords;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services {
-	public class ClusterStorageWriterService : StorageWriterService,
+	public class ClusterStorageWriterService {
+	}
+
+	public class ClusterStorageWriterService<TStreamId> : StorageWriterService<TStreamId>,
 		IHandle<ReplicationMessage.ReplicaSubscribed>,
 		IHandle<ReplicationMessage.CreateChunk>,
 		IHandle<ReplicationMessage.RawChunkBulk>,
@@ -36,11 +40,14 @@ namespace EventStore.Core.Services {
 			TimeSpan minFlushDelay,
 			TFChunkDb db,
 			TFChunkWriter writer,
-			IIndexWriter indexWriter,
+			IIndexWriter<TStreamId> indexWriter,
+			IRecordFactory<TStreamId> recordFactory,
+			IStreamNameIndex<TStreamId> streamNameIndex,
+			ISystemStreamLookup<TStreamId> systemStreams,
 			IEpochManager epochManager,
 			QueueStatsManager queueStatsManager,
 			Func<long> getLastIndexedPosition)
-			: base(bus, subscribeToBus, minFlushDelay, db, writer, indexWriter, epochManager, queueStatsManager) {
+			: base(bus, subscribeToBus, minFlushDelay, db, writer, indexWriter, recordFactory, streamNameIndex, systemStreams, epochManager, queueStatsManager) {
 			Ensure.NotNull(getLastIndexedPosition, "getLastCommitPosition");
 
 			_getLastIndexedPosition = getLastIndexedPosition;

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnablePersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnablePersistentSubscriptionConsumerStrategy.cs
@@ -6,12 +6,12 @@
 	using PinnedState;
 
 	internal abstract class PinnablePersistentSubscriptionConsumerStrategy : IPersistentSubscriptionConsumerStrategy {
-		private IHasher _hash;
+		private IHasher<string> _hash;
 		protected static readonly char LinkToSeparator = '@';
 		private readonly PinnedConsumerState _state = new PinnedConsumerState();
 		private readonly object _stateLock = new object();
 
-		public PinnablePersistentSubscriptionConsumerStrategy(IHasher streamHasher) {
+		public PinnablePersistentSubscriptionConsumerStrategy(IHasher<string> streamHasher) {
 			_hash = streamHasher;
 		}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedByCorrelationPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedByCorrelationPersistentSubscriptionConsumerStrategy.cs
@@ -8,7 +8,7 @@
 
 	class PinnedByCorrelationPersistentSubscriptionConsumerStrategy : PinnedPersistentSubscriptionConsumerStrategy {
 		
-		public PinnedByCorrelationPersistentSubscriptionConsumerStrategy(IHasher streamHasher) : base(streamHasher) {
+		public PinnedByCorrelationPersistentSubscriptionConsumerStrategy(IHasher<string> streamHasher) : base(streamHasher) {
 		}
 
 		public override string Name {

--- a/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedPersistentSubscriptionConsumerStrategy.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/ConsumerStrategy/PinnedPersistentSubscriptionConsumerStrategy.cs
@@ -3,7 +3,7 @@ using EventStore.Core.Index.Hashes;
 
 namespace EventStore.Core.Services.PersistentSubscription.ConsumerStrategy {
 	class PinnedPersistentSubscriptionConsumerStrategy : PinnablePersistentSubscriptionConsumerStrategy {
-		public PinnedPersistentSubscriptionConsumerStrategy(IHasher streamHasher) : base(streamHasher) {
+		public PinnedPersistentSubscriptionConsumerStrategy(IHasher<string> streamHasher) : base(streamHasher) {
 		}
 
 		public override string Name {

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/CommitCheckResult.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/CommitCheckResult.cs
@@ -1,7 +1,7 @@
 namespace EventStore.Core.Services.Storage.ReaderIndex {
-	public struct CommitCheckResult {
+	public struct CommitCheckResult<TStreamId> {
 		public readonly CommitDecision Decision;
-		public readonly string EventStreamId;
+		public readonly TStreamId EventStreamId;
 		public readonly long CurrentVersion;
 		public readonly long StartEventNumber;
 		public readonly long EndEventNumber;
@@ -9,7 +9,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		public readonly long IdempotentLogPosition;
 
 		public CommitCheckResult(CommitDecision decision,
-			string eventStreamId,
+			TStreamId eventStreamId,
 			long currentVersion,
 			long startEventNumber,
 			long endEventNumber,

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IReadIndex.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IReadIndex.cs
@@ -6,14 +6,8 @@ using EventStore.Core.Util;
 namespace EventStore.Core.Services.Storage.ReaderIndex {
 	public interface IReadIndex {
 		long LastIndexedPosition { get; }
-		
-		IIndexWriter IndexWriter { get; }		
-				
-		ReadIndexStats GetStatistics();
 
-		IndexReadEventResult ReadEvent(string streamId, long eventNumber);
-		IndexReadStreamResult ReadStreamEventsBackward(string streamId, long fromEventNumber, int maxCount);
-		IndexReadStreamResult ReadStreamEventsForward(string streamId, long fromEventNumber, int maxCount);
+		ReadIndexStats GetStatistics();
 
 		/// <summary>
 		/// Returns event records in the sequence they were committed into TF.
@@ -41,13 +35,26 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		IndexReadAllResult ReadAllEventsBackwardFiltered(TFPos pos, int maxCount, int maxSearchWindow,
 			IEventFilter eventFilter);
 
-		bool IsStreamDeleted(string streamId);
-		long GetStreamLastEventNumber(string streamId);
-		StreamMetadata GetStreamMetadata(string streamId);
-		StorageMessage.EffectiveAcl GetEffectiveAcl(string streamId);
-		string GetEventStreamIdByTransactionId(long transactionId);
-
 		void Close();
 		void Dispose();
+	}
+
+	public interface IReadIndex<TStreamId> : IReadIndex {
+		IIndexWriter<TStreamId> IndexWriter { get; }
+
+		// streamId drives the read, streamName is only for populating on the result.
+		// this was less messy than safely adding the streamName to the EventRecord at some point after construction
+		IndexReadEventResult ReadEvent(string streamName, TStreamId streamId, long eventNumber);
+		IndexReadStreamResult ReadStreamEventsBackward(string streamName, TStreamId streamId, long fromEventNumber, int maxCount);
+		IndexReadStreamResult ReadStreamEventsForward(string streamName, TStreamId streamId, long fromEventNumber, int maxCount);
+
+		bool IsStreamDeleted(TStreamId streamId);
+		long GetStreamLastEventNumber(TStreamId streamId);
+		StreamMetadata GetStreamMetadata(TStreamId streamId);
+		StorageMessage.EffectiveAcl GetEffectiveAcl(TStreamId streamId);
+		TStreamId GetEventStreamIdByTransactionId(long transactionId);
+
+		TStreamId GetStreamId(string streamName);
+		string GetStreamName(TStreamId streamId);
 	}
 }

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -6,8 +6,8 @@ using System.Text;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Index;
-using EventStore.Core.Index.Hashes;
 using EventStore.Core.Messages;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.LogRecords;
@@ -19,19 +19,28 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		void Init(long buildToPosition);
 		void Dispose();
 		long Commit(CommitLogRecord commit, bool isTfEof, bool cacheLastEventNumber);
-		long Commit(IList<PrepareLogRecord> commitedPrepares, bool isTfEof, bool cacheLastEventNumber);
 		long GetCommitLastEventNumber(CommitLogRecord commit);
 	}
 
-	public class IndexCommitter : IIndexCommitter {
+	public interface IIndexCommitter<TStreamId> : IIndexCommitter {
+		long Commit(IList<IPrepareLogRecord<TStreamId>> commitedPrepares, bool isTfEof, bool cacheLastEventNumber);
+	}
+
+	public abstract class IndexCommitter {
 		public static readonly ILogger Log = Serilog.Log.ForContext<IndexCommitter>();
+	}
+
+	public class IndexCommitter<TStreamId> : IndexCommitter, IIndexCommitter<TStreamId> {
+		private static EqualityComparer<TStreamId> StreamIdComparer { get; } = EqualityComparer<TStreamId>.Default;
 
 		public long LastIndexedPosition => _indexChk.Read();
 
 		private readonly IPublisher _bus;
-		private readonly IIndexBackend _backend;
-		private readonly IIndexReader _indexReader;
-		private readonly ITableIndex _tableIndex;
+		private readonly IIndexBackend<TStreamId> _backend;
+		private readonly IIndexReader<TStreamId> _indexReader;
+		private readonly ITableIndex<TStreamId> _tableIndex;
+		private readonly IStreamNameLookup<TStreamId> _streamNames;
+		private readonly ISystemStreamLookup<TStreamId> _systemStreams;
 		private readonly bool _additionalCommitChecks;
 		private long _persistedPreparePos = -1;
 		private long _persistedCommitPos = -1;
@@ -40,15 +49,19 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 
 		public IndexCommitter(
 			IPublisher bus,
-			IIndexBackend backend,
-			IIndexReader indexReader,
-			ITableIndex tableIndex,
+			IIndexBackend<TStreamId> backend,
+			IIndexReader<TStreamId> indexReader,
+			ITableIndex<TStreamId> tableIndex,
+			IStreamNameLookup<TStreamId> streamNames,
+			ISystemStreamLookup<TStreamId> systemStreams,
 			ICheckpoint indexChk,
 			bool additionalCommitChecks) {
 			_bus = bus;
 			_backend = backend;
 			_indexReader = indexReader;
 			_tableIndex = tableIndex;
+			_streamNames = streamNames;
+			_systemStreams = systemStreams;
 			_indexChk = indexChk;
 			_additionalCommitChecks = additionalCommitChecks;
 		}
@@ -79,14 +92,14 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				var fullRebuild = startPosition == 0;
 				reader.Reposition(startPosition);
 
-				var commitedPrepares = new List<PrepareLogRecord>();
+				var commitedPrepares = new List<IPrepareLogRecord<TStreamId>>();
 
 				long processed = 0;
 				SeqReadResult result;
 				while ((result = reader.TryReadNext()).Success && result.LogRecord.LogPosition < buildToPosition) {
 					switch (result.LogRecord.RecordType) {
 						case LogRecordType.Prepare: {
-								var prepare = (PrepareLogRecord)result.LogRecord;
+								var prepare = (IPrepareLogRecord<TStreamId>)result.LogRecord;
 								if (prepare.Flags.HasAnyOf(PrepareFlags.IsCommitted)) {
 									if (prepare.Flags.HasAnyOf(PrepareFlags.SingleWrite)) {
 										Commit(commitedPrepares, false, false);
@@ -174,18 +187,18 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			if (commit.LogPosition < lastIndexedPosition || (commit.LogPosition == lastIndexedPosition && !_indexRebuild))
 				return eventNumber; // already committed
 
-			string streamId = null;
-			var indexEntries = new List<IndexKey>();
-			var prepares = new List<PrepareLogRecord>();
+			TStreamId streamId = default;
+			var indexEntries = new List<IndexKey<TStreamId>>();
+			var prepares = new List<IPrepareLogRecord<TStreamId>>();
 
 			foreach (var prepare in GetTransactionPrepares(commit.TransactionPosition, commit.LogPosition)) {
 				if (prepare.Flags.HasNoneOf(PrepareFlags.StreamDelete | PrepareFlags.Data))
 					continue;
 
-				if (streamId == null) {
+				if (StreamIdComparer.Equals(streamId, default)) {
 					streamId = prepare.EventStreamId;
 				} else {
-					if (prepare.EventStreamId != streamId)
+					if (!StreamIdComparer.Equals(prepare.EventStreamId, streamId))
 						throw new Exception(string.Format("Expected stream: {0}, actual: {1}. LogPosition: {2}",
 							streamId, prepare.EventStreamId, commit.LogPosition));
 				}
@@ -196,7 +209,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 
 				if (new TFPos(commit.LogPosition, prepare.LogPosition) >
 					new TFPos(_persistedCommitPos, _persistedPreparePos)) {
-					indexEntries.Add(new IndexKey(streamId, eventNumber, prepare.LogPosition));
+					indexEntries.Add(new IndexKey<TStreamId>(streamId, eventNumber, prepare.LogPosition));
 					prepares.Add(prepare);
 				}
 			}
@@ -218,11 +231,11 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					_backend.SetStreamLastEventNumber(streamId, eventNumber);
 				}
 
-				if (SystemStreams.IsMetastream(streamId))
-					_backend.SetStreamMetadata(SystemStreams.OriginalStreamOf(streamId),
+				if (_systemStreams.IsMetaStream(streamId))
+					_backend.SetStreamMetadata(_systemStreams.OriginalStreamOf(streamId),
 						null); // invalidate cached metadata
 
-				if (streamId == SystemStreams.SettingsStream)
+				if (StreamIdComparer.Equals(streamId, _systemStreams.SettingsStream))
 					_backend.SetSystemSettings(DeserializeSystemSettings(prepares[prepares.Count - 1].Data));
 			}
 
@@ -234,19 +247,21 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			_indexChk.Write(newLastIndexedPosition);
 			_indexChk.Flush();
 
-			if (!_indexRebuild)
+			if (!_indexRebuild) {
+				var streamName = _streamNames.LookupName(streamId);
 				for (int i = 0, n = indexEntries.Count; i < n; ++i) {
 					_bus.Publish(
 						new StorageMessage.EventCommitted(
 							commit.LogPosition,
-							new EventRecord(indexEntries[i].Version, prepares[i]),
+							new EventRecord(indexEntries[i].Version, prepares[i], streamName),
 							isTfEof && i == n - 1));
 				}
+			}
 
 			return eventNumber;
 		}
 
-		public long Commit(IList<PrepareLogRecord> commitedPrepares, bool isTfEof, bool cacheLastEventNumber) {
+		public long Commit(IList<IPrepareLogRecord<TStreamId>> commitedPrepares, bool isTfEof, bool cacheLastEventNumber) {
 			long eventNumber = EventNumber.Invalid;
 
 			if (commitedPrepares.Count == 0)
@@ -255,15 +270,15 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			var lastIndexedPosition = _indexChk.Read();
 			var lastPrepare = commitedPrepares[commitedPrepares.Count - 1];
 
-			string streamId = lastPrepare.EventStreamId;
-			var indexEntries = new List<IndexKey>();
-			var prepares = new List<PrepareLogRecord>();
+			var streamId = lastPrepare.EventStreamId;
+			var indexEntries = new List<IndexKey<TStreamId>>();
+			var prepares = new List<IPrepareLogRecord<TStreamId>>();
 
 			foreach (var prepare in commitedPrepares) {
 				if (prepare.Flags.HasNoneOf(PrepareFlags.StreamDelete | PrepareFlags.Data))
 					continue;
 
-				if (prepare.EventStreamId != streamId) {
+				if (!StreamIdComparer.Equals(prepare.EventStreamId, streamId)) {
 					var sb = new StringBuilder();
 					sb.Append(string.Format("ERROR: Expected stream: {0}, actual: {1}.", streamId,
 						prepare.EventStreamId));
@@ -299,7 +314,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 
 				if (new TFPos(prepare.LogPosition, prepare.LogPosition) >
 					new TFPos(_persistedCommitPos, _persistedPreparePos)) {
-					indexEntries.Add(new IndexKey(streamId, eventNumber, prepare.LogPosition));
+					indexEntries.Add(new IndexKey<TStreamId>(streamId, eventNumber, prepare.LogPosition));
 					prepares.Add(prepare);
 				}
 			}
@@ -321,11 +336,11 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					_backend.SetStreamLastEventNumber(streamId, eventNumber);
 				}
 
-				if (SystemStreams.IsMetastream(streamId))
-					_backend.SetStreamMetadata(SystemStreams.OriginalStreamOf(streamId),
+				if (_systemStreams.IsMetaStream(streamId))
+					_backend.SetStreamMetadata(_systemStreams.OriginalStreamOf(streamId),
 						null); // invalidate cached metadata
 
-				if (streamId == SystemStreams.SettingsStream)
+				if (StreamIdComparer.Equals(streamId, _systemStreams.SettingsStream))
 					_backend.SetSystemSettings(DeserializeSystemSettings(prepares[prepares.Count - 1].Data));
 			}
 
@@ -337,19 +352,21 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			_indexChk.Write(newLastIndexedPosition);
 			_indexChk.Flush();
 
-			if (!_indexRebuild)
+			if (!_indexRebuild) {
+				var streamName = _streamNames.LookupName(streamId);
 				for (int i = 0, n = indexEntries.Count; i < n; ++i) {
 					_bus.Publish(
 						new StorageMessage.EventCommitted(
 							prepares[i].LogPosition,
-							new EventRecord(indexEntries[i].Version, prepares[i]),
+							new EventRecord(indexEntries[i].Version, prepares[i], streamName),
 							isTfEof && i == n - 1));
 				}
+			}
 
 			return eventNumber;
 		}
 
-		private IEnumerable<PrepareLogRecord> GetTransactionPrepares(long transactionPos, long commitPos) {
+		private IEnumerable<IPrepareLogRecord<TStreamId>> GetTransactionPrepares(long transactionPos, long commitPos) {
 			using (var reader = _backend.BorrowReader()) {
 				reader.Reposition(transactionPos);
 
@@ -359,7 +376,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					if (result.LogRecord.RecordType != LogRecordType.Prepare)
 						continue;
 
-					var prepare = (PrepareLogRecord)result.LogRecord;
+					var prepare = (IPrepareLogRecord<TStreamId>)result.LogRecord;
 					if (prepare.TransactionPosition == transactionPos) {
 						yield return prepare;
 						if (prepare.Flags.HasAnyOf(PrepareFlags.TransactionEnd))
@@ -369,7 +386,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			}
 		}
 
-		private void CheckStreamVersion(string streamId, long newEventNumber, CommitLogRecord commit) {
+		private void CheckStreamVersion(TStreamId streamId, long newEventNumber, CommitLogRecord commit) {
 			if (newEventNumber == EventNumber.DeletedStream)
 				return;
 
@@ -385,16 +402,16 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			}
 		}
 
-		private void CheckDuplicateEvents(string streamId, CommitLogRecord commit, IList<IndexKey> indexEntries,
-			IList<PrepareLogRecord> prepares) {
+		private void CheckDuplicateEvents(TStreamId streamId, CommitLogRecord commit, IList<IndexKey<TStreamId>> indexEntries,
+			IList<IPrepareLogRecord<TStreamId>> prepares) {
 			using (var reader = _backend.BorrowReader()) {
 				var entries = _tableIndex.GetRange(streamId, indexEntries[0].Version,
 					indexEntries[indexEntries.Count - 1].Version);
 				foreach (var indexEntry in entries) {
 					int prepareIndex = (int)(indexEntry.Version - indexEntries[0].Version);
 					var prepare = prepares[prepareIndex];
-					PrepareLogRecord indexedPrepare = GetPrepare(reader, indexEntry.Position);
-					if (indexedPrepare != null && indexedPrepare.EventStreamId == prepare.EventStreamId) {
+					IPrepareLogRecord<TStreamId> indexedPrepare = GetPrepare(reader, indexEntry.Position);
+					if (indexedPrepare != null && StreamIdComparer.Equals(indexedPrepare.EventStreamId, prepare.EventStreamId)) {
 						if (Debugger.IsAttached)
 							Debugger.Break();
 						else
@@ -408,7 +425,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 
 		private SystemSettings GetSystemSettings() {
-			var res = _indexReader.ReadEvent(SystemStreams.SettingsStream, -1);
+			var res = _indexReader.ReadEvent(IndexReader.UnspecifiedStreamName, _systemStreams.SettingsStream, -1);
 			return res.Result == ReadEventResult.Success ? DeserializeSystemSettings(res.Record.Data) : null;
 		}
 
@@ -422,14 +439,14 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			return null;
 		}
 
-		private static PrepareLogRecord GetPrepare(TFReaderLease reader, long logPosition) {
+		private static IPrepareLogRecord<TStreamId> GetPrepare(TFReaderLease reader, long logPosition) {
 			RecordReadResult result = reader.TryReadAt(logPosition);
 			if (!result.Success)
 				return null;
 			if (result.LogRecord.RecordType != LogRecordType.Prepare)
 				throw new Exception(string.Format("Incorrect type of log record {0}, expected Prepare record.",
 					result.LogRecord.RecordType));
-			return (PrepareLogRecord)result.LogRecord;
+			return (IPrepareLogRecord<TStreamId>)result.LogRecord;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/TransactionInfo.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/TransactionInfo.cs
@@ -1,9 +1,9 @@
 namespace EventStore.Core.Services.Storage.ReaderIndex {
-	public struct TransactionInfo {
+	public struct TransactionInfo<TStreamId> {
 		public readonly int TransactionOffset;
-		public readonly string EventStreamId;
+		public readonly TStreamId EventStreamId;
 
-		public TransactionInfo(int transactionOffset, string eventStreamId) {
+		public TransactionInfo(int transactionOffset, TStreamId eventStreamId) {
 			TransactionOffset = transactionOffset;
 			EventStreamId = eventStreamId;
 		}

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -4,6 +4,7 @@ using System.Security.Claims;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.Checkpoint;
@@ -14,7 +15,11 @@ using EventStore.Core.Messaging;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.Services.Storage {
-	public class StorageReaderWorker : IHandle<ClientMessage.ReadEvent>,
+	public abstract class StorageReaderWorker {
+		protected static readonly ILogger Log = Serilog.Log.ForContext<StorageReaderWorker>();
+	}
+
+	public class StorageReaderWorker<TStreamId> : StorageReaderWorker, IHandle<ClientMessage.ReadEvent>,
 		IHandle<ClientMessage.ReadStreamEventsBackward>,
 		IHandle<ClientMessage.ReadStreamEventsForward>,
 		IHandle<ClientMessage.ReadAllEventsForward>,
@@ -23,11 +28,11 @@ namespace EventStore.Core.Services.Storage {
 		IHandle<StorageMessage.EffectiveStreamAclRequest>,
 		IHandle<StorageMessage.StreamIdFromTransactionIdRequest>,
 		IHandle<StorageMessage.BatchLogExpiredMessages>, IHandle<ClientMessage.FilteredReadAllEventsBackward> {
-		private static readonly ILogger Log = Serilog.Log.ForContext<StorageReaderWorker>();
 		private static readonly ResolvedEvent[] EmptyRecords = new ResolvedEvent[0];
 
 		private readonly IPublisher _publisher;
-		private readonly IReadIndex _readIndex;
+		private readonly IReadIndex<TStreamId> _readIndex;
+		private readonly ISystemStreamLookup<TStreamId> _systemStreams;
 		private readonly IReadOnlyCheckpoint _writerCheckpoint;
 		private readonly int _queueId;
 		private static readonly char[] LinkToSeparator = { '@' };
@@ -39,14 +44,20 @@ namespace EventStore.Core.Services.Storage {
 		private long _expiredBatchCount;
 		private bool _batchLoggingEnabled;
 
-		public StorageReaderWorker(IPublisher publisher, IReadIndex readIndex, IReadOnlyCheckpoint writerCheckpoint,
+		public StorageReaderWorker(
+			IPublisher publisher,
+			IReadIndex<TStreamId> readIndex,
+			ISystemStreamLookup<TStreamId> systemStreams,
+			IReadOnlyCheckpoint writerCheckpoint,
 			int queueId) {
 			Ensure.NotNull(publisher, "publisher");
 			Ensure.NotNull(readIndex, "readIndex");
+			Ensure.NotNull(systemStreams, nameof(systemStreams));
 			Ensure.NotNull(writerCheckpoint, "writerCheckpoint");
 
 			_publisher = publisher;
 			_readIndex = readIndex;
+			_systemStreams = systemStreams;
 			_writerCheckpoint = writerCheckpoint;
 			_queueId = queueId;
 		}
@@ -248,15 +259,16 @@ namespace EventStore.Core.Services.Storage {
 				msg.Envelope.ReplyWith(new StorageMessage.OperationCancelledMessage(msg.CancellationToken));
 				return;
 			}
-			var acl = _readIndex.GetEffectiveAcl(msg.StreamId);
+			var acl = _readIndex.GetEffectiveAcl(_readIndex.GetStreamId(msg.StreamId));
 			msg.Envelope.ReplyWith(new StorageMessage.EffectiveStreamAclResponse(acl));
 		}
 
 		private ClientMessage.ReadEventCompleted ReadEvent(ClientMessage.ReadEvent msg) {
 			using (HistogramService.Measure(ReaderReadHistogram)) {
 				try {
-
-					var result = _readIndex.ReadEvent(msg.EventStreamId, msg.EventNumber);
+					var streamName = msg.EventStreamId;
+					var streamId = _readIndex.GetStreamId(streamName);
+					var result = _readIndex.ReadEvent(streamName, streamId, msg.EventNumber);
 					var record = result.Result == ReadEventResult.Success && msg.ResolveLinkTos
 						? ResolveLinkToEvent(result.Record, msg.User, null)
 						: ResolvedEvent.ForUnresolvedEvent(result.Record);
@@ -265,7 +277,7 @@ namespace EventStore.Core.Services.Storage {
 					if ((result.Result == ReadEventResult.NoStream ||
 						 result.Result == ReadEventResult.NotFound) &&
 						result.OriginalStreamExists &&
-						SystemStreams.IsSystemStream(msg.EventStreamId)) {
+						_systemStreams.IsSystemStream(streamId)) {
 						return NoData(msg, ReadEventResult.Success);
 					}
 
@@ -287,13 +299,15 @@ namespace EventStore.Core.Services.Storage {
 						throw new ArgumentException($"Read size too big, should be less than {MaxPageSize} items");
 					}
 
+					var streamName = msg.EventStreamId;
+					var streamId = _readIndex.GetStreamId(msg.EventStreamId);
 					if (msg.ValidationStreamVersion.HasValue &&
-						_readIndex.GetStreamLastEventNumber(msg.EventStreamId) == msg.ValidationStreamVersion)
+						_readIndex.GetStreamLastEventNumber(streamId) == msg.ValidationStreamVersion)
 						return NoData(msg, ReadStreamResult.NotModified, lastIndexPosition,
 							msg.ValidationStreamVersion.Value);
 
 					var result =
-						_readIndex.ReadStreamEventsForward(msg.EventStreamId, msg.FromEventNumber, msg.MaxCount);
+						_readIndex.ReadStreamEventsForward(streamName, streamId, msg.FromEventNumber, msg.MaxCount);
 					CheckEventsOrder(msg, result);
 					var resolvedPairs = ResolveLinkToEvents(result.Records, msg.ResolveLinkTos, msg.User);
 					if (resolvedPairs == null)
@@ -319,13 +333,15 @@ namespace EventStore.Core.Services.Storage {
 						throw new ArgumentException($"Read size too big, should be less than {MaxPageSize} items");
 					}
 
+					var streamName = msg.EventStreamId;
+					var streamId = _readIndex.GetStreamId(msg.EventStreamId);
 					if (msg.ValidationStreamVersion.HasValue &&
-						_readIndex.GetStreamLastEventNumber(msg.EventStreamId) == msg.ValidationStreamVersion)
+						_readIndex.GetStreamLastEventNumber(streamId) == msg.ValidationStreamVersion)
 						return NoData(msg, ReadStreamResult.NotModified, lastIndexedPosition,
 							msg.ValidationStreamVersion.Value);
 
 
-					var result = _readIndex.ReadStreamEventsBackward(msg.EventStreamId, msg.FromEventNumber,
+					var result = _readIndex.ReadStreamEventsBackward(streamName, streamId, msg.FromEventNumber,
 						msg.MaxCount);
 					CheckEventsOrder(msg, result);
 					var resolvedPairs = ResolveLinkToEvents(result.Records, msg.ResolveLinkTos, msg.User);
@@ -368,7 +384,7 @@ namespace EventStore.Core.Services.Storage {
 					if (resolved == null)
 						return NoData(msg, ReadAllResult.AccessDenied, pos, lastIndexedPosition);
 
-					var metadata = _readIndex.GetStreamMetadata(SystemStreams.AllStream);
+					var metadata = _readIndex.GetStreamMetadata(_systemStreams.AllStream);
 					return new ClientMessage.ReadAllEventsForwardCompleted(
 						msg.CorrelationId, ReadAllResult.Success, null, resolved, metadata, false, msg.MaxCount,
 						res.CurrentPos, res.NextPos, res.PrevPos, lastIndexedPosition);
@@ -404,7 +420,7 @@ namespace EventStore.Core.Services.Storage {
 					if (resolved == null)
 						return NoData(msg, ReadAllResult.AccessDenied, pos, lastIndexedPosition);
 
-					var metadata = _readIndex.GetStreamMetadata(SystemStreams.AllStream);
+					var metadata = _readIndex.GetStreamMetadata(_systemStreams.AllStream);
 					return new ClientMessage.ReadAllEventsBackwardCompleted(
 						msg.CorrelationId, ReadAllResult.Success, null, resolved, metadata, false, msg.MaxCount,
 						res.CurrentPos, res.NextPos, res.PrevPos, lastIndexedPosition);
@@ -444,7 +460,7 @@ namespace EventStore.Core.Services.Storage {
 						return NoDataForFilteredCommand(msg, FilteredReadAllResult.AccessDenied, pos,
 							lastIndexedPosition);
 
-					var metadata = _readIndex.GetStreamMetadata(SystemStreams.AllStream);
+					var metadata = _readIndex.GetStreamMetadata(_systemStreams.AllStream);
 					return new ClientMessage.FilteredReadAllEventsForwardCompleted(
 						msg.CorrelationId, FilteredReadAllResult.Success, null, resolved, metadata, false,
 						msg.MaxCount,
@@ -487,7 +503,7 @@ namespace EventStore.Core.Services.Storage {
 						return NoDataForFilteredCommand(msg, FilteredReadAllResult.AccessDenied, pos,
 							lastIndexedPosition);
 
-					var metadata = _readIndex.GetStreamMetadata(SystemStreams.AllStream);
+					var metadata = _readIndex.GetStreamMetadata(_systemStreams.AllStream);
 					return new ClientMessage.FilteredReadAllEventsBackwardCompleted(
 						msg.CorrelationId, FilteredReadAllResult.Success, null, resolved, metadata, false,
 						msg.MaxCount,
@@ -595,9 +611,9 @@ namespace EventStore.Core.Services.Storage {
 					var linkPayload = Helper.UTF8NoBom.GetString(eventRecord.Data.Span);
 					var parts = linkPayload.Split(LinkToSeparator, 2);
 					if (long.TryParse(parts[0], out long eventNumber)) {
-						var streamId = parts[1];
-
-						var res = _readIndex.ReadEvent(streamId, eventNumber);
+						var streamName = parts[1];
+						var streamId = _readIndex.GetStreamId(streamName);
+						var res = _readIndex.ReadEvent(streamName, streamId, eventNumber);
 						if (res.Result == ReadEventResult.Success)
 							return ResolvedEvent.ForResolvedLink(res.Record, eventRecord, commitPosition);
 
@@ -699,7 +715,8 @@ namespace EventStore.Core.Services.Storage {
 				message.Envelope.ReplyWith(new StorageMessage.OperationCancelledMessage(message.CancellationToken));
 			}
 			var streamId = _readIndex.GetEventStreamIdByTransactionId(message.TransactionId);
-			message.Envelope.ReplyWith(new StorageMessage.StreamIdFromTransactionIdResponse(streamId));
+			var streamName = _readIndex.GetStreamName(streamId);
+			message.Envelope.ReplyWith(new StorageMessage.StreamIdFromTransactionIdResponse(streamName));
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -10,7 +10,7 @@ using Google.Protobuf;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
-	partial class Streams {
+	partial class Streams<TStreamId> {
 		public override async Task<AppendResp> Append(
 			IAsyncStreamReader<AppendReq> requestStream,
 			ServerCallContext context) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -10,7 +10,7 @@ using EventStore.Client.Streams;
 using Grpc.Core;
 
 namespace EventStore.Core.Services.Transport.Grpc {
-	partial class Streams {
+	partial class Streams<TStreamId> {
 		public override async Task<DeleteResp> Delete(DeleteReq request, ServerCallContext context) {
 			var options = request.Options;
 			var streamName = options.StreamIdentifier;

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -18,7 +18,7 @@ using ReadDirection = EventStore.Client.Streams.ReadReq.Types.Options.Types.Read
 using StreamOptionOneofCase = EventStore.Client.Streams.ReadReq.Types.Options.StreamOptionOneofCase;
 
 namespace EventStore.Core.Services.Transport.Grpc {
-	partial class Streams {
+	partial class Streams<TStreamId> {
 		public override async Task Read(
 			ReadReq request,
 			IServerStreamWriter<ReadResp> responseStream,
@@ -103,7 +103,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					(StreamOptionOneofCase.Stream,
 					CountOptionOneofCase.Subscription,
 					ReadDirection.Forwards,
-					FilterOptionOneofCase.NoFilter) => new Enumerators.StreamSubscription(
+					FilterOptionOneofCase.NoFilter) => new Enumerators.StreamSubscription<TStreamId>(
 						_publisher,
 						request.Options.Stream.StreamIdentifier,
 						request.Options.Stream.ToSubscriptionStreamRevision(),

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
@@ -4,15 +4,15 @@ using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Plugins.Authorization;
 
 namespace EventStore.Core.Services.Transport.Grpc {
-	public partial class Streams : EventStore.Client.Streams.Streams.StreamsBase {
+	public partial class Streams<TStreamId> : EventStore.Client.Streams.Streams.StreamsBase {
 		private readonly IPublisher _publisher;
-		private readonly IReadIndex _readIndex;
+		private readonly IReadIndex<TStreamId> _readIndex;
 		private readonly int _maxAppendSize;
 		private readonly IAuthorizationProvider _provider;
 		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Streams.Read);
 		private static readonly Operation WriteOperation = new Operation(Plugins.Authorization.Operations.Streams.Write);
 		private static readonly Operation DeleteOperation = new Operation(Plugins.Authorization.Operations.Streams.Delete);
-		public Streams(IPublisher publisher, IReadIndex readIndex,
+		public Streams(IPublisher publisher, IReadIndex<TStreamId> readIndex,
 			int maxAppendSize, IAuthorizationProvider provider) {
 			if (publisher == null) throw new ArgumentNullException(nameof(publisher));
 			_publisher = publisher;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -722,7 +722,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			return _readSide.TryReadClosestBackward(logicalPosition);
 		}
 
-		public RecordWriteResult TryAppend(LogRecord record) {
+		public RecordWriteResult TryAppend(ILogRecord record) {
 			if (_isReadOnly)
 				throw new InvalidOperationException("Cannot write to a read-only block.");
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunkReadSide.cs
@@ -50,7 +50,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 						return RecordReadResult.Failure;
 					}
 
-					LogRecord record;
+					ILogRecord record;
 					int length;
 					var result = TryReadForwardInternal(workItem, logicalPosition, out length, out record);
 					return new RecordReadResult(result, -1, record, length);
@@ -70,7 +70,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 						return RecordReadResult.Failure;
 
 					int length;
-					LogRecord record;
+					ILogRecord record;
 					if (!TryReadForwardInternal(workItem, logicalPosition, out length, out record))
 						return RecordReadResult.Failure;
 
@@ -93,7 +93,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 						return RecordReadResult.Failure;
 
 					int length;
-					LogRecord record;
+					ILogRecord record;
 					if (!TryReadBackwardInternal(workItem, logicalPosition, out length, out record))
 						return RecordReadResult.Failure;
 
@@ -275,7 +275,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 						return RecordReadResult.Failure;
 					}
 
-					LogRecord record;
+					ILogRecord record;
 					int length;
 					var result = TryReadForwardInternal(workItem, actualPosition, out length, out record);
 					return new RecordReadResult(result, -1, record, length);
@@ -333,7 +333,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 						return RecordReadResult.Failure;
 
 					int length;
-					LogRecord record;
+					ILogRecord record;
 					if (!TryReadForwardInternal(workItem, actualPosition, out length, out record))
 						return RecordReadResult.Failure;
 
@@ -361,7 +361,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 						return RecordReadResult.Failure;
 
 					int length;
-					LogRecord record;
+					ILogRecord record;
 					if (!TryReadBackwardInternal(workItem, actualPosition, out length, out record))
 						return RecordReadResult.Failure;
 
@@ -467,7 +467,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			}
 
 			protected bool TryReadForwardInternal(ReaderWorkItem workItem, long actualPosition, out int length,
-				out LogRecord record) {
+				out ILogRecord record) {
 				length = -1;
 				record = null;
 
@@ -517,7 +517,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			}
 
 			protected bool TryReadBackwardInternal(ReaderWorkItem workItem, long actualPosition, out int length,
-				out LogRecord record) {
+				out ILogRecord record) {
 				length = -1;
 				record = null;
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkChaser.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkChaser.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			// NOOP
 		}
 
-		public bool TryReadNext(out LogRecord record) {
+		public bool TryReadNext(out ILogRecord record) {
 			var res = TryReadNext();
 			record = res.LogRecord;
 			return res.Success;

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			// DO NOTHING
 		}
 
-		public bool Write(LogRecord record, out long newPos) {
+		public bool Write(ILogRecord record, out long newPos) {
 			var result = _currentChunk.TryAppend(record);
 			if (result.Success)
 				_writerCheckpoint.Write(result.NewPosition + _currentChunk.ChunkHeader.ChunkStartPosition);

--- a/src/EventStore.Core/TransactionLog/ITransactionFileChaser.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileChaser.cs
@@ -9,7 +9,7 @@ namespace EventStore.Core.TransactionLog {
 		void Open();
 
 		SeqReadResult TryReadNext();
-		bool TryReadNext(out LogRecord record);
+		bool TryReadNext(out ILogRecord record);
 
 		void Close();
 		void Flush();

--- a/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
@@ -5,7 +5,7 @@ using EventStore.Core.TransactionLog.LogRecords;
 namespace EventStore.Core.TransactionLog {
 	public interface ITransactionFileWriter : IDisposable {
 		void Open();
-		bool Write(LogRecord record, out long newPos);
+		bool Write(ILogRecord record, out long newPos);
 		void Flush();
 		void Close();
 

--- a/src/EventStore.Core/TransactionLog/LogRecords/ILogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/ILogRecord.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+
+namespace EventStore.Core.TransactionLog.LogRecords {
+	public interface ILogRecord {
+		LogRecordType RecordType { get; }
+		byte Version { get; }
+		public long LogPosition { get; }
+		void WriteTo(BinaryWriter writer);
+		long GetNextLogPosition(long logicalPosition, int length);
+		long GetPrevLogPosition(long logicalPosition, int length);
+		int GetSizeWithLengthPrefixAndSuffix();
+	}
+}

--- a/src/EventStore.Core/TransactionLog/LogRecords/IPrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/IPrepareLogRecord.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace EventStore.Core.TransactionLog.LogRecords {
+	// This interface specifies what the Storage, TF and Index machinery requires
+	// in order to handle a prepare (i.e. data) record.
+	// The V2 prepare implements it trivially
+	public interface IPrepareLogRecord : ILogRecord {
+		PrepareFlags Flags { get; }
+		long TransactionPosition { get; }
+		int TransactionOffset { get; }
+		long ExpectedVersion { get; }
+		Guid EventId { get; }
+		Guid CorrelationId { get; }
+		DateTime TimeStamp { get; }
+		string EventType { get; }
+		ReadOnlyMemory<byte> Data { get; }
+		ReadOnlyMemory<byte> Metadata { get; }
+	}
+
+	public interface IPrepareLogRecord<TStreamId> : IPrepareLogRecord {
+		TStreamId EventStreamId { get; }
+	}
+}

--- a/src/EventStore.Core/TransactionLog/LogRecords/ISystemLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/ISystemLogRecord.cs
@@ -1,0 +1,6 @@
+﻿namespace EventStore.Core.TransactionLog.LogRecords {
+	public interface ISystemLogRecord : ILogRecord {
+		SystemRecordType SystemRecordType { get; }
+		EpochRecord GetEpochRecord();
+	}
+}

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -38,21 +38,21 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 		}
 	}
 
-	public class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord> {
+	public class PrepareLogRecord : LogRecord, IEquatable<PrepareLogRecord>, IPrepareLogRecord<string> {
 		public const byte PrepareRecordVersion = 1;
 
-		public readonly PrepareFlags Flags;
-		public readonly long TransactionPosition;
-		public readonly int TransactionOffset;
-		public readonly long ExpectedVersion; // if IsCommitted is set, this is final EventNumber
-		public readonly string EventStreamId;
+		public PrepareFlags Flags { get; }
+		public long TransactionPosition { get; }
+		public int TransactionOffset { get; }
+		public long ExpectedVersion { get; } // if IsCommitted is set, this is final EventNumber
+		public string EventStreamId { get; }
 
-		public readonly Guid EventId;
-		public readonly Guid CorrelationId;
-		public readonly DateTime TimeStamp;
-		public readonly string EventType;
-		public readonly ReadOnlyMemory<byte> Data;
-		public readonly ReadOnlyMemory<byte> Metadata;
+		public Guid EventId { get; }
+		public Guid CorrelationId { get; }
+		public DateTime TimeStamp { get; }
+		public string EventType { get; }
+		public ReadOnlyMemory<byte> Data { get; }
+		public ReadOnlyMemory<byte> Metadata { get; }
 
 		public long InMemorySize {
 			get {

--- a/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/SystemLogRecord.cs
@@ -15,11 +15,11 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 		Bson = 3
 	}
 
-	public class SystemLogRecord : LogRecord, IEquatable<SystemLogRecord> {
+	public class SystemLogRecord : LogRecord, IEquatable<SystemLogRecord>, ISystemLogRecord {
 		public const byte SystemRecordVersion = 0;
 
 		public readonly DateTime TimeStamp;
-		public readonly SystemRecordType SystemRecordType;
+		public SystemRecordType SystemRecordType { get; }
 		public readonly SystemRecordSerialization SystemRecordSerialization;
 		public readonly long Reserved;
 		public readonly ReadOnlyMemory<byte> Data;

--- a/src/EventStore.Core/TransactionLog/ReadResults.cs
+++ b/src/EventStore.Core/TransactionLog/ReadResults.cs
@@ -6,10 +6,10 @@ namespace EventStore.Core.TransactionLog {
 
 		public readonly bool Success;
 		public readonly long NextPosition;
-		public readonly LogRecord LogRecord;
+		public readonly ILogRecord LogRecord;
 		public readonly int RecordLength;
 
-		public RecordReadResult(bool success, long nextPosition, LogRecord logRecord, int recordLength) {
+		public RecordReadResult(bool success, long nextPosition, ILogRecord logRecord, int recordLength) {
 			Success = success;
 			LogRecord = logRecord;
 			NextPosition = nextPosition;
@@ -30,14 +30,14 @@ namespace EventStore.Core.TransactionLog {
 
 		public readonly bool Success;
 		public readonly bool Eof;
-		public readonly LogRecord LogRecord;
+		public readonly ILogRecord LogRecord;
 		public readonly int RecordLength;
 		public readonly long RecordPrePosition;
 		public readonly long RecordPostPosition;
 
 		public SeqReadResult(bool success,
 			bool eof,
-			LogRecord logRecord,
+			ILogRecord logRecord,
 			int recordLength,
 			long recordPrePosition,
 			long recordPostPosition) {


### PR DESCRIPTION
Changed: Generalized TF and Index in preparation for LogV3

In LogV2 the event records (prepare records) contain the stream name as a string. In LogV3 the stream will be identified by a long.
LogV3 also has a different record header format, which does not include the logical position of each record.

We'd prefer to keep using the existing Index and TF machinery for now since it is mature. This PR generalises that machinery to support
both log formats and their different ways of identifying streams.

I've tried to make the changes as obvious as possible, avoiding refactoring or whitespace adjustments in order to make the changes
as easy to read as possible, since it does affect quite a few lines.
