### PR TITLE
Drop leading / from paths-ignore

### DIFF
--- a/.github/workflows/build-container-alpine.yml
+++ b/.github/workflows/build-container-alpine.yml
@@ -3,8 +3,8 @@ name: Build Alpine Container
 on:
   pull_request:
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
   push:
     branches:
@@ -13,8 +13,8 @@ on:
     tags:
       - oss-v*
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
 
 jobs:

--- a/.github/workflows/build-container-buster-slim.yml
+++ b/.github/workflows/build-container-buster-slim.yml
@@ -3,8 +3,8 @@ name: Build Buster Slim Container
 on:
   pull_request:
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
   push:
     branches:
@@ -13,8 +13,8 @@ on:
     tags:
       - oss-v*
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
 
 jobs:

--- a/.github/workflows/build-container-focal.yml
+++ b/.github/workflows/build-container-focal.yml
@@ -3,8 +3,8 @@ name: Build Focal Container
 on:
   pull_request:
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
   push:
     branches:
@@ -13,8 +13,8 @@ on:
     tags:
       - oss-v*
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
 
 jobs:

--- a/.github/workflows/build-ubuntu-18.04.yml
+++ b/.github/workflows/build-ubuntu-18.04.yml
@@ -3,8 +3,8 @@ name: Build Ubuntu 18.04
 on:
   pull_request:
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
   push:
     branches:
@@ -13,8 +13,8 @@ on:
     tags:
       - oss-v*
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
 
 jobs:

--- a/.github/workflows/build-ubuntu-20.04-arm64.yml
+++ b/.github/workflows/build-ubuntu-20.04-arm64.yml
@@ -2,8 +2,8 @@ name: Build Ubuntu 20.04 ARM64
 on:
   pull_request:
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
   push:
     branches:
@@ -12,8 +12,8 @@ on:
     tags:
       - oss-v*
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
 
 jobs:

--- a/.github/workflows/build-windows-2019.yml
+++ b/.github/workflows/build-windows-2019.yml
@@ -3,8 +3,8 @@ name: Build Windows 2019
 on:
   pull_request:
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
   push:
     branches:
@@ -13,8 +13,8 @@ on:
     tags:
       - oss-v*
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
 
 jobs:

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -3,8 +3,8 @@ name: Common
 on:
   pull_request:
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
   push:
     branches:
@@ -13,8 +13,8 @@ on:
     tags:
       - oss-v*
     paths-ignore:
-      - "/docs/**"
-      - "/samples/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
 
 jobs:

--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -2,9 +2,9 @@ name: Pull Request check
 on:
   pull_request:
     paths-ignore:
-      - "/src/*.Tests/**"
-      - "/docs/**"
-      - "/samples/**"
+      - "src/*.Tests/**"
+      - "docs/**"
+      - "samples/**"
       - "**.md"
     types: [opened, edited]
 jobs:


### PR DESCRIPTION
This is probably why we are getting unwanted builds
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet don't have leading /