### PR TITLE
Prevent emitted checkpoint streams from being deleted when not enabled.

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/verify_persistent_state_rules_for_deleting_streams.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/verify_persistent_state_rules_for_deleting_streams.cs
@@ -1,0 +1,35 @@
+namespace EventStore.Projections.Core.Tests.Services.projections_manager{
+	using Core.Services.Management;
+	using NUnit.Framework;
+
+	[TestFixture]
+	public class VerifyPersistentStateRulesForDeletingStreams {
+		[Test]
+		[TestCase(true,true,true)]
+		[TestCase(false,true,false)]
+		[TestCase(true,false,false)]
+		[TestCase(false,false,false)]
+		public void EmitStreamNeedsDeletedAsExpected(bool emitEnabled,bool deleteEmitStreams,bool expectedResult) {
+			ManagedProjection.PersistedState persistedState = new ManagedProjection.PersistedState();
+
+			persistedState.EmitEnabled = emitEnabled;
+			persistedState.DeleteEmittedStreams = deleteEmitStreams;
+
+			Assert.IsTrue(persistedState.EmitStreamNeedsDeleted() == expectedResult);
+		}
+
+		[Test]
+		[TestCase(true, true, false)]
+		[TestCase(false, true, true)]
+		[TestCase(true, false, false)]
+		[TestCase(false, false, false)]
+		public void CheckpointStreamNeedsDeletedAsExpected(bool checkPointsDisabled, bool deleteCheckpointStreams, bool expectedResult) {
+			ManagedProjection.PersistedState persistedState = new ManagedProjection.PersistedState();
+
+			persistedState.CheckpointsDisabled = checkPointsDisabled;
+			persistedState.DeleteCheckpointStream = deleteCheckpointStreams;
+
+			Assert.IsTrue(persistedState.CheckpointStreamNeedsDeleted() == expectedResult);
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_emitted_not_enabled.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_and_emitted_not_enabled.cs
@@ -1,0 +1,52 @@
+namespace EventStore.Projections.Core.Tests.Services.projections_manager{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Runtime.CompilerServices;
+	using Core.Services;
+	using EventStore.Common.Utils;
+	using EventStore.Core.Messages;
+	using EventStore.Core.Messaging;
+	using EventStore.Core.Tests;
+	using Messages;
+	using NUnit.Framework;
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class WhenDeletingAPersistentProjectionAndEmittedNotEnabled<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		private string _projectionName;
+
+		protected override void Given() {
+			_projectionName = "test-projection";
+			AllWritesSucceed();
+			NoOtherStreams();
+		}
+
+		protected override IEnumerable<WhenStep> When() {
+			yield return new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid());
+			yield return
+				new ProjectionManagementMessage.Command.Post(
+				                                             new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
+				                                             ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
+				                                             enabled: true, checkpointsEnabled: true, emitEnabled: false, trackEmittedStreams: false);
+			yield return
+				new ProjectionManagementMessage.Command.Disable(
+				                                                new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);
+			yield return
+				new ProjectionManagementMessage.Command.Delete(
+				                                               new PublishEnvelope(_bus), _projectionName,
+				                                               ProjectionManagementMessage.RunAs.System, true, true, true);
+		}
+
+		[Test, Category("v8")]
+		public void a_projection_deleted_event_is_written() {
+			var deletedStreamEvents = _consumer.HandledMessages.OfType<ClientMessage.DeleteStream>().ToList();
+
+			Assert.AreEqual(deletedStreamEvents.Count, 1);
+
+			Assert.AreEqual(deletedStreamEvents.First().EventStreamId,$"$projections-{_projectionName}-checkpoint");
+
+			Assert.AreEqual(true, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Any(x => x.Events[0].EventType == ProjectionEventTypes.ProjectionDeleted && Helper.UTF8NoBom.GetString(x.Events[0].Data) == _projectionName));
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_with_default_options.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_deleting_a_persistent_projection_with_default_options.cs
@@ -27,7 +27,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 				new ProjectionManagementMessage.Command.Post(
 					new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
 					ProjectionManagementMessage.RunAs.System, "JS", @"fromAll().when({$any:function(s,e){return s;}});",
-					enabled: true, checkpointsEnabled: true, emitEnabled: false, trackEmittedStreams: false);
+					enabled: true, checkpointsEnabled: true, emitEnabled: false, trackEmittedStreams: true);
 			yield return
 				new ProjectionManagementMessage.Command.Disable(
 					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);
@@ -39,6 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 
 		[Test, Category("v8")]
 		public void a_projection_deleted_event_is_written() {
+			var deletedStreamEvents =_consumer.HandledMessages.OfType<ClientMessage.DeleteStream>().ToList();
 			Assert.AreEqual(true, _consumer.HandledMessages.OfType<ClientMessage.WriteEvents>().Any(x => x.Events[0].EventType == ProjectionEventTypes.ProjectionDeleted && Helper.UTF8NoBom.GetString(x.Events[0].Data) == _projectionName));
 		}
 	}


### PR DESCRIPTION
Fixed: Prevent emitted checkpoint streams from being deleted when not enabled.

Fixed PR from #3023

I directly applied the suggestions I would have made in the previous PR. All were about getting rid of unnecessary changes (empty namespace and lines).

cc @StevenBlair123 