### PR TITLE
samples http-APi : default acl is set on $settings not $settings/metadata

### DIFF
--- a/samples/http-api/update-default-acl.sh
+++ b/samples/http-api/update-default-acl.sh
@@ -1,3 +1,3 @@
-curl -i -d @override-default.json http://127.0.0.1:2113/streams/%24settings/metadata /
+curl -i -d @override-default.json http://127.0.0.1:2113/streams/%24settings /
     --user admin:changeit /
     -H "Content-Type: application/vnd.eventstore.events+json"


### PR DESCRIPTION
curl sample  for setting the default acl is wrong , 
it's on .../$settings not .../settings/metadata