### PR TITLE
Improve lookup of first non-expired events in long stream with maxage

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		{
 		}
 
-		public IEnumerable<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion, int? limit = null)
+		public IReadOnlyList<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion, int? limit = null)
 		{
 			var entries = new List<IndexEntry>();
 			if(_indexEntries.ContainsKey(streamId)){

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -46,9 +46,9 @@ namespace EventStore.Core.Tests.Services.Storage {
 			return false;
 		}
 
-		public IEnumerable<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion,
+		public IReadOnlyList<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion,
 			int? limit = null) {
-			yield break;
+			return Array.Empty<IndexEntry>();
 		}
 
 		public void Scavenge(IIndexScavengerLog log, CancellationToken ct) {

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_very_long_stream_with_max_age_and_mostly_expired_events.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_very_long_stream_with_max_age_and_mostly_expired_events.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Diagnostics;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNextEventNumber
+{
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class
+		when_reading_very_long_stream_with_max_age_and_mostly_expired_events<TLogFormat, TStreamId> : ReadIndexTestScenario<TLogFormat, TStreamId> {
+		public when_reading_very_long_stream_with_max_age_and_mostly_expired_events():base(maxEntriesInMemTable: 500_000, chunkSize: TFConsts.ChunkSize) {
+			
+		}
+		protected override void WriteTestScenario() {
+			var now = DateTime.UtcNow;
+			var metadata = string.Format(@"{{""$maxAge"":{0}}}", (int)TimeSpan.FromMinutes(20).TotalSeconds);
+			WriteStreamMetadata("ES", 0, metadata, now.AddMinutes(-100));
+			for (int i = 0; i < 1_000_000; i++) {
+				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-50), retryOnFail:true);
+			}
+
+			for (int i = 1_000_000; i < 1_000_010; i++) {
+				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-1), retryOnFail:true);	
+			}
+		}
+
+		[Test, Explicit, Category("LongRunning")]
+		public void on_read_from_beginning() {
+			Stopwatch sw = Stopwatch.StartNew();
+			var res = ReadIndex.ReadStreamEventsForward("ES", 1, 10);
+			var elapsed = sw.Elapsed;
+			Assert.Less(elapsed, TimeSpan.FromSeconds(1));
+			Assert.AreEqual(9, res.Records.Length);
+		}
+	}
+}

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -22,6 +22,6 @@ namespace EventStore.Core.Index {
 		bool TryGetLatestEntry(TStreamId streamId, out IndexEntry entry);
 		bool TryGetOldestEntry(TStreamId streamId, out IndexEntry entry);
 
-		IEnumerable<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion, int? limit = null);
+		IReadOnlyList<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion, int? limit = null);
 	}
 }

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -621,7 +621,7 @@ namespace EventStore.Core.Index {
 			return false;
 		}
 
-		public IEnumerable<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion,
+		public IReadOnlyList<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion,
 			int? limit = null) {
 			ulong hash = CreateHash(streamId);
 			var counter = 0;
@@ -640,7 +640,7 @@ namespace EventStore.Core.Index {
 			throw new InvalidOperationException("Files are locked.");
 		}
 
-		private IEnumerable<IndexEntry> GetRangeInternal(ulong hash, long startVersion, long endVersion,
+		private IReadOnlyList<IndexEntry> GetRangeInternal(ulong hash, long startVersion, long endVersion,
 			int? limit = null) {
 			if (startVersion < 0)
 				throw new ArgumentOutOfRangeException("startVersion");

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Threading;
 using EventStore.Common.Utils;
@@ -94,7 +95,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 
 		IndexReadEventResult IIndexReader<TStreamId>.ReadEvent(string streamName, TStreamId streamId, long eventNumber) {
 			Ensure.Valid(streamId, _validator);
-			if (eventNumber < -1) throw new ArgumentOutOfRangeException("eventNumber");
+			if (eventNumber < -1)
+				throw new ArgumentOutOfRangeException("eventNumber");
 			using (var reader = _backend.BorrowReader()) {
 				return ReadEventInternal(reader, streamName, streamId, eventNumber);
 			}
@@ -108,7 +110,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				return new IndexReadEventResult(ReadEventResult.StreamDeleted, metadata, lastEventNumber,
 					originalStreamExists);
 			if (lastEventNumber == ExpectedVersion.NoStream || metadata.TruncateBefore == EventNumber.DeletedStream)
-				return new IndexReadEventResult(ReadEventResult.NoStream, metadata,lastEventNumber,
+				return new IndexReadEventResult(ReadEventResult.NoStream, metadata, lastEventNumber,
 					originalStreamExists);
 			if (lastEventNumber == EventNumber.Invalid)
 				return new IndexReadEventResult(ReadEventResult.NoStream, metadata, lastEventNumber,
@@ -124,13 +126,13 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				minEventNumber = Math.Max(minEventNumber, metadata.TruncateBefore.Value);
 			//TODO(clc): confirm this logic, it seems that reads less than min should be invaild rather than found
 			if (eventNumber < minEventNumber || eventNumber > lastEventNumber)
-				return new IndexReadEventResult(ReadEventResult.NotFound, metadata,  lastEventNumber,
+				return new IndexReadEventResult(ReadEventResult.NotFound, metadata, lastEventNumber,
 					originalStreamExists);
 
 			var prepare = ReadPrepareInternal(reader, streamId, eventNumber);
 			if (prepare != null) {
 				if (metadata.MaxAge.HasValue && prepare.TimeStamp < DateTime.UtcNow - metadata.MaxAge.Value)
-					return new IndexReadEventResult(ReadEventResult.NotFound, metadata,  lastEventNumber,
+					return new IndexReadEventResult(ReadEventResult.NotFound, metadata, lastEventNumber,
 						originalStreamExists);
 				return new IndexReadEventResult(ReadEventResult.Success, new EventRecord(eventNumber, prepare, streamName),
 					metadata, lastEventNumber, originalStreamExists);
@@ -158,7 +160,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 
 		private IPrepareLogRecord<TStreamId> ReadPrepare(TFReaderLease reader, TStreamId streamId, long eventNumber) {
 			var recordsQuery = _tableIndex.GetRange(streamId, eventNumber, eventNumber)
-				.Select(x => new {x.Version, Prepare = ReadPrepareInternal(reader, x.Position)})
+				.Select(x => new { x.Version, Prepare = ReadPrepareInternal(reader, x.Position) })
 				.Where(x => x.Prepare != null && StreamIdComparer.Equals(x.Prepare.EventStreamId, streamId))
 				.GroupBy(x => x.Version).Select(x => x.Last()).ToList();
 			if (recordsQuery.Count() == 1) {
@@ -236,20 +238,20 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
 						metadata, minEventNumber, lastEventNumber, isEndOfStream: false);
 				startEventNumber = Math.Max(startEventNumber, minEventNumber);
-
+				if (metadata.MaxAge.HasValue) {
+					return ForStreamWithMaxAge(streamId, streamName,
+						fromEventNumber, maxCount,
+						startEventNumber, endEventNumber, lastEventNumber,
+						metadata.MaxAge.Value, metadata, _tableIndex, reader, skipIndexScanOnRead);
+				}
 				var recordsQuery = _tableIndex.GetRange(streamId, startEventNumber, endEventNumber)
-					.Select(x => new {x.Version, Prepare = ReadPrepareInternal(reader, x.Position)})
+					.Select(x => new { x.Version, Prepare = ReadPrepareInternal(reader, x.Position) })
 					.Where(x => x.Prepare != null && StreamIdComparer.Equals(x.Prepare.EventStreamId, streamId));
 				if (!skipIndexScanOnRead) {
 					recordsQuery = recordsQuery.OrderByDescending(x => x.Version)
 						.GroupBy(x => x.Version).Select(x => x.Last());
 				}
-
-				if (metadata.MaxAge.HasValue) {
-					var ageThreshold = DateTime.UtcNow - metadata.MaxAge.Value;
-					recordsQuery = recordsQuery.Where(x => x.Prepare.TimeStamp >= ageThreshold);
-				}
-
+				
 				var records = recordsQuery.Reverse().Select(x => new EventRecord(x.Version, x.Prepare, streamName)).ToArray();
 
 				long nextEventNumber = Math.Min(endEventNumber + 1, lastEventNumber + 1);
@@ -258,6 +260,184 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				var isEndOfStream = endEventNumber >= lastEventNumber;
 				return new IndexReadStreamResult(endEventNumber, maxCount, records, metadata,
 					nextEventNumber, lastEventNumber, isEndOfStream);
+			}
+
+			static IndexReadStreamResult ForStreamWithMaxAge(TStreamId streamId,
+				string streamName,
+				long fromEventNumber, int maxCount, long startEventNumber,
+				long endEventNumber, long lastEventNumber, TimeSpan maxAge, StreamMetadata metadata,
+				ITableIndex<TStreamId> tableIndex, TFReaderLease reader, bool skipIndexScanOnRead) {
+				if (startEventNumber > lastEventNumber) {
+					return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
+						metadata, lastEventNumber + 1, lastEventNumber, isEndOfStream: true);
+				}
+
+				var ageThreshold = DateTime.UtcNow - maxAge;
+				var nextEventNumber = lastEventNumber;
+				var indexEntries = tableIndex.GetRange(streamId, startEventNumber, endEventNumber);
+
+				//Move to the first valid entries. At this point we could instead return an empty result set with the minimum set, but that would 
+				//involve an additional set of reads for no good reason
+				while (indexEntries.Count == 0) {
+					// this will generally only iterate once, unless a scavenge completes exactly now, in which case it might iterate twice
+					if (tableIndex.TryGetOldestEntry(streamId, out var oldest)) {
+						startEventNumber = oldest.Version;
+						endEventNumber = startEventNumber + maxCount - 1;
+						indexEntries = tableIndex.GetRange(streamId, startEventNumber, endEventNumber, maxCount);
+					} else {
+						//scavenge completed and deleted our stream? return empty set and get the client to try again?
+						return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
+							metadata, lastEventNumber + 1, lastEventNumber, isEndOfStream: false);
+					}
+				}
+
+				var results = new List<EventRecord>();
+				for (int i = 0; i < indexEntries.Count; i++) {
+					var prepare = ReadPrepareInternal(reader, indexEntries[i].Position);
+
+					//LOGV2
+					if (typeof(TStreamId) == typeof(string) &&
+					    (prepare == null || !StreamIdComparer.Equals(prepare.EventStreamId, streamId))) {
+						continue;
+					}
+
+					if (prepare?.TimeStamp >= ageThreshold) {
+						results.Add(new EventRecord(indexEntries[i].Version, prepare, streamName));
+					} else {
+						break;
+					}
+
+				}
+
+				if (results.Count > 0) {
+					//We got at least one event in the correct age range, so we will return whatever was valid and indicate where to read from next
+					nextEventNumber = results[0].EventNumber + 1;
+					results.Reverse();
+
+					var isEndOfStream = endEventNumber >= lastEventNumber;
+					return new IndexReadStreamResult(endEventNumber, maxCount, results.ToArray(), metadata,
+						nextEventNumber, lastEventNumber, isEndOfStream);
+				}
+
+				//we didn't find anything valid yet, now we need to search
+
+				//check high value will be valid
+				if (tableIndex.TryGetLatestEntry(streamId, out var latest)) {
+					var end = ReadPrepareInternal(reader, latest.Position);
+					if (end.TimeStamp < ageThreshold || latest.Version < fromEventNumber) {
+						//No events in the stream are < max age, so return an empty set
+						return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
+							metadata, latest.Version + 1, latest.Version, isEndOfStream: true);
+					}
+				} else {
+					//For some reason there is no last event in this stream, maybe a scavenge completed and deleted the stream, send back for retry
+					return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
+						metadata, lastEventNumber + 1, lastEventNumber, isEndOfStream: false);
+				}
+
+
+				
+				var low = indexEntries[0].Version;
+				var high = latest.Version;
+				while (low <= high) {
+					var mid = low + ((high - low) / 2);
+					indexEntries = tableIndex.GetRange(streamId, mid, mid + maxCount, maxCount);
+					if (indexEntries.Count > 0) {
+						nextEventNumber = indexEntries[0].Version + 1;
+					}
+
+					var lowPrepare = LowPrepare(reader, indexEntries, streamId);
+					if (lowPrepare?.TimeStamp >= ageThreshold) {
+						high = mid - 1;
+						nextEventNumber = lowPrepare.ExpectedVersion + 1;
+						continue;
+					}
+
+					var highPrepare = HighPrepare(reader, indexEntries, streamId);
+					if (highPrepare?.TimeStamp < ageThreshold) {
+						low = mid + indexEntries.Count;
+						continue;
+					}
+
+					//ok, some entries must match, if not (due to time moving forwards) we can just reissue based on the current mid
+					for (int i = 0; i < indexEntries.Count; i++) {
+						var prepare = ReadPrepareInternal(reader, indexEntries[i].Position);
+						
+						//LOGV2
+						if (typeof(TStreamId) == typeof(string) &&
+						    (prepare == null || !StreamIdComparer.Equals(prepare.EventStreamId, streamId))) {
+							continue;
+						}
+						if (prepare?.TimeStamp >= ageThreshold) {
+							results.Add(new EventRecord(indexEntries[i].Version, prepare, streamName));
+						} else {
+							break;
+						}
+					}
+
+					if (results.Count > 0) {
+						//We got at least one event in the correct age range, so we will return whatever was valid and indicate where to read from next
+						endEventNumber = results[0].EventNumber;
+						nextEventNumber = endEventNumber + 1;
+						results.Reverse();
+						var isEndOfStream = endEventNumber >= lastEventNumber;
+
+						var maxEventNumberToReturn = fromEventNumber + maxCount;
+						while (results.Count > 0 && results[^1].EventNumber > maxEventNumberToReturn) {
+							nextEventNumber = results[^1].EventNumber;
+							results.Remove(results[^1]);
+						}
+
+						if (results.Count == 0) nextEventNumber--;
+						return new IndexReadStreamResult(endEventNumber, maxCount, results.ToArray(), metadata,
+							nextEventNumber, lastEventNumber, isEndOfStream);
+					}
+
+					break;
+				}
+
+				//We didn't find anything, send back to the client with the latest position to retry
+				return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
+					metadata, nextEventNumber, lastEventNumber, isEndOfStream: false);
+				[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+				static IPrepareLogRecord<TStreamId> LowPrepare(TFReaderLease tfReaderLease,
+					IReadOnlyList<IndexEntry> entries, TStreamId streamId) {
+					
+					if (typeof(TStreamId) == typeof(string)) {
+						for (int i = entries.Count - 1; i >= 0; i--) {
+							var prepare = ReadPrepareInternal(tfReaderLease, entries[i].Position);
+							if (prepare != null && StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+								return prepare;
+						}
+					}
+
+					for (int i = entries.Count - 1; i >= 0; i--) {
+						var prepare = ReadPrepareInternal(tfReaderLease, entries[i].Position);
+						if (prepare != null) return prepare;
+					}
+
+					return null;
+				}
+
+				[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+				static IPrepareLogRecord<TStreamId> HighPrepare(TFReaderLease tfReaderLease,
+					IReadOnlyList<IndexEntry> entries, TStreamId streamId) {
+					
+					if (typeof(TStreamId) == typeof(string)) {
+						for (int i = 0; i < entries.Count; i++) {
+							var prepare = ReadPrepareInternal(tfReaderLease, entries[i].Position);
+							if (prepare != null && StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+								return prepare;
+						}
+					}
+
+					for (int i = 0; i < entries.Count; i++) {
+						var prepare = ReadPrepareInternal(tfReaderLease, entries[i].Position);
+						if (prepare != null) return prepare;
+					}
+
+					return null;
+				}
 			}
 		}
 
@@ -303,7 +483,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				}
 
 				var recordsQuery = _tableIndex.GetRange(streamId, startEventNumber, endEventNumber)
-					.Select(x => new {x.Version, Prepare = ReadPrepareInternal(reader, x.Position)})
+					.Select(x => new { x.Version, Prepare = ReadPrepareInternal(reader, x.Position) })
 					.Where(x => x.Prepare != null && StreamIdComparer.Equals(x.Prepare.EventStreamId, streamId));
 				if (!skipIndexScanOnRead) {
 					recordsQuery = recordsQuery.OrderByDescending(x => x.Version)
@@ -319,10 +499,10 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				var records = recordsQuery.Select(x => new EventRecord(x.Version, x.Prepare, streamName)).ToArray();
 
 				isEndOfStream = isEndOfStream
-				                || startEventNumber == 0
-				                || (startEventNumber <= lastEventNumber
-				                    && (records.Length == 0 ||
-				                        records[records.Length - 1].EventNumber != startEventNumber));
+								|| startEventNumber == 0
+								|| (startEventNumber <= lastEventNumber
+									&& (records.Length == 0 ||
+										records[records.Length - 1].EventNumber != startEventNumber));
 				long nextEventNumber = isEndOfStream ? -1 : Math.Min(startEventNumber - 1, lastEventNumber);
 				return new IndexReadStreamResult(endEventNumber, maxCount, records, metadata,
 					nextEventNumber, lastEventNumber, isEndOfStream);
@@ -356,7 +536,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				return new StorageMessage.EffectiveAcl(acl, sysAcl, defAcl);
 			}
 		}
-		
+
 		long IIndexReader<TStreamId>.GetStreamLastEventNumber(TStreamId streamId) {
 			Ensure.Valid(streamId, _validator);
 			using (var reader = _backend.BorrowReader()) {
@@ -374,8 +554,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		private long GetStreamLastEventNumberCached(TFReaderLease reader, TStreamId streamId) {
 			// if this is metastream -- check if original stream was deleted, if yes -- metastream is deleted as well
 			if (_systemStreams.IsMetaStream(streamId)
-			    && GetStreamLastEventNumberCached(reader, _systemStreams.OriginalStreamOf(streamId)) ==
-			    EventNumber.DeletedStream)
+				&& GetStreamLastEventNumberCached(reader, _systemStreams.OriginalStreamOf(streamId)) ==
+				EventNumber.DeletedStream)
 				return EventNumber.DeletedStream;
 
 			var cache = _backend.TryGetStreamLastEventNumber(streamId);


### PR DESCRIPTION
Added: Faster seek for first non-expired events in long streams with $max-age set 

fixes #2973 