### PR TITLE
Expect the correct TCP command

### DIFF
--- a/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
@@ -54,6 +54,7 @@ namespace EventStore.TestClient.Commands {
 			int total = 0;
 			var sw = new Stopwatch();
 			var tcpCommand = forward ? TcpCommand.ReadAllEventsForward : TcpCommand.ReadAllEventsBackward;
+			var tcpCommandToReceive = forward ? TcpCommand.ReadAllEventsForwardCompleted : TcpCommand.ReadAllEventsBackwardCompleted;
 
 			context.Client.CreateTcpConnection(
 				context,
@@ -68,7 +69,7 @@ namespace EventStore.TestClient.Commands {
 					conn.EnqueueSend(package);
 				},
 				handlePackage: (conn, pkg) => {
-					if (pkg.Command != tcpCommand) {
+					if (pkg.Command != tcpCommandToReceive) {
 						context.Fail(reason: string.Format("Unexpected TCP package: {0}.", pkg.Command));
 						return;
 					}


### PR DESCRIPTION
Fixed: Rdall for TestClient

Before fix we get

```
>>> rdall
[43000, 8,13:58:34.462,INF] Processing command: "rdall".
[43000, 5,13:58:34.481,DBG] Segments count: 1, buffers count: 512, should be when full: 512
[43000, 4,13:58:34.485,INF] ["127.0.0.1:1113", L"127.0.0.1:50684"]: Reading all "FORWARD"...
[43000, 8,13:58:34.537,ERR] Error during execution of command: "Unexpected TCP package: ReadAllEventsForwardCompleted.".
[43000, 8,13:58:34.537,INF] Command exited with code 1.
```