### PR TITLE
Fix log message templates

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -159,7 +159,7 @@ namespace EventStore.Core.Tests.Helpers {
 
 			Log.Information(
 				"\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"
-				+ "{11,-25} {12}\n" + "{13,-25} {14}\n" + "{15,-25} {16}\n" + "{17,-25} {18}\n" + "{19,-25} {20}\n\n",
+				+ "{11,-25} {12}\n" + "{13,-25} {14}\n" + "{15,-25} {16}\n" + "{17,-25} {18}\n\n",
 				"ES VERSION:", VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp,
 				"OS:", OS.OsFlavor, Environment.OSVersion, "RUNTIME:", OS.GetRuntimeVersion(),
 				Marshal.SizeOf(typeof(IntPtr)) * 8, "GC:",

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -137,8 +137,7 @@ namespace EventStore.Core.Tests.Helpers {
 					 + "{11,-25} {12}\n"
 					 + "{13,-25} {14}\n"
 					 + "{15,-25} {16}\n"
-					 + "{17,-25} {18}\n"
-					 + "{19,-25} {20}\n\n",
+					 + "{17,-25} {18}\n\n",
 				"ES VERSION:", VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp,
 				"OS:", OS.OsFlavor, Environment.OSVersion,
 				"RUNTIME:", OS.GetRuntimeVersion(), Marshal.SizeOf(typeof(IntPtr)) * 8,

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStreamReader.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStreamReader.cs
@@ -90,7 +90,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			async Task HandleTimeout(string streamName) {
 				var backOff = GetBackOffDelay(retryCount);
 				Log.Warning(
-					"Timed out reading from stream: {stream{. Retrying in {retryInterval} seconds.",
+					"Timed out reading from stream: {stream}. Retrying in {retryInterval} seconds.",
 					streamName, backOff);
 				await Task.Delay(TimeSpan.FromSeconds(backOff)).ConfigureAwait(false);
 				BeginReadEventsInternal(eventSource, startPosition, countToLoad, batchSize, maxWindowSize, resolveLinkTos,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavengerLogManager.cs
@@ -173,7 +173,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					SystemAccounts.System, m => {
 						if (m.Result != OperationResult.Success) {
 							Log.Error(
-								"Failed to set $ops read permission for the {stream} stream. Reason: {reason}",
+								"Failed to write the $maxAge of {days} and set $ops read permission for the {stream} stream. Reason: {reason}",
 								_scavengeHistoryMaxAge.TotalDays, scavengeIdStream, m.Result);
 						}
 					});


### PR DESCRIPTION
Fixed: incorrect log message templates

My IDE detected some errors in log message templates (unused fields and properties)