### PR TITLE
[release/oss-v20.10] Clear HeadingEventReader cache when stopping

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/HeadingEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/HeadingEventReader.cs
@@ -142,6 +142,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			EnsureStarted();
 			_headEventReader.Pause();
 			_headEventReader = null;
+			EmptyCache();
 			_started = false;
 		}
 
@@ -244,6 +245,11 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 			var lastAvailableCommittedEvent = _lastMessages.Peek();
 			_subscribeFromPosition = lastAvailableCommittedEvent.Position;
+		}
+
+		private void EmptyCache() {
+			_lastMessages.Clear();
+			_subscribeFromPosition = new TFPos(long.MaxValue, long.MaxValue);
 		}
 
 		private void AddSubscriber(Guid publishWithCorrelationId, IReaderSubscription subscription) {


### PR DESCRIPTION
Fixed: Clear HeadingEventReader cache when stopping the readers

Backports https://github.com/EventStore/EventStore/pull/3233 to 20.10.5

