### PR TITLE
Update auto-configuration of reader threads

### DIFF
--- a/docs/configuration/auto-configured-options.md
+++ b/docs/configuration/auto-configured-options.md
@@ -1,0 +1,51 @@
+# Auto-Configured Options
+
+Some options are configured at startup to make better use of the available resources on larger instances or machines.
+
+These options are `StreamInfoCacheCapacity`, `ReaderThreadsCount`, and `WorkerThreads`.
+
+## StreamInfoCacheCapacity
+
+| Format               | Syntax |
+| :------------------- | :----- |
+| Command line         | `--stream-info-cache-capacity` |
+| YAML                 | `StreamInfoCacheCapacity` |
+| Environment variable | `STREAM_INFO_CACHE_CAPACITY` | 
+
+This option sets the maximum number of entries to keep in the stream info cache. This is the lookup that contains the information of any stream that has recently been read or written to. Having entries in this cache significantly improves write and read performance to cached streams on larger databases.
+
+The cache is configured at startup based on the available free memory at the time. If there is 4gb or more available, it will be configured to take at most 75% of the remaining memory, otherwise it will take at most 50%. The minimum that it can be set to is 100,000 entries.
+
+The option is set to 0 by default, which enables auto-configuration. The default on previous versions of EventStoreDb was 100,000 entries.
+
+## ReaderThreadsCount
+
+| Option Name               | Syntax |
+| :------------------- | :----- |
+| Command line         | `--reader-threads-count` |
+| YAML                 | `ReaderThreadsCount` |
+| Environment variable | `READER_THREADS_COUNT` | 
+
+This option configures the number of reader threads available to EventStoreDb. Having more reader threads allows more concurrent reads to be processed.
+
+The reader threads count will be set at startup to twice the number of available processors, with a minimum of 4 and a maximum of 16 threads.
+
+The option is set to 0 by default, which enables auto-configuration. The default on previous versions of EventStoreDb was 4 threads.
+
+:::warning
+Increasing the reader threads count too high can cause read timeouts if your disk cannot handle the increased load.
+:::
+
+## WorkerThreads
+
+| Option Name               | Syntax |
+| :------------------- | :----- |
+| Command line         | `--worker-threads` |
+| YAML                 | `WorkerThreads` |
+| Environment variable | `WORKER_THREADS` | 
+
+Worker Threads configures the number of threads available to the pool of worker services.
+
+At startup the number of worker threads will be set to 10 if there are more than 4 reader threads. Otherwise, it will be set to have 5 threads available.
+
+The option is set to 0 by default, which enables auto-configuration. The default on previous versions of EventStoreDb was 5 threads.

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -26,6 +26,7 @@ module.exports = [
         path: "configuration/",
         children: [
             "configuration/",
+            "configuration/auto-configured-options.md"
         ]
     },
     {

--- a/src/EventStore.Core.Tests/Settings/ReaderThreadCountCalculatorTests.cs
+++ b/src/EventStore.Core.Tests/Settings/ReaderThreadCountCalculatorTests.cs
@@ -4,27 +4,25 @@ using NUnit.Framework;
 namespace EventStore.Core.Tests.Settings {
 	[TestFixture]
 	public class ReaderThreadCountCalculatorTests {
-		const ulong GigaByte = CacheSizeCalculator.Gigabyte;
+		[TestCase]
+		public void configured_takes_precedence() => Test(configuredCount: 1, processorCount: 4, expected: 1);
 
 		[TestCase]
-		public void configured_takes_precedence() => Test(configuredCount: 1, mem: GigaByte, expected: 1);
+		public void enforces_minimum() => Test(configuredCount: 0, processorCount: 1, expected: 4);
 
 		[TestCase]
-		public void enforces_minimum() => Test(configuredCount: 0, mem: 200, expected: 4);
+		public void enforces_maximum() => Test(configuredCount: 0, processorCount: 20, expected: 16);
 
 		[TestCase]
-		public void enforces_maximum() => Test(configuredCount: 0, mem: 128 * GigaByte, expected: 16);
+		public void at_3_cores() => Test(configuredCount: 0, processorCount: 3, expected: 6);
 
 		[TestCase]
-		public void at_001gib() => Test(configuredCount: 0, mem: 1 * GigaByte, expected: 4);
+		public void at_4_cores() => Test(configuredCount: 0, processorCount: 4, expected: 8);
 
 		[TestCase]
-		public void at_004gib() => Test(configuredCount: 0, mem: 4 * GigaByte, expected: 8);
+		public void at_6_cores() => Test(configuredCount: 0, processorCount: 6, expected: 12);
 
-		[TestCase]
-		public void at_008gib() => Test(configuredCount: 0, mem: 8 * GigaByte, expected: 16);
-
-		public static void Test(int configuredCount, ulong mem, int expected) =>
-			Assert.AreEqual(expected, ThreadCountCalculator.CalculateReaderThreadCount(configuredCount, mem));
+		public static void Test(int configuredCount, int processorCount, int expected) =>
+			Assert.AreEqual(expected, ThreadCountCalculator.CalculateReaderThreadCount(configuredCount, processorCount));
 	}
 }

--- a/src/EventStore.Core/Settings/ThreadCountCalculator.cs
+++ b/src/EventStore.Core/Settings/ThreadCountCalculator.cs
@@ -5,12 +5,11 @@ namespace EventStore.Core.Settings {
 	public static class ThreadCountCalculator {
 		private const int ReaderThreadCountFloor = 4;
 
-		public static int CalculateReaderThreadCount(int configuredCount, ulong availableMemoryBytes) {
+		public static int CalculateReaderThreadCount(int configuredCount, int processorCount) {
 			if (configuredCount > 0)
 				return configuredCount;
 
-			var estimatedGigabytes = Math.Floor(availableMemoryBytes / (float)CacheSizeCalculator.Gigabyte);
-			var readerCount = Math.Clamp(estimatedGigabytes * 2, ReaderThreadCountFloor, 16);
+			var readerCount = Math.Clamp(processorCount * 2, ReaderThreadCountFloor, 16);
 
 			return (int)readerCount;
 		}

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -1407,13 +1407,14 @@ namespace EventStore.Core {
 			using var statsHelper = new SystemStatsHelper(_log, new InMemoryCheckpoint(), "", statsCollectionPeriod);
 			var availableMem = statsHelper.GetFreeMem();
 
+			var processorCount = Environment.ProcessorCount;
 			var newReaderThreadsCount =
-				ThreadCountCalculator.CalculateReaderThreadCount(_readerThreadsCount, availableMem);
+				ThreadCountCalculator.CalculateReaderThreadCount(_readerThreadsCount, processorCount);
 			_log.Information(
 				"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
-				"Calculated based on {availableMem:N0} bytes of free memory and configured value of {configuredCount:N0}",
+				"Calculated based on processor count of {processorCount:N0} and configured value of {configuredCount:N0}",
 				newReaderThreadsCount,
-				availableMem, _readerThreadsCount);
+				processorCount, _readerThreadsCount);
 			_readerThreadsCount = newReaderThreadsCount;
 
 			var newWorkerThreadsCount =


### PR DESCRIPTION
Updated: auto configuration for reader threads now uses processor count

This PR contains some of the changes in https://github.com/EventStore/EventStore/pull/2902

* Auto-configure the number of reader threads based on the number of processors rather than memory
* Add auto-configuration documentation page