### PR TITLE
Fixed the dead link to v5 http API

### DIFF
--- a/docs/introduction/clients.md
+++ b/docs/introduction/clients.md
@@ -34,7 +34,7 @@ EventStoreDB also offers an HTTP-based interface, based specifically on the [Ato
 
 ### EventStoreDB supported clients
 
--   [HTTP API](../../http-api/README.md)
+-   [HTTP API](../../docs/http-api/README.md)
 
 ### Community developed clients
 


### PR DESCRIPTION
Per finding on Discuss https://discuss.eventstore.com/t/evenstore-5-http-api-documentation-not-available/3390.

Preview: https://deploy-preview-406--developers-eventstore.netlify.app/.