### PR TITLE
Always finish reading RequestStream before completing the gRPC call

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -139,11 +139,13 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private void Start() {
 			_started = true;
 			_bus.Publish(new SubscriptionMessage.PersistentSubscriptionsStarted());
+			Log.Debug("Persistent Subscriptions have been started.");
 		}
 
 		private void Stop() {
 			_started = false;
 			_bus.Publish(new SubscriptionMessage.PersistentSubscriptionsStopped());
+			Log.Debug("Persistent Subscriptions have been stopped.");
 		}
 
 		public void Handle(ClientMessage.UnsubscribeFromStream message) {

--- a/src/EventStore.Core/Services/Transport/Grpc/AsyncStreamExtensions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/AsyncStreamExtensions.cs
@@ -17,6 +17,7 @@
 #endregion
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 
@@ -29,9 +30,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		/// Reads the entire stream and executes an async action for each element.
 		/// </summary>
 		public static async ValueTask ForEachAsync<T>(this IAsyncStreamReader<T> streamReader,
-			Func<T, ValueTask> asyncAction)
+			Func<T, ValueTask> asyncAction,
+			CancellationToken token)
 			where T : class {
-			while (await streamReader.MoveNext().ConfigureAwait(false)) {
+			while (await streamReader.MoveNext(token).ConfigureAwait(false)) {
 				await asyncAction(streamReader.Current).ConfigureAwait(false);
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Read.cs
@@ -63,8 +63,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			var subscriptionId = await enumerator.Started.ConfigureAwait(false);
 
+			var read = ValueTask.CompletedTask;
+			var cts = new CancellationTokenSource();
 			try {
-				var read = requestStream.ForEachAsync(HandleAckNack);
+				read = PumpRequestStream(cts.Token);
 
 				await responseStream.WriteAsync(new ReadResp {
 					SubscriptionConfirmation = new ReadResp.Types.SubscriptionConfirmation {
@@ -77,10 +79,19 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						Event = ConvertToReadEvent(enumerator.Current)
 					}).ConfigureAwait(false);
 				}
-
-				await read.ConfigureAwait(false);
 			} catch (IOException) {
 				Log.Information("Subscription {correlationId} to {subscriptionId} disposed. The request stream was closed.", correlationId, subscriptionId);
+			} finally {
+				// make sure we stop reading the request stream before leaving this method
+				cts.Cancel();
+				await read.ConfigureAwait(false);
+			}
+
+			async ValueTask PumpRequestStream(CancellationToken token) {
+				try {
+					await requestStream.ForEachAsync(HandleAckNack, token).ConfigureAwait(false);
+				} catch {
+				}
 			}
 
 			ValueTask HandleAckNack(ReadReq request) {


### PR DESCRIPTION
Fixed: InvalidOperationException caused by reading RequestStream after completing the PersistentSubscription gRPC call

Otherwise possible to get "Reading is already in progress" error on a _subsequent_ request.
Which manifests itself to the client as InvalidOperationException : Status(StatusCode="Unknown", Detail="Exception was thrown by the handler.")

This is a backport of https://github.com/EventStore/EventStore/pull/3287