### PR TITLE
[Cherry-Pick] Handle epochs that are not written on the current leader

### DIFF
--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -1,0 +1,349 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.Transport.Tcp;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
+
+	public class when_replica_subscribes_with_no_common_epochs<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		public override void When() {
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+			Writer.Write(CreateLogRecord(2, "test"), out _);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			Writer.Write(CreateLogRecord(4, "test"), out _);
+			EpochManager.WriteNewEpoch(1);
+
+			var epochs = new [] {
+				new Epoch(1010, 1, Guid.NewGuid()),
+				new Epoch(999, 2, Guid.NewGuid())
+			};
+
+			AddSubscription(_replicaId, true, epochs, 1010, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_a_replica_subscribed_message_from_start() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.Zero(subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+
+	public class when_replica_with_same_epochs_subscribes_from_last_epoch_position<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		private EpochRecord _lastEpoch;
+
+		public override void When() {
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+			Writer.Write(CreateLogRecord(2, "test"), out _);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			Writer.Write(CreateLogRecord(4, "test"), out _);
+			EpochManager.WriteNewEpoch(1);
+
+			_lastEpoch = EpochManager.GetLastEpoch();
+			var epochs = EpochManager.GetLastEpochs(10)
+				.Select(e => new Epoch(e.EpochPosition, e.EpochNumber, e.EpochId)).ToArray();
+
+			AddSubscription(_replicaId, true, epochs, _lastEpoch.EpochPosition, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_a_replica_subscribed_message_from_last_epoch_position() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.AreEqual(_lastEpoch.EpochPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+
+	public class when_replica_with_same_epochs_subscribes_from_position_less_than_last_epoch_position<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		private EpochRecord _lastEpoch;
+		private long _subscribedPosition;
+
+		public override void When() {
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+			Writer.Write(CreateLogRecord(2, "test"), out _);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			Writer.Write(CreateLogRecord(4, "test"), out _subscribedPosition);
+			EpochManager.WriteNewEpoch(1);
+
+			_lastEpoch = EpochManager.GetLastEpoch();
+			var epochs = EpochManager.GetLastEpochs(10)
+				.Select(e => new Epoch(e.EpochPosition, e.EpochNumber, e.EpochId)).ToArray();
+
+			AddSubscription(_replicaId, true, epochs, _subscribedPosition, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_a_replica_subscribed_message_from_requested_position() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.AreEqual(_subscribedPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+
+	public class when_replica_with_additional_epochs_subscribes_to_position_past_leaders_last_epoch<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		private List<Epoch> _replicaEpochs;
+
+		public override void When() {
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+			Writer.Write(CreateLogRecord(2, "test"), out _);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			Writer.Write(CreateLogRecord(4, "test"), out _);
+			EpochManager.WriteNewEpoch(1);
+			Writer.Write(CreateLogRecord(5, "test"), out _);
+			Writer.Write(CreateLogRecord(6, "test"), out _);
+			Writer.Write(CreateLogRecord(7, "test"), out var lastWritePosition);
+			Writer.Flush();
+
+			_replicaEpochs = new List<Epoch> {
+				new Epoch(lastWritePosition + 2000, 4, Guid.NewGuid()),
+				new Epoch(lastWritePosition + 1000, 3, Guid.NewGuid()),
+				new Epoch(lastWritePosition, 2, Guid.NewGuid()),
+			};
+			_replicaEpochs.AddRange(EpochManager.GetLastEpochs(10)
+				.Select(e => new Epoch(e.EpochPosition, e.EpochNumber, e.EpochId)).ToList());
+
+			AddSubscription(_replicaId, true, _replicaEpochs.ToArray(), lastWritePosition + 2000, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_replica_subscribed_message_for_epoch_after_common_epoch() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.AreEqual(_replicaEpochs[2].EpochPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+
+	public class when_replica_subscribes_with_epoch_that_doesnt_exist_on_leader_but_is_before_leaders_last_epoch<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		private List<Epoch> _replicaEpochs;
+
+		public override void When() {
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+			Writer.Write(CreateLogRecord(2, "test"), out var otherEpochLogPosition);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			Writer.Write(CreateLogRecord(4, "test"), out _);
+			EpochManager.WriteNewEpoch(2);
+
+			var firstEpoch = EpochManager.GetLastEpochs(10).First(e => e.EpochNumber == 0);
+			_replicaEpochs = new List<Epoch> {
+				new Epoch(otherEpochLogPosition, 1, Guid.NewGuid()),
+				new Epoch(firstEpoch.EpochPosition, firstEpoch.EpochNumber, firstEpoch.EpochId)
+			};
+
+			AddSubscription(_replicaId, true, _replicaEpochs.ToArray(), _replicaEpochs[0].EpochPosition, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_replica_subscribed_message_for_epoch_after_common_epoch() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.AreEqual(_replicaEpochs[0].EpochPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+
+	public class when_replica_subscribes_with_additional_epoch_past_leaders_writer_checkpoint<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		private List<Epoch> _replicaEpochs;
+
+		public override void When() {
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+			Writer.Write(CreateLogRecord(2, "test"), out _);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			Writer.Write(CreateLogRecord(4, "test"), out _);
+			EpochManager.WriteNewEpoch(1);
+
+			var subscribePosition = Db.Config.WriterCheckpoint.ReadNonFlushed() + 1000;
+			_replicaEpochs = new List<Epoch> {
+				new Epoch(subscribePosition, 2, Guid.NewGuid()),
+			};
+			_replicaEpochs.AddRange(EpochManager.GetLastEpochs(10)
+				.Select(e => new Epoch(e.EpochPosition, e.EpochNumber, e.EpochId)).ToList());
+
+			AddSubscription(_replicaId, true, _replicaEpochs.ToArray(), subscribePosition, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_replica_subscribed_message_for_leaders_writer_checkpoint() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.AreEqual(Db.Config.WriterCheckpoint.ReadNonFlushed(), subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+
+	public class when_replica_subscribes_with_additional_epoch_and_leader_has_epoch_after_common_epoch<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		private List<Epoch> _replicaEpochs;
+
+		public override void When() {
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+			Writer.Write(CreateLogRecord(2, "test"), out _);
+			EpochManager.WriteNewEpoch(1);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			Writer.Write(CreateLogRecord(4, "test"), out _);
+			EpochManager.WriteNewEpoch(4);
+
+			var subscribePosition = Db.Config.WriterCheckpoint.ReadNonFlushed() + 1000;
+			_replicaEpochs = new List<Epoch> {
+				new Epoch(subscribePosition, 2, Guid.NewGuid()),
+			};
+			_replicaEpochs.AddRange(EpochManager.GetLastEpochs(10)
+				.Where(e => e.EpochNumber < 4)
+				.Select(e => new Epoch(e.EpochPosition, e.EpochNumber, e.EpochId)).ToList());
+
+			AddSubscription(_replicaId, true, _replicaEpochs.ToArray(), subscribePosition, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_replica_subscribed_message_for_leaders_epoch_after_common_epoch() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.AreEqual(EpochManager.GetLastEpoch().EpochPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+
+	[TestFixture]
+	public class when_replica_subscribes_with_uncached_epoch<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		private List<Epoch> _replicaEpochs;
+		public override void When() {
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			EpochManager.WriteNewEpoch(1);
+
+			// The EpochManager for these tests only caches 5 epochs
+			_replicaEpochs = EpochManager.GetLastEpochs(2)
+				.Select(e => new Epoch(e.EpochPosition, e.EpochNumber, e.EpochId)).ToList();
+
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+			EpochManager.WriteNewEpoch(2);
+			Writer.Write(CreateLogRecord(2, "test"), out _);
+			EpochManager.WriteNewEpoch(3);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			EpochManager.WriteNewEpoch(4);
+			Writer.Write(CreateLogRecord(4, "test"), out _);
+			EpochManager.WriteNewEpoch(5);
+			Writer.Write(CreateLogRecord(5, "test"), out _);
+			EpochManager.WriteNewEpoch(6);
+
+			AddSubscription(_replicaId, true, _replicaEpochs.ToArray(), _replicaEpochs[0].EpochPosition, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_a_replica_subscribed_message_common_epoch() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.AreEqual(_replicaEpochs[0].EpochPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+
+	[TestFixture]
+	public class when_replica_subscribes_with_uncached_epoch_that_does_not_exist_on_leader<TLogFormat, TStreamId>
+		: with_replication_service_and_epoch_manager<TLogFormat, TStreamId> {
+		private readonly Guid _replicaId = Guid.NewGuid();
+		private TcpConnectionManager _replicaManager;
+		private List<Epoch> _replicaEpochs;
+		private EpochRecord[] _uncachedLeaderEpochs;
+		public override void When() {
+			// The EpochManager for these tests only caches 5 epochs
+			// Epochs 2 and 3 don't exist
+			EpochManager.WriteNewEpoch(0);
+			Writer.Write(CreateLogRecord(0, "test"), out _);
+			EpochManager.WriteNewEpoch(1);
+			Writer.Write(CreateLogRecord(1, "test"), out _);
+
+			_uncachedLeaderEpochs = EpochManager.GetLastEpochs(2);
+
+			EpochManager.WriteNewEpoch(4);
+			Writer.Write(CreateLogRecord(2, "test"), out _);
+			EpochManager.WriteNewEpoch(5);
+			Writer.Write(CreateLogRecord(3, "test"), out _);
+			EpochManager.WriteNewEpoch(6);
+			Writer.Write(CreateLogRecord(4, "test"), out _);
+			EpochManager.WriteNewEpoch(7);
+			Writer.Write(CreateLogRecord(5, "test"), out _);
+			EpochManager.WriteNewEpoch(8);
+
+			_replicaEpochs = new List<Epoch> {
+				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 800, 3, Guid.NewGuid()),
+				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 400, 2, Guid.NewGuid()),
+				new Epoch(_uncachedLeaderEpochs[0].EpochPosition, _uncachedLeaderEpochs[0].EpochNumber, _uncachedLeaderEpochs[0].EpochId),
+				new Epoch(_uncachedLeaderEpochs[1].EpochPosition, _uncachedLeaderEpochs[1].EpochNumber, _uncachedLeaderEpochs[1].EpochId)
+			};
+
+			AddSubscription(_replicaId, true, _replicaEpochs.ToArray(), _replicaEpochs[0].EpochPosition, out _replicaManager);
+		}
+
+		[Test]
+		public void subscription_is_sent_a_replica_subscribed_message_to_epoch_position_after_common_epoch() {
+			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
+				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			Assert.AreEqual(1, subscribed.Length);
+			Assert.AreEqual(EpochManager.GetLastEpochs(5).First(x => x.EpochNumber == 4).EpochPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Core.Authentication.InternalAuthentication;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Replication;
+using EventStore.Core.Services.Storage.EpochManager;
+using EventStore.Core.Services.Transport.Tcp;
+using EventStore.Core.Tests.Authentication;
+using EventStore.Core.Tests.Authorization;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.Services.Transport.Tcp;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
+
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public abstract class with_replication_service_and_epoch_manager<TLogFormat, TStreamId>  : SpecificationWithDirectoryPerTestFixture {
+		private const int _connectionPendingSendBytesThreshold = 10 * 1024;
+		private const int _connectionQueueSizeThreshold = 50000;
+
+		protected int ClusterSize = 3;
+		protected InMemoryBus Publisher = new InMemoryBus("publisher");
+		protected InMemoryBus TcpSendPublisher = new InMemoryBus("tcpSend");
+		protected LeaderReplicationService Service;
+		protected ConcurrentQueue<TcpMessage.TcpSend> TcpSends = new ConcurrentQueue<TcpMessage.TcpSend>();
+		private static readonly IRecordFactory<TStreamId> _recordFactory = LogFormatHelper<TLogFormat, TStreamId>.RecordFactory;
+		protected Guid LeaderId = Guid.NewGuid();
+
+		protected TFChunkDbConfig DbConfig;
+		protected EpochManager EpochManager;
+		protected TFChunkDb Db;
+		protected TFChunkWriter Writer;
+
+		[OneTimeSetUp]
+		public override async Task TestFixtureSetUp() {
+			await base.TestFixtureSetUp();
+			TcpSendPublisher.Subscribe(new AdHocHandler<TcpMessage.TcpSend>(msg => TcpSends.Enqueue(msg)));
+
+			DbConfig = CreateDbConfig();
+			Db = new TFChunkDb(DbConfig);
+			Db.Open();
+
+			Writer = new TFChunkWriter(Db);
+			EpochManager = new EpochManager(
+				Publisher,
+				5,
+				DbConfig.EpochCheckpoint,
+				Writer,
+				1, 1,
+				() => new TFChunkReader(Db, Db.Config.WriterCheckpoint,
+					optimizeReadSideCache: Db.Config.OptimizeReadSideCache),
+				_recordFactory,
+				Guid.NewGuid());
+			Service = new LeaderReplicationService(
+				Publisher,
+				LeaderId,
+				Db,
+				TcpSendPublisher,
+				EpochManager,
+				ClusterSize,
+				false,
+				new QueueStatsManager());
+
+			Service.Handle(new SystemMessage.SystemStart());
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+
+			When();
+		}
+
+		[OneTimeTearDown]
+		public override async Task TestFixtureTearDown() {
+			await base.TestFixtureTearDown();
+			Service.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), true, true));
+		}
+
+		public IPrepareLogRecord<TStreamId> CreateLogRecord(long eventNumber, string eventType, string data = "*************") {
+			var tStreamId = LogFormatHelper<TLogFormat, TStreamId>.StreamId;
+			return LogRecord.Prepare(_recordFactory, Db.Config.WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+				tStreamId, eventNumber, PrepareFlags.None, eventType, Encoding.UTF8.GetBytes(data),
+				null, DateTime.UtcNow);
+		}
+
+		public Guid AddSubscription(Guid replicaId, bool isPromotable, Epoch[] epochs, long logPosition, out TcpConnectionManager manager) {
+			var tcpConn = new DummyTcpConnection() { ConnectionId = replicaId };
+
+			manager = new TcpConnectionManager(
+				"Test Subscription Connection manager", TcpServiceType.External, new ClientTcpDispatcher(2_000),
+				InMemoryBus.CreateTest(), tcpConn, InMemoryBus.CreateTest(),
+				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
+					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
+					new StubPasswordHashAlgorithm(), 1, false),
+				new AuthorizationGateway(new TestAuthorizationProvider()), 
+				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
+				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
+			var subRequest = new ReplicationMessage.ReplicaSubscriptionRequest(
+				Guid.NewGuid(),
+				new NoopEnvelope(),
+				manager,
+				logPosition,
+				Guid.NewGuid(),
+				epochs,
+				PortsHelper.GetLoopback(),
+				LeaderId,
+				replicaId,
+				isPromotable);
+			Service.Handle(subRequest);
+			return tcpConn.ConnectionId;
+		}
+
+		public abstract void When();
+
+		public TcpMessage.TcpSend[] GetTcpSendsFor(TcpConnectionManager connection) {
+			var sentMessages = new List<TcpMessage.TcpSend>();
+			while (TcpSends.TryDequeue(out var msg)) {
+				if (msg.ConnectionManager == connection)
+					sentMessages.Add(msg);
+			}
+
+			return sentMessages.ToArray();
+		}
+
+		private TFChunkDbConfig CreateDbConfig() {
+			ICheckpoint writerChk = new InMemoryCheckpoint(Checkpoint.Writer);
+			ICheckpoint chaserChk = new InMemoryCheckpoint(Checkpoint.Chaser);
+			ICheckpoint epochChk = new InMemoryCheckpoint(Checkpoint.Epoch, initValue: -1);
+			ICheckpoint proposalChk = new InMemoryCheckpoint(Checkpoint.Proposal, initValue: -1);
+			ICheckpoint truncateChk = new InMemoryCheckpoint(Checkpoint.Truncate, initValue: -1);
+			ICheckpoint replicationCheckpoint = new InMemoryCheckpoint(-1);
+			ICheckpoint indexCheckpoint = new InMemoryCheckpoint(-1);
+			ICheckpoint streamExistenceFilterCheckpoint = new InMemoryCheckpoint(-1);
+			var nodeConfig = new TFChunkDbConfig(
+				PathName, 
+				new VersionedPatternFileNamingStrategy(PathName, "chunk-"),
+				TFConsts.ChunkSize,
+				TFConsts.ChunksCacheSize,
+				writerChk,
+				chaserChk,
+				epochChk,
+				proposalChk,
+				truncateChk,
+				replicationCheckpoint,
+				indexCheckpoint,
+				streamExistenceFilterCheckpoint,
+				Constants.TFChunkInitialReaderCountDefault,
+				Constants.TFChunkMaxReaderCountDefault,
+				true);
+			return nodeConfig;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -6,8 +6,10 @@ using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.DataStructures;
 using EventStore.Core.LogAbstraction;
+using EventStore.Core.Exceptions;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
 using ILogger = Serilog.ILogger;
 using EventStore.LogCommon;
@@ -197,7 +199,6 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 			Ensure.Nonnegative(epochNumber, "epochNumber");
 			Ensure.NotEmptyGuid(epochId, "epochId");
 
-
 			if (epochNumber > LastEpochNumber)
 				return false;
 
@@ -207,6 +208,10 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 				if (epoch != null) {
 					return epoch.EpochId == epochId && epoch.EpochPosition == epochPosition;
 				}
+
+				if (_firstCachedEpoch.Value != null && epochNumber > _firstCachedEpoch.Value.EpochNumber)
+					// This isn't a cache miss, we don't have that epoch on this node
+					return false;
 			}
 
 			// epochNumber < _minCachedEpochNumber
@@ -221,6 +226,9 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 
 				epoch = sysRec.GetEpochRecord();
 				return epoch.EpochNumber == epochNumber && epoch.EpochId == epochId;
+			} catch(Exception ex) when (ex is InvalidReadException || ex is UnableToReadPastEndOfStreamException) {
+				Log.Information(ex, "Failed to read epoch {epochNumber} at {epochPosition}.", epochNumber, epochPosition);
+				return false;
 			} finally {
 				_readers.Return(reader);
 			}


### PR DESCRIPTION
Fixed: Prevent the EpochManager from attempting to read epochs that should have been cached

Cherry-picks https://github.com/EventStore/EventStore/pull/3189 to master.