### PR TITLE
Improve lookup of first non-expired events in long stream with maxage

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		{
 		}
 
-		public IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null)
+		public IReadOnlyList<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null)
 		{
 			var entries = new List<IndexEntry>();
 			if(_indexEntries.ContainsKey(streamId)){

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -46,9 +46,9 @@ namespace EventStore.Core.Tests.Services.Storage {
 			return false;
 		}
 
-		public IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion,
+		public IReadOnlyList<IndexEntry> GetRange(string streamId, long startVersion, long endVersion,
 			int? limit = null) {
-			yield break;
+			return Array.Empty<IndexEntry>();
 		}
 
 		public void Scavenge(IIndexScavengerLog log, CancellationToken ct) {

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age_and_max_count_and_max_age_is_more_strict.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age_and_max_count_and_max_age_is_more_strict.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using EventStore.Core.Data;
 using NUnit.Framework;
 using ReadStreamResult = EventStore.Core.Services.Storage.ReaderIndex.ReadStreamResult;
@@ -193,6 +194,70 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 
 			var records = res.Records;
 			Assert.AreEqual(0, records.Length);
+		}
+	}
+
+	public class
+		when_reading_stream_with_max_age_and_a_mostly_expired : ReadIndexTestScenario {
+
+		public when_reading_stream_with_max_age_and_a_mostly_expired() :
+			base(maxEntriesInMemTable: 50, chunkSize: 100000) {
+		}
+
+		protected override void WriteTestScenario() {
+			var now = DateTime.UtcNow;
+
+			var metadata = string.Format(@"{{""$maxAge"":{0}}}",
+				(int)TimeSpan.FromMinutes(20).TotalSeconds);
+
+			WriteStreamMetadata("ES", 0, metadata);
+			var start = 0;
+			var end = 1008;
+			for (int i = start; i < end; i++) {
+				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-100), retryOnFail: true);
+			}
+
+			start = end;
+			end += 5;
+			for (int i = start; i < end; i++) {
+				WriteSingleEvent("ES", i, "bla", now, retryOnFail: true);
+			}
+		}
+
+		[Test]
+		public void reading_forward_should_match_reading_backwards_in_reverse() {
+			var backwardsCollected = new List<EventRecord>();
+			var forwardsCollected = new List<EventRecord>();
+			var from = long.MaxValue;
+			while (true) {
+				var backwards = ReadIndex.ReadStreamEventsBackward("ES", from, 7);
+				for (int i = 0; i < backwards.Records.Length; i++) {
+					backwardsCollected.Add(backwards.Records[i]);
+				}
+
+				from = backwards.NextEventNumber;
+				if (backwards.IsEndOfStream) break;
+			}
+
+			from = 0;
+			while (true) {
+				var forwards = ReadIndex.ReadStreamEventsForward("ES", from, 7);
+				for (int i = 0; i < forwards.Records.Length; i++) {
+					forwardsCollected.Add(forwards.Records[i]);
+				}
+
+				from = forwards.NextEventNumber;
+				if (forwards.IsEndOfStream) break;
+			}
+
+			Assert.AreEqual(forwardsCollected.Count, backwardsCollected.Count);
+			backwardsCollected.Reverse();
+			for (int i = 0; i < backwardsCollected.Count; i++) {
+				Assert.AreEqual(backwardsCollected[i].EventId, forwardsCollected[i].EventId);
+				Assert.AreEqual(backwardsCollected[i].EventType, forwardsCollected[i].EventType);
+				Assert.AreEqual(backwardsCollected[i].ExpectedVersion, forwardsCollected[i].ExpectedVersion);
+				Assert.AreEqual(backwardsCollected[i].EventNumber, forwardsCollected[i].EventNumber);
+			}
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_very_long_stream_with_max_age_and_mostly_expired_events.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_very_long_stream_with_max_age_and_mostly_expired_events.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNextEventNumber {
+	public class
+		when_reading_very_long_stream_with_max_age_and_mostly_expired_events : ReadIndexTestScenario {
+		public when_reading_very_long_stream_with_max_age_and_mostly_expired_events() : base(
+			maxEntriesInMemTable: 500_000, chunkSize: TFConsts.ChunkSize) {
+		}
+
+		protected override void WriteTestScenario() {
+			var now = DateTime.UtcNow;
+			var metadata = string.Format(@"{{""$maxAge"":{0}}}", (int)TimeSpan.FromMinutes(20).TotalSeconds);
+			WriteStreamMetadata("ES", 0, metadata, now.AddMinutes(-100));
+			for (int i = 0; i < 1_000_000; i++) {
+				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-50), retryOnFail: true);
+			}
+
+			for (int i = 1_000_000; i < 1_000_010; i++) {
+				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-1), retryOnFail: true);
+			}
+		}
+
+		[Test, Explicit, Category("LongRunning")]
+		public void on_read_from_beginning() {
+			Stopwatch sw = Stopwatch.StartNew();
+			var res = ReadIndex.ReadStreamEventsForward("ES", 1, 10);
+			var elapsed = sw.Elapsed;
+			Assert.Less(elapsed, TimeSpan.FromSeconds(1));
+			Assert.AreEqual(9, res.Records.Length);
+		}
+	}
+}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -5,6 +5,7 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64</Platforms>
+		<LangVersion>9</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 			<FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Index {
 		bool TryGetLatestEntry(string streamId, out IndexEntry entry);
 		bool TryGetOldestEntry(string streamId, out IndexEntry entry);
 
-		IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null);
+		IReadOnlyList<IndexEntry> GetRange(string streamId, long startVersion, long endVersion, int? limit = null);
 
 		void Scavenge(IIndexScavengerLog log, CancellationToken ct);
 		Task MergeIndexes();

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -614,7 +614,7 @@ namespace EventStore.Core.Index {
 			return false;
 		}
 
-		public IEnumerable<IndexEntry> GetRange(string streamId, long startVersion, long endVersion,
+		public IReadOnlyList<IndexEntry> GetRange(string streamId, long startVersion, long endVersion,
 			int? limit = null) {
 			ulong hash = CreateHash(streamId);
 			var counter = 0;
@@ -633,7 +633,7 @@ namespace EventStore.Core.Index {
 			throw new InvalidOperationException("Files are locked.");
 		}
 
-		private IEnumerable<IndexEntry> GetRangeInternal(ulong hash, long startVersion, long endVersion,
+		private IReadOnlyList<IndexEntry> GetRangeInternal(ulong hash, long startVersion, long endVersion,
 			int? limit = null) {
 			if (startVersion < 0)
 				throw new ArgumentOutOfRangeException("startVersion");


### PR DESCRIPTION
Added: Faster seek for first non-expired events in long streams with $max-age set

Backports https://github.com/EventStore/EventStore/pull/2981 to 20.10
Fixes: https://github.com/EventStore/home/issues/561