### PR TITLE
Truncate the StreamExistenceFilter checkpoint if necessary on writer truncation

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/LogAbstraction/INameExistenceFilterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogAbstraction/INameExistenceFilterTests.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.XUnit.Tests.LogAbstraction {
 		public void can_initialize() {
 			var names = new[] { "can_initialize" };
 			var initializer = new MockExistenceFilterInitializer(names);
-			Sut.Initialize(initializer);
+			Sut.Initialize(initializer, 0);
 
 			foreach (var name in names)
 				Assert.True(Sut.MightContain(name));

--- a/src/EventStore.Core.XUnit.Tests/LogAbstraction/LogFormatAbstractorV2Tests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogAbstraction/LogFormatAbstractorV2Tests.cs
@@ -28,13 +28,13 @@ namespace EventStore.Core.XUnit.Tests.LogAbstraction {
 
 		[Fact]
 		public void can_init() {
-			_sut.StreamExistenceFilter.Initialize(new MockExistenceFilterInitializer("1"));
+			_sut.StreamExistenceFilter.Initialize(new MockExistenceFilterInitializer("1"), 0);
 			Assert.True(_sut.StreamExistenceFilterReader.MightContain("1"));
 		}
 
 		[Fact]
 		public void can_confirm() {
-			_sut.StreamExistenceFilter.Initialize(new MockExistenceFilterInitializer());
+			_sut.StreamExistenceFilter.Initialize(new MockExistenceFilterInitializer(), 0);
 
 			var prepare = LogRecord.SingleWrite(
 				factory: _sut.RecordFactory,

--- a/src/EventStore.Core.XUnit.Tests/LogAbstraction/LogFormatAbstractorV3Tests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogAbstraction/LogFormatAbstractorV3Tests.cs
@@ -38,7 +38,7 @@ namespace EventStore.Core.XUnit.Tests.LogAbstraction {
 		public LogFormatAbstractorV3Tests() {
 			TryDeleteDirectory();
 			_sut.StreamNamesProvider.SetReader(_mockIndexReader);
-			_sut.StreamExistenceFilter.Initialize(_sut.StreamExistenceFilterInitializer);
+			_sut.StreamExistenceFilter.Initialize(_sut.StreamExistenceFilterInitializer, 0);
 			Assert.False(GetOrReserve(_stream, out _streamId, out _, out _));
 			Assert.False(GetOrReserve(_systemStream, out _systemStreamId, out _, out _));
 			Assert.False(GetOrReserveEventType(_eventType, out _eventTypeId, out _, out _));

--- a/src/EventStore.Core.XUnit.Tests/LogAbstraction/MockExistenceFilterInitializer.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogAbstraction/MockExistenceFilterInitializer.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.XUnit.Tests.LogAbstraction {
 			_names = names;
 		}
 
-		public void Initialize(INameExistenceFilter filter) {
+		public void Initialize(INameExistenceFilter filter, long truncateToPosition) {
 			int checkpoint = 0;
 			foreach (var name in _names) {
 				filter.Add(name);

--- a/src/EventStore.Core.XUnit.Tests/LogV2/LogV2StreamExistenceFilterInitializerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV2/LogV2StreamExistenceFilterInitializerTests.cs
@@ -66,10 +66,29 @@ namespace EventStore.Core.XUnit.Tests.LogV2 {
 		[Fact]
 		public void can_initialize_empty() {
 			Assert.Equal(-1, _filter.CurrentCheckpoint);
-			_sut.Initialize(_filter);
+			_sut.Initialize(_filter, 0);
 			Assert.Equal(-1, _filter.CurrentCheckpoint);
 			Assert.Empty(_filter.Hashes);
 			Assert.Equal(1, _log.NumReads);
+		}
+
+		[Theory]
+		[InlineData(100, 600)] // if we do truncate (to 100)
+		[InlineData(1000, 1000)] // if we dont truncate
+		[InlineData(2000, 1000)] // if we dont truncate
+		public void can_truncate(long truncateTo, long expectedCheckpoint) {
+			_filter.CurrentCheckpoint = 1000;
+
+			AddEventToSut("1", 0);
+			AddEventToSut("2", 0);
+			AddEventToSut("3", 0);
+			AddEventToSut("4", 0);
+			AddEventToSut("5", 0);
+			AddEventToSut("6", 0);
+
+			_sut.Initialize(_filter, truncateTo);
+
+			Assert.Equal(expectedCheckpoint, _filter.CurrentCheckpoint);
 		}
 
 		[Fact]
@@ -82,7 +101,7 @@ namespace EventStore.Core.XUnit.Tests.LogV2 {
 			AddEventToSut("3", 0);
 			AddEventToSut("3", 1);
 
-			_sut.Initialize(_filter);
+			_sut.Initialize(_filter, 0);
 
 			Assert.Equal(600, _filter.CurrentCheckpoint);
 			Assert.Equal(3, _filter.Hashes.Count);
@@ -100,7 +119,7 @@ namespace EventStore.Core.XUnit.Tests.LogV2 {
 			AddEventToSut("5", 0);
 			AddEventToSut("6", 0);
 
-			_sut.Initialize(_filter);
+			_sut.Initialize(_filter, 0);
 
 			Assert.Equal(600, _filter.CurrentCheckpoint);
 			Assert.Equal(6, _filter.Hashes.Count);
@@ -119,7 +138,7 @@ namespace EventStore.Core.XUnit.Tests.LogV2 {
 			AddEventToSut("3", 0);
 			AddEventToSut("3", 1);
 
-			_sut.Initialize(_filter);
+			_sut.Initialize(_filter, 0);
 
 			Assert.Equal(600, _filter.CurrentCheckpoint);
 			Assert.Equal(3, _filter.Hashes.Count);
@@ -144,7 +163,7 @@ namespace EventStore.Core.XUnit.Tests.LogV2 {
 			var hasher = new CompositeHasher<string>(new XXHashUnsafe(), new Murmur3AUnsafe());
 			// addDelayMs: we want to initialize the filter slowly, to give the ptables longer to move around
 			var slowFilter = new MockExistenceFilter(hasher, addDelayMs: 1);
-			_sut.Initialize(slowFilter);
+			_sut.Initialize(slowFilter, 0);
 
 			Assert.Equal(numEvents * _recordOffset, slowFilter.CurrentCheckpoint);
 			Assert.Equal(numStreams, slowFilter.Hashes.Count);
@@ -174,7 +193,7 @@ namespace EventStore.Core.XUnit.Tests.LogV2 {
 			var filter = new MockExistenceFilter(hasher: null);
 
 			var ex = Assert.Throws<NotSupportedException>(() => {
-				sut.Initialize(filter);
+				sut.Initialize(filter, 0);
 			});
 			Assert.Equal(
 				"The Stream Existence Filter is not supported with V1 index files. " +

--- a/src/EventStore.Core.XUnit.Tests/LogV2/MockExistenceFilter.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV2/MockExistenceFilter.cs
@@ -32,8 +32,12 @@ namespace EventStore.Core.XUnit.Tests.LogV2 {
 		public void Dispose() {
 		}
 
-		public void Initialize(INameExistenceFilterInitializer source) {
-			source.Initialize(this);
+		public void Initialize(INameExistenceFilterInitializer source, long truncateToPosition) {
+			source.Initialize(this, truncateToPosition);
+		}
+
+		public void TruncateTo(long checkpoint) {
+			CurrentCheckpoint = checkpoint;
 		}
 
 		public void Verify(double corruptionThreshold) { }

--- a/src/EventStore.Core.XUnit.Tests/LogV3/LogV3StreamExistenceFilterInitializerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV3/LogV3StreamExistenceFilterInitializerTests.cs
@@ -10,7 +10,7 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 			var sut = new LogV3StreamExistenceFilterInitializer(new MockNameLookup(new()));
 
 			var filter = new MockExistenceFilter();
-			filter.Initialize(sut);
+			filter.Initialize(sut, 0);
 
 			Assert.Equal(-1, filter.CurrentCheckpoint);
 			Assert.Empty(filter.Streams);
@@ -25,7 +25,7 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 			}));
 
 			var filter = new MockExistenceFilter();
-			filter.Initialize(sut);
+			filter.Initialize(sut, 0);
 
 			Assert.Equal(1026, filter.CurrentCheckpoint);
 			Assert.True(filter.MightContain("1024"));

--- a/src/EventStore.Core.XUnit.Tests/LogV3/MockExistenceFilter.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV3/MockExistenceFilter.cs
@@ -18,8 +18,12 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 		public void Dispose() {
 		}
 
-		public void Initialize(INameExistenceFilterInitializer source) {
-			source.Initialize(this);
+		public void Initialize(INameExistenceFilterInitializer source, long truncateToPosition) {
+			source.Initialize(this, truncateToPosition);
+		}
+
+		public void TruncateTo(long checkpoint) {
+			CurrentCheckpoint = checkpoint;
 		}
 
 		public void Verify(double corruptionThreshold) { }

--- a/src/EventStore.Core/LogAbstraction/Common/NoNameExistenceFilter.cs
+++ b/src/EventStore.Core/LogAbstraction/Common/NoNameExistenceFilter.cs
@@ -1,6 +1,7 @@
 namespace EventStore.Core.LogAbstraction.Common {
 	public class NoNameExistenceFilter : INameExistenceFilter {
-		public void Initialize(INameExistenceFilterInitializer source) { }
+		public void Initialize(INameExistenceFilterInitializer source, long truncateToPosition) { }
+		public void TruncateTo(long checkpoint) { }
 		public void Verify(double corruptionThreshold) { }
 		public long CurrentCheckpoint { get; set; } = -1;
 

--- a/src/EventStore.Core/LogAbstraction/INameExistenceFilter.cs
+++ b/src/EventStore.Core/LogAbstraction/INameExistenceFilter.cs
@@ -2,7 +2,8 @@
 
 namespace EventStore.Core.LogAbstraction {
 	public interface INameExistenceFilter : IExistenceFilterReader<string>, IDisposable {
-		void Initialize(INameExistenceFilterInitializer source);
+		void Initialize(INameExistenceFilterInitializer source, long truncateToPosition);
+		void TruncateTo(long checkpoint);
 		void Verify(double corruptionThreshold);
 		void Add(string name);
 		void Add(ulong hash);

--- a/src/EventStore.Core/LogAbstraction/INameExistenceFilterInitializer.cs
+++ b/src/EventStore.Core/LogAbstraction/INameExistenceFilterInitializer.cs
@@ -1,5 +1,5 @@
 namespace EventStore.Core.LogAbstraction {
 	public interface INameExistenceFilterInitializer {
-		void Initialize(INameExistenceFilter filter);
+		void Initialize(INameExistenceFilter filter, long truncateToPosition);
 	}
 }

--- a/src/EventStore.Core/LogV3/LogV3StreamExistenceFilterInitializer.cs
+++ b/src/EventStore.Core/LogV3/LogV3StreamExistenceFilterInitializer.cs
@@ -12,7 +12,9 @@ namespace EventStore.Core.LogV3 {
 			_streamNames = streamNames;
 		}
 
-		public void Initialize(INameExistenceFilter filter) {
+		public void Initialize(INameExistenceFilter filter, long truncateToPosition) {
+			// todo: truncate if necessary. implementation will likely depend on how the indexes come out
+
 			if (!_streamNames.TryGetLastValue(out var sourceLastStreamId))
 				return;
 

--- a/src/EventStore.Core/LogV3/StreamExistenceFilterValidator.cs
+++ b/src/EventStore.Core/LogV3/StreamExistenceFilterValidator.cs
@@ -15,7 +15,11 @@ namespace EventStore.Core.LogV3 {
 			set => _wrapped.CurrentCheckpoint = value;
 		}
 
-		public void Initialize(INameExistenceFilterInitializer source) => _wrapped.Initialize(source);
+		public void Initialize(INameExistenceFilterInitializer source, long truncateToPosition) =>
+			_wrapped.Initialize(source, truncateToPosition);
+
+		public void TruncateTo(long checkpoint) =>
+			_wrapped.TruncateTo(checkpoint);
 
 		public void Verify(double corruptionThreshold) => _wrapped.Verify(corruptionThreshold);
 

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -188,6 +188,9 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				startTime = DateTime.UtcNow;
 
 				// now that the main index has caught up, we initialize the stream existence filter to add any missing entries.
+				// while the index above is concerned with building exactly to the buildToPosition and not beyond, that isn't
+				// important for the streamexistencefiler since false positives are allowed. it only cares about truncating back
+				// to the buildToPosition (if necessary).
 				// V2:
 				// reads the index and transaction file forward from the last checkpoint (a log position) and adds stream names to the filter, possibly multiple times
 				// but it's not an issue since it's idempotent
@@ -198,7 +201,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				// V2/V3 note: it's possible that we add extra uncommitted entries to the filter if the index or log later gets truncated when joining
 				// the cluster but false positives are not a problem since it's a probabilistic filter
 				Log.Debug("Initializing the StreamExistenceFilter. The filter can be disabled by setting the configuration option \"StreamExistenceFilterSize\" to 0");
-				_streamExistenceFilter.Initialize(_streamExistenceFilterInitializer);
+				_streamExistenceFilter.Initialize(_streamExistenceFilterInitializer, truncateToPosition: buildToPosition);
 				Log.Debug("StreamExistenceFilter initialized. Time elapsed: {elapsed}.",
 					DateTime.UtcNow - startTime);
 


### PR DESCRIPTION
Fixed: StreamExistenceFilter truncation corner case

We previously thought that this wasn't necessary but it is - if we don't truncate the filter checkpoint when the writer checkpoint is truncated then:
- the writer might move forward from the point it was truncated to, adding those records to the filter
- the node might exit _before those records were flushed to disk_ in the filter
- on restart the filter wont know that it missed anything