### PR TITLE
Fix flakey tests

### DIFF
--- a/src/EventStore.Core.Tests/AssertEx.cs
+++ b/src/EventStore.Core.Tests/AssertEx.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using KellermanSoftware.CompareNetObjects;
 using NUnit.Framework;
@@ -66,7 +67,12 @@ namespace EventStore.Core.Tests {
 		/// <param name="msg">A message to display if the condition is not satisfied.</param>
 		/// <param name="yieldThread">If true, the thread relinquishes the remainder of its time
 		/// slice to any thread of equal priority that is ready to run.</param>
-		public static void IsOrBecomesTrue(Func<bool> func, TimeSpan? timeout = null, string msg = null, bool yieldThread = false) {
+		public static void IsOrBecomesTrue(Func<bool> func, TimeSpan? timeout = null,
+			string msg = "AssertEx.IsOrBecomesTrue() timed out", bool yieldThread = false,
+			[CallerMemberName] string memberName = "",
+			[CallerFilePath] string sourceFilePath = "",
+			[CallerLineNumber] int sourceLineNumber = 0) {
+			
 			if (func()) {
 				return; 
 			}
@@ -90,7 +96,7 @@ namespace EventStore.Core.Tests {
 				spin = new SpinWait();
 			}
 
-			Assert.Fail(msg ?? "");
+			Assert.Fail($"{msg} in {memberName} {sourceFilePath}:{sourceLineNumber}");
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/ClientAPI/persistent_connect_integration_tests.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/persistent_connect_integration_tests.cs
@@ -12,8 +12,6 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class happy_case_writing_and_subscribing_to_normal_events_manual_ack<TLogFormat, TStreamId>
 		: SpecificationWithMiniNode<TLogFormat, TStreamId> {
-		private readonly string StreamName = Guid.NewGuid().ToString();
-		private readonly string GroupName = Guid.NewGuid().ToString();
 		private const int BufferCount = 10;
 		private const int EventWriteCount = BufferCount * 2;
 
@@ -24,14 +22,16 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 		[Test]
 		public async Task Test() {
+			var streamName = Guid.NewGuid().ToString();
+			var groupName = Guid.NewGuid().ToString();
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromCurrent()
 				.ResolveLinkTos()
 				.Build();
 
-			await _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials);
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName,
+			await _conn.CreatePersistentSubscriptionAsync(streamName, groupName, settings, DefaultData.AdminCredentials);
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName,
 				(subscription, resolvedEvent) => {
 					subscription.Acknowledge(resolvedEvent);
 
@@ -48,7 +48,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
 
-				await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
+				await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
 			}
 
 			if (!_eventsReceived.WaitOne(TimeSpan.FromSeconds(5))) {
@@ -62,8 +62,6 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class happy_case_writing_and_subscribing_to_normal_events_auto_ack<TLogFormat, TStreamId> : SpecificationWithMiniNode<TLogFormat, TStreamId> {
-		private readonly string StreamName = Guid.NewGuid().ToString();
-		private readonly string GroupName = Guid.NewGuid().ToString();
 		private const int BufferCount = 10;
 		private const int EventWriteCount = BufferCount * 2;
 
@@ -74,14 +72,16 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 		[Test]
 		public async Task Test() {
+			var streamName = Guid.NewGuid().ToString();
+			var groupName = Guid.NewGuid().ToString();
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromCurrent()
 				.ResolveLinkTos()
 				.Build();
-			await _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials)
+			await _conn.CreatePersistentSubscriptionAsync(streamName, groupName, settings, DefaultData.AdminCredentials)
 ;
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName,
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName,
 				(subscription, resolvedEvent) => {
 					if (Interlocked.Increment(ref _eventReceivedCount) == EventWriteCount) {
 						_eventsReceived.Set();
@@ -96,7 +96,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
 
-				await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
+				await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
 			}
 
 			if (!_eventsReceived.WaitOne(TimeSpan.FromSeconds(5))) {
@@ -110,8 +110,6 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class happy_case_catching_up_to_normal_events_auto_ack<TLogFormat, TStreamId> : SpecificationWithMiniNode<TLogFormat, TStreamId> {
-		private readonly string StreamName = Guid.NewGuid().ToString();
-		private readonly string GroupName = Guid.NewGuid().ToString();
 		private const int BufferCount = 10;
 		private const int EventWriteCount = BufferCount * 2;
 
@@ -123,6 +121,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 		[Test]
 		public async Task Test() {
+			var streamName = Guid.NewGuid().ToString();
+			var groupName = Guid.NewGuid().ToString();
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromBeginning()
@@ -131,11 +131,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
 
-				await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
+				await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
 			}
 
-			await _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials);
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName,
+			await _conn.CreatePersistentSubscriptionAsync(streamName, groupName, settings, DefaultData.AdminCredentials);
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName,
 				(subscription, resolvedEvent) => {
 					if (Interlocked.Increment(ref _eventReceivedCount) == EventWriteCount) {
 						_eventsReceived.Set();
@@ -160,8 +160,6 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class happy_case_catching_up_to_normal_events_manual_ack<TLogFormat, TStreamId> : SpecificationWithMiniNode<TLogFormat, TStreamId> {
-		private readonly string StreamName = Guid.NewGuid().ToString();
-		private readonly string GroupName = Guid.NewGuid().ToString();
 		private const int BufferCount = 10;
 		private const int EventWriteCount = BufferCount * 2;
 
@@ -173,6 +171,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 		[Test]
 		public async Task Test() {
+			var streamName = Guid.NewGuid().ToString();
+			var groupName = Guid.NewGuid().ToString();
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromBeginning()
@@ -181,11 +181,11 @@ namespace EventStore.Core.Tests.ClientAPI {
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
 
-				await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
+				await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
 			}
 
-			await _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials);
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName,
+			await _conn.CreatePersistentSubscriptionAsync(streamName, groupName, settings, DefaultData.AdminCredentials);
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName,
 				(subscription, resolvedEvent) => {
 					subscription.Acknowledge(resolvedEvent);
 					if (Interlocked.Increment(ref _eventReceivedCount) == EventWriteCount) {
@@ -210,8 +210,6 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class happy_case_catching_up_to_link_to_events_manual_ack<TLogFormat, TStreamId> : SpecificationWithMiniNode<TLogFormat, TStreamId> {
-		private readonly string StreamName = Guid.NewGuid().ToString();
-		private readonly string GroupName = Guid.NewGuid().ToString();
 		private const int BufferCount = 10;
 		private const int EventWriteCount = BufferCount * 2;
 
@@ -222,6 +220,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 		[Test]
 		public async Task Test() {
+			var streamName = Guid.NewGuid().ToString();
+			var groupName = Guid.NewGuid().ToString();
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromBeginning()
@@ -229,12 +229,12 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.Build();
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
-				await _conn.AppendToStreamAsync(StreamName + "original", ExpectedVersion.Any, DefaultData.AdminCredentials,
+				await _conn.AppendToStreamAsync(streamName + "original", ExpectedVersion.Any, DefaultData.AdminCredentials,
 					eventData);
 			}
 
-			await _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials);
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName,
+			await _conn.CreatePersistentSubscriptionAsync(streamName, groupName, settings, DefaultData.AdminCredentials);
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName,
 				(subscription, resolvedEvent) => {
 					subscription.Acknowledge(resolvedEvent);
 					if (Interlocked.Increment(ref _eventReceivedCount) == EventWriteCount) {
@@ -249,8 +249,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 				autoAck: false);
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), SystemEventTypes.LinkTo, false,
-					Encoding.UTF8.GetBytes(i + "@" + StreamName + "original"), null);
-				await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
+					Encoding.UTF8.GetBytes(i + "@" + streamName + "original"), null);
+				await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
 			}
 
 			if (!_eventsReceived.WaitOne(TimeSpan.FromSeconds(5))) {
@@ -264,8 +264,6 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class happy_case_catching_up_to_link_to_events_auto_ack<TLogFormat, TStreamId> : SpecificationWithMiniNode<TLogFormat, TStreamId> {
-		private readonly string StreamName = Guid.NewGuid().ToString();
-		private readonly string GroupName = Guid.NewGuid().ToString();
 		private const int BufferCount = 10;
 		private const int EventWriteCount = BufferCount * 2;
 
@@ -276,6 +274,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 		[Test]
 		public async Task Test() {
+			var streamName = Guid.NewGuid().ToString();
+			var groupName = Guid.NewGuid().ToString();
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromBeginning()
@@ -283,12 +283,12 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.Build();
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
-				await _conn.AppendToStreamAsync(StreamName + "original", ExpectedVersion.Any, DefaultData.AdminCredentials,
+				await _conn.AppendToStreamAsync(streamName + "original", ExpectedVersion.Any, DefaultData.AdminCredentials,
 					eventData);
 			}
 
-			await _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials);
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName,
+			await _conn.CreatePersistentSubscriptionAsync(streamName, groupName, settings, DefaultData.AdminCredentials);
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName,
 				(subscription, resolvedEvent) => {
 					if (Interlocked.Increment(ref _eventReceivedCount) == EventWriteCount) {
 						_eventsReceived.Set();
@@ -302,8 +302,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 				autoAck: true);
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), SystemEventTypes.LinkTo, false,
-					Encoding.UTF8.GetBytes(i + "@" + StreamName + "original"), null);
-				await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
+					Encoding.UTF8.GetBytes(i + "@" + streamName + "original"), null);
+				await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
 			}
 
 			if (!_eventsReceived.WaitOne(TimeSpan.FromSeconds(5))) {
@@ -317,8 +317,6 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class when_writing_and_subscribing_to_normal_events_manual_nack<TLogFormat, TStreamId>
 		: SpecificationWithMiniNode<TLogFormat, TStreamId> {
-		private readonly string StreamName = Guid.NewGuid().ToString();
-		private readonly string GroupName = Guid.NewGuid().ToString();
 		private const int BufferCount = 10;
 		private const int EventWriteCount = BufferCount * 2;
 
@@ -329,14 +327,16 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 		[Test]
 		public async Task Test() {
+			var streamName = Guid.NewGuid().ToString();
+			var groupName = Guid.NewGuid().ToString();
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromCurrent()
 				.ResolveLinkTos()
 				.Build();
 
-			await _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials);
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName,
+			await _conn.CreatePersistentSubscriptionAsync(streamName, groupName, settings, DefaultData.AdminCredentials);
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName,
 				(subscription, resolvedEvent) => {
 					subscription.Fail(resolvedEvent, PersistentSubscriptionNakEventAction.Park, "fail");
 
@@ -353,7 +353,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 			for (var i = 0; i < EventWriteCount; i++) {
 				var eventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
 
-				await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
+				await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, eventData);
 			}
 
 			if (!_eventsReceived.WaitOne(TimeSpan.FromSeconds(5))) {
@@ -367,11 +367,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V3), typeof(long))]
 	public class when_connection_drops_messages_that_have_run_out_of_retries_are_not_retried<TLogFormat, TStreamId>
 		: SpecificationWithMiniNode<TLogFormat, TStreamId> {
-		private readonly string StreamName = Guid.NewGuid().ToString();
-		private readonly string GroupName = Guid.NewGuid().ToString();
-
 		private readonly TaskCompletionSource<bool> _subscriptionDropped = new TaskCompletionSource<bool>();
-
 		private readonly TaskCompletionSource<bool> _eventReceived = new TaskCompletionSource<bool>();
 		private ResolvedEvent _receivedEvent;
 
@@ -388,15 +384,17 @@ namespace EventStore.Core.Tests.ClientAPI {
 			_conn.Close();
 			_conn = BuildConnection(_node);
 			await _conn.ConnectAsync();
-
+			
+			var streamName = Guid.NewGuid().ToString();
+			var groupName = Guid.NewGuid().ToString();
 			var settings = PersistentSubscriptionSettings
 				.Create()
 				.StartFromCurrent()
 				.WithMaxRetriesOf(0) // Don't retry messages
 				.Build();
 
-			await _conn.CreatePersistentSubscriptionAsync(StreamName, GroupName, settings, DefaultData.AdminCredentials);
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName,
+			await _conn.CreatePersistentSubscriptionAsync(streamName, groupName, settings, DefaultData.AdminCredentials);
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName,
 				(subscription, resolvedEvent) => {
 					_conn.Close();
 					return Task.CompletedTask;
@@ -408,14 +406,14 @@ namespace EventStore.Core.Tests.ClientAPI {
 				bufferSize: 10, autoAck: false, userCredentials: DefaultData.AdminCredentials);
 
 			var parkedEventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
-			await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, parkedEventData);
+			await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, parkedEventData);
 
 			await _subscriptionDropped.Task.WithTimeout();
 
 			_conn = BuildConnection(_node);
 			await _conn.ConnectAsync();
 
-			await _conn.ConnectToPersistentSubscriptionAsync(StreamName, GroupName, (subscription, resolvedEvent) => {
+			await _conn.ConnectToPersistentSubscriptionAsync(streamName, groupName, (subscription, resolvedEvent) => {
 				subscription.Acknowledge(resolvedEvent);
 				_receivedEvent = resolvedEvent;
 				_eventReceived.TrySetResult(true);
@@ -425,7 +423,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 
 			// Ensure we only get the new event, not the previous one
 			var newEventData = new EventData(Guid.NewGuid(), "SomeEvent", false, new byte[0], new byte[0]);
-			await _conn.AppendToStreamAsync(StreamName, ExpectedVersion.Any, DefaultData.AdminCredentials, newEventData);
+			await _conn.AppendToStreamAsync(streamName, ExpectedVersion.Any, DefaultData.AdminCredentials, newEventData);
 
 			await _eventReceived.Task.WithTimeout();
 			Assert.AreEqual(newEventData.EventId, _receivedEvent.Event.EventId);

--- a/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_follower.cs
+++ b/src/EventStore.Core.Tests/Http/Cluster/when_requesting_from_follower.cs
@@ -29,16 +29,17 @@ namespace EventStore.Core.Tests.Http.Cluster {
 			var replica = GetFollowers().First();
 			_followerEndPoint = replica.HttpEndPoint;
 			_client = replica.CreateHttpClient();
-
 			// Wait for the admin user created event to be replicated before starting our tests
 			var leaderIndex = GetLeader().Db.Config.IndexCheckpoint.Read();
-			AssertEx.IsOrBecomesTrue(()=> replica.Db.Config.IndexCheckpoint.Read() == leaderIndex);
-			
+			AssertEx.IsOrBecomesTrue(()=> replica.Db.Config.IndexCheckpoint.Read() >= leaderIndex, 
+				msg: $"Waiting for replica to reach index checkpoint timed out! ({leaderIndex})");
+
 			var path = $"streams/{TestStream}";
 			var response = await PostEvent(_followerEndPoint, path, requireLeader: false);
 			Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
 			leaderIndex = GetLeader().Db.Config.IndexCheckpoint.Read();
-			AssertEx.IsOrBecomesTrue(()=> replica.Db.Config.IndexCheckpoint.Read() == leaderIndex);
+			AssertEx.IsOrBecomesTrue(()=> replica.Db.Config.IndexCheckpoint.Read() >= leaderIndex,
+				msg: $"Waiting for test stream to be synced with follower timed out! ({leaderIndex})");
 		}
 
 		public override Task TestFixtureTearDown() {


### PR DESCRIPTION
Fixed: Tests failing with empty error message in `EventStore.Core.Tests.Http.Cluster.when_requesting_from_follower.*`.
Fixed: Tests failing with `already exists` error because same initial values were being re-used in `EventStore.Core.Tests.ClientAPI.when_connection_drops_messages_that_have_run_out_of_retries_are_not_retried`.