### PR TITLE
Persistent Subscriptions - Set last checkpoint to last known message on load

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -124,6 +124,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 					_lastCheckpointedSequenceNumber = 0L;
 					_lastKnownSequenceNumber = 0L;
 					_lastKnownMessage = _settings.EventSource.GetStreamPositionFor(checkpoint);
+					_statistics.SetLastCheckPoint(_lastKnownMessage);
 
 					Log.Debug("Subscription {subscriptionId}: read checkpoint {checkpoint}", _settings.SubscriptionId,
 						checkpoint);


### PR DESCRIPTION
Fixed: Set last checkpoint for persistent subscriptions when they are loaded

Fixes https://github.com/EventStore/EventStore/issues/3238