### PR TITLE
Updated "Event Stream" documentation's sidebar configuration to follow convention

### DIFF
--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -136,7 +136,9 @@ module.exports = [
     {
         title: "Event streams",
         collapsable: true,
+        path: "streams/",
         children: [
+            "streams/",
             "streams/metadata-and-reserved-names.md",
             "streams/deleting-streams-and-events.md",
             "streams/system-streams.md"

--- a/docs/streams/README.md
+++ b/docs/streams/README.md
@@ -1,0 +1,10 @@
+# Event Streams
+
+EventStoreDB is a database designed for storing events. In contrast with state-oriented databases that only keeps the latest version of the entity state, you can store each state change as a separate event.
+
+Events are logically grouped into streams. They are the representation of the entities. All the entity state mutation ends up as the persisted event. 
+
+Read more:
+- [Metadata and reserved names.](./metadata-and-reserved-names.md)
+- [Deleting streams and events.](./deleting-streams-and-events.md)
+- [System events and streams.](./system-streams.md)


### PR DESCRIPTION
This PR is adding the README file to align it with other database docs convention. This is also a preparation to makes docs compliant with the docs v2 structure.

Preview: https://6141cc09b486c319d05fb76d--developers-eventstore.netlify.app/server/v5/docs/streams/

_**Disclaimer**: I'm not a huge fan of those intro pages, but they're also in other places, and we'll have to tackle that in general later on._