### PR TITLE
Prevent deadlock risk when creating a PersistentSubscriptionGroup

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PersistentSubscriptionTests.cs
@@ -1238,14 +1238,15 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			//events 2 & 3 should still be in _outstandingMessages buffer
 			Assert.AreEqual(sub.OutstandingMessageCount, 2);
 			//retry queue should be empty
-			Assert.AreEqual(sub.StreamBuffer.RetryBufferCount, 0);
+			Assert.True(sub.TryGetStreamBuffer(out var streamBuffer));
+			Assert.AreEqual(streamBuffer.RetryBufferCount, 0);
 
 			//Disconnect the client
 			sub.RemoveClientByConnectionId(clientConnectionId);
 
 			//this should empty the _outstandingMessages buffer and move events 2 & 3 to the retry queue
 			Assert.AreEqual(sub.OutstandingMessageCount, 0);
-			Assert.AreEqual(sub.StreamBuffer.RetryBufferCount, 2);
+			Assert.AreEqual(streamBuffer.RetryBufferCount, 2);
 
 			//mark the checkpoint which should still be at event 1 although the _lastKnownMessage value is 3.
 			sub.TryMarkCheckpoint(false);

--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -483,7 +483,8 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 			Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
 			Assert.That(client2Envelope.Replies.Count, Is.EqualTo(0));
-			Assert.That(sub.StreamBuffer.BufferCount, Is.EqualTo(1));
+			Assert.True(sub.TryGetStreamBuffer(out var streamBuffer));
+			Assert.That(streamBuffer.BufferCount, Is.EqualTo(1));
 
 			sub.NotifyLiveSubscriptionMessage(Helper.BuildLinkEvent(Guid.NewGuid(), subsctiptionStream, 2,
 				Helper.BuildFakeEvent(Guid.NewGuid(), "type", "streamName-2", 0), false));
@@ -491,14 +492,14 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			Assert.That(client1Envelope.Replies.Count, Is.EqualTo(1));
 			Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));
 
-			Assert.That(sub.StreamBuffer.BufferCount, Is.EqualTo(1));
+			Assert.That(streamBuffer.BufferCount, Is.EqualTo(1));
 
 			sub.AcknowledgeMessagesProcessed(correlationId, new[] { message1 });
 
 			Assert.That(client1Envelope.Replies.Count, Is.EqualTo(2));
 			Assert.That(client2Envelope.Replies.Count, Is.EqualTo(1));
 
-			Assert.That(sub.StreamBuffer.BufferCount, Is.EqualTo(0));
+			Assert.That(streamBuffer.BufferCount, Is.EqualTo(0));
 		}
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStats.cs
@@ -75,6 +75,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 			long parkedMessageCount = _settings.MessageParker.ParkedMessageCount;
 
+			var gotBuffer = _parent.TryGetStreamBuffer(out var streamBuffer);
+
 			return new MonitoringMessage.PersistentSubscriptionInfo() {
 				EventSource = _parent.EventSource,
 				GroupName = _parent.GroupName,
@@ -95,9 +97,9 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				ReadBatchSize = _settings.ReadBatchSize,
 				ResolveLinktos = _settings.ResolveLinkTos,
 				StartFrom = _settings.StartFrom?.ToString(),
-				ReadBufferCount = _parent.StreamBuffer.ReadBufferCount,
-				RetryBufferCount = _parent.StreamBuffer.RetryBufferCount,
-				LiveBufferCount = _parent.StreamBuffer.LiveBufferCount,
+				ReadBufferCount = gotBuffer ? streamBuffer.ReadBufferCount : 0,
+				RetryBufferCount = gotBuffer ? streamBuffer.RetryBufferCount : 0,
+				LiveBufferCount = gotBuffer ? streamBuffer.LiveBufferCount : 0,
 				ExtraStatistics = _settings.ExtraStatistics,
 				TotalInFlightMessages = totalInflight,
 				OutstandingMessagesCount = _parent.OutstandingMessageCount,


### PR DESCRIPTION
Fixed: Prevent risk of deadlock when creating a PersistentSubscriptionGroup

The StreamBuffer getter used to implicity block waiting on the _streamBufferSource task.

However, threads that called this would commonly be holding the _lock which OnCheckpointLoaded
needs to acquire to be able to set the result in _streamBufferSource.

Therefore a deadlock could occur.

We have introduced TryGetStreamBuffer which does not block. Caller decides
what to do if the buffer is not available yet.

The deadlock:

```
OS Thread Id: 0x8b1
        Child SP               IP Call Site
00007F9C7CD83480 00007f9d2f1c3376 [HelperMethodFrame_1OBJ: 00007f9c7cd83480] System.Threading.Monitor.ReliableEnter(System.Object, Boolean ByRef)
00007F9C7CD835D0 00007F9CBBB132A2 EventStore.Core.Services.PersistentSubscription.PersistentSubscription.OnCheckpointLoaded(System.String) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs @ 135]
00007F9C7CD83640 00007F9CBBB13225 EventStore.Core.Services.PersistentSubscription.PersistentSubscriptionCheckpointReader+ResponseHandler.LoadStateCompleted(ReadStreamEventsBackwardCompleted) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionCheckpointReader.cs @ 43]
00007F9C7CD83670 00007F9CBAF59369 EventStore.Core.Messaging.RequestResponseDispatcher`2[[System.__Canon, System.Private.CoreLib],[System.__Canon, System.Private.CoreLib]].Handle(System.__Canon) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Messaging/RequestResponseDispatcher.cs @ 69]
00007F9C7CD836E0 00007F9CBAF59286 EventStore.Core.Messaging.RequestResponseDispatcher`2[[System.__Canon, System.Private.CoreLib],[System.__Canon, System.Private.CoreLib]].EventStore.Core.Bus.IHandle<TResponse>.Handle(System.__Canon) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Messaging/RequestResponseDispatcher.cs @ 48]
00007F9C7CD836F0 00007F9CBA4A6ECD EventStore.Core.Bus.MessageHandler`1[[System.__Canon, System.Private.CoreLib]].TryHandle(EventStore.Core.Messaging.Message) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Bus/MessageHandler.cs @ 30]
00007F9C7CD83730 00007F9CB8BE95DC EventStore.Core.Bus.InMemoryBus.Publish(EventStore.Core.Messaging.Message) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Bus/InMemoryBus.cs @ 290]
00007F9C7CD837C0 00007F9CB8C09585 EventStore.Core.Services.VNode.VNodeFSM.Handle(EventStore.Core.Messaging.Message) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Services/VNode/VNodeFSM.cs @ 91]
00007F9C7CD83810 00007F9CB8BC0000 EventStore.Core.Bus.QueuedHandlerMRES.ReadFromQueue(System.Object) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Bus/QueuedHandlerMRES.cs @ 119]
00007F9C7CD83870 00007F9CB4AB067F System.Threading.ThreadHelper.ThreadStart_Context(System.Object) [/_/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs @ 46]
00007F9C7CD83890 00007F9CB4AB9A61 System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object) [/_/src/libraries/System.Private.CoreLib/src/System/Threading/ExecutionContext.cs @ 186]
00007F9C7CD838E0 00007F9CB4AB0711 System.Threading.ThreadHelper.ThreadStart(System.Object) [/_/src/coreclr/src/System.Private.CoreLib/src/System/Threading/Thread.CoreCLR.cs @ 74]
00007F9C7CD83CE0 00007f9d2e419957 [DebuggerU2MCatchHandlerFrame: 00007f9c7cd83ce0]
```

```
OS Thread Id: 0x34a081
        Child SP               IP Call Site
00007F9C2EFFBEE0 00007f9d2f1c3376 [HelperMethodFrame_1OBJ: 00007f9c2effbee0] System.Threading.Monitor.ObjWait(Boolean, Int32, System.Object)
00007F9C2EFFC010 00007F9CBA4A01AA System.Threading.ManualResetEventSlim.Wait(Int32, System.Threading.CancellationToken) [/_/src/libraries/System.Private.CoreLib/src/System/Threading/ManualResetEventSlim.cs @ 590]
00007F9C2EFFC090 00007F9CB4ACF480 System.Threading.Tasks.Task.SpinThenBlockingWait(Int32, System.Threading.CancellationToken) [/_/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs @ 2849]
00007F9C2EFFC0F0 00007F9CB4ACF31B System.Threading.Tasks.Task.InternalWaitCore(Int32, System.Threading.CancellationToken) [/_/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Task.cs @ 2788]
00007F9C2EFFC140 00007F9CB4AC755A System.Threading.Tasks.Task`1[[System.__Canon, System.Private.CoreLib]].GetResultCore(Boolean) [/_/src/libraries/System.Private.CoreLib/src/System/Threading/Tasks/Future.cs @ 464]
00007F9C2EFFC160 00007F9CBBA8483D EventStore.Core.Services.PersistentSubscription.PersistentSubscription.TryMarkCheckpoint(Boolean) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs @ 417]
00007F9C2EFFC3F0 00007F9CBBAEE9FD EventStore.Core.Services.PersistentSubscription.PersistentSubscription.NotifyLiveSubscriptionMessage(EventStore.Core.Data.ResolvedEvent) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs @ 275]
00007F9C2EFFC690 00007F9CBBA77226 EventStore.Core.Services.PersistentSubscription.PersistentSubscriptionService`1[[System.__Canon, System.Private.CoreLib]].ProcessEventCommited(System.String, Int64, EventStore.Core.Data.EventRecord) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs @ 856]
00007F9C2EFFC780 00007F9CBA4A6ECD EventStore.Core.Bus.MessageHandler`1[[System.__Canon, System.Private.CoreLib]].TryHandle(EventStore.Core.Messaging.Message) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Bus/MessageHandler.cs @ 30]
00007F9C2EFFC7C0 00007F9CB8BE95DC EventStore.Core.Bus.InMemoryBus.Publish(EventStore.Core.Messaging.Message) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Bus/InMemoryBus.cs @ 290]
00007F9C2EFFC850 00007F9CB8C0A1D9 EventStore.Core.Bus.QueuedHandlerThreadPool.ReadFromQueue(System.Object) [/home/runner/work/TrainStation/TrainStation/build/oss-eventstore/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs @ 135]
00007F9C2EFFC8A0 00007F9CBA49B69C System.Threading.ThreadPoolWorkQueue.Dispatch() [/_/src/libraries/System.Private.CoreLib/src/System/Threading/ThreadPool.cs @ 677]
00007F9C2EFFCC80 00007f9d2e419957 [DebuggerU2MCatchHandlerFrame: 00007f9c2effcc80]
OS Thread Id: 0x13791
```