### PR TITLE
Swallow Diagnostics Exception on Shutdown

### DIFF
--- a/src/EventStore.Core/Services/Monitoring/Utils/EventCountersHelper.cs
+++ b/src/EventStore.Core/Services/Monitoring/Utils/EventCountersHelper.cs
@@ -132,7 +132,11 @@ namespace EventStore.Core.Services.Monitoring.Utils {
 		}
 
 		public void Dispose() {
-			_session?.Stop();
+			try {
+				_session?.Stop();
+			} catch (ServerNotAvailableException) {
+			}
+
 			_session?.Dispose();
 		}
 	}


### PR DESCRIPTION
Fixed: swallow ServerNotAvailableException on shutdown
