### PR TITLE
Fix partitionBy not working with numbers.

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/Jint/when_partitioning_by_custom_rule_returning_a_number.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/when_partitioning_by_custom_rule_returning_a_number.cs
@@ -1,0 +1,32 @@
+using System;
+using EventStore.Core.Data;
+using EventStore.Projections.Core.Services.Processing;
+using NUnit.Framework;
+using ResolvedEvent = EventStore.Projections.Core.Services.Processing.ResolvedEvent;
+
+namespace EventStore.Projections.Core.Tests.Services.Jint {
+	[TestFixture]
+	public class when_partitioning_by_custom_rule_returning_a_number : TestFixtureWithInterpretedProjection {
+		protected override void Given() {
+			_projection = @"
+                fromAll().partitionBy(function(event){
+                    return event.body.index;
+                }).when({$any:function(event, state) {
+                    return {};
+                }});
+            ";
+		}
+
+		[Test]
+		public void get_state_partition_returns_correct_result() {
+			var result = _stateHandler.GetStatePartition(
+				CheckpointTag.FromPosition(0, 100, 50), "category",
+				new ResolvedEvent(
+					"stream1", 0, "stream1", 0, false, new TFPos(100, 50), Guid.NewGuid(), "type1", true,
+					@"{""index"": 42}", "metadata"));
+
+			Assert.AreEqual("42", result);
+		}
+
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
@@ -138,9 +138,10 @@ namespace EventStore.Projections.Core.Services.Interpreted {
 			_engine.ResetConstraints();
 			var envelope = _interpreterRuntime.CreateEnvelope("", data, category);
 			var partition = _interpreterRuntime.GetPartition(envelope);
-			if (partition == JsValue.Null || partition == JsValue.Undefined || !partition.IsString())
+			if (partition == JsValue.Null || partition == JsValue.Undefined || !(partition.IsString() || partition.IsNumber()))
 				return null;
-			return partition.AsString();
+
+			return partition.IsNumber() ? partition.AsNumber().ToString() : partition.AsString();
 		}
 
 		public bool ProcessPartitionCreated(string partition, CheckpointTag createPosition, ResolvedEvent @event,


### PR DESCRIPTION
Fixed: Fix `partitionBy` not working with numbers

Fixes #3318 