### PR TITLE
Make streams with MaxAge respect SkipIndexScanOnRead

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
@@ -1,13 +1,15 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using EventStore.ClientAPI;
+using EventStore.Core.Data;
 using NUnit.Framework;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services.Storage.ReaderIndex;
-using System.Collections.Generic;
+using ExpectedVersion = EventStore.ClientAPI.ExpectedVersion;
 
 namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 	// both the stream names hash to the same value using XXHash.
@@ -21,7 +23,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		protected int _maxMemTableSize = 5;
 		protected TableIndex _tableIndex;
 		protected IIndexReader _indexReader;
-		protected FakeIndexBackend _indexBackend;
+		protected IIndexBackend _indexBackend;
 		protected IHasher _lowHasher;
 		protected IHasher _highHasher;
 		protected string _indexDir;
@@ -63,6 +65,15 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		}
 	}
 
+	class UseMaxAgeFixtureArgs: IEnumerable
+	{
+		public IEnumerator GetEnumerator()
+		{
+			yield return true;
+			yield return false;
+		}
+	}
+
 	[TestFixture]
 	public class when_stream_does_not_exist : HashCollisionTestFixture {
 		protected override void given() {
@@ -82,65 +93,104 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class when_stream_is_out_of_range_of_read_limit : HashCollisionTestFixture {
+		private readonly bool _useMaxAge;
+		private readonly string stream1Id = "account--696193173";
+		private readonly string stream2Id = "LPN-FC002_LPK51001";
+
+		public when_stream_is_out_of_range_of_read_limit(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
+
 		protected override void given() {
 			_hashCollisionReadLimit = 1;
 		}
 
 		protected override void when() {
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(stream1Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+				_indexBackend.SetStreamMetadata(stream2Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1
-			_tableIndex.Add(1, "account--696193173", 0, 0);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 0, 3);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 1, 5);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 2, 7);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 3, 9);
+			_tableIndex.Add(1, stream1Id, 0, 0);
+			_tableIndex.Add(1, stream2Id, 0, 3);
+			_tableIndex.Add(1, stream2Id, 1, 5);
+			_tableIndex.Add(1, stream2Id, 2, 7);
+			_tableIndex.Add(1, stream2Id, 3, 9);
 			//mem table
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 4, 13);
+			_tableIndex.Add(1, stream2Id, 4, 13);
 		}
 
 		[Test]
 		public void should_return_invalid_event_number() {
 			Assert.AreEqual(EventStore.Core.Data.EventNumber.Invalid,
-				_indexReader.GetStreamLastEventNumber("account--696193173"));
+				_indexReader.GetStreamLastEventNumber(stream1Id));
 		}
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class when_stream_is_in_of_range_of_read_limit : HashCollisionTestFixture {
+		private readonly bool _useMaxAge;
+		private readonly string stream1Id = "account--696193173";
+		private readonly string stream2Id = "LPN-FC002_LPK51001";
+
+		public when_stream_is_in_of_range_of_read_limit(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
+
 		protected override void given() {
 			_hashCollisionReadLimit = 5;
 		}
 
 		protected override void when() {
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(stream1Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+				_indexBackend.SetStreamMetadata(stream2Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1
-			_tableIndex.Add(1, "account--696193173", 0, 0);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 0, 3);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 1, 5);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 2, 7);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 3, 9);
+			_tableIndex.Add(1, stream1Id, 0, 0);
+			_tableIndex.Add(1, stream2Id, 0, 3);
+			_tableIndex.Add(1, stream2Id, 1, 5);
+			_tableIndex.Add(1, stream2Id, 2, 7);
+			_tableIndex.Add(1, stream2Id, 3, 9);
 			//mem table
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 4, 13);
+			_tableIndex.Add(1, stream2Id, 4, 13);
 		}
 
 		[Test]
 		public void should_return_last_event_number() {
-			Assert.AreEqual(0, _indexReader.GetStreamLastEventNumber("account--696193173"));
+			Assert.AreEqual(0, _indexReader.GetStreamLastEventNumber(stream1Id));
 		}
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class when_hash_read_limit_is_not_reached : HashCollisionTestFixture {
+		private readonly bool _useMaxAge;
+
+		public when_hash_read_limit_is_not_reached(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
+
 		protected override void given() {
 			_hashCollisionReadLimit = 3;
 		}
 
 		protected override void when() {
+			string stream1Id = "account--696193173";
+			string stream2Id = "LPN-FC002_LPK51001";
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(stream1Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+				_indexBackend.SetStreamMetadata(stream2Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1
-			_tableIndex.Add(1, "account--696193173", 0, 0);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 0, 3);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 1, 5);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 2, 7);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 3, 9);
+			_tableIndex.Add(1, stream1Id, 0, 0);
+			_tableIndex.Add(1, stream2Id, 0, 3);
+			_tableIndex.Add(1, stream2Id, 1, 5);
+			_tableIndex.Add(1, stream2Id, 2, 7);
+			_tableIndex.Add(1, stream2Id, 3, 9);
 		}
 
 		[Test]
@@ -150,27 +200,23 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		}
 	}
 
-	[TestFixture(true)]
-	[TestFixture(false)]
+	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class when_index_contains_duplicate_entries : HashCollisionTestFixture {
-		private string streamId = "account--696193173";
-		private readonly bool _withMaxAge;
+		private readonly string streamId = "account--696193173";
+		private readonly bool _useMaxAge;
 
-		public when_index_contains_duplicate_entries(bool withMaxAge) {
-			_withMaxAge = withMaxAge;
+		public when_index_contains_duplicate_entries(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
 		}
-
 		protected override void given() {
 			_hashCollisionReadLimit = 5;
 		}
 
 		protected override void when() {
-			if (_withMaxAge) {
-				_indexBackend.SetStreamMetadata(
-					streamId,
-					new Data.StreamMetadata(maxAge: TimeSpan.FromDays(1)));
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(streamId, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
 			}
-
 			//ptable 1
 			_tableIndex.Add(1, streamId, 0, 2);
 			_tableIndex.Add(1, streamId, 0, 4);
@@ -225,9 +271,15 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class
 		when_index_contains_duplicate_entries_and_the_duplicate_is_a_64bit_index_entry : HashCollisionTestFixture {
-		private string streamId = "account--696193173";
+		private readonly string streamId = "account--696193173";
+		private readonly bool _useMaxAge;
+
+		public when_index_contains_duplicate_entries_and_the_duplicate_is_a_64bit_index_entry(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
 
 		protected override void given() {
 			_maxMemTableSize = 3;
@@ -235,6 +287,9 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		}
 
 		protected override void when() {
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(streamId, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1 with 32bit indexes
 			_tableIndex.Add(1, streamId, 0, 2);
 			_tableIndex.Add(1, streamId, 1, 4);
@@ -315,7 +370,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		protected override void when() {
 			_indexBackend.SetStreamMetadata(
 				_evenStream,
-				new Data.StreamMetadata(maxAge: TimeSpan.FromDays(1)));
+				new StreamMetadata(maxAge: TimeSpan.FromDays(1)));
 
 			_tableIndex.Add(1, _evenStream, 5, 0);
 			_tableIndex.Add(1, _evenStream, 6, 2);
@@ -326,18 +381,11 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 
 		[Test]
 		public void can_read() {
-			//qq here we probably fail to get the evenstream
 			var result = _indexReader.ReadStreamEventsForward(
 				streamId: _evenStream,
 				fromEventNumber: 0,
 				maxCount: 2);
 
-			//qq the behaviour between having no events and having expired events is different
-			//    with scavenged events (i.e. here) the read will start from the first present events
-			//    with expired events that have not been scavenged the read will be empty because
-			//    the first present are deemd out of range
-			// when_reading_very_long_stream_with_max_age_and_mostly_expired_events 
-			Assert.AreEqual(ReadStreamResult.Success, result.Result);
 			Assert.AreEqual(2, result.Records.Length);
 			Assert.AreEqual(5, result.Records[0].EventNumber);
 			Assert.AreEqual(6, result.Records[1].EventNumber);
@@ -346,7 +394,8 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 
 	public class FakeIndexBackend : IIndexBackend {
 		private readonly TFReaderLease _readerLease;
-		private readonly Dictionary<string, Data.StreamMetadata> _metadatas = new Dictionary<string, Data.StreamMetadata>();
+		private readonly Dictionary<string, IndexBackend.MetadataCached> _streamMetadata =
+			new Dictionary<string, IndexBackend.MetadataCached>();
 
 		public FakeIndexBackend(TFReaderLease readerLease) {
 			_readerLease = readerLease;
@@ -361,8 +410,8 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		}
 
 		public IndexBackend.MetadataCached TryGetStreamMetadata(string streamId) {
-			if (_metadatas.TryGetValue(streamId, out var metadata))
-				return new IndexBackend.MetadataCached(1, metadata);
+			if (_streamMetadata.TryGetValue(streamId, out var metadata))
+				return metadata;
 			return new IndexBackend.MetadataCached();
 		}
 
@@ -372,7 +421,8 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 
 		public EventStore.Core.Data.StreamMetadata UpdateStreamMetadata(int cacheVersion, string streamId,
 			EventStore.Core.Data.StreamMetadata metadata) {
-			return null;
+			_streamMetadata[streamId] = new IndexBackend.MetadataCached(1, metadata);
+			return metadata;
 		}
 
 		public long? SetStreamLastEventNumber(string streamId, long lastEventNumber) {
@@ -381,8 +431,8 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 
 		public EventStore.Core.Data.StreamMetadata SetStreamMetadata(string streamId,
 			EventStore.Core.Data.StreamMetadata metadata) {
-			_metadatas[streamId] = metadata;
-			return null;
+			_streamMetadata[streamId] = new IndexBackend.MetadataCached(1, metadata);
+			return metadata;
 		}
 
 		public void SetSystemSettings(EventStore.Core.Data.SystemSettings systemSettings) {

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age.cs
@@ -14,11 +14,11 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 
 			var metadata = string.Format(@"{{""$maxAge"":{0}}}", (int)TimeSpan.FromMinutes(20).TotalSeconds);
 			WriteStreamMetadata("ES", 0, metadata, now.AddMinutes(-100));
-			WriteSingleEvent("ES", 0, "bla", now.AddMinutes(-50));
-			WriteSingleEvent("ES", 1, "bla", now.AddMinutes(-25));
-			_event2 = WriteSingleEvent("ES", 2, "bla", now.AddMinutes(-15));
-			_event3 = WriteSingleEvent("ES", 3, "bla", now.AddMinutes(-11));
-			_event4 = WriteSingleEvent("ES", 4, "bla", now.AddMinutes(-3));
+			WriteSingleEvent("ES", 0, "bla", now.AddMinutes(-50)); // expired
+			WriteSingleEvent("ES", 1, "bla", now.AddMinutes(-25)); // expired
+			_event2 = WriteSingleEvent("ES", 2, "bla", now.AddMinutes(-15)); // active
+			_event3 = WriteSingleEvent("ES", 3, "bla", now.AddMinutes(-11)); // active
+			_event4 = WriteSingleEvent("ES", 4, "bla", now.AddMinutes(-3)); // active
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age_and_max_count_and_max_age_is_more_strict.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age_and_max_count_and_max_age_is_more_strict.cs
@@ -18,12 +18,12 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 				(int)TimeSpan.FromMinutes(20).TotalSeconds);
 
 			WriteStreamMetadata("ES", 0, metadata);
-			WriteSingleEvent("ES", 0, "bla", now.AddMinutes(-100));
-			WriteSingleEvent("ES", 1, "bla", now.AddMinutes(-50));
-			WriteSingleEvent("ES", 2, "bla", now.AddMinutes(-25));
-			_event3 = WriteSingleEvent("ES", 3, "bla", now.AddMinutes(-15));
-			_event4 = WriteSingleEvent("ES", 4, "bla", now.AddMinutes(-11));
-			_event5 = WriteSingleEvent("ES", 5, "bla", now.AddMinutes(-3));
+			WriteSingleEvent("ES", 0, "bla", now.AddMinutes(-100)); // expired: maxcount & maxage
+			WriteSingleEvent("ES", 1, "bla", now.AddMinutes(-50)); // expired: maxage
+			WriteSingleEvent("ES", 2, "bla", now.AddMinutes(-25)); // expired: maxage
+			_event3 = WriteSingleEvent("ES", 3, "bla", now.AddMinutes(-15)); // active
+			_event4 = WriteSingleEvent("ES", 4, "bla", now.AddMinutes(-11)); // active
+			_event5 = WriteSingleEvent("ES", 5, "bla", now.AddMinutes(-3)); // active
 		}
 
 		[Test]
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 			on_read_forward_from_start_to_expired_next_event_number_is_expired_by_age_plus_1_and_its_not_end_of_stream() {
 			var res = ReadIndex.ReadStreamEventsForward("ES", 0, 2);
 			Assert.AreEqual(ReadStreamResult.Success, res.Result);
-			Assert.AreEqual(2, res.NextEventNumber);
+			Assert.AreEqual(3, res.NextEventNumber); // new path fast forwards to here
 			Assert.AreEqual(5, res.LastEventNumber);
 			Assert.IsFalse(res.IsEndOfStream);
 

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_very_long_stream_with_max_age_and_some_expired_events.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_very_long_stream_with_max_age_and_some_expired_events.cs
@@ -4,9 +4,10 @@ using EventStore.Core.TransactionLog.Chunks;
 using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNextEventNumber {
+	// test the binary chop where it has to repeatedly lower the high bound
 	public class
-		when_reading_very_long_stream_with_max_age_and_mostly_expired_events : ReadIndexTestScenario {
-		public when_reading_very_long_stream_with_max_age_and_mostly_expired_events() : base(
+		when_reading_very_long_stream_with_max_age_and_some_expired_events : ReadIndexTestScenario {
+		public when_reading_very_long_stream_with_max_age_and_some_expired_events() : base(
 			maxEntriesInMemTable: 500_000, chunkSize: TFConsts.ChunkSize) {
 		}
 
@@ -14,11 +15,11 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 			var now = DateTime.UtcNow;
 			var metadata = string.Format(@"{{""$maxAge"":{0}}}", (int)TimeSpan.FromMinutes(20).TotalSeconds);
 			WriteStreamMetadata("ES", 0, metadata, now.AddMinutes(-100));
-			for (int i = 0; i < 1_000_000; i++) {
+			for (int i = 0; i < 20; i++) {
 				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-50), retryOnFail: true);
 			}
 
-			for (int i = 1_000_000; i < 1_000_015; i++) {
+			for (int i = 20; i < 1_000_000; i++) {
 				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-1), retryOnFail: true);
 			}
 		}
@@ -29,21 +30,15 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 			var res = ReadIndex.ReadStreamEventsForward("ES", 1, 10);
 			var elapsed = sw.Elapsed;
 
-			Assert.AreEqual(1_000_000, res.NextEventNumber);
+			Assert.AreEqual(20, res.NextEventNumber);
 			Assert.AreEqual(0, res.Records.Length);
 			Assert.AreEqual(false, res.IsEndOfStream);
 
 			res = ReadIndex.ReadStreamEventsForward("ES", res.NextEventNumber, 10);
 
-			Assert.AreEqual(1_000_010, res.NextEventNumber);
+			Assert.AreEqual(30, res.NextEventNumber);
 			Assert.AreEqual(10, res.Records.Length);
 			Assert.AreEqual(false, res.IsEndOfStream);
-
-			res = ReadIndex.ReadStreamEventsForward("ES", res.NextEventNumber, 10);
-
-			Assert.AreEqual(1_000_015, res.NextEventNumber);
-			Assert.AreEqual(5, res.Records.Length);
-			Assert.AreEqual(true, res.IsEndOfStream);
 
 			Assert.Less(elapsed, TimeSpan.FromSeconds(1));
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/with_invalid_max_age_and_normal_max_count.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/with_invalid_max_age_and_normal_max_count.cs
@@ -1,11 +1,10 @@
 using System;
 using EventStore.Core.Data;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using NUnit.Framework;
 using ReadStreamResult = EventStore.Core.Services.Storage.ReaderIndex.ReadStreamResult;
 
 namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
-	[TestFixture, Ignore("Metadata must be valid.")]
+	[TestFixture]
 	public class with_invalid_max_age_and_normal_max_count : ReadIndexTestScenario {
 		private EventRecord _r1;
 		private EventRecord _r2;
@@ -28,10 +27,10 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
 		}
 
 		[Test]
-		public void on_single_event_read_invalid_value_is_ignored() {
+		public void on_single_event_read_all_metadata_is_ignored() {
 			var result = ReadIndex.ReadEvent("ES", 0);
-			Assert.AreEqual(ReadEventResult.NotFound, result.Result);
-			Assert.IsNull(result.Record);
+			Assert.AreEqual(ReadEventResult.Success, result.Result);
+			Assert.AreEqual(_r2, result.Record);
 
 			result = ReadIndex.ReadEvent("ES", 1);
 			Assert.AreEqual(ReadEventResult.Success, result.Result);
@@ -51,29 +50,31 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
 		}
 
 		[Test]
-		public void on_forward_range_read_invalid_value_is_ignored() {
+		public void on_forward_range_read_metadata_is_ignored() {
 			var result = ReadIndex.ReadStreamEventsForward("ES", 0, 100);
 			Assert.AreEqual(ReadStreamResult.Success, result.Result);
-			Assert.AreEqual(4, result.Records.Length);
-			Assert.AreEqual(_r3, result.Records[0]);
-			Assert.AreEqual(_r4, result.Records[1]);
-			Assert.AreEqual(_r5, result.Records[2]);
-			Assert.AreEqual(_r6, result.Records[3]);
+			Assert.AreEqual(5, result.Records.Length);
+			Assert.AreEqual(_r2, result.Records[0]);
+			Assert.AreEqual(_r3, result.Records[1]);
+			Assert.AreEqual(_r4, result.Records[2]);
+			Assert.AreEqual(_r5, result.Records[3]);
+			Assert.AreEqual(_r6, result.Records[4]);
 		}
 
 		[Test]
-		public void on_backward_range_read_invalid_value_is_ignored() {
+		public void on_backward_range_read_metadata_is_ignored() {
 			var result = ReadIndex.ReadStreamEventsBackward("ES", -1, 100);
 			Assert.AreEqual(ReadStreamResult.Success, result.Result);
-			Assert.AreEqual(4, result.Records.Length);
+			Assert.AreEqual(5, result.Records.Length);
 			Assert.AreEqual(_r6, result.Records[0]);
 			Assert.AreEqual(_r5, result.Records[1]);
 			Assert.AreEqual(_r4, result.Records[2]);
 			Assert.AreEqual(_r3, result.Records[3]);
+			Assert.AreEqual(_r2, result.Records[4]);
 		}
 
 		[Test]
-		public void on_read_all_forward_both_values_are_ignored() {
+		public void on_read_all_forward_metadata_is_ignored() {
 			var records = ReadIndex.ReadAllEventsForward(new TFPos(0, 0), 100).Records;
 			Assert.AreEqual(6, records.Count);
 			Assert.AreEqual(_r1, records[0].Event);
@@ -85,7 +86,7 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
 		}
 
 		[Test]
-		public void on_read_all_backward_both_values_are_ignored() {
+		public void on_read_all_backward_metadata_is_ignored() {
 			var records = ReadIndex.ReadAllEventsBackward(GetBackwardReadPos(), 100).Records;
 			Assert.AreEqual(6, records.Count);
 			Assert.AreEqual(_r6, records[0].Event);

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/with_invalid_max_count_and_normal_max_age.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/with_invalid_max_count_and_normal_max_age.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using EventStore.Core.Data;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using NUnit.Framework;
 using ReadStreamResult = EventStore.Core.Services.Storage.ReaderIndex.ReadStreamResult;
 
 namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
-	[TestFixture, Ignore("Metadata must be valid.")]
+	[TestFixture]
 	public class with_invalid_max_count_and_normal_max_age : ReadIndexTestScenario {
 		private EventRecord _r1;
 		private EventRecord _r2;
@@ -28,10 +27,10 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
 		}
 
 		[Test]
-		public void on_single_event_read_invalid_value_is_ignored() {
+		public void on_single_event_read_metadata_is_ignored() {
 			var result = ReadIndex.ReadEvent("ES", 0);
-			Assert.AreEqual(ReadEventResult.NotFound, result.Result);
-			Assert.IsNull(result.Record);
+			Assert.AreEqual(ReadEventResult.Success, result.Result);
+			Assert.AreEqual(_r2, result.Record);
 
 			result = ReadIndex.ReadEvent("ES", 1);
 			Assert.AreEqual(ReadEventResult.Success, result.Result);
@@ -51,29 +50,31 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
 		}
 
 		[Test]
-		public void on_forward_range_read_invalid_value_is_ignored() {
+		public void on_forward_range_read_metadata_is_ignored() {
 			var result = ReadIndex.ReadStreamEventsForward("ES", 0, 100);
 			Assert.AreEqual(ReadStreamResult.Success, result.Result);
-			Assert.AreEqual(4, result.Records.Length);
-			Assert.AreEqual(_r3, result.Records[0]);
-			Assert.AreEqual(_r4, result.Records[1]);
-			Assert.AreEqual(_r5, result.Records[2]);
-			Assert.AreEqual(_r6, result.Records[3]);
+			Assert.AreEqual(5, result.Records.Length);
+			Assert.AreEqual(_r2, result.Records[0]);
+			Assert.AreEqual(_r3, result.Records[1]);
+			Assert.AreEqual(_r4, result.Records[2]);
+			Assert.AreEqual(_r5, result.Records[3]);
+			Assert.AreEqual(_r6, result.Records[4]);
 		}
 
 		[Test]
-		public void on_backward_range_read_invalid_value_is_ignored() {
+		public void on_backward_range_read_metadata_is_ignored() {
 			var result = ReadIndex.ReadStreamEventsBackward("ES", -1, 100);
 			Assert.AreEqual(ReadStreamResult.Success, result.Result);
-			Assert.AreEqual(4, result.Records.Length);
+			Assert.AreEqual(5, result.Records.Length);
 			Assert.AreEqual(_r6, result.Records[0]);
 			Assert.AreEqual(_r5, result.Records[1]);
 			Assert.AreEqual(_r4, result.Records[2]);
 			Assert.AreEqual(_r3, result.Records[3]);
+			Assert.AreEqual(_r2, result.Records[4]);
 		}
 
 		[Test]
-		public void on_read_all_forward_both_values_are_ignored() {
+		public void on_read_all_forward_metadata_is_ignored() {
 			var records = ReadIndex.ReadAllEventsForward(new TFPos(0, 0), 100).Records;
 			Assert.AreEqual(6, records.Count);
 			Assert.AreEqual(_r1, records[0].Event);
@@ -85,7 +86,7 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
 		}
 
 		[Test]
-		public void on_read_all_backward_both_values_are_ignored() {
+		public void on_read_all_backward_metadata_is_ignored() {
 			var records = ReadIndex.ReadAllEventsBackward(GetBackwardReadPos(), 100).Records;
 			Assert.AreEqual(6, records.Count);
 			Assert.AreEqual(_r6, records[0].Event);


### PR DESCRIPTION
Fixed: MaxAge fast path: corner cases and support for SkipIndexScanOnRead

Make streams with MaxAge respect SkipIndexScanOnRead. Also assorted corner cases on the max age optimized path to handle indexing corner cases (hash collisions, duplicate events, transactions, mixed bitness of index tables)
