### PR TITLE
Make Leader Election timeout configurable

### DIFF
--- a/docs/clustering/gossip.md
+++ b/docs/clustering/gossip.md
@@ -79,3 +79,17 @@ Please note that the `GossipOnSingleNode` option has been deprecated in this ver
 | Environment variable | `EVENTSTORE_GOSSIP_ON_SINGLE_NODE` |
 
 **Default**: `false`
+
+## Leader Election Timeout
+
+The Leader Elections are separate to the node gossip, and are used to elect a node as Leader and assign roles to the other nodes.
+
+In some cases the leader election messages may be delayed, which can result in elections taking longer than they should. If you start seeing election timeouts in the logs or if you've needed to increase the gossip timeout due to a congested network, then you should consider increasing the leader election timeout as well.
+
+| Format               | Syntax |
+| :------------------- | :----- |
+| Command line         | `--leader-election-timeout-ms` |
+| YAML                 | `LeaderElectionTimeoutMs` |
+| Environment variable | `EVENTSTORE_LEADER_ELECTION_TIMEOUT_MS` |
+
+**Default**: `1000` (in milliseconds).

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -231,6 +231,7 @@ namespace EventStore.ClusterNode {
 				.WithGossipInterval(TimeSpan.FromMilliseconds(options.GossipIntervalMs))
 				.WithGossipAllowedTimeDifference(TimeSpan.FromMilliseconds(options.GossipAllowedDifferenceMs))
 				.WithGossipTimeout(TimeSpan.FromMilliseconds(options.GossipTimeoutMs))
+				.WithLeaderElectionTimeout(TimeSpan.FromMilliseconds(options.LeaderElectionTimeoutMs))
 				.WithClusterGossipPort(options.ClusterGossipPort)
 				.WithMinFlushDelay(TimeSpan.FromMilliseconds(options.MinFlushDelayMs))
 				.WithPrepareTimeout(TimeSpan.FromMilliseconds(options.PrepareTimeoutMs))

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -144,6 +144,7 @@ namespace EventStore.Core.Tests.Helpers {
 				keepAliveInterval: TimeSpan.FromSeconds(10), keepAliveTimeout: TimeSpan.FromSeconds(10),
 				readOnlyReplica: readOnlyReplica,
 				streamInfoCacheCapacity: Opts.StreamInfoCacheCapacityDefault,
+				leaderElectionTimeout: TimeSpan.FromMilliseconds(Opts.LeaderElectionTimeoutMsDefault),
 				enableExternalTCP: true,
 				disableHttps: !useHttps,
 				enableAtomPubOverHTTP: true);

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ClusterSettingsFactory.cs
@@ -61,6 +61,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				Constants.PTableMaxReaderCountDefault,
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10),
 				Opts.StreamInfoCacheCapacityDefault,
+				TimeSpan.FromMilliseconds(Opts.LeaderElectionTimeoutMsDefault),
 				readOnlyReplica: isReadOnlyReplica,
 				disableHttps: !useHttps);
 

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionServiceUnit.cs
@@ -57,7 +57,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new InMemoryCheckpoint(ChaserCheckpoint),
 				new InMemoryCheckpoint(ProposalCheckpoint),
 				new FakeEpochManager(),
-				() => -1, 0, new FakeTimeProvider());
+				() => -1, 0, new FakeTimeProvider(),
+				TimeSpan.FromMilliseconds(1_000));
 			ElectionsService.SubscribeMessages(_bus);
 
 			InputMessages = new List<Message>();

--- a/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/ElectionsServiceTests.cs
@@ -22,6 +22,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 		private IBus _bus;
 		protected FakePublisher _publisher;
 		protected Guid _epochId;
+		protected TimeSpan LeaderElectionProgressTimeout = TimeSpan.FromMilliseconds(1_000);
 
 		protected static Func<int, VNodeInfo> NodeFactory = (id) => new VNodeInfo(
 			Guid.Parse($"00000000-0000-0000-0000-00000000000{id}"), id,
@@ -54,7 +55,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new InMemoryCheckpoint(0),
 				new InMemoryCheckpoint(0),
 				new InMemoryCheckpoint(-1),
-				new FakeEpochManager(), () => 0L, 0, _timeProvider);
+				new FakeEpochManager(), () => 0L, 0, _timeProvider,
+				TimeSpan.FromMilliseconds(1_000));
 			_sut.SubscribeMessages(_bus);
 		}
 	}
@@ -75,14 +77,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				TimerMessage.Schedule.Create(
-					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					LeaderElectionProgressTimeout,
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(0)),
 			};
@@ -204,14 +204,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, newView),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, newView),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				TimerMessage.Schedule.Create(
-					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					LeaderElectionProgressTimeout,
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(1)),
 			};
@@ -289,12 +287,10 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.ViewChangeProof(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.ViewChangeProof(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				TimerMessage.Schedule.Create(
 					Core.Services.ElectionsService.SendViewChangeProofInterval,
 					new PublishEnvelope(_publisher),
@@ -382,14 +378,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, 10),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.ViewChange(_node.InstanceId, _node.HttpEndPoint, 10),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				TimerMessage.Schedule.Create(
-					Core.Services.ElectionsService.LeaderElectionProgressTimeout,
+					LeaderElectionProgressTimeout,
 					new PublishEnvelope(_publisher),
 					new ElectionMessage.ElectionsTimedOut(10)),
 			};
@@ -437,12 +431,10 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.Prepare(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.Prepare(_node.InstanceId, _node.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout))
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout))
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -545,8 +537,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.PrepareOk(0,
 						_node.InstanceId, _node.HttpEndPoint, -1, -1, Guid.Empty, Guid.Empty, 0, 0, 0, 0, _clusterInfo),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -662,14 +653,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.Proposal(_node.InstanceId, _node.HttpEndPoint,
 						proposalMessage.LeaderId,
 						proposalMessage.LeaderHttpEndPoint, 0, 0, 0, _epochId, Guid.Empty, 0, 0, 0, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.Proposal(_node.InstanceId, _node.HttpEndPoint,
 						proposalMessage.LeaderId,
 						proposalMessage.LeaderHttpEndPoint, 0, 0, 0, _epochId, Guid.Empty, 0, 0, 0, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout))
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout))
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -839,14 +828,12 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.Accept(_node.InstanceId, _node.HttpEndPoint,
 						_nodeThree.InstanceId,
 						_nodeThree.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.Accept(_node.InstanceId, _node.HttpEndPoint,
 						_nodeThree.InstanceId,
 						_nodeThree.HttpEndPoint, 0),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -1079,12 +1066,10 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			var expected = new Message[] {
 				new GrpcMessage.SendOverGrpc(_nodeTwo.HttpEndPoint,
 					new ElectionMessage.LeaderIsResigning(_node.InstanceId, _node.HttpEndPoint),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 				new GrpcMessage.SendOverGrpc(_nodeThree.HttpEndPoint,
 					new ElectionMessage.LeaderIsResigning(_node.InstanceId, _node.HttpEndPoint),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -1108,8 +1093,7 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new ElectionMessage.LeaderIsResigningOk(
 						_nodeTwo.InstanceId, _nodeTwo.HttpEndPoint,
 						_node.InstanceId, _node.HttpEndPoint),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(Core.Services.ElectionsService.LeaderElectionProgressTimeout)),
+					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)),
 			};
 			AssertEx.AssertUsingDeepCompare(_publisher.Messages.ToArray(), expected);
 		}
@@ -1241,7 +1225,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					new InMemoryCheckpoint(0),
 					new InMemoryCheckpoint(0),
 					new InMemoryCheckpoint(-1),
-					new FakeEpochManager(), () => 0L, 0, new FakeTimeProvider());
+					new FakeEpochManager(), () => 0L, 0, new FakeTimeProvider(),
+					TimeSpan.FromMilliseconds(1_000));
 			});
 		}
 	}

--- a/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/LeaderNode/ElectionsServiceUnitTests.cs
@@ -54,7 +54,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 					readerCheckpoint,
 					proposalCheckpoint,
 					epochManager,
-					() => -1, 0, new FakeTimeProvider());
+					() => -1, 0, new FakeTimeProvider(),
+					TimeSpan.FromMilliseconds(1_000));
 				electionsService.SubscribeMessages(inputBus);
 
 				var nodeId = i;

--- a/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/Randomized/RandomizedElectionsTestCase.cs
@@ -81,7 +81,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService.Randomized {
 					new InMemoryCheckpoint(),
 					new InMemoryCheckpoint(-1),
 					new FakeEpochManager(),
-					() => -1, 0, new FakeTimeProvider());
+					() => -1, 0, new FakeTimeProvider(),
+					TimeSpan.FromMilliseconds(1_000));
 				electionsService.SubscribeMessages(inputBus);
 
 				outputBus.Subscribe(sendOverHttpHandler);

--- a/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/GossipService/NodeGossipServiceTests.cs
@@ -205,8 +205,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
-					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)),
+					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout)),
 				TimerMessage.Schedule.Create(GossipServiceBase.GossipStartupInterval, new PublishEnvelope(_bus),
 					new GossipMessage.Gossip(1)));
 		}
@@ -228,8 +227,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
-					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)),
+					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout)),
 				TimerMessage.Schedule.Create(_gossipInterval, new PublishEnvelope(_bus),
 					new GossipMessage.Gossip(++_gossipRound)));
 		}
@@ -283,8 +281,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
-					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)),
+					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout)),
 				TimerMessage.Schedule.Create(GossipServiceBase.GossipStartupInterval, new PublishEnvelope(_bus),
 					new GossipMessage.Gossip(++_gossipRound)));
 		}
@@ -306,8 +303,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 						MemberInfoForVNode(_currentNode, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeTwo, _timeProvider.UtcNow),
 						InitialStateForVNode(_nodeThree, _timeProvider.UtcNow)),
-					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)),
+					_currentNode.HttpEndPoint), _timeProvider.LocalTime.Add(_gossipTimeout)),
 				TimerMessage.Schedule.Create(_gossipInterval, new PublishEnvelope(_bus),
 					new GossipMessage.Gossip(++_gossipRound)));
 		}
@@ -609,8 +605,7 @@ namespace EventStore.Core.Tests.Services.GossipService {
 		public void should_issue_get_gossip() {
 			ExpectMessages(
 				new GrpcMessage.SendOverGrpc(_currentNode.HttpEndPoint, new GossipMessage.GetGossip(),
-					_timeProvider.LocalTime.Add(_gossipTimeout),
-					_timeProvider.LocalTime.Add(_gossipInterval)));
+					_timeProvider.LocalTime.Add(_gossipTimeout)));
 		}
 	}
 

--- a/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
+++ b/src/EventStore.Core/Cluster/Settings/ClusterVNodeSettings.cs
@@ -62,6 +62,7 @@ namespace EventStore.Core.Cluster.Settings {
 		public readonly TimeSpan GossipInterval;
 		public readonly TimeSpan GossipAllowedTimeDifference;
 		public readonly TimeSpan GossipTimeout;
+		public readonly TimeSpan LeaderElectionTimeout;
 		public readonly TimeSpan IntTcpHeartbeatTimeout;
 		public readonly TimeSpan IntTcpHeartbeatInterval;
 		public readonly TimeSpan ExtTcpHeartbeatTimeout;
@@ -154,6 +155,7 @@ namespace EventStore.Core.Cluster.Settings {
 			TimeSpan keepAliveInterval,
 			TimeSpan keepAliveTimeout,
 			int streamInfoCacheCapacity,
+			TimeSpan leaderElectionTimeout,
 			string index = null, bool enableHistograms = false,
 			bool skipIndexVerify = false,
 			int indexCacheDepth = 16,
@@ -264,6 +266,7 @@ namespace EventStore.Core.Cluster.Settings {
 			GossipInterval = gossipInterval;
 			GossipAllowedTimeDifference = gossipAllowedTimeDifference;
 			GossipTimeout = gossipTimeout;
+			LeaderElectionTimeout = leaderElectionTimeout;
 			IntTcpHeartbeatTimeout = intTcpHeartbeatTimeout;
 			IntTcpHeartbeatInterval = intTcpHeartbeatInterval;
 			ExtTcpHeartbeatTimeout = extTcpHeartbeatTimeout;

--- a/src/EventStore.Core/ClusterNodeOptions.cs
+++ b/src/EventStore.Core/ClusterNodeOptions.cs
@@ -295,6 +295,9 @@ namespace EventStore.Core {
 		[ArgDescription(Opts.GossipTimeoutMsDescr, Opts.ClusterGroup)]
 		public int GossipTimeoutMs { get; set; }
 
+		[ArgDescription(Opts.LeaderElectionTimeoutMsDescr, Opts.ClusterGroup)]
+		public int LeaderElectionTimeoutMs { get; set; }
+
 		[ArgDescription(Opts.ReadOnlyReplicaDescr, Opts.ClusterGroup)]
 		public bool ReadOnlyReplica { get; set; }
 
@@ -453,6 +456,7 @@ namespace EventStore.Core {
 			GossipIntervalMs = Opts.GossipIntervalMsDefault;
 			GossipAllowedDifferenceMs = Opts.GossipAllowedDifferenceMsDefault;
 			GossipTimeoutMs = Opts.GossipTimeoutMsDefault;
+			LeaderElectionTimeoutMs = Opts.LeaderElectionTimeoutMsDefault;
 			IndexCacheDepth = Opts.IndexCacheDepthDefault;
 			SkipIndexVerify = Opts.SkipIndexVerifyDefault;
 			OptimizeIndexMerge = Opts.OptimizeIndexMergeDefault;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -763,7 +763,8 @@ namespace EventStore.Core {
 					epochManager,
 					() => readIndex.LastIndexedPosition,
 					vNodeSettings.NodePriority,
-					_timeProvider);
+					_timeProvider,
+					vNodeSettings.LeaderElectionTimeout);
 				electionsService.SubscribeMessages(_mainBus);
 			}
 

--- a/src/EventStore.Core/Messages/GrpcMessage.cs
+++ b/src/EventStore.Core/Messages/GrpcMessage.cs
@@ -13,13 +13,11 @@ namespace EventStore.Core.Messages {
 
 			public readonly EndPoint DestinationEndpoint;
 			public readonly Message Message;
-			public readonly DateTime Deadline;
 			public readonly DateTime LiveUntil;
 
-			public SendOverGrpc(EndPoint destinationEndpoint, Message message, DateTime deadline, DateTime liveUntil) {
+			public SendOverGrpc(EndPoint destinationEndpoint, Message message, DateTime liveUntil) {
 				DestinationEndpoint = destinationEndpoint;
 				Message = message;
-				Deadline = deadline;
 				LiveUntil = liveUntil;
 			}
 		}

--- a/src/EventStore.Core/Services/ElectionsService.cs
+++ b/src/EventStore.Core/Services/ElectionsService.cs
@@ -39,9 +39,8 @@ namespace EventStore.Core.Services {
 		IHandle<ClientMessage.ResignNode>,
 		IHandle<ElectionMessage.LeaderIsResigning>,
 		IHandle<ElectionMessage.LeaderIsResigningOk> {
-		public static readonly TimeSpan LeaderElectionProgressTimeout = TimeSpan.FromMilliseconds(1000);
-		public static readonly TimeSpan LeaderElectionGrpcRequestTimeout = TimeSpan.FromMilliseconds(2000);
 		public static readonly TimeSpan SendViewChangeProofInterval = TimeSpan.FromMilliseconds(5000);
+		private readonly TimeSpan _leaderElectionProgressTimeout;
 
 		private static readonly ILogger Log = Serilog.Log.ForContext<ElectionsService>();
 		private static readonly EndPointComparer IPComparer = new EndPointComparer();
@@ -87,7 +86,8 @@ namespace EventStore.Core.Services {
 			IEpochManager epochManager,
 			Func<long> getLastCommitPosition,
 			int nodePriority,
-			ITimeProvider timeProvider) {
+			ITimeProvider timeProvider,
+			TimeSpan leaderElectionTimeout) {
 			Ensure.NotNull(publisher, nameof(publisher));
 			Ensure.NotNull(memberInfo, nameof(memberInfo));
 			Ensure.Positive(clusterSize, nameof(clusterSize));
@@ -99,6 +99,10 @@ namespace EventStore.Core.Services {
 			Ensure.NotNull(timeProvider, nameof(timeProvider));
 			if (memberInfo.IsReadOnlyReplica) {
 				throw new ArgumentException("Read-only replicas are not allowed to run the Elections service.");
+			}
+			if (leaderElectionTimeout.TotalSeconds < 1) {
+				throw new ArgumentOutOfRangeException(nameof(leaderElectionTimeout),
+					$"{nameof(leaderElectionTimeout)} should not be less than 1 second.");
 			}
 
 			_publisher = publisher;
@@ -112,6 +116,7 @@ namespace EventStore.Core.Services {
 			_getLastCommitPosition = getLastCommitPosition;
 			_nodePriority = nodePriority;
 			_timeProvider = timeProvider;
+			_leaderElectionProgressTimeout = leaderElectionTimeout;
 
 			var lastEpoch = _epochManager.LastEpochNumber;
 			if (_proposalCheckpoint.Read() < lastEpoch) {
@@ -195,8 +200,7 @@ namespace EventStore.Core.Services {
 
 			_resigningLeaderInstanceId = message.LeaderId;
 			_publisher.Publish(new GrpcMessage.SendOverGrpc(message.LeaderHttpEndPoint, leaderIsResigningMessageOk,
-				_timeProvider.LocalTime.Add(LeaderElectionGrpcRequestTimeout),
-				_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)));
+				_timeProvider.LocalTime.Add(_leaderElectionProgressTimeout)));
 		}
 
 		public void Handle(ElectionMessage.LeaderIsResigningOk message) {
@@ -264,7 +268,7 @@ namespace EventStore.Core.Services {
 			var viewChangeMsg = new ElectionMessage.ViewChange(_memberInfo.InstanceId, _memberInfo.HttpEndPoint, view);
 			Handle(viewChangeMsg);
 			SendToAllExceptMe(viewChangeMsg);
-			_publisher.Publish(TimerMessage.Schedule.Create(LeaderElectionProgressTimeout,
+			_publisher.Publish(TimerMessage.Schedule.Create(_leaderElectionProgressTimeout,
 				_publisherEnvelope,
 				new ElectionMessage.ElectionsTimedOut(view)));
 		}
@@ -272,8 +276,7 @@ namespace EventStore.Core.Services {
 		private void SendToAllExceptMe(Message message) {
 			foreach (var server in _servers.Where(x => x.InstanceId != _memberInfo.InstanceId)) {
 				_publisher.Publish(new GrpcMessage.SendOverGrpc(server.HttpEndPoint, message,
-					_timeProvider.LocalTime.Add(LeaderElectionGrpcRequestTimeout),
-					_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)));
+					_timeProvider.LocalTime.Add(_leaderElectionProgressTimeout)));
 			}
 		}
 
@@ -322,7 +325,7 @@ namespace EventStore.Core.Services {
 
 			_lastAttemptedView = message.InstalledView;
 
-			_publisher.Publish(TimerMessage.Schedule.Create(LeaderElectionProgressTimeout,
+			_publisher.Publish(TimerMessage.Schedule.Create(_leaderElectionProgressTimeout,
 				_publisherEnvelope,
 				new ElectionMessage.ElectionsTimedOut(_lastAttemptedView)));
 
@@ -377,8 +380,7 @@ namespace EventStore.Core.Services {
 
 			var prepareOk = CreatePrepareOk(message.View);
 			_publisher.Publish(new GrpcMessage.SendOverGrpc(message.ServerHttpEndPoint, prepareOk,
-				_timeProvider.LocalTime.Add(LeaderElectionGrpcRequestTimeout),
-				_timeProvider.LocalTime.Add(LeaderElectionProgressTimeout)));
+				_timeProvider.LocalTime.Add(_leaderElectionProgressTimeout)));
 		}
 
 		private ElectionMessage.PrepareOk CreatePrepareOk(int view) {

--- a/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
@@ -133,8 +133,7 @@ namespace EventStore.Core.Services.Gossip {
 					_timeProvider, DeadMemberRemovalPeriod, CurrentRole);
 				_bus.Publish(new GrpcMessage.SendOverGrpc(node.HttpEndPoint,
 					new GossipMessage.SendGossip(_cluster, _memberInfo.HttpEndPoint),
-					_timeProvider.LocalTime.Add(GossipTimeout),
-					_timeProvider.LocalTime.Add(GossipInterval)));
+					_timeProvider.LocalTime.Add(GossipTimeout)));
 			}
 
 			var interval = message.GossipRound < GossipRoundStartupThreshold ? GossipStartupInterval : GossipInterval;
@@ -236,8 +235,7 @@ namespace EventStore.Core.Services.Gossip {
 				message.VNodeEndPoint);
 			_bus.Publish(new GrpcMessage.SendOverGrpc(node.HttpEndPoint,
 				new GossipMessage.GetGossip(),
-				_timeProvider.LocalTime.Add(GossipTimeout),
-				_timeProvider.LocalTime.Add(GossipInterval)));
+				_timeProvider.LocalTime.Add(GossipTimeout)));
 		}
 
 		public void Handle(GossipMessage.GetGossipReceived message) {

--- a/src/EventStore.Core/Services/GrpcSendService.cs
+++ b/src/EventStore.Core/Services/GrpcSendService.cs
@@ -26,43 +26,43 @@ namespace EventStore.Core.Services {
 			switch (message.Message) {
 				case GossipMessage.SendGossip sendGossip:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendGossip(sendGossip, message.DestinationEndpoint, message.Deadline);
+						.SendGossip(sendGossip, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case GossipMessage.GetGossip _:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.GetGossip(message.DestinationEndpoint, message.Deadline);
+						.GetGossip(message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.ViewChange viewChange:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendViewChange(viewChange, message.DestinationEndpoint, message.Deadline);
+						.SendViewChange(viewChange, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.ViewChangeProof proof:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendViewChangeProof(proof, message.DestinationEndpoint, message.Deadline);
+						.SendViewChangeProof(proof, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.Prepare prepare:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendPrepare(prepare, message.DestinationEndpoint, message.Deadline);
+						.SendPrepare(prepare, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.PrepareOk prepareOk:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendPrepareOk(prepareOk, message.DestinationEndpoint, message.Deadline);
+						.SendPrepareOk(prepareOk, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.Proposal proposal:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendProposal(proposal, message.DestinationEndpoint, message.Deadline);
+						.SendProposal(proposal, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.Accept accept:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendAccept(accept, message.DestinationEndpoint, message.Deadline);
+						.SendAccept(accept, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.LeaderIsResigning resigning:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendLeaderIsResigning(resigning, message.DestinationEndpoint, message.Deadline);
+						.SendLeaderIsResigning(resigning, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				case ElectionMessage.LeaderIsResigningOk resigningOk:
 					_eventStoreClientCache.Get(message.DestinationEndpoint)
-						.SendLeaderIsResigningOk(resigningOk, message.DestinationEndpoint, message.Deadline);
+						.SendLeaderIsResigningOk(resigningOk, message.DestinationEndpoint, message.LiveUntil);
 					break;
 				default:
 					throw new NotImplementedException($"Message of type {message.Message.GetType().Name} cannot be handled.");

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -289,6 +289,10 @@ namespace EventStore.Core.Util {
 		public const string GossipTimeoutMsDescr = "The timeout, in ms, on gossip to another node.";
 		public const int GossipTimeoutMsDefault = 2500;
 
+		public const string LeaderElectionTimeoutMsDescr =
+			"The timeout, in milliseconds, on election messages to other nodes.";
+		public const int LeaderElectionTimeoutMsDefault = 1_000;
+
 		public const string DisableAdminUiDescr = "Disables the admin ui on the HTTP endpoint";
 		public const bool DisableAdminUiDefault = false;
 

--- a/src/EventStore.Core/VNodeBuilder.cs
+++ b/src/EventStore.Core/VNodeBuilder.cs
@@ -96,6 +96,7 @@ namespace EventStore.Core {
 		protected TimeSpan _gossipAllowedTimeDifference;
 		protected TimeSpan _deadMemberRemovalPeriod;
 		protected TimeSpan _gossipTimeout;
+		protected TimeSpan _leaderElectionTimeout;
 		protected GossipAdvertiseInfo _gossipAdvertiseInfo;
 
 		protected TimeSpan _intTcpHeartbeatTimeout;
@@ -226,6 +227,7 @@ namespace EventStore.Core {
 			_gossipInterval = TimeSpan.FromMilliseconds(Opts.GossipIntervalMsDefault);
 			_gossipAllowedTimeDifference = TimeSpan.FromMilliseconds(Opts.GossipAllowedDifferenceMsDefault);
 			_gossipTimeout = TimeSpan.FromMilliseconds(Opts.GossipTimeoutMsDefault);
+			_leaderElectionTimeout = TimeSpan.FromMilliseconds(Opts.LeaderElectionTimeoutMsDefault);
 
 			_intTcpHeartbeatInterval = TimeSpan.FromMilliseconds(Opts.IntTcpHeartbeatIntervalDefault);
 			_intTcpHeartbeatTimeout = TimeSpan.FromMilliseconds(Opts.IntTcpHeartbeatTimeoutDefault);
@@ -876,6 +878,16 @@ namespace EventStore.Core {
 		}
 
 		/// <summary>
+		/// Sets the leader election timeout
+		/// </summary>
+		/// <param name="leaderElectionTimeout">The leader election timeout</param>
+		/// <returns>A <see cref="VNodeBuilder"/> with the options set</returns>
+		public VNodeBuilder WithLeaderElectionTimeout(TimeSpan leaderElectionTimeout) {
+			_leaderElectionTimeout = leaderElectionTimeout;
+			return this;
+		}
+
+		/// <summary>
 		/// Sets the minimum flush delay
 		/// </summary>
 		/// <param name="minFlushDelay">The minimum flush delay</param>
@@ -1521,6 +1533,7 @@ namespace EventStore.Core {
 				ComputePTableMaxReaderCount(ESConsts.PTableInitialReaderCount, _readerThreadsCount),
 				_keepAliveInterval, _keepAliveTimeout,
 				_streamInfoCacheCapacity,
+				_leaderElectionTimeout,
 				_index,
 				enableHistograms: _enableHistograms,
 				skipIndexVerify: _skipIndexVerify,


### PR DESCRIPTION
Added: LeaderElectionTimeoutMs option to allow configuring the timeout for election messages.

Backports PR https://github.com/EventStore/EventStore/pull/3121 to 20.10.
Fixes https://github.com/EventStore/home/issues/605.
Adds the `LeaderElectionTimeoutMs` option which configures the LiveUntil and Deadlines of messages in ElectionsService

- Deadlines when sending messages over gRPC will be based on the LiveUntil of the messages, rather than setting a deadline separately.
- Update GossipService to use the GossipTimeout as the LiveUntil of gossip messages.