### PR TITLE
Update sourcelink package version

### DIFF
--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -63,6 +63,6 @@
     </ItemGroup>
   </Target>
   <ItemGroup>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 </Project>

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
       <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
       <PackageReference Include="protobuf-net" Version="2.4.0" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' OR '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Net.Http" />


### PR DESCRIPTION
Bumped version of [Microsoft Sourcelink](https://www.nuget.org/packages/Microsoft.SourceLink.GitHub) package used by ClientAPI to _1.0.0_. Was previously _1.0.0-beta-63127-02_.

The previous version was causing build to fail on Ubuntu 18+. The issue had been patched in nuget package a while ago.

Relevant PR on sourcelink repo: [#288](https://github.com/dotnet/sourcelink/pull/288).

Related issue on ES docs with workaround: [#361](https://github.com/EventStore/documentation-old/issues/361)

Other related issues:
- [dotnet roslyn #29289](https://github.com/dotnet/roslyn/issues/29289)
- [ms fhir-server #262](https://github.com/microsoft/fhir-server/issues/262)