### PR TITLE
Added verification if message is of NotHandled type in PersistentSubscriptions Read message handling

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -205,6 +205,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					groupName, streamName, bufferSize, string.Empty, user));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
+					if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+						_subscriptionIdSource.TrySetException(ex);
+						return;
+					}
+					
 					switch (message) {
 						case ClientMessage.SubscriptionDropped dropped:
 							switch (dropped.Reason) {


### PR DESCRIPTION
Fixed: Added verification checking if a message is of NotHandled type in PersistentSubscriptions Read message handling

Backports PR https://github.com/EventStore/EventStore/pull/3158 to 20.10.
Fixes https://github.com/EventStore/home/issues/634