### PR TITLE
[ForwardPort master] Make streams with MaxAge respect SkipIndexScanOnRead

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
@@ -1,7 +1,8 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using EventStore.ClientAPI;
-using EventStore.Core.Tests;
+using EventStore.Core.Data;
 using NUnit.Framework;
 using EventStore.Core.Index;
 using EventStore.Core.Index.Hashes;
@@ -9,8 +10,14 @@ using EventStore.Core.LogAbstraction;
 using EventStore.Core.TransactionLog;
 using EventStore.Core.TransactionLog.LogRecords;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using ExpectedVersion = EventStore.ClientAPI.ExpectedVersion;
 
 namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
+	// both the stream names hash to the same value using XXHash.
+	// they are different for Murmur3 so we use v1 tables here.
+	// we use a fake TransactionFileReader that attributes:
+	//    odd  positions to LPN-FC002_LPK51001
+	//    even positions to account--696193173
 	[TestFixture]
 	public class HashCollisionTestFixture : SpecificationWithDirectoryPerTestFixture {
 		protected int _hashCollisionReadLimit = 5;
@@ -71,6 +78,15 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		}
 	}
 
+	class UseMaxAgeFixtureArgs: IEnumerable
+	{
+		public IEnumerator GetEnumerator()
+		{
+			yield return true;
+			yield return false;
+		}
+	}
+
 	[TestFixture]
 	public class when_stream_does_not_exist : HashCollisionTestFixture {
 		protected override void given() {
@@ -90,65 +106,104 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class when_stream_is_out_of_range_of_read_limit : HashCollisionTestFixture {
+		private readonly bool _useMaxAge;
+		private readonly string stream1Id = "account--696193173";
+		private readonly string stream2Id = "LPN-FC002_LPK51001";
+
+		public when_stream_is_out_of_range_of_read_limit(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
+
 		protected override void given() {
 			_hashCollisionReadLimit = 1;
 		}
 
 		protected override void when() {
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(stream1Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+				_indexBackend.SetStreamMetadata(stream2Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1
-			_tableIndex.Add(1, "account--696193173", 0, 0);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 0, 3);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 1, 5);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 2, 7);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 3, 9);
+			_tableIndex.Add(1, stream1Id, 0, 0);
+			_tableIndex.Add(1, stream2Id, 0, 3);
+			_tableIndex.Add(1, stream2Id, 1, 5);
+			_tableIndex.Add(1, stream2Id, 2, 7);
+			_tableIndex.Add(1, stream2Id, 3, 9);
 			//mem table
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 4, 13);
+			_tableIndex.Add(1, stream2Id, 4, 13);
 		}
 
 		[Test]
 		public void should_return_invalid_event_number() {
 			Assert.AreEqual(EventStore.Core.Data.EventNumber.Invalid,
-				_indexReader.GetStreamLastEventNumber("account--696193173"));
+				_indexReader.GetStreamLastEventNumber(stream1Id));
 		}
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class when_stream_is_in_of_range_of_read_limit : HashCollisionTestFixture {
+		private readonly bool _useMaxAge;
+		private readonly string stream1Id = "account--696193173";
+		private readonly string stream2Id = "LPN-FC002_LPK51001";
+
+		public when_stream_is_in_of_range_of_read_limit(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
+
 		protected override void given() {
 			_hashCollisionReadLimit = 5;
 		}
 
 		protected override void when() {
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(stream1Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+				_indexBackend.SetStreamMetadata(stream2Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1
-			_tableIndex.Add(1, "account--696193173", 0, 0);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 0, 3);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 1, 5);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 2, 7);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 3, 9);
+			_tableIndex.Add(1, stream1Id, 0, 0);
+			_tableIndex.Add(1, stream2Id, 0, 3);
+			_tableIndex.Add(1, stream2Id, 1, 5);
+			_tableIndex.Add(1, stream2Id, 2, 7);
+			_tableIndex.Add(1, stream2Id, 3, 9);
 			//mem table
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 4, 13);
+			_tableIndex.Add(1, stream2Id, 4, 13);
 		}
 
 		[Test]
 		public void should_return_last_event_number() {
-			Assert.AreEqual(0, _indexReader.GetStreamLastEventNumber("account--696193173"));
+			Assert.AreEqual(0, _indexReader.GetStreamLastEventNumber(stream1Id));
 		}
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class when_hash_read_limit_is_not_reached : HashCollisionTestFixture {
+		private readonly bool _useMaxAge;
+
+		public when_hash_read_limit_is_not_reached(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
+
 		protected override void given() {
 			_hashCollisionReadLimit = 3;
 		}
 
 		protected override void when() {
+			string stream1Id = "account--696193173";
+			string stream2Id = "LPN-FC002_LPK51001";
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(stream1Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+				_indexBackend.SetStreamMetadata(stream2Id, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1
-			_tableIndex.Add(1, "account--696193173", 0, 0);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 0, 3);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 1, 5);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 2, 7);
-			_tableIndex.Add(1, "LPN-FC002_LPK51001", 3, 9);
+			_tableIndex.Add(1, stream1Id, 0, 0);
+			_tableIndex.Add(1, stream2Id, 0, 3);
+			_tableIndex.Add(1, stream2Id, 1, 5);
+			_tableIndex.Add(1, stream2Id, 2, 7);
+			_tableIndex.Add(1, stream2Id, 3, 9);
 		}
 
 		[Test]
@@ -159,14 +214,22 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class when_index_contains_duplicate_entries : HashCollisionTestFixture {
-		private string streamId = "account--696193173";
+		private readonly string streamId = "account--696193173";
+		private readonly bool _useMaxAge;
 
+		public when_index_contains_duplicate_entries(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
 		protected override void given() {
 			_hashCollisionReadLimit = 5;
 		}
 
 		protected override void when() {
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(streamId, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1
 			_tableIndex.Add(1, streamId, 0, 2);
 			_tableIndex.Add(1, streamId, 0, 4);
@@ -221,9 +284,15 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 	}
 
 	[TestFixture]
+	[TestFixtureSource(typeof(UseMaxAgeFixtureArgs))]
 	public class
 		when_index_contains_duplicate_entries_and_the_duplicate_is_a_64bit_index_entry : HashCollisionTestFixture {
-		private string streamId = "account--696193173";
+		private readonly string streamId = "account--696193173";
+		private readonly bool _useMaxAge;
+
+		public when_index_contains_duplicate_entries_and_the_duplicate_is_a_64bit_index_entry(bool useMaxAge) {
+			_useMaxAge = useMaxAge;
+		}
 
 		protected override void given() {
 			_maxMemTableSize = 3;
@@ -231,6 +300,9 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		}
 
 		protected override void when() {
+			if (_useMaxAge) {
+				_indexBackend.SetStreamMetadata(streamId, new StreamMetadata(maxAge:TimeSpan.FromDays(1)));
+			}
 			//ptable 1 with 32bit indexes
 			_tableIndex.Add(1, streamId, 0, 2);
 			_tableIndex.Add(1, streamId, 1, 4);
@@ -308,8 +380,40 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		}
 	}
 
+	[TestFixture]
+	public class when_stream_has_max_age : HashCollisionTestFixture {
+		private readonly string _oddStream = "LPN-FC002_LPK51001";
+		private readonly string _evenStream = "account--696193173";
+
+		protected override void when() {
+			_indexBackend.SetStreamMetadata(
+				_evenStream,
+				new StreamMetadata(maxAge: TimeSpan.FromDays(1)));
+
+			_tableIndex.Add(1, _evenStream, 5, 0);
+			_tableIndex.Add(1, _evenStream, 6, 2);
+			_tableIndex.Add(1, _oddStream, 5, 3);
+			_tableIndex.Add(1, _oddStream, 6, 5);
+			_tableIndex.Add(1, _oddStream, 7, 7);
+		}
+
+		[Test]
+		public void can_read() {
+			var result = _indexReader.ReadStreamEventsForward(
+				streamName: _evenStream,
+				fromEventNumber: 0,
+				maxCount: 2);
+
+			Assert.AreEqual(2, result.Records.Length);
+			Assert.AreEqual(5, result.Records[0].EventNumber);
+			Assert.AreEqual(6, result.Records[1].EventNumber);
+		}
+	}
+
 	public class FakeIndexBackend<TStreamId> : IIndexBackend<TStreamId> {
-		private TFReaderLease _readerLease;
+		private readonly TFReaderLease _readerLease;
+		private readonly Dictionary<TStreamId, IndexBackend<TStreamId>.MetadataCached> _streamMetadata =
+			new();
 
 		public FakeIndexBackend(TFReaderLease readerLease) {
 			_readerLease = readerLease;
@@ -324,6 +428,8 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 		}
 
 		public IndexBackend<TStreamId>.MetadataCached TryGetStreamMetadata(TStreamId streamId) {
+			if (_streamMetadata.TryGetValue(streamId, out var metadata))
+				return metadata;
 			return new IndexBackend<TStreamId>.MetadataCached();
 		}
 
@@ -333,7 +439,8 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 
 		public EventStore.Core.Data.StreamMetadata UpdateStreamMetadata(int cacheVersion, TStreamId streamId,
 			EventStore.Core.Data.StreamMetadata metadata) {
-			return null;
+			_streamMetadata[streamId] = new IndexBackend<TStreamId>.MetadataCached(1, metadata);
+			return metadata;
 		}
 
 		public long? SetStreamLastEventNumber(TStreamId streamId, long lastEventNumber) {
@@ -342,7 +449,8 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 
 		public EventStore.Core.Data.StreamMetadata SetStreamMetadata(TStreamId streamId,
 			EventStore.Core.Data.StreamMetadata metadata) {
-			return null;
+			_streamMetadata[streamId] = new IndexBackend<TStreamId>.MetadataCached(1, metadata);
+			return metadata;
 		}
 
 		public void SetSystemSettings(EventStore.Core.Data.SystemSettings systemSettings) {

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age.cs
@@ -16,11 +16,11 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 
 			var metadata = string.Format(@"{{""$maxAge"":{0}}}", (int)TimeSpan.FromMinutes(20).TotalSeconds);
 			WriteStreamMetadata("ES", 0, metadata, now.AddMinutes(-100));
-			WriteSingleEvent("ES", 0, "bla", now.AddMinutes(-50));
-			WriteSingleEvent("ES", 1, "bla", now.AddMinutes(-25));
-			_event2 = WriteSingleEvent("ES", 2, "bla", now.AddMinutes(-15));
-			_event3 = WriteSingleEvent("ES", 3, "bla", now.AddMinutes(-11));
-			_event4 = WriteSingleEvent("ES", 4, "bla", now.AddMinutes(-3));
+			WriteSingleEvent("ES", 0, "bla", now.AddMinutes(-50)); // expired
+			WriteSingleEvent("ES", 1, "bla", now.AddMinutes(-25)); // expired
+			_event2 = WriteSingleEvent("ES", 2, "bla", now.AddMinutes(-15)); // active
+			_event3 = WriteSingleEvent("ES", 3, "bla", now.AddMinutes(-11)); // active
+			_event4 = WriteSingleEvent("ES", 4, "bla", now.AddMinutes(-3)); // active
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age_and_max_count_and_max_age_is_more_strict.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_stream_with_max_age_and_max_count_and_max_age_is_more_strict.cs
@@ -20,12 +20,12 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 				(int)TimeSpan.FromMinutes(20).TotalSeconds);
 
 			WriteStreamMetadata("ES", 0, metadata);
-			WriteSingleEvent("ES", 0, "bla", now.AddMinutes(-100));
-			WriteSingleEvent("ES", 1, "bla", now.AddMinutes(-50));
-			WriteSingleEvent("ES", 2, "bla", now.AddMinutes(-25));
-			_event3 = WriteSingleEvent("ES", 3, "bla", now.AddMinutes(-15));
-			_event4 = WriteSingleEvent("ES", 4, "bla", now.AddMinutes(-11));
-			_event5 = WriteSingleEvent("ES", 5, "bla", now.AddMinutes(-3));
+			WriteSingleEvent("ES", 0, "bla", now.AddMinutes(-100)); // expired: maxcount & maxage
+			WriteSingleEvent("ES", 1, "bla", now.AddMinutes(-50)); // expired: maxage
+			WriteSingleEvent("ES", 2, "bla", now.AddMinutes(-25)); // expired: maxage
+			_event3 = WriteSingleEvent("ES", 3, "bla", now.AddMinutes(-15)); // active
+			_event4 = WriteSingleEvent("ES", 4, "bla", now.AddMinutes(-11)); // active
+			_event5 = WriteSingleEvent("ES", 5, "bla", now.AddMinutes(-3)); // active
 		}
 
 		[Test]
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 			on_read_forward_from_start_to_expired_next_event_number_is_expired_by_age_plus_1_and_its_not_end_of_stream() {
 			var res = ReadIndex.ReadStreamEventsForward("ES", 0, 2);
 			Assert.AreEqual(ReadStreamResult.Success, res.Result);
-			Assert.AreEqual(2, res.NextEventNumber);
+			Assert.AreEqual(3, res.NextEventNumber); // new path fast forwards to here
 			Assert.AreEqual(5, res.LastEventNumber);
 			Assert.IsFalse(res.IsEndOfStream);
 

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_very_long_stream_with_max_age_and_some_expired_events.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/ReadRangeAndNextEventNumber/when_reading_very_long_stream_with_max_age_and_some_expired_events.cs
@@ -3,25 +3,26 @@ using System.Diagnostics;
 using EventStore.Core.TransactionLog.Chunks;
 using NUnit.Framework;
 
-namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNextEventNumber
-{
+namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNextEventNumber {
+	// test the binary chop where it has to repeatedly lower the high bound
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
 	public class
-		when_reading_very_long_stream_with_max_age_and_mostly_expired_events<TLogFormat, TStreamId> : ReadIndexTestScenario<TLogFormat, TStreamId> {
-		public when_reading_very_long_stream_with_max_age_and_mostly_expired_events():base(maxEntriesInMemTable: 500_000, chunkSize: TFConsts.ChunkSize) {
-			
+		when_reading_very_long_stream_with_max_age_and_some_expired_events<TLogFormat, TStreamId> : ReadIndexTestScenario<TLogFormat, TStreamId> {
+		public when_reading_very_long_stream_with_max_age_and_some_expired_events() : base(
+			maxEntriesInMemTable: 500_000, chunkSize: TFConsts.ChunkSize) {
 		}
+
 		protected override void WriteTestScenario() {
 			var now = DateTime.UtcNow;
 			var metadata = string.Format(@"{{""$maxAge"":{0}}}", (int)TimeSpan.FromMinutes(20).TotalSeconds);
 			WriteStreamMetadata("ES", 0, metadata, now.AddMinutes(-100));
-			for (int i = 0; i < 1_000_000; i++) {
-				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-50), retryOnFail:true);
+			for (int i = 0; i < 20; i++) {
+				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-50), retryOnFail: true);
 			}
 
-			for (int i = 1_000_000; i < 1_000_015; i++) {
-				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-1), retryOnFail:true);	
+			for (int i = 20; i < 1_000_000; i++) {
+				WriteSingleEvent("ES", i, "bla", now.AddMinutes(-1), retryOnFail: true);
 			}
 		}
 
@@ -31,21 +32,15 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.ReadRangeAndNext
 			var res = ReadIndex.ReadStreamEventsForward("ES", 1, 10);
 			var elapsed = sw.Elapsed;
 
-			Assert.AreEqual(1_000_000, res.NextEventNumber);
+			Assert.AreEqual(20, res.NextEventNumber);
 			Assert.AreEqual(0, res.Records.Length);
 			Assert.AreEqual(false, res.IsEndOfStream);
 
 			res = ReadIndex.ReadStreamEventsForward("ES", res.NextEventNumber, 10);
 
-			Assert.AreEqual(1_000_010, res.NextEventNumber);
+			Assert.AreEqual(30, res.NextEventNumber);
 			Assert.AreEqual(10, res.Records.Length);
 			Assert.AreEqual(false, res.IsEndOfStream);
-
-			res = ReadIndex.ReadStreamEventsForward("ES", res.NextEventNumber, 10);
-
-			Assert.AreEqual(1_000_015, res.NextEventNumber);
-			Assert.AreEqual(5, res.Records.Length);
-			Assert.AreEqual(true, res.IsEndOfStream);
 
 			Assert.Less(elapsed, TimeSpan.FromSeconds(1));
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/with_invalid_max_age_and_normal_max_count.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/with_invalid_max_age_and_normal_max_count.cs
@@ -1,11 +1,10 @@
 using System;
 using EventStore.Core.Data;
-using EventStore.Core.Services.Storage.ReaderIndex;
 using NUnit.Framework;
 using ReadStreamResult = EventStore.Core.Services.Storage.ReaderIndex.ReadStreamResult;
 
 namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
-	[TestFixture, Ignore("Metadata must be valid.")]
+	[TestFixture]
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
 	public class with_invalid_max_age_and_normal_max_count<TLogFormat, TStreamId> : ReadIndexTestScenario<TLogFormat, TStreamId> {
@@ -30,10 +29,10 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
 		}
 
 		[Test]
-		public void on_single_event_read_invalid_value_is_ignored() {
+		public void on_single_event_read_all_metadata_is_ignored() {
 			var result = ReadIndex.ReadEvent("ES", 0);
-			Assert.AreEqual(ReadEventResult.NotFound, result.Result);
-			Assert.IsNull(result.Record);
+			Assert.AreEqual(ReadEventResult.Success, result.Result);
+			Assert.AreEqual(_r2, result.Record);
 
 			result = ReadIndex.ReadEvent("ES", 1);
 			Assert.AreEqual(ReadEventResult.Success, result.Result);
@@ -53,49 +52,77 @@ namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount {
 		}
 
 		[Test]
-		public void on_forward_range_read_invalid_value_is_ignored() {
+		public void on_forward_range_read_metadata_is_ignored() {
 			var result = ReadIndex.ReadStreamEventsForward("ES", 0, 100);
 			Assert.AreEqual(ReadStreamResult.Success, result.Result);
-			Assert.AreEqual(4, result.Records.Length);
-			Assert.AreEqual(_r3, result.Records[0]);
-			Assert.AreEqual(_r4, result.Records[1]);
-			Assert.AreEqual(_r5, result.Records[2]);
-			Assert.AreEqual(_r6, result.Records[3]);
+			Assert.AreEqual(5, result.Records.Length);
+			Assert.AreEqual(_r2, result.Records[0]);
+			Assert.AreEqual(_r3, result.Records[1]);
+			Assert.AreEqual(_r4, result.Records[2]);
+			Assert.AreEqual(_r5, result.Records[3]);
+			Assert.AreEqual(_r6, result.Records[4]);
 		}
 
 		[Test]
-		public void on_backward_range_read_invalid_value_is_ignored() {
+		public void on_backward_range_read_metadata_is_ignored() {
 			var result = ReadIndex.ReadStreamEventsBackward("ES", -1, 100);
 			Assert.AreEqual(ReadStreamResult.Success, result.Result);
-			Assert.AreEqual(4, result.Records.Length);
+			Assert.AreEqual(5, result.Records.Length);
 			Assert.AreEqual(_r6, result.Records[0]);
 			Assert.AreEqual(_r5, result.Records[1]);
 			Assert.AreEqual(_r4, result.Records[2]);
 			Assert.AreEqual(_r3, result.Records[3]);
+			Assert.AreEqual(_r2, result.Records[4]);
 		}
 
 		[Test]
-		public void on_read_all_forward_both_values_are_ignored() {
+		public void on_read_all_forward_metadata_is_ignored() {
 			var records = ReadIndex.ReadAllEventsForward(new TFPos(0, 0), 100).Records;
-			Assert.AreEqual(6, records.Count);
-			Assert.AreEqual(_r1, records[0].Event);
-			Assert.AreEqual(_r2, records[1].Event);
-			Assert.AreEqual(_r3, records[2].Event);
-			Assert.AreEqual(_r4, records[3].Event);
-			Assert.AreEqual(_r5, records[4].Event);
-			Assert.AreEqual(_r6, records[5].Event);
+
+			if (LogFormatHelper<TLogFormat, TStreamId>.IsV2) {
+				Assert.AreEqual(6, records.Count);
+				Assert.AreEqual(_r1, records[0].Event);
+				Assert.AreEqual(_r2, records[1].Event);
+				Assert.AreEqual(_r3, records[2].Event);
+				Assert.AreEqual(_r4, records[3].Event);
+				Assert.AreEqual(_r5, records[4].Event);
+				Assert.AreEqual(_r6, records[5].Event);
+			} else {
+				Assert.AreEqual(8, records.Count);
+				Assert.AreEqual("$stream", records[0].Event.EventType);
+				Assert.AreEqual(_r1, records[1].Event); // metadata
+				Assert.AreEqual("$event-type", records[2].Event.EventType);
+				Assert.AreEqual(_r2, records[3].Event);
+				Assert.AreEqual(_r3, records[4].Event);
+				Assert.AreEqual(_r4, records[5].Event);
+				Assert.AreEqual(_r5, records[6].Event);
+				Assert.AreEqual(_r6, records[7].Event);
+			}
 		}
 
 		[Test]
-		public void on_read_all_backward_both_values_are_ignored() {
+		public void on_read_all_backward_metadata_is_ignored() {
 			var records = ReadIndex.ReadAllEventsBackward(GetBackwardReadPos(), 100).Records;
-			Assert.AreEqual(6, records.Count);
-			Assert.AreEqual(_r6, records[0].Event);
-			Assert.AreEqual(_r5, records[1].Event);
-			Assert.AreEqual(_r4, records[2].Event);
-			Assert.AreEqual(_r3, records[3].Event);
-			Assert.AreEqual(_r2, records[4].Event);
-			Assert.AreEqual(_r1, records[5].Event);
+
+			if (LogFormatHelper<TLogFormat, TStreamId>.IsV2) {
+				Assert.AreEqual(6, records.Count);
+				Assert.AreEqual(_r6, records[0].Event);
+				Assert.AreEqual(_r5, records[1].Event);
+				Assert.AreEqual(_r4, records[2].Event);
+				Assert.AreEqual(_r3, records[3].Event);
+				Assert.AreEqual(_r2, records[4].Event);
+				Assert.AreEqual(_r1, records[5].Event);
+			} else {
+				Assert.AreEqual(8, records.Count);
+				Assert.AreEqual(_r6, records[0].Event);
+				Assert.AreEqual(_r5, records[1].Event);
+				Assert.AreEqual(_r4, records[2].Event);
+				Assert.AreEqual(_r3, records[3].Event);
+				Assert.AreEqual(_r2, records[4].Event);
+				Assert.AreEqual("$event-type", records[5].Event.EventType);
+				Assert.AreEqual(_r1, records[6].Event); // metadata
+				Assert.AreEqual("$stream", records[7].Event.EventType);
+			}
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -247,7 +247,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					return ForStreamWithMaxAge(streamId, streamName,
 						fromEventNumber, maxCount,
 						startEventNumber, endEventNumber, lastEventNumber,
-						metadata.MaxAge.Value, metadata, _tableIndex, reader, _eventTypes);
+						metadata.MaxAge.Value, metadata, _tableIndex, reader, _eventTypes,
+						skipIndexScanOnRead);
 				}
 				var recordsQuery = _tableIndex.GetRange(streamId, startEventNumber, endEventNumber)
 					.Select(x => new { x.Version, Prepare = ReadPrepareInternal(reader, x.Position) })
@@ -267,11 +268,13 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					nextEventNumber, lastEventNumber, isEndOfStream);
 			}
 
-			static IndexReadStreamResult ForStreamWithMaxAge(TStreamId streamId,
+			IndexReadStreamResult ForStreamWithMaxAge(TStreamId streamId,
 				string streamName,
 				long fromEventNumber, int maxCount, long startEventNumber,
 				long endEventNumber, long lastEventNumber, TimeSpan maxAge, StreamMetadata metadata,
-				ITableIndex<TStreamId> tableIndex, TFReaderLease reader, INameLookup<TStreamId> eventTypes) {
+				ITableIndex<TStreamId> tableIndex, TFReaderLease reader, INameLookup< TStreamId> eventTypes,
+				bool skipIndexScanOnRead) {
+
 				if (startEventNumber > lastEventNumber) {
 					return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
 						metadata, lastEventNumber + 1, lastEventNumber, isEndOfStream: true);
@@ -284,11 +287,13 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				//Move to the first valid entries. At this point we could instead return an empty result set with the minimum set, but that would 
 				//involve an additional set of reads for no good reason
 				while (indexEntries.Count == 0) {
+					// we didn't find any indexEntries, and we already early returned in the case that startEventNumber > lastEventNumber
+					// so we must be reading before the oldest entry for this stream hash.
 					// this will generally only iterate once, unless a scavenge completes exactly now, in which case it might iterate twice
 					if (tableIndex.TryGetOldestEntry(streamId, out var oldest)) {
 						startEventNumber = oldest.Version;
 						endEventNumber = startEventNumber + maxCount - 1;
-						indexEntries = tableIndex.GetRange(streamId, startEventNumber, endEventNumber, maxCount);
+						indexEntries = tableIndex.GetRange(streamId, startEventNumber, endEventNumber);
 					} else {
 						//scavenge completed and deleted our stream? return empty set and get the client to try again?
 						return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
@@ -296,13 +301,12 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					}
 				}
 
-				var results = new List<EventRecord>();
+				var results = new ResultsDeduplicator(maxCount, skipIndexScanOnRead);
+
 				for (int i = 0; i < indexEntries.Count; i++) {
 					var prepare = ReadPrepareInternal(reader, indexEntries[i].Position);
 
-					//LOGV2
-					if (typeof(TStreamId) == typeof(string) &&
-					    (prepare == null || !StreamIdComparer.Equals(prepare.EventStreamId, streamId))) {
+					if (prepare == null || !StreamIdComparer.Equals(prepare.EventStreamId, streamId)) {
 						continue;
 					}
 
@@ -311,68 +315,72 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					} else {
 						break;
 					}
-
 				}
 
 				if (results.Count > 0) {
 					//We got at least one event in the correct age range, so we will return whatever was valid and indicate where to read from next
-					nextEventNumber = results[0].EventNumber + 1;
-					results.Reverse();
+					var resultsArray = results.ProduceArray();
+					nextEventNumber = resultsArray[0].EventNumber + 1;
+					Array.Reverse(resultsArray);
 
 					var isEndOfStream = endEventNumber >= lastEventNumber;
-					return new IndexReadStreamResult(endEventNumber, maxCount, results.ToArray(), metadata,
+					return new IndexReadStreamResult(endEventNumber, maxCount, resultsArray, metadata,
 						nextEventNumber, lastEventNumber, isEndOfStream);
 				}
 
 				//we didn't find anything valid yet, now we need to search
+				//the entries we found were all either scavenged, or expired, or for another stream.
 
-				//check high value will be valid
-				if (tableIndex.TryGetLatestEntry(streamId, out var latest)) {
-					var end = ReadPrepareInternal(reader, latest.Position);
-					if (end.TimeStamp < ageThreshold || latest.Version < fromEventNumber) {
-						//No events in the stream are < max age, so return an empty set
-						return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
-							metadata, latest.Version + 1, latest.Version, isEndOfStream: true);
-					}
-				} else {
-					//For some reason there is no last event in this stream, maybe a scavenge completed and deleted the stream, send back for retry
+				//check high value will be valid, otherwise early return.
+				// this resolves hash collisions itself
+				var lastEvent = ReadPrepareInternal(reader, streamId, eventNumber: lastEventNumber);
+				if (lastEvent == null || lastEvent.TimeStamp < ageThreshold || lastEventNumber < fromEventNumber) {
+					//No events in the stream are < max age, so return an empty set
 					return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
-						metadata, lastEventNumber + 1, lastEventNumber, isEndOfStream: false);
+						metadata, lastEventNumber + 1, lastEventNumber, isEndOfStream: true);
 				}
 
-
-				
+				// intuition for loop termination here is that the two explicit continue cases are
+				// the only way to continue the iteration. apart from those it return;s or break;s.
+				// the two continue cases always narrow the gap between low and high
+				//
+				// low, mid, and high are event numbers (versions)
+				// attempt to initialize low to the latest (highest) entry that we found but in the unlikely event that
+				// they're out of version order thats still ok, low will just be lower than it could have been.
 				var low = indexEntries[0].Version;
-				var high = latest.Version;
+				var high = lastEventNumber;
 				while (low <= high) {
 					var mid = low + ((high - low) / 2);
-					indexEntries = tableIndex.GetRange(streamId, mid, mid + maxCount, maxCount);
+					indexEntries = tableIndex.GetRange(streamId, mid, mid + maxCount - 1);
 					if (indexEntries.Count > 0) {
 						nextEventNumber = indexEntries[0].Version + 1;
 					}
 
-					var lowPrepare = LowPrepare(reader, indexEntries, streamId);
+					// be really careful if adjusting these, to make sure that the loop still terminates
+					var (lowPrepareVersion, lowPrepare) = LowPrepare(reader, indexEntries, streamId);
 					if (lowPrepare?.TimeStamp >= ageThreshold) {
+						// found a lowPrepare for this stream. it has not expired. chop lower in case there are more
 						high = mid - 1;
-						nextEventNumber = lowPrepare.ExpectedVersion + 1;
+						nextEventNumber = lowPrepareVersion;
 						continue;
 					}
 
-					var highPrepare = HighPrepare(reader, indexEntries, streamId);
+					var (highPrepareVersion, highPrepare) = HighPrepare(reader, indexEntries, streamId);
 					if (highPrepare?.TimeStamp < ageThreshold) {
-						low = mid + indexEntries.Count;
+						// found a highPrepare for this stream. it has expired. chop higher
+						low = highPrepareVersion + 1;
 						continue;
 					}
 
 					//ok, some entries must match, if not (due to time moving forwards) we can just reissue based on the current mid
+					// also might have no matches because the getrange call returned addresses that
+					// were all scavenged or for other streams, in which case we won't add anything to results here
 					for (int i = 0; i < indexEntries.Count; i++) {
 						var prepare = ReadPrepareInternal(reader, indexEntries[i].Position);
-						
-						//LOGV2
-						if (typeof(TStreamId) == typeof(string) &&
-						    (prepare == null || !StreamIdComparer.Equals(prepare.EventStreamId, streamId))) {
+
+						if (prepare == null || !StreamIdComparer.Equals(prepare.EventStreamId, streamId))
 							continue;
-						}
+
 						if (prepare?.TimeStamp >= ageThreshold) {
 							results.Add(CreateEventRecord(indexEntries[i].Version, prepare, streamName, eventTypes));
 						} else {
@@ -382,19 +390,20 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 
 					if (results.Count > 0) {
 						//We got at least one event in the correct age range, so we will return whatever was valid and indicate where to read from next
-						endEventNumber = results[0].EventNumber;
+						var resultsList = results.ProduceList();
+						endEventNumber = resultsList[0].EventNumber;
 						nextEventNumber = endEventNumber + 1;
-						results.Reverse();
+						resultsList.Reverse();
 						var isEndOfStream = endEventNumber >= lastEventNumber;
 
-						var maxEventNumberToReturn = fromEventNumber + maxCount;
-						while (results.Count > 0 && results[^1].EventNumber > maxEventNumberToReturn) {
-							nextEventNumber = results[^1].EventNumber;
-							results.Remove(results[^1]);
+						var maxEventNumberToReturn = fromEventNumber + maxCount - 1;
+						while (resultsList.Count > 0 && resultsList[^1].EventNumber > maxEventNumberToReturn) {
+							nextEventNumber = resultsList[^1].EventNumber;
+							resultsList.RemoveAt(resultsList.Count - 1);
+							isEndOfStream = false;
 						}
 
-						if (results.Count == 0) nextEventNumber--;
-						return new IndexReadStreamResult(endEventNumber, maxCount, results.ToArray(), metadata,
+						return new IndexReadStreamResult(endEventNumber, maxCount, resultsList.ToArray(), metadata,
 							nextEventNumber, lastEventNumber, isEndOfStream);
 					}
 
@@ -404,44 +413,35 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				//We didn't find anything, send back to the client with the latest position to retry
 				return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
 					metadata, nextEventNumber, lastEventNumber, isEndOfStream: false);
+
 				[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-				static IPrepareLogRecord<TStreamId> LowPrepare(TFReaderLease tfReaderLease,
-					IReadOnlyList<IndexEntry> entries, TStreamId streamId) {
-					
-					if (typeof(TStreamId) == typeof(string)) {
-						for (int i = entries.Count - 1; i >= 0; i--) {
-							var prepare = ReadPrepareInternal(tfReaderLease, entries[i].Position);
-							if (prepare != null && StreamIdComparer.Equals(prepare.EventStreamId, streamId))
-								return prepare;
-						}
-					}
+				static (long, IPrepareLogRecord<TStreamId>) LowPrepare(
+					TFReaderLease tfReaderLease,
+					IReadOnlyList<IndexEntry> entries,
+					TStreamId streamId) {
 
 					for (int i = entries.Count - 1; i >= 0; i--) {
 						var prepare = ReadPrepareInternal(tfReaderLease, entries[i].Position);
-						if (prepare != null) return prepare;
+						if (prepare != null && StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+							return (entries[i].Version, prepare);
 					}
 
-					return null;
+					return (default, null);
 				}
 
 				[MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
-				static IPrepareLogRecord<TStreamId> HighPrepare(TFReaderLease tfReaderLease,
-					IReadOnlyList<IndexEntry> entries, TStreamId streamId) {
-					
-					if (typeof(TStreamId) == typeof(string)) {
-						for (int i = 0; i < entries.Count; i++) {
-							var prepare = ReadPrepareInternal(tfReaderLease, entries[i].Position);
-							if (prepare != null && StreamIdComparer.Equals(prepare.EventStreamId, streamId))
-								return prepare;
-						}
-					}
+				static (long, IPrepareLogRecord<TStreamId>) HighPrepare(
+					TFReaderLease tfReaderLease,
+					IReadOnlyList<IndexEntry> entries,
+					TStreamId streamId) {
 
 					for (int i = 0; i < entries.Count; i++) {
 						var prepare = ReadPrepareInternal(tfReaderLease, entries[i].Position);
-						if (prepare != null) return prepare;
+						if (prepare != null && StreamIdComparer.Equals(prepare.EventStreamId, streamId))
+							return (entries[i].Version, prepare);
 					}
 
-					return null;
+					return (default, null);
 				}
 			}
 		}
@@ -690,13 +690,86 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		private EventRecord CreateEventRecord(long version, IPrepareLogRecord<TStreamId> prepare, string streamName) {
 			return CreateEventRecord(version, prepare, streamName, _eventTypes);
 		}
-		
+
 		private static EventRecord CreateEventRecord(long version, IPrepareLogRecord<TStreamId> prepare,
 			string streamName, INameLookup<TStreamId> eventTypeLookup) {
-			
+
 			var eventTypeName = eventTypeLookup.LookupName(prepare.EventType);
-			
+
 			return new EventRecord(version, prepare, streamName, eventTypeName);
+		}
+
+		// This struct implements the IndexScanOnRead logic.
+		//
+		// The IndexScanOnRead logic deals with the case that there are duplicate
+		// EventNumbers for a single stream (note: not talking about hash collisions), which
+		// may also be out of order (possible when there are a mix of index table bitnesses)
+		//
+		// It deals with them by removing duplicates as they are added (preferring the record
+		// with the lower LogPosition) and then sorting by EventNumber (descending) on output.
+		//
+		// If SkipIndexScanOnRead is true, then it is assumed that the EventRecords are added
+		// (1) in EventNumber order descending and (2) without duplicate EventNumbers.
+		public readonly struct ResultsDeduplicator {
+			// when deduplicating, maps event number to index in _results
+			private readonly Dictionary<long, int> _dict;
+			private readonly List<EventRecord> _results;
+			private readonly bool _skipIndexScanOnRead;
+			private static readonly Comparison<EventRecord> _byEventNumberDesc = CompareByEventNumberDesc;
+
+			public ResultsDeduplicator(int maxCount, bool skipIndexScanOnRead) {
+				var capacity = Math.Min(maxCount, 256);
+				_dict = skipIndexScanOnRead
+					? null
+					: new Dictionary<long, int>(capacity);
+				_results = new List<EventRecord>(capacity);
+				_skipIndexScanOnRead = skipIndexScanOnRead;
+			}
+
+			public int Count => _results.Count;
+
+			public EventRecord[] ProduceArray() {
+				var array = _results.ToArray();
+
+				if (!_skipIndexScanOnRead) {
+					// we already deduplicated on the way in, just sort here
+					Array.Sort(array, _byEventNumberDesc);
+				}
+
+				return array;
+			}
+
+			public List<EventRecord> ProduceList() {
+				var list = _results.ToList();
+
+				if (!_skipIndexScanOnRead) {
+					list.Sort(_byEventNumberDesc);
+				}
+
+				return list;
+			}
+
+			public void Add(EventRecord evt) {
+				if (_skipIndexScanOnRead) {
+					_results.Add(evt);
+					return;
+				}
+
+				if (_dict.TryGetValue(evt.EventNumber, out var i)) {
+					if (_results[i].LogPosition > evt.LogPosition) {
+						_results[i] = evt;
+					} else {
+						// ignore
+					}
+				} else {
+					_results.Add(evt);
+					_dict[evt.EventNumber] = _results.Count - 1;
+				}
+			}
+
+			private static int CompareByEventNumberDesc(EventRecord x, EventRecord y) {
+				return y.EventNumber.CompareTo(x.EventNumber);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixed: MaxAge fast path: corner cases and support for SkipIndexScanOnRead

Make streams with MaxAge respect SkipIndexScanOnRead. Also assorted corner cases on the max age optimized path to handle indexing corner cases (hash collisions, duplicate events, transactions, mixed bitness of index tables)

Forward port of #3330