### PR TITLE
Fix Bug in Checkpoints on Live Filtered Subscriptions

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -289,7 +289,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							if (startPosition != Position.End) {
 								ReadHistoricalEvents(startPosition);
 							} else {
-								NotifyCaughtUp(startPosition);
+								NotifyCaughtUp(Position.FromInt64(caughtUp.CommitPosition, caughtUp.PreparePosition));
 							}
 
 							void NotifyCaughtUp(Position position) {


### PR DESCRIPTION
Fixed: use last indexed position of all stream when consumer subscribes to all filtered live
