### PR TITLE
Configure kestrel with kestrelsettings.json

### DIFF
--- a/docs/networking/http.md
+++ b/docs/networking/http.md
@@ -63,3 +63,45 @@ After having pinged for keepalive check, the server waits for a duration of `kee
 **Default**: `10000`
 
 As a general rule, we do not recommend putting EventStoreDB behind a load balancer. However, if you are using it and want to benefit from the Keepalive feature, then you should make sure if the compatible settings are properly set. Some load balancers may also override the Keepalive settings. Most of them require setting the idle timeout larger/longer than the `keepAliveTimeout`. We suggest checking the load balancer documentation before using Keepalive pings. 
+
+## Kestrel Settings
+
+It's generally not expected that you'll need to update the kestrel configuration that EventStoreDB has set by default, but it's good to know that you can update the following settings if needed.
+
+The Kestrel Settings are configured in the `kestrelsettings.json` file. This file is expected to be found in the [default onfiguration directory](/configuration/).
+
+### MaxConcurrentConnections
+
+Sets the maximum number of open connections. See the docs [here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.maxconcurrentconnections?view=aspnetcore-5.0).
+
+This is configured with `Kestrel.Limits.MaxConcurrentConnections` in the settings file.
+
+**Default**: `5000`
+
+### MaxConcurrentUpgradedConnections
+
+Sets the maximum number of open, upgraded connections. An upgraded connection is one that has been switched from HTTP to another protocol, such as WebSockets. See the docs [here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.kestrelserverlimits.maxconcurrentupgradedconnections?view=aspnetcore-5.0).
+
+This is configured with `Kestrel.Limits.MaxConcurrentUpgradedConnections` in the settings file.
+
+**Default**: `5000`
+
+### Http2 InitialConnectionWindowSize
+
+Sets how much request body data the server is willing to receive and buffer at a time aggregated across all requests (streams) per connection. Note requests are also limited by `KestrelInitialStreamWindowSize`
+
+The value must be greater than or equal to 65,535 and less than 2^31. See the docs [here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.initialconnectionwindowsize?view=aspnetcore-5.0).
+
+This is configured with `Kestrel.Limits.Http2.InitialConnectionWindowSize` in the settings file.
+
+**Default**: `131072 * 1024`
+
+### Http2 InitialStreamWindowSize
+
+Sets how much request body data the server is willing to receive and buffer at a time per stream. Note connections are also limited by `KestrelInitialConnectionWindowSize`
+
+Value must be greater than or equal to 65,535 and less than 2^31. See the docs [here](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.server.kestrel.core.http2limits.initialstreamwindowsize?view=aspnetcore-5.0).
+
+This is configured with `Kestrel.Limits.Http2.InitialStreamWindowSize` in the settings file.
+
+**Default**: `98304 * 1024`

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -23,6 +23,9 @@
 						<Link>logconfig.json</Link>
 						<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 				</None>
+				<None Update="kestrelsettings.json">
+				  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+				</None>
 		</ItemGroup>
 		<ItemGroup>
 				<Content Include="app2.ico" />

--- a/src/EventStore.ClusterNode/kestrelsettings.json
+++ b/src/EventStore.ClusterNode/kestrelsettings.json
@@ -1,0 +1,12 @@
+{
+	"Kestrel": {
+		"Limits": {
+			"MaxConcurrentConnections": 5000,
+			"MaxConcurrentUpgradedConnections": 5000,
+			"Http2": {
+				"InitialConnectionWindowSize": 134217728,
+				"InitialStreamWindowSize": 100663296
+			}
+		}
+	}
+}

--- a/src/EventStore.Common/Configuration/EventStoreKestrelConfiguration.cs
+++ b/src/EventStore.Common/Configuration/EventStoreKestrelConfiguration.cs
@@ -1,0 +1,31 @@
+using System.IO;
+using System.Linq;
+using EventStore.Common.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+
+namespace EventStore.Common.Configuration {
+	public static class EventStoreKestrelConfiguration {
+		public static IConfiguration GetConfiguration(string kestrelConfig = "kestrelsettings.json") {
+			var potentialKestrelConfigurationDirectories = Locations.GetPotentialConfigurationDirectories();
+			var kestrelConfigurationDirectory =
+				potentialKestrelConfigurationDirectories.FirstOrDefault(directory =>
+					File.Exists(Path.Combine(directory, kestrelConfig)));
+			if (kestrelConfigurationDirectory is null) return new ConfigurationBuilder().Build();
+
+			return new ConfigurationBuilder()
+				.AddJsonFile(config => {
+					config.Optional = true;
+					config.FileProvider = new PhysicalFileProvider(kestrelConfigurationDirectory) {
+						UseActivePolling = true,
+						UsePollingFileWatcher = true
+					};
+					config.OnLoadException = context => Serilog.Log.Error(context.Exception, "err");
+					config.Path = kestrelConfig;
+					config.ReloadOnChange = true;
+				})
+				.Build()
+				.GetSection("Kestrel");
+		}
+	}
+}

--- a/src/EventStore.Common/Log/EventStoreLoggerConfiguration.cs
+++ b/src/EventStore.Common/Log/EventStoreLoggerConfiguration.cs
@@ -53,10 +53,7 @@ namespace EventStore.Common.Log {
 					"The given log path starts with a '~'. Event Store does not expand '~'.");
 			}
 
-			var potentialLogConfigurationDirectories = new[] {
-				Locations.ApplicationDirectory,
-				Locations.DefaultConfigurationDirectory
-			}.Distinct();
+			var potentialLogConfigurationDirectories = Locations.GetPotentialConfigurationDirectories();
 			var logConfigurationDirectory =
 				potentialLogConfigurationDirectories.FirstOrDefault(directory =>
 					File.Exists(Path.Combine(directory, logConfig)));

--- a/src/EventStore.Common/Utils/Locations.cs
+++ b/src/EventStore.Common/Utils/Locations.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 
@@ -78,6 +79,17 @@ namespace EventStore.Common.Utils {
 			var precedenceList = locations.Distinct().ToList();
 			return precedenceList.FirstOrDefault(Directory.Exists) ??
 			       precedenceList.Last();
+		}
+
+		/// <summary>
+		/// Returns the directories that potentially contain any configuration files.
+		/// </summary>
+		/// <returns></returns>
+		public static string[] GetPotentialConfigurationDirectories() {
+			return new [] {
+				ApplicationDirectory,
+				DefaultConfigurationDirectory
+			}.Distinct().ToArray();
 		}
 	}
 }


### PR DESCRIPTION
Added: Add the ability to configure kestrel with kestrelsettings.json

Add a kestrel settings file with the default settings from PR https://github.com/EventStore/EventStore/pull/2902 and https://github.com/EventStore/EventStore/pull/2934.
Add docs about configuring kestrel settings.