### PR TITLE
Log v3/stream records

### DIFF
--- a/src/EventStore.Core.Tests.XUnit/LogAbstraction/LogFormatAbstractorV3Tests.cs
+++ b/src/EventStore.Core.Tests.XUnit/LogAbstraction/LogFormatAbstractorV3Tests.cs
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.XUnit.LogAbstraction {
 				streamRecord: out var record);
 
 			if (record is LogV3StreamRecord streamRecord) {
-				createdId = streamRecord.Record.SubHeader.ReferenceId;
+				createdId = streamRecord.Record.SubHeader.ReferenceNumber;
 				createdName = streamRecord.StreamName;
 				_mockIndexReader.Add(streamRecord.ExpectedVersion + 1, streamRecord);
 				return false;

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -267,8 +267,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 					var tPos = prepare.TransactionPosition == prepare.LogPosition
 						? newPos
 						: prepare.TransactionPosition;
-					prepare = _recordFactory.CopyForRetry(
-						prepare: prepare,
+					prepare = prepare.CopyForRetry(
 						logPosition: newPos,
 						transactionPosition: tPos);
 					if (!Writer.Write(prepare, out newPos))

--- a/src/EventStore.Core/LogAbstraction/IRecordFactory.cs
+++ b/src/EventStore.Core/LogAbstraction/IRecordFactory.cs
@@ -7,6 +7,15 @@ namespace EventStore.Core.LogAbstraction {
 	}
 
 	public interface IRecordFactory<TStreamId> : IRecordFactory {
+		bool ExplicitStreamCreation { get; }
+
+		IPrepareLogRecord<TStreamId> CreateStreamRecord(
+			Guid streamId,
+			long logPosition,
+			DateTime timeStamp,
+			TStreamId streamNumber,
+			string streamName);
+
 		IPrepareLogRecord<TStreamId> CreatePrepare(
 			long logPosition,
 			Guid correlationId,
@@ -20,26 +29,5 @@ namespace EventStore.Core.LogAbstraction {
 			string eventType,
 			ReadOnlyMemory<byte> data,
 			ReadOnlyMemory<byte> metadata);
-
-		IPrepareLogRecord<TStreamId> CopyForRetry(
-			IPrepareLogRecord<TStreamId> prepare,
-			long logPosition,
-			long transactionPosition) {
-
-			var result = CreatePrepare(
-				logPosition: logPosition,
-				correlationId: prepare.CorrelationId,
-				eventId: prepare.EventId,
-				transactionPosition: transactionPosition,
-				transactionOffset: prepare.TransactionOffset,
-				eventStreamId: prepare.EventStreamId,
-				expectedVersion: prepare.ExpectedVersion,
-				timeStamp: prepare.TimeStamp,
-				flags: prepare.Flags,
-				eventType: prepare.EventType,
-				data: prepare.Data,
-				metadata: prepare.Metadata);
-			return result;
-		}
 	}
 }

--- a/src/EventStore.Core/LogAbstraction/IStreamNameIndexExtensions.cs
+++ b/src/EventStore.Core/LogAbstraction/IStreamNameIndexExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.LogAbstraction {
+	public static class IStreamNameIndexExtensions {
+		// Generates a StreamRecord if necessary
+		public static void GetOrAddId<TStreamId>(
+			this IStreamNameIndex<TStreamId> streamNameIndex,
+			IRecordFactory<TStreamId> recordFactory,
+			string streamName,
+			long logPosition,
+			out TStreamId streamId,
+			out IPrepareLogRecord<TStreamId> streamRecord) {
+
+			var preExisting = streamNameIndex.GetOrAddId(streamName, out streamId, out var createdId, out var createdName);
+
+			var appendNewStream = recordFactory.ExplicitStreamCreation && !preExisting;
+			if (!appendNewStream) {
+				streamRecord = null;
+				return;
+			}
+
+			streamRecord = recordFactory.CreateStreamRecord(
+				streamId: Guid.NewGuid(),
+				logPosition: logPosition,
+				timeStamp: DateTime.UtcNow,
+				streamNumber: createdId,
+				streamName: createdName);
+		}
+	}
+}

--- a/src/EventStore.Core/LogV2/LogV2RecordFactory.cs
+++ b/src/EventStore.Core/LogV2/LogV2RecordFactory.cs
@@ -7,6 +7,16 @@ namespace EventStore.Core.LogV2 {
 		public LogV2RecordFactory() {
 		}
 
+		public bool ExplicitStreamCreation => false;
+
+		public IPrepareLogRecord<string> CreateStreamRecord(
+			Guid streamId,
+			long logPosition,
+			DateTime timeStamp,
+			string streamNumber,
+			string streamName) =>
+			throw new NotSupportedException();
+
 		public ISystemLogRecord CreateEpoch(EpochRecord epoch) {
 			var result = new SystemLogRecord(
 				logPosition: epoch.EpochPosition,

--- a/src/EventStore.Core/LogV3/LogV3RecordFactory.cs
+++ b/src/EventStore.Core/LogV3/LogV3RecordFactory.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.LogV3 {
 				streamId: streamId,
 				logPosition: logPosition,
 				timeStamp: timeStamp,
-				streamNumber: streamNumber,
+				streamNumber: (uint)streamNumber, // todo: switch to uint
 				streamName: streamName);
 
 			return result;

--- a/src/EventStore.Core/LogV3/LogV3RecordFactory.cs
+++ b/src/EventStore.Core/LogV3/LogV3RecordFactory.cs
@@ -7,6 +7,25 @@ namespace EventStore.Core.LogV3 {
 		public LogV3RecordFactory() {
 		}
 
+		public bool ExplicitStreamCreation => true;
+
+		public IPrepareLogRecord<long> CreateStreamRecord(
+			Guid streamId,
+			long logPosition,
+			DateTime timeStamp,
+			long streamNumber,
+			string streamName) {
+
+			var result = new LogV3StreamRecord(
+				streamId: streamId,
+				logPosition: logPosition,
+				timeStamp: timeStamp,
+				streamNumber: streamNumber,
+				streamName: streamName);
+
+			return result;
+		}
+
 		public ISystemLogRecord CreateEpoch(EpochRecord epoch) {
 			var result = new LogV3EpochLogRecord(
 				logPosition: epoch.EpochPosition,

--- a/src/EventStore.Core/LogV3/LogV3SystemStreams.cs
+++ b/src/EventStore.Core/LogV3/LogV3SystemStreams.cs
@@ -89,6 +89,9 @@ namespace EventStore.Core.LogV3 {
 				streamId == NoSystemStream)
 				return true;
 
+			if (streamId == NoUserStream)
+				return false;
+
 			var streamName = _streamNames.LookupName(streamId);
 			return SystemStreams.IsSystemStream(streamName);
 		}

--- a/src/EventStore.Core/LogV3/StreamIdToNameFromStandardIndex.cs
+++ b/src/EventStore.Core/LogV3/StreamIdToNameFromStandardIndex.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.LogV3 {
+	public class StreamIdToNameFromStandardIndex : IStreamNameLookup<long> {
+		private readonly IIndexReader<long> _indexReader;
+
+		public StreamIdToNameFromStandardIndex(IIndexReader<long> indexReader) {
+			_indexReader = indexReader;
+		}
+
+		public string LookupName(long streamId) {
+			if (streamId % 2 == 1)
+				throw new ArgumentOutOfRangeException(nameof(streamId), "streamId must be even");
+
+			// we divided by two when calculating the position in the stream, since we dont
+			// explicitly create metastreams.
+			var record = _indexReader.ReadPrepare(LogV3SystemStreams.StreamsCreatedStreamNumber, streamId / 2);
+
+			if (record is not LogV3StreamRecord streamRecord)
+				throw new Exception($"Unexpected log record type: {record}.");
+			return streamRecord.StreamName;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -99,6 +99,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				SeqReadResult result;
 				while ((result = reader.TryReadNext()).Success && result.LogRecord.LogPosition < buildToPosition) {
 					switch (result.LogRecord.RecordType) {
+						case LogRecordType.Stream:
 						case LogRecordType.Prepare: {
 								var prepare = (IPrepareLogRecord<TStreamId>)result.LogRecord;
 								if (prepare.Flags.HasAnyOf(PrepareFlags.IsCommitted)) {

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -193,7 +193,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			if (!result.Success)
 				return null;
 
-			if (result.LogRecord.RecordType != LogRecordType.Prepare)
+			if (result.LogRecord.RecordType != LogRecordType.Prepare &&
+				result.LogRecord.RecordType != LogRecordType.Stream)
 				throw new Exception(string.Format("Incorrect type of log record {0}, expected Prepare record.",
 					result.LogRecord.RecordType));
 			return (IPrepareLogRecord<TStreamId>)result.LogRecord;

--- a/src/EventStore.Core/Services/Storage/StorageChaser.cs
+++ b/src/EventStore.Core/Services/Storage/StorageChaser.cs
@@ -179,6 +179,7 @@ namespace EventStore.Core.Services.Storage {
 
 		private void ProcessLogRecord(SeqReadResult result) {
 			switch (result.LogRecord.RecordType) {
+				case LogRecordType.Stream:
 				case LogRecordType.Prepare: {
 					var record = (IPrepareLogRecord<TStreamId>)result.LogRecord;
 					ProcessPrepareRecord(record, result.RecordPostPosition);

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -68,6 +68,7 @@ namespace EventStore.Core.Services {
 		public const string StreamReference = "$@";
 		public const string StreamMetadata = "$metadata";
 		public const string Settings = "$settings";
+		public const string StreamCreated = "$stream";
 
 		public const string V2__StreamCreated_InIndex = "StreamCreated";
 		public const string V1__StreamCreated__ = "$stream-created";

--- a/src/EventStore.Core/TransactionLog/LogRecords/IPrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/IPrepareLogRecord.cs
@@ -19,5 +19,6 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 
 	public interface IPrepareLogRecord<TStreamId> : IPrepareLogRecord {
 		TStreamId EventStreamId { get; }
+		IPrepareLogRecord<TStreamId> CopyForRetry(long logPosition, long transactionPosition);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogRecord.cs
@@ -46,6 +46,9 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 				case LogRecordType.StreamWrite:
 					return new LogV3StreamWriteRecord(LogV3Reader.ReadBytes(recordType, version, reader, length));
 
+				case LogRecordType.Stream:
+					return new LogV3StreamRecord(LogV3Reader.ReadBytes(recordType, version, reader, length));
+
 				default:
 					throw new ArgumentOutOfRangeException("recordType");
 			}

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogV3StreamRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogV3StreamRecord.cs
@@ -18,7 +18,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 		public int TransactionOffset => 0;
 		// since we are storing only even ids, divide by 2 so that they are contiguous
 		// then we can do a stream read of $streams-created if we want
-		public long ExpectedVersion => Record.SubHeader.ReferenceId / 2 - 1;
+		public long ExpectedVersion => Record.SubHeader.ReferenceNumber / 2 - 1;
 		public Guid EventId => Record.Header.RecordId;
 		//qq hmm
 		public Guid CorrelationId { get; } = Guid.NewGuid();
@@ -33,7 +33,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 			Guid streamId,
 			long logPosition,
 			DateTime timeStamp,
-			long streamNumber,
+			uint streamNumber,
 			string streamName) : base() {
 
 			Record = RecordCreator.CreateStreamRecord(
@@ -56,7 +56,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 				streamId: Record.Header.RecordId,
 				timeStamp: Record.Header.TimeStamp,
 				logPosition: logPosition,
-				streamNumber: Record.SubHeader.ReferenceId,
+				streamNumber: Record.SubHeader.ReferenceNumber,
 				streamName: Record.StringPayload);
 		}
 	}

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogV3StreamRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogV3StreamRecord.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using EventStore.Core.LogV3;
+using EventStore.Core.Services;
+using EventStore.LogV3;
+
+namespace EventStore.Core.TransactionLog.LogRecords {
+	// todo: when we have partition records etc there might be a baseclass to refactor
+	// the string payload to.
+	//
+	//qq we probably dont want to treat these are normal events for projections, subscriptions, etc.
+	// however, we do want to index them (for now) so that we can use them to look up the names.
+	// we might need to suppress the StorageMessage.EventCommitted sending.
+	public class LogV3StreamRecord : LogV3Record<StringPayloadRecord<Raw.StreamHeader>>, IPrepareLogRecord<long> {
+		public long EventStreamId => LogV3SystemStreams.StreamsCreatedStreamNumber;
+		// so we can see the stream name in the webui if we want
+		public PrepareFlags Flags => PrepareFlags.SingleWrite | PrepareFlags.IsCommitted | PrepareFlags.IsJson;
+		public long TransactionPosition => LogPosition;
+		public int TransactionOffset => 0;
+		// since we are storing only even ids, divide by 2 so that they are contiguous
+		// then we can do a stream read of $streams-created if we want
+		public long ExpectedVersion => Record.SubHeader.ReferenceId / 2 - 1;
+		public Guid EventId => Record.Header.RecordId;
+		//qq hmm
+		public Guid CorrelationId { get; } = Guid.NewGuid();
+		public string EventType => SystemEventTypes.StreamCreated;
+		// so we can see the stream name in the webui if we want
+		public ReadOnlyMemory<byte> Data => Record.Payload;
+		public ReadOnlyMemory<byte> Metadata => ReadOnlyMemory<byte>.Empty;
+
+		public string StreamName => Record.StringPayload;
+
+		public LogV3StreamRecord(
+			Guid streamId,
+			long logPosition,
+			DateTime timeStamp,
+			long streamNumber,
+			string streamName) : base() {
+
+			Record = RecordCreator.CreateStreamRecord(
+				streamId: streamId,
+				timeStamp: timeStamp,
+				logPosition: logPosition,
+				streamNumber: streamNumber,
+				streamName: streamName,
+				partitionId: Guid.Empty,
+				streamTypeId: Guid.Empty);
+		}
+
+		public LogV3StreamRecord(ReadOnlyMemory<byte> bytes) : base() {
+			Record = StringPayloadRecord.Create(new RecordView<Raw.StreamHeader>(bytes));
+		}
+
+		//qq is this covered by tests
+		public IPrepareLogRecord<long> CopyForRetry(long logPosition, long transactionPosition) {
+			return new LogV3StreamRecord(
+				streamId: Record.Header.RecordId,
+				timeStamp: Record.Header.TimeStamp,
+				logPosition: logPosition,
+				streamNumber: Record.SubHeader.ReferenceId,
+				streamName: Record.StringPayload);
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/LogRecords/LogV3StreamWriteRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/LogV3StreamWriteRecord.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using EventStore.Common.Utils;
 using EventStore.LogCommon;
 using EventStore.LogV3;
@@ -68,6 +68,23 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 		public string EventType => Record.Event.SystemMetadata.EventType;
 		public ReadOnlyMemory<byte> Data => Record.Event.Data;
 		public ReadOnlyMemory<byte> Metadata => Record.Event.Metadata;
+
+		//qq is this covered by tests
+		public IPrepareLogRecord<long> CopyForRetry(long logPosition, long transactionPosition) {
+			return new LogV3StreamWriteRecord(
+				logPosition: logPosition,
+				transactionPosition: transactionPosition,
+				transactionOffset: TransactionOffset,
+				correlationId: CorrelationId,
+				eventId: EventId,
+				eventStreamId: EventStreamId,
+				expectedVersion: ExpectedVersion,
+				timeStamp: TimeStamp,
+				flags: Flags,
+				eventType: EventType,
+				data: Data.Span,
+				metadata: Metadata.Span);
+		}
 
 		public bool Equals(LogV3StreamWriteRecord other) {
 			if (ReferenceEquals(null, other)) return false;

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -140,6 +140,22 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 			if (InMemorySize > TFConsts.MaxLogRecordSize) throw new Exception("Record too large.");
 		}
 
+		public IPrepareLogRecord<string> CopyForRetry(long logPosition, long transactionPosition) {
+			return new PrepareLogRecord(
+				logPosition: logPosition,
+				correlationId: CorrelationId,
+				eventId: EventId,
+				transactionPosition: transactionPosition,
+				transactionOffset: TransactionOffset,
+				eventStreamId: EventStreamId,
+				expectedVersion: ExpectedVersion,
+				timeStamp: TimeStamp,
+				flags: Flags,
+				eventType: EventType,
+				data: Data,
+				metadata: Metadata);
+		}
+
 		public override void WriteTo(BinaryWriter writer) {
 			base.WriteTo(writer);
 

--- a/src/EventStore.LogCommon/LogRecordType.cs
+++ b/src/EventStore.LogCommon/LogRecordType.cs
@@ -9,5 +9,6 @@ namespace EventStore.LogCommon {
 		ContentType = 6,
 		Partition = 7,
 		StreamWrite = 8,
+		Stream = 9,
 	}
 }

--- a/src/EventStore.LogV3.Tests/LayoutInspections.cs
+++ b/src/EventStore.LogV3.Tests/LayoutInspections.cs
@@ -18,6 +18,7 @@ namespace EventStore.LogV3.Tests {
 		[InlineData(typeof(Raw.EventHeader))]
 		[InlineData(typeof(Raw.PartitionHeader))]
 		[InlineData(typeof(Raw.PartitionTypeHeader))]
+		[InlineData(typeof(Raw.StreamHeader))]
 		[InlineData(typeof(Raw.StreamTypeHeader))]
 		[InlineData(typeof(Raw.StreamWriteHeader))]
 		[InlineData(typeof(Raw.EventTypeHeader))]

--- a/src/EventStore.LogV3.Tests/RecordCreatorTests.cs
+++ b/src/EventStore.LogV3.Tests/RecordCreatorTests.cs
@@ -88,6 +88,28 @@ namespace EventStore.LogV3.Tests {
 		}
 
 		[Fact]
+		public void can_create_stream_record() {
+			var record = RecordCreator.CreateStreamRecord(
+				streamId: _guid1,
+				timeStamp: _dateTime1,
+				logPosition: _long1,
+				streamNumber: _long2,
+				streamName: _string1,
+				partitionId: _guid2,
+				streamTypeId: _guid3);
+
+			Assert.Equal(LogRecordType.Stream, record.Header.Type);
+			Assert.Equal(LogRecordVersion.LogRecordV0, record.Header.Version);
+			Assert.Equal(_guid1, record.Header.RecordId);
+			Assert.Equal(_dateTime1, record.Header.TimeStamp);
+			Assert.Equal(_long1, record.Header.LogPosition);
+			Assert.Equal(_guid2, record.SubHeader.PartitionId);
+			Assert.Equal(_long2, record.SubHeader.ReferenceId);
+			Assert.Equal(_guid3, record.SubHeader.StreamTypeId);
+			Assert.Equal(_string1, record.StringPayload);
+		}
+
+		[Fact]
 		public void can_create_stream_type_record() {
 			var record = RecordCreator.CreateStreamTypeRecord(
 				timeStamp: _dateTime1,

--- a/src/EventStore.LogV3.Tests/RecordCreatorTests.cs
+++ b/src/EventStore.LogV3.Tests/RecordCreatorTests.cs
@@ -93,7 +93,7 @@ namespace EventStore.LogV3.Tests {
 				streamId: _guid1,
 				timeStamp: _dateTime1,
 				logPosition: _long1,
-				streamNumber: _long2,
+				streamNumber: _uint1,
 				streamName: _string1,
 				partitionId: _guid2,
 				streamTypeId: _guid3);
@@ -104,7 +104,7 @@ namespace EventStore.LogV3.Tests {
 			Assert.Equal(_dateTime1, record.Header.TimeStamp);
 			Assert.Equal(_long1, record.Header.LogPosition);
 			Assert.Equal(_guid2, record.SubHeader.PartitionId);
-			Assert.Equal(_long2, record.SubHeader.ReferenceId);
+			Assert.Equal(_uint1, record.SubHeader.ReferenceNumber);
 			Assert.Equal(_guid3, record.SubHeader.StreamTypeId);
 			Assert.Equal(_string1, record.StringPayload);
 		}

--- a/src/EventStore.LogV3.Tests/RecordLayoutTests.cs
+++ b/src/EventStore.LogV3.Tests/RecordLayoutTests.cs
@@ -34,6 +34,7 @@ namespace EventStore.LogV3.Tests {
 		[Fact] public void EventHeaderLayout() => AssertSize<Raw.EventHeader>(Raw.EventHeader.Size);
 		[Fact] public void PartitionHeaderLayout() => AssertSize<Raw.PartitionHeader>(Raw.PartitionHeader.Size);
 		[Fact] public void PartitionTypeHeaderLayout() => AssertSize<Raw.PartitionTypeHeader>(Raw.PartitionTypeHeader.Size);
+		[Fact] public void StreamHeaderLayout() => AssertSize<Raw.StreamHeader>(Raw.StreamHeader.Size);
 		[Fact] public void StreamTypeHeaderLayout() => AssertSize<Raw.StreamTypeHeader>(Raw.StreamTypeHeader.Size);
 		[Fact] public void StreamWriteHeaderLayout() => AssertSize<Raw.StreamWriteHeader>(Raw.StreamWriteHeader.Size);
 		[Fact] public void EventTypeHeaderLayout() => AssertSize<Raw.EventTypeHeader>(Raw.EventTypeHeader.Size);

--- a/src/EventStore.LogV3/Raw.cs
+++ b/src/EventStore.LogV3/Raw.cs
@@ -175,6 +175,29 @@ namespace EventStore.LogV3 {
 		}
 
 		[StructLayout(LayoutKind.Explicit, Size = Size, Pack = 1)]
+		public struct StreamHeader {
+			[FieldOffset(0)] public Guid _partitionId;
+			[FieldOffset(16)] public Guid _streamTypeId;
+			[FieldOffset(32)] public long _referenceId;
+			public const int Size = 40;
+
+			public Guid PartitionId {
+				get => _partitionId;
+				set => _partitionId = value;
+			}
+
+			public Guid StreamTypeId {
+				get => _streamTypeId;
+				set => _streamTypeId = value;
+			}
+
+			public long ReferenceId {
+				get => _referenceId;
+				set => _referenceId = value;
+			}
+		}
+
+		[StructLayout(LayoutKind.Explicit, Size = Size, Pack = 1)]
 		public struct StreamTypeHeader {
 			[FieldOffset(0)] public Guid _partitionId;
 			public const int Size = 16;

--- a/src/EventStore.LogV3/Raw.cs
+++ b/src/EventStore.LogV3/Raw.cs
@@ -176,10 +176,10 @@ namespace EventStore.LogV3 {
 
 		[StructLayout(LayoutKind.Explicit, Size = Size, Pack = 1)]
 		public struct StreamHeader {
-			[FieldOffset(0)] public Guid _partitionId;
-			[FieldOffset(16)] public Guid _streamTypeId;
-			[FieldOffset(32)] public long _referenceId;
-			public const int Size = 40;
+			[FieldOffset(0)] private Guid _partitionId;
+			[FieldOffset(16)] private Guid _streamTypeId;
+			[FieldOffset(32)] private uint _referenceNumber;
+			public const int Size = 36;
 
 			public Guid PartitionId {
 				get => _partitionId;
@@ -191,9 +191,9 @@ namespace EventStore.LogV3 {
 				set => _streamTypeId = value;
 			}
 
-			public long ReferenceId {
-				get => _referenceId;
-				set => _referenceId = value;
+			public uint ReferenceNumber {
+				get => _referenceNumber;
+				set => _referenceNumber = value;
 			}
 		}
 

--- a/src/EventStore.LogV3/RecordCreator.cs
+++ b/src/EventStore.LogV3/RecordCreator.cs
@@ -119,7 +119,7 @@ namespace EventStore.LogV3 {
 			Guid streamId,
 			DateTime timeStamp,
 			long logPosition,
-			long streamNumber,
+			uint streamNumber,
 			string streamName,
 			Guid partitionId,
 			Guid streamTypeId) {
@@ -137,7 +137,7 @@ namespace EventStore.LogV3 {
 
 			subHeader.PartitionId = partitionId;
 			subHeader.StreamTypeId = streamTypeId;
-			subHeader.ReferenceId = streamNumber;
+			subHeader.ReferenceNumber = streamNumber;
 
 			PopulateString(streamName, record.Payload.Span);
 

--- a/src/EventStore.LogV3/RecordCreator.cs
+++ b/src/EventStore.LogV3/RecordCreator.cs
@@ -12,6 +12,7 @@ namespace EventStore.LogV3 {
 		private static byte CurrentVersion(this ref Raw.EpochHeader _) => LogRecordVersion.LogRecordV1;
 		private static byte CurrentVersion(this ref Raw.PartitionHeader _) => LogRecordVersion.LogRecordV0;
 		private static byte CurrentVersion(this ref Raw.PartitionTypeHeader _) => LogRecordVersion.LogRecordV0;
+		private static byte CurrentVersion(this ref Raw.StreamHeader _) => LogRecordVersion.LogRecordV0;
 		private static byte CurrentVersion(this ref Raw.StreamTypeHeader _) => LogRecordVersion.LogRecordV0;
 		private static byte CurrentVersion(this ref Raw.StreamWriteHeader _) => LogRecordVersion.LogRecordV0;
 		private static byte CurrentVersion(this ref Raw.EventTypeHeader _) => LogRecordVersion.LogRecordV0;
@@ -20,6 +21,7 @@ namespace EventStore.LogV3 {
 		private static LogRecordType Type(this ref Raw.EpochHeader _) => LogRecordType.System;
 		private static LogRecordType Type(this ref Raw.PartitionHeader _) => LogRecordType.Partition;
 		private static LogRecordType Type(this ref Raw.PartitionTypeHeader _) => LogRecordType.PartitionType;
+		private static LogRecordType Type(this ref Raw.StreamHeader _) => LogRecordType.Stream;
 		private static LogRecordType Type(this ref Raw.StreamTypeHeader _) => LogRecordType.StreamType;
 		private static LogRecordType Type(this ref Raw.StreamWriteHeader _) => LogRecordType.StreamWrite;
 		private static LogRecordType Type(this ref Raw.EventTypeHeader _) => LogRecordType.EventType;
@@ -109,6 +111,35 @@ namespace EventStore.LogV3 {
 
 			subHeader.PartitionId = partitionId;
 			PopulateString(name, record.Payload.Span);
+
+			return StringPayloadRecord.Create(record);
+		}
+
+		public static StringPayloadRecord<Raw.StreamHeader> CreateStreamRecord(
+			Guid streamId,
+			DateTime timeStamp,
+			long logPosition,
+			long streamNumber,
+			string streamName,
+			Guid partitionId,
+			Guid streamTypeId) {
+
+			var payloadLength = _utf8NoBom.GetByteCount(streamName);
+			var record = MutableRecordView<Raw.StreamHeader>.Create(payloadLength);
+			ref var header = ref record.Header;
+			ref var subHeader = ref record.SubHeader;
+
+			header.RecordId = streamId;
+			header.Type = subHeader.Type();
+			header.Version = subHeader.CurrentVersion();
+			header.TimeStamp = timeStamp;
+			header.LogPosition = logPosition;
+
+			subHeader.PartitionId = partitionId;
+			subHeader.StreamTypeId = streamTypeId;
+			subHeader.ReferenceId = streamNumber;
+
+			PopulateString(streamName, record.Payload.Span);
 
 			return StringPayloadRecord.Create(record);
 		}

--- a/src/EventStore.LogV3/RecordView.cs
+++ b/src/EventStore.LogV3/RecordView.cs
@@ -5,6 +5,7 @@ namespace EventStore.LogV3 {
 	public interface IRecordView {
 		ReadOnlyMemory<byte> Bytes { get; }
 		ref readonly Raw.RecordHeader Header { get; }
+		ReadOnlyMemory<byte> Payload { get; }
 	}
 
 	// Immutable, generic, view of a record

--- a/src/EventStore.LogV3/StreamWriteRecord.cs
+++ b/src/EventStore.LogV3/StreamWriteRecord.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.Runtime.InteropServices;
 
@@ -13,6 +13,7 @@ namespace EventStore.LogV3 {
 		public ref readonly Raw.RecordHeader Header => ref Record.Header;
 		public ref readonly Raw.StreamWriteId WriteId => ref Record.RecordId<Raw.StreamWriteId>();
 		public ref readonly Raw.StreamWriteHeader SubHeader => ref Record.SubHeader;
+		public ReadOnlyMemory<byte> Payload => Record.Payload;
 		public StreamWriteSystemMetadata SystemMetadata { get; }
 
 		public StreamWriteRecord(RecordView<Raw.StreamWriteHeader> record) {

--- a/src/EventStore.LogV3/StringPayloadRecord.cs
+++ b/src/EventStore.LogV3/StringPayloadRecord.cs
@@ -19,6 +19,7 @@ namespace EventStore.LogV3 {
 
 		public ref readonly Raw.RecordHeader Header => ref Record.Header;
 		public ref readonly TSubHeader SubHeader => ref Record.SubHeader;
+		public ReadOnlyMemory<byte> Payload => Record.Payload;
 		public string StringPayload => Encoding.UTF8.GetString(Record.Payload.Span);
 
 		public StringPayloadRecord(RecordView<TSubHeader> record) {


### PR DESCRIPTION
Main work:
- Add Stream records
- Index them
- Use the index for the id -> name lookup

Misc work:
- Move `CopyForRetry` to IPrepareLogRecord<> so that each kind of prepare can create a copy of the same type

Further work:
- resolve //qq's
- unit test adjustments
     - stuff in TransactionLog/LogRecords might need some testing attention (running existing tests against v3)
     - same for Core/Services/Storage
     - the rest should be covered in the tests already