### PR TITLE
Wait for Replication and Indexing to complete before becoming leader

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/read_all_events_filtered_paging_should.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_all_events_filtered_paging_should.cs
@@ -115,8 +115,8 @@ namespace EventStore.Core.Tests.ClientAPI {
 				.GetAwaiter()
 				.GetResult();
 
-			// Includes system events at start of stream
-			var expectedCount = 12;
+			// Includes system events at start of stream (inc epoch-information)
+			var expectedCount = 11;
 
 			if (LogFormatHelper<TLogFormat, TStreamId>.IsV3) {
 				// account for stream records: $scavenges, $user-admin, $user-ops, $users, stream-a

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -103,7 +103,11 @@ namespace EventStore.Core.Tests.Integration {
 			_nodes[1].Start();
 			_nodes[2].Start();
 
-			await Task.WhenAll(_nodes.Select(x => x.Started)).WithTimeout(TimeSpan.FromSeconds(30));
+			try {
+				await Task.WhenAll(_nodes.Select(x => x.Started)).WithTimeout(TimeSpan.FromSeconds(30));
+			} catch (TimeoutException ex) {
+				throw new TimeoutException($"Cluster nodes did not start. Statuses: {_nodes[0].NodeState}/{_nodes[1].NodeState}/{_nodes[2].NodeState}", ex);
+			}
 			
 			// wait for cluster to be fully operational, tests depend on leader and followers
 			AssertEx.IsOrBecomesTrue(() => _nodes.Any(x => x.NodeState == Data.VNodeState.Leader),

--- a/src/EventStore.Core.Tests/Integration/when_node_becomes_leader_with_unindexed_data.cs
+++ b/src/EventStore.Core.Tests/Integration/when_node_becomes_leader_with_unindexed_data.cs
@@ -1,0 +1,306 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using EventStore.Client.Streams;
+using EventStore.Common.Utils;
+using EventStore.Core.Data;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Core.Tests.Helpers;
+using Google.Protobuf;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Empty = EventStore.Client.Empty;
+using RecordedEvent = EventStore.Client.Streams.ReadResp.Types.ReadEvent.Types.RecordedEvent;
+using GrpcMetadata = EventStore.Core.Services.Transport.Grpc.Constants.Metadata;
+
+namespace EventStore.Core.Tests.Integration {
+	[Explicit]
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class when_node_becomes_leader_with_unindexed_data<TLogFormat, TStreamId> : specification_with_cluster<TLogFormat, TStreamId> {
+		private const string FakeHostAdvertiseAs = "192.168.123.123";
+		private const string Username = "admin";
+		private const string Password = "changeit";
+
+		private const string AuthenticationScheme = "Basic";
+		private readonly string AuthenticationValue = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{Username}:{Password}"));
+		private class CommitTimeoutException : Exception { }
+		private class WrongExpectedVersionException : Exception { }
+
+		private EndPoint[][] _nodeGossipSeeds;
+		private HttpClient _httpClient;
+
+		protected override async Task Given() {
+			_nodeGossipSeeds = new[] {
+				new EndPoint[] {_nodeEndpoints[1].HttpEndPoint, _nodeEndpoints[2].HttpEndPoint},
+				new EndPoint[] {_nodeEndpoints[0].HttpEndPoint, _nodeEndpoints[2].HttpEndPoint},
+				new EndPoint[] {_nodeEndpoints[0].HttpEndPoint, _nodeEndpoints[1].HttpEndPoint}
+			};
+			_httpClient = new HttpClient(new SocketsHttpHandler {
+				SslOptions = {
+					RemoteCertificateValidationCallback = delegate { return true; }
+				}
+			}, true);
+			await base.Given();
+		}
+		private CallOptions GetCallOptions()
+		{
+			return new(
+				credentials: CallCredentials.FromInterceptor((_, metadata) => {
+					metadata.Add("authorization", $"{AuthenticationScheme} {AuthenticationValue}");
+					return Task.CompletedTask;
+				}),
+				deadline: DateTime.UtcNow.AddSeconds(5));
+		}
+
+		private async Task AppendEvent(IPEndPoint endpoint, string stream, long expectedVersion) {
+			using var channel = GrpcChannel.ForAddress(new Uri($"https://{endpoint}"),
+				new GrpcChannelOptions { HttpClient = _httpClient });
+			var streamClient = new Streams.StreamsClient(channel);
+			var call = streamClient.Append(GetCallOptions());
+
+			var optionsAppendReq = new AppendReq {
+				Options = new() {
+					StreamIdentifier = new() {
+						StreamName = ByteString.CopyFromUtf8(stream)
+					},
+				}
+			};
+			switch (expectedVersion) {
+				case ExpectedVersion.Any:
+					optionsAppendReq.Options.Any = new Empty();
+					break;
+				case ExpectedVersion.NoStream:
+					optionsAppendReq.Options.NoStream = new Empty();
+					break;
+				default:
+					optionsAppendReq.Options.Revision = (ulong) expectedVersion;
+					break;
+			}
+
+			await call.RequestStream.WriteAsync(optionsAppendReq);
+			await call.RequestStream.WriteAsync(new AppendReq {
+				ProposedMessage = new() {
+					Id = new() {
+						String = Uuid.FromGuid(Guid.NewGuid()).ToString()
+					},
+					Data = ByteString.Empty,
+					Metadata = {
+						[GrpcMetadata.Type] = "type",
+						[GrpcMetadata.ContentType] = GrpcMetadata.ContentTypes.ApplicationJson
+					}
+				}
+			});
+
+			await call.RequestStream.CompleteAsync();
+			try {
+				var appendResp = await call.ResponseAsync;
+				switch (appendResp.ResultCase)
+				{
+					case AppendResp.ResultOneofCase.Success:
+						return;
+					case AppendResp.ResultOneofCase.WrongExpectedVersion:
+						throw new WrongExpectedVersionException();
+				}
+			}
+			catch (RpcException ex) when (ex.Status.StatusCode == StatusCode.DeadlineExceeded) {
+				throw new CommitTimeoutException();
+			}
+		}
+
+		private async Task<IEnumerable<RecordedEvent>> ReadAllEvents(IPEndPoint endpoint) {
+			using var channel = GrpcChannel.ForAddress(new Uri($"https://{endpoint}"),
+				new GrpcChannelOptions { HttpClient = _httpClient });
+			var streamClient = new Streams.StreamsClient(channel);
+
+			var call = streamClient.Read(new ReadReq {
+				Options = new() {
+					All = new() {
+						Start = new Empty()
+					},
+					ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+					Count = ulong.MaxValue,
+					NoFilter = new Empty(),
+					UuidOption = new() { Structured = new() }
+				}
+			}, GetCallOptions());
+
+			return await (from response in call.ResponseStream.ReadAllAsync() where response.Event != null select response.Event.Event).ToListAsync();
+		}
+
+		private MiniClusterNode<TLogFormat, TStreamId> CreateNode(int index, Endpoints endpoints, EndPoint[] gossipSeeds,
+			int nodePriority, string intHostAdvertiseAs) => new(
+			PathName, index, endpoints.InternalTcp,
+			endpoints.ExternalTcp, endpoints.HttpEndPoint,
+			subsystems: Array.Empty<ISubsystem>(), gossipSeeds: gossipSeeds, inMemDb: false,
+			nodePriority: nodePriority, intHostAdvertiseAs: intHostAdvertiseAs);
+
+		private Task StartNode(int i, int priority, string intHostAdvertiseAs = null) {
+			_nodes[i] = CreateNode(i, _nodeEndpoints[i], _nodeGossipSeeds[i], priority, intHostAdvertiseAs);
+			_nodes[i].Start();
+			return Task.CompletedTask;
+		}
+
+		private async Task<HttpStatusCode> GetLiveStatus(IPEndPoint httpEndPoint){
+			var response = await _httpClient.GetAsync($"https://{httpEndPoint}/health/live");
+			return response.StatusCode;
+		}
+
+		private async Task WaitForAllNodesToBeLive() {
+			for (int i = 0; i < 3; i++) {
+				await WaitForNodeToBeLive(i);
+			}
+		}
+
+		private async Task WaitForNodeToBeLive(int idx) {
+			while (await GetLiveStatus(_nodes[idx].HttpEndPoint) != HttpStatusCode.NoContent) {
+				await Task.Delay(100);
+			}
+		}
+
+		private async Task WaitForAllNodesToBeCaughtUp(int maxIdx = 3) {
+			while (true) {
+				var prevWriter = long.MinValue;
+				var prevChaser = long.MinValue;
+				var caughtUp = true;
+				for (int i = 0; i < maxIdx; i++) {
+					var writer = _nodes[i].Db.Config.WriterCheckpoint.ReadNonFlushed();
+					var chaser = _nodes[i].Db.Config.ChaserCheckpoint.ReadNonFlushed();
+
+					if (prevWriter == long.MinValue) prevWriter = writer;
+					if (prevChaser == long.MinValue) prevChaser = chaser;
+					if (chaser != writer || writer != prevWriter) {
+						caughtUp = false;
+					}
+				}
+
+				if (caughtUp) break;
+				await Task.Delay(100);
+			}
+		}
+
+		private async Task ShutdownNode(int i, bool keepDb) => await _nodes[i].Shutdown(keepDb: keepDb);
+
+		private async Task ShutdownAllNodes(int maxIdx = 3, bool keepDb = false) {
+			for (int i = 0; i < maxIdx; i++) {
+				await ShutdownNode(i, keepDb);
+			}
+		}
+
+		private async Task ResignLeader(int leaderIdx) {
+			var httpEndPoint = _nodes[leaderIdx].HttpEndPoint;
+			var request = new HttpRequestMessage(HttpMethod.Post, $"https://{httpEndPoint}/admin/node/resign") {
+				Content = new StringContent(""),
+				Headers = {
+					Authorization = new AuthenticationHeaderValue(AuthenticationScheme, AuthenticationValue)
+				}
+			};
+
+			var response = await _httpClient.SendAsync(request);
+			if (response.StatusCode != HttpStatusCode.OK) {
+				throw new Exception($"Unexpected status code: {response.StatusCode}");
+			}
+
+			var start = DateTime.UtcNow;
+			while (_nodes[leaderIdx].NodeState != VNodeState.Unknown && DateTime.UtcNow - start < TimeSpan.FromSeconds(2)) {
+				await Task.Delay(100);
+			}
+		}
+
+		[SetUp]
+		public async Task SetUp() {
+			// reset the node states between tests
+			for (int i = 0; i < 3; i++) {
+				await _nodes[i].Shutdown(keepDb: false);
+			}
+
+			for (int i = 0; i < 3; i++) {
+				_nodes[i] = CreateNode(i, _nodeEndpoints[i], _nodeGossipSeeds[i], 0, null);
+				_nodes[i].Start();
+			}
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		[Explicit, Category("LongRunning"), Timeout(80000), NonParallelizable]
+		public async Task new_events_should_have_correct_event_numbers(bool appendInitialEvent) {
+			await WaitForAllNodesToBeLive();
+
+			if (appendInitialEvent) {
+				// append event 0@test
+				await AppendEvent(_nodes[0].HttpEndPoint, "test", ExpectedVersion.NoStream);
+			}
+
+			await WaitForAllNodesToBeCaughtUp();
+			await ShutdownAllNodes(keepDb: true);
+
+			// make node 1 become the leader by setting its priority to 1
+			// node 0 can't become a follower since it can't replicate over internal TCP due to the fake --int-host-advertise-as
+			await StartNode(0, priority: 0, intHostAdvertiseAs: FakeHostAdvertiseAs);
+			await StartNode(1, priority: 1, intHostAdvertiseAs: FakeHostAdvertiseAs);
+
+			try {
+				await WaitForNodeToBeLive(1).WithTimeout(TimeSpan.FromSeconds(10));
+				Assert.AreEqual(VNodeState.Leader, _nodes[1].NodeState);
+			} catch (TimeoutException) {
+				// want to get stuck in preleader since replication isn't possible
+				Assert.AreEqual(VNodeState.PreLeader, _nodes[1].NodeState);
+				return;
+			}
+
+			// append event 1@test. Expect a commit timeout since there is no quorum.
+			Assert.ThrowsAsync<CommitTimeoutException>(async () => {
+				await AppendEvent(_nodes[1].HttpEndPoint, "test", appendInitialEvent ? 0 : ExpectedVersion.NoStream);
+			});
+
+			// resign the leader node so that it goes into the Unknown state and to trigger new elections
+			await ResignLeader(1);
+
+			// wait for the node to become Leader again
+			while (_nodes[1].NodeState != VNodeState.Leader) {
+				await Task.Delay(100);
+			}
+
+			// append event 1@test again. Expect a commit timeout since there is no quorum.
+			Assert.ThrowsAsync<CommitTimeoutException>(async () => {
+				await AppendEvent(_nodes[1].HttpEndPoint, "test", appendInitialEvent ? 0 : ExpectedVersion.NoStream);
+			});
+
+			// shut down both nodes
+			await ShutdownAllNodes(maxIdx: 2, keepDb: true);
+
+			// start both nodes again without the fake --int-host-advertise-as so that they can form a cluster
+			await StartNode(0, priority: 0);
+			await StartNode(1, priority: 1);
+			try {
+				await _nodes[0].Started.WithTimeout(TimeSpan.FromSeconds(10));
+				await _nodes[1].Started.WithTimeout(TimeSpan.FromSeconds(10));
+			} catch (TimeoutException) {
+				// this is expected in logv3 because by creating the duplicate events above we also
+				// created duplicate stream records which it will detect and complain about it
+				throw new Exception($"Couldn't start one or more nodes: {_nodes[0].NodeState} {_nodes[1].NodeState}");
+			}
+			Assert.AreEqual(VNodeState.Follower, _nodes[0].NodeState);
+			Assert.AreEqual(VNodeState.Leader, _nodes[1].NodeState);
+
+			// wait for data replication
+			await WaitForAllNodesToBeCaughtUp(maxIdx: 2);
+
+			// read "test" events from $all
+			var events =
+				(await ReadAllEvents(_nodes[1].HttpEndPoint))
+				.Where(x => x.StreamIdentifier!.StreamName.ToStringUtf8() == "test").ToArray();
+
+			Assert.AreEqual(appendInitialEvent ? 3 : 2, events.Length);
+			for (int i = 0; i < (appendInitialEvent ? 3 : 2); i++) {
+				Assert.AreEqual(i, events[i].StreamRevision, $"i = {i}, revision = {events[i].StreamRevision}");
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -500,7 +500,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 			);
 
 		protected override Message When() =>
-			new SystemMessage.BecomeLeader(Guid.NewGuid(),0);
+			new SystemMessage.BecomeLeader(Guid.NewGuid());
 
 		[Test]
 		public void should_update_gossip() {

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -325,8 +325,8 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			EpochManager.WriteNewEpoch(8);
 
 			_replicaEpochs = new List<Epoch> {
-				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 800, 3, Guid.NewGuid()),
-				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 400, 2, Guid.NewGuid()),
+				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 8000, 3, Guid.NewGuid()),
+				new Epoch(_uncachedLeaderEpochs[0].EpochPosition + 4000, 2, Guid.NewGuid()),
 				new Epoch(_uncachedLeaderEpochs[0].EpochPosition, _uncachedLeaderEpochs[0].EpochNumber, _uncachedLeaderEpochs[0].EpochId),
 				new Epoch(_uncachedLeaderEpochs[1].EpochPosition, _uncachedLeaderEpochs[1].EpochNumber, _uncachedLeaderEpochs[1].EpochId)
 			};

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				queueStatsManager: new QueueStatsManager());
 
 			Service.Handle(new SystemMessage.SystemStart());
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			ReplicaSubscriptionId = AddSubscription(ReplicaId, true, out ReplicaManager1);
 			ReplicaSubscriptionId2 = AddSubscription(ReplicaId2, true, out ReplicaManager2);
@@ -114,7 +114,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		public abstract void When();
 		protected void BecomeLeader() {
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 		}
 
 		protected void BecomeUnknown() {

--- a/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/with_clustered_replication_tracking_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReplicationTracking/with_clustered_replication_tracking_service.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Replication.ReplicationTracking {
 		public abstract void When();
 		
 		protected void BecomeLeader() {
-			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 		}
 
 		protected void BecomeUnknown() {

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
@@ -17,13 +17,18 @@ using EventStore.Core.Services.Storage.EpochManager;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Core.TransactionLog.LogRecords;
 using System.Threading;
+using EventStore.Core.Services;
+using EventStore.Common.Utils;
+using Newtonsoft.Json.Linq;
+using EventStore.Core.LogV3;
 
 namespace EventStore.Core.Tests.Services.Storage {
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
 	public class when_having_TFLog_with_existing_epochs<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture, IDisposable {
 		private TFChunkDb _db;
-		private EpochManager _epochManager;
+		private EpochManager<TStreamId> _epochManager;
+		private LogFormatAbstractor<TStreamId> _logFormat;
 		private LinkedList<EpochRecord> _cache;
 		private TFChunkReader _reader;
 		private TFChunkWriter _writer;
@@ -31,14 +36,13 @@ namespace EventStore.Core.Tests.Services.Storage {
 		private readonly Guid _instanceId = Guid.NewGuid();
 		private readonly List<Message> _published = new List<Message>();
 		private List<EpochRecord> _epochs;
-		private static readonly IRecordFactory<TStreamId> _recordFactory = LogFormatHelper<TLogFormat, TStreamId>.RecordFactory;
 
 		private int GetNextEpoch() {
 			return (int)Interlocked.Increment(ref _currentEpoch);
 		}
 		private long _currentEpoch = -1;
-		private EpochManager GetManager() {
-			return new EpochManager(_mainBus,
+		private EpochManager<TStreamId> GetManager() {
+			return new EpochManager<TStreamId>(_mainBus,
 				10,
 				_db.Config.EpochCheckpoint,
 				_writer,
@@ -46,17 +50,22 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
-				_recordFactory,
+				_logFormat.RecordFactory,
+				_logFormat.StreamNameIndex,
+				_logFormat.EventTypeIndex,
+				_logFormat.CreatePartitionManager(
+					reader: new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+					writer: _writer),
 				_instanceId);
 		}
-		private LinkedList<EpochRecord> GetCache(EpochManager manager) {
-			return (LinkedList<EpochRecord>)typeof(EpochManager).GetField("_epochs", BindingFlags.NonPublic | BindingFlags.Instance)
+		private LinkedList<EpochRecord> GetCache(EpochManager<TStreamId> manager) {
+			return (LinkedList<EpochRecord>)typeof(EpochManager<TStreamId>).GetField("_epochs", BindingFlags.NonPublic | BindingFlags.Instance)
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
 			long pos = _writer.Checkpoint.ReadNonFlushed();
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
-			var rec = _recordFactory.CreateEpoch(epoch);
+			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);
 			_writer.Flush();
 			return epoch;
@@ -64,6 +73,12 @@ namespace EventStore.Core.Tests.Services.Storage {
 		[OneTimeSetUp]
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
+
+			var indexDirectory = GetFilePathFor("index");
+			_logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory.Create(new() {
+				IndexDirectory = indexDirectory,
+			});
+
 			_mainBus = new InMemoryBus(nameof(when_having_an_epoch_manager_and_empty_tf_log<TLogFormat, TStreamId>));
 			_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
 			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
@@ -237,11 +252,46 @@ namespace EventStore.Core.Tests.Services.Storage {
 			Assert.That(_cache.First.Value.EpochNumber == _epochs[20].EpochNumber);
 			Assert.That(_cache.Last.Value.EpochNumber == _epochs[29].EpochNumber);
 
+			// can write an epoch with epoch information (even though previous epochs
+			// dont have epoch information)
+			_epochManager.WriteNewEpoch(GetNextEpoch());
+			_epochManager.WriteNewEpoch(GetNextEpoch());
+			var epochsWritten = _published.OfType<SystemMessage.EpochWritten>().ToArray();
+			Assert.AreEqual(2, epochsWritten.Length);
+			for (int i = 0; i < epochsWritten.Length; i++) {
+				_reader.Reposition(epochsWritten[i].Epoch.EpochPosition);
+				_reader.TryReadNext(); // read epoch
+				IPrepareLogRecord<TStreamId> epochInfo;
+				while (true) {
+					var result = _reader.TryReadNext();
+					Assert.True(result.Success);
+					if (result.LogRecord is IPrepareLogRecord<TStreamId> prepare) {
+						epochInfo = prepare;
+						break;
+					}
+				}
+				var expectedStreamId = LogFormatHelper<TLogFormat, TStreamId>.Choose<TStreamId>(
+					SystemStreams.EpochInformationStream,
+					LogV3SystemStreams.EpochInformationStreamNumber);
+				var expectedEventType = LogFormatHelper<TLogFormat, TStreamId>.Choose<TStreamId>(
+					SystemEventTypes.EpochInformation,
+					LogV3SystemEventTypes.EpochInformationNumber);
+				Assert.AreEqual(expectedStreamId, epochInfo.EventStreamId);
+				Assert.AreEqual(expectedEventType, epochInfo.EventType);
+				Assert.AreEqual(i - 1, epochInfo.ExpectedVersion);
+				Assert.AreEqual(_instanceId, epochInfo.Data.ParseJson<EpochDto>().LeaderInstanceId);
+			}
 		}
+
+		public class EpochDto {
+			public Guid LeaderInstanceId { get; set; }
+		}
+
 		public void Dispose() {
 			//epochManager?.Dispose();
 			//reader?.Dispose();
 			try {
+				_logFormat?.Dispose();
 				_writer?.Dispose();
 			} catch {
 				//workaround for TearDown error

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
@@ -24,7 +24,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
 	public sealed class when_starting_having_TFLog_with_existing_epochs<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture, IDisposable {
 		private TFChunkDb _db;
-		private EpochManager _epochManager;
+		private EpochManager<TStreamId> _epochManager;
+		private LogFormatAbstractor<TStreamId> _logFormat;
 		private LinkedList<EpochRecord> _cache;
 		private TFChunkReader _reader;
 		private TFChunkWriter _writer;
@@ -32,15 +33,14 @@ namespace EventStore.Core.Tests.Services.Storage {
 		private readonly Guid _instanceId = Guid.NewGuid();
 		private readonly List<Message> _published = new List<Message>();
 		private List<EpochRecord> _epochs;
-		private static readonly IRecordFactory<TStreamId> _recordFactory = LogFormatHelper<TLogFormat, TStreamId>.RecordFactory;
 
 		private static int GetNextEpoch() {
 			return (int)Interlocked.Increment(ref _currentEpoch);
 		}
 		private static long _currentEpoch = -1;
 
-		private EpochManager GetManager() {
-			return new EpochManager(_mainBus,
+		private EpochManager<TStreamId> GetManager() {
+			return new EpochManager<TStreamId>(_mainBus,
 				10,
 				_db.Config.EpochCheckpoint,
 				_writer,
@@ -48,11 +48,16 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
-				_recordFactory,
+				_logFormat.RecordFactory,
+				_logFormat.StreamNameIndex,
+				_logFormat.EventTypeIndex,
+				_logFormat.CreatePartitionManager(
+					reader: new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+					writer: _writer),
 				_instanceId);
 		}
-		private LinkedList<EpochRecord> GetCache(EpochManager manager) {
-			return (LinkedList<EpochRecord>)typeof(EpochManager).GetField("_epochs", BindingFlags.NonPublic | BindingFlags.Instance)
+		private LinkedList<EpochRecord> GetCache(EpochManager<TStreamId> manager) {
+			return (LinkedList<EpochRecord>)typeof(EpochManager<TStreamId>).GetField("_epochs", BindingFlags.NonPublic | BindingFlags.Instance)
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
@@ -67,6 +72,12 @@ namespace EventStore.Core.Tests.Services.Storage {
 		[OneTimeSetUp]
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
+
+			var indexDirectory = GetFilePathFor("index");
+			_logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory.Create(new() {
+				IndexDirectory = indexDirectory,
+			});
+
 			_mainBus = new InMemoryBus(nameof(when_starting_having_TFLog_with_existing_epochs<TLogFormat, TStreamId>));
 			_mainBus.Subscribe(new AdHocHandler<SystemMessage.EpochWritten>(m => _published.Add(m)));
 			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
@@ -104,7 +115,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		[Test]
 		public void starting_epoch_manager_with_cache_larger_than_epoch_count_loads_all_epochs() {
 
-			_epochManager = new EpochManager(_mainBus,
+			_epochManager = new EpochManager<TStreamId>(_mainBus,
 				1000,
 				_db.Config.EpochCheckpoint,
 				_writer,
@@ -112,7 +123,12 @@ namespace EventStore.Core.Tests.Services.Storage {
 				maxReaderCount: 5,
 				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
 					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
-				_recordFactory,
+				_logFormat.RecordFactory,
+				_logFormat.StreamNameIndex,
+				_logFormat.EventTypeIndex,
+				_logFormat.CreatePartitionManager(
+					reader: new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+					writer: _writer),
 				_instanceId);
 			_epochManager.Init();
 			_cache = GetCache(_epochManager);
@@ -127,6 +143,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			//epochManager?.Dispose();
 			//reader?.Dispose();
 			try {
+				_logFormat?.Dispose();
 				_writer?.Dispose();
 			} catch {
 				//workaround for TearDown error

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/SubscribeToAllFilteredTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/SubscribeToAllFilteredTests.cs
@@ -103,6 +103,8 @@ namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
 					_position &&
 					response.Event.Event.StreamIdentifier.StreamName.ToStringUtf8() != StreamName);
 
+				// skip the epochinfo - which isn't in unfiltered all reads so we haven't accounted for it above
+				skippedEventCount += 1;
 				_expected = skippedEventCount / _checkpointInterval;
 
 				await foreach (var response in StreamsClient.Read(new ReadReq {

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/InaugurationManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/InaugurationManagerTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Net;
+using EventStore.Core.Cluster;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.VNode;
+using EventStore.Core.Tests.Fakes;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+	public abstract class InaugurationManagerTests {
+		protected readonly Guid _correlationId1 = Guid.Parse("00000000-0000-0000-0000-0000000000c1");
+		protected readonly Guid _correlationId2 = Guid.Parse("00000000-0000-0000-0000-0000000000c2");
+		protected readonly Guid _correlationId3 = Guid.Parse("00000000-0000-0000-0000-0000000000c3");
+		protected readonly int _epochNumber = 15;
+		protected readonly MemberInfo _leader =
+			MemberInfo.ForVNode(
+				default, default, default, default,
+				new DnsEndPoint("localhost", default), default, default, default,
+				new DnsEndPoint("localhost", default), default, default, default,
+				default, default, default, default, default, default, default, default);
+		protected readonly long _replicationTarget = 400;
+		protected readonly long _indexTarget = 400;
+
+		protected InaugurationManager _sut;
+		protected FakePublisher _publisher;
+		protected InMemoryCheckpoint _replicationCheckpoint;
+		protected InMemoryCheckpoint _indexCheckpoint;
+
+		[SetUp]
+		public void SetUp() {
+			_publisher = new FakePublisher();
+			_replicationCheckpoint = new InMemoryCheckpoint();
+			_indexCheckpoint = new InMemoryCheckpoint();
+			_sut = new InaugurationManager(_publisher, _replicationCheckpoint, _indexCheckpoint);
+			Given();
+		}
+
+		protected abstract void Given();
+
+		protected void When(Message m) {
+			_sut.Handle((dynamic)m);
+		}
+
+		protected SystemMessage.EpochWritten GenEpoch(int epochNumber) {
+			var epoch = new SystemMessage.EpochWritten(new EpochRecord(
+							epochPosition: _replicationTarget - 1,
+							epochNumber: epochNumber,
+							epochId: Guid.NewGuid(),
+							prevEpochPosition: _replicationTarget - 20,
+							timeStamp: DateTime.UtcNow,
+							leaderInstanceId: Guid.NewGuid()));
+			return epoch;
+		}
+
+		protected void ProgressReplication() {
+			_replicationCheckpoint.Write(_replicationTarget / 2);
+			_replicationCheckpoint.Flush();
+		}
+
+		protected void CompleteReplication() {
+			_replicationCheckpoint.Write(_replicationTarget);
+			_replicationCheckpoint.Flush();
+		}
+
+		protected void ProgressIndexing() {
+			_indexCheckpoint.Write(_indexTarget / 2);
+			_indexCheckpoint.Flush();
+		}
+
+		protected void CompleteIndexing() {
+			_indexCheckpoint.Write(_indexTarget);
+			_indexCheckpoint.Flush();
+		}
+
+		protected static T AssertIsType<T>(object o) {
+			Assert.IsInstanceOf<T>(o);
+			return (T)o;
+		}
+
+		// check that we have reset to initial state, do this by checking we can
+		// proceed forward from it
+		protected void AssertInitial() {
+			Assert.IsEmpty(_publisher.Messages);
+			_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId3));
+			AssertWaitingForChaser(_correlationId3);
+		}
+
+		// check that we have reset to waiting fo chaser, do this by checking we can
+		// proceed forward from it
+		protected void AssertWaitingForChaser(Guid expectedCorrelationId) {
+			Assert.IsEmpty(_publisher.Messages);
+			_sut.Handle(new SystemMessage.ChaserCaughtUp(expectedCorrelationId));
+			Assert.AreEqual(1, _publisher.Messages.Count);
+			Assert.IsInstanceOf<SystemMessage.WriteEpoch>(_publisher.Messages[0]);
+		}
+
+		protected void AssertSentBecomeLeader() {
+			Assert.AreEqual(1, _publisher.Messages.Count);
+			var becomeLeader = AssertIsType<SystemMessage.BecomeLeader>(_publisher.Messages[0]);
+			Assert.AreEqual(_correlationId1, becomeLeader.CorrelationId);
+			_publisher.Messages.Clear();
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_initial_state.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_initial_state.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+	[TestFixture]
+	public class given_initial_state : InaugurationManagerTests {
+		protected override void Given() {
+			_publisher.Messages.Clear();
+		}
+
+		[Test]
+		public void when_become_pre_leader() {
+			When(new SystemMessage.BecomePreLeader(_correlationId1));
+			AssertWaitingForChaser(_correlationId1);
+		}
+
+		[Test]
+		public void when_become_other_node_state() {
+			When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_chaser.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using EventStore.Core.Messages;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+
+	[TestFixture]
+	public class given_waiting_for_chaser : InaugurationManagerTests {
+		protected override void Given() {
+			_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+			_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
+			_publisher.Messages.Clear();
+		}
+
+		[Test]
+		public void when_chaser_caught_up() {
+			When(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			Assert.AreEqual(1, _publisher.Messages.Count);
+			var writeEpoch = AssertIsType<SystemMessage.WriteEpoch>(_publisher.Messages[0]);
+			Assert.AreEqual(_epochNumber, writeEpoch.EpochNumber);
+		}
+
+		[Test]
+		public void when_chaser_caught_up_with_unknown_correlation_id() {
+			When(new SystemMessage.ChaserCaughtUp(_correlationId2));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_become_pre_leader() {
+			When(new SystemMessage.BecomePreLeader(_correlationId2));
+			AssertWaitingForChaser(_correlationId2);
+		}
+
+		[Test]
+		public void when_become_other_node_state() {
+			When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_conditions.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_waiting_for_conditions.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+	[TestFixture]
+	public class given_waiting_for_conditions : InaugurationManagerTests {
+		protected override void Given() {
+			_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+			_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
+			_sut.Handle(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			_sut.Handle(GenEpoch(_epochNumber));
+			_publisher.Messages.Clear();
+		}
+
+		[Test]
+		public void when_transition_triggered_by_indexedto() {
+			ProgressReplication();
+			ProgressIndexing();
+			CompleteReplication();
+			CompleteIndexing();
+			Assert.IsEmpty(_publisher.Messages);
+
+			When(new ReplicationTrackingMessage.IndexedTo(_indexCheckpoint.Read()));
+
+			AssertSentBecomeLeader();
+		}
+
+		[Test]
+		public void when_transition_triggered_by_replicatedto() {
+			ProgressReplication();
+			ProgressIndexing();
+			CompleteReplication();
+			CompleteIndexing();
+			Assert.IsEmpty(_publisher.Messages);
+
+			When(new ReplicationTrackingMessage.ReplicatedTo(_replicationCheckpoint.Read()));
+
+			AssertSentBecomeLeader();
+		}
+
+		[Test]
+		public void when_transition_triggered_by_checkconditions() {
+			CompleteReplication();
+			CompleteIndexing();
+			Assert.IsEmpty(_publisher.Messages);
+
+			When(new SystemMessage.CheckInaugurationConditions());
+
+			Assert.AreEqual(2, _publisher.Messages.Count);
+			Assert.IsInstanceOf<TimerMessage.Schedule>(_publisher.Messages[0]);
+			_publisher.Messages.RemoveAt(0);
+
+			AssertSentBecomeLeader();
+		}
+
+		[Test]
+		public void cant_become_leader_twice() {
+			CompleteReplication();
+			CompleteIndexing();
+			Assert.IsEmpty(_publisher.Messages);
+
+			When(new ReplicationTrackingMessage.ReplicatedTo(_replicationCheckpoint.Read()));
+			When(new SystemMessage.CheckInaugurationConditions());
+
+			AssertSentBecomeLeader();
+		}
+
+		[Test]
+		public void when_epoch_written() {
+			When(GenEpoch(_epochNumber));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_chaser_caught_up() {
+			When(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_become_pre_leader() {
+			When(new SystemMessage.BecomePreLeader(_correlationId2));
+			AssertWaitingForChaser(_correlationId2);
+		}
+
+		[Test]
+		public void when_become_other_node_state() {
+			When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_writing_epoch.cs
+++ b/src/EventStore.Core.Tests/Services/VNode/InaugurationManager/given_writing_epoch.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.VNode.InaugurationManagement {
+	[TestFixture]
+	public class given_writing_epoch : InaugurationManagerTests {
+		protected override void Given() {
+			_sut.Handle(new ElectionMessage.ElectionsDone(123, _epochNumber, _leader));
+			_sut.Handle(new SystemMessage.BecomePreLeader(_correlationId1));
+			_sut.Handle(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			_publisher.Messages.Clear();
+		}
+
+		[Test]
+		public void when_epoch_written() {
+			When(GenEpoch(_epochNumber));
+			Assert.AreEqual(2, _publisher.Messages.Count);
+			Assert.IsInstanceOf<SystemMessage.EnablePreLeaderReplication>(_publisher.Messages[0]);
+			var schedule = AssertIsType<TimerMessage.Schedule>(_publisher.Messages[1]);
+			Assert.IsInstanceOf<SystemMessage.CheckInaugurationConditions>(schedule.ReplyMessage);
+		}
+
+		[Test]
+		public void when_epoch_written_with_unexpected_number() {
+			When(GenEpoch(_epochNumber + 1));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_epoch_written_and_conditions_instantly_met() {
+			CompleteReplication();
+			CompleteIndexing();
+			When(GenEpoch(_epochNumber));
+
+			Assert.AreEqual(3, _publisher.Messages.Count);
+			Assert.IsInstanceOf<SystemMessage.EnablePreLeaderReplication>(_publisher.Messages[0]);
+			Assert.IsInstanceOf<SystemMessage.BecomeLeader>(_publisher.Messages[1]);
+			Assert.IsInstanceOf<TimerMessage.Schedule>(_publisher.Messages[2]);
+		}
+
+		[Test]
+		public void when_chaser_caught_up() {
+			When(new SystemMessage.ChaserCaughtUp(_correlationId1));
+			Assert.IsEmpty(_publisher.Messages);
+		}
+
+		[Test]
+		public void when_become_pre_leader() {
+			When(new SystemMessage.BecomePreLeader(_correlationId2));
+			AssertWaitingForChaser(_correlationId2);
+		}
+
+		[Test]
+		public void when_become_other_node_state() {
+			When(new SystemMessage.BecomeUnknown(Guid.NewGuid()));
+			AssertInitial();
+		}
+	}
+}

--- a/src/EventStore.Core/LogV3/LogV3SystemEventTypes.cs
+++ b/src/EventStore.Core/LogV3/LogV3SystemEventTypes.cs
@@ -12,11 +12,15 @@ namespace EventStore.Core.LogV3 {
 		public const EventTypeId StreamCreatedNumber = 2;
 		public const EventTypeId StreamMetadataNumber = 3;
 		public const EventTypeId StreamDeletedNumber = 4;
+		public const EventTypeId EpochInformationNumber = 5;
 
 		public static bool TryGetSystemEventTypeId(string type, out EventTypeId eventTypeId) {
 			switch (type) {
 				case SystemEventTypes.EmptyEventType:
 					eventTypeId = EmptyEventTypeNumber;
+					return true;
+				case SystemEventTypes.EpochInformation:
+					eventTypeId = EpochInformationNumber;
 					return true;
 				case SystemEventTypes.EventTypeDefined:
 					eventTypeId = EventTypeDefinedNumber;
@@ -44,6 +48,7 @@ namespace EventStore.Core.LogV3 {
 
 			name = eventTypeId switch {
 				EmptyEventTypeNumber => SystemEventTypes.EmptyEventType,
+				EpochInformationNumber => SystemEventTypes.EpochInformation,
 				EventTypeDefinedNumber => SystemEventTypes.EventTypeDefined,
 				StreamCreatedNumber => SystemEventTypes.StreamCreated,
 				StreamMetadataNumber => SystemEventTypes.StreamMetadata,

--- a/src/EventStore.Core/LogV3/LogV3SystemStreams.cs
+++ b/src/EventStore.Core/LogV3/LogV3SystemStreams.cs
@@ -38,6 +38,8 @@ namespace EventStore.Core.LogV3 {
 		// virtual stream so that we can index EventTypeRecords for looking up event type names
 		public const StreamId EventTypesStreamNumber = 10;
 
+		public const StreamId EpochInformationStreamNumber = 12;
+
 		public StreamId AllStream => AllStreamNumber;
 		public StreamId SettingsStream => SettingsStreamNumber;
 
@@ -60,6 +62,7 @@ namespace EventStore.Core.LogV3 {
 
 			name = streamId switch {
 				AllStreamNumber => SystemStreams.AllStream,
+				EpochInformationStreamNumber => SystemStreams.EpochInformationStream,
 				EventTypesStreamNumber => SystemStreams.EventTypesStream,
 				SettingsStreamNumber => SystemStreams.SettingsStream,
 				StreamsCreatedStreamNumber => SystemStreams.StreamsCreatedStream,
@@ -73,6 +76,9 @@ namespace EventStore.Core.LogV3 {
 			switch (name) {
 				case SystemStreams.AllStream:
 					streamId = AllStreamNumber;
+					return true;
+				case SystemStreams.EpochInformationStream:
+					streamId = EpochInformationStreamNumber;
 					return true;
 				case SystemStreams.EventTypesStream:
 					streamId = EventTypesStreamNumber;

--- a/src/EventStore.Core/LogV3/NameIndex.cs
+++ b/src/EventStore.Core/LogV3/NameIndex.cs
@@ -199,7 +199,7 @@ namespace EventStore.Core.LogV3 {
 				addedValue = value;
 				addedName = name;
 				_reservations[name] = value;
-				Log.Debug("{indexName} reserved new entry: {key}:{value}", _indexName, name, value);
+				Log.Verbose("{indexName} reserved new entry: {key}:{value}", _indexName, name, value);
 			}
 		}
 	}

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -135,10 +135,7 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public readonly int EpochNumber;
-
-			public BecomeLeader(Guid correlationId, int epochNumber) : base(correlationId, VNodeState.Leader) {
-				EpochNumber = epochNumber;
+			public BecomeLeader(Guid correlationId) : base(correlationId, VNodeState.Leader) {
 			}
 		}
 
@@ -401,6 +398,28 @@ namespace EventStore.Core.Messages {
 			public ChaserCaughtUp(Guid correlationId) {
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				CorrelationId = correlationId;
+			}
+		}
+
+		public class EnablePreLeaderReplication : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public EnablePreLeaderReplication() {
+			}
+		}
+
+		public class CheckInaugurationConditions : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public CheckInaugurationConditions() {
 			}
 		}
 

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -49,10 +49,9 @@ namespace EventStore.Core.Services {
 			ISystemStreamLookup<TStreamId> systemStreams,
 			IEpochManager epochManager,
 			QueueStatsManager queueStatsManager,
-			Func<long> getLastIndexedPosition,
-			IPartitionManager partitionManager)
+			Func<long> getLastIndexedPosition)
 			: base(bus, subscribeToBus, minFlushDelay, db, writer, indexWriter, recordFactory, streamNameIndex,
-				eventTypeIndex, emptyEventTypeId, systemStreams, epochManager, queueStatsManager, partitionManager) {
+				eventTypeIndex, emptyEventTypeId, systemStreams, epochManager, queueStatsManager) {
 			Ensure.NotNull(getLastIndexedPosition, "getLastCommitPosition");
 
 			_getLastIndexedPosition = getLastIndexedPosition;

--- a/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
+++ b/src/EventStore.Core/Services/Replication/LeaderReplicationService.cs
@@ -26,6 +26,7 @@ namespace EventStore.Core.Services.Replication {
 	public class LeaderReplicationService : IMonitoredQueue,
 		IHandle<SystemMessage.SystemStart>,
 		IHandle<SystemMessage.StateChangeMessage>,
+		IHandle<SystemMessage.EnablePreLeaderReplication>,
 		IHandle<ReplicationMessage.ReplicaSubscriptionRequest>,
 		IHandle<ReplicationMessage.ReplicaLogPositionAck>,
 		IHandle<ReplicationMessage.GetReplicationStats>,
@@ -68,6 +69,7 @@ namespace EventStore.Core.Services.Replication {
 		private volatile bool _newSubscriptions;
 		private TimeSpan _noQuorumTimestamp = TimeSpan.Zero;
 		private bool _noQuorumNotified;
+		private bool _preLeaderReplicationEnabled;
 		private ManualResetEventSlim _flushSignal = new ManualResetEventSlim(false, 1);
 		private readonly TaskCompletionSource<object> _tcs = new TaskCompletionSource<object>();
 
@@ -111,6 +113,11 @@ namespace EventStore.Core.Services.Replication {
 		public void Handle(SystemMessage.StateChangeMessage message) {
 			_state = message.State;
 
+			if (message.State == VNodeState.PreLeader) {
+				_preLeaderReplicationEnabled = false;
+				_noQuorumTimestamp = TimeSpan.Zero;
+			}
+
 			if (message.State == VNodeState.Leader)
 				_noQuorumTimestamp = TimeSpan.Zero;
 
@@ -118,11 +125,29 @@ namespace EventStore.Core.Services.Replication {
 				_stop = true;
 		}
 
+		public void Handle(SystemMessage.EnablePreLeaderReplication message) {
+			_preLeaderReplicationEnabled = true;
+		}
+
+		private bool CanAcceptSubscription(ReplicationMessage.ReplicaSubscriptionRequest message) {
+			return CanAcceptSubscriptions() && message.LeaderId == _instanceId;
+		}
+
+		private bool CanAcceptSubscriptions() {
+			if (_state == VNodeState.Leader)
+				return true;
+
+			if (_state == VNodeState.PreLeader && _preLeaderReplicationEnabled)
+				return true;
+
+			return false;
+		}
+
 		public void Handle(ReplicationMessage.ReplicaSubscriptionRequest message) {
 			_publisher.Publish(new SystemMessage.VNodeConnectionEstablished(message.ReplicaEndPoint,
 				message.Connection.ConnectionId));
 
-			if (_state != VNodeState.Leader || message.LeaderId != _instanceId) {
+			if (!CanAcceptSubscription(message)) {
 				message.Envelope.ReplyWith(
 					new ReplicationMessage.ReplicaSubscriptionRetry(_instanceId, message.SubscriptionId));
 				return;
@@ -531,7 +556,7 @@ namespace EventStore.Core.Services.Replication {
 		}
 
 		private void ManageNoQuorumDetection() {
-			if (_state == VNodeState.Leader) {
+			if (CanAcceptSubscriptions()) {
 				var now = _stopwatch.Elapsed;
 				if (_subscriptions.Count(x => x.Value.IsPromotable) >= _clusterSize / 2) // everything is ok
 					_noQuorumTimestamp = TimeSpan.Zero;

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/AllReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/AllReader.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 
 		public IndexReadAllResult ReadAllEventsForward(TFPos pos, int maxCount) {
-			return ReadAllEventsForwardInternal(pos, maxCount, maxCount, EventFilter.DefaultAllFilter);
+			return ReadAllEventsForwardInternal(pos, maxCount, int.MaxValue, EventFilter.DefaultAllFilter);
 		}
 
 		public IndexReadAllResult FilteredReadAllEventsForward(TFPos pos, int maxCount, int maxSearchWindow,
@@ -182,7 +182,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 		
 		public IndexReadAllResult ReadAllEventsBackward(TFPos pos, int maxCount) {
-			return ReadAllEventsBackwardInternal(pos, maxCount, maxCount, EventFilter.DefaultAllFilter);
+			return ReadAllEventsBackwardInternal(pos, maxCount, int.MaxValue, EventFilter.DefaultAllFilter);
 		}
 
 		public IndexReadAllResult FilteredReadAllEventsBackward(TFPos pos, int maxCount, int maxSearchWindow,

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -25,6 +25,7 @@ namespace EventStore.Core.Services {
 		public const string SettingsStream = "$settings";
 		public const string StatsStreamPrefix = "$stats";
 		public const string ScavengesStream = "$scavenges";
+		public const string EpochInformationStream = "$epoch-information";
 
 		public static bool IsSystemStream(string streamId) {
 			return streamId.Length != 0 && streamId[0] == '$';
@@ -70,6 +71,7 @@ namespace EventStore.Core.Services {
 		public const string StreamMetadata = "$metadata";
 		public const string Settings = "$settings";
 		public const string StreamCreated = "$stream";
+		public const string EpochInformation = "$epoch-information";
 
 		public const string V2__StreamCreated_InIndex = "StreamCreated";
 		public const string V1__StreamCreated__ = "$stream-created";

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -34,7 +34,6 @@ namespace EventStore.Core.Services.VNode {
 
 		private VNodeState _state = VNodeState.Initializing;
 		private MemberInfo _leader;
-		private int _currentEpoch;
 		private Guid _stateCorrelationId = Guid.NewGuid();
 		private Guid _subscriptionId = Guid.Empty;
 		private readonly int _clusterSize;
@@ -91,7 +90,6 @@ namespace EventStore.Core.Services.VNode {
 			                                               options.Database.CommitTimeoutMs + 300);
 
 			_fsm = CreateFSM();
-			_currentEpoch = -1;
 		}
 
 		public void SetMainQueue(IQueuedHandler mainQueue) {
@@ -105,8 +103,8 @@ namespace EventStore.Core.Services.VNode {
 			var stm = new VNodeFSMBuilder(() => _state)
 				.InAnyState()
 				.When<SystemMessage.StateChangeMessage>()
-				.Do(m => Application.Exit(ExitCode.Error,
-					string.Format("{0} message was unhandled in {1}.", m.GetType().Name, GetType().Name)))
+					.Do(m => Application.Exit(ExitCode.Error,
+						string.Format("{0} message was unhandled in {1}. State: {2}", m.GetType().Name, GetType().Name, _state)))
 				.When<AuthenticationMessage.AuthenticationProviderInitialized>().Do(Handle)
 				.When<AuthenticationMessage.AuthenticationProviderInitializationFailed>().Do(Handle)
 				.When<SystemMessage.SubSystemInitialized>().Do(Handle)
@@ -286,10 +284,12 @@ namespace EventStore.Core.Services.VNode {
 				.InState(VNodeState.PreReadOnlyReplica)
 				.When<SystemMessage.BecomeReadOnlyReplica>().Do(Handle)
 				.InStates(VNodeState.PreLeader, VNodeState.Leader, VNodeState.ResigningLeader)
+				.When<SystemMessage.NoQuorumMessage>().Do(Handle)
 				.When<GossipMessage.GossipUpdated>().Do(HandleAsLeader)
 				.When<ReplicationMessage.ReplicaSubscriptionRequest>().ForwardTo(_outputBus)
 				.When<ReplicationMessage.ReplicaLogPositionAck>().ForwardTo(_outputBus)
 				.InAllStatesExcept(VNodeState.PreLeader, VNodeState.Leader, VNodeState.ResigningLeader)
+				.When<SystemMessage.NoQuorumMessage>().Ignore()
 				.When<ReplicationMessage.ReplicaSubscriptionRequest>().Ignore()
 				.InState(VNodeState.PreLeader)
 				.When<SystemMessage.BecomeLeader>().Do(Handle)
@@ -297,7 +297,6 @@ namespace EventStore.Core.Services.VNode {
 				.When<SystemMessage.ChaserCaughtUp>().Do(HandleAsPreLeader)
 				.WhenOther().ForwardTo(_outputBus)
 				.InStates(VNodeState.Leader, VNodeState.ResigningLeader)
-				.When<SystemMessage.NoQuorumMessage>().Do(Handle)
 				.When<StorageMessage.WritePrepares>().ForwardTo(_outputBus)
 				.When<StorageMessage.WriteDelete>().ForwardTo(_outputBus)
 				.When<StorageMessage.WriteTransactionStart>().ForwardTo(_outputBus)
@@ -306,7 +305,6 @@ namespace EventStore.Core.Services.VNode {
 				.When<StorageMessage.WriteCommit>().ForwardTo(_outputBus)
 				.WhenOther().ForwardTo(_outputBus)
 				.InAllStatesExcept(VNodeState.Leader, VNodeState.ResigningLeader)
-				.When<SystemMessage.NoQuorumMessage>().Ignore()
 				.When<SystemMessage.InitiateLeaderResignation>().Ignore()
 				.When<SystemMessage.BecomeResigningLeader>().Ignore()
 				.When<StorageMessage.WritePrepares>().Ignore()
@@ -529,7 +527,6 @@ namespace EventStore.Core.Services.VNode {
 		}
 
 		private void Handle(ElectionMessage.ElectionsDone message) {
-			_currentEpoch = message.ProposalNumber;
 			if (_leader != null && _leader.InstanceId == message.Leader.InstanceId) {
 				//if the leader hasn't changed, we skip state changes through PreLeader or PreReplica
 				if (_leader.InstanceId == _nodeInfo.InstanceId && _state == VNodeState.Leader) {
@@ -1053,7 +1050,6 @@ namespace EventStore.Core.Services.VNode {
 				return;
 
 			_outputBus.Publish(message);
-			_fsm.Handle(new SystemMessage.BecomeLeader(_stateCorrelationId, _currentEpoch));
 		}
 
 		private void HandleAsPreReplica(SystemMessage.ChaserCaughtUp message) {

--- a/src/EventStore.Core/Services/VNode/InaugurationManager.cs
+++ b/src/EventStore.Core/Services/VNode/InaugurationManager.cs
@@ -1,0 +1,237 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.Checkpoint;
+using ILogger = Serilog.ILogger;
+
+namespace EventStore.Core.Services.VNode {
+	public class InaugurationManager :
+		IHandle<SystemMessage.StateChangeMessage>,
+		IHandle<SystemMessage.ChaserCaughtUp>,
+		IHandle<SystemMessage.EpochWritten>,
+		IHandle<SystemMessage.CheckInaugurationConditions>,
+		IHandle<ElectionMessage.ElectionsDone>,
+		IHandle<ReplicationTrackingMessage.ReplicatedTo>,
+		IHandle<ReplicationTrackingMessage.IndexedTo> {
+
+		private readonly ILogger _log = Serilog.Log.ForContext<InaugurationManager>();
+		private readonly IPublisher _publisher;
+		private readonly IReadOnlyCheckpoint _replicationCheckpoint;
+		private readonly IReadOnlyCheckpoint _indexCheckpoint;
+		private readonly Message _scheduleCheckInaugurationConditions;
+
+		private VNodeState _nodeState;
+		private ManagerState _managerState;
+		private Guid _stateCorrelationId;
+		private int _currentEpochNumber;
+		private long _replicationCheckpointTarget;
+		private long _indexCheckpointTarget;
+
+		private enum ManagerState {
+			Initial,
+			WaitingForChaser,
+			WritingEpoch,
+			WaitingForConditions,
+			BecomingLeader,
+		}
+
+		public InaugurationManager(
+			IPublisher publisher,
+			IReadOnlyCheckpoint replicationCheckpoint,
+			IReadOnlyCheckpoint indexCheckpoint) {
+
+			_log.Information("Using {name}", nameof(InaugurationManager));
+			_publisher = publisher;
+			_replicationCheckpoint = replicationCheckpoint;
+			_indexCheckpoint = indexCheckpoint;
+
+			_scheduleCheckInaugurationConditions = TimerMessage.Schedule.Create(
+				triggerAfter: TimeSpan.FromSeconds(1),
+				envelope: new PublishEnvelope(_publisher),
+				replyMessage: new SystemMessage.CheckInaugurationConditions());
+		}
+
+		public void Handle(ElectionMessage.ElectionsDone received) {
+			_currentEpochNumber = received.ProposalNumber;
+			Received(received, "currentEpochNumber {currentEpochNumber}.", _currentEpochNumber);
+		}
+
+		public void Handle(SystemMessage.StateChangeMessage received) {
+			if (received is SystemMessage.BecomePreLeader becomePreLeader) {
+				HandleBecomePreLeader(becomePreLeader);
+			} else {
+				HandleBecomeOtherNodeState(received);
+			}
+		}
+
+		private void HandleBecomePreLeader(SystemMessage.BecomePreLeader received) {
+			Received(
+				received,
+				"Starting inauguration process with correlation id {currentCorrelationId}. Waiting for chaser.",
+				received.CorrelationId);
+			_nodeState = received.State;
+			_managerState = ManagerState.WaitingForChaser;
+			_stateCorrelationId = received.CorrelationId;
+		}
+
+		private void HandleBecomeOtherNodeState(SystemMessage.StateChangeMessage received) {
+			if (_managerState != ManagerState.Initial) {
+				Received(received, "Inauguration process is now stopped.");
+				_managerState = ManagerState.Initial;
+			}
+
+			_nodeState = received.State;
+		}
+
+		public void Handle(SystemMessage.ChaserCaughtUp received) {
+			if (_managerState != ManagerState.WaitingForChaser) {
+				// will get this in prereplica and prereadonly replica
+				Ignore(received, "Not waiting for chaser.");
+			} else if (received.CorrelationId != _stateCorrelationId) {
+				Ignore(
+					received,
+					"Current correlation id is {currentCorrelationId} but received {receivedCorrelationId}.",
+					_stateCorrelationId,
+					received.CorrelationId);
+			} else {
+				Respond(
+					received,
+					new SystemMessage.WriteEpoch(_currentEpochNumber),
+					"currentEpochNumber {currentEpochNumber}.",
+					_currentEpochNumber);
+				_managerState = ManagerState.WritingEpoch;
+			}
+		}
+
+		public void Handle(SystemMessage.EpochWritten received) {
+			if (_managerState != ManagerState.WritingEpoch) {
+				Ignore(received, "Not writing epoch.");
+			} else if (received.Epoch.EpochNumber != _currentEpochNumber) {
+				Ignore(
+					received,
+					"Current epoch number is {currentEpochNumber} but received {receivedEpochNumber}.",
+					_currentEpochNumber,
+					received.Epoch.EpochNumber);
+			} else {
+				Respond(received, new SystemMessage.EnablePreLeaderReplication());
+				_managerState = ManagerState.WaitingForConditions;
+
+				// want to replicate past the start of the epoch we just wrote.
+				_replicationCheckpointTarget = received.Epoch.EpochPosition + 1;
+
+				// and index past it too, to the $epoch-information event that immediately follows it
+				_indexCheckpointTarget = received.Epoch.EpochPosition + 1;
+
+				ConsiderBecomingLeader(received, log: true);
+				_publisher.Publish(_scheduleCheckInaugurationConditions);
+			}
+		}
+
+		public void Handle(ReplicationTrackingMessage.ReplicatedTo received) {
+			if (_managerState != ManagerState.WaitingForConditions) {
+				// silently ignore. we'll get these all the time
+			} else {
+				ConsiderBecomingLeader(received, log: false);
+			}
+		}
+
+		public void Handle(ReplicationTrackingMessage.IndexedTo received) {
+			if (_managerState != ManagerState.WaitingForConditions) {
+				// silently ignore. we'll get these all the time
+			} else {
+				ConsiderBecomingLeader(received, log: false);
+			}
+		}
+
+		public void Handle(SystemMessage.CheckInaugurationConditions received) {
+			if (_managerState != ManagerState.WaitingForConditions) {
+				Ignore(received, "Not waiting for conditions.");
+			} else {
+				Respond(received, _scheduleCheckInaugurationConditions);
+				ConsiderBecomingLeader(received, log: true);
+			}
+		}
+
+		private void ConsiderBecomingLeader(Message received, bool log) {
+			var replicationCurrent = _replicationCheckpoint.Read();
+			var indexCurrent = _indexCheckpoint.Read();
+			var replicationDone = replicationCurrent >= _replicationCheckpointTarget;
+			var indexDone = indexCurrent >= _indexCheckpointTarget;
+
+			if (log || (replicationDone && indexDone)) {
+				LogExtraInformation(
+					"Replication {progress}: {current:N0}/{target:N0}. Remaining: {remaining:N0}.",
+					replicationDone ? "DONE" : "IN PROGRESS",
+					replicationCurrent,
+					_replicationCheckpointTarget,
+					Math.Max(0, _replicationCheckpointTarget - replicationCurrent));
+
+				LogExtraInformation(
+					"Index {progress}: {current:N0}/{target:N0}. Remaining: {remaining:N0}.",
+					indexDone ? "DONE" : "IN PROGRESS",
+					indexCurrent,
+					_indexCheckpointTarget,
+					Math.Max(0, _indexCheckpointTarget - indexCurrent));
+			}
+
+			if (replicationDone && indexDone) {
+				// transition to leader!
+				Respond(
+					received,
+					new SystemMessage.BecomeLeader(_stateCorrelationId),
+					"Correlation id {currentCorrelationId}",
+					_stateCorrelationId);
+				_managerState = ManagerState.Initial;
+			}
+		}
+
+		private void Received(Message received, string template = null, params object[] templateArgs) {
+			LogExtraInformation(
+				Combine(template, "RECEIVED {received}."),
+				Combine(templateArgs, received.GetType().Name));
+		}
+
+		private void Respond(Message received, Message send, string template = null, params object[] templateArgs) {
+			LogExtraInformation(
+				Combine(template, "RECEIVED {received}. RESPONDING with {send}."),
+				Combine(templateArgs, received.GetType().Name, send.GetType().Name));
+			_publisher.Publish(send);
+		}
+
+		private void Ignore(Message received, string template = null, params object[] templateArgs) {
+			LogExtraInformation(
+				Combine(template, "IGNORING {received}."),
+				Combine(templateArgs, received.GetType().Name));
+		}
+
+		private void LogExtraInformation(string template = null, params object[] templateArgs) {
+			_log.Information(
+				Combine(template, "{name} in state ({nodeState}, {managerState}):"),
+				Combine(templateArgs, nameof(InaugurationManager), _nodeState, _managerState));
+		}
+
+		private static string Combine(string template2, string template1) {
+			if (template1 is null)
+				return template2;
+
+			if (template2 is null)
+				return template1;
+
+			return $"{template1} {template2}";
+		}
+
+		private static object[] Combine(object[] args2, params object[] args1) {
+			if (args1 is null)
+				return args2;
+
+			if (args2 is null)
+				return args1;
+
+			return args1.Concat(args2).ToArray();
+		}
+	}
+}

--- a/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_restarting.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_restarting.cs
@@ -17,7 +17,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -72,7 +72,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 		protected override void Given() {
 			// Start subsystem
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			 var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -141,7 +141,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -186,7 +186,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			WaitForStartMessage();
 			
@@ -209,7 +209,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -244,7 +244,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;

--- a/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_starting.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/when_projection_subsystem_starting.cs
@@ -20,7 +20,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				}));
 			
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			
@@ -50,7 +50,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				}));
 			
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 			
 			WaitForStartMessage();
 
@@ -75,7 +75,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMsg = WaitForStartMessage();
 			_instanceCorrelation = startMsg.InstanceCorrelationId;
@@ -103,7 +103,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -127,7 +127,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		[Test]
 		public void should_allow_starting_the_subsystem_again() {
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 			var startMessage = WaitForStartMessage();
 			
 			Assert.AreNotEqual(_instanceCorrelation, startMessage.InstanceCorrelationId);
@@ -141,7 +141,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -169,7 +169,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 
 		protected override void Given() {
 			Subsystem.Handle(new SystemMessage.SystemCoreReady());
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			var startMessage = WaitForStartMessage();
 			_instanceCorrelation = startMessage.InstanceCorrelationId;
@@ -184,7 +184,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 			WaitForStopMessage();
 
 			// Become leader again before subsystem fully stopped
-			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid(),0));
+			Subsystem.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
 			Subsystem.Handle(new ProjectionSubsystemMessage.ComponentStopped(
 				ProjectionManager.ServiceName, _instanceCorrelation));


### PR DESCRIPTION
Fixed: race condition where a node becomes leader and immediately writes to streams that have recently been written to but not indexed, resulting in events with incorrect numbers in their streams.

Forwards port of  https://github.com/EventStore/EventStore/pull/3187
- This change ensures that before becoming leader we successfully write an epoch and get it replicated. Thus demonstrating that we are in a fit state to become leader.
- Therefore the log is successfully replicated before we transition to leader.
- We also wait for the records to be indexed before we transition to leader, otherwise incorrect event numbers can be written because the latest events are not known to the index or IndexWriter


- The InaugurationManager is reponsible for making sure the conditions are met for transitioning to leader.
- In the PreLeader state we now accept replication subscriptions and monitor for quorum, transitioning to Unknown if a quorum is not maintained (exactly as we did in the leader state before)


