### PR TITLE
Integrate first V3 record: Epoch

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -68,8 +68,9 @@ namespace EventStore.ClusterNode {
 
 			var plugInContainer = FindPlugins();
 
+			//var logFormat = LogFormatAbstractor.V3;
 			var logFormat = LogFormatAbstractor.V2;
-			Node = new ClusterVNode<string>(_options, logFormat, GetAuthenticationProviderFactory(), GetAuthorizationProviderFactory(),
+			Node = ClusterVNode.Create(_options, logFormat, GetAuthenticationProviderFactory(), GetAuthorizationProviderFactory(),
 				GetPersistentSubscriptionConsumerStrategyFactories());
 
 			var runProjections = _options.Projections.RunProjections;

--- a/src/EventStore.Core.Tests.XUnit/LogV3/LogV3RecordFactoryTests.cs
+++ b/src/EventStore.Core.Tests.XUnit/LogV3/LogV3RecordFactoryTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.LogV3;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.LogCommon;
+using Xunit;
+
+namespace EventStore.Core.Tests.XUnit.LogV3 {
+	// we dont want too many tests here, rather pass this factory into the higher up
+	// integration tests like we do for the v2 factory.
+	public class LogV3RecordFactoryTests {
+		readonly Guid _guid1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
+		readonly Guid _guid2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
+		readonly DateTime _dateTime1 = new DateTime(2020, 01, 01, 01, 01, 01);
+		readonly long _long1 = 1;
+		readonly long _long2 = 2;
+		readonly long _long3 = 3;
+		readonly int _int100 = 100;
+		readonly string _string1 = "one";
+		readonly string _string2 = "two";
+		readonly LogV3RecordFactory _sut = new(LogFormatAbstractor.V2.RecordFactory);
+		readonly PrepareFlags _prepareflags = PrepareFlags.SingleWrite;
+		readonly ReadOnlyMemory<byte> _bytes1 = new byte[10];
+		readonly ReadOnlyMemory<byte> _bytes2 = new byte[10];
+
+		[Fact]
+		public void can_create_epoch() {
+			var epochNumber = 5;
+			var epochIn = new EpochRecord(
+				epochPosition: _long1,
+				epochNumber: epochNumber,
+				epochId: _guid1,
+				prevEpochPosition: _long2,
+				timeStamp: _dateTime1,
+				leaderInstanceId: _guid2);
+
+			var systemEpoch = _sut.CreateEpoch(epochIn);
+
+			var epochOut = systemEpoch.GetEpochRecord();
+
+			Assert.Equal(_long1, systemEpoch.LogPosition);
+			Assert.Equal(LogRecordType.System, systemEpoch.RecordType);
+			Assert.Equal(SystemRecordType.Epoch, systemEpoch.SystemRecordType);
+			Assert.Equal(_long1, systemEpoch.Version);
+
+			Assert.Equal(epochIn.EpochPosition, epochOut.EpochPosition);
+			Assert.Equal(epochIn.TimeStamp, epochOut.TimeStamp);
+			Assert.Equal(epochIn.EpochId, epochOut.EpochId);
+			Assert.Equal(epochIn.EpochNumber, epochOut.EpochNumber);
+			Assert.Equal(epochIn.PrevEpochPosition, epochOut.PrevEpochPosition);
+			Assert.Equal(epochIn.LeaderInstanceId, epochOut.LeaderInstanceId);
+		}
+
+		[Fact]
+		public void can_create_prepare() {
+			var prepare = _sut.CreatePrepare(
+				logPosition: _long1,
+				correlationId: _guid1,
+				eventId: _guid2,
+				transactionPosition: _long2,
+				transactionOffset: _int100,
+				eventStreamId: _string1,
+				expectedVersion: _long3,
+				timeStamp: _dateTime1,
+				flags: _prepareflags,
+				eventType: _string2,
+				data: _bytes1,
+				metadata: _bytes2);
+
+			Assert.Equal(_long1, prepare.LogPosition);
+			Assert.Equal(_guid1, prepare.CorrelationId);
+			Assert.Equal(_guid2, prepare.EventId);
+			Assert.Equal(_long2, prepare.TransactionPosition);
+			Assert.Equal(_int100, prepare.TransactionOffset);
+			Assert.Equal(_string1, prepare.EventStreamId);
+			Assert.Equal(_long3, prepare.ExpectedVersion);
+			Assert.Equal(_dateTime1, prepare.TimeStamp);
+			Assert.Equal(_prepareflags, prepare.Flags);
+			Assert.Equal(_string2, prepare.EventType);
+			Assert.Equal(_bytes1, prepare.Data);
+			Assert.Equal(_bytes2, prepare.Metadata);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using EventStore.Core.Bus;
-using EventStore.Core.LogV2;
+using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.TransactionLog;
@@ -19,8 +19,12 @@ using EventStore.Core.TransactionLog.LogRecords;
 using System.Threading;
 
 namespace EventStore.Core.Tests.Services.Storage {
+	public sealed class when_having_an_epoch_manager_and_empty_tf_log_v3 : when_having_an_epoch_manager_and_empty_tf_log {
+		protected override IRecordFactory RecordFactory => LogFormatAbstractor.V3.RecordFactory;
+	}
+
 	[TestFixture]
-	public sealed class when_having_an_epoch_manager_and_empty_tf_log : SpecificationWithDirectoryPerTestFixture, IDisposable {
+	public class when_having_an_epoch_manager_and_empty_tf_log : SpecificationWithDirectoryPerTestFixture, IDisposable {
 		private TFChunkDb _db;
 		private EpochManager _epochManager;
 		private LinkedList<EpochRecord> _cache;
@@ -29,10 +33,11 @@ namespace EventStore.Core.Tests.Services.Storage {
 		private IBus _mainBus;
 		private readonly Guid _instanceId = Guid.NewGuid();
 		private readonly List<Message> _published = new List<Message>();
-		private static int GetNextEpoch() {
+		protected virtual IRecordFactory RecordFactory => LogFormatAbstractor.V2.RecordFactory;
+		private int GetNextEpoch() {
 			return (int)Interlocked.Increment(ref _currentEpoch);
 		}
-		private static long _currentEpoch = -1;
+		private long _currentEpoch = -1;
 		private EpochManager GetManager() {
 			return new EpochManager(_mainBus,
 				10,
@@ -42,7 +47,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
-				new LogV2RecordFactory(),
+				RecordFactory,
 				_instanceId);
 		}
 		private LinkedList<EpochRecord> GetCache(EpochManager manager) {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -65,6 +65,25 @@ namespace EventStore.Core {
 	public abstract class ClusterVNode {
 		protected static readonly ILogger Log = Serilog.Log.ForContext<ClusterVNode>();
 
+		public static ClusterVNode<TStreamId> Create<TStreamId>(
+			ClusterVNodeOptions options,
+			LogFormatAbstractor<TStreamId> logFormat,
+			AuthenticationProviderFactory authenticationProviderFactory = null,
+			AuthorizationProviderFactory authorizationProviderFactory = null,
+			IReadOnlyList<IPersistentSubscriptionConsumerStrategyFactory> factories = null,
+			Guid? instanceId = null,
+			int debugIndex = 0) {
+
+			return new ClusterVNode<TStreamId>(
+				options,
+				logFormat,
+				authenticationProviderFactory,
+				authorizationProviderFactory,
+				factories,
+				instanceId,
+				debugIndex);
+		}
+
 		abstract public TFChunkDb Db { get; }
 		abstract public GossipAdvertiseInfo GossipAdvertiseInfo { get; }
 		abstract public IQueuedHandler MainQueue { get; }

--- a/src/EventStore.Core/LogAbstraction/LogFormatAbstractor.cs
+++ b/src/EventStore.Core/LogAbstraction/LogFormatAbstractor.cs
@@ -1,11 +1,13 @@
 ﻿using EventStore.Common.Utils;
 using EventStore.Core.Index.Hashes;
 using EventStore.Core.LogV2;
+using EventStore.Core.LogV3;
 using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.LogAbstraction {
 	public class LogFormatAbstractor {
 		public static LogFormatAbstractor<string> V2 { get; }
+		public static LogFormatAbstractor<string> V3 { get; }
 
 		static LogFormatAbstractor() {
 			var streamNameIndex = new LogV2StreamNameIndex();
@@ -20,6 +22,19 @@ namespace EventStore.Core.LogAbstraction {
 				string.Empty,
 				new LogV2Sizer(),
 				new LogV2RecordFactory());
+
+			// just like v2 for now except epochs
+			V3 = new LogFormatAbstractor<string>(
+				new XXHashUnsafe(),
+				new Murmur3AUnsafe(),
+				streamNameIndex,
+				streamNameIndex,
+				new StreamNameLookupSingletonFactory<string>(streamNameIndex),
+				new LogV2SystemStreams(),
+				new LogV2StreamIdValidator(),
+				string.Empty,
+				new LogV2Sizer(),
+				new LogV3RecordFactory(V2.RecordFactory));
 		}
 	}
 

--- a/src/EventStore.Core/LogV3/LogV3RecordFactory.cs
+++ b/src/EventStore.Core/LogV3/LogV3RecordFactory.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.LogV3 {
+	public class LogV3RecordFactory : IRecordFactory<string> {
+		private readonly IRecordFactory<string> _logV2RecordFactory;
+
+		public LogV3RecordFactory(IRecordFactory<string> logV2RecordFactory) {
+			_logV2RecordFactory = logV2RecordFactory;
+		}
+
+		public ISystemLogRecord CreateEpoch(EpochRecord epoch) {
+			var result = new LogV3EpochLogRecord(
+				logPosition: epoch.EpochPosition,
+				timeStamp: epoch.TimeStamp,
+				epochNumber: epoch.EpochNumber,
+				epochId: epoch.EpochId,
+				prevEpochPosition: epoch.PrevEpochPosition,
+				leaderInstanceId: epoch.LeaderInstanceId);
+			return result;
+		}
+
+		// using v2 until v3 prepares are implemented
+		public IPrepareLogRecord<string> CreatePrepare(
+			long logPosition,
+			Guid correlationId,
+			Guid eventId,
+			long transactionPosition,
+			int transactionOffset,
+			string eventStreamId,
+			long expectedVersion,
+			DateTime timeStamp,
+			PrepareFlags flags,
+			string eventType,
+			ReadOnlyMemory<byte> data,
+			ReadOnlyMemory<byte> metadata) {
+
+			return _logV2RecordFactory.CreatePrepare(
+				logPosition,
+				correlationId,
+				eventId,
+				transactionPosition,
+				transactionOffset,
+				eventStreamId,
+				expectedVersion,
+				timeStamp,
+				flags,
+				eventType,
+				data,
+				metadata);
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogV3EpochLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogV3EpochLogRecord.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using EventStore.LogV3;
+
+namespace EventStore.Core.TransactionLog.LogRecords {
+	public class LogV3EpochLogRecord : LogV3Record<Raw.EpochHeader>, ISystemLogRecord {
+		public SystemRecordType SystemRecordType => SystemRecordType.Epoch;
+
+		public LogV3EpochLogRecord(
+			long logPosition,
+			DateTime timeStamp,
+			int epochNumber,
+			Guid epochId,
+			long prevEpochPosition,
+			Guid leaderInstanceId) : base() {
+
+			Record = RecordCreator.CreateEpochRecord(
+				timeStamp: timeStamp,
+				logPosition: logPosition,
+				epochNumber: epochNumber,
+				epochId: epochId,
+				prevEpochPosition: prevEpochPosition,
+				leaderInstanceId: leaderInstanceId);
+		}
+
+		public LogV3EpochLogRecord(ReadOnlyMemory<byte> bytes) : base(bytes) {
+		}
+
+		public EpochRecord GetEpochRecord() => new EpochRecord(
+			epochPosition: Record.Header.LogPosition,
+			epochNumber: Record.SubHeader.EpochNumber,
+			epochId: Record.Header.RecordId,
+			prevEpochPosition: Record.SubHeader.PrevEpochPosition,
+			timeStamp: Record.Header.TimeStamp,
+			leaderInstanceId: Record.SubHeader.LeaderInstanceId);
+	}
+}

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogV3Reader.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogV3Reader.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.IO;
+using EventStore.LogCommon;
+using EventStore.LogV3;
+
+namespace EventStore.Core.TransactionLog.LogRecords {
+	public static class LogV3Reader {
+		public static LogV3EpochLogRecord ReadEpoch(LogRecordType type, byte version, BinaryReader reader) {
+			// temporary: we happen to know the length of an epoch, its always the same.
+			// later we will pass the size in since we will need it for dynamically sized records.
+			var length = Raw.RecordHeader.Size + Raw.EpochHeader.Size;
+			var bytes = ReadBytes(type, version, reader, length);
+			return new LogV3EpochLogRecord(bytes);
+		}
+
+		private static byte[] ReadBytes(LogRecordType type, byte version, BinaryReader reader, int recordLength) {
+			// todo: if we could get some confidence that we would return to the pool
+			// (e.g. with reference counting) then we could use arraypool here. or just maybe a ring buffer
+			// var bytes = ArrayPool<byte>.Shared.Rent(length);
+			var bytes = new byte[recordLength];
+			bytes[0] = (byte)type;
+			bytes[1] = version;
+			reader.Read(bytes.AsSpan(2..recordLength));
+			return bytes;
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogV3Record.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogV3Record.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.IO;
+using EventStore.LogCommon;
+using EventStore.LogV3;
+
+namespace EventStore.Core.TransactionLog.LogRecords {
+	// This is the adapter to plug V3 records into the standard machinery.
+	public class LogV3Record<T> : ILogRecord where T : unmanaged {
+		public RecordView<T> Record { get; init; }
+
+		public long GetNextLogPosition(long logicalPosition, int length) {
+			return logicalPosition + length + 2 * sizeof(int);
+		}
+
+		public long GetPrevLogPosition(long logicalPosition, int length) {
+			return logicalPosition - length - 2 * sizeof(int);
+		}
+
+		public LogRecordType RecordType => Record.Header.Type;
+
+		public byte Version => Record.Header.Version;
+
+		public long LogPosition => Record.Header.LogPosition;
+
+		public DateTime TimeStamp => Record.Header.TimeStamp;
+
+		public LogV3Record() {
+		}
+
+		public LogV3Record(ReadOnlyMemory<byte> populatedBytes) {
+			Record = new RecordView<T>(populatedBytes);
+		}
+
+		public void WriteTo(BinaryWriter writer) {
+			writer.Write(Record.Bytes.Span);
+		}
+
+		public int GetSizeWithLengthPrefixAndSuffix() {
+			return 2 * sizeof(int) + Record.Bytes.Length;
+		}
+	}
+}


### PR DESCRIPTION
Added: V3 Epoch integration

- This connects up the Epoch record in the v3 project via the record factory abstraction point
- V3 Epochs are distinguished from V2 epochs with the version field
- V3 is enabled/disabled manually in ClusterVNodeHostedService