### PR TITLE
Adjust V3 schema

### DIFF
--- a/src/EventStore.Core.Tests.XUnit/LogV3/LogV3RecordFactoryTests.cs
+++ b/src/EventStore.Core.Tests.XUnit/LogV3/LogV3RecordFactoryTests.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Tests.XUnit.LogV3 {
 	public class LogV3RecordFactoryTests {
 		readonly Guid _guid1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
 		readonly Guid _guid2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
-		readonly DateTime _dateTime1 = new DateTime(2020, 01, 01, 01, 01, 01);
+		readonly DateTime _dateTime1 = new(0x08_D9_15_80_C3_A1_00_00);
 		readonly long _long1 = 1;
 		readonly long _long2 = 2;
 		readonly long _long3 = 3;

--- a/src/EventStore.Core.Tests/ClientAPI/persistent_connect_integration_tests.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/persistent_connect_integration_tests.cs
@@ -385,6 +385,10 @@ namespace EventStore.Core.Tests.ClientAPI {
 			if (_attempts == 1)
 				throw new Exception("throw on first attempt to ensure retry is working");
 
+			_conn.Close();
+			_conn = BuildConnection(_node);
+			await _conn.ConnectAsync();
+
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromCurrent()

--- a/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_follower.cs
+++ b/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_follower.cs
@@ -14,6 +14,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class when_requesting_from_follower<TLogFormat, TStreamId> : specification_with_cluster<TLogFormat, TStreamId> {
+		const int Retries = 5;
 		private const string TestStream = "test-stream";
 		private IPEndPoint _followerEndPoint;
 		private IPEndPoint _leaderEndPoint;
@@ -46,6 +47,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task post_events_should_succeed_when_leader_not_required() {
 			var path = $"streams/{TestStream}";
 			var response = await PostEvent(_followerEndPoint, path, requireLeader: false);
@@ -54,6 +56,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task delete_stream_should_succeed_when_leader_not_required() {
 			var path = $"streams/{TestStream}";
 			var response = await DeleteStream(_followerEndPoint, path, requireLeader: false);
@@ -62,6 +65,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task read_from_stream_forward_should_succeed_when_leader_not_required() {
 			var path = $"streams/{TestStream}/0/forward/1";
 			var response = await ReadStream(_followerEndPoint, path, requireLeader: false);
@@ -71,7 +75,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 
 		static int _attempts = 0;
 		[Test]
-		[Retry(10)]
+		[Retry(Retries)]
 		public async Task read_from_stream_backward_should_succeed_when_leader_not_required() {
 			_attempts++;
 			if (_attempts == 1)
@@ -84,6 +88,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task read_from_all_forward_should_succeed_when_leader_not_required() {
 			var path = $"streams/$all/00000000000000000000000000000000/forward/1";
 			var response = await ReadStream(_followerEndPoint, path, requireLeader: false);
@@ -92,6 +97,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task read_from_all_backward_should_succeed_when_leader_not_required() {
 			var path = $"streams/$all";
 			var response = await ReadStream(_followerEndPoint, path, requireLeader: false);
@@ -100,6 +106,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task should_redirect_to_leader_when_writing_with_requires_leader() {
 			var path = $"streams/{TestStream}";
 			var response = await PostEvent(_followerEndPoint, path);
@@ -110,6 +117,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task should_redirect_to_leader_when_deleting_with_requires_leader() {
 			var path = $"streams/{TestStream}";
 			var response = await DeleteStream(_followerEndPoint, path, requireLeader: true);
@@ -120,6 +128,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task should_redirect_to_leader_when_reading_from_stream_backwards_with_requires_leader() {
 			var path = $"streams/{TestStream}";
 			var response = await ReadStream(_followerEndPoint, path, requireLeader: true);
@@ -130,6 +139,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task should_redirect_to_leader_when_reading_from_stream_forwards_with_requires_leader() {
 			var path = $"streams/{TestStream}/0/forward/1";
 			var response = await ReadStream(_followerEndPoint, path, requireLeader: true);
@@ -140,6 +150,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task should_redirect_to_leader_when_reading_from_all_backwards_with_requires_leader() {
 			var path = $"streams/$all";
 			var response = await ReadStream(_followerEndPoint, path, requireLeader: true);
@@ -150,6 +161,7 @@ namespace EventStore.Core.Tests.Http.Cluster {
 		}
 
 		[Test]
+		[Retry(Retries)]
 		public async Task should_redirect_to_leader_when_reading_from_all_forwards_with_requires_leader() {
 			var path = $"streams/$all/00000000000000000000000000000000/forward/1";
 			var response = await ReadStream(_followerEndPoint, path, requireLeader: true);

--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -34,6 +34,7 @@ namespace EventStore.Core.Tests.Integration {
 				var state = _nodes[i].NodeState;
 				if (state == VNodeState.Leader) leaders++;
 				else if (state == VNodeState.Follower) followers++;
+				else throw new Exception($"node {i} in unexpected state {state}");
 			}
 
 			Assert.AreEqual(1, leaders);

--- a/src/EventStore.Core.Tests/Services/RequestManagement/ReadMgr/when_reading_an_event_committed_on_leader_and_on_followers.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/ReadMgr/when_reading_an_event_committed_on_leader_and_on_followers.cs
@@ -93,6 +93,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.ReadMgr {
 		}
 
 		[Test]
+		[Retry(5)]
 		public void should_be_able_to_read_event_from_all_forward_on_followers() {
 			var followers = GetFollowers();
 			var quorum = (followers.Count() + 1) / 2 + 1;
@@ -107,6 +108,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.ReadMgr {
 		}
 
 		[Test]
+		[Retry(5)]
 		public void should_be_able_to_read_event_from_all_backward_on_followers() {
 			var followers = GetFollowers();
 			var quorum = (followers.Count() + 1) / 2 + 1;
@@ -121,6 +123,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.ReadMgr {
 		}
 
 		[Test]
+		[Retry(5)]
 		public void should_be_able_to_read_event_from_stream_forward_on_followers() {
 			var followers = GetFollowers();
 			var quorum = (followers.Count() + 1) / 2 + 1;
@@ -136,6 +139,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.ReadMgr {
 		}
 
 		[Test]
+		[Retry(5)]
 		public void should_be_able_to_read_event_from_stream_backward_on_followers() {
 			var followers = GetFollowers();
 			var quorum = (followers.Count() + 1) / 2 + 1;
@@ -150,6 +154,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.ReadMgr {
 		}
 
 		[Test]
+		[Retry(5)]
 		public void should_be_able_to_read_event_on_followers() {
 			var followers = GetFollowers();
 			var quorum = (followers.Count() + 1) / 2 + 1;

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -44,19 +44,20 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 			_id3 = Guid.NewGuid();
 
 			_logFormat.StreamNameIndex.GetOrAddId("duplicate_stream", out var streamId, out _, out _);
+			var expectedVersion = ExpectedVersion.NoStream;
 
 			//stream id: duplicate_stream at version: 0
-			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, 0, _id1, _id1, 0, 0, streamId, ExpectedVersion.Any,
+			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, 0, _id1, _id1, 0, 0, streamId, expectedVersion++,
 				PrepareFlags.SingleWrite, "type", new byte[0], new byte[0], DateTime.UtcNow), out pos1);
 			Writer.Write(new CommitLogRecord(pos1, _id1, 0, DateTime.UtcNow, 0), out pos2);
 
 			//stream id: duplicate_stream at version: 1
-			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos2, _id2, _id2, pos2, 0, streamId, ExpectedVersion.Any,
+			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos2, _id2, _id2, pos2, 0, streamId, expectedVersion++,
 				PrepareFlags.SingleWrite, "type", new byte[0], new byte[0], DateTime.UtcNow), out pos3);
 			Writer.Write(new CommitLogRecord(pos3, _id2, pos2, DateTime.UtcNow, 1), out pos4);
 
 			//stream id: duplicate_stream at version: 2
-			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos4, _id3, _id3, pos4, 0, streamId, ExpectedVersion.Any,
+			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos4, _id3, _id3, pos4, 0, streamId, expectedVersion++,
 				PrepareFlags.SingleWrite, "type", new byte[0], new byte[0], DateTime.UtcNow), out pos5);
 			Writer.Write(new CommitLogRecord(pos5, _id3, pos4, DateTime.UtcNow, 2), out pos6);
 		}
@@ -68,7 +69,7 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 			_logFormat.StreamNameIndex.GetOrAddId("duplicate_stream", out var streamId, out _, out _);
 
 			//stream id: duplicate_stream at version: 0 (duplicate event/index entry)
-			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos6, _id4, _id4, pos6, 0, streamId, ExpectedVersion.Any,
+			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos6, _id4, _id4, pos6, 0, streamId, ExpectedVersion.NoStream,
 				PrepareFlags.SingleWrite, "type", new byte[0], new byte[0], DateTime.UtcNow), out pos7);
 			Writer.Write(new CommitLogRecord(pos7, _id4, pos6, DateTime.UtcNow, 0), out pos8);
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_prepares_and_commits.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_prepares_and_commits.cs
@@ -20,13 +20,16 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 			long pos1, pos2, pos3, pos4, pos5, pos6;
 			_streamNameIndex.GetOrAddId("test1", out var streamId1, out _, out _);
 			_streamNameIndex.GetOrAddId("test2", out var streamId2, out _, out _);
-			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, 0, _id1, _id1, 0, 0, streamId1, ExpectedVersion.Any,
+			var expectedVersion1 = ExpectedVersion.NoStream;
+			var expectedVersion2 = ExpectedVersion.NoStream;
+
+			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, 0, _id1, _id1, 0, 0, streamId1, expectedVersion1++,
 					PrepareFlags.SingleWrite, "type", new byte[0], new byte[0], DateTime.UtcNow),
 				out pos1);
-			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos1, _id2, _id2, pos1, 0, streamId2, ExpectedVersion.Any,
+			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos1, _id2, _id2, pos1, 0, streamId2, expectedVersion2++,
 					PrepareFlags.SingleWrite, "type", new byte[0], new byte[0], DateTime.UtcNow),
 				out pos2);
-			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos2, _id3, _id3, pos2, 0, streamId2, ExpectedVersion.Any,
+			Writer.Write(LogRecord.Prepare(_logFormat.RecordFactory, pos2, _id3, _id3, pos2, 0, streamId2, expectedVersion2++,
 					PrepareFlags.SingleWrite, "type", new byte[0], new byte[0], DateTime.UtcNow),
 				out pos3);
 			Writer.Write(new CommitLogRecord(pos3, _id1, 0, DateTime.UtcNow, 0), out pos4);

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/TFChunkDbCreationHelper.cs
@@ -116,7 +116,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 
 					ILogRecord record;
 
-					var expectedVersion = transInfo.FirstPrepareId == rec.Id ? streamVersion : ExpectedVersion.Any;
+					var expectedVersion = transInfo.FirstPrepareId == rec.Id ? streamVersion : ExpectedVersion.NoStream;
 					switch (rec.Type) {
 						case Rec.RecType.Prepare: {
 							record = CreateLogRecord(rec, transInfo, logPos, expectedVersion);

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -32,7 +32,9 @@ namespace EventStore.Core.Tests.TransactionLog {
 			var logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormat;
 			var streamName = "es-to-scavenge";
 			logFormat.StreamNameIndex.GetOrAddId(streamName, out var streamId, out _, out _);
-			_p1 = LogRecord.SingleWrite(logFormat.RecordFactory, 0, Guid.NewGuid(), Guid.NewGuid(), streamId, ExpectedVersion.Any, "et1",
+			var expectedVersion = ExpectedVersion.NoStream;
+
+			_p1 = LogRecord.SingleWrite(logFormat.RecordFactory, 0, Guid.NewGuid(), Guid.NewGuid(), streamId, expectedVersion++, "et1",
 				new byte[2048], new byte[] { 5, 7 });
 			_res1 = chunk.TryAppend(_p1);
 
@@ -40,7 +42,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_cres1 = chunk.TryAppend(_c1);
 
 			_p2 = LogRecord.SingleWrite(logFormat.RecordFactory, _cres1.NewPosition,
-				Guid.NewGuid(), Guid.NewGuid(), streamId, ExpectedVersion.Any, "et1",
+				Guid.NewGuid(), Guid.NewGuid(), streamId, expectedVersion++, "et1",
 				new byte[2048], new byte[] { 5, 7 });
 			_res2 = chunk.TryAppend(_p2);
 
@@ -48,7 +50,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_cres2 = chunk.TryAppend(_c2);
 
 			_p3 = LogRecord.SingleWrite(logFormat.RecordFactory, _cres2.NewPosition,
-				Guid.NewGuid(), Guid.NewGuid(), streamId, ExpectedVersion.Any, "et1",
+				Guid.NewGuid(), Guid.NewGuid(), streamId, expectedVersion++, "et1",
 				new byte[2048], new byte[] { 5, 7 });
 			_res3 = chunk.TryAppend(_p3);
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
@@ -31,6 +31,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			var logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormat;
 			var streamName = "es1";
 			logFormat.StreamNameIndex.GetOrAddId(streamName, out var streamId, out _, out _);
+			var expectedVersion = ExpectedVersion.NoStream;
 			var pos = 0;
 			for (int i = 0; i < RecordsCount; ++i) {
 				if (i > 0 && i % 3 == 0) {
@@ -40,7 +41,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				}
 
 				_records[i] = LogRecord.SingleWrite(logFormat.RecordFactory, pos,
-					Guid.NewGuid(), Guid.NewGuid(), streamId, ExpectedVersion.Any, "et1",
+					Guid.NewGuid(), Guid.NewGuid(), streamId, expectedVersion++, "et1",
 					new byte[1200], new byte[] { 5, 7 });
 				_results[i] = chunk.TryAppend(_records[i]);
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_few_chunks.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormat;
 			logFormat.StreamNameIndex.GetOrAddId("es1", out var streamId, out _, out _);
+			var expectedVersion = ExpectedVersion.NoStream;
 
 			var pos = 0;
 			for (int i = 0; i < RecordsCount; ++i) {
@@ -43,7 +44,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				}
 
 				_records[i] = LogRecord.SingleWrite(logFormat.RecordFactory, pos,
-					Guid.NewGuid(), Guid.NewGuid(), streamId, ExpectedVersion.Any, "et1",
+					Guid.NewGuid(), Guid.NewGuid(), streamId, expectedVersion++, "et1",
 					new byte[1200], new byte[] { 5, 7 });
 				_results[i] = chunk.TryAppend(_records[i]);
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk.cs
@@ -33,10 +33,11 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormat;
 			logFormat.StreamNameIndex.GetOrAddId("es1", out var streamId, out _, out _);
+			var expectedVersion = ExpectedVersion.NoStream;
 
 			for (int i = 0; i < _records.Length; ++i) {
 				_records[i] = LogRecord.SingleWrite(logFormat.RecordFactory, i == 0 ? 0 : _results[i - 1].NewPosition,
-					Guid.NewGuid(), Guid.NewGuid(), streamId, ExpectedVersion.Any, "et1",
+					Guid.NewGuid(), Guid.NewGuid(), streamId, expectedVersion++, "et1",
 					new byte[] { 0, 1, 2 }, new byte[] { 5, 7 });
 				_results[i] = chunk.TryAppend(_records[i]);
 			}

--- a/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_sequentially_reading_db_with_one_chunk_ending_with_prepare.cs
@@ -34,6 +34,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_results = new RecordWriteResult[RecordsCount];
 			var logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormat;
 			logFormat.StreamNameIndex.GetOrAddId("es1", out var streamId, out _, out _);
+			var expectedVersion = ExpectedVersion.NoStream;
 
 			for (int i = 0; i < _records.Length - 1; ++i) {
 				_records[i] = LogRecord.SingleWrite(
@@ -42,7 +43,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 					Guid.NewGuid(),
 					Guid.NewGuid(),
 					streamId,
-					ExpectedVersion.Any,
+					expectedVersion++,
 					"et1",
 					new byte[] { 0, 1, 2 },
 					new byte[] { 5, 7 });
@@ -57,7 +58,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				_results[_records.Length - 1 - 1].NewPosition,
 				0,
 				streamId,
-				ExpectedVersion.Any,
+				expectedVersion++,
 				PrepareFlags.Data,
 				"et1",
 				new byte[] { 0, 1, 2 },

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
@@ -77,7 +77,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				Assert.AreEqual(p.EventId, _eventId);
 				Assert.AreEqual(p.EventStreamId, streamId);
 				Assert.AreEqual(p.ExpectedVersion, 1234);
-				Assert.AreEqual(p.TimeStamp, new DateTime(2012, 12, 21));
+				Assert.That(p.TimeStamp, Is.EqualTo(new DateTime(2012, 12, 21)).Within(20).Milliseconds);
 				Assert.AreEqual(p.Flags, PrepareFlags.SingleWrite);
 				Assert.AreEqual(p.EventType, "type");
 				Assert.AreEqual(p.Data.Length, 5);

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
@@ -77,7 +77,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				Assert.AreEqual(p.EventId, _eventId);
 				Assert.AreEqual(p.EventStreamId, streamId);
 				Assert.AreEqual(p.ExpectedVersion, 1234);
-				Assert.That(p.TimeStamp, Is.EqualTo(new DateTime(2012, 12, 21)).Within(20).Milliseconds);
+				Assert.That(p.TimeStamp, Is.EqualTo(new DateTime(2012, 12, 21)).Within(7).Milliseconds);
 				Assert.AreEqual(p.Flags, PrepareFlags.SingleWrite);
 				Assert.AreEqual(p.EventType, "type");
 				Assert.AreEqual(p.Data.Length, 5);

--- a/src/EventStore.Core/LogV3/LogV3RecordFactory.cs
+++ b/src/EventStore.Core/LogV3/LogV3RecordFactory.cs
@@ -5,6 +5,12 @@ using EventStore.Core.TransactionLog.LogRecords;
 namespace EventStore.Core.LogV3 {
 	public class LogV3RecordFactory : IRecordFactory<long> {
 		public LogV3RecordFactory() {
+			if (!BitConverter.IsLittleEndian) {
+				// to support big endian we would need to adjust some of the bit
+				// operatiosn in the raw v3 structs, and adjust the way that the
+				// v3 records are written/read from disk (currently blitted)
+				throw new NotSupportedException();
+			}
 		}
 
 		public ISystemLogRecord CreateEpoch(EpochRecord epoch) {

--- a/src/EventStore.LogV3.Tests/LayoutInspections.cs
+++ b/src/EventStore.LogV3.Tests/LayoutInspections.cs
@@ -24,7 +24,7 @@ namespace EventStore.LogV3.Tests {
 		[InlineData(typeof(Raw.ContentTypeHeader))]
 		public void InspectLayout(Type t) {
 			var layout = TypeLayout.GetLayout(t);
-			_output.WriteLine($"{layout}");
+			_output.WriteLine(layout.ToString(recursively: false));
 		}
 	}
 }

--- a/src/EventStore.LogV3.Tests/RecordCreatorTests.cs
+++ b/src/EventStore.LogV3.Tests/RecordCreatorTests.cs
@@ -8,7 +8,7 @@ namespace EventStore.LogV3.Tests {
 		readonly Guid _guid1 = Guid.Parse("00000000-0000-0000-0000-000000000001");
 		readonly Guid _guid2 = Guid.Parse("00000000-0000-0000-0000-000000000002");
 		readonly Guid _guid3 = Guid.Parse("00000000-0000-0000-0000-000000000003");
-		readonly DateTime _dateTime1 = new DateTime(2020, 01, 01, 01, 01, 01);
+		readonly DateTime _dateTime1 = new(0x08_D9_15_80_C3_A1_00_00);
 		readonly int _int1 = 1;
 		readonly long _long1 = 1;
 		readonly long _long2 = 2;
@@ -16,9 +16,9 @@ namespace EventStore.LogV3.Tests {
 		readonly long _long4 = 4;
 		readonly uint _uint1 = 5;
 		readonly ushort _ushort1 = 6;
-		readonly byte _byte1 = 8;
 		readonly string _string1 = "one";
 		readonly Raw.EventFlags _prepareflags = (Raw.EventFlags)3;
+		readonly Raw.PartitionFlags _partitionFlags = (Raw.PartitionFlags)4;
 		readonly ReadOnlyMemory<byte> _bytes1 = new byte[] { 0x10 };
 		readonly ReadOnlyMemory<byte> _bytes2 = new byte[] { 0x20, 0x01 };
 		readonly ReadOnlyMemory<byte> _bytes3 = new byte[] { 0x30, 0x01, 0x01 };
@@ -55,7 +55,8 @@ namespace EventStore.LogV3.Tests {
 				partitionId: _guid1,
 				partitionTypeId: _guid2,
 				parentPartitionId: _guid3,
-				flags: _byte1,
+				flags: _partitionFlags,
+				referenceNumber: _ushort1,
 				name: _string1);
 
 			Assert.Equal(LogRecordType.Partition, record.Header.Type);
@@ -65,7 +66,8 @@ namespace EventStore.LogV3.Tests {
 			Assert.Equal(_long1, record.Header.LogPosition);
 			Assert.Equal(_guid2, record.SubHeader.PartitionTypeId);
 			Assert.Equal(_guid3, record.SubHeader.ParentPartitionId);
-			Assert.Equal(_byte1, record.SubHeader.Flags);
+			Assert.Equal(_partitionFlags, record.SubHeader.Flags);
+			Assert.Equal(_ushort1, record.SubHeader.ReferenceNumber);
 			Assert.Equal(_string1, record.StringPayload);
 		}
 		
@@ -111,7 +113,8 @@ namespace EventStore.LogV3.Tests {
 				timeStamp: _dateTime1,
 				logPosition: _long1,
 				eventTypeId: _guid1,
-				partitionId: _guid2,
+				parentEventTypeId: _guid2,
+				partitionId: _guid3,
 				referenceNumber: _uint1,
 				version: _ushort1,
 				name: _string1);
@@ -121,7 +124,8 @@ namespace EventStore.LogV3.Tests {
 			Assert.Equal(_dateTime1, record.Header.TimeStamp);
 			Assert.Equal(_guid1, record.Header.RecordId);
 			Assert.Equal(_long1, record.Header.LogPosition);
-			Assert.Equal(_guid2, record.SubHeader.PartitionId);
+			Assert.Equal(_guid2, record.SubHeader.ParentEventTypeId);
+			Assert.Equal(_guid3, record.SubHeader.PartitionId);
 			Assert.Equal(_uint1, record.SubHeader.ReferenceNumber);
 			Assert.Equal(_ushort1, record.SubHeader.Version);
 			Assert.Equal(_string1, record.StringPayload);
@@ -170,7 +174,10 @@ namespace EventStore.LogV3.Tests {
 			Assert.Equal<Guid>(_guid1, record.SystemMetadata.CorrelationId);
 			Assert.Equal(_long2, record.SystemMetadata.TransactionPosition);
 			Assert.Equal(_int1, record.SystemMetadata.TransactionOffset);
+			Assert.Equal(0, record.SystemMetadata.StartingEventNumberRoot);
+			Assert.Equal(0, record.SystemMetadata.StartingEventNumberCategory);
 			Assert.Equal(0, record.WriteId.CategoryNumber);
+			Assert.Equal(0, record.WriteId.ParentTopicNumber);
 			Assert.Equal(0, record.WriteId.TopicNumber);
 			Assert.Equal(_long3, record.WriteId.StreamNumber);
 			Assert.Equal(_long4, record.WriteId.StartingEventNumber);

--- a/src/EventStore.LogV3.Tests/RecordHeaderTests.cs
+++ b/src/EventStore.LogV3.Tests/RecordHeaderTests.cs
@@ -6,6 +6,7 @@ namespace EventStore.LogV3.Tests {
 		[Fact]
 		public void can_set_time_stamp() {
 			var header = new Raw.RecordHeader {
+				TimeStamp = new DateTime(2000, 03, 21),
 				Type = LogCommon.LogRecordType.EventType,
 				Version = 0x45,
 			};

--- a/src/EventStore.LogV3.Tests/RecordHeaderTests.cs
+++ b/src/EventStore.LogV3.Tests/RecordHeaderTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Xunit;
+
+namespace EventStore.LogV3.Tests {
+	public class RecordHeaderTests {
+		[Fact]
+		public void can_set_time_stamp() {
+			var header = new Raw.RecordHeader {
+				Type = LogCommon.LogRecordType.EventType,
+				Version = 0x45,
+			};
+
+			var now = DateTime.UtcNow;
+			header.TimeStamp = now;
+
+			Assert.Equal(LogCommon.LogRecordType.EventType, header.Type);
+			Assert.Equal(0x45, header.Version);
+			Assert.Equal(now, header.TimeStamp, TimeSpan.FromMilliseconds(20));
+		}
+
+		[Fact]
+		public void can_get_time_stamp() {
+			var timeStamp = new DateTime(0x08_D9_15_80_C3_A1_00_00);
+			var header = new Raw.RecordHeader {
+				TimeStamp = timeStamp,
+			};
+
+			header.Type = LogCommon.LogRecordType.EventType;
+			header.Version = 0x45;
+
+			Assert.Equal(LogCommon.LogRecordType.EventType, header.Type);
+			Assert.Equal(0x45, header.Version);
+			Assert.Equal(timeStamp, header.TimeStamp);
+		}
+	}
+}

--- a/src/EventStore.LogV3.Tests/RecordHeaderTests.cs
+++ b/src/EventStore.LogV3.Tests/RecordHeaderTests.cs
@@ -16,7 +16,7 @@ namespace EventStore.LogV3.Tests {
 
 			Assert.Equal(LogCommon.LogRecordType.EventType, header.Type);
 			Assert.Equal(0x45, header.Version);
-			Assert.Equal(now, header.TimeStamp, TimeSpan.FromMilliseconds(20));
+			Assert.Equal(now, header.TimeStamp, TimeSpan.FromMilliseconds(7));
 		}
 
 		[Fact]

--- a/src/EventStore.LogV3.Tests/StreamWriteIdTests.cs
+++ b/src/EventStore.LogV3.Tests/StreamWriteIdTests.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Xunit;
+
+namespace EventStore.LogV3.Tests {
+	public class StreamWriteIdTests {
+		[Theory]
+		[InlineData(Raw.StreamWriteId.MaxStartingEventNumber + 2)]
+		[InlineData(-1)]
+		public void cant_set_starting_event_number_out_of_range(long x) {
+			var writeId = new Raw.StreamWriteId {
+				ParentTopicNumber = 15,
+			};
+
+			Assert.Throws<ArgumentOutOfRangeException>(() => {
+				writeId.StartingEventNumber = x;
+			});
+			Assert.Equal(15, writeId.ParentTopicNumber);
+		}
+
+		[Theory]
+		[InlineData(Raw.StreamWriteId.EventNumberDeletedStream)]
+		[InlineData(Raw.StreamWriteId.MaxStartingEventNumber)]
+		[InlineData(0)]
+		public void can_set_starting_event_number(long x) {
+			var writeId = new Raw.StreamWriteId {
+				ParentTopicNumber = 15,
+			};
+
+			writeId.StartingEventNumber = x;
+
+			Assert.Equal(15, writeId.ParentTopicNumber);
+			Assert.Equal(x, writeId.StartingEventNumber);
+		}
+
+		[Fact]
+		public void can_get_starting_event_number() {
+			var writeId = new Raw.StreamWriteId {
+				StartingEventNumber = Raw.StreamWriteId.MaxStartingEventNumber,
+			};
+
+			writeId.ParentTopicNumber = 15;
+
+			Assert.Equal(15, writeId.ParentTopicNumber);
+			Assert.Equal(Raw.StreamWriteId.MaxStartingEventNumber, writeId.StartingEventNumber);
+		}
+	}
+}

--- a/src/EventStore.LogV3.Tests/StreamWriteIdTests.cs
+++ b/src/EventStore.LogV3.Tests/StreamWriteIdTests.cs
@@ -23,6 +23,7 @@ namespace EventStore.LogV3.Tests {
 		[InlineData(0)]
 		public void can_set_starting_event_number(long x) {
 			var writeId = new Raw.StreamWriteId {
+				StartingEventNumber = 123,
 				ParentTopicNumber = 15,
 			};
 

--- a/src/EventStore.LogV3/Protos/stream_write_system_metadata.proto
+++ b/src/EventStore.LogV3/Protos/stream_write_system_metadata.proto
@@ -7,4 +7,6 @@ message StreamWriteSystemMetadata {
 	int64 transaction_position = 1;
 	int32 transaction_offset = 2;
 	ProtoGuid correlation_id = 3;
+	int64 starting_event_number_root = 4;
+	int64 starting_event_number_category = 5;
 }

--- a/src/EventStore.LogV3/RecordCreator.cs
+++ b/src/EventStore.LogV3/RecordCreator.cs
@@ -67,7 +67,8 @@ namespace EventStore.LogV3 {
 			Guid partitionId,
 			Guid partitionTypeId,
 			Guid parentPartitionId,
-			byte flags,
+			Raw.PartitionFlags flags,
+			ushort referenceNumber,
 			string name) {
 
 			var payloadLength = _utf8NoBom.GetByteCount(name);
@@ -84,6 +85,7 @@ namespace EventStore.LogV3 {
 			subHeader.PartitionTypeId = partitionTypeId;
 			subHeader.ParentPartitionId = parentPartitionId;
 			subHeader.Flags = flags;
+			subHeader.ReferenceNumber = referenceNumber;
 			PopulateString(name, record.Payload.Span);
 
 			return StringPayloadRecord.Create(record);
@@ -141,6 +143,7 @@ namespace EventStore.LogV3 {
 			DateTime timeStamp,
 			long logPosition,
 			Guid eventTypeId,
+			Guid parentEventTypeId,
 			Guid partitionId,
 			uint referenceNumber,
 			ushort version,
@@ -157,6 +160,7 @@ namespace EventStore.LogV3 {
 			header.RecordId = eventTypeId;
 			header.LogPosition = logPosition;
 
+			subHeader.ParentEventTypeId = parentEventTypeId;
 			subHeader.PartitionId = partitionId;
 			subHeader.ReferenceNumber = referenceNumber;
 			subHeader.Version = version;
@@ -209,6 +213,8 @@ namespace EventStore.LogV3 {
 				CorrelationId = correlationId,
 				TransactionPosition = transactionPosition,
 				TransactionOffset = transactionOffset,
+				StartingEventNumberRoot = 0,
+				StartingEventNumberCategory = 0,
 			};
 
 			var eventSystemMetadata = new EventSystemMetadata {
@@ -235,7 +241,7 @@ namespace EventStore.LogV3 {
 			header.TimeStamp = timeStamp;
 			header.LogPosition = logPosition;
 
-			// todo recordId.ParentTopicNumber = 0;
+			recordId.ParentTopicNumber = 0;
 			recordId.TopicNumber = 0;
 			recordId.CategoryNumber = 0;
 			recordId.StreamNumber = (uint)streamNumber; // todo: remove cast


### PR DESCRIPTION
Updated: Assorted minor adjustments to V3 schema following discussions

- Use 6 bytes for timestamp at the expense of precision
  (populated by DateTime.UtcNow which is of similar precision)
- PartitionHeader: ushort enum for flags, add reference number
- EventTypeNumber: unsigned
- Add parent topic number
- Add starting event numbers to metadata
  metadata for flexibility, and protobufs has variable length encoding
- Adjust field order so no padding required