### PR TITLE
Fix parsing of yaml config options specified as an array

### DIFF
--- a/src/EventStore.Common/Configuration/YamlConfigurationFileParser.cs
+++ b/src/EventStore.Common/Configuration/YamlConfigurationFileParser.cs
@@ -55,7 +55,14 @@ namespace EventStore.Common.Configuration {
 				throw new FormatException($"Duplicate key '{currentKey}' found.");
 			}
 
-			_data[currentKey] = IsNullValue(yamlValue) ? null : yamlValue.Value;
+			if (currentKey.Contains(":")) {
+				var key = currentKey.Split(":").First();
+				var value = IsNullValue(yamlValue) ? null : yamlValue.Value;
+				_data[key] = _data.ContainsKey(key) ? $"{_data[key]},{value}" : value;
+			} else {
+				_data[currentKey] = IsNullValue(yamlValue) ? null : yamlValue.Value;
+			}
+
 			ExitContext();
 		}
 

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Common.Configuration;
+using EventStore.Common.Utils;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Primitives;
 using NUnit.Framework;
@@ -158,6 +159,8 @@ namespace EventStore.Core.Tests {
 
 				Assert.AreEqual(yamlConfiguration.FullName, options.Application.Config);
 				Assert.IsTrue(options.Database.MemDb);
+				Assert.AreEqual("127.0.0.1:1113,127.0.0.1:2113",
+					string.Join(",", options.Cluster.GossipSeed.Select(x => $"{x.GetHost()}:{x.GetPort()}")));
 			} finally {
 				yamlConfiguration.Delete();
 			}
@@ -168,6 +171,7 @@ namespace EventStore.Core.Tests {
 				await writer.WriteAsync(new StringBuilder()
 					.AppendLine("---")
 					.AppendLine("MemDb: true")
+					.AppendLine("GossipSeed: ['127.0.0.1:1113', '127.0.0.1:2113']")
 					.AppendLine("SECTION:")
 					.AppendLine("  Something: Value")
 				);


### PR DESCRIPTION
Fixed: Parsing of yaml config options specified as an array

If an option is specified as an array, join the values together into a comma-separated string when parsing the yaml file.

This is to fix an error when parsing arrays in a yaml file, for example:

```
GossipSeed: ['127.0.0.1:2113','127.0.0.1:3113']
```

Would give the following error, due to the way the context is built up in the parser:

```
 Error while parsing options: The option GossipSeed:1 is not a known option. (Parameter 'GossipSeed:1')
```