### PR TITLE
Make VS nunit adapter happy

### DIFF
--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -372,16 +372,18 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			public int[] NodePriorities { get; set; } = { 1, 1, 1 };
 			public int[] EpochNumbers { get; set; } = { -1, -1, -1 };
 
+			private static int _id = 0;
 			private static string GenerateName(int expectedLeaderCandidateNode, int?[] previousLeader,
 				long[] writerCheckpoints,
 				long[] chaserCheckpoints, int[] nodePriorities, int[] epochNumbers) {
 				var nameBuilder = new StringBuilder();
+				nameBuilder.Append($"{_id++} ");
 				if (writerCheckpoints != null) {
 					if (nameBuilder.Length == 0)
 						nameBuilder.Append("Nodes with ");
 					else
 						nameBuilder.Append(" and ");
-					nameBuilder.AppendFormat("writer checkpoints ( {0} )", string.Join(",",
+					nameBuilder.AppendFormat("writer checkpoints << {0} >>", string.Join(",",
 						writerCheckpoints.Where(x => x != 1).Select((x, i) => $"{i} : wcp {x}")));
 				}
 
@@ -390,7 +392,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						nameBuilder.Append("Nodes with ");
 					else
 						nameBuilder.Append(" and ");
-					nameBuilder.AppendFormat("chaser checkpoints ( {0} )", string.Join(",",
+					nameBuilder.AppendFormat("chaser checkpoints << {0} >>", string.Join(",",
 						chaserCheckpoints.Where(x => x != 1).Select((x, i) => $"{i} : ccp {x}")));
 				}
 
@@ -399,12 +401,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 						nameBuilder.Append("Nodes with ");
 					else
 						nameBuilder.Append(" and ");
-					nameBuilder.AppendFormat("node priorities ( {0} )", string.Join(",",
+					nameBuilder.AppendFormat("node priorities << {0} >>", string.Join(",",
 						nodePriorities.Where(x => x != 0).Select((x, i) => $"{i} : np {x}")));
 				}
 				if (epochNumbers != null) {
 					nameBuilder.Append(nameBuilder.Length == 0 ? "Nodes with " : " and ");
-					nameBuilder.AppendFormat("epoch numbers ( {0} )", string.Join(",",
+					nameBuilder.AppendFormat("epoch numbers << {0} >>", string.Join(",",
 						epochNumbers.Where(x => x != 0).Select((x, i) => $"{i} : en {x}")));
 				}
 


### PR DESCRIPTION
Fixed: test adapter error when running all tests in visual studio

- give each instance of the parameterized test a unique name (otherwise they aren't all shown/counted(/run?) in VS)
- use chevrons instead of brackets.. using brackets causes an extra test to be shown in VS (with a similar name only without the brackets present) that cannot be run. this does not itself cause an error, BUT causes the following error when run in conjunction with other tests that also have brackets in their names such as in LegacyPolicyVerification

`An exception occurred while invoking executor 'executor://nunit3testexecutor/': Incorrect format for TestCaseFilter Error: Missing '('. Specify the correct format and try again. Note that the incorrect format can lead to no test getting executed.`