### PR TITLE
Fix using the wrong advertised host value in a cluster configuration.

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -852,8 +852,8 @@ namespace EventStore.Core {
 
 			_httpService = new KestrelHttpService(ServiceAccessibility.Public, _mainQueue, new TrieUriRouter(),
 				_workersHandler, options.Application.LogHttpRequests,
-				GossipAdvertiseInfo.AdvertiseExternalHostAs,
-				GossipAdvertiseInfo.AdvertiseHttpPortAs,
+				string.IsNullOrEmpty(GossipAdvertiseInfo.AdvertiseHostToClientAs) ? GossipAdvertiseInfo.AdvertiseExternalHostAs : GossipAdvertiseInfo.AdvertiseHostToClientAs,
+				GossipAdvertiseInfo.AdvertiseHttpPortToClientAs == 0 ? GossipAdvertiseInfo.AdvertiseHttpPortAs : GossipAdvertiseInfo.AdvertiseHttpPortToClientAs,
 				options.Auth.DisableFirstLevelHttpAuthorization,
 				NodeInfo.HttpEndPoint);
 


### PR DESCRIPTION
Fixed: Use the right advertised host value in a cluster configuration.