### PR TITLE
Ensure IODispatcher clears up pending requests

### DIFF
--- a/src/EventStore.Core.Tests/Authentication/with_internal_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Authentication/with_internal_authentication_provider.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Plugins.Authentication;
@@ -18,7 +19,8 @@ namespace EventStore.Core.Tests.Authentication {
 			_bus.Subscribe(_ioDispatcher.Writer);
 			_bus.Subscribe(_ioDispatcher.StreamDeleter);
 			_bus.Subscribe(_ioDispatcher.Awaker);
-			_bus.Subscribe(_ioDispatcher);
+			_bus.Subscribe<IODispatcherDelayedMessage>(_ioDispatcher);
+			_bus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher);
 
 			PasswordHashAlgorithm passwordHashAlgorithm = new StubPasswordHashAlgorithm();
 			_internalAuthenticationProvider =

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/IODispatcherTestHelpers.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/IODispatcherTestHelpers.cs
@@ -3,6 +3,7 @@ using System.Text;
 using EventStore.Core.Data;
 using EventStore.Core.Helpers;
 using EventStore.Core.Bus;
+using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog.LogRecords;
 using ResolvedEvent = EventStore.Core.Data.ResolvedEvent;
 
@@ -22,7 +23,8 @@ namespace EventStore.Core.Tests.Helpers.IODispatcherTests {
 		}
 
 		public static void SubscribeIODispatcher(IODispatcher ioDispatcher, IBus bus) {
-			bus.Subscribe(ioDispatcher);
+			bus.Subscribe<IODispatcherDelayedMessage>(ioDispatcher);
+			bus.Subscribe<ClientMessage.NotHandled>(ioDispatcher);
 			bus.Subscribe(ioDispatcher.ForwardReader);
 			bus.Subscribe(ioDispatcher.BackwardReader);
 			bus.Subscribe(ioDispatcher.Writer);

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithReadWriteDispatchers.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithReadWriteDispatchers.cs
@@ -65,7 +65,8 @@ namespace EventStore.Core.Tests.Helpers {
 			_bus.Subscribe(_ioDispatcher.Writer);
 			_bus.Subscribe(_ioDispatcher.StreamDeleter);
 			_bus.Subscribe(_ioDispatcher.Awaker);
-			_bus.Subscribe(_ioDispatcher);
+			_bus.Subscribe<IODispatcherDelayedMessage>(_ioDispatcher);
+			_bus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher);
 		}
 
 		protected virtual ManualQueue GiveInputQueue() {

--- a/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProviderFactory.cs
@@ -25,7 +25,8 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 				bus.Subscribe(_dispatcher.Writer);
 				bus.Subscribe(_dispatcher.StreamDeleter);
 				bus.Subscribe(_dispatcher.Awaker);
-				bus.Subscribe(_dispatcher);
+				bus.Subscribe<IODispatcherDelayedMessage>(_dispatcher);
+				bus.Subscribe<ClientMessage.NotHandled>(_dispatcher);
 			}
 
 			var usersController =
@@ -49,7 +50,8 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 			_components.MainBus.Subscribe(ioDispatcher.Writer);
 			_components.MainBus.Subscribe(ioDispatcher.StreamDeleter);
 			_components.MainBus.Subscribe(ioDispatcher.Awaker);
-			_components.MainBus.Subscribe(ioDispatcher);
+			_components.MainBus.Subscribe<IODispatcherDelayedMessage>(_dispatcher);
+			_components.MainBus.Subscribe<ClientMessage.NotHandled>(_dispatcher);
 
 			return provider;
 		}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1110,7 +1110,8 @@ namespace EventStore.Core {
 			_mainBus.Subscribe<ClientMessage.ReadAllEventsForwardCompleted>(ioDispatcher.AllForwardReader);
 			_mainBus.Subscribe<ClientMessage.FilteredReadAllEventsForwardCompleted>(ioDispatcher.AllForwardFilteredReader);
 			_mainBus.Subscribe<ClientMessage.DeleteStreamCompleted>(ioDispatcher.StreamDeleter);
-			_mainBus.Subscribe(ioDispatcher);
+			_mainBus.Subscribe<IODispatcherDelayedMessage>(ioDispatcher);
+			_mainBus.Subscribe<ClientMessage.NotHandled>(ioDispatcher);
 			var perSubscrBus = new InMemoryBus("PersistentSubscriptionsBus", true, TimeSpan.FromMilliseconds(50));
 			var perSubscrQueue = new QueuedHandlerThreadPool(perSubscrBus, "PersistentSubscriptions", _queueStatsManager, false);
 			_mainBus.Subscribe(perSubscrQueue.WidenFrom<SystemMessage.StateChangeMessage, Message>());

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -163,19 +163,19 @@ namespace EventStore.Core.Services.VNode {
 				.When<ClientMessage.ReadStreamEventsBackward>().ForwardTo(_outputBus)
 				.When<ClientMessage.ReadAllEventsForward>().ForwardTo(_outputBus)
 				.When<ClientMessage.ReadAllEventsBackward>().ForwardTo(_outputBus)
-				.When<ClientMessage.WriteEvents>().Ignore()
-				.When<ClientMessage.TransactionStart>().Ignore()
-				.When<ClientMessage.TransactionWrite>().Ignore()
-				.When<ClientMessage.TransactionCommit>().Ignore()
-				.When<ClientMessage.DeleteStream>().Ignore()
-				.When<ClientMessage.CreatePersistentSubscriptionToStream>().Ignore()
-				.When<ClientMessage.ConnectToPersistentSubscriptionToStream>().Ignore()
-				.When<ClientMessage.UpdatePersistentSubscriptionToStream>().Ignore()
-				.When<ClientMessage.DeletePersistentSubscriptionToStream>().Ignore()
-				.When<ClientMessage.CreatePersistentSubscriptionToAll>().Ignore()
-				.When<ClientMessage.ConnectToPersistentSubscriptionToAll>().Ignore()
-				.When<ClientMessage.UpdatePersistentSubscriptionToAll>().Ignore()
-				.When<ClientMessage.DeletePersistentSubscriptionToAll>().Ignore()
+				.When<ClientMessage.WriteEvents>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.TransactionStart>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.TransactionWrite>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.TransactionCommit>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.DeleteStream>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.CreatePersistentSubscriptionToStream>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.ConnectToPersistentSubscriptionToStream>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.UpdatePersistentSubscriptionToStream>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.DeletePersistentSubscriptionToStream>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.CreatePersistentSubscriptionToAll>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.ConnectToPersistentSubscriptionToAll>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.UpdatePersistentSubscriptionToAll>().Do(HandleAsResigningLeader)
+				.When<ClientMessage.DeletePersistentSubscriptionToAll>().Do(HandleAsResigningLeader)
 				.When<SystemMessage.RequestQueueDrained>().Do(Handle)
 				.InAllStatesExcept(VNodeState.ResigningLeader)
 				.When<SystemMessage.RequestQueueDrained>().Ignore()
@@ -586,6 +586,46 @@ namespace EventStore.Core.Services.VNode {
 			if (Interlocked.Decrement(ref _subSystemInitsToExpect) == 0) {
 				_outputBus.Publish(new SystemMessage.SystemReady());
 			}
+		}
+
+		private void HandleAsResigningLeader(ClientMessage.WriteEvents message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.TransactionStart message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.TransactionWrite message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.TransactionCommit message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.DeleteStream message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.CreatePersistentSubscriptionToStream message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.ConnectToPersistentSubscriptionToStream message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.UpdatePersistentSubscriptionToStream message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.DeletePersistentSubscriptionToStream message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.CreatePersistentSubscriptionToAll message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.ConnectToPersistentSubscriptionToAll message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.UpdatePersistentSubscriptionToAll message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
+		}
+		private void HandleAsResigningLeader(ClientMessage.DeletePersistentSubscriptionToAll message) {
+			DenyRequestBecauseNotReady(message.Envelope, message.CorrelationId);
 		}
 
 		private void HandleAsNonLeader(ClientMessage.ReadEvent message) {

--- a/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
@@ -23,7 +23,8 @@ namespace EventStore.Projections.Core.Tests.Services {
 			_node.Node.MainBus.Subscribe(_ioDispatcher.Writer);
 			_node.Node.MainBus.Subscribe(_ioDispatcher.StreamDeleter);
 			_node.Node.MainBus.Subscribe(_ioDispatcher.Awaker);
-			_node.Node.MainBus.Subscribe(_ioDispatcher);
+			_node.Node.MainBus.Subscribe<IODispatcherDelayedMessage>(_ioDispatcher);
+			_node.Node.MainBus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher);
 			_projectionNamesBuilder = ProjectionNamesBuilder.CreateForTest(_projectionName);
 			_emittedStreamsTracker = new EmittedStreamsTracker(_ioDispatcher,
 				new ProjectionConfig(null, 1000, 1000 * 1000, 100, 500, true, true, false, false,

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -51,7 +51,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 			_bus.Subscribe(_ioDispatcher.BackwardReader);
 			_bus.Subscribe(_ioDispatcher.ForwardReader);
 			_bus.Subscribe(_ioDispatcher.Writer);
-			_bus.Subscribe(_ioDispatcher);
+			_bus.Subscribe<IODispatcherDelayedMessage>(_ioDispatcher);
+			_bus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher);
 			IProjectionStateHandler projectionStateHandler = new FakeProjectionStateHandler();
 			_projectionConfig =
 				new ProjectionConfig(null, 5, 10, 1000, 250, true, true, false, false, true, 10000, 1);

--- a/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
@@ -115,6 +115,7 @@ namespace EventStore.Projections.Core {
 				coreInputBus.Subscribe<ClientMessage.DeleteStreamCompleted>(_ioDispatcher.StreamDeleter);
 				coreInputBus.Subscribe<IODispatcherDelayedMessage>(_ioDispatcher.Awaker);
 				coreInputBus.Subscribe<IODispatcherDelayedMessage>(_ioDispatcher);
+				coreInputBus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher);
 				coreInputBus.Subscribe<CoreProjectionProcessingMessage.CheckpointCompleted>(_projectionCoreService);
 				coreInputBus.Subscribe<CoreProjectionProcessingMessage.CheckpointLoaded>(_projectionCoreService);
 				coreInputBus.Subscribe<CoreProjectionProcessingMessage.PrerecordedEventsLoaded>(_projectionCoreService);


### PR DESCRIPTION
Fixed: Ensure the IODispatcher clears up pending requests

Fixes https://github.com/EventStore/EventStore/issues/2687

- `ResigningLeader` state now responds to write requests with `NotHandled.NotReady`
- Enable IODispatcher to handle NotHandled messages, and clear pending requests when one is received.