### PR TITLE
Log statistics for TestClient wrfl commands

### DIFF
--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.TestClient.Commands;
 using EventStore.TestClient.Commands.DvuBasic;
+using EventStore.TestClient.Statistics;
 using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
 using ILogger = Serilog.ILogger;
 #pragma warning disable 1591
@@ -33,6 +34,7 @@ namespace EventStore.TestClient {
 			_tcpTestClient = new TcpTestClient(options, interactiveMode, Log);
 			_grpcTestClient = new GrpcTestClient(options, Log);
 			_clientApiTestClient = new ClientApiTcpTestClient(options, Log);
+
 			RegisterProcessors(cancellationTokenSource);
 		}
 
@@ -126,7 +128,8 @@ namespace EventStore.TestClient {
 		private int Execute(string[] args) {
 			Log.Information("Processing command: {command}.", string.Join(" ", args));
 
-			var context = new CommandProcessorContext(_tcpTestClient, _grpcTestClient, _clientApiTestClient, Options.Timeout, Log, new ManualResetEventSlim(true));
+			var context = new CommandProcessorContext(_tcpTestClient, _grpcTestClient, _clientApiTestClient, Options.Timeout,
+				Log, Options.StatsLog, Options.OutputCsv, new ManualResetEventSlim(true));
 
 			int exitCode;
 			if (_commands.TryProcess(context, args, out exitCode)) {

--- a/src/EventStore.TestClient/ClientApiTcpCommands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/ClientApiTcpCommands/WriteFloodProcessor.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using EventStore.ClientAPI;
 using EventStore.ClientAPI.Exceptions;
 using EventStore.TestClient.Commands;
+using EventStore.TestClient.Statistics;
 using EventData = EventStore.ClientAPI.EventData;
 using ExpectedVersion = EventStore.Core.Data.ExpectedVersion;
 using StreamDeletedException = EventStore.ClientAPI.Exceptions.StreamDeletedException;
@@ -50,28 +51,21 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 				}
 			}
 
+			var stats = new WriteFloodStats(Keyword, context.OutputCsv, args);
 			var monitor = new RequestMonitor();
-			WriteFlood(context, clientsCnt, requestsCnt, streamsCnt, size, batchSize, streamPrefix, monitor)
+			WriteFlood(context, stats, clientsCnt, requestsCnt, streamsCnt, size, batchSize, streamPrefix, monitor)
 				.GetAwaiter().GetResult();
 			return true;
 		}
 
-		private async Task WriteFlood(CommandProcessorContext context, int clientsCnt, long requestsCnt, int streamsCnt,
+		private async Task WriteFlood(CommandProcessorContext context, WriteFloodStats stats, int clientsCnt, long requestsCnt, int streamsCnt,
 			int size, int batchSize, string streamPrefix, RequestMonitor monitor) {
 			context.IsAsync();
 
 			var doneEvent = new ManualResetEventSlim(false);
 			var clients = new List<IEventStoreConnection>();
 
-			long succ = 0;
 			long last = 0;
-			long fail = 0;
-			long prepTimeout = 0;
-			long commitTimeout = 0;
-			long forwardTimeout = 0;
-			long wrongExpVersion = 0;
-			long streamDeleted = 0;
-			long all = 0;
 
 			var streams = Enumerable.Range(0, streamsCnt).Select(x =>
 				string.IsNullOrWhiteSpace(streamPrefix)
@@ -83,6 +77,7 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 				streams.LastOrDefault());
 
 			var start = new TaskCompletionSource();
+			stats.StartTime = DateTime.UtcNow;
 			var sw2 = new Stopwatch();
 			var capacity = 2000 / clientsCnt;
 			var clientTasks = new List<Task>();
@@ -116,9 +111,9 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 					pending.Add(client.AppendToStreamAsync(streams[rnd.Next(streamsCnt)], ExpectedVersion.Any, events)
 						.ContinueWith(t => {
 							monitor.EndOperation(corrid);
-							if (t.IsCompletedSuccessfully) Interlocked.Add(ref succ, batchSize);
+							if (t.IsCompletedSuccessfully) Interlocked.Add(ref stats.Succ, batchSize);
 							else {
-								if (Interlocked.Increment(ref fail) % 1000 == 0) {
+								if (Interlocked.Increment(ref stats.Fail) % 1000 == 0) {
 									Console.Write("#");
 								}
 
@@ -126,33 +121,35 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 									var exception = t.Exception.Flatten();
 									switch (exception.InnerException) {
 										case WrongExpectedVersionException _:
-											Interlocked.Increment(ref wrongExpVersion);
+											Interlocked.Increment(ref stats.WrongExpVersion);
 											break;
 										case StreamDeletedException _:
-											Interlocked.Increment(ref streamDeleted);
+											Interlocked.Increment(ref stats.StreamDeleted);
 											break;
 										case OperationTimedOutException _:
-											Interlocked.Increment(ref commitTimeout);
+											Interlocked.Increment(ref stats.CommitTimeout);
 											break;
 									}
 								}
 							}
 
-							Interlocked.Add(ref succ, batchSize);
-							if (succ - last > 1000) {
-								last = succ;
+							Interlocked.Add(ref stats.Succ, batchSize);
+							if (stats.Succ - last > 1000) {
+								last = stats.Succ;
 								Console.Write(".");
 							}
 
-							var localAll = Interlocked.Add(ref all, batchSize);
+							var localAll = Interlocked.Add(ref stats.All, batchSize);
 							if (localAll % 100000 == 0) {
-								var elapsed = sw2.Elapsed;
+								stats.Elapsed = sw2.Elapsed;
+								stats.Rate = 1000.0 * 100000 / stats.Elapsed.TotalMilliseconds;
 								sw2.Restart();
 								context.Log.Debug(
 									"\nDONE TOTAL {writes} WRITES IN {elapsed} ({rate:0.0}/s) [S:{success}, F:{failures} (WEV:{wrongExpectedVersion}, P:{prepareTimeout}, C:{commitTimeout}, F:{forwardTimeout}, D:{streamDeleted})].",
-									localAll, elapsed, 1000.0 * 100000 / elapsed.TotalMilliseconds,
-									succ, fail,
-									wrongExpVersion, prepTimeout, commitTimeout, forwardTimeout, streamDeleted);
+									localAll, stats.Elapsed, stats.Rate,
+									stats.Succ, stats.Fail,
+									stats.WrongExpVersion, stats.PrepTimeout, stats.CommitTimeout, stats.ForwardTimeout, stats.StreamDeleted);
+								stats.WriteStatsToFile(context.StatsLogger);
 							}
 
 							if (localAll >= requestsCnt) {
@@ -165,9 +162,9 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 
 						while (pending.Count > 0 && Task.WhenAny(pending).IsCompleted) {
 							pending.RemoveAll(x => x.IsCompleted);
-							if (succ - last > 1000) {
+							if (stats.Succ - last > 1000) {
 								Console.Write(".");
-								last = succ;
+								last = stats.Succ;
 							}
 						}
 					}
@@ -186,11 +183,12 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 
 			context.Log.Information(
 				"Completed. Successes: {success}, failures: {failures} (WRONG VERSION: {wrongExpectedVersion}, P: {prepareTimeout}, C: {commitTimeout}, F: {forwardTimeout}, D: {streamDeleted})",
-				succ, fail,
-				wrongExpVersion, prepTimeout, commitTimeout, forwardTimeout, streamDeleted);
+				stats.Succ, stats.Fail,
+				stats.WrongExpVersion, stats.PrepTimeout, stats.CommitTimeout, stats.ForwardTimeout, stats.StreamDeleted);
+			stats.WriteStatsToFile(context.StatsLogger);
 
-			var reqPerSec = (all + 0.0) / sw.ElapsedMilliseconds * 1000;
-			context.Log.Information("{requests} requests completed in {elapsed}ms ({rate:0.00} reqs per sec).", all,
+			var reqPerSec = (stats.All + 0.0) / sw.ElapsedMilliseconds * 1000;
+			context.Log.Information("{requests} requests completed in {elapsed}ms ({rate:0.00} reqs per sec).", stats.All,
 				sw.ElapsedMilliseconds, reqPerSec);
 
 			PerfUtils.LogData(
@@ -198,9 +196,9 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 				PerfUtils.Row(PerfUtils.Col("clientsCnt", clientsCnt),
 					PerfUtils.Col("requestsCnt", requestsCnt),
 					PerfUtils.Col("ElapsedMilliseconds", sw.ElapsedMilliseconds)),
-				PerfUtils.Row(PerfUtils.Col("successes", succ), PerfUtils.Col("failures", fail)));
+				PerfUtils.Row(PerfUtils.Col("successes", stats.Succ), PerfUtils.Col("failures", stats.Fail)));
 
-			var failuresRate = (int)(100 * fail / (fail + succ));
+			var failuresRate = (int)(100 * stats.Fail / (stats.Fail + stats.Succ));
 			PerfUtils.LogTeamCityGraphData(string.Format("{0}-{1}-{2}-reqPerSec", Keyword, clientsCnt, requestsCnt),
 				(int)reqPerSec);
 			PerfUtils.LogTeamCityGraphData(
@@ -213,7 +211,7 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 				string.Format("{0}-c{1}-r{2}-st{3}-s{4}-failureSuccessRate", Keyword, clientsCnt, requestsCnt,
 					streamsCnt, size), failuresRate);
 			monitor.GetMeasurementDetails();
-			if (Interlocked.Read(ref succ) != requestsCnt)
+			if (Interlocked.Read(ref stats.Succ) != requestsCnt)
 				context.Fail(reason: "There were errors or not all requests completed.");
 			else
 				context.Success();

--- a/src/EventStore.TestClient/ClientOptions.cs
+++ b/src/EventStore.TestClient/ClientOptions.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Text;
+using Serilog;
 
 #pragma warning disable 1591
 
@@ -26,8 +27,9 @@ namespace EventStore.TestClient {
 		public bool UseTls { get; init; }
 		public bool TlsValidateServer { get; init; }
 
-		//[ArgDescription("A connection string to connect to a node/cluster. Used by gRPC only.")]
 		public string ConnectionString { get; set; }
+		public bool OutputCsv { get; set; }
+		public ILogger StatsLog { get; set; }
 
 		public ClientOptions() {
 			Command = Array.Empty<string>();
@@ -42,6 +44,7 @@ namespace EventStore.TestClient {
 			UseTls = false;
 			TlsValidateServer = false;
 			ConnectionString = string.Empty;
+			OutputCsv = true;
 		}
 
 		public override string ToString() {

--- a/src/EventStore.TestClient/CommandProcessorContext.cs
+++ b/src/EventStore.TestClient/CommandProcessorContext.cs
@@ -7,7 +7,7 @@ using ILogger = Serilog.ILogger;
 namespace EventStore.TestClient {
 	/// <summary>
 	/// This context is passed to the instances of <see cref="ICmdProcessor"/>
-	/// when they are executed. It can also be used for async syncrhonization
+	/// when they are executed. It can also be used for async synchronization
 	/// </summary>
 	public class CommandProcessorContext {
 		public int ExitCode;
@@ -17,7 +17,17 @@ namespace EventStore.TestClient {
 		/// <summary>
 		/// Current logger of the test client
 		/// </summary>
-		public readonly Serilog.ILogger Log;
+		public readonly ILogger Log;
+
+		/// <summary>
+		/// Stats logger for the test client
+		/// </summary>
+		public readonly ILogger StatsLogger;
+
+		/// <summary>
+		/// Whether stats should be CSV or Json
+		/// </summary>
+		public bool OutputCsv = false;
 
 		public readonly TcpTestClient _tcpTestClient;
 		public readonly GrpcTestClient _grpcTestClient;
@@ -27,13 +37,16 @@ namespace EventStore.TestClient {
 		private int _completed;
 		private int _timeout;
 
-		public CommandProcessorContext(TcpTestClient tcpTestClient, GrpcTestClient grpcTestClient, ClientApiTcpTestClient clientApiTestClient, int timeout, ILogger log, ManualResetEventSlim doneEvent) {
+		public CommandProcessorContext(TcpTestClient tcpTestClient, GrpcTestClient grpcTestClient, ClientApiTcpTestClient clientApiTestClient,
+			int timeout, ILogger log, ILogger statsLogger, bool outputCsv, ManualResetEventSlim doneEvent) {
 			_tcpTestClient = tcpTestClient;
 			_grpcTestClient = grpcTestClient;
 			_clientApiTestClient = clientApiTestClient;
 			Log = log;
+			StatsLogger = statsLogger;
 			_doneEvent = doneEvent;
 			_timeout = timeout;
+			OutputCsv = outputCsv;
 		}
 
 		public void Completed(int exitCode = (int)Common.Utils.ExitCode.Success, Exception error = null,

--- a/src/EventStore.TestClient/Program.cs
+++ b/src/EventStore.TestClient/Program.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Common.Log;
 using EventStore.Common.Utils;
+using EventStore.TestClient.Statistics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -11,6 +12,10 @@ using Serilog;
 
 #nullable enable
 namespace EventStore.TestClient {
+	internal enum StatsFormat {
+		Csv,
+		Json
+	}
 	internal static class Program {
 		/// <summary>
 		///
@@ -30,16 +35,21 @@ namespace EventStore.TestClient {
 		/// <param name="useTls"></param>
 		/// <param name="tlsValidateServer"></param>
 		/// <param name="connectionString">The connection string to use when connecting to the server. Not used by the raw TCP client</param>
+		/// <param name="statsFormat">The format for the stats log.</param>
 		/// <returns></returns>
 		public static async Task<int> Main(bool version = false, FileInfo? log = null, bool whatIf = false,
 			string[]? command = null, string host = "localhost", int tcpPort = 1113, int httpPort = 2113,
 			int timeout = Timeout.Infinite, int readWindow = 2000, int writeWindow = 2000, int pingWindow = 2000,
-			bool reconnect = true, bool useTls = false, bool tlsValidateServer = false, string connectionString = "") {
+			bool reconnect = true, bool useTls = false, bool tlsValidateServer = false, string connectionString = "",
+			StatsFormat statsFormat = StatsFormat.Csv) {
 			Log.Logger = EventStoreLoggerConfiguration.ConsoleLog;
 
 			try {
 				var logsDirectory = log?.FullName ?? Locations.DefaultTestClientLogDirectory;
 				EventStoreLoggerConfiguration.Initialize(logsDirectory, "client");
+				var statsLog = statsFormat == StatsFormat.Csv
+					? TestClientCsvLoggerConfiguration.Initialize(logsDirectory, "client")
+					: Log.ForContext(Serilog.Core.Constants.SourceContextPropertyName, "REGULAR-STATS-LOGGER");
 
 				var options = new ClientOptions {
 					Timeout = timeout,
@@ -53,7 +63,9 @@ namespace EventStore.TestClient {
 					UseTls = useTls,
 					TlsValidateServer = tlsValidateServer,
 					ConnectionString = connectionString,
-					Command = command ?? Array.Empty<string>()
+					Command = command ?? Array.Empty<string>(),
+					OutputCsv = statsFormat == StatsFormat.Csv,
+					StatsLog = statsLog
 				};
 
 				var hostedService = new TestClientHostedService(options);

--- a/src/EventStore.TestClient/Statistics/TestClientCsvLoggerConfiguration.cs
+++ b/src/EventStore.TestClient/Statistics/TestClientCsvLoggerConfiguration.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Threading;
+using EventStore.Common.Exceptions;
+using Serilog;
+
+namespace EventStore.TestClient.Statistics {
+	/// <summary>
+	/// Csv logger configuration for the TestClient
+	/// </summary>
+	public class TestClientCsvLoggerConfiguration {
+		private static int Initialized;
+		private static readonly string outputTemplate = "{Message}{NewLine}";
+
+		/// <summary>
+		/// Initialize the csv logger
+		/// </summary>
+		/// <param name="logsDirectory"></param>
+		/// <param name="componentName"></param>
+		public static ILogger Initialize(string logsDirectory, string componentName) {
+			if (Interlocked.Exchange(ref Initialized, 1) == 1) {
+				throw new InvalidOperationException($"{nameof(Initialize)} may not be called more than once.");
+			}
+
+			if (logsDirectory.StartsWith("~")) {
+				throw new ApplicationInitializationException(
+					"The given log path starts with a '~'. Event Store does not expand '~'.");
+			}
+
+			var filename = Path.Combine(logsDirectory, $"{componentName}/log-stats.csv");
+			return new LoggerConfiguration()
+				.WriteTo.File(filename, outputTemplate: outputTemplate)
+				.CreateLogger();
+		}
+	}
+}

--- a/src/EventStore.TestClient/Statistics/WriteFloodStats.cs
+++ b/src/EventStore.TestClient/Statistics/WriteFloodStats.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using EventStore.Core.Services.Monitoring.Stats;
+using EventStore.Core.Services.Monitoring.Utils;
+using Serilog;
+
+namespace EventStore.TestClient.Statistics {
+	/// <summary>
+	/// Statistics for WriteFlood
+	/// </summary>
+	public class WriteFloodStats {
+		/// <summary>
+		/// The number of successful writes
+		/// </summary>
+		public long Succ = 0;
+		/// <summary>
+		/// The number of failing writes
+		/// </summary>
+		public long Fail = 0;
+		/// <summary>
+		/// The number of writes that failed with PrepareTimeout
+		/// </summary>
+		public long PrepTimeout = 0;
+		/// <summary>
+		/// The number of writes that failed with CommitTimeout
+		/// </summary>
+		public long CommitTimeout = 0;
+		/// <summary>
+		/// The number of writes that failed with ForwardTimeout
+		/// </summary>
+		public long ForwardTimeout = 0;
+		/// <summary>
+		/// The number of writes that failed with WrongExpectedVersion
+		/// </summary>
+		public long WrongExpVersion = 0;
+		/// <summary>
+		/// The number of writes that failed with StreamDeleted
+		/// </summary>
+		public long StreamDeleted = 0;
+		/// <summary>
+		/// The total number of completed writes
+		/// </summary>
+		public long All = 0;
+		/// <summary>
+		/// The amount of time that has elapsed since the last measurement
+		/// </summary>
+		public TimeSpan Elapsed = TimeSpan.Zero;
+		/// <summary>
+		/// The time in UTC that the command was started
+		/// </summary>
+		public DateTime StartTime = DateTime.UtcNow;
+		/// <summary>
+		/// The command that was run
+		/// </summary>
+		public string Command;
+		/// <summary>
+		/// The current write rate
+		/// </summary>
+		public double Rate;
+		/// <summary>
+		/// The command and arguments used to run this command
+		/// </summary>
+		public string CommandString;
+
+		private bool _csv;
+
+		/// <summary>
+		/// </summary>
+		/// <param name="command"></param>
+		/// <param name="csv"></param>
+		/// <param name="args"></param>
+		public WriteFloodStats(string command, bool csv, string[] args) {
+			Command = command;
+			_csv = csv;
+			CommandString = $"{Command} {string.Join(" ", args)}";
+		}
+
+		private Dictionary<string, object> GetStats() {
+			var stats = new Dictionary<string, object>();
+			stats[$"{Command}-starttime"] = StartTime.ToString("O", CultureInfo.InvariantCulture);
+			stats[$"{Command}-succ"] = Succ;
+			stats[$"{Command}-fail"] = Fail;
+			stats[$"{Command}-prepTimeout"] = PrepTimeout;
+			stats[$"{Command}-commitTimeout"] = CommitTimeout;
+			stats[$"{Command}-forwardTimeout"] = ForwardTimeout;
+			stats[$"{Command}-wrongExpVersion"] = WrongExpVersion;
+			stats[$"{Command}-streamDeleted"] = StreamDeleted;
+			stats[$"{Command}-all"] = All;
+			stats[$"{Command}-elapsed"] = Elapsed;
+			stats[$"{Command}-rate"] = Rate;
+			stats[$"{Command}-command"] = CommandString;
+
+			return stats;
+		}
+
+		private string _lastWrittenCsvHeader = string.Empty;
+		/// <summary>
+		/// Write the current round of stats to the log
+		/// </summary>
+		/// <param name="log">The logger to write to</param>
+		public void WriteStatsToFile(ILogger log) {
+			try {
+				var statsContainer = new StatsContainer();
+				statsContainer.Add(GetStats());
+				var rawStats = statsContainer.GetStats(useGrouping: false, useMetadata: false);
+				if (!_csv) {
+					rawStats.Add("timestamp", DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture));
+					log.Information("{@stats}", rawStats);
+				} else {
+					var writeHeader = false;
+					var header = StatsCsvEncoder.GetHeader(rawStats);
+					if (header != _lastWrittenCsvHeader) {
+						_lastWrittenCsvHeader = header;
+						writeHeader = true;
+					}
+
+					var line = StatsCsvEncoder.GetLine(rawStats);
+					var timestamp = GetTimestamp(line);
+
+					if(writeHeader){
+						log.Information(Environment.NewLine);
+						log.Information(header);
+					}
+					log.Information(line);
+				}
+
+			} catch (Exception ex) {
+				Log.Error(ex, "Error on regular stats collection.");
+			}
+		}
+
+		private DateTime? GetTimestamp(string line) {
+			var separatorIdx = line.IndexOf(',');
+			if(separatorIdx == -1)
+				return null;
+
+			try{
+				return DateTime.Parse(line.Substring(0, separatorIdx)).ToUniversalTime();
+			}
+			catch{
+				return null;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added: Json and csv stats for writeflood commands in testclient.

Adds the `--stats-format` option which can be set to either `csv` or `json`. It is csv by default.
Adds statistics logging to the writeflood commands: `wrfl`, `wrflgrpc`, and `wrfltcp`.

The csv output writes to `log-stats.csv` in the logs directory:

```
Time,WRFL-starttime,WRFL-succ,WRFL-fail,WRFL-prepTimeout,WRFL-commitTimeout,WRFL-forwardTimeout,WRFL-wrongExpVersion,WRFL-streamDeleted,WRFL-all,WRFL-elapsed,WRFL-rate,WRFL-command
2021-05-06T10:30:35.7870583Z,2021-05-06T10:30:32.7322786Z,100000,0,0,0,0,0,0,100000,00:00:03.0113139,33208.095642237764,WRFL 10 100000 1000
2021-05-06T10:30:35.8065617Z,2021-05-06T10:30:32.7322786Z,100000,0,0,0,0,0,0,100000,00:00:03.0113139,33208.095642237764,WRFL 10 100000 1000


Time,WRFLGRPC-starttime,WRFLGRPC-succ,WRFLGRPC-fail,WRFLGRPC-prepTimeout,WRFLGRPC-commitTimeout,WRFLGRPC-forwardTimeout,WRFLGRPC-wrongExpVersion,WRFLGRPC-streamDeleted,WRFLGRPC-all,WRFLGRPC-elapsed,WRFLGRPC-rate,WRFLGRPC-command
2021-05-06T10:30:59.9602148Z,2021-05-06T10:30:43.3867332Z,100000,0,0,0,0,0,0,100000,00:00:00,0,WRFLGRPC 10 100000 1000


Time,WRFLTCP-starttime,WRFLTCP-succ,WRFLTCP-fail,WRFLTCP-prepTimeout,WRFLTCP-commitTimeout,WRFLTCP-forwardTimeout,WRFLTCP-wrongExpVersion,WRFLTCP-streamDeleted,WRFLTCP-all,WRFLTCP-elapsed,WRFLTCP-rate,WRFLTCP-command
2021-05-06T10:31:11.7979770Z,2021-05-06T10:31:07.2815446Z,200000,0,0,0,0,0,0,100000,00:00:04.4690265,22376.237867463977,WRFLTCP 10 100000 1000
2021-05-06T10:31:11.7982746Z,2021-05-06T10:31:07.2815446Z,200000,0,0,0,0,0,0,100000,00:00:04.4690265,22376.237867463977,WRFLTCP 10 100000 1000
```

The json output writes to `log-stats.json` in the logs directory:

```
{"@t":"2021-05-04T08:48:06.2931081Z","@mt":"{@stats}","stats":{"wrfl-starttime":"2021-05-04T08:47:34.1165833Z","wrfl-succ":1800004,"wrfl-fail":0,"wrfl-prepTimeout":0,"wrfl-commitTimeout":0,"wrfl-forwardTimeout":0,"wrfl-wrongExpVersion":0,"wrfl-streamDeleted":0,"wrfl-all":900002,"wrfl-elapsed":"00:00:03.5927206","wrfl-rate":27834.05979301591,"wrfl-command":"wrfltcp 10 1000000 1000","timestamp":"2021-05-04T08:48:06.2930717Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":19488,"ThreadId":28}
{"@t":"2021-05-04T08:48:09.9631954Z","@mt":"{@stats}","stats":{"wrfl-starttime":"2021-05-04T08:47:34.1165833Z","wrfl-succ":2000000,"wrfl-fail":0,"wrfl-prepTimeout":0,"wrfl-commitTimeout":0,"wrfl-forwardTimeout":0,"wrfl-wrongExpVersion":0,"wrfl-streamDeleted":0,"wrfl-all":1000000,"wrfl-elapsed":"00:00:03.6696625","wrfl-rate":27250.462406283958,"wrfl-command":"wrfltcp 10 1000000 1000","timestamp":"2021-05-04T08:48:09.9631458Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":19488,"ThreadId":9}
{"@t":"2021-05-04T08:48:09.9638915Z","@mt":"{@stats}","stats":{"wrfl-starttime":"2021-05-04T08:47:34.1165833Z","wrfl-succ":2000000,"wrfl-fail":0,"wrfl-prepTimeout":0,"wrfl-commitTimeout":0,"wrfl-forwardTimeout":0,"wrfl-wrongExpVersion":0,"wrfl-streamDeleted":0,"wrfl-all":1000000,"wrfl-elapsed":"00:00:03.6696625","wrfl-rate":27250.462406283958,"wrfl-command":"wrfltcp 10 1000000 1000","timestamp":"2021-05-04T08:48:09.9638650Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":19488,"ThreadId":9}
{"@t":"2021-05-04T08:52:50.8430411Z","@mt":"{@stats}","stats":{"wrflgrpc-starttime":"2021-05-04T08:52:34.4680953Z","wrflgrpc-succ":100073,"wrflgrpc-fail":0,"wrflgrpc-prepTimeout":0,"wrflgrpc-commitTimeout":0,"wrflgrpc-forwardTimeout":0,"wrflgrpc-wrongExpVersion":0,"wrflgrpc-streamDeleted":0,"wrflgrpc-all":100073,"wrflgrpc-elapsed":"00:00:16.3373880","wrflgrpc-rate":6120.990699370058,"wrflgrpc-command":"wrflgrpc 10 1000000","timestamp":"2021-05-04T08:52:50.8391847Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":13924,"ThreadId":7}
{"@t":"2021-05-04T08:53:03.7352365Z","@mt":"{@stats}","stats":{"wrflgrpc-starttime":"2021-05-04T08:52:34.4680953Z","wrflgrpc-succ":200007,"wrflgrpc-fail":0,"wrflgrpc-prepTimeout":0,"wrflgrpc-commitTimeout":0,"wrflgrpc-forwardTimeout":0,"wrflgrpc-wrongExpVersion":0,"wrflgrpc-streamDeleted":0,"wrflgrpc-all":200007,"wrflgrpc-elapsed":"00:00:12.8628315","wrflgrpc-rate":7774.4157653001985,"wrflgrpc-command":"wrflgrpc 10 1000000","timestamp":"2021-05-04T08:53:03.7351268Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":13924,"ThreadId":4}
{"@t":"2021-05-04T08:53:19.4307908Z","@mt":"{@stats}","stats":{"wrflgrpc-starttime":"2021-05-04T08:52:34.4680953Z","wrflgrpc-succ":300004,"wrflgrpc-fail":0,"wrflgrpc-prepTimeout":0,"wrflgrpc-commitTimeout":0,"wrflgrpc-forwardTimeout":0,"wrflgrpc-wrongExpVersion":0,"wrflgrpc-streamDeleted":0,"wrflgrpc-all":300004,"wrflgrpc-elapsed":"00:00:15.7423784","wrflgrpc-rate":6352.343811021593,"wrflgrpc-command":"wrflgrpc 10 1000000","timestamp":"2021-05-04T08:53:19.4307505Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":13924,"ThreadId":46}
{"@t":"2021-05-04T08:53:35.4792649Z","@mt":"{@stats}","stats":{"wrflgrpc-starttime":"2021-05-04T08:52:34.4680953Z","wrflgrpc-succ":400007,"wrflgrpc-fail":0,"wrflgrpc-prepTimeout":0,"wrflgrpc-commitTimeout":0,"wrflgrpc-forwardTimeout":0,"wrflgrpc-wrongExpVersion":0,"wrflgrpc-streamDeleted":0,"wrflgrpc-all":400007,"wrflgrpc-elapsed":"00:00:16.0470786","wrflgrpc-rate":6231.726190959144,"wrflgrpc-command":"wrflgrpc 10 1000000","timestamp":"2021-05-04T08:53:35.4792194Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":13924,"ThreadId":37}
{"@t":"2021-05-04T08:53:55.4828993Z","@mt":"{@stats}","stats":{"wrfltcp-starttime":"2021-05-04T08:53:50.8932000Z","wrfltcp-succ":200122,"wrfltcp-fail":0,"wrfltcp-prepTimeout":0,"wrfltcp-commitTimeout":0,"wrfltcp-forwardTimeout":0,"wrfltcp-wrongExpVersion":0,"wrfltcp-streamDeleted":0,"wrfltcp-all":100061,"wrfltcp-elapsed":"00:00:04.4435157","wrfltcp-rate":22504.702751472218,"wrfltcp-command":"wrfltcp 10 10000000","timestamp":"2021-05-04T08:53:55.4662461Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":15204,"ThreadId":40}
{"@t":"2021-05-04T08:54:01.1887790Z","@mt":"{@stats}","stats":{"wrfltcp-starttime":"2021-05-04T08:53:50.8932000Z","wrfltcp-succ":400006,"wrfltcp-fail":0,"wrfltcp-prepTimeout":0,"wrfltcp-commitTimeout":0,"wrfltcp-forwardTimeout":0,"wrfltcp-wrongExpVersion":0,"wrfltcp-streamDeleted":0,"wrfltcp-all":200002,"wrfltcp-elapsed":"00:00:05.7293885","wrfltcp-rate":17453.869640712965,"wrfltcp-command":"wrfltcp 10 10000000","timestamp":"2021-05-04T08:54:01.1886670Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":15204,"ThreadId":42}
{"@t":"2021-05-04T08:54:06.4512093Z","@mt":"{@stats}","stats":{"wrfltcp-starttime":"2021-05-04T08:53:50.8932000Z","wrfltcp-succ":600004,"wrfltcp-fail":0,"wrfltcp-prepTimeout":0,"wrfltcp-commitTimeout":0,"wrfltcp-forwardTimeout":0,"wrfltcp-wrongExpVersion":0,"wrfltcp-streamDeleted":0,"wrfltcp-all":300002,"wrfltcp-elapsed":"00:00:05.2600617","wrfltcp-rate":19011.183842197137,"wrfltcp-command":"wrfltcp 10 10000000","timestamp":"2021-05-04T08:54:06.4487029Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":15204,"ThreadId":14}
{"@t":"2021-05-04T08:54:11.6083134Z","@mt":"{@stats}","stats":{"wrfltcp-starttime":"2021-05-04T08:53:50.8932000Z","wrfltcp-succ":800002,"wrfltcp-fail":0,"wrfltcp-prepTimeout":0,"wrfltcp-commitTimeout":0,"wrfltcp-forwardTimeout":0,"wrfltcp-wrongExpVersion":0,"wrfltcp-streamDeleted":0,"wrfltcp-all":400001,"wrfltcp-elapsed":"00:00:05.1591154","wrfltcp-rate":19383.167897349223,"wrfltcp-command":"wrfltcp 10 10000000","timestamp":"2021-05-04T08:54:11.6082674Z"},"SourceContext":"REGULAR-STATS-LOGGER","ProcessId":15204,"ThreadId":34}
```