### PR TITLE
Handle truncated streams when reading events for projections

### DIFF
--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -415,7 +415,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			private List<JToken> _entries;
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>("/streams/" + LinkedStreamName + "/0/forward/10?embed=rich",
+				_feed = await GetJson<JObject>("/streams/" + LinkedStreamName + "/0/forward/10",extra: "embed=rich",
 					accept: ContentType.Json);
 				_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
 			}

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -309,6 +309,7 @@ namespace EventStore.Core.Services.Storage {
 
 					var result =
 						_readIndex.ReadStreamEventsForward(streamName, streamId, msg.FromEventNumber, msg.MaxCount);
+					
 					CheckEventsOrder(msg, result);
 					var resolvedPairs = ResolveLinkToEvents(result.Records, msg.ResolveLinkTos, msg.User);
 					if (resolvedPairs == null)

--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
@@ -251,11 +251,11 @@ namespace EventStore.Projections.Core.Services.Processing {
 						break;
 					case ReadStreamResult.Success:
 						_reader.UpdateNextStreamPosition(message.EventStreamId, message.NextEventNumber);
-						var isEof = message.Events.Length == 0;
-						_eofs[message.EventStreamId] = isEof;
+						_eofs[message.EventStreamId] = (message.Events.Length == 0) && message.IsEndOfStream;
 						EnqueueEvents(message);
 						ProcessBuffersAndContinue(eventStreamId: message.EventStreamId);
 						break;
+				
 					default:
 						throw new NotSupportedException(
 							String.Format("ReadEvents result code was not recognized. Code: {0}", message.Result));

--- a/src/EventStore.Projections.Core/Services/Processing/PartitionCompletedWorkItem.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/PartitionCompletedWorkItem.cs
@@ -31,7 +31,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		protected override void WriteOutput() {
 			_projection.EmitEofResult(_partition, _state.Result, _checkpointTag, Guid.Empty, null);
-			//NOTE: write output is an ordered processing stage
+			// NOTE: write output is an ordered processing stage
 			//      thus all the work items before have been already processed
 			//      and as we are processing in the stream-by-stream mode
 			//      it is safe to clean everything before this position up

--- a/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
@@ -90,7 +90,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				case ReadStreamResult.Success:
 					var oldFromSequenceNumber = StartFrom(message, _fromSequenceNumber);
 					_fromSequenceNumber = message.NextEventNumber;
-					var eof = message.Events.Length == 0;
+					var eof = (message.Events.Length == 0) && message.IsEndOfStream;
 					_eof = eof;
 					var willDispose = eof && _stopOnEof;
 

--- a/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
@@ -63,7 +63,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				return;
 			}
 
-			var eof = message.Events.Length == 0;
+			var eof = (message.Events.Length == 0) && message.IsEndOfStream;
 			_eof = eof;
 			var willDispose = _stopOnEof && eof;
 			var oldFrom = _from;

--- a/src/EventStore.Projections.Core/Services/v8/V8ProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/v8/V8ProjectionStateHandler.cs
@@ -10,6 +10,8 @@ using Newtonsoft.Json.Linq;
 using Serilog;
 
 namespace EventStore.Projections.Core.Services.v8 {
+	using System.Threading;
+	using Client.PersistentSubscriptions;
 
 	public class V8ProjectionStateHandler : IProjectionStateHandler {
 		private readonly PreludeScript _prelude;
@@ -122,6 +124,7 @@ namespace EventStore.Projections.Core.Services.v8 {
 			CheckDisposed();
 			_query.InitializeShared();
 		}
+
 
 		public string GetStatePartition(
 			CheckpointTag eventPosition, string category, ResolvedEvent @event) {


### PR DESCRIPTION
Fixed: Fix projections getting stuck when reading from truncated streams

Fixes https://github.com/EventStore/EventStore/issues/2954