### PR TITLE
Prevent deadlock risk when creating a PersistentSubscriptionGroup

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/read_from_persistent_subscription_with_link_resolution_when_stream_name_contains_at_symbol.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/read_from_persistent_subscription_with_link_resolution_when_stream_name_contains_at_symbol.cs
@@ -8,9 +8,7 @@ using ExpectedVersion = EventStore.ClientAPI.ExpectedVersion;
 
 namespace EventStore.Core.Tests.ClientAPI {
 	[Category("LongRunning"), Category("ClientAPI")]
-	[TestFixture(typeof(LogFormat.V2), typeof(string))]
-	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-	public class read_from_persistent_subscription_with_link_resolution_when_stream_name_contains_at_symbol<TLogFormat, TStreamId> : SpecificationWithMiniNode<TLogFormat, TStreamId> {
+	public class read_from_persistent_subscription_with_link_resolution_when_stream_name_contains_at_symbol : SpecificationWithMiniNode {
 		private string _result;
 
 		protected override async Task When() {

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -842,14 +842,15 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			//events 2 & 3 should still be in _outstandingMessages buffer
 			Assert.AreEqual(sub.OutstandingMessageCount, 2);
 			//retry queue should be empty
-			Assert.AreEqual(sub.StreamBuffer.RetryBufferCount, 0);
+			Assert.True(sub.TryGetStreamBuffer(out var streamBuffer));
+			Assert.AreEqual(streamBuffer.RetryBufferCount, 0);
 
 			//Disconnect the client
 			sub.RemoveClientByConnectionId(clientConnectionId);
 
 			//this should empty the _outstandingMessages buffer and move events 2 & 3 to the retry queue
 			Assert.AreEqual(sub.OutstandingMessageCount, 0);
-			Assert.AreEqual(sub.StreamBuffer.RetryBufferCount, 2);
+			Assert.AreEqual(streamBuffer.RetryBufferCount, 2);
 
 			//mark the checkpoint which should still be at event 1 although the _lastKnownMessage value is 3.
 			sub.TryMarkCheckpoint(false);

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -483,7 +483,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 			Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
 			Assert.That(client2Envelope.Replies.Count, Is.EqualTo(0));
-			Assert.That(sub.StreamBuffer.BufferCount, Is.EqualTo(1));
+			Assert.True(sub.TryGetStreamBuffer(out var streamBuffer));
+			Assert.That(streamBuffer.BufferCount, Is.EqualTo(1));
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 2,
 				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
@@ -491,14 +492,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
 			Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));
 
-			Assert.That(sub.StreamBuffer.BufferCount, Is.EqualTo(1));
+			Assert.That(streamBuffer.BufferCount, Is.EqualTo(1));
 
 			sub.AcknowledgeMessagesProcessed(correlationId, new[] { message1 });
 
 			Assert.That(client1Envelope.Replies.Count, Is.EqualTo(2));
 			Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));
 
-			Assert.That(sub.StreamBuffer.BufferCount, Is.EqualTo(0));
+			Assert.That(streamBuffer.BufferCount, Is.EqualTo(0));
 		}
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -71,6 +71,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				});
 			}
 
+			var gotBuffer = _parent.TryGetStreamBuffer(out var streamBuffer);
+
 			return new MonitoringMessage.SubscriptionInfo() {
 				EventStreamId = _parent.EventStreamId,
 				GroupName = _parent.GroupName,
@@ -91,9 +93,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				ReadBatchSize = _settings.ReadBatchSize,
 				ResolveLinktos = _settings.ResolveLinkTos,
 				StartFrom = _settings.StartFrom,
-				ReadBufferCount = _parent.StreamBuffer.ReadBufferCount,
-				RetryBufferCount = _parent.StreamBuffer.RetryBufferCount,
-				LiveBufferCount = _parent.StreamBuffer.LiveBufferCount,
+				ReadBufferCount = gotBuffer ? streamBuffer.ReadBufferCount : 0,
+				RetryBufferCount = gotBuffer ? streamBuffer.RetryBufferCount : 0,
+				LiveBufferCount = gotBuffer ? streamBuffer.LiveBufferCount : 0,
 				ExtraStatistics = _settings.ExtraStatistics,
 				TotalInFlightMessages = totalInflight,
 				OutstandingMessagesCount = _parent.OutstandingMessageCount,


### PR DESCRIPTION
Fixed: Prevent risk of deadlock when creating a PersistentSubscriptionGroup

The StreamBuffer getter used to implicity block waiting on the _streamBufferSource task.

However, threads that called this would commonly be holding the _lock which OnCheckpointLoaded
needs to acquire to be able to set the result in _streamBufferSource.

Therefore a deadlock could occur.

We have introduced TryGetStreamBuffer which does not block. Caller decides
what to do if the buffer is not available yet.

In 20.10 (and earlier) the deadlock was possible by using the http api to read a subscription, which would call GetNextNOrLessMessages and access the StreamBuffer

Also possibly by replaying parked messages which would transition the PersistentSubscription out of the NotReady state which is the guard against early StreamBuffer access in some other methods