### PR TITLE
Optimise some slow running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,7 @@ jobs:
       run: |
         find ./src -maxdepth 1 -type d -name "*.Tests"  -print0 \
           | xargs -I{} -0 -n1 bash -c \
-          'dotnet test --configuration ${{ matrix.configuration }} --blame --blame-hang-timeout 5min --settings ./ci/ci.runsettings --logger:"GitHubActions;report-warnings=false" --logger:html --logger:trx --logger:"console;verbosity=normal" --results-directory=$(pwd)/test-results/$1 $1' - '{}'
+          'dotnet test --configuration ${{ matrix.configuration }} --blame --blame-hang-timeout 5min --blame-hang-dump-type mini --settings ./ci/ci.runsettings --logger:"GitHubActions;report-warnings=false" --logger:html --logger:trx --logger:"console;verbosity=normal" --results-directory=$(pwd)/test-results/$1 $1' - '{}'
     - name: Collect Test Results
       shell: bash
       if: always()

--- a/src/EventStore.Core.Tests/Index/IndexVAny/midpoint_assertions.cs
+++ b/src/EventStore.Core.Tests/Index/IndexVAny/midpoint_assertions.cs
@@ -1,45 +1,55 @@
 ﻿using System;
+using System.Collections;
 using EventStore.Core.Index;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Index.IndexVAny {
+
 	[TestFixture]
 	public class midpoint_assertions {
 		private const long MAX_INDEX_ENTRIES = 1000000000000L;
-	    private const int MAX_TEST_DEPTH = 35;
-	    private const int MAX_DEPTH = 28;
-	    private readonly byte[] IndexVersions = { PTableVersions.IndexV1,  PTableVersions.IndexV2,  PTableVersions.IndexV3, PTableVersions.IndexV4 };
+		private const int MAX_TEST_DEPTH = 35;
+		private const int MAX_DEPTH = 28;
+		private static readonly byte[] IndexVersions = { PTableVersions.IndexV1, PTableVersions.IndexV2, PTableVersions.IndexV3, PTableVersions.IndexV4 };
 
-	    private static int getIncrement(long numIndexEntries) {
-		    if (numIndexEntries < 100) return 1;
-		    if (numIndexEntries < 1000000) return 1337;
-		    return 133333337;
-	    }
+		private static int getIncrement(long numIndexEntries) {
+			if (numIndexEntries < 100)
+				return 1;
+			if (numIndexEntries < 1000000)
+				return 1337;
+			return 133333337;
+		}
 
-		[Test]
-		public void file_size_should_be_greater_or_equal_after_adding_midpoints() {
-			foreach (var version in IndexVersions) {
-				for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES; numIndexEntries += getIncrement(numIndexEntries)) {
+		public class TestCases : IEnumerable {
+			public IEnumerator GetEnumerator() {
+				foreach (var version in IndexVersions) {
 					for (int minDepth = 0; minDepth <= MAX_TEST_DEPTH; minDepth++) {
-						string testCase = $"numIndexEntries: {numIndexEntries}, minDepth: {minDepth}, version: {version}";
-						var midpointCount = PTable.GetRequiredMidpointCountCached(numIndexEntries, version, minDepth);
-						if (version < PTableVersions.IndexV4) {
-							Assert.AreEqual(0, midpointCount, testCase);
-						} else {
-							Assert.GreaterOrEqual(midpointCount, Math.Min(1<<Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
-							Assert.LessOrEqual(midpointCount, Math.Max(2, numIndexEntries), testCase);
-						}
-
-						long fileSizeUpToIndexEntries = PTable.GetFileSizeUpToIndexEntries(numIndexEntries, version);
-						long fileSizeUpToMidpointEntries =
-							PTable.GetFileSizeUpToMidpointEntries(fileSizeUpToIndexEntries, midpointCount, version);
-
-						if (version < PTableVersions.IndexV4) {
-							Assert.AreEqual(fileSizeUpToIndexEntries, fileSizeUpToMidpointEntries, testCase);
-						} else {
-							Assert.GreaterOrEqual(fileSizeUpToMidpointEntries, fileSizeUpToIndexEntries, testCase);
-						}
+						yield return new object[] { version, minDepth };
 					}
+				}
+			}
+		}
+
+		[Test, TestCaseSource(typeof(TestCases))]
+		public void file_size_should_be_greater_or_equal_after_adding_midpoints(byte version, int minDepth) {
+			for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES; numIndexEntries += getIncrement(numIndexEntries)) {
+				string testCase = $"numIndexEntries: {numIndexEntries}, minDepth: {minDepth}, version: {version}";
+				var midpointCount = PTable.GetRequiredMidpointCountCached(numIndexEntries, version, minDepth);
+				if (version < PTableVersions.IndexV4) {
+					Assert.AreEqual(0, midpointCount, testCase);
+				} else {
+					Assert.GreaterOrEqual(midpointCount, Math.Min(1 << Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
+					Assert.LessOrEqual(midpointCount, Math.Max(2, numIndexEntries), testCase);
+				}
+
+				long fileSizeUpToIndexEntries = PTable.GetFileSizeUpToIndexEntries(numIndexEntries, version);
+				long fileSizeUpToMidpointEntries =
+					PTable.GetFileSizeUpToMidpointEntries(fileSizeUpToIndexEntries, midpointCount, version);
+
+				if (version < PTableVersions.IndexV4) {
+					Assert.AreEqual(fileSizeUpToIndexEntries, fileSizeUpToMidpointEntries, testCase);
+				} else {
+					Assert.GreaterOrEqual(fileSizeUpToMidpointEntries, fileSizeUpToIndexEntries, testCase);
 				}
 			}
 		}
@@ -48,11 +58,11 @@ namespace EventStore.Core.Tests.Index.IndexVAny {
 		public void for_a_fixed_min_depth_and_increasing_index_entries_midpoint_count_should_increase_monotonically() {
 			for (int minDepth = 0; minDepth <= MAX_TEST_DEPTH; minDepth++) {
 				long prevMidpointCount = 0L;
-				for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES;  numIndexEntries += getIncrement(numIndexEntries)) {
+				for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES; numIndexEntries += getIncrement(numIndexEntries)) {
 					string testCase = $"numIndexEntries: {numIndexEntries}, minDepth: {minDepth}";
 					var midpointCount = PTable.GetRequiredMidpointCountCached(numIndexEntries, PTableVersions.IndexV4, minDepth);
 					Assert.GreaterOrEqual(midpointCount, prevMidpointCount, testCase);
-					Assert.GreaterOrEqual(midpointCount, Math.Min(1<<Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
+					Assert.GreaterOrEqual(midpointCount, Math.Min(1 << Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
 					Assert.LessOrEqual(midpointCount, Math.Max(2, numIndexEntries), testCase);
 					prevMidpointCount = midpointCount;
 				}
@@ -61,18 +71,17 @@ namespace EventStore.Core.Tests.Index.IndexVAny {
 
 		[Test]
 		public void for_a_fixed_number_of_index_entries_and_increasing_min_depth_midpoint_count_should_increase_monotonically() {
-			for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES;  numIndexEntries += getIncrement(numIndexEntries)) {
+			for (long numIndexEntries = 0; numIndexEntries < MAX_INDEX_ENTRIES; numIndexEntries += getIncrement(numIndexEntries)) {
 				long prevMidpointCount = 0L;
 				for (int minDepth = 0; minDepth <= MAX_TEST_DEPTH; minDepth++) {
 					string testCase = $"numIndexEntries: {numIndexEntries}, minDepth: {minDepth}";
 					var midpointCount = PTable.GetRequiredMidpointCountCached(numIndexEntries, PTableVersions.IndexV4, minDepth);
 					Assert.GreaterOrEqual(midpointCount, prevMidpointCount, testCase);
-					Assert.GreaterOrEqual(midpointCount, Math.Min(1<<Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
+					Assert.GreaterOrEqual(midpointCount, Math.Min(1 << Math.Min(MAX_DEPTH, minDepth), numIndexEntries), testCase);
 					Assert.LessOrEqual(midpointCount, Math.Max(2, numIndexEntries), testCase);
 					prevMidpointCount = midpointCount;
 				}
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
Changed : Optimise some slow running tests

- Compare byte arrays with `Span.SequenceEqual` and only fall back to slower byte per byte assertion if that fails for the following tests : 
```
EventStore.Core.Tests.TransactionLog.Unbuffered.UnbufferedTests.same_as_file_stream_on_reads
EventStore.Core.Tests.TransactionLog.Unbuffered.UnbufferedTests.same_as_file_stream_on_reads_with_bigger_buffer
EventStore.Core.Tests.TransactionLog.Unbuffered.UnbufferedTests.when_reading_multiple_times_exact_page_size
EventStore.Core.Tests.TransactionLog.Unbuffered.UnbufferedTests.when_reading_multiple_times_offset_page_size
```
Indicative comparison between CI run times for master@https://github.com/EventStore/EventStore/commit/f1d32f19c422abad9c91ca36aabf71f3be116f53 ([Build #3106](https://github.com/EventStore/EventStore/runs/3686949611?check_suite_focus=true)) before and this PR [(Build #3112)](https://github.com/EventStore/EventStore/actions/runs/1268559695) after on Ubuntu 18.04
![chart (1)](https://user-images.githubusercontent.com/20010676/134859845-57c1c457-90e7-4ba1-90c7-4f18198694cd.png)

- Split `EventStore.Core.Tests.Index.IndexVAny.midpoint_assertions.file_size_should_be_greater_or_equal_after_adding_midpoints` into multiple faster tests cases. 
- Add `--blame-hang-dump-type mini` to CI test step minimise disk usage on CI machines