### PR TITLE
Switch grpc projections disable/abort write checkpoint option

### DIFF
--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
@@ -24,8 +24,8 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			var envelope = new CallbackEnvelope(OnMessage);
 
 			_queue.Publish(options.WriteCheckpoint
-				? (Message)new ProjectionManagementMessage.Command.Abort(envelope, name, runAs)
-				: new ProjectionManagementMessage.Command.Disable(envelope, name, runAs));
+				? new ProjectionManagementMessage.Command.Disable(envelope, name, runAs)
+				: (Message)new ProjectionManagementMessage.Command.Abort(envelope, name, runAs));
 
 			await disableSource.Task.ConfigureAwait(false);
 


### PR DESCRIPTION
Fixed: In gRPC projection management, disable a projection when writing a checkpoint, and abort it if not writing a checkpoint.

Disabling a projection causes a checkpoint to be written before it is stopped.
Aborting a projection stops the projection without writing a checkpoint.

The mismatch was discovered while implementing projection management in [Rust](https://github.com/EventStore/EventStoreDB-Client-Rust/issues/60).
This will break the other clients that have implemented projection management, so we need to decide if this is something we want to do now.