### PR TITLE
implement non-subscription gRPC filtered reads of $all

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/ReadAllForwardsFilteredTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/ReadAllForwardsFilteredTests.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client.Streams;
+using EventStore.Core.Services.Transport.Grpc;
+using Google.Protobuf;
+using Grpc.Core;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
+	[TestFixture]
+	public class ReadAllForwardsFilteredTests {
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class when_reading_all_forwards_filtered<TLogFormat, TStreamId>
+		  : GrpcSpecification<TLogFormat, TStreamId> {
+			private const string StreamId = nameof(when_reading_all_forwards_filtered<TLogFormat, TStreamId>);
+
+			private Position _positionOfLastWrite;
+			private readonly List<ReadResp> _responses = new();
+
+			protected override async Task Given() {
+				var response = await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamId) },
+						Any = new()
+					},
+					CorrelationId = Uuid.NewUuid().ToDto(),
+					IsFinal = true,
+					ProposedMessages = { CreateEvents(50) }
+				});
+
+				_positionOfLastWrite = new Position(response.Success.Position.CommitPosition,
+					response.Success.Position.PreparePosition);
+			}
+
+			protected override async Task When() {
+				_responses.AddRange(await StreamsClient.Read(new() {
+					Options = new() {
+						UuidOption = new() { Structured = new() },
+						Count = 20,
+						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+						ResolveLinks = true,
+						All = new() {
+							Start = new()
+						},
+						Filter = new() {
+							Max = 32,
+							CheckpointIntervalMultiplier = 4,
+							StreamIdentifier = new() { Prefix = { StreamId } }
+						}
+					}
+				}, GetCallOptions(AdminCredentials)).ResponseStream.ReadAllAsync().ToArrayAsync());
+			}
+
+			[Test]
+			public void should_not_receive_null_events() {
+				Assert.False(_responses.Where(x => x.AllStreamPosition is null)
+					.Any(x => x.Event is null));
+			}
+
+			[Test]
+			public void should_read_a_number_of_events_equal_to_the_max_count() {
+				Assert.AreEqual(20, _responses.Count(x => x.Event is not null));
+			}
+
+			[Test]
+			public void should_read_the_correct_events() {
+				Assert.True(_responses
+					.Where(x => x.Event is not null)
+					.All(x =>
+						new Position(x.Event.Event.CommitPosition, x.Event.Event.PreparePosition) <=
+						_positionOfLastWrite));
+
+				Assert.AreEqual(0, _responses.First(x => x.Event is not null).Event.Event.StreamRevision);
+				Assert.AreEqual(19, _responses.Last(x => x.Event is not null).Event.Event.StreamRevision);
+
+				Assert.True(_responses
+					.Where(x => x.Event is not null)
+					.All(x => x.Event.Event.StreamIdentifier.StreamName.ToStringUtf8() == StreamId));
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using EventStore.Client.Streams;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using Serilog;
+using IReadIndex = EventStore.Core.Services.Storage.ReaderIndex.IReadIndex;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	partial class Enumerators {
+		public class ReadAllBackwardsFiltered : IAsyncEnumerator<ReadResp> {
+			private static readonly ILogger Log = Serilog.Log.ForContext<ReadAllBackwardsFiltered>();
+
+			private readonly IPublisher _bus;
+			private readonly ulong _maxCount;
+			private readonly bool _resolveLinks;
+			private readonly IEventFilter _eventFilter;
+			private readonly ClaimsPrincipal _user;
+			private readonly bool _requiresLeader;
+			private readonly IReadIndex _readIndex;
+			private readonly DateTime _deadline;
+			private readonly ReadReq.Types.Options.Types.UUIDOption _uuidOption;
+			private readonly uint _maxSearchWindow;
+			private readonly CancellationToken _cancellationToken;
+			private readonly SemaphoreSlim _semaphore;
+			private readonly Channel<ReadResp> _channel;
+
+			private ReadResp _current;
+
+			public ReadResp Current => _current;
+
+			public ReadAllBackwardsFiltered(IPublisher bus,
+				Position position,
+				ulong maxCount,
+				bool resolveLinks,
+				IEventFilter eventFilter,
+				ClaimsPrincipal user,
+				bool requiresLeader,
+				IReadIndex readIndex,
+				uint? maxSearchWindow,
+				DateTime deadline,
+				ReadReq.Types.Options.Types.UUIDOption uuidOption,
+				CancellationToken cancellationToken) {
+				if (bus == null) {
+					throw new ArgumentNullException(nameof(bus));
+				}
+
+				if (eventFilter == null) {
+					throw new ArgumentNullException(nameof(eventFilter));
+				}
+
+				if (readIndex == null) {
+					throw new ArgumentNullException(nameof(readIndex));
+				}
+
+				_bus = bus;
+				_maxCount = maxCount;
+				_resolveLinks = resolveLinks;
+				_eventFilter = eventFilter;
+				_user = user;
+				_requiresLeader = requiresLeader;
+				_readIndex = readIndex;
+				_maxSearchWindow = maxSearchWindow ?? ReadBatchSize;
+				_deadline = deadline;
+				_uuidOption = uuidOption;
+				_cancellationToken = cancellationToken;
+				_semaphore = new SemaphoreSlim(1, 1);
+				_channel = Channel.CreateBounded<ReadResp>(BoundedChannelOptions);
+
+				ReadPage(position);
+			}
+
+			public ValueTask DisposeAsync() {
+				_channel.Writer.TryComplete();
+				return new ValueTask(Task.CompletedTask);
+			}
+
+			public async ValueTask<bool> MoveNextAsync() {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+					return false;
+				}
+
+				_current = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+
+				return true;
+			}
+
+			private void ReadPage(Position startPosition, ulong readCount = 0) {
+				var correlationId = Guid.NewGuid();
+
+				var (commitPosition, preparePosition) = startPosition.ToInt64();
+
+				_bus.Publish(new ClientMessage.FilteredReadAllEventsBackward(
+					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
+					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
+					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user, expires: _deadline));
+
+				async Task OnMessage(Message message, CancellationToken ct) {
+					if (message is ClientMessage.NotHandled notHandled &&
+					    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+						_channel.Writer.TryComplete(ex);
+						return;
+					}
+
+					if (!(message is ClientMessage.FilteredReadAllEventsBackwardCompleted completed)) {
+						_channel.Writer.TryComplete(
+							RpcExceptions.UnknownMessage<ClientMessage.FilteredReadAllEventsBackwardCompleted>(message));
+						return;
+					}
+
+					switch (completed.Result) {
+						case FilteredReadAllResult.Success:
+							var nextPosition = completed.NextPos;
+
+							foreach (var @event in completed.Events) {
+								if (readCount >= _maxCount) {
+									await _channel.Writer.WriteAsync(new ReadResp {
+										AllStreamPosition = new () {
+											NextPosition = new() {
+												CommitPosition = (ulong)nextPosition.CommitPosition,
+												PreparePosition = (ulong)nextPosition.PreparePosition
+											},
+											LastPosition = new() {
+												CommitPosition = (ulong)completed.CurrentPos.CommitPosition,
+												PreparePosition = (ulong)completed.CurrentPos.PreparePosition
+											}
+										}
+									}, ct).ConfigureAwait(false);
+									_channel.Writer.TryComplete();
+									return;
+								}
+								await _channel.Writer.WriteAsync(new ReadResp {
+									Event = ConvertToReadEvent(_uuidOption, @event)
+								}, _cancellationToken).ConfigureAwait(false);
+								nextPosition = @event.OriginalPosition ?? TFPos.Invalid;
+								readCount++;
+							}
+
+							if (completed.IsEndOfStream) {
+								await _channel.Writer.WriteAsync(new ReadResp {
+									AllStreamPosition = new() {
+										NextPosition = new() {
+											CommitPosition = (ulong)nextPosition.CommitPosition,
+											PreparePosition = (ulong)nextPosition.PreparePosition
+										},
+										LastPosition = new() {
+											CommitPosition = (ulong)completed.CurrentPos.CommitPosition,
+											PreparePosition = (ulong)completed.CurrentPos.PreparePosition
+										}
+									}
+								}, _cancellationToken).ConfigureAwait(false);
+								_channel.Writer.TryComplete();
+								return;
+							}
+
+							ReadPage(Position.FromInt64(
+								completed.NextPos.CommitPosition,
+								completed.NextPos.PreparePosition), readCount);
+							return;
+						case FilteredReadAllResult.AccessDenied:
+							_channel.Writer.TryComplete(RpcExceptions.AccessDenied());
+							return;
+						default:
+							_channel.Writer.TryComplete(RpcExceptions.UnknownError(completed.Result));
+							return;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using EventStore.Client.Streams;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.Storage.ReaderIndex;
+using Serilog;
+using IReadIndex = EventStore.Core.Services.Storage.ReaderIndex.IReadIndex;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	partial class Enumerators {
+		public class ReadAllForwardsFiltered : IAsyncEnumerator<ReadResp> {
+			private static readonly ILogger Log = Serilog.Log.ForContext<ReadAllForwardsFiltered>();
+
+			private readonly IPublisher _bus;
+			private readonly ulong _maxCount;
+			private readonly bool _resolveLinks;
+			private readonly IEventFilter _eventFilter;
+			private readonly ClaimsPrincipal _user;
+			private readonly bool _requiresLeader;
+			private readonly IReadIndex _readIndex;
+			private readonly DateTime _deadline;
+			private readonly ReadReq.Types.Options.Types.UUIDOption _uuidOption;
+			private readonly uint _maxSearchWindow;
+			private readonly CancellationToken _cancellationToken;
+			private readonly SemaphoreSlim _semaphore;
+			private readonly Channel<ReadResp> _channel;
+
+			private ReadResp _current;
+
+			public ReadResp Current => _current;
+
+			public ReadAllForwardsFiltered(IPublisher bus,
+				Position position,
+				ulong maxCount,
+				bool resolveLinks,
+				IEventFilter eventFilter,
+				ClaimsPrincipal user,
+				bool requiresLeader,
+				IReadIndex readIndex,
+				uint? maxSearchWindow,
+				DateTime deadline,
+				ReadReq.Types.Options.Types.UUIDOption uuidOption,
+				CancellationToken cancellationToken) {
+				if (bus == null) {
+					throw new ArgumentNullException(nameof(bus));
+				}
+
+				if (eventFilter == null) {
+					throw new ArgumentNullException(nameof(eventFilter));
+				}
+
+				if (readIndex == null) {
+					throw new ArgumentNullException(nameof(readIndex));
+				}
+
+				_bus = bus;
+				_maxCount = maxCount;
+				_resolveLinks = resolveLinks;
+				_eventFilter = eventFilter;
+				_user = user;
+				_requiresLeader = requiresLeader;
+				_readIndex = readIndex;
+				_maxSearchWindow = maxSearchWindow ?? ReadBatchSize;
+				_deadline = deadline;
+				_uuidOption = uuidOption;
+				_cancellationToken = cancellationToken;
+				_semaphore = new SemaphoreSlim(1, 1);
+				_channel = Channel.CreateBounded<ReadResp>(BoundedChannelOptions);
+
+				ReadPage(position);
+			}
+
+			public ValueTask DisposeAsync() {
+				_channel.Writer.TryComplete();
+				return new ValueTask(Task.CompletedTask);
+			}
+
+			public async ValueTask<bool> MoveNextAsync() {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+					return false;
+				}
+
+				_current = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+
+				return true;
+			}
+
+			private void ReadPage(Position startPosition, ulong readCount = 0) {
+				var correlationId = Guid.NewGuid();
+
+				var (commitPosition, preparePosition) = startPosition.ToInt64();
+
+				_bus.Publish(new ClientMessage.FilteredReadAllEventsForward(
+					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
+					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
+					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user, expires: _deadline));
+
+				async Task OnMessage(Message message, CancellationToken ct) {
+					if (message is ClientMessage.NotHandled notHandled &&
+					    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+						_channel.Writer.TryComplete(ex);
+						return;
+					}
+
+					if (!(message is ClientMessage.FilteredReadAllEventsForwardCompleted completed)) {
+						_channel.Writer.TryComplete(
+							RpcExceptions.UnknownMessage<ClientMessage.FilteredReadAllEventsForwardCompleted>(message));
+						return;
+					}
+
+					switch (completed.Result) {
+						case FilteredReadAllResult.Success:
+							var nextPosition = completed.NextPos;
+
+							foreach (var @event in completed.Events) {
+								if (readCount >= _maxCount) {
+									await _channel.Writer.WriteAsync(new ReadResp {
+										AllStreamPosition = new () {
+											NextPosition = new() {
+												CommitPosition = (ulong)nextPosition.CommitPosition,
+												PreparePosition = (ulong)nextPosition.PreparePosition
+											},
+											LastPosition = new() {
+												CommitPosition = (ulong)completed.CurrentPos.CommitPosition,
+												PreparePosition = (ulong)completed.CurrentPos.PreparePosition
+											}
+										}
+									}, ct).ConfigureAwait(false);
+									_channel.Writer.TryComplete();
+									return;
+								}
+								await _channel.Writer.WriteAsync(new ReadResp {
+									Event = ConvertToReadEvent(_uuidOption, @event)
+								}, _cancellationToken).ConfigureAwait(false);
+								nextPosition = @event.OriginalPosition ?? TFPos.Invalid;
+								readCount++;
+							}
+
+							if (completed.IsEndOfStream) {
+								await _channel.Writer.WriteAsync(new ReadResp {
+									AllStreamPosition = new() {
+										NextPosition = new() {
+											CommitPosition = (ulong)nextPosition.CommitPosition,
+											PreparePosition = (ulong)nextPosition.PreparePosition
+										},
+										LastPosition = new() {
+											CommitPosition = (ulong)completed.CurrentPos.CommitPosition,
+											PreparePosition = (ulong)completed.CurrentPos.PreparePosition
+										}
+									}
+								}, _cancellationToken).ConfigureAwait(false);
+								_channel.Writer.TryComplete();
+								return;
+							}
+
+							ReadPage(Position.FromInt64(
+								completed.NextPos.CommitPosition,
+								completed.NextPos.PreparePosition), readCount);
+							return;
+						case FilteredReadAllResult.AccessDenied:
+							_channel.Writer.TryComplete(RpcExceptions.AccessDenied());
+							return;
+						default:
+							_channel.Writer.TryComplete(RpcExceptions.UnknownError(completed.Result));
+							return;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -85,6 +85,27 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							context.CancellationToken),
 					(StreamOptionOneofCase.All,
 						CountOptionOneofCase.Count,
+						ReadDirection.Forwards,
+						FilterOptionOneofCase.Filter) => new Enumerators.ReadAllForwardsFiltered(
+							_publisher,
+							request.Options.All.ToPosition(),
+							request.Options.Count,
+							request.Options.ResolveLinks,
+							ConvertToEventFilter(true, request.Options.Filter),
+							user,
+							requiresLeader,
+							_readIndex,
+							request.Options.Filter.WindowCase switch {
+								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
+								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
+									.Max,
+								_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
+							},
+							context.Deadline,
+							options.UuidOption,
+							context.CancellationToken),
+					(StreamOptionOneofCase.All,
+						CountOptionOneofCase.Count,
 						ReadDirection.Backwards,
 						FilterOptionOneofCase.NoFilter) => new Enumerators.ReadAllBackwards(
 							_publisher,
@@ -93,6 +114,27 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							request.Options.ResolveLinks,
 							user,
 							requiresLeader,
+							context.Deadline,
+							options.UuidOption,
+							context.CancellationToken),
+					(StreamOptionOneofCase.All,
+						CountOptionOneofCase.Count,
+						ReadDirection.Backwards,
+						FilterOptionOneofCase.Filter) => new Enumerators.ReadAllBackwardsFiltered(
+							_publisher,
+							request.Options.All.ToPosition(),
+							request.Options.Count,
+							request.Options.ResolveLinks,
+							ConvertToEventFilter(true, request.Options.Filter),
+							user,
+							requiresLeader,
+							_readIndex,
+							request.Options.Filter.WindowCase switch {
+								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
+								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
+									.Max,
+								_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
+							},
 							context.Deadline,
 							options.UuidOption,
 							context.CancellationToken),


### PR DESCRIPTION
closes #3128

I think this also connects/closes #2980 (didn't see that before I made my issue, sorry for the noise!)

This PR adds enumerators for reading the $all stream forwards and backwards with a filter outside of a subscription in the gRPC API.

The enumerator is a combination of the SubscribeAllFiltered and ReadAllForwards, switching out ReadAllForward's `ClientMessage.ReadAllEventsForward` to the `ClientMessage.FilteredReadAllEventsForward` versions (and same for the Backwards direction).

I've tried out the changes manually against the Elixir community gRPC client here: https://github.com/NFIBrokerage/spear/pull/56#issue-980658981 and it seems to work pretty well!

I'm a total C# noob so if anything here is out of the ordinary, don't be shy to push some changes or let me know :slightly_smiling_face: 