### PR TITLE
Do not log IOException when closing gRPC connection

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs
@@ -93,7 +93,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					} catch (OperationCanceledException) {
 						tcs.TrySetCanceled(cancellationToken);
 					} catch (IOException ex) {
-						Log.Information(ex, "Closing gRPC client connection: {message}", ex.GetBaseException().Message);
+						Log.Information("Closing gRPC client connection: {message}", ex.GetBaseException().Message);
 						tcs.TrySetException(ex);
 					}
 					catch (Exception ex) {


### PR DESCRIPTION
Removed: Stack track in log when closing gRPC connection

Stack trace doesn't add much and is somewhat alarming. The message itself contains the required information