### PR TITLE
Fix parameter count mismatch when loading the dashboard in the UI

### DIFF
--- a/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
@@ -146,6 +146,6 @@ namespace EventStore.Core {
 		}
 
 		[AttributeUsage(AttributeTargets.Property)]
-		private class OptionGroupAttribute : Attribute{}
+		internal class OptionGroupAttribute : Attribute{}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/InfoController.cs
@@ -95,7 +95,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 
 		public OptionStructure[] GetOptionsInfo(ClusterVNodeOptions options) {
 			var optionsToSendToClient = new List<OptionStructure>();
-			foreach (PropertyInfo sectionInfo in typeof(ClusterVNodeOptions).GetProperties()) {
+			var optionGroups = typeof(ClusterVNodeOptions).GetProperties()
+				.Where(p => p.IsDefined(typeof(ClusterVNodeOptions.OptionGroupAttribute)));
+			foreach (PropertyInfo sectionInfo in optionGroups) {
 				var section = sectionInfo.GetValue(options, null);
 				foreach (PropertyInfo property in sectionInfo.PropertyType.GetProperties()) {
 					var argumentDescriptionAttribute = property.GetCustomAttribute<DescriptionAttribute>();


### PR DESCRIPTION
Fixed: Parameter count mismatch when loading the dashboard in the UI

The error got triggered after making some properties [public](https://github.com/EventStore/EventStore/pull/2942/files#diff-1dd89ac865ed1c15ef4818505683c34557ed5211d447d772626e7c83be3c8140R36) on `ClusterVNodeProperties` in order to remove `InternalsVisibleTo`.