### PR TITLE
[Backport] Make logconfig.json location fully configurable

### DIFF
--- a/src/EventStore.Common/Options/IOptions.cs
+++ b/src/EventStore.Common/Options/IOptions.cs
@@ -4,6 +4,7 @@
 		bool Version { get; }
 		string Config { get; }
 		string Log { get; }
+		string LogConfig { get; }
 		bool WhatIf { get; }
 	}
 }

--- a/src/EventStore.Core.Tests/Common/EventStoreOptionsTests/TestArgs.cs
+++ b/src/EventStore.Core.Tests/Common/EventStoreOptionsTests/TestArgs.cs
@@ -7,6 +7,7 @@ namespace EventStore.Core.Tests.Common {
 		public bool Version { get; set; }
 		public string Config { get; set; }
 		public string Log { get; set; }
+		public string LogConfig { get; set; }
 		public IPEndPoint[] GossipSeed { get; set; }
 		public bool WhatIf { get; set; }
 		public ProjectionType RunProjections { get; set; }

--- a/src/EventStore.Core/ClusterNodeOptions.cs
+++ b/src/EventStore.Core/ClusterNodeOptions.cs
@@ -18,6 +18,9 @@ namespace EventStore.Core {
 		[ArgDescription(Opts.LogLevelDescr, Opts.AppGroup)]
 		public LogLevel LogLevel { get; set; }
 
+		[ArgDescription(Opts.LogConfigDescr, Opts.AppGroup)]
+		public string LogConfig { get; set; }
+
 		[ArgDescription(Opts.ConfigsDescr, Opts.AppGroup)]
 		public string Config { get; set; }
 
@@ -336,6 +339,7 @@ namespace EventStore.Core {
 			Version = Opts.ShowVersionDefault;
 			Log = Locations.DefaultLogDirectory;
 			LogLevel = Opts.LogLevelDefault;
+			LogConfig = Opts.LogConfigDefault;
 			WhatIf = Opts.WhatIfDefault;
 
 			IntIp = Opts.InternalIpDefault;

--- a/src/EventStore.Core/EventStoreHostedService.cs
+++ b/src/EventStore.Core/EventStoreHostedService.cs
@@ -84,7 +84,7 @@ namespace EventStore.Core {
 
 			string logsDirectory =
 				Path.GetFullPath(options.Log.IsNotEmptyString() ? options.Log : GetLogsDirectory(options));
-			EventStoreLoggerConfiguration.Initialize(logsDirectory, componentName);
+			EventStoreLoggerConfiguration.Initialize(logsDirectory, componentName, options.LogConfig);
 
 			Log.Information("\n{description,-25} {version} ({branch}/{hashtag}, {timestamp})", "ES VERSION:",
 				VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp);

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -43,6 +43,9 @@ namespace EventStore.Core.Util {
 		public const string LogLevelDescr = "Sets the minimum log level. For more granular settings, please edit logconfig.json.";
 		public const LogLevel LogLevelDefault = LogLevel.Default;
 
+		public const string LogConfigDescr = "The name of the log configuration file.";
+		public const string LogConfigDefault = "logconfig.json";
+
 		public const string ConfigsDescr = "Configuration files.";
 		public static readonly string[] ConfigsDefault = new string[0];
 

--- a/src/EventStore.TestClient/ClientOptions.cs
+++ b/src/EventStore.TestClient/ClientOptions.cs
@@ -26,6 +26,10 @@ namespace EventStore.TestClient {
 		/// </summary>
 		[ArgDescription(Opts.LogsDescr)] public string Log { get; set; }
 		/// <summary>
+		/// The name of the log config file.
+		/// </summary>	
+		[ArgDescription(Opts.LogConfigDescr)] public string LogConfig { get; set; }
+		/// <summary>
 		/// Path to the config file.
 		/// </summary>
 		[ArgDescription(Opts.ConfigsDescr)] public string Config { get; set; }
@@ -96,6 +100,7 @@ namespace EventStore.TestClient {
 			Help = Opts.ShowHelpDefault;
 			Version = Opts.ShowVersionDefault;
 			Log = Locations.DefaultTestClientLogDirectory;
+			LogConfig = Opts.LogConfigDefault;
 			WhatIf = Opts.WhatIfDefault;
 			Host = IPAddress.Loopback.ToString();
 			TcpPort = 1113;


### PR DESCRIPTION
Added: A configuration option to set the path of the log configuration file

Backports https://github.com/EventStore/EventStore/pull/3002 to 20.10