### PR TITLE
Make Leader Election timeout configurable

### DIFF
--- a/docs/clustering/gossip.md
+++ b/docs/clustering/gossip.md
@@ -79,3 +79,17 @@ Please note that the `GossipOnSingleNode` option has been deprecated in this ver
 | Environment variable | `EVENTSTORE_GOSSIP_ON_SINGLE_NODE` |
 
 **Default**: `true`
+
+## Leader Election Timeout
+
+The Leader Elections are separate to the node gossip, and are used to elect a node as Leader and assign roles to the other nodes.
+
+In some cases the leader election messages may be delayed, which can result in elections taking longer than they should. If you start seeing election timeouts in the logs or if you've needed to increase the gossip timeout due to a congested network, then you should consider increasing the leader election timeout as well.
+
+| Format               | Syntax |
+| :------------------- | :----- |
+| Command line         | `--leader-election-timeout-ms` |
+| YAML                 | `LeaderElectionTimeoutMs` |
+| Environment variable | `EVENTSTORE_LEADER_ELECTION_TIMEOUT_MS` |
+
+**Default**: `1000` (in milliseconds).

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -57,7 +57,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new InMemoryCheckpoint(ChaserCheckpoint),
 				new InMemoryCheckpoint(ProposalCheckpoint),
 				new FakeEpochManager(),
-				() => -1, 0, new FakeTimeProvider());
+				() => -1, 0, new FakeTimeProvider(),
+				TimeSpan.FromMilliseconds(1_000));
 			ElectionsService.SubscribeMessages(_bus);
 
 			InputMessages = new List<Message>();

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -22,6 +22,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		private IBus _bus;
 		protected FakePublisher _publisher;
 		protected Guid _epochId;
+		protected TimeSpan LeaderElectionProgressTimeout = TimeSpan.FromMilliseconds(1_000);
 
 		protected static Func<int, VNodeInfo> NodeFactory = (id) => new VNodeInfo(
 			Guid.Parse($"00000000-0000-0000-0000-00000000000{id}"), id,
@@ -54,7 +55,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new InMemoryCheckpoint(0),
 				new InMemoryCheckpoint(0),
 				new InMemoryCheckpoint(-1),
-				new FakeEpochManager(), () => 0L, 0, _timeProvider);
+				new FakeEpochManager(), () => 0L, 0, _timeProvider,
+				LeaderElectionProgressTimeout);
 			_sut.SubscribeMessages(_bus);
 		}
 	}
@@ -75,14 +77,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				TimerMessage.Schedule.Create(
-					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					LeaderElectionProgressTimeout,
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(0)),
 			};
@@ -204,14 +204,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, newView),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, newView),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				TimerMessage.Schedule.Create(
-					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					LeaderElectionProgressTimeout,
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(1)),
 			};
@@ -289,12 +287,10 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.ViewChangeProof(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.ViewChangeProof(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				TimerMessage.Schedule.Create(
 					Core.Services.ElectionsService.SendViewChangeProofInterval,
 					new PublishEnvelope(_publisher),
@@ -382,14 +378,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, 10),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, 10),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				TimerMessage.Schedule.Create(
-					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					LeaderElectionProgressTimeout,
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(10)),
 			};
@@ -437,12 +431,10 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.Prepare(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.Prepare(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout))
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout))
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -545,8 +537,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.PrepareOk(0,
 						_node.InstanceId, _node.HttpEndPoint, -1, -1, Guid.Empty, Guid.Empty, 0, 0, 0, 0, _clusterInfo),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -662,14 +653,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.Proposal(_node.InstanceId, _node.HttpEndPoint,
 						proposalMessage.LeaderId,
 						proposalMessage.LeaderHttpEndPoint, 0, 0, 0, _epochId, Guid.Empty, 0, 0, 0, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.Proposal(_node.InstanceId, _node.HttpEndPoint,
 						proposalMessage.LeaderId,
 						proposalMessage.LeaderHttpEndPoint, 0, 0, 0, _epochId, Guid.Empty, 0, 0, 0, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout))
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout))
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -839,14 +828,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.Accept(_node.InstanceId, _node.HttpEndPoint,
 						_nodeThree.InstanceId,
 						_nodeThree.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.Accept(_node.InstanceId, _node.HttpEndPoint,
 						_nodeThree.InstanceId,
 						_nodeThree.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -1079,12 +1066,10 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.LeaderIsResigning(_node.InstanceId, _node.HttpEndPoint),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.LeaderIsResigning(_node.InstanceId, _node.HttpEndPoint),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -1108,8 +1093,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.LeaderIsResigningOk(
 						_nodeTwo.InstanceId, _nodeTwo.HttpEndPoint,
 						_node.InstanceId, _node.HttpEndPoint),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -1241,7 +1225,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new InMemoryCheckpoint(0),
 					new InMemoryCheckpoint(0),
 					new InMemoryCheckpoint(-1),
-					new FakeEpochManager(), () => 0L, 0, new FakeTimeProvider());
+					new FakeEpochManager(), () => 0L, 0, new FakeTimeProvider(),
+					TimeSpan.FromMilliseconds(1_000));
 			});
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -54,7 +54,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					readerCheckpoint,
 					proposalCheckpoint,
 					epochManager,
-					() => -1, 0, new FakeTimeProvider());
+					() => -1, 0, new FakeTimeProvider(),
+					TimeSpan.FromMilliseconds(1_000));
 				electionsService.SubscribeMessages(inputBus);
 
 				var nodeId = i;

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
@@ -81,7 +81,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 					new InMemoryCheckpoint(),
 					new InMemoryCheckpoint(-1),
 					new FakeEpochManager(),
-					() => -1, 0, new FakeTimeProvider());
+					() => -1, 0, new FakeTimeProvider(),
+					TimeSpan.FromMilliseconds(1_000));
 				electionsService.SubscribeMessages(inputBus);
 
 				outputBus.Subscribe(sendOverHttpHandler);

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -205,8 +205,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
-					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)),
+					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout)),
 				TimerMessage.Schedule.Create(GossipServiceBase.GossipStartupInterval, new PublishEnvelope(_bus),
 					new GossipMessage.Gossip(1)));
 		}
@@ -228,8 +227,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
-					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)),
+					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout)),
 				TimerMessage.Schedule.Create(_gossipInterval, new PublishEnvelope(_bus),
 					new GossipMessage.Gossip(++_gossipRound)));
 		}
@@ -283,8 +281,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
-					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)),
+					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout)),
 				TimerMessage.Schedule.Create(GossipServiceBase.GossipStartupInterval, new PublishEnvelope(_bus),
 					new GossipMessage.Gossip(++_gossipRound)));
 		}
@@ -306,8 +303,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
-					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)),
+					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout)),
 				TimerMessage.Schedule.Create(_gossipInterval, new PublishEnvelope(_bus),
 					new GossipMessage.Gossip(++_gossipRound)));
 		}
@@ -609,8 +605,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 		public void should_issue_get_gossip() {
 			ExpectMessages(
 				new GrpcMessage.SendOverGrpc(_currentNode.HttpEndPoint, new GossipMessage.GetGossip(),
-					_timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)));
+					_timeProvider.LocalTime.Add(_gossipTimeout)));
 		}
 	}
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1227,7 +1227,8 @@ namespace EventStore.Core {
 					epochManager,
 					() => readIndex.LastIndexedPosition,
 					options.Cluster.NodePriority,
-					_timeProvider);
+					_timeProvider,
+					TimeSpan.FromMilliseconds(options.Cluster.LeaderElectionTimeoutMs));
 				electionsService.SubscribeMessages(_mainBus);
 			}
 

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -287,6 +287,9 @@ namespace EventStore.Core {
 			[Description("The number of seconds a dead node will remain in the gossip before being pruned.")]
 			public int DeadMemberRemovalPeriodSec { get; init; } = 1_800;
 
+			[Description("The timeout, in milliseconds, on election messages to other nodes.")]
+			public int LeaderElectionTimeoutMs { get; init; } = 1_000;
+
 			public int QuorumSize => ClusterSize == 1 ? 1 : ClusterSize / 2 + 1;
 			public int PrepareAckCount => PrepareCount > QuorumSize ? PrepareCount : QuorumSize;
 			public int CommitAckCount => CommitCount > QuorumSize ? CommitCount : QuorumSize;
@@ -307,7 +310,8 @@ namespace EventStore.Core {
 				ReadOnlyReplica = configurationRoot.GetValue<bool>(nameof(ReadOnlyReplica)),
 				UnsafeAllowSurplusNodes = configurationRoot.GetValue<bool>(nameof(UnsafeAllowSurplusNodes)),
 				DeadMemberRemovalPeriodSec = configurationRoot.GetValue<int>(nameof(DeadMemberRemovalPeriodSec)),
-				StreamInfoCacheCapacity = configurationRoot.GetValue<int>(nameof(StreamInfoCacheCapacity))
+				StreamInfoCacheCapacity = configurationRoot.GetValue<int>(nameof(StreamInfoCacheCapacity)),
+				LeaderElectionTimeoutMs = configurationRoot.GetValue<int>(nameof(LeaderElectionTimeoutMs))
 			};
 		}
 

--- a/src/EventStore.Core/Messages/GrpcMessage.cs
+++ b/src/EventStore.Core/Messages/GrpcMessage.cs
@@ -13,13 +13,11 @@ namespace EventStore.Core.Messages {
 
 			public readonly EndPoint DestinationEndpoint;
 			public readonly Message Message;
-			public readonly DateTime Deadline;
 			public readonly DateTime LiveUntil;
 
-			public SendOverGrpc(EndPoint destinationEndpoint, Message message, DateTime deadline, DateTime liveUntil) {
+			public SendOverGrpc(EndPoint destinationEndpoint, Message message, DateTime liveUntil) {
 				DestinationEndpoint = destinationEndpoint;
 				Message = message;
-				Deadline = deadline;
 				LiveUntil = liveUntil;
 			}
 		}

--- a/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
@@ -133,8 +133,7 @@ namespace EventStore.Core.Services.Gossip {
 					_timeProvider, DeadMemberRemovalPeriod);
 				_bus.Publish(new GrpcMessage.SendOverGrpc(node.HttpEndPoint,
 					new GossipMessage.SendGossip(_cluster, _memberInfo.HttpEndPoint),
-					_timeProvider.LocalTime.Add(GossipTimeout),
-					_timeProvider.LocalTime.Add(GossipInterval)));
+					_timeProvider.LocalTime.Add(GossipTimeout)));
 			}
 
 			var interval = message.GossipRound < GossipRoundStartupThreshold ? GossipStartupInterval : GossipInterval;
@@ -236,8 +235,7 @@ namespace EventStore.Core.Services.Gossip {
 				message.VNodeEndPoint);
 			_bus.Publish(new GrpcMessage.SendOverGrpc(node.HttpEndPoint,
 				new GossipMessage.GetGossip(),
-				_timeProvider.LocalTime.Add(GossipTimeout),
-				_timeProvider.LocalTime.Add(GossipInterval)));
+				_timeProvider.LocalTime.Add(GossipTimeout)));
 		}
 
 		public void Handle(GossipMessage.GetGossipReceived message) {

--- a/src/EventStore.Core/Services/GrpcSendService.cs
+++ b/src/EventStore.Core/Services/GrpcSendService.cs
@@ -26,43 +26,43 @@ namespace EventStore.Core.Services {
 			switch (message.Message) {
 				case GossipMessage.SendGossip sendGossip:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendGossip(sendGossip, message.DestinationEndpoint, message.Deadline);
+						.SendGossip(sendGossip, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case GossipMessage.GetGossip _:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.GetGossip(message.DestinationEndpoint, message.Deadline);
+						.GetGossip(message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.ViewChange viewChange:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendViewChange(viewChange, message.DestinationEndpoint, message.Deadline);
+						.SendViewChange(viewChange, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.ViewChangeProof proof:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendViewChangeProof(proof, message.DestinationEndpoint, message.Deadline);
+						.SendViewChangeProof(proof, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.Prepare prepare:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendPrepare(prepare, message.DestinationEndpoint, message.Deadline);
+						.SendPrepare(prepare, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.PrepareOk prepareOk:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendPrepareOk(prepareOk, message.DestinationEndpoint, message.Deadline);
+						.SendPrepareOk(prepareOk, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.Proposal proposal:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendProposal(proposal, message.DestinationEndpoint, message.Deadline);
+						.SendProposal(proposal, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.Accept accept:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendAccept(accept, message.DestinationEndpoint, message.Deadline);
+						.SendAccept(accept, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.LeaderIsResigning resigning:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendLeaderIsResigning(resigning, message.DestinationEndpoint, message.Deadline);
+						.SendLeaderIsResigning(resigning, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.LeaderIsResigningOk resigningOk:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendLeaderIsResigningOk(resigningOk, message.DestinationEndpoint, message.Deadline);
+						.SendLeaderIsResigningOk(resigningOk, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				default:
 					throw new NotImplementedException($"Message of type {message.Message.GetType().Name} cannot be handled.");


### PR DESCRIPTION
Added: LeaderElectionTimeoutMs option to allow configuring the timeout for election messages.

Adds the LeaderElectionTimeoutMs option which configures the LiveUntil and Deadlines of messages in ElectionsService

- Deadlines when sending messages over gRPC will be based on the LiveUntil of the messages, rather than setting a deadline separately.
- Update GossipService to use the GossipTimeout as the LiveUntil of gossip messages.