### PR TITLE
Added verification if message is of NotHandled type in PersistentSubscriptions Read message handling

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -229,6 +229,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				}
 
 				async Task OnMessage(Message message, CancellationToken ct) {
+					if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+						_subscriptionIdSource.TrySetException(ex);
+						return;
+					}
+					
 					switch (message) {
 						case ClientMessage.SubscriptionDropped dropped:
 							switch (dropped.Reason) {


### PR DESCRIPTION
Fixed: Added verification checking if a message is of NotHandled type in PersistentSubscriptions Read message handling

I noticed we were missing check for NotHandled message type in the PersistentSubscription Read message handling? We have such in other places, e.g. https://github.com/EventStore/EventStore/blob/master/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Create.cs#L165).

This PR is not fixing the root cause, but at least the message should be cleaner than the current one: `Envelope callback expected either PersistentSubscriptionConfirmation or NotHandled, received NotHandled instead.`

See more in: https://github.com/EventStore/EventStore-Client-NodeJS/issues/160.

I'm not sure how to test that. I wasn't able to find reference tests for NotHandled messages in other places.