### PR TITLE
[Forward Port oss-v21.10] Reintroduce FileCheckpoints

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_file_checkpoints.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_file_checkpoints.cs
@@ -1,0 +1,34 @@
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Checkpoint;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog {
+	[TestFixture]
+	public class when_reading_file_checkpoints : SpecificationWithFile {
+		[Test]
+		public void mem_mapped_file_checkpoint_can_be_read_as_file_checkpoint() {
+			var memoryMapped = new MemoryMappedFileCheckpoint(Filename);
+			memoryMapped.Write(0xDEAD);
+			memoryMapped.Flush();
+			memoryMapped.Dispose();
+
+			var fileCheckpoint = new FileCheckpoint(Filename);
+			var read = fileCheckpoint.Read();
+			fileCheckpoint.Dispose();
+			Assert.AreEqual(0xDEAD, read);
+		}
+
+		[Test]
+		public void file_checkpoint_can_be_read_as_mem_mapped_file_checkpoint() {
+			var fileCheckpoint = new FileCheckpoint(Filename);
+			fileCheckpoint.Write(0xDEAD);
+			fileCheckpoint.Flush();
+			fileCheckpoint.Dispose();
+
+			var memoryMapped = new MemoryMappedFileCheckpoint(Filename);
+			var read = memoryMapped.Read();
+			memoryMapped.Dispose();
+			Assert.AreEqual(0xDEAD, read);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_a_file_checksum_to_a_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_a_file_checksum_to_a_file.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Checkpoint;
+using NUnit.Framework;
+using EventStore.Core.Tests.Helpers;
+
+namespace EventStore.Core.Tests.TransactionLog {
+	[TestFixture]
+	public class when_writing_a_file_checksum_to_a_file : SpecificationWithFile {
+		[Test]
+		public void a_null_file_throws_argumentnullexception() {
+			Assert.Throws<ArgumentNullException>(() => new FileCheckpoint(null));
+		}
+
+		[Test]
+		public void name_is_set() {
+			var checksum = new FileCheckpoint(HelperExtensions.GetFilePathFromAssembly("filename"), "test");
+			Assert.AreEqual("test", checksum.Name);
+			checksum.Close();
+		}
+
+		[Test]
+		public void reading_off_same_instance_gives_most_up_to_date_info() {
+			var checkSum = new FileCheckpoint(Filename);
+			checkSum.Write(0xDEAD);
+			checkSum.Flush();
+			var read = checkSum.Read();
+			checkSum.Close();
+			Assert.AreEqual(0xDEAD, read);
+		}
+
+		[Test]
+		public void can_read_existing_checksum() {
+			var checksum = new FileCheckpoint(Filename);
+			checksum.Write(0xDEAD);
+			checksum.Close();
+			checksum = new FileCheckpoint(Filename);
+			var val = checksum.Read();
+			checksum.Close();
+			Assert.AreEqual(0xDEAD, val);
+		}
+
+		[Test]
+		public async Task the_new_value_is_not_accessible_if_not_flushed_even_with_delay() {
+			var checkSum = new FileCheckpoint(Filename);
+			var readChecksum = new FileCheckpoint(Filename);
+			checkSum.Write(1011);
+			await Task.Delay(200);
+			Assert.AreEqual(0, readChecksum.Read());
+			checkSum.Close();
+			readChecksum.Close();
+		}
+
+		[Test]
+		public void the_new_value_is_accessible_after_flush() {
+			var checkSum = new FileCheckpoint(Filename);
+			var readChecksum = new FileCheckpoint(Filename);
+			checkSum.Write(1011);
+			checkSum.Flush();
+			Assert.AreEqual(1011, readChecksum.Read());
+			checkSum.Close();
+			readChecksum.Close();
+		}
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -418,17 +418,33 @@ namespace EventStore.Core {
 					var truncateCheckFilename = Path.Combine(dbPath, Checkpoint.Truncate + ".chk");
 					var streamExistenceFilterCheckFilename = Path.Combine(streamExistencePath, Checkpoint.StreamExistenceFilter + ".chk");
 
-					writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
-					chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
-					epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true,
-						initValue: -1);
-					proposalChk = new MemoryMappedFileCheckpoint(proposalCheckFilename, Checkpoint.Proposal,
-						cached: true,
-						initValue: -1);
-					truncateChk = new MemoryMappedFileCheckpoint(truncateCheckFilename, Checkpoint.Truncate,
-						cached: true, initValue: -1);
-					streamExistenceFilterChk = new MemoryMappedFileCheckpoint(streamExistenceFilterCheckFilename, Checkpoint.StreamExistenceFilter,
-						cached: true, initValue: -1);
+					if (OS.IsUnix) {
+						Log.Debug("Using File Checkpoints");
+						writerChk = new FileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
+						chaserChk = new FileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
+						epochChk = new FileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true,
+							initValue: -1);
+						proposalChk = new FileCheckpoint(proposalCheckFilename, Checkpoint.Proposal,
+							cached: true,
+							initValue: -1);
+						truncateChk = new FileCheckpoint(truncateCheckFilename, Checkpoint.Truncate,
+							cached: true, initValue: -1);
+						streamExistenceFilterChk = new FileCheckpoint(streamExistenceFilterCheckFilename, Checkpoint.StreamExistenceFilter,
+							cached: true, initValue: -1);
+					} else {
+						Log.Debug("Using Memory Mapped File Checkpoints");
+						writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
+						chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
+						epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true,
+							initValue: -1);
+						proposalChk = new MemoryMappedFileCheckpoint(proposalCheckFilename, Checkpoint.Proposal,
+							cached: true,
+							initValue: -1);
+						truncateChk = new MemoryMappedFileCheckpoint(truncateCheckFilename, Checkpoint.Truncate,
+							cached: true, initValue: -1);
+						streamExistenceFilterChk = new MemoryMappedFileCheckpoint(streamExistenceFilterCheckFilename, Checkpoint.StreamExistenceFilter,
+							cached: true, initValue: -1);
+					}
 				}
 
 				var cache = options.Database.CachedChunks >= 0

--- a/src/EventStore.Core/TransactionLog/Checkpoint/FileCheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/FileCheckpoint.cs
@@ -1,0 +1,100 @@
+using System;
+using System.IO;
+using System.Threading;
+using EventStore.Common.Utils;
+
+namespace EventStore.Core.TransactionLog.Checkpoint {
+	public class FileCheckpoint : ICheckpoint {
+		private readonly string _name;
+		private readonly string _filename;
+		private readonly FileStream _fileStream;
+
+		private long _last;
+		private long _lastFlushed;
+		private readonly bool _cached;
+
+		private readonly BinaryWriter _writer;
+		private readonly BinaryReader _reader;
+
+		public FileCheckpoint(string filename)
+			: this(filename, Guid.NewGuid().ToString()) {
+		}
+
+		public FileCheckpoint(string filename, string name, bool cached = false, bool mustExist = false,
+			long initValue = 0) {
+			_filename = filename;
+			_name = name;
+			_cached = cached;
+			var old = File.Exists(filename);
+			_fileStream = new FileStream(_filename,
+				mustExist ? FileMode.Open : FileMode.OpenOrCreate,
+				FileAccess.ReadWrite,
+				FileShare.ReadWrite);
+			if (_fileStream.Length != 8)
+				_fileStream.SetLength(8);
+			_reader = new BinaryReader(_fileStream);
+			_writer = new BinaryWriter(_fileStream);
+			if (old)
+				_last = _lastFlushed = ReadCurrent();
+			else {
+				_last = initValue;
+				Flush();
+			}
+		}
+
+		private long ReadCurrent() {
+			_fileStream.Seek(0, SeekOrigin.Begin);
+			return _reader.ReadInt64();
+		}
+
+		public void Close() {
+			Flush();
+			_reader.Close();
+			_writer.Close();
+			_fileStream.Close();
+		}
+
+		public string Name {
+			get { return _name; }
+		}
+
+		public void Write(long checkpoint) {
+			Interlocked.Exchange(ref _last, checkpoint);
+		}
+
+		public void Flush() {
+			var last = Interlocked.Read(ref _last);
+			if (last == _lastFlushed)
+				return;
+
+			_fileStream.Seek(0, SeekOrigin.Begin);
+			_writer.Write(last);
+
+			_fileStream.FlushToDisk();
+			Interlocked.Exchange(ref _lastFlushed, last);
+
+			OnFlushed(last);
+		}
+
+		public long Read() {
+			return _cached ? Interlocked.Read(ref _lastFlushed) : ReadCurrent();
+		}
+
+		public long
+			ReadNonFlushed() {
+			return Interlocked.Read(ref _last);
+		}
+
+		public event Action<long> Flushed;
+
+		public void Dispose() {
+			Close();
+		}
+
+		protected virtual void OnFlushed(long obj) {
+			var onFlushed = Flushed;
+			if (onFlushed != null)
+				onFlushed.Invoke(obj);
+		}
+	}
+}


### PR DESCRIPTION
Changed: Use file checkpoints on Linux and memory mapped checkpoints on Windows

Forward ports https://github.com/EventStore/EventStore/pull/3332 to release/oss-v21.10

- Reintroduce FileCheckpoint
- Use FileCheckpoints on Linux and MemoryMappedCheckpoints on Windows