### PR TITLE
Quorum detection fix

### DIFF
--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -111,6 +111,9 @@ namespace EventStore.Core.Services.Replication {
 		public void Handle(SystemMessage.StateChangeMessage message) {
 			_state = message.State;
 
+			if (message.State == VNodeState.Leader)
+				_noQuorumTimestamp = TimeSpan.Zero;
+
 			if (message.State == VNodeState.ShuttingDown)
 				_stop = true;
 		}


### PR DESCRIPTION
Fixed: Node stays stuck in Leader state until next elections if a quorum never emerges

If a quorum never emerges, the Leader stays stuck as Leader until the next elections are triggered by other nodes.

```
private void ManageNoQuorumDetection() {
    if (_state == VNodeState.Leader) {
        var now = _stopwatch.Elapsed;
        if (_subscriptions.Count(x => x.Value.IsPromotable) >= _clusterSize / 2) // everything is ok
            _noQuorumTimestamp = TimeSpan.Zero;
        else {
```
In the above snippet, _noQuorumTimestamp is reset to TimeSpan.Zero only when a quorum is first detected.
But.. if there's never an initial quorum, _noQuorumTimestamp will keep its previous value (which will no longer be zero, after the first quorum timeout)

This can be reproduced by launching 2 nodes out of a 3-node cluster with both nodes having `--int-host-advertise-as` set to a fictitious IP address. Elections will succeed but not the internal TCP connection to the leader.

The fix just resets the timestamp to zero, when the state changes to leader meaning "Assume that I have a quorum right now, and time out in the next 3 seconds if an initial quorum is not formed"

