### PR TITLE
Allow the server to send a list of supported gRPC methods to clients

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -1539,6 +1539,70 @@
       }
     },
     {
+      "protopath": "Grpc:/:clientcapabilities.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "SupportedMethods",
+            "fields": [
+              {
+                "id": 1,
+                "name": "Methods",
+                "type": "SupportedMethod",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "EventStoreServerVersion",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SupportedMethod",
+            "fields": [
+              {
+                "id": 1,
+                "name": "MethodName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "ServiceName",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "ClientCapabilities",
+            "rpcs": [
+              {
+                "name": "GetSupportedMethods",
+                "in_type": "event_store.client.Empty",
+                "out_type": "SupportedMethods"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "shared.proto"
+          }
+        ],
+        "package": {
+          "name": "event_store.client.client_capabilities"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "com.eventstore.dbclient.proto.clientcapabilities"
+          }
+        ]
+      }
+    },
+    {
       "protopath": "Grpc:/:cluster.proto",
       "def": {
         "enums": [

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -55,6 +55,7 @@
 		<Protobuf Include="..\Protos\Grpc\streams.proto" Link="Protos\streams.proto" GrpcServices="Client" ProtoRoot="../Protos/Grpc" Access="Internal" />
 		<Protobuf Include="..\Protos\Grpc\users.proto" Link="Protos\users.proto" GrpcServices="Client" ProtoRoot="../Protos/Grpc" Access="Internal" />
 		<Protobuf Include="..\Protos\Grpc\monitoring.proto" Link="Protos\monitoring.proto" GrpcServices="Client" ProtoRoot="../Protos/Grpc" Access="Internal" />
+		<Protobuf Include="..\Protos\Grpc\clientcapabilities.proto" Link="Protos\clientcapabilities.proto" GrpcServices="Client" ProtoRoot="../Protos/Grpc" Access="Internal" />
 		<None Include="Resources\es-tile.png">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/ClientCapabilitiesTests/ClientCapabilitiesTest.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/ClientCapabilitiesTests/ClientCapabilitiesTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Client.ClientCapabilities;
+using EventStore.Core.Tests.Integration;
+using Google.Protobuf.Reflection;
+using Grpc.Net.Client;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.ClientCapabilitiesTests {
+	public class ClientCapabilitiesTest {
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_getting_supported_methods<TLogFormat, TStreamId> : specification_with_cluster<TLogFormat, TStreamId> {
+
+			private List<SupportedMethod> _supportedEndPoints = new ();
+			private List<SupportedMethod> _expectedEndPoints = new ();
+			private string _serverVersion;
+
+			protected override async Task Given() {
+				_expectedEndPoints.AddRange(GetEndPoints(Client.Streams.Streams.Descriptor));
+				_expectedEndPoints.AddRange(GetEndPoints(Client.PersistentSubscriptions.PersistentSubscriptions.Descriptor));
+				_expectedEndPoints.AddRange(GetEndPoints(Client.Operations.Operations.Descriptor));
+				_expectedEndPoints.AddRange(GetEndPoints(Client.Users.Users.Descriptor));
+				_expectedEndPoints.AddRange(GetEndPoints(Client.Gossip.Gossip.Descriptor));
+				_expectedEndPoints.AddRange(GetEndPoints(Client.Monitoring.Monitoring.Descriptor));
+				_expectedEndPoints.AddRange(GetEndPoints(ClientCapabilities.Descriptor));
+
+				var node = GetLeader();
+				await Task.WhenAll(node.AdminUserCreated, node.Started);
+
+				using var channel = GrpcChannel.ForAddress(new Uri($"https://{node.HttpEndPoint}"),
+					new GrpcChannelOptions {
+						HttpClient = new HttpClient(new SocketsHttpHandler {
+							SslOptions = {
+								RemoteCertificateValidationCallback = delegate { return true; }
+							}
+						}, true)
+					});
+				var client = new ClientCapabilities.ClientCapabilitiesClient(channel);
+
+				var resp = await client.GetSupportedMethodsAsync(new Empty());
+				_supportedEndPoints = resp.Methods.ToList();
+				_serverVersion = resp.EventStoreServerVersion;
+
+			}
+			private SupportedMethod[] GetEndPoints(ServiceDescriptor desc) =>
+				desc.Methods.Select(x => new SupportedMethod {MethodName = x.Name, ServiceName = x.Service.FullName}).ToArray();
+
+			[Test]
+			public void should_receive_expected_endpoints() {
+				CollectionAssert.AreEquivalent(_expectedEndPoints, _supportedEndPoints);
+			}
+
+			[Test]
+			public void should_receive_the_correct_eventstore_version() {
+				Assert.AreEqual(EventStore.Common.Utils.VersionInfo.Version, _serverVersion);
+			}
+		}
+	}
+}
+

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -28,6 +28,7 @@ using ElectionsService = EventStore.Core.Services.Transport.Grpc.Cluster.Electio
 using Operations = EventStore.Core.Services.Transport.Grpc.Operations;
 using ClusterGossip = EventStore.Core.Services.Transport.Grpc.Cluster.Gossip;
 using ClientGossip = EventStore.Core.Services.Transport.Grpc.Gossip;
+using ClientCapabilities = EventStore.Core.Services.Transport.Grpc.ClientCapabilities;
 
 namespace EventStore.Core {
 	public class ClusterVNodeStartup<TStreamId> : IStartup, IHandle<SystemMessage.SystemReady>,
@@ -135,7 +136,8 @@ namespace EventStore.Core {
 				.UseEndpoints(ep => ep.MapGrpcService<Elections>())
 				.UseEndpoints(ep => ep.MapGrpcService<Operations>())
 				.UseEndpoints(ep => ep.MapGrpcService<ClientGossip>())
-				.UseEndpoints(ep => ep.MapGrpcService<Monitoring>());
+				.UseEndpoints(ep => ep.MapGrpcService<Monitoring>())
+				.UseEndpoints(ep => ep.MapGrpcService<ClientCapabilities>());
 
 			_subsystems.Aggregate(app, (b, subsystem) => subsystem.Configure(b));
 		}
@@ -163,6 +165,7 @@ namespace EventStore.Core {
 						.AddSingleton(new Elections(_mainQueue, _authorizationProvider))
 						.AddSingleton(new ClientGossip(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Monitoring(_monitoringQueue))
+						.AddSingleton<ClientCapabilities>()
 						.AddGrpc()
 						.AddServiceOptions<Streams<TStreamId>>(options =>
 							options.MaxReceiveMessageSize = TFConsts.EffectiveMaxLogRecordSize)

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -73,5 +73,8 @@
 		<Protobuf Include="..\Protos\Grpc\monitoring.proto" GrpcServices="Server" LinkBase="Services/Transport/Grpc" ProtoRoot="../Protos/Grpc" Access="Internal">
 			<Link>Services\Transport\Grpc\Protos\monitoring.proto</Link>
 		</Protobuf>
+		<Protobuf Include="..\Protos\Grpc\clientcapabilities.proto" GrpcServices="Server" LinkBase="Services/Transport/Grpc" ProtoRoot="../Protos/Grpc" Access="Internal">
+			<Link>Services\Transport\Grpc\Protos\clientcapabilities.proto</Link>
+		</Protobuf>
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Core/Services/Transport/Grpc/FeatureDiscovery.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/FeatureDiscovery.cs
@@ -1,0 +1,36 @@
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Client.ClientCapabilities;
+using Grpc.AspNetCore.Server;
+using Grpc.Core;
+using Microsoft.AspNetCore.Routing;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	internal partial class ClientCapabilities
+		: EventStore.Client.ClientCapabilities.ClientCapabilities.ClientCapabilitiesBase {
+		public const int ApiVersion = 1;
+		private readonly EndpointDataSource _endpointDataSource;
+
+		public ClientCapabilities(EndpointDataSource endpointDataSource) {
+			_endpointDataSource = endpointDataSource;
+		}
+
+		public override Task<SupportedMethods> GetSupportedMethods(Empty request, ServerCallContext context) {
+			var supportedEndpoints = _endpointDataSource.Endpoints
+				.Select(x => x.Metadata.FirstOrDefault(m => m is GrpcMethodMetadata))
+				.OfType<GrpcMethodMetadata>()
+				.Where(x => x.Method.ServiceName.Contains("client"))
+				.Select(x => new SupportedMethod {
+					MethodName = x.Method.Name,
+					ServiceName = x.Method.ServiceName
+				});
+
+			var result = new SupportedMethods {
+				EventStoreServerVersion = EventStore.Common.Utils.VersionInfo.Version
+			};
+			result.Methods.AddRange(supportedEndpoints.Distinct());
+			return Task.FromResult(result);
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/ServiceBase.cs
@@ -29,6 +29,13 @@ namespace EventStore.Client.PersistentSubscriptions {
 	}
 }
 
+namespace EventStore.Client.FeatureDiscovery {
+	partial class FeatureDiscovery {
+		partial class FeatureDiscoveryBase : ServiceBase {
+		}
+	}
+}
+
 namespace EventStore.Client.Streams {
 	partial class Streams {
 		partial class StreamsBase : ServiceBase {

--- a/src/Protos/Grpc/clientcapabilities.proto
+++ b/src/Protos/Grpc/clientcapabilities.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+package event_store.client.client_capabilities;
+option java_package = "com.eventstore.dbclient.proto.clientcapabilities";
+import "shared.proto";
+
+service ClientCapabilities {
+	rpc GetSupportedMethods (event_store.client.Empty) returns (SupportedMethods);
+}
+
+message SupportedMethods {
+	repeated SupportedMethod Methods = 1;
+	string EventStoreServerVersion = 2;
+}
+
+message SupportedMethod {
+	string MethodName = 1;
+	string ServiceName = 2;
+}
+


### PR DESCRIPTION
Added: ClientCapabilities proto for discovering which gRPC methods are available on the server

Fixes https://github.com/EventStore/home/issues/567

Adds a simple gRPC service that provides a list of all gRPC endpoints available on the server, as well as the EventStoreDB server version.

The supported methods look like the following and corresponds to the Service Descriptor in the client:

```
{ "MethodName": "Read", "ServiceName": "event_store.client.gossip.Gossip" }
```