### PR TITLE
Fix flakey tests

### DIFF
--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -142,6 +142,6 @@ namespace EventStore.Core.Tests.Integration {
 
 		protected MiniClusterNode<TLogFormat, TStreamId> GetLeader() => _nodes.First(x => x.NodeState == Data.VNodeState.Leader);
 
-		protected MiniClusterNode<TLogFormat, TStreamId>[] GetFollowers() => _nodes.Where(x => x.NodeState != Data.VNodeState.Leader).ToArray();
+		protected MiniClusterNode<TLogFormat, TStreamId>[] GetFollowers() => _nodes.Where(x => x.NodeState == Data.VNodeState.Follower).ToArray();
 	}
 }

--- a/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
+++ b/src/EventStore.Core.Tests/Integration/when_cluster_nodes_are_restarted.cs
@@ -29,8 +29,12 @@ namespace EventStore.Core.Tests.Integration {
 		public void cluster_should_stabilize() {
 			var leaders = 0;
 			var followers = 0;
+			var acceptedStates = new[] {VNodeState.Leader, VNodeState.Follower};
 
 			for (int i = 0; i < 3; i++) {
+				AssertEx.IsOrBecomesTrue(() => acceptedStates.Contains(_nodes[i].NodeState),
+					TimeSpan.FromSeconds(5), $"node {i} failed to become a leader/follower");
+
 				var state = _nodes[i].NodeState;
 				if (state == VNodeState.Leader) leaders++;
 				else if (state == VNodeState.Follower) followers++;


### PR DESCRIPTION
Fixed: Only return nodes in Follower state.
Fixed: Wait for node to become a leader/follower.