### PR TITLE
Handle truncated streams when reading events for projections

### DIFF
--- a/src/EventStore.Core.Tests/Http/Streams/feed.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/feed.cs
@@ -415,7 +415,7 @@ namespace EventStore.Core.Tests.Http.Streams {
 			private List<JToken> _entries;
 
 			protected override async Task When() {
-				_feed = await GetJson<JObject>("/streams/" + LinkedStreamName + "/0/forward/10?embed=rich",
+				_feed = await GetJson<JObject>("/streams/" + LinkedStreamName + "/0/forward/10",extra: "embed=rich",
 					accept: ContentType.Json);
 				_entries = _feed != null ? _feed["entries"].ToList() : new List<JToken>();
 			}

--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
@@ -251,8 +251,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 						break;
 					case ReadStreamResult.Success:
 						_reader.UpdateNextStreamPosition(message.EventStreamId, message.NextEventNumber);
-						var isEof = message.Events.Length == 0;
-						_eofs[message.EventStreamId] = isEof;
+						_eofs[message.EventStreamId] = (message.Events.Length == 0) && message.IsEndOfStream;
 						EnqueueEvents(message);
 						ProcessBuffersAndContinue(eventStreamId: message.EventStreamId);
 						break;

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamEventReader.cs
@@ -121,7 +121,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					CheckEof();
 					break;
 				case ReadStreamResult.Success:
-					if (message.Events.Length == 0) {
+					if ((message.Events.Length == 0) && message.IsEndOfStream) {
 						// the end
 						_eofs[message.EventStreamId] = true;
 						UpdateSafePositionToJoin(message.EventStreamId, MessageToLastCommitPosition(message));
@@ -129,6 +129,9 @@ namespace EventStore.Projections.Core.Services.Processing {
 						CheckEof();
 					} else {
 						_eofs[message.EventStreamId] = false;
+						if (message.Events.Length == 0) {
+							_fromPositions.Streams[message.EventStreamId] = message.NextEventNumber;
+						}
 						for (int index = 0; index < message.Events.Length; index++) {
 							var @event = message.Events[index].Event;
 							var @link = message.Events[index].Link;

--- a/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
@@ -90,7 +90,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				case ReadStreamResult.Success:
 					var oldFromSequenceNumber = StartFrom(message, _fromSequenceNumber);
 					_fromSequenceNumber = message.NextEventNumber;
-					var eof = message.Events.Length == 0;
+					var eof = (message.Events.Length == 0) && message.IsEndOfStream;
 					_eof = eof;
 					var willDispose = eof && _stopOnEof;
 

--- a/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
@@ -63,7 +63,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				return;
 			}
 
-			var eof = message.Events.Length == 0;
+			var eof = (message.Events.Length == 0) && message.IsEndOfStream;
 			_eof = eof;
 			var willDispose = _stopOnEof && eof;
 			var oldFrom = _from;


### PR DESCRIPTION
Fixed: Fix projections getting stuck when reading from truncated streams

Fixes #2954