### PR TITLE
Add extra logging on startup

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
@@ -465,6 +465,8 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			}
 
 			public void Emit(LogEvent logEvent) {
+				if (logEvent.Exception is null)
+					return;
 				_output.Append(logEvent.RenderMessage());
 				_logEventReceived.TrySetResult(logEvent.Exception);
 			}

--- a/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -85,11 +85,10 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 			lock (_locker) {
 				var reader = _readers.Get();
 				try {
-
 					long epochPos = _checkpoint.Read();
-					if (epochPos < 0
-					) // we probably have lost/uninitialized epoch checkpoint scan back to find the most recent epoch in the log
-					{
+					if (epochPos < 0) {
+						// we probably have lost/uninitialized epoch checkpoint scan back to find the most recent epoch in the log
+						Log.Information("No epoch checkpoint. Scanning log backwards for most recent epoch...");
 						reader.Reposition(_writer.Checkpoint.Read());
 
 						SeqReadResult result;
@@ -101,6 +100,8 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 							epochPos = rec.LogPosition;
 							break;
 						}
+
+						Log.Information("Done scanning log backwards for most recent epoch.");
 					}
 
 					//read back down the chain of epochs in the log until the cache is full

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -154,11 +154,18 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				}
 			}
 
+			_log.Information("Ensuring no excessive chunks...");
 			EnsureNoExcessiveChunks(lastChunkNum);
+			_log.Information("Done ensuring no excessive chunks.");
 
 			if (!readOnly) {
+				_log.Information("Removing old chunk versions...");
 				RemoveOldChunksVersions(lastChunkNum);
+				_log.Information("Done removing old chunk versions.");
+
+				_log.Information("Cleaning up temp files...");
 				CleanUpTempFiles();
+				_log.Information("Done cleaning up temp files.");
 			}
 
 			if (verifyHash && lastChunkNum > 0) {


### PR DESCRIPTION
Added: Extra logging on startup

A couple of operations on startup can take a long time but didn't log what the server was doing

- Scanning the log backwards for an epoch (not typically necessary but potentially slow).
- Checking for chunk overlaps and removing old versions of chunks.