### PR TITLE
Breaking change: Handle missing case for UpdatePersistentSubscriptionTo{Stream,All}Result.DoesNotExist

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Update.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Update.cs
@@ -156,6 +156,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 								.AccessDenied:
 								updatePersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
 								return;
+							case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+								.UpdatePersistentSubscriptionToStreamResult.DoesNotExist:
+								updatePersistentSubscriptionSource.TrySetException(
+									RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
+								return;
 							default:
 								updatePersistentSubscriptionSource.TrySetException(
 									RpcExceptions.UnknownError(completed.Result));
@@ -181,6 +186,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 								.UpdatePersistentSubscriptionToAllResult
 								.AccessDenied:
 								updatePersistentSubscriptionSource.TrySetException(RpcExceptions.AccessDenied());
+								return;
+							case ClientMessage.UpdatePersistentSubscriptionToAllCompleted
+								.UpdatePersistentSubscriptionToAllResult.DoesNotExist:
+								updatePersistentSubscriptionSource.TrySetException(
+									RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, request.Options.GroupName));
 								return;
 							default:
 								updatePersistentSubscriptionSource.TrySetException(


### PR DESCRIPTION
Fixed: Handle missing case for UpdatePersistentSubscriptionTo{Stream,All}Result.DoesNotExist

Same as https://github.com/EventStore/EventStore/pull/2933 which was merged into wrong branch.