### PR TITLE
Fix latest 20.10 image not available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,20 +109,20 @@ jobs:
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        repository: docker.pkg.github.com/eventstore/eventstore/eventstore
+        repository: ghcr.io/eventstore/eventstore
         tag-latest: false
         additional-tags: ${{ env.VERSION }}
-        registry: https://docker.pkg.github.com
+        registry: https://ghcr.io
     - name: Docker Push CI
       uses: jen20/action-docker-build@v1
       if: github.event_name == 'push' && matrix.container-runtime == 'bionic'
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        repository: docker.pkg.github.com/eventstore/eventstore/eventstore
+        repository: ghcr.io/eventstore/eventstore
         tag-latest: false
         additional-tags: ci
-        registry: https://docker.pkg.github.com
+        registry: https://ghcr.io
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fixed: 20.10.5 image not available under `ghcr.io/eventstore/eventstore:20.10.5-buster-slim`