### PR TITLE
Wait for Replication and Indexing to complete before becoming leader

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/read_all_events_filtered_paging_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_all_events_filtered_paging_should.cs
@@ -112,7 +112,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.GetAwaiter()
 				.GetResult();
 
-			Assert.AreEqual(2, slice.Events.Length); // Includes system events at start of stream
+			Assert.AreEqual(1, slice.Events.Length); // Includes system events at start of stream (inc epoch-information)
 		}
 
 		[Test, Category("LongRunning")]

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -504,7 +504,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			);
 
 		protected override Message When() =>
-			new SystemMessage.BecomeLeader(Guid.NewGuid(),0);
+			new SystemMessage.BecomeLeader(Guid.NewGuid());
 
 		[Test]
 		public void should_update_gossip() {

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -324,8 +324,8 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			EpochManager.WriteNewEpoch(8);
 
 			_replicaEpochs = new List<Epoch> {
-				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 800, 3, Guid.NewGuid()),
-				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 400, 2, Guid.NewGuid()),
+				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 8000, 3, Guid.NewGuid()),
+				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 4000, 2, Guid.NewGuid()),
 				new Epoch(_uncachedLeaderEpochs[0].EpochPosition, _uncachedLeaderEpochs[0].EpochNumber, _uncachedLeaderEpochs[0].EpochId),
 				new Epoch(_uncachedLeaderEpochs[1].EpochPosition, _uncachedLeaderEpochs[1].EpochNumber, _uncachedLeaderEpochs[1].EpochId)
 			};

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				queueStatsManager: new QueueStatsManager());
 
 			Service.Handle(new SystemMessage.SystemStart());
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			ReplicaSubscriptionId = AddSubscription(ReplicaId, true, out ReplicaManager1);
 			ReplicaSubscriptionId2 = AddSubscription(ReplicaId2, true, out ReplicaManager2);
@@ -114,7 +114,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		public abstract void When();
 		protected void BecomeLeader() {
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 		}
 
 		protected void BecomeUnknown() {

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -71,7 +71,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				new QueueStatsManager());
 
 			Service.Handle(new SystemMessage.SystemStart());
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			When();
 		}

--- a/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/with_clustered_replication_tracking_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/with_clustered_replication_tracking_service.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Replication.ReplicationTracking {
 		public abstract void When();
 		
 		protected void BecomeLeader() {
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 		}
 
 		protected void BecomeUnknown() {

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/InaugurationManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/InaugurationManagerTests.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using EventStore.Core.Cluster;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.VNode;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+	public abstract class InaugurationManagerTests {
+		protected readonly Guid _correlationId1 = Guid.Parse("00000000-0000-0000-0000-0000000000c1");
+		protected readonly Guid _correlationId2 = Guid.Parse("00000000-0000-0000-0000-0000000000c2");
+		protected readonly Guid _correlationId3 = Guid.Parse("00000000-0000-0000-0000-0000000000c3");
+		protected readonly int _epochNumber = 15;
+		protected readonly MemberInfo _leader =
+			new MemberInfo(new MemberInfoDto {
+				InternalTcpIp = "localhost",
+				HttpEndPointIp = "localhost",
+			});
+		protected readonly long _replicationTarget = 400;
+		protected readonly long _indexTarget = 400;
+
+		protected InaugurationManager _sut;
+		protected FakePublisher _publisher;
+		protected InMemoryCheckpoint _replicationCheckpoint;
+		protected InMemoryCheckpoint _indexCheckpoint;
+
+		[SetUp]
+		public void SetUp() {
+			_publisher = new FakePublisher();
+			_replicationCheckpoint = new InMemoryCheckpoint();
+			_indexCheckpoint = new InMemoryCheckpoint();
+			_sut = new InaugurationManager(_publisher, _replicationCheckpoint, _indexCheckpoint);
+			Given();
+		}
+
+		protected abstract void Given();
+
+		protected void When(Message m) {
+			_sut.Handle((dynamic)m);
+		}
+
+		protected SystemMessage.EpochWritten GenEpoch(int epochNumber) {
+			var epoch = new SystemMessage.EpochWritten(new EpochRecord(
+							epochPosition: _replicationTarget - 1,
+							epochNumber: epochNumber,
+							epochId: Guid.NewGuid(),
+							prevEpochPosition: _replicationTarget - 20,
+							timeStamp: DateTime.UtcNow,
+							leaderInstanceId: Guid.NewGuid()));
+			return epoch;
+		}
+
+		protected void ProgressReplication() {
+			_replicationCheckpoint.Write(_replicationTarget / 2);
+			_replicationCheckpoint.Flush();
+		}
+
+		protected void CompleteReplication() {
+			_replicationCheckpoint.Write(_replicationTarget);
+			_replicationCheckpoint.Flush();
+		}
+
+		protected void ProgressIndexing() {
+			_indexCheckpoint.Write(_indexTarget / 2);
+			_indexCheckpoint.Flush();
+		}
+
+		protected void CompleteIndexing() {
+			_indexCheckpoint.Write(_indexTarget);
+			_indexCheckpoint.Flush();
+		}
+
+		protected static T AssertIsType<T>(object o) {
+			Assert.IsInstanceOf<T>(o);
+			return (T)o;
+		}
+
+		// check that we have reset to initial state, do this by checking we can
+		// proceed forward from it
+		protected void AssertInitial() {
+			Assert.IsEmpty(_publisher.Messages);
+			_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId3));
+			AssertWaitingForChaser(_correlationId3);
+		}
+
+		// check that we have reset to waiting fo chaser, do this by checking we can
+		// proceed forward from it
+		protected void AssertWaitingForChaser(Guid expectedCorrelationId) {
+			Assert.IsEmpty(_publisher.Messages);
+			_sut.Handle(new SystemMessage.ChaserCaughtUp(expectedCorrelationId));
+			Assert.AreEqual(1, _publisher.Messages.Count);
+			Assert.IsInstanceOf<SystemMessage.WriteEpoch>(_publisher.Messages[0]);
+		}
+
+		protected void AssertSentBecomeLeader() {
+			Assert.AreEqual(1, _publisher.Messages.Count);
+			var becomeLeader = AssertIsType<SystemMessage.BecomeLeader>(_publisher.Messages[0]);
+			Assert.AreEqual(_correlationId1, becomeLeader.CorrelationId);
+			_publisher.Messages.Clear();
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_initial_state.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_initial_state.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+	[TestFixture]
+	public class given_initial_state : InaugurationManagerTests {
+		protected override void Given() {
+			_publisher.Messages.Clear();
+		}
+
+		[Test]
+		public void when_become_pre_leader() {
+			When(new SystemMessage.BecomePreLeader(_correlationId1));
+			AssertWaitingForChaser(_correlationId1);
+		}
+
+		[Test]
+		public void when_become_other_node_state() {
+			When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+
+	[TestFixture]
+	public class given_waiting_for_chaser : InaugurationManagerTests {
+		protected override void Given() {
+			_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+			_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
+			_publisher.Messages.Clear();
+		}
+
+		[Test]
+		public void when_chaser_caught_up() {
+			When(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			Assert.AreEqual(1, _publisher.Messages.Count);
+			var writeEpoch = AssertIsType<SystemMessage.WriteEpoch>(_publisher.Messages[0]);
+			Assert.AreEqual(_epochNumber, writeEpoch.EpochNumber);
+		}
+
+		[Test]
+		public void when_chaser_caught_up_with_unknown_correlation_id() {
+			When(new SystemMessage.ChaserCaughtUp(_correlationId2));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_become_pre_leader() {
+			When(new SystemMessage.BecomePreLeader(_correlationId2));
+			AssertWaitingForChaser(_correlationId2);
+		}
+
+		[Test]
+		public void when_become_other_node_state() {
+			When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_conditions.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_conditions.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+	[TestFixture]
+	public class given_waiting_for_conditions : InaugurationManagerTests {
+		protected override void Given() {
+			_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+			_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
+			_sut.Handle(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			_sut.Handle(GenEpoch(_epochNumber));
+			_publisher.Messages.Clear();
+		}
+
+		[Test]
+		public void when_transition_triggered_by_indexedto() {
+			ProgressReplication();
+			ProgressIndexing();
+			CompleteReplication();
+			CompleteIndexing();
+			Assert.IsEmpty(_publisher.Messages);
+
+			When(new ReplicationTrackingMessage.IndexedTo(_indexCheckpoint.Read()));
+
+			AssertSentBecomeLeader();
+		}
+
+		[Test]
+		public void when_transition_triggered_by_replicatedto() {
+			ProgressReplication();
+			ProgressIndexing();
+			CompleteReplication();
+			CompleteIndexing();
+			Assert.IsEmpty(_publisher.Messages);
+
+			When(new ReplicationTrackingMessage.ReplicatedTo(_replicationCheckpoint.Read()));
+
+			AssertSentBecomeLeader();
+		}
+
+		[Test]
+		public void when_transition_triggered_by_checkconditions() {
+			CompleteReplication();
+			CompleteIndexing();
+			Assert.IsEmpty(_publisher.Messages);
+
+			When(new SystemMessage.CheckInaugurationConditions());
+
+			Assert.AreEqual(2, _publisher.Messages.Count);
+			Assert.IsInstanceOf<TimerMessage.Schedule>(_publisher.Messages[0]);
+			_publisher.Messages.RemoveAt(0);
+
+			AssertSentBecomeLeader();
+		}
+
+		[Test]
+		public void cant_become_leader_twice() {
+			CompleteReplication();
+			CompleteIndexing();
+			Assert.IsEmpty(_publisher.Messages);
+
+			When(new ReplicationTrackingMessage.ReplicatedTo(_replicationCheckpoint.Read()));
+			When(new SystemMessage.CheckInaugurationConditions());
+
+			AssertSentBecomeLeader();
+		}
+
+		[Test]
+		public void when_epoch_written() {
+			When(GenEpoch(_epochNumber));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_chaser_caught_up() {
+			When(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_become_pre_leader() {
+			When(new SystemMessage.BecomePreLeader(_correlationId2));
+			AssertWaitingForChaser(_correlationId2);
+		}
+
+		[Test]
+		public void when_become_other_node_state() {
+			When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_writing_epoch.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_writing_epoch.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+	[TestFixture]
+	public class given_writing_epoch : InaugurationManagerTests {
+		protected override void Given() {
+			_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+			_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
+			_sut.Handle(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			_publisher.Messages.Clear();
+		}
+
+		[Test]
+		public void when_epoch_written() {
+			When(GenEpoch(_epochNumber));
+			Assert.AreEqual(2, _publisher.Messages.Count);
+			Assert.IsInstanceOf<SystemMessage.EnablePreLeaderReplication>(_publisher.Messages[0]);
+			var schedule = AssertIsType<TimerMessage.Schedule>(_publisher.Messages[1]);
+			Assert.IsInstanceOf<SystemMessage.CheckInaugurationConditions>(schedule.ReplyMessage);
+		}
+
+		[Test]
+		public void when_epoch_written_with_unexpected_number() {
+			When(GenEpoch(_epochNumber + 1));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_epoch_written_and_conditions_instantly_met() {
+			CompleteReplication();
+			CompleteIndexing();
+			When(GenEpoch(_epochNumber));
+
+			Assert.AreEqual(3, _publisher.Messages.Count);
+			Assert.IsInstanceOf<SystemMessage.EnablePreLeaderReplication>(_publisher.Messages[0]);
+			Assert.IsInstanceOf<SystemMessage.BecomeLeader>(_publisher.Messages[1]);
+			Assert.IsInstanceOf<TimerMessage.Schedule>(_publisher.Messages[2]);
+		}
+
+		[Test]
+		public void when_chaser_caught_up() {
+			When(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_become_pre_leader() {
+			When(new SystemMessage.BecomePreLeader(_correlationId2));
+			AssertWaitingForChaser(_correlationId2);
+		}
+
+		[Test]
+		public void when_become_other_node_state() {
+			When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -135,10 +135,7 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public readonly int EpochNumber;
-
-			public BecomeLeader(Guid correlationId, int epochNumber) : base(correlationId, VNodeState.Leader) {
-				EpochNumber = epochNumber;
+			public BecomeLeader(Guid correlationId) : base(correlationId, VNodeState.Leader) {
 			}
 		}
 
@@ -401,6 +398,28 @@ namespace EventStore.Core.Messages {
 			public ChaserCaughtUp(Guid correlationId) {
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				CorrelationId = correlationId;
+			}
+		}
+
+		public class EnablePreLeaderReplication : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public EnablePreLeaderReplication() {
+			}
+		}
+
+		public class CheckInaugurationConditions : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public CheckInaugurationConditions() {
 			}
 		}
 

--- a/src/EventStore.Core/Services/Replication/ReplicationTrackingService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicationTrackingService.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Services.Replication {
 		}
 
 		public bool IsCurrent() {
-			Debug.Assert(_state == VNodeState.Leader);
+			Debug.Assert(_state == VNodeState.Leader || _state == VNodeState.PreLeader);
 			return Interlocked.Read(ref _publishedPosition) == _replicationCheckpoint.Read();
 		}
 
@@ -72,7 +72,7 @@ namespace EventStore.Core.Services.Replication {
 			try {
 				while (!_stop) {
 					_replicationChange.Reset();
-					if (_state == VNodeState.Leader) {
+					if (_state == VNodeState.Leader || _state == VNodeState.PreLeader) {
 						//Publish Log Commit Position
 						var newPos = _replicationCheckpoint.Read();
 						if (newPos > Interlocked.Read(ref _publishedPosition)) {
@@ -96,7 +96,7 @@ namespace EventStore.Core.Services.Replication {
 		}
 
 		public void Handle(ReplicationTrackingMessage.LeaderReplicatedTo message) {
-			if (_state != VNodeState.Leader && message.LogPosition > _replicationCheckpoint.Read()) {
+			if (_state != VNodeState.Leader && _state != VNodeState.PreLeader && message.LogPosition > _replicationCheckpoint.Read()) {
 				_replicationCheckpoint.Write(message.LogPosition);
 				_replicationCheckpoint.Flush();
 				_publisher.Publish(new ReplicationTrackingMessage.ReplicatedTo(message.LogPosition));
@@ -136,7 +136,7 @@ namespace EventStore.Core.Services.Replication {
 
 
 		public void Handle(ReplicationTrackingMessage.ReplicaWriteAck message) {
-			if (_state != VNodeState.Leader) { return; }
+			if (_state != VNodeState.Leader && _state != VNodeState.PreLeader) { return; }
 			if (_replicaLogPositions.TryGetValue(message.SubscriptionId, out var position) &&
 				message.ReplicationLogPosition <= position) { return; }
 			_replicaLogPositions.AddOrUpdate(message.SubscriptionId, message.ReplicationLogPosition, (k, v) => message.ReplicationLogPosition);
@@ -144,7 +144,7 @@ namespace EventStore.Core.Services.Replication {
 		}
 
 		public void Handle(ReplicationTrackingMessage.WriterCheckpointFlushed message) {
-			if (_state != VNodeState.Leader) { return; }
+			if (_state != VNodeState.Leader && _state != VNodeState.PreLeader) { return; }
 			UpdateReplicationPosition();
 		}
 
@@ -157,7 +157,7 @@ namespace EventStore.Core.Services.Replication {
 		}
 
 		public void Handle(SystemMessage.VNodeConnectionLost msg) {
-			if (_state != VNodeState.Leader || !msg.SubscriptionId.HasValue) return;
+			if ((_state != VNodeState.Leader && _state != VNodeState.PreLeader) || !msg.SubscriptionId.HasValue) return;
 			_replicaLogPositions.TryRemove(msg.SubscriptionId.Value, out _);
 		}
 

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/AllReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/AllReader.cs
@@ -48,7 +48,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 
 		public IndexReadAllResult ReadAllEventsForward(TFPos pos, int maxCount) {
-			return ReadAllEventsForwardInternal(pos, maxCount, maxCount, EventFilter.None);
+			return ReadAllEventsForwardInternal(pos, maxCount, int.MaxValue, EventFilter.DefaultAllFilter);
 		}
 
 		public IndexReadAllResult FilteredReadAllEventsForward(TFPos pos, int maxCount, int maxSearchWindow,
@@ -169,7 +169,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 		
 		public IndexReadAllResult ReadAllEventsBackward(TFPos pos, int maxCount) {
-			return ReadAllEventsBackwardInternal(pos, maxCount, maxCount, EventFilter.None);
+			return ReadAllEventsBackwardInternal(pos, maxCount, int.MaxValue, EventFilter.DefaultAllFilter);
 		}
 
 		public IndexReadAllResult FilteredReadAllEventsBackward(TFPos pos, int maxCount, int maxSearchWindow,

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/EventFilter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/EventFilter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
@@ -7,6 +8,7 @@ using EventStore.Core.Messages;
 namespace EventStore.Core.Services.Storage.ReaderIndex {
 	public static class EventFilter {
 		public static IEventFilter None => new AlwaysAllowStrategy();
+		public static IEventFilter DefaultAllFilter { get; } = new DefaultAllFilterStrategy();
 
 		public static class StreamName {
 			public static IEventFilter Prefixes(params string[] prefixes)
@@ -44,6 +46,14 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				StreamName.Regex(filter.Data[0]),
 				_ => throw new Exception() // Invalid filter
 			};
+		}
+
+		public sealed class DefaultAllFilterStrategy : IEventFilter {
+			[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+			public bool IsEventAllowed(EventRecord eventRecord) =>
+				eventRecord.EventStreamId != SystemStreams.EpochInformationStream;
+
+			public override string ToString() => nameof(DefaultAllFilterStrategy);
 		}
 
 		private class AlwaysAllowStrategy : IEventFilter {

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -23,6 +23,7 @@ namespace EventStore.Core.Services {
 		public const string SettingsStream = "$settings";
 		public const string StatsStreamPrefix = "$stats";
 		public const string ScavengesStream = "$scavenges";
+		public const string EpochInformationStream = "$epoch-information";
 
 		public static bool IsSystemStream(string streamId) {
 			return streamId.Length != 0 && streamId[0] == '$';
@@ -67,6 +68,7 @@ namespace EventStore.Core.Services {
 		public const string StreamReference = "$@";
 		public const string StreamMetadata = "$metadata";
 		public const string Settings = "$settings";
+		public const string EpochInformation = "$epoch-information";
 
 		public const string V2__StreamCreated_InIndex = "StreamCreated";
 		public const string V1__StreamCreated__ = "$stream-created";

--- a/src/EventStore.Core/Services/VNode/InaugurationManager.cs
+++ b/src/EventStore.Core/Services/VNode/InaugurationManager.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.Checkpoint;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.Core.Services.VNode {
+	public class InaugurationManager :
+		IHandle<SystemMessage.StateChangeMessage>,
+		IHandle<SystemMessage.ChaserCaughtUp>,
+		IHandle<SystemMessage.EpochWritten>,
+		IHandle<SystemMessage.CheckInaugurationConditions>,
+		IHandle<ElectionMessage.ElectionsDone>,
+		IHandle<ReplicationTrackingMessage.ReplicatedTo>,
+		IHandle<ReplicationTrackingMessage.IndexedTo> {
+
+		private readonly ILogger _log = Serilog.Log.ForContext<InaugurationManager>();
+		private readonly IPublisher _publisher;
+		private readonly ICheckpoint _replicationCheckpoint;
+		private readonly ICheckpoint _indexCheckpoint;
+		private readonly Message _scheduleCheckInaugurationConditions;
+
+		private VNodeState _nodeState;
+		private ManagerState _managerState;
+		private Guid _stateCorrelationId;
+		private int _currentEpochNumber;
+		private long _replicationCheckpointTarget;
+		private long _indexCheckpointTarget;
+
+		private enum ManagerState {
+			Initial,
+			WaitingForChaser,
+			WritingEpoch,
+			WaitingForConditions,
+			BecomingLeader,
+		}
+
+		public InaugurationManager(
+			IPublisher publisher,
+			ICheckpoint replicationCheckpoint,
+			ICheckpoint indexCheckpoint) {
+
+			_log.Information("Using {name}", nameof(InaugurationManager));
+			_publisher = publisher;
+			_replicationCheckpoint = replicationCheckpoint;
+			_indexCheckpoint = indexCheckpoint;
+
+			_scheduleCheckInaugurationConditions = TimerMessage.Schedule.Create(
+				triggerAfter: TimeSpan.FromSeconds(1),
+				envelope: new PublishEnvelope(_publisher),
+				replyMessage: new SystemMessage.CheckInaugurationConditions());
+		}
+
+		public void Handle(ElectionMessage.ElectionsDone received) {
+			_currentEpochNumber = received.ProposalNumber;
+			Received(received, "currentEpochNumber {currentEpochNumber}.", _currentEpochNumber);
+		}
+
+		public void Handle(SystemMessage.StateChangeMessage received) {
+			if (received is SystemMessage.BecomePreLeader becomePreLeader) {
+				HandleBecomePreLeader(becomePreLeader);
+			} else {
+				HandleBecomeOtherNodeState(received);
+			}
+		}
+
+		private void HandleBecomePreLeader(SystemMessage.BecomePreLeader received) {
+			Received(
+				received,
+				"Starting inauguration process with correlation id {currentCorrelationId}. Waiting for chaser.",
+				received.CorrelationId);
+			_nodeState = received.State;
+			_managerState = ManagerState.WaitingForChaser;
+			_stateCorrelationId = received.CorrelationId;
+		}
+
+		private void HandleBecomeOtherNodeState(SystemMessage.StateChangeMessage received) {
+			if (_managerState != ManagerState.Initial) {
+				Received(received, "Inauguration process is now stopped.");
+				_managerState = ManagerState.Initial;
+			}
+
+			_nodeState = received.State;
+		}
+
+		public void Handle(SystemMessage.ChaserCaughtUp received) {
+			if (_managerState != ManagerState.WaitingForChaser) {
+				// will get this in prereplica and prereadonly replica
+				Ignore(received, "Not waiting for chaser.");
+			} else if (received.CorrelationId != _stateCorrelationId) {
+				Ignore(
+					received,
+					"Current correlation id is {currentCorrelationId} but received {receivedCorrelationId}.",
+					_stateCorrelationId,
+					received.CorrelationId);
+			} else {
+				Respond(
+					received,
+					new SystemMessage.WriteEpoch(_currentEpochNumber),
+					"currentEpochNumber {currentEpochNumber}.",
+					_currentEpochNumber);
+				_managerState = ManagerState.WritingEpoch;
+			}
+		}
+
+		public void Handle(SystemMessage.EpochWritten received) {
+			if (_managerState != ManagerState.WritingEpoch) {
+				Ignore(received, "Not writing epoch.");
+			} else if (received.Epoch.EpochNumber != _currentEpochNumber) {
+				Ignore(
+					received,
+					"Current epoch number is {currentEpochNumber} but received {receivedEpochNumber}.",
+					_currentEpochNumber,
+					received.Epoch.EpochNumber);
+			} else {
+				Respond(received, new SystemMessage.EnablePreLeaderReplication());
+				_managerState = ManagerState.WaitingForConditions;
+
+				// want to replicate past the start of the epoch we just wrote.
+				_replicationCheckpointTarget = received.Epoch.EpochPosition + 1;
+
+				// and index past it too, to the $epoch-information event that immediately follows it
+				_indexCheckpointTarget = received.Epoch.EpochPosition + 1;
+
+				ConsiderBecomingLeader(received, log: true);
+				_publisher.Publish(_scheduleCheckInaugurationConditions);
+			}
+		}
+
+		public void Handle(ReplicationTrackingMessage.ReplicatedTo received) {
+			if (_managerState != ManagerState.WaitingForConditions) {
+				// silently ignore. we'll get these all the time
+			} else {
+				ConsiderBecomingLeader(received, log: false);
+			}
+		}
+
+		public void Handle(ReplicationTrackingMessage.IndexedTo received) {
+			if (_managerState != ManagerState.WaitingForConditions) {
+				// silently ignore. we'll get these all the time
+			} else {
+				ConsiderBecomingLeader(received, log: false);
+			}
+		}
+
+		public void Handle(SystemMessage.CheckInaugurationConditions received) {
+			if (_managerState != ManagerState.WaitingForConditions) {
+				Ignore(received, "Not waiting for conditions.");
+			} else {
+				Respond(received, _scheduleCheckInaugurationConditions);
+				ConsiderBecomingLeader(received, log: true);
+			}
+		}
+
+		private void ConsiderBecomingLeader(Message received, bool log) {
+			var replicationCurrent = _replicationCheckpoint.Read();
+			var indexCurrent = _indexCheckpoint.Read();
+			var replicationDone = replicationCurrent >= _replicationCheckpointTarget;
+			var indexDone = indexCurrent >= _indexCheckpointTarget;
+
+			if (log || (replicationDone && indexDone)) {
+				LogExtraInformation(
+					"Replication {progress}: {current:N0}/{target:N0}. Remaining: {remaining:N0}.",
+					replicationDone ? "DONE" : "IN PROGRESS",
+					replicationCurrent,
+					_replicationCheckpointTarget,
+					Math.Max(0, _replicationCheckpointTarget - replicationCurrent));
+
+				LogExtraInformation(
+					"Index {progress}: {current:N0}/{target:N0}. Remaining: {remaining:N0}.",
+					indexDone ? "DONE" : "IN PROGRESS",
+					indexCurrent,
+					_indexCheckpointTarget,
+					Math.Max(0, _indexCheckpointTarget - indexCurrent));
+			}
+
+			if (replicationDone && indexDone) {
+				// transition to leader!
+				Respond(
+					received,
+					new SystemMessage.BecomeLeader(_stateCorrelationId),
+					"Correlation id {currentCorrelationId}",
+					_stateCorrelationId);
+				_managerState = ManagerState.Initial;
+			}
+		}
+
+		private void Received(Message received, string template = null, params object[] templateArgs) {
+			LogExtraInformation(
+				Combine(template, "RECEIVED {received}."),
+				Combine(templateArgs, received.GetType().Name));
+		}
+
+		private void Respond(Message received, Message send, string template = null, params object[] templateArgs) {
+			LogExtraInformation(
+				Combine(template, "RECEIVED {received}. RESPONDING with {send}."),
+				Combine(templateArgs, received.GetType().Name, send.GetType().Name));
+			_publisher.Publish(send);
+		}
+
+		private void Ignore(Message received, string template = null, params object[] templateArgs) {
+			LogExtraInformation(
+				Combine(template, "IGNORING {received}."),
+				Combine(templateArgs, received.GetType().Name));
+		}
+
+		private void LogExtraInformation(string template = null, params object[] templateArgs) {
+			_log.Information(
+				Combine(template, "{name} in state ({nodeState}, {managerState}):"),
+				Combine(templateArgs, nameof(InaugurationManager), _nodeState, _managerState));
+		}
+
+		private static string Combine(string template2, string template1) {
+			if (template1 is null)
+				return template2;
+
+			if (template2 is null)
+				return template1;
+
+			return $"{template1} {template2}";
+		}
+
+		private static object[] Combine(object[] args2, params object[] args1) {
+			if (args1 is null)
+				return args2;
+
+			if (args2 is null)
+				return args1;
+
+			return args1.Concat(args2).ToArray();
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_restarting.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_restarting.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -72,7 +72,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 		protected override void Given() {
 			// Start subsystem
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			 var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -141,7 +141,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -186,7 +186,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			WaitForStartMessage();
 			
@@ -209,7 +209,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -244,7 +244,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;

--- a/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_starting.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_starting.cs
@@ -20,7 +20,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				}));
 			
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				}));
 			
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 			
 			WaitForStartMessage();
 
@@ -75,7 +75,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -103,7 +103,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -127,7 +127,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		[Test]
 		public void should_allow_starting_the_subsystem_again() {
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 			var startMessage = WaitForStartMessage();
 			
 			Assert.AreNotEqual(_instanceCorrelation, startMessage.InstanceCorrelationId);
@@ -141,7 +141,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -169,7 +169,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -184,7 +184,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 			WaitForStopMessage();
 
 			// Become leader again before subsystem fully stopped
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			Subsystem.Handle(new ProjectionSubsystemMessage.ComponentStopped(
 				ProjectionManager.ServiceName, _instanceCorrelation));


### PR DESCRIPTION
Fixed: race condition where a node becomes leader and immediately writes to streams that have recently been written to but not indexed, resulting in events with incorrect numbers in their streams.

- This change ensures that before becoming leader we successfully write an epoch and get it replicated. Thus demonstrating that we are in a fit state to become leader.
- Therefore the log is successfully replicated before we transition to leader.
- We also wait for the records to be indexed before we transition to leader, otherwise incorrect event numbers can be written because the latest events are not known to the index or IndexWriter


- The InaugurationManager is reponsible for making sure the conditions are met for transitioning to leader.
- In the PreLeader state we now accept replication subscriptions and monitor for quorum, transitioning to Unknown if a quorum is not maintained (exactly as we did in the leader state before)


- Works as a rolling upgrade from 20.10.0