### PR TITLE
add NFIBrokerage/spear as a community gRPC client for Elixir

### DIFF
--- a/docs/introduction/clients.md
+++ b/docs/introduction/clients.md
@@ -23,6 +23,7 @@ Read more in the [gRPC clients documentation](../../../../clients/grpc/getting-s
 ### Community developed clients
 
 - [Ruby](https://github.com/yousty/event_store_client)
+- [Elixir](https://github.com/NFIBrokerage/spear)
 
 ## TCP protocol
 


### PR DESCRIPTION
hello! :wave:

We've been working on an Elixir client for the gRPC interface in [`NFIBrokerage/spear`](https://github.com/NFIBrokerage/spear). It closes over most of the API and is getting pretty stable so I wanted to add it to the documentation on community adapters here. Let me know what you think!