### PR TITLE
[release/v20.10] Removed the job check from cherry-pick-pr-for-label action.

### DIFF
--- a/.github/workflows/cherry-pick-pr-for-label.yml
+++ b/.github/workflows/cherry-pick-pr-for-label.yml
@@ -4,12 +4,11 @@ on:
     types: [closed]
 jobs:
   cherry_pick_pr_for_label:
-    if: github.event.pull_request.merged == 'true'
     name: Cherry pick PR commits for label
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Cherry Pick PR for label
-        uses: EventStore/Automations/cherry-pick-pr-for-label@cherry_pick_for_label
+        uses: EventStore/Automations/cherry-pick-pr-for-label@master
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cherry-picked #2903 