### PR TITLE
Add filtered persistent subscriptions to $all

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -2848,6 +2848,66 @@
                     "id": 3,
                     "name": "end",
                     "type": "event_store.client.shared.Empty"
+                  },
+                  {
+                    "id": 4,
+                    "name": "filter",
+                    "type": "FilterOptions"
+                  },
+                  {
+                    "id": 5,
+                    "name": "no_filter",
+                    "type": "event_store.client.shared.Empty"
+                  }
+                ],
+                "messages": [
+                  {
+                    "name": "FilterOptions",
+                    "fields": [
+                      {
+                        "id": 1,
+                        "name": "stream_identifier",
+                        "type": "Expression"
+                      },
+                      {
+                        "id": 2,
+                        "name": "event_type",
+                        "type": "Expression"
+                      },
+                      {
+                        "id": 3,
+                        "name": "max",
+                        "type": "uint32"
+                      },
+                      {
+                        "id": 4,
+                        "name": "count",
+                        "type": "event_store.client.shared.Empty"
+                      },
+                      {
+                        "id": 5,
+                        "name": "checkpointIntervalMultiplier",
+                        "type": "uint32"
+                      }
+                    ],
+                    "messages": [
+                      {
+                        "name": "Expression",
+                        "fields": [
+                          {
+                            "id": 1,
+                            "name": "regex",
+                            "type": "string"
+                          },
+                          {
+                            "id": 2,
+                            "name": "prefix",
+                            "type": "string",
+                            "is_repeated": true
+                          }
+                        ]
+                      }
+                    ]
                   }
                 ]
               },

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1010,6 +1010,7 @@ namespace EventStore.Core {
 			_mainBus.Subscribe<ClientMessage.WriteEventsCompleted>(ioDispatcher.Writer);
 			_mainBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(ioDispatcher.ForwardReader);
 			_mainBus.Subscribe<ClientMessage.ReadAllEventsForwardCompleted>(ioDispatcher.AllForwardReader);
+			_mainBus.Subscribe<ClientMessage.FilteredReadAllEventsForwardCompleted>(ioDispatcher.AllForwardFilteredReader);
 			_mainBus.Subscribe<ClientMessage.DeleteStreamCompleted>(ioDispatcher.StreamDeleter);
 			_mainBus.Subscribe(ioDispatcher);
 			var perSubscrBus = new InMemoryBus("PersistentSubscriptionsBus", true, TimeSpan.FromMilliseconds(50));

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1198,6 +1198,8 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
+			public readonly IEventFilter EventFilter;
+
 			public readonly TFPos StartFrom;
 			public readonly int MessageTimeoutMilliseconds;
 			public readonly bool RecordStatistics;
@@ -1216,7 +1218,7 @@ namespace EventStore.Core.Messages {
 			public readonly int CheckPointAfterMilliseconds;
 
 			public CreatePersistentSubscriptionToAll(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
-				string groupName, bool resolveLinkTos, TFPos startFrom,
+				string groupName, IEventFilter eventFilter, bool resolveLinkTos, TFPos startFrom,
 				int messageTimeoutMilliseconds, bool recordStatistics, int maxRetryCount, int bufferSize,
 				int liveBufferSize, int readbatchSize,
 				int checkPointAfterMilliseconds, int minCheckPointCount, int maxCheckPointCount,
@@ -1224,6 +1226,7 @@ namespace EventStore.Core.Messages {
 				: base(internalCorrId, correlationId, envelope, user, expires) {
 				ResolveLinkTos = resolveLinkTos;
 				GroupName = groupName;
+				EventFilter = eventFilter;
 				StartFrom = startFrom;
 				MessageTimeoutMilliseconds = messageTimeoutMilliseconds;
 				RecordStatistics = recordStatistics;

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionEventSource.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionEventSource.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.PersistentSubscription {
 	public interface IPersistentSubscriptionEventSource {
@@ -10,5 +11,6 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		IPersistentSubscriptionStreamPosition StreamStartPosition { get; }
 		IPersistentSubscriptionStreamPosition GetStreamPositionFor(ResolvedEvent @event);
 		IPersistentSubscriptionStreamPosition GetStreamPositionFor(string checkpoint);
+		IEventFilter EventFilter { get; }
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionStreamReader.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/IPersistentSubscriptionStreamReader.cs
@@ -3,7 +3,11 @@ using EventStore.Core.Data;
 
 namespace EventStore.Core.Services.PersistentSubscription {
 	public interface IPersistentSubscriptionStreamReader {
-		void BeginReadEvents(IPersistentSubscriptionEventSource eventSource, IPersistentSubscriptionStreamPosition startPosition, int countToLoad, int batchSize, bool resolveLinkTos, bool skipFirstEvent,
-			Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> onEventsFound, Action<string> onError);
+		void BeginReadEvents(IPersistentSubscriptionEventSource eventSource,
+			IPersistentSubscriptionStreamPosition startPosition, int countToLoad, int batchSize, int maxWindowSize,
+			bool resolveLinkTos, bool skipFirstEvent,
+			Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> onEventsFound,
+			Action<IPersistentSubscriptionStreamPosition, long> onEventsSkipped,
+			Action<string> onError);
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -80,6 +80,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			if (persistentSubscriptionParams.ReadBatchSize >= persistentSubscriptionParams.BufferSize) {
 				throw new ArgumentOutOfRangeException($"{nameof(persistentSubscriptionParams.ReadBatchSize)} may not be greater than or equal to {nameof(persistentSubscriptionParams.BufferSize)}");
 			}
+
 			_totalTimeWatch = new Stopwatch();
 			_settings = persistentSubscriptionParams;
 			_nextEventToPullFrom = _settings.EventSource.StreamStartPosition;
@@ -243,6 +244,10 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		public void NotifyLiveSubscriptionMessage(ResolvedEvent resolvedEvent) {
 			lock (_lock) {
 				if (_settings.EventSource.GetStreamPositionFor(resolvedEvent).CompareTo(_settings.StartFrom) < 0) {
+					return;
+				}
+
+				if (_settings.EventSource.EventFilter != null && !_settings.EventSource.EventFilter.IsEventAllowed(resolvedEvent.Event)) {
 					return;
 				}
 

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionAllStreamEventSource.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionAllStreamEventSource.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.PersistentSubscription {
 	public class PersistentSubscriptionAllStreamEventSource : IPersistentSubscriptionEventSource {
@@ -8,6 +9,16 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		public string EventStreamId => throw new InvalidOperationException();
 		public bool FromAll => true;
 		public override string ToString() => SystemStreams.AllStream;
+		public IEventFilter EventFilter { get; }
+
+		public PersistentSubscriptionAllStreamEventSource(IEventFilter eventFilter) {
+			EventFilter = eventFilter;
+		}
+
+		public PersistentSubscriptionAllStreamEventSource() {
+			EventFilter = null;
+		}
+
 		public IPersistentSubscriptionStreamPosition StreamStartPosition  => new PersistentSubscriptionAllStreamPosition(0L, 0L);
 		public IPersistentSubscriptionStreamPosition GetStreamPositionFor(ResolvedEvent @event) {
 			if (@event.OriginalPosition.HasValue) {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionAllStreamPosition.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionAllStreamPosition.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using EventStore.Core.Data;
 
 namespace EventStore.Core.Services.PersistentSubscription {
 	public class PersistentSubscriptionAllStreamPosition : IPersistentSubscriptionStreamPosition {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConfig.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionConfig.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using EventStore.Common.Utils;
+using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.PersistentSubscription {
 	public class PersistentSubscriptionConfig {
@@ -54,6 +55,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 	public class PersistentSubscriptionEntry {
 		public string Stream;
 		public string Group;
+		public EventFilter.EventFilterDto Filter;
 		public bool ResolveLinkTos;
 		public bool ExtraStatistics;
 		public int MessageTimeout;

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionParams.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.PersistentSubscription {
 	public class PersistentSubscriptionParams {

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionSingleStreamEventSource.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionSingleStreamEventSource.cs
@@ -1,11 +1,13 @@
 using System;
 using EventStore.Core.Data;
+using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.PersistentSubscription {
 	public class PersistentSubscriptionSingleStreamEventSource : IPersistentSubscriptionEventSource {
 		public bool FromStream => true;
 		public string EventStreamId { get; }
 		public bool FromAll => false;
+		public IEventFilter EventFilter => null;
 
 		public PersistentSubscriptionSingleStreamEventSource(string eventStreamId) {
 			EventStreamId = eventStreamId ?? throw new ArgumentNullException(nameof(eventStreamId));

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStreamReader.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStreamReader.cs
@@ -25,11 +25,13 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void BeginReadEvents(IPersistentSubscriptionEventSource eventSource,
-			IPersistentSubscriptionStreamPosition startPosition, int countToLoad, int batchSize, bool resolveLinkTos,
-			bool skipFirstEvent,
-			Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> onEventsFound, Action<string> onError) {
-			BeginReadEventsInternal(eventSource, startPosition, countToLoad, batchSize, resolveLinkTos,
-				skipFirstEvent, onEventsFound, onError, 0);
+			IPersistentSubscriptionStreamPosition startPosition, int countToLoad, int batchSize,
+			int maxWindowSize, bool resolveLinkTos, bool skipFirstEvent,
+			Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> onEventsFound,
+			Action<IPersistentSubscriptionStreamPosition, long> onEventsSkipped,
+			Action<string> onError) {
+			BeginReadEventsInternal(eventSource, startPosition, countToLoad, batchSize, maxWindowSize, resolveLinkTos,
+				skipFirstEvent, onEventsFound, onEventsSkipped, onError, 0);
 		}
 
 		private int GetBackOffDelay(int retryCount) {
@@ -38,14 +40,16 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		private void BeginReadEventsInternal(IPersistentSubscriptionEventSource eventSource,
-			IPersistentSubscriptionStreamPosition startPosition, int countToLoad, int batchSize, bool resolveLinkTos, bool skipFirstEvent,
-			Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> onEventsFound, Action<string> onError, int retryCount) {
+			IPersistentSubscriptionStreamPosition startPosition, int countToLoad, int batchSize, int maxWindowSize, bool resolveLinkTos, bool skipFirstEvent,
+			Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> onEventsFound,
+			Action<IPersistentSubscriptionStreamPosition, long> onEventsSkipped,
+			Action<string> onError, int retryCount) {
 			var actualBatchSize = GetBatchSize(batchSize);
 
 			if (eventSource.FromStream) {
 				_ioDispatcher.ReadForward(
 					eventSource.EventStreamId, startPosition.StreamEventNumber, Math.Min(countToLoad, actualBatchSize),
-					resolveLinkTos, SystemAccounts.System, new ResponseHandler(onEventsFound, onError, skipFirstEvent).FetchCompleted,
+					resolveLinkTos, SystemAccounts.System, new ResponseHandler(onEventsFound, onEventsSkipped, onError, skipFirstEvent).FetchCompleted,
 					async () => await HandleTimeout(eventSource.EventStreamId).ConfigureAwait(false),
 					Guid.NewGuid());
 			} else if (eventSource.FromAll) {
@@ -59,22 +63,23 @@ namespace EventStore.Core.Services.PersistentSubscription {
 						null,
 						SystemAccounts.System,
 						null,
-						new ResponseHandler(onEventsFound, onError, skipFirstEvent).FetchAllCompleted,
+						new ResponseHandler(onEventsFound, onEventsSkipped, onError, skipFirstEvent).FetchAllCompleted,
 						async () => await HandleTimeout(SystemStreams.AllStream).ConfigureAwait(false),
 						Guid.NewGuid());
 				} else {
+					var maxSearchWindow = Math.Max(actualBatchSize, maxWindowSize);
 					_ioDispatcher.ReadAllForwardFiltered(
 						startPosition.TFPosition.Commit,
 						startPosition.TFPosition.Prepare,
 						Math.Min(countToLoad, actualBatchSize),
 						resolveLinkTos,
 						true,
-						actualBatchSize, // TODO: We need to set the max window size for the subscriptions
+						maxSearchWindow,
 						null,
 						eventSource.EventFilter,
 						SystemAccounts.System,
 						null,
-						new ResponseHandler(onEventsFound, onError, skipFirstEvent).FetchAllFilteredCompleted,
+						new ResponseHandler(onEventsFound, onEventsSkipped, onError, skipFirstEvent).FetchAllFilteredCompleted,
 						async () => await HandleTimeout($"{SystemStreams.AllStream} with filter {eventSource.EventFilter}").ConfigureAwait(false),
 						Guid.NewGuid());
 				}
@@ -88,8 +93,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					"Timed out reading from stream: {stream{. Retrying in {retryInterval} seconds.",
 					streamName, backOff);
 				await Task.Delay(TimeSpan.FromSeconds(backOff)).ConfigureAwait(false);
-				BeginReadEventsInternal(eventSource, startPosition, countToLoad, batchSize, resolveLinkTos,
-					skipFirstEvent, onEventsFound, onError, retryCount + 1);
+				BeginReadEventsInternal(eventSource, startPosition, countToLoad, batchSize, maxWindowSize, resolveLinkTos,
+					skipFirstEvent, onEventsFound, onEventsSkipped, onError, retryCount + 1);
 			}
 		}
 
@@ -99,11 +104,14 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 		private class ResponseHandler {
 			private readonly Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> _onFetchCompleted;
+			private readonly Action<IPersistentSubscriptionStreamPosition, long> _onEventsSkipped;
 			private readonly Action<string> _onError;
 			private readonly bool _skipFirstEvent;
 
-			public ResponseHandler(Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> onFetchCompleted, Action<string> onError, bool skipFirstEvent) {
+			public ResponseHandler(Action<ResolvedEvent[], IPersistentSubscriptionStreamPosition, bool> onFetchCompleted,
+				Action<IPersistentSubscriptionStreamPosition, long> onEventsSkipped, Action<string> onError, bool skipFirstEvent) {
 				_onFetchCompleted = onFetchCompleted;
+				_onEventsSkipped = onEventsSkipped;
 				_skipFirstEvent = skipFirstEvent;
 				_onError = onError;
 			}
@@ -141,8 +149,16 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			public void FetchAllFilteredCompleted(ClientMessage.FilteredReadAllEventsForwardCompleted msg) {
 				switch (msg.Result) {
 					case FilteredReadAllResult.Success:
+						if (msg.Events.Length == 0 && msg.ConsideredEventsCount > 0) {
+							// Checkpoint on the position we read from rather than the next position
+							// to prevent skipping the next event when loading from the checkpoint
+							_onEventsSkipped(
+								new PersistentSubscriptionAllStreamPosition(msg.CurrentPos.CommitPosition, msg.CurrentPos.PreparePosition),
+								msg.ConsideredEventsCount);
+						}
 						_onFetchCompleted(_skipFirstEvent ? msg.Events.Skip(1).ToArray() : msg.Events,
 							new PersistentSubscriptionAllStreamPosition(msg.NextPos.CommitPosition, msg.NextPos.PreparePosition), msg.IsEndOfStream);
+
 						break;
 					case FilteredReadAllResult.AccessDenied:
 						_onError($"Read access denied for stream: {SystemStreams.AllStream}");

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionToAllParamsBuilder.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionToAllParamsBuilder.cs
@@ -1,6 +1,6 @@
 using System;
-using EventStore.Common.Utils;
 using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
+using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Services.PersistentSubscription {
 	/// <summary>
@@ -10,12 +10,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		/// <summary>
 		/// Creates a new <see cref="PersistentSubscriptionParamsBuilder"></see> object
 		/// </summary>
-		/// <param name="streamName">The name of the stream for the subscription</param>
 		/// <param name="groupName">The name of the group of the subscription</param>
+		/// <param name="filter">The optional filter for the subscription</param>
 		/// <returns>a new <see cref="PersistentSubscriptionParamsBuilder"></see> object</returns>
-		public static PersistentSubscriptionParamsBuilder CreateFor(string groupName) {
+		public static PersistentSubscriptionParamsBuilder CreateFor(string groupName, IEventFilter filter = null) {
 			return new PersistentSubscriptionToAllParamsBuilder()
-				.FromAll()
+				.FromAll(filter)
 				.StartFrom(0L, 0L)
 				.SetGroup(groupName)
 				.SetSubscriptionId("$all" + ":" + groupName)
@@ -32,8 +32,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				.WithNamedConsumerStrategy(new RoundRobinPersistentSubscriptionConsumerStrategy());
 		}
 
-		public PersistentSubscriptionToAllParamsBuilder FromAll() {
-			WithEventSource(new PersistentSubscriptionAllStreamEventSource());
+		public PersistentSubscriptionToAllParamsBuilder FromAll(IEventFilter filter = null) {
+			WithEventSource(new PersistentSubscriptionAllStreamEventSource(filter));
 			return this;
 		}
 

--- a/src/Protos/Grpc/persistent.proto
+++ b/src/Protos/Grpc/persistent.proto
@@ -117,6 +117,26 @@ message CreateReq {
 			event_store.client.shared.Empty start = 2;
 			event_store.client.shared.Empty end = 3;
 		}
+		oneof filter_option {
+			FilterOptions filter = 4;
+			event_store.client.shared.Empty no_filter = 5;
+		}
+		message FilterOptions {
+			oneof filter {
+				Expression stream_identifier = 1;
+				Expression event_type = 2;
+			}
+			oneof window {
+				uint32 max = 3;
+				event_store.client.shared.Empty count = 4;
+			}
+			uint32 checkpointIntervalMultiplier = 5;
+
+			message Expression {
+				string regex = 1;
+				repeated string prefix = 2;
+			}
+		}
 	}
 
 	message Position {


### PR DESCRIPTION
Updated: Allow specifying a filter when creating a persistent subscription to $all

This is only exposed over gRPC.
Fixes https://github.com/EventStore/home/issues/433