### PR TITLE
Allow ExpectedVersion.StreamExists for Delete and Tombstone

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/append_to_stream.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/append_to_stream.cs
@@ -319,7 +319,9 @@ namespace EventStore.Core.Tests.ClientAPI {
 			using (var store = BuildConnection(_node)) {
 				await store.ConnectAsync();
 
-				await store.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: false);
+				await store.AppendToStreamAsync(stream, ExpectedVersion.NoStream, TestEvent.NewTestEvent());
+
+				await store.DeleteStreamAsync(stream, ExpectedVersion.StreamExists, hardDelete: false);
 
 				await AssertEx.ThrowsAsync<StreamDeletedException>(
 					() => store.AppendToStreamAsync(stream, ExpectedVersion.StreamExists, TestEvent.NewTestEvent()));

--- a/src/EventStore.Core.Tests/ClientAPI/soft_delete.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/soft_delete.cs
@@ -257,7 +257,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream =
 				"setting_json_metadata_on_empty_soft_deleted_stream_recreates_stream_not_overriding_metadata";
 
-			await _conn.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: false);
+			await _conn.SetStreamMetadataAsync(stream, ExpectedVersion.Any, StreamMetadata.Build()
+				.SetTruncateBefore(long.MaxValue));
 
 			Assert.AreEqual(1, (await _conn.SetStreamMetadataAsync(stream, 0,
 				StreamMetadata.Build().SetMaxCount(100)
@@ -324,7 +325,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 			const string stream =
 				"setting_nonjson_metadata_on_empty_soft_deleted_stream_recreates_stream_overriding_metadata";
 
-			await _conn.DeleteStreamAsync(stream, ExpectedVersion.NoStream, hardDelete: false);
+			await _conn.SetStreamMetadataAsync(stream, ExpectedVersion.Any, StreamMetadata.Build()
+				.SetTruncateBefore(long.MaxValue));
 
 			Assert.AreEqual(1, (await _conn.SetStreamMetadataAsync(stream, 0, new byte[256])).NextExpectedVersion);
 

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
-		<PackageReference Include="GitHubActionsTestLogger" Version="1.2.0"/>
+		<PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
 		<PackageReference Include="Grpc.Core" Version="2.35.0" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.35.0" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.6" />

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/DeleteTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/DeleteTests.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client.Streams;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Transport.Grpc;
+using Google.Protobuf;
+using Grpc.Core;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
+	[TestFixture]
+	public class DeleteTests {
+		private const string StreamName = nameof(DeleteTests);
+
+		public abstract class DeleteExistingStreamSpecification<TLogFormat, TStreamId>
+			: GrpcSpecification<TLogFormat, TStreamId> {
+			private readonly DeleteReq.Types.Options _options;
+			private Exception _caughtException;
+
+			private DeleteExistingStreamSpecification(DeleteReq.Types.Options options) {
+				_options = new(options) {
+					StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamName) }
+				};
+			}
+
+			protected DeleteExistingStreamSpecification(StreamRevision expectedStreamRevision) : this(
+				new DeleteReq.Types.Options {
+					Revision = expectedStreamRevision.ToUInt64(),
+				}) {
+			}
+
+			protected DeleteExistingStreamSpecification(long expectedStreamState) : this(expectedStreamState switch {
+				ExpectedVersion.Any => new DeleteReq.Types.Options { Any = new() },
+				ExpectedVersion.NoStream => new DeleteReq.Types.Options { NoStream = new() },
+				ExpectedVersion.StreamExists => new DeleteReq.Types.Options { StreamExists = new() },
+				_ => throw new InvalidOperationException()
+			}) {
+			}
+
+			[Test]
+			public void no_exception_is_thrown() {
+				Assert.Null(_caughtException);
+			}
+
+			[Test]
+			public async Task the_stream_is_deleted() {
+				using var call = StreamsClient.Read(new() {
+					Options = new() {
+						UuidOption = new() { Structured = new() },
+						NoFilter = new(),
+						ResolveLinks = false,
+						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+						Count = 1,
+						Stream = new() {
+							StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamName) },
+							Start = new()
+						}
+					}
+				}, GetCallOptions());
+
+				var responses = await call.ResponseStream.ReadAllAsync().ToArrayAsync();
+
+				Assert.AreEqual(1, responses.Length);
+				Assert.AreEqual(new ReadResp {
+					StreamNotFound = new() {
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamName) }
+					}
+				}, responses[0]);
+			}
+
+			protected override async Task Given() => await AppendToStreamBatch(new BatchAppendReq {
+				Options = new() {
+					NoStream = new(),
+					StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamName) }
+				},
+				CorrelationId = Uuid.NewUuid().ToDto(),
+				IsFinal = true,
+				ProposedMessages = { CreateEvents(1) }
+			});
+
+			protected override async Task When() {
+				using var call = StreamsClient.DeleteAsync(new() {
+					Options = _options
+				}, GetCallOptions());
+
+				try {
+					await call.ResponseAsync;
+				} catch (Exception ex) {
+					_caughtException = ex;
+				}
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class DeleteExistingStreamExpectedRevision<TLogFormat, TStreamId>
+			: DeleteExistingStreamSpecification<TLogFormat, TStreamId> {
+			public DeleteExistingStreamExpectedRevision() : base(StreamRevision.Start) { }
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class DeleteExistingStreamAny<TLogFormat, TStreamId>
+			: DeleteExistingStreamSpecification<TLogFormat, TStreamId> {
+			public DeleteExistingStreamAny() : base(ExpectedVersion.Any) { }
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class DeleteExistingStreamExists<TLogFormat, TStreamId>
+			: DeleteExistingStreamSpecification<TLogFormat, TStreamId> {
+			public DeleteExistingStreamExists() : base(ExpectedVersion.StreamExists) { }
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/TombstoneTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/TombstoneTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client.Streams;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Transport.Grpc;
+using Google.Protobuf;
+using Grpc.Core;
+using NUnit.Framework;
+using GrpcConstants = EventStore.Core.Services.Transport.Grpc.Constants;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
+	[TestFixture]
+	public class TombstoneTests {
+		private const string StreamName = nameof(TombstoneTests);
+
+		public abstract class TombstoneExistingStreamSpecification<TLogFormat, TStreamId>
+			: GrpcSpecification<TLogFormat, TStreamId> {
+			private readonly TombstoneReq.Types.Options _options;
+			private Exception _caughtException;
+
+			private TombstoneExistingStreamSpecification(TombstoneReq.Types.Options options) {
+				_options = new(options) {
+					StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamName) }
+				};
+			}
+
+			protected TombstoneExistingStreamSpecification(StreamRevision expectedStreamRevision) : this(
+				new TombstoneReq.Types.Options {
+					Revision = expectedStreamRevision.ToUInt64(),
+				}) { }
+
+			protected TombstoneExistingStreamSpecification(long expectedStreamState) : this(expectedStreamState switch {
+				ExpectedVersion.Any => new TombstoneReq.Types.Options { Any = new() },
+				ExpectedVersion.NoStream => new TombstoneReq.Types.Options { NoStream = new() },
+				ExpectedVersion.StreamExists => new TombstoneReq.Types.Options { StreamExists = new() },
+				_ => throw new InvalidOperationException()
+			}){ }
+
+			[Test]
+			public void no_exception_is_thrown() {
+				Assert.Null(_caughtException);
+			}
+			
+			[Test]
+			public void the_stream_is_deleted() {
+				var ex = Assert.ThrowsAsync<RpcException>(async () => {
+					using var call = StreamsClient.Read(new () {
+						Options = new() {
+							UuidOption = new() { Structured = new() },
+							NoFilter = new(),
+							ResolveLinks = false,
+							ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+							Count = 1,
+							Stream = new() {
+								StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamName) },
+								Start = new()
+							}
+						}
+					}, GetCallOptions());
+
+					await call.ResponseStream.ReadAllAsync().ToArrayAsync();
+				});
+
+				Assert.NotNull(ex);
+				Assert.AreEqual(StatusCode.FailedPrecondition, ex.Status.StatusCode);
+				Assert.Contains((GrpcConstants.Exceptions.ExceptionKey, GrpcConstants.Exceptions.StreamDeleted),
+					ex.Trailers.Select(x => (x.Key, x.Value)).ToArray());
+			}
+
+			protected override Task Given() => _options.ExpectedStreamRevisionCase switch {
+				TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream => Task.CompletedTask,
+				_ => AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						NoStream = new(),
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamName) }
+					},
+					CorrelationId = Uuid.NewUuid().ToDto(),
+					IsFinal = true,
+					ProposedMessages = { CreateEvents(1) }
+				}).AsTask()
+			};
+
+			protected override async Task When() {
+				using var call = StreamsClient.TombstoneAsync(new() {
+					Options = _options
+				}, GetCallOptions());
+
+				try {
+					await call.ResponseAsync;
+				} catch (Exception ex) {
+					_caughtException = ex;
+				}
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class TombstoneExistingStreamExpectedRevision<TLogFormat, TStreamId>
+			: TombstoneExistingStreamSpecification<TLogFormat, TStreamId> {
+			public TombstoneExistingStreamExpectedRevision() : base(StreamRevision.Start) { }
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class TombstoneExistingStreamAny<TLogFormat, TStreamId>
+			: TombstoneExistingStreamSpecification<TLogFormat, TStreamId> {
+			public TombstoneExistingStreamAny() : base(ExpectedVersion.Any) { }
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class TombstoneExistingStreamNoStream<TLogFormat, TStreamId>
+			: TombstoneExistingStreamSpecification<TLogFormat, TStreamId> {
+			public TombstoneExistingStreamNoStream() : base(ExpectedVersion.NoStream) { }
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class TombstoneExistingStreamExists<TLogFormat, TStreamId>
+			: TombstoneExistingStreamSpecification<TLogFormat, TStreamId> {
+			public TombstoneExistingStreamExists() : base(ExpectedVersion.StreamExists) { }
+		}
+	}
+}

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -464,11 +464,12 @@ namespace EventStore.Core.Messages {
 				IReadOnlyDictionary<string, string> tokens = null, CancellationToken cancellationToken = default)
 				: base(internalCorrId, correlationId, envelope, requireLeader, user, tokens) {
 				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
-				if (expectedVersion < Data.ExpectedVersion.Any)
-					throw new ArgumentOutOfRangeException(nameof(expectedVersion));
-
 				EventStreamId = eventStreamId;
-				ExpectedVersion = expectedVersion;
+				ExpectedVersion = expectedVersion switch {
+					Data.ExpectedVersion.Invalid => throw new ArgumentOutOfRangeException(nameof(expectedVersion)),
+					< Data.ExpectedVersion.StreamExists => throw new ArgumentOutOfRangeException(nameof(expectedVersion)),
+					_ => expectedVersion
+				};
 				HardDelete = hardDelete;
 				CancellationToken = cancellationToken;
 			}

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -413,6 +413,15 @@ namespace EventStore.Core.Services.Storage {
 					// SOFT DELETE
 					var metastreamId = _systemStreams.MetaStreamOf(streamId);
 					var expectedVersion = _indexWriter.GetStreamLastEventNumber(metastreamId);
+
+					if (_indexWriter.GetStreamLastEventNumber(streamId) < 0 && expectedVersion < 0) {
+						var result = new CommitCheckResult<TStreamId>(CommitDecision.WrongExpectedVersion, streamId,
+							-1, -1, -1, false);
+						ActOnCommitCheckFailure(message.Envelope, message.CorrelationId, result);
+						return;
+					}
+
+
 					const PrepareFlags flags = PrepareFlags.SingleWrite | PrepareFlags.IsCommitted |
 											   PrepareFlags.IsJson;
 					var data = new StreamMetadata(truncateBefore: EventNumber.DeletedStream).ToJsonBytes();


### PR DESCRIPTION
Added: support for ExpectedVersion.StreamExists in Soft Delete and Tombstone stream operations
Changed: Soft Deleting a stream that was never created now results in an error
