### PR TITLE
Fixed 20.10 docker image in documentation samples

### DIFF
--- a/samples/server/docker-compose-cluster.yaml
+++ b/samples/server/docker-compose-cluster.yaml
@@ -17,7 +17,7 @@ services:
       - ./certs:/certs
 
   node1.eventstore: &template
-    image: eventstore/eventstore:20.10.1-buster-slim
+    image: eventstore/eventstore:20.10.2-buster-slim
     container_name: node1.eventstore
     env_file:
       - vars.env

--- a/samples/server/docker-compose.yaml
+++ b/samples/server/docker-compose.yaml
@@ -1,8 +1,8 @@
-version: '3.4'
+version: "3.4"
 
 services:
   eventstore.db:
-    image: eventstore/eventstore:20.10.1-buster-slim
+    image: eventstore/eventstore:20.10.2-buster-slim
     environment:
       - EVENTSTORE_CLUSTER_SIZE=1
       - EVENTSTORE_RUN_PROJECTIONS=All
@@ -26,4 +26,3 @@ services:
 volumes:
   eventstore-volume-data:
   eventstore-volume-logs:
-


### PR DESCRIPTION
Docker configuration docs were pointing to the non-existing `20.10.1-buster-slim` version. Fixed to target proper `20.10.2-buster-slim`.

Per: https://stackoverflow.com/questions/68453271/eventstore-stops-silently-at-startup/68453422#comment120979245_68453422.