### PR TITLE
Persistent subscriptions: Rename LastProcessedEventPosition to LastCheckpointedEventPosition

### DIFF
--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -103,7 +103,7 @@ namespace EventStore.Core.Messages {
 			public int AveragePerSecond { get; set; }
 			public long TotalItems { get; set; }
 			public long CountSinceLastMeasurement { get; set; }
-			public string LastProcessedEventPosition { get; set; }
+			public string LastCheckpointedEventPosition { get; set; }
 			public string LastKnownMessage { get; set; }
 			public bool ResolveLinktos { get; set; }
 			public string StartFrom { get; set; }

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -104,7 +104,7 @@ namespace EventStore.Core.Messages {
 			public long TotalItems { get; set; }
 			public long CountSinceLastMeasurement { get; set; }
 			public string LastCheckpointedEventPosition { get; set; }
-			public string LastKnownMessage { get; set; }
+			public string LastKnownEventPosition { get; set; }
 			public bool ResolveLinktos { get; set; }
 			public string StartFrom { get; set; }
 			public int MessageTimeoutMilliseconds { get; set; }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -82,7 +82,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				Connections = connections,
 				AveragePerSecond = avgItemsPerSecond,
 				LastCheckpointedEventPosition = _lastCheckpointedEventPosition?.ToString(),
-				LastKnownMessage = _lastKnownEventPosition?.ToString(),
+				LastKnownEventPosition = _lastKnownEventPosition?.ToString(),
 				TotalItems = totalItems,
 				CountSinceLastMeasurement = lastItems,
 				CheckPointAfterMilliseconds = (int)_settings.CheckPointAfter.TotalMilliseconds,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -9,7 +9,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private long _totalItems;
 		private TimeSpan _lastTotalTime;
 		private long _lastTotalItems;
-		private IPersistentSubscriptionStreamPosition _lastEventPosition;
+		private IPersistentSubscriptionStreamPosition _lastCheckpointedEventPosition;
 		private IPersistentSubscriptionStreamPosition _lastKnownEventPosition;
 		private readonly PersistentSubscription _parent;
 		private readonly Stopwatch _totalTimeWatch;
@@ -26,8 +26,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			Interlocked.Increment(ref _totalItems);
 		}
 
-		public void SetLastCheckPoint(IPersistentSubscriptionStreamPosition lastEventPosition) {
-			_lastEventPosition = lastEventPosition;
+		public void SetLastCheckPoint(IPersistentSubscriptionStreamPosition lastCheckpointedEventPosition) {
+			_lastCheckpointedEventPosition = lastCheckpointedEventPosition;
 		}
 
 		public void SetLastKnownEventPosition(IPersistentSubscriptionStreamPosition knownEventPosition) {
@@ -81,7 +81,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				Status = _parent.State.ToString(),
 				Connections = connections,
 				AveragePerSecond = avgItemsPerSecond,
-				LastProcessedEventPosition = _lastEventPosition?.ToString(),
+				LastCheckpointedEventPosition = _lastCheckpointedEventPosition?.ToString(),
 				LastKnownMessage = _lastKnownEventPosition?.ToString(),
 				TotalItems = totalItems,
 				CountSinceLastMeasurement = lastItems,

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -879,9 +879,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					#pragma warning restore 612
 					LastKnownEventPosition = stat.LastKnownMessage,
 					#pragma warning disable 612
-					LastProcessedEventNumber = long.TryParse(stat.LastProcessedEventPosition, out var lastProcessedPos) ? lastProcessedPos : 0,
+					LastProcessedEventNumber = long.TryParse(stat.LastCheckpointedEventPosition, out var lastProcessedPos) ? lastProcessedPos : 0,
 					#pragma warning restore 612
-					LastProcessedEventPosition = stat.LastProcessedEventPosition,
+					LastCheckpointedEventPosition = stat.LastCheckpointedEventPosition,
 					ReadBufferCount = stat.ReadBufferCount,
 					LiveBufferCount = stat.LiveBufferCount,
 					RetryBufferCount = stat.RetryBufferCount,
@@ -959,9 +959,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					#pragma warning restore 612
 					LastKnownEventPosition = stat.LastKnownMessage,
 					#pragma warning disable 612
-					LastProcessedEventNumber = long.TryParse(stat.LastProcessedEventPosition, out var lastEventPos) ? lastEventPos : 0,
+					LastProcessedEventNumber = long.TryParse(stat.LastCheckpointedEventPosition, out var lastEventPos) ? lastEventPos : 0,
 					#pragma warning restore 612
-					LastProcessedEventPosition = stat.LastProcessedEventPosition,
+					LastCheckpointedEventPosition = stat.LastCheckpointedEventPosition,
 					ParkedMessageUri = MakeUrl(manager,
 						string.Format(parkedMessageUriTemplate, escapedStreamId, escapedGroupName)),
 					GetMessagesUri = MakeUrl(manager,
@@ -1023,7 +1023,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			public decimal AverageItemsPerSecond { get; set; }
 			public long TotalItemsProcessed { get; set; }
 			[Obsolete] public long LastProcessedEventNumber { get; set; }
-			public string LastProcessedEventPosition { get; set; }
+			public string LastCheckpointedEventPosition { get; set; }
 			[Obsolete] public long LastKnownEventNumber { get; set; }
 			public string LastKnownEventPosition { get; set; }
 			public int ConnectionCount { get; set; }
@@ -1042,7 +1042,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			public long TotalItemsProcessed { get; set; }
 			public long CountSinceLastMeasurement { get; set; }
 			[Obsolete] public long LastProcessedEventNumber { get; set; }
-			public string LastProcessedEventPosition { get; set; }
+			public string LastCheckpointedEventPosition { get; set; }
 			[Obsolete] public long LastKnownEventNumber { get; set; }
 			public string LastKnownEventPosition { get; set; }
 			public int ReadBufferCount { get; set; }

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -875,9 +875,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					TotalItemsProcessed = stat.TotalItems,
 					CountSinceLastMeasurement = stat.CountSinceLastMeasurement,
 					#pragma warning disable 612
-					LastKnownEventNumber = long.TryParse(stat.LastKnownMessage, out var lastKnownMsg) ? lastKnownMsg : 0,
+					LastKnownEventNumber = long.TryParse(stat.LastKnownEventPosition, out var lastKnownMsg) ? lastKnownMsg : 0,
 					#pragma warning restore 612
-					LastKnownEventPosition = stat.LastKnownMessage,
+					LastKnownEventPosition = stat.LastKnownEventPosition,
 					#pragma warning disable 612
 					LastProcessedEventNumber = long.TryParse(stat.LastCheckpointedEventPosition, out var lastProcessedPos) ? lastProcessedPos : 0,
 					#pragma warning restore 612
@@ -955,9 +955,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					AverageItemsPerSecond = stat.AveragePerSecond,
 					TotalItemsProcessed = stat.TotalItems,
 					#pragma warning disable 612
-					LastKnownEventNumber = long.TryParse(stat.LastKnownMessage, out var lastKnownMsg) ? lastKnownMsg : 0,
+					LastKnownEventNumber = long.TryParse(stat.LastKnownEventPosition, out var lastKnownMsg) ? lastKnownMsg : 0,
 					#pragma warning restore 612
-					LastKnownEventPosition = stat.LastKnownMessage,
+					LastKnownEventPosition = stat.LastKnownEventPosition,
 					#pragma warning disable 612
 					LastProcessedEventNumber = long.TryParse(stat.LastCheckpointedEventPosition, out var lastEventPos) ? lastEventPos : 0,
 					#pragma warning restore 612

--- a/src/EventStore.Transport.Http/Codecs/JsonCodec.cs
+++ b/src/EventStore.Transport.Http/Codecs/JsonCodec.cs
@@ -28,7 +28,7 @@ namespace EventStore.Transport.Http.Codecs {
 		public static readonly JsonSerializerSettings ToSettings = new JsonSerializerSettings {
 			ContractResolver = new CamelCasePropertyNamesContractResolver(),
 			DateFormatHandling = DateFormatHandling.IsoDateFormat,
-			NullValueHandling = NullValueHandling.Ignore,
+			NullValueHandling = NullValueHandling.Include,
 			DefaultValueHandling = DefaultValueHandling.Include,
 			MissingMemberHandling = MissingMemberHandling.Ignore,
 			TypeNameHandling = TypeNameHandling.None,


### PR DESCRIPTION
Fixed: Persistent subscriptions: Rename LastProcessedEventPosition to LastCheckpointedEventPosition

Fixes: https://github.com/eventstore/home/issues/505
Note that renaming  `LastProcessedEventPosition` to `LastCheckpointedEventPosition` is a breaking change between 21.6 and the upcoming 21.6.1 patch release (`LastProcessedEventPosition` was added in 21.6)

The PR also:
- Renames `LastKnownMessage` to `LastKnownEventPosition` for consistency but that's only internally and doesn't affect any external interface.
- Modifies the JSON codec to include null values when serializing so that it's easier to handle on the UI side.