### PR TITLE
Update server protos for persistent subscriptions

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -3092,7 +3092,13 @@
                   {
                     "id": 13,
                     "name": "named_consumer_strategy",
-                    "type": "ConsumerStrategy"
+                    "type": "ConsumerStrategy",
+                    "options": [
+                      {
+                        "name": "deprecated",
+                        "value": "true"
+                      }
+                    ]
                   },
                   {
                     "id": 4,
@@ -3113,6 +3119,11 @@
                     "id": 15,
                     "name": "checkpoint_after_ms",
                     "type": "int32"
+                  },
+                  {
+                    "id": 16,
+                    "name": "consumer_strategy",
+                    "type": "string"
                   }
                 ]
               }
@@ -3352,6 +3363,360 @@
           },
           {
             "name": "DeleteResp"
+          },
+          {
+            "name": "GetInfoReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "stream_identifier",
+                    "type": "event_store.client.StreamIdentifier"
+                  },
+                  {
+                    "id": 2,
+                    "name": "all",
+                    "type": "event_store.client.Empty"
+                  },
+                  {
+                    "id": 3,
+                    "name": "group_name",
+                    "type": "string"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "GetInfoResp",
+            "fields": [
+              {
+                "id": 1,
+                "name": "subscription_info",
+                "type": "SubscriptionInfo"
+              }
+            ]
+          },
+          {
+            "name": "SubscriptionInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "event_source",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "group_name",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "status",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "connections",
+                "type": "ConnectionInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "average_per_second",
+                "type": "int32"
+              },
+              {
+                "id": 6,
+                "name": "total_items",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "count_since_last_measurement",
+                "type": "int64"
+              },
+              {
+                "id": 8,
+                "name": "last_checkpointed_event_position",
+                "type": "string"
+              },
+              {
+                "id": 9,
+                "name": "last_known_event_position",
+                "type": "string"
+              },
+              {
+                "id": 10,
+                "name": "resolve_link_tos",
+                "type": "bool"
+              },
+              {
+                "id": 11,
+                "name": "start_from",
+                "type": "string"
+              },
+              {
+                "id": 12,
+                "name": "message_timeout_milliseconds",
+                "type": "int32"
+              },
+              {
+                "id": 13,
+                "name": "extra_statistics",
+                "type": "bool"
+              },
+              {
+                "id": 14,
+                "name": "max_retry_count",
+                "type": "int32"
+              },
+              {
+                "id": 15,
+                "name": "live_buffer_size",
+                "type": "int32"
+              },
+              {
+                "id": 16,
+                "name": "buffer_size",
+                "type": "int32"
+              },
+              {
+                "id": 17,
+                "name": "read_batch_size",
+                "type": "int32"
+              },
+              {
+                "id": 18,
+                "name": "check_point_after_milliseconds",
+                "type": "int32"
+              },
+              {
+                "id": 19,
+                "name": "min_check_point_count",
+                "type": "int32"
+              },
+              {
+                "id": 20,
+                "name": "max_check_point_count",
+                "type": "int32"
+              },
+              {
+                "id": 21,
+                "name": "read_buffer_count",
+                "type": "int32"
+              },
+              {
+                "id": 22,
+                "name": "live_buffer_count",
+                "type": "int64"
+              },
+              {
+                "id": 23,
+                "name": "retry_buffer_count",
+                "type": "int32"
+              },
+              {
+                "id": 24,
+                "name": "total_in_flight_messages",
+                "type": "int32"
+              },
+              {
+                "id": 25,
+                "name": "outstanding_messages_count",
+                "type": "int32"
+              },
+              {
+                "id": 26,
+                "name": "named_consumer_strategy",
+                "type": "string"
+              },
+              {
+                "id": 27,
+                "name": "max_subscriber_count",
+                "type": "int32"
+              },
+              {
+                "id": 28,
+                "name": "parked_message_count",
+                "type": "int64"
+              }
+            ],
+            "messages": [
+              {
+                "name": "ConnectionInfo",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "from",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "username",
+                    "type": "string"
+                  },
+                  {
+                    "id": 3,
+                    "name": "average_items_per_second",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 4,
+                    "name": "total_items",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 5,
+                    "name": "count_since_last_measurement",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 6,
+                    "name": "observed_measurements",
+                    "type": "Measurement",
+                    "is_repeated": true
+                  },
+                  {
+                    "id": 7,
+                    "name": "available_slots",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 8,
+                    "name": "in_flight_messages",
+                    "type": "int32"
+                  },
+                  {
+                    "id": 9,
+                    "name": "connection_name",
+                    "type": "string"
+                  }
+                ]
+              },
+              {
+                "name": "Measurement",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "key",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "value",
+                    "type": "int64"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ReplayParkedReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "group_name",
+                    "type": "string"
+                  },
+                  {
+                    "id": 2,
+                    "name": "stream_identifier",
+                    "type": "event_store.client.StreamIdentifier"
+                  },
+                  {
+                    "id": 3,
+                    "name": "all",
+                    "type": "event_store.client.Empty"
+                  },
+                  {
+                    "id": 4,
+                    "name": "stop_at",
+                    "type": "int64"
+                  },
+                  {
+                    "id": 5,
+                    "name": "no_limit",
+                    "type": "event_store.client.Empty"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ReplayParkedResp"
+          },
+          {
+            "name": "ListReq",
+            "fields": [
+              {
+                "id": 1,
+                "name": "options",
+                "type": "Options"
+              }
+            ],
+            "messages": [
+              {
+                "name": "Options",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "list_all_subscriptions",
+                    "type": "event_store.client.Empty"
+                  },
+                  {
+                    "id": 2,
+                    "name": "list_for_stream",
+                    "type": "StreamOption"
+                  }
+                ]
+              },
+              {
+                "name": "StreamOption",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "stream",
+                    "type": "event_store.client.StreamIdentifier"
+                  },
+                  {
+                    "id": 2,
+                    "name": "all",
+                    "type": "event_store.client.Empty"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "ListResp",
+            "fields": [
+              {
+                "id": 1,
+                "name": "subscriptions",
+                "type": "SubscriptionInfo",
+                "is_repeated": true
+              }
+            ]
           }
         ],
         "services": [
@@ -3379,6 +3744,26 @@
                 "out_type": "ReadResp",
                 "in_streamed": true,
                 "out_streamed": true
+              },
+              {
+                "name": "GetInfo",
+                "in_type": "GetInfoReq",
+                "out_type": "GetInfoResp"
+              },
+              {
+                "name": "ReplayParked",
+                "in_type": "ReplayParkedReq",
+                "out_type": "ReplayParkedResp"
+              },
+              {
+                "name": "List",
+                "in_type": "ListReq",
+                "out_type": "ListResp"
+              },
+              {
+                "name": "RestartSubsystem",
+                "in_type": "event_store.client.Empty",
+                "out_type": "event_store.client.Empty"
               }
             ]
           }

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
-		<PackageReference Include="GitHubActionsTestLogger" Version="1.2.0"/>
+		<PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
 		<PackageReference Include="Grpc.Core" Version="2.39.1" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.6" />

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
@@ -1,0 +1,360 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Client.PersistentSubscriptions;
+using EventStore.Client.Streams;
+using EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests;
+using Google.Protobuf;
+using Grpc.Core;
+using NUnit.Framework;
+using StreamsReadReq = EventStore.Client.Streams.ReadReq;
+using StreamsReadResp = EventStore.Client.Streams.ReadResp;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.PersistentSubscriptionTests {
+	public class GetInfoTests {
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_getting_info_for_persistent_subscription_group_on_stream<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private string _groupName = "test-group";
+			private string _streamName = "test-stream";
+			private SubscriptionInfo _actualSubscriptionInfo;
+			private SubscriptionInfo _expectedSubscriptionInfo;
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+
+			protected override async Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+				await _persistentSubscriptionsClient.CreateAsync(new CreateReq {
+					Options = new CreateReq.Types.Options {
+						GroupName = _groupName,
+						Stream = new CreateReq.Types.StreamOptions {
+							Start = new Empty(),
+							StreamIdentifier = new StreamIdentifier {
+								StreamName = ByteString.CopyFromUtf8(_streamName)
+							}
+						},
+						Settings = TestPersistentSubscriptionSettings
+					}
+				}, GetCallOptions(AdminCredentials));
+				_expectedSubscriptionInfo = GetSubscriptionInfoFromSettings(TestPersistentSubscriptionSettings,
+					_groupName, _streamName, "0", string.Empty);
+			}
+
+			protected override async Task When() {
+				var resp = await _persistentSubscriptionsClient.GetInfoAsync(new GetInfoReq {
+					Options = new GetInfoReq.Types.Options {
+						GroupName = _groupName,
+						StreamIdentifier = new StreamIdentifier {
+							StreamName = ByteString.CopyFromUtf8(_streamName)
+						}
+					}
+				}, GetCallOptions(AdminCredentials));
+				_actualSubscriptionInfo = resp.SubscriptionInfo;
+			}
+
+			[Test]
+			public void should_receive_the_correct_stats() {
+				Assert.AreEqual(_expectedSubscriptionInfo, _actualSubscriptionInfo);
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_listing_persistent_subscriptions_on_stream<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private string _streamName = "test-stream";
+			private List<SubscriptionInfo> _actualSubscriptionInfo;
+			private List<SubscriptionInfo> _expectedSubscriptionInfo = new();
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+
+			protected override async Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+				var groupNames = new[] { "groupA", "groupB", "groupC" };
+				foreach (var group in groupNames) {
+					await _persistentSubscriptionsClient.CreateAsync(new CreateReq {
+						Options = new CreateReq.Types.Options {
+							GroupName = group,
+							Stream = new CreateReq.Types.StreamOptions {
+								Start = new Empty(),
+								StreamIdentifier = new StreamIdentifier {
+									StreamName = ByteString.CopyFromUtf8(_streamName)
+								}
+							},
+							Settings = TestPersistentSubscriptionSettings
+						}
+					}, GetCallOptions(AdminCredentials));
+					_expectedSubscriptionInfo.Add(GetSubscriptionInfoFromSettings(
+						TestPersistentSubscriptionSettings, group, _streamName, "0", string.Empty));
+				}
+			}
+
+			protected override async Task When() {
+				var resp = await _persistentSubscriptionsClient.ListAsync(new ListReq {
+					Options = new ListReq.Types.Options {
+						ListForStream = new ListReq.Types.StreamOption{
+							Stream = new StreamIdentifier {
+								StreamName = ByteString.CopyFromUtf8(_streamName)
+							}
+						}
+					}
+				}, GetCallOptions(AdminCredentials));
+				_actualSubscriptionInfo = resp.Subscriptions.ToList();
+			}
+
+			[Test]
+			public void should_receive_the_correct_stats() {
+				CollectionAssert.AreEquivalent(_expectedSubscriptionInfo, _actualSubscriptionInfo);
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_listing_persistent_subscriptions_on_all_stream<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private List<SubscriptionInfo> _actualSubscriptionInfo;
+			private List<SubscriptionInfo> _expectedSubscriptionInfo = new();
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+
+			protected override async Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+				var groupNames = new[] {"groupA", "groupB", "groupC"};
+				foreach (var group in groupNames) {
+					await _persistentSubscriptionsClient.CreateAsync(new CreateReq {
+						Options = new CreateReq.Types.Options {
+							GroupName = group,
+							All = new CreateReq.Types.AllOptions {
+								Start = new Empty()
+							},
+							Settings = TestPersistentSubscriptionSettings
+						}
+					}, GetCallOptions(AdminCredentials));
+				}
+
+				var events = await GetAllEvents(StreamsClient, GetCallOptions(AdminCredentials));
+
+				var lastPosition = (long)events.Last().Event.CommitPosition;
+				_expectedSubscriptionInfo = groupNames.Select(x =>
+					GetSubscriptionInfoFromSettings(TestPersistentSubscriptionSettings, x, "$all", "C:0/P:0",
+						$"C:{lastPosition}/P:{lastPosition}")).ToList();
+			}
+
+			protected override async Task When() {
+				// Get the subscription info
+				var resp = await _persistentSubscriptionsClient.ListAsync(new ListReq {
+					Options = new ListReq.Types.Options {
+						ListForStream = new ListReq.Types.StreamOption {
+							All = new Empty()
+						}
+					}
+				}, GetCallOptions(AdminCredentials));
+				_actualSubscriptionInfo = resp.Subscriptions.ToList();
+			}
+
+			[Test]
+			public void should_receive_the_correct_stats() {
+				// Set the buffer counts to 0 to make comparison easier
+				_actualSubscriptionInfo.ForEach(x => x.LiveBufferCount = 0);
+				_actualSubscriptionInfo.ForEach(x => x.ReadBufferCount = 0);
+				CollectionAssert.AreEquivalent(_expectedSubscriptionInfo, _actualSubscriptionInfo);
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_listing_all_persistent_subscriptions<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private List<SubscriptionInfo> _actualSubscriptionInfo;
+			private List<SubscriptionInfo> _expectedSubscriptionInfo = new();
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+
+			protected override async Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+				var subscriptionNames = new Dictionary<string, string[]> {
+					{"streamA", new[] {"groupA"}},
+					{"streamB", new[] {"groupB-1", "groupB-2"}},
+					{"streamC", new[] {"groupC"}},
+				};
+				foreach (var (stream, groupNames) in subscriptionNames) {
+					foreach (var group in groupNames) {
+						await _persistentSubscriptionsClient.CreateAsync(new CreateReq {
+							Options = new CreateReq.Types.Options {
+								GroupName = group,
+								Stream = new CreateReq.Types.StreamOptions {
+									Start = new Empty(),
+									StreamIdentifier = new StreamIdentifier {
+										StreamName = ByteString.CopyFromUtf8(stream)
+									}
+								},
+								Settings = TestPersistentSubscriptionSettings
+							}
+						}, GetCallOptions(AdminCredentials));
+						_expectedSubscriptionInfo.Add(GetSubscriptionInfoFromSettings(
+							TestPersistentSubscriptionSettings, group, stream, "0",	string.Empty));
+					}
+				}
+				await _persistentSubscriptionsClient.CreateAsync(new CreateReq {
+					Options = new CreateReq.Types.Options {
+						GroupName = "groupD",
+						All = new CreateReq.Types.AllOptions {
+							Start = new Empty()
+						},
+						Settings = TestPersistentSubscriptionSettings
+					}
+				}, GetCallOptions(AdminCredentials));
+
+				var events = await GetAllEvents(StreamsClient, GetCallOptions(AdminCredentials));
+
+				var lastPosition = (long)events.Last().Event.CommitPosition;
+				_expectedSubscriptionInfo.Add(GetSubscriptionInfoFromSettings(
+					TestPersistentSubscriptionSettings, "groupD", "$all", "C:0/P:0",
+					$"C:{lastPosition}/P:{lastPosition}"));
+			}
+
+			protected override async Task When() {
+				var resp = await _persistentSubscriptionsClient.ListAsync(new ListReq {
+					Options = new ListReq.Types.Options {
+						ListAllSubscriptions = new Empty()
+					}
+				}, GetCallOptions(AdminCredentials));
+				_actualSubscriptionInfo = resp.Subscriptions.ToList();
+			}
+
+			[Test]
+			public void should_receive_the_correct_stats() {
+				// Set the buffer counts to 0 to make comparison easier
+				_actualSubscriptionInfo.ForEach(x => x.LiveBufferCount = 0);
+				_actualSubscriptionInfo.ForEach(x => x.ReadBufferCount = 0);
+				CollectionAssert.AreEquivalent(_expectedSubscriptionInfo, _actualSubscriptionInfo);
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_getting_info_for_persistent_subscription_group_on_all<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private string _groupName = "test-group";
+			private SubscriptionInfo _actualSubscriptionInfo;
+			private SubscriptionInfo _expectedSubscriptionInfo;
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+
+			protected override async Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+				await _persistentSubscriptionsClient.CreateAsync(new CreateReq {
+					Options = new CreateReq.Types.Options {
+						GroupName = _groupName,
+						All = new CreateReq.Types.AllOptions {
+							Start = new Empty()
+						},
+						Settings = TestPersistentSubscriptionSettings
+					}
+				}, GetCallOptions(AdminCredentials));
+
+				var events = await GetAllEvents(StreamsClient, GetCallOptions(AdminCredentials));
+
+				var lastPosition = (long)events.Last().Event.CommitPosition;
+				_expectedSubscriptionInfo =
+					GetSubscriptionInfoFromSettings(TestPersistentSubscriptionSettings, _groupName,
+						"$all", "C:0/P:0", $"C:{lastPosition}/P:{lastPosition}");
+			}
+
+			protected override async Task When() {
+				var resp = await _persistentSubscriptionsClient.GetInfoAsync(new GetInfoReq {
+					Options = new GetInfoReq.Types.Options {
+						GroupName = _groupName,
+						All = new Empty()
+					}
+				}, GetCallOptions(AdminCredentials));
+				_actualSubscriptionInfo = resp.SubscriptionInfo;
+			}
+
+			[Test]
+			public void should_receive_the_correct_stats() {
+				// Set the buffer counts to 0 to make comparison easier
+				_actualSubscriptionInfo.LiveBufferCount = 0;
+				_actualSubscriptionInfo.ReadBufferCount = 0;
+				Assert.AreEqual(_expectedSubscriptionInfo, _actualSubscriptionInfo);
+			}
+		}
+
+		private static async Task<List<StreamsReadResp>> GetAllEvents(Streams.StreamsClient client, CallOptions callOptions) {
+			var call = client.Read(new() {
+				Options = new() {
+					ReadDirection = StreamsReadReq.Types.Options.Types.ReadDirection.Forwards,
+					Count = 100,
+					NoFilter = new(),
+					UuidOption = new() { Structured = new() },
+					All = new() {
+						Start = new()
+					}
+				}
+			}, callOptions);
+
+			var events = new List<StreamsReadResp>();
+			await foreach (var evnt in call.ResponseStream.ReadAllAsync()) {
+				if (evnt.ContentCase is StreamsReadResp.ContentOneofCase.Event) {
+					events.Add(evnt);
+
+				}
+			}
+			return events;
+		}
+
+		private static CreateReq.Types.Settings TestPersistentSubscriptionSettings => new CreateReq.Types.Settings {
+			CheckpointAfterMs = 10000,
+			ExtraStatistics = true,
+			MaxCheckpointCount = 20,
+			MinCheckpointCount = 10,
+			MaxRetryCount = 30,
+			MaxSubscriberCount = 40,
+			MessageTimeoutMs = 20000,
+			HistoryBufferSize = 60,
+			LiveBufferSize = 10,
+			ConsumerStrategy = "Pinned",
+			ReadBatchSize = 50
+		};
+
+		private static SubscriptionInfo GetSubscriptionInfoFromSettings(
+			CreateReq.Types.Settings settings, string groupName, string streamName, string startFrom, string lastKnownEvent) {
+			return new() {
+				EventSource = streamName,
+				GroupName = groupName,
+				Status = "Live",
+				AveragePerSecond = 0,
+				TotalItems = 0,
+				CountSinceLastMeasurement = 0,
+				LastCheckpointedEventPosition = string.Empty,
+				LastKnownEventPosition = lastKnownEvent,
+				ResolveLinkTos = settings.ResolveLinks,
+				StartFrom = startFrom,
+				MessageTimeoutMilliseconds = settings.MessageTimeoutMs,
+				ExtraStatistics = settings.ExtraStatistics,
+				MaxRetryCount = settings.MaxRetryCount,
+				LiveBufferSize = settings.LiveBufferSize,
+				BufferSize = settings.HistoryBufferSize,
+				ReadBatchSize = settings.ReadBatchSize,
+				CheckPointAfterMilliseconds = settings.CheckpointAfterMs,
+				MinCheckPointCount = settings.MinCheckpointCount,
+				MaxCheckPointCount = settings.MaxCheckpointCount,
+				ReadBufferCount = 0,
+				LiveBufferCount = 0,
+				RetryBufferCount = 0,
+				TotalInFlightMessages = 0,
+				OutstandingMessagesCount = 0,
+				NamedConsumerStrategy = "Pinned",
+				MaxSubscriberCount = settings.MaxSubscriberCount,
+				ParkedMessageCount = 0
+			};
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/ReplayParkedTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/ReplayParkedTests.cs
@@ -1,0 +1,349 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Client.PersistentSubscriptions;
+using EventStore.Client.Streams;
+using EventStore.Core.Services.Transport.Grpc;
+using EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests;
+using Google.Protobuf;
+using Grpc.Core;
+using NUnit.Framework;
+using ReadReq = EventStore.Client.PersistentSubscriptions.ReadReq;
+using ReadResp = EventStore.Client.PersistentSubscriptions.ReadResp;
+using StreamsReadReq = EventStore.Client.Streams.ReadReq;
+using StreamsReadResp = EventStore.Client.Streams.ReadResp;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.PersistentSubscriptionTests {
+	public class ReplayParkedTests {
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_replaying_parked_messages_with_no_limit_for_existing_subscription<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private string _groupName = "test-group";
+			private string _streamName = "test-stream";
+			private int _eventCount = 10;
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+			private AsyncDuplexStreamingCall<ReadReq, ReadResp> _subscriptionStream;
+			private List<ulong> _expectedEventVersions = new List<ulong>();
+			private List<ulong> _actualEventVersions = new List<ulong>();
+
+			protected override async Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+				await CreateTestPersistentSubscription(_persistentSubscriptionsClient, _streamName, _groupName, GetCallOptions(AdminCredentials));
+
+				_subscriptionStream = await SubscribeToPersistentSubscription(
+					_persistentSubscriptionsClient, _groupName, _streamName, GetCallOptions(AdminCredentials));
+
+				// Write events to the subscription
+				var writeRes = await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						Any = new(),
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(_streamName) }
+					},
+					IsFinal = true,
+					ProposedMessages = { CreateEvents(_eventCount) },
+					CorrelationId = Uuid.NewUuid().ToDto(),
+				});
+				Assert.NotNull(writeRes.Success);
+
+				// Park all of the messages
+				for(var i = 0; i < _eventCount; i++) {
+					Assert.True(await _subscriptionStream.ResponseStream.MoveNext());
+					Assert.AreEqual(ReadResp.ContentOneofCase.Event, _subscriptionStream.ResponseStream.Current.ContentCase);
+					var evnt = _subscriptionStream.ResponseStream.Current.Event;
+					await _subscriptionStream.RequestStream.WriteAsync(new ReadReq {
+						Nack = new ReadReq.Types.Nack {
+							Action = ReadReq.Types.Nack.Types.Action.Park,
+							Ids = {
+							evnt.Event.Id
+						},
+							Reason = "testing"
+						}
+					});
+				}
+
+				// Check that the events were parked
+				await WaitForEventsInStream(
+					StreamsClient, $"$persistentsubscription-{_streamName}::{_groupName}-parked", _eventCount, GetCallOptions(AdminCredentials));
+			}
+
+			protected override async Task When() {
+				await _persistentSubscriptionsClient.ReplayParkedAsync(new ReplayParkedReq {
+					Options = new ReplayParkedReq.Types.Options {
+						GroupName = _groupName,
+						StreamIdentifier = new StreamIdentifier {
+							StreamName = ByteString.CopyFromUtf8(_streamName)
+						},
+						NoLimit = new()
+					}
+				}, GetCallOptions(AdminCredentials));
+				for (var i = 0; i < _eventCount; i++) {
+					Assert.True(await _subscriptionStream.ResponseStream.MoveNext());
+					var curr = _subscriptionStream.ResponseStream.Current;
+					Assert.AreEqual(ReadResp.ContentOneofCase.Event, curr.ContentCase);
+					_actualEventVersions.Add(curr.Event.Event.StreamRevision);
+
+					// Ack the event otherwise the test can throw an error
+					await _subscriptionStream.RequestStream.WriteAsync(new ReadReq {
+							Ack = new ReadReq.Types.Ack {
+								Ids = {
+								curr.Event.Event.Id
+							},
+						}
+					});
+				}
+			}
+
+			[Test]
+			public void should_receive_replayed_messages() {
+				_expectedEventVersions = Enumerable.Range(0, _eventCount).Select(x => (ulong)x).ToList();
+				CollectionAssert.AreEqual(_expectedEventVersions, _actualEventVersions);
+			}
+
+			[TearDown]
+			public void Teardown() {
+				_subscriptionStream.Dispose();
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_replaying_parked_messages_with_a_replay_limit_for_existing_subscription<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private string _groupName = "test-group";
+			private string _streamName = "test-stream";
+			private int _eventCount = 10;
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+			private AsyncDuplexStreamingCall<ReadReq, ReadResp> _subscriptionStream;
+			private List<ulong> _expectedEventVersions = new List<ulong>();
+			private List<ulong> _actualEventVersions = new List<ulong>();
+
+			protected override async Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+
+				await CreateTestPersistentSubscription(_persistentSubscriptionsClient, _streamName, _groupName, GetCallOptions(AdminCredentials));
+
+				_subscriptionStream = await SubscribeToPersistentSubscription(
+					_persistentSubscriptionsClient, _groupName, _streamName, GetCallOptions(AdminCredentials));
+
+				// Write events to the subscription
+				var writeRes = await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						Any = new(),
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(_streamName) }
+					},
+					IsFinal = true,
+					ProposedMessages = { CreateEvents(_eventCount) },
+					CorrelationId = Uuid.NewUuid().ToDto(),
+				});
+				Assert.NotNull(writeRes.Success);
+
+				// Park all of the messages
+				for (var i = 0; i < _eventCount; i++) {
+					Assert.True(await _subscriptionStream.ResponseStream.MoveNext());
+					Assert.AreEqual(ReadResp.ContentOneofCase.Event, _subscriptionStream.ResponseStream.Current.ContentCase);
+					var evnt = _subscriptionStream.ResponseStream.Current.Event;
+					//_allEventIds.Add(Uuid.FromDto(evnt.Event.Id));
+					await _subscriptionStream.RequestStream.WriteAsync(new ReadReq {
+						Nack = new ReadReq.Types.Nack {
+							Action = ReadReq.Types.Nack.Types.Action.Park,
+							Ids = {
+							evnt.Event.Id
+						},
+							Reason = "testing"
+						}
+					});
+				}
+
+				// Check that the events were parked
+				await WaitForEventsInStream(
+					StreamsClient, $"$persistentsubscription-{_streamName}::{_groupName}-parked", _eventCount, GetCallOptions(AdminCredentials));
+			}
+
+			protected override async Task When() {
+				await _persistentSubscriptionsClient.ReplayParkedAsync(new ReplayParkedReq {
+					Options = new ReplayParkedReq.Types.Options {
+						GroupName = _groupName,
+						StreamIdentifier = new StreamIdentifier {
+							StreamName = ByteString.CopyFromUtf8(_streamName)
+						},
+						StopAt = 1
+					}
+				}, GetCallOptions(AdminCredentials));
+
+				Assert.True(await _subscriptionStream.ResponseStream.MoveNext());
+				var evnt = _subscriptionStream.ResponseStream.Current.Event.Event;
+				_actualEventVersions.Add(evnt.StreamRevision);
+				// Ack the event otherwise the test can throw an error
+				await _subscriptionStream.RequestStream.WriteAsync(new ReadReq {
+					Ack = new ReadReq.Types.Ack {
+						Ids = {
+							evnt.Id
+						},
+					}
+				});
+
+				// Write one more event so we can be sure the other parked messages aren't being replayed
+				var writeRes = await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						Any = new(),
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(_streamName) }
+					},
+					IsFinal = true,
+					ProposedMessages = { CreateEvents(1) },
+					CorrelationId = Uuid.NewUuid().ToDto(),
+				});
+				Assert.NotNull(writeRes.Success);
+
+				Assert.True(await _subscriptionStream.ResponseStream.MoveNext());
+				evnt = _subscriptionStream.ResponseStream.Current.Event.Event;
+				_actualEventVersions.Add(evnt.StreamRevision);
+
+				// Ack the event otherwise the test can throw an error
+				await _subscriptionStream.RequestStream.WriteAsync(new ReadReq {
+					Ack = new ReadReq.Types.Ack {
+						Ids = {
+							evnt.Id
+						},
+					}
+				});
+			}
+
+			[Test]
+			public void should_receive_one_replayed_message_and_new_message() {
+				_expectedEventVersions = new List<ulong> { 0, 10 };
+				CollectionAssert.AreEqual(_expectedEventVersions, _actualEventVersions);
+			}
+
+			[TearDown]
+			public void Teardown() {
+				_subscriptionStream.Dispose();
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_replaying_parked_messages_for_non_existent_subscription<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private string _groupName = "test-group";
+			private string _streamName = "test-stream";
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+			private Exception _exception;
+
+			protected override Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+				return Task.CompletedTask;
+			}
+
+			protected override async Task When() {
+				try {
+					await _persistentSubscriptionsClient.ReplayParkedAsync(new ReplayParkedReq {
+						Options = new ReplayParkedReq.Types.Options {
+							GroupName = _groupName,
+							StreamIdentifier = new StreamIdentifier {
+								StreamName = ByteString.CopyFromUtf8(_streamName)
+							},
+							NoLimit = new()
+						}
+					}, GetCallOptions(AdminCredentials));
+				} catch(Exception e) {
+					_exception = e;
+				}
+			}
+
+			[Test]
+			public void should_receive_not_found_error() {
+				Assert.IsInstanceOf<RpcException>(_exception);
+				Assert.AreEqual(StatusCode.NotFound, ((RpcException)_exception).Status.StatusCode);
+			}
+		}
+
+		private static async Task<AsyncDuplexStreamingCall<ReadReq, ReadResp>> SubscribeToPersistentSubscription(
+			PersistentSubscriptions.PersistentSubscriptionsClient client, string groupName, string streamName, CallOptions callOptions) {
+			var call = client.Read(callOptions);
+
+			await call.RequestStream.WriteAsync(new ReadReq {
+				Options = new ReadReq.Types.Options {
+					GroupName = groupName,
+					StreamIdentifier = new StreamIdentifier {
+						StreamName = ByteString.CopyFromUtf8(streamName)
+					},
+					BufferSize = 10,
+					UuidOption = new ReadReq.Types.Options.Types.UUIDOption {
+						Structured = new Empty()
+					}
+				}
+			}).ConfigureAwait(false);
+			if (!await call.ResponseStream.MoveNext().ConfigureAwait(false) ||
+				call.ResponseStream.Current.ContentCase != ReadResp.ContentOneofCase.SubscriptionConfirmation) {
+				throw new InvalidOperationException();
+			}
+
+			return call;
+		}
+
+		private static async Task<StreamsReadResp[]> WaitForEventsInStream(
+			Streams.StreamsClient streamsClient, string streamName, int count, CallOptions callOptions) {
+			using var call = streamsClient.Read(new() {
+				Options = new() {
+					Subscription = new(),
+					NoFilter = new(),
+					ReadDirection = StreamsReadReq.Types.Options.Types.ReadDirection.Forwards,
+					UuidOption = new() { Structured = new() },
+					Stream = new() {
+						StreamIdentifier = new() {
+							StreamName = ByteString.CopyFromUtf8(streamName)
+						},
+						Start = new()
+					}
+				}
+			}, callOptions);
+
+			var events = new List<StreamsReadResp>();
+			await foreach (var evnt in call.ResponseStream.ReadAllAsync()) {
+				if (evnt.ContentCase is StreamsReadResp.ContentOneofCase.Event) {
+					events.Add(evnt);
+					if (events.Count >= count)
+						break;
+				}
+			}
+			return events.ToArray();
+		}
+
+		private static async Task CreateTestPersistentSubscription(
+			PersistentSubscriptions.PersistentSubscriptionsClient client, string streamName, string groupName, CallOptions callOptions) {
+			var settings = new CreateReq.Types.Settings {
+				CheckpointAfterMs = 10000,
+				ExtraStatistics = true,
+				MaxCheckpointCount = 20,
+				MinCheckpointCount = 10,
+				MaxRetryCount = 30,
+				MaxSubscriberCount = 40,
+				MessageTimeoutMs = 20000,
+				HistoryBufferSize = 60,
+				LiveBufferSize = 10,
+				ConsumerStrategy = "Pinned",
+				ReadBatchSize = 50
+			};
+
+			await client.CreateAsync(new CreateReq {
+				Options = new CreateReq.Types.Options {
+					GroupName = groupName,
+					Stream = new CreateReq.Types.StreamOptions {
+						Start = new Empty(),
+						StreamIdentifier = new StreamIdentifier {
+							StreamName = ByteString.CopyFromUtf8(streamName)
+						}
+					},
+					Settings = settings
+				}
+			}, callOptions);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/RestartSubsystemTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/RestartSubsystemTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Client.PersistentSubscriptions;
+using EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.PersistentSubscriptionTests {
+	internal class RestartSubsystemTests {
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class
+			when_restarting_the_persistent_subscription_subsystem<TLogFormat, TStreamId>
+				: GrpcSpecification<TLogFormat, TStreamId> {
+			private PersistentSubscriptions.PersistentSubscriptionsClient _persistentSubscriptionsClient;
+			private Exception _exception;
+
+			protected override Task Given() {
+				_persistentSubscriptionsClient = new PersistentSubscriptions.PersistentSubscriptionsClient(Channel);
+				return Task.CompletedTask;
+			}
+
+			protected override async Task When() {
+				try {
+					await _persistentSubscriptionsClient.RestartSubsystemAsync(new Empty(), GetCallOptions(AdminCredentials));
+				} catch (Exception e) {
+					_exception = e;
+				}
+			}
+
+			[Test]
+			public void should_not_throw_an_exception() {
+				Assert.IsNull(_exception);
+			}
+		}
+
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
@@ -22,7 +22,7 @@ using GrpcMetadata = EventStore.Core.Services.Transport.Grpc.Constants.Metadata;
 namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
 	public abstract class GrpcSpecification<TLogFormat, TStreamId> : IDisposable {
 		private readonly TestServer _server;
-		private readonly GrpcChannel _channel;
+		protected readonly GrpcChannel Channel;
 		private readonly IHost _host;
 		private readonly MiniNode<TLogFormat, TStreamId> _node;
 		protected MiniNode<TLogFormat, TStreamId> Node => _node;
@@ -37,13 +37,13 @@ namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
 					.Configure(_node.Node.Startup.Configure));
 			_host = builder.Start();
 			_server = _host.GetTestServer();
-			_channel = GrpcChannel.ForAddress(new UriBuilder {
+			Channel = GrpcChannel.ForAddress(new UriBuilder {
 				Scheme = Uri.UriSchemeHttps
 			}.Uri, new GrpcChannelOptions {
 				HttpClient = _server.CreateClient(),
 				DisposeHttpClient = true
 			});
-			StreamsClient = new Streams.StreamsClient(_channel);
+			StreamsClient = new Streams.StreamsClient(Channel);
 			_batchAppender = new BatchAppender(StreamsClient);
 		}
 
@@ -104,7 +104,7 @@ namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
 		public void Dispose() {
 			_batchAppender.DisposeAsync().GetAwaiter().GetResult();
 			_server?.Dispose();
-			_channel?.Dispose();
+			Channel?.Dispose();
 			_host?.Dispose();
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Create.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Create.cs
@@ -31,6 +31,15 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			}
 
 			string streamId = null;
+			string consumerStrategy = null;
+			if (settings.ConsumerStrategy is null) { /*for backwards compatibility*/
+			#pragma warning disable 612
+				consumerStrategy = settings.NamedConsumerStrategy.ToString();
+			#pragma warning restore 612
+
+			} else {
+				consumerStrategy = settings.ConsumerStrategy;
+			}
 
 			switch (request.Options.StreamOptionCase)
 			{
@@ -53,6 +62,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						startRevision = new StreamRevision(request.Options.Settings.Revision);
 						#pragma warning restore 612
 					}
+
 					_publisher.Publish(
 						new ClientMessage.CreatePersistentSubscriptionToStream(
 							correlationId,
@@ -84,7 +94,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							settings.MinCheckpointCount,
 							settings.MaxCheckpointCount,
 							settings.MaxSubscriberCount,
-							settings.NamedConsumerStrategy.ToString(),
+							consumerStrategy,
 							user));
 					break;
 				}
@@ -140,7 +150,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							settings.MinCheckpointCount,
 							settings.MaxCheckpointCount,
 							settings.MaxSubscriberCount,
-							settings.NamedConsumerStrategy.ToString(),
+							consumerStrategy,
 							user));
 					break;
 				default:

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Info.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Info.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client.PersistentSubscriptions;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Plugins.Authorization;
+using Grpc.Core;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	internal partial class PersistentSubscriptions {
+		private static readonly Operation GetInfoOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Statistics);
+		public override async Task<GetInfoResp> GetInfo(GetInfoReq request, ServerCallContext context) {
+			var getPersistentSubscriptionInfoSource = new TaskCompletionSource<GetInfoResp>();
+
+			var user = context.GetHttpContext().User;
+
+			if (!await _authorizationProvider.CheckAccessAsync(user,
+				GetInfoOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw RpcExceptions.AccessDenied();
+			}
+
+			string streamId = request.Options.StreamOptionCase switch {
+				GetInfoReq.Types.Options.StreamOptionOneofCase.All => "$all",
+				GetInfoReq.Types.Options.StreamOptionOneofCase.StreamIdentifier => request.Options.StreamIdentifier,
+				_ => throw new InvalidOperationException()
+			};
+
+			_publisher.Publish(new MonitoringMessage.GetPersistentSubscriptionStats(
+				new CallbackEnvelope(HandleGetPersistentSubscriptionStatsCompleted),
+				streamId,
+				request.Options.GroupName));
+			return await getPersistentSubscriptionInfoSource.Task.ConfigureAwait(false);
+
+			void HandleGetPersistentSubscriptionStatsCompleted(Message message) {
+				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+					getPersistentSubscriptionInfoSource.TrySetException(ex);
+					return;
+				}
+
+				if (message is MonitoringMessage.GetPersistentSubscriptionStatsCompleted completed) {
+					switch (completed.Result) {
+						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success:
+							var getInfoResp = new GetInfoResp {
+								SubscriptionInfo = ParseSubscriptionInfo(completed.SubscriptionStats.First())
+							};
+							getPersistentSubscriptionInfoSource.TrySetResult(getInfoResp);
+							return;
+						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound:
+							getPersistentSubscriptionInfoSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
+									request.Options.GroupName));
+							return;
+						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady:
+							getPersistentSubscriptionInfoSource.TrySetException(
+								RpcExceptions.ServerNotReady());
+							return;
+						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Fail:
+							getPersistentSubscriptionInfoSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+									completed.ErrorString));
+							return;
+						default:
+							getPersistentSubscriptionInfoSource.TrySetException(
+								RpcExceptions.UnknownError(completed.Result));
+							return;
+					}
+				}
+				getPersistentSubscriptionInfoSource.TrySetException(
+					RpcExceptions.UnknownMessage<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>(
+						message));
+			}
+		}
+
+		public override async Task<ListResp> List(ListReq request, ServerCallContext context) {
+			var listPersistentSubscriptionsSource = new TaskCompletionSource<ListResp>();
+			var correlationId = Guid.NewGuid();
+
+			var user = context.GetHttpContext().User;
+
+			if (!await _authorizationProvider.CheckAccessAsync(user,
+				GetInfoOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw RpcExceptions.AccessDenied();
+			}
+
+			var streamId = string.Empty;
+			switch (request.Options.ListOptionCase)
+			{
+				case ListReq.Types.Options.ListOptionOneofCase.ListAllSubscriptions:
+					_publisher.Publish(new MonitoringMessage.GetAllPersistentSubscriptionStats(
+						new CallbackEnvelope(HandleListSubscriptionsCompleted)));
+					break;
+				case ListReq.Types.Options.ListOptionOneofCase.ListForStream:
+					streamId = request.Options.ListForStream.StreamOptionCase switch {
+						ListReq.Types.StreamOption.StreamOptionOneofCase.All => "$all",
+						ListReq.Types.StreamOption.StreamOptionOneofCase.Stream => request.Options.ListForStream.Stream,
+						_ => throw new InvalidOperationException()
+					};
+					_publisher.Publish(new MonitoringMessage.GetStreamPersistentSubscriptionStats(
+						new CallbackEnvelope(HandleListSubscriptionsCompleted),
+						streamId
+					));
+					break;
+				default:
+					throw new InvalidOperationException();
+			}
+
+			return await listPersistentSubscriptionsSource.Task.ConfigureAwait(false);
+
+			void HandleListSubscriptionsCompleted(Message message) {
+				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+					listPersistentSubscriptionsSource.TrySetException(ex);
+					return;
+				}
+
+				if (message is MonitoringMessage.GetPersistentSubscriptionStatsCompleted completed) {
+					switch (completed.Result) {
+						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Success:
+							var listResp = new ListResp();
+							listResp.Subscriptions.AddRange(
+								completed.SubscriptionStats.Select(ParseSubscriptionInfo)
+							);
+							listPersistentSubscriptionsSource.TrySetResult(listResp);
+							return;
+						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotFound:
+							listPersistentSubscriptionsSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId, ""));
+							return;
+						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.NotReady:
+							listPersistentSubscriptionsSource.TrySetException(
+								RpcExceptions.ServerNotReady());
+							return;
+						case MonitoringMessage.GetPersistentSubscriptionStatsCompleted.OperationStatus.Fail:
+							listPersistentSubscriptionsSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, "", completed.ErrorString));
+							return;
+						default:
+							listPersistentSubscriptionsSource.TrySetException(
+								RpcExceptions.UnknownError(completed.Result));
+							return;
+					}
+				}
+				listPersistentSubscriptionsSource.TrySetException(
+					RpcExceptions.UnknownMessage<MonitoringMessage.GetPersistentSubscriptionStatsCompleted>(
+						message));
+			}
+		}
+
+		private SubscriptionInfo ParseSubscriptionInfo(MonitoringMessage.PersistentSubscriptionInfo input) {
+			var connectionInfo = new List<SubscriptionInfo.Types.ConnectionInfo>();
+			foreach (var conn in input.Connections) {
+				var connInfo = new SubscriptionInfo.Types.ConnectionInfo {
+					From = conn.From,
+					Username = conn.Username,
+					AverageItemsPerSecond = conn.AverageItemsPerSecond,
+					TotalItems = conn.TotalItems,
+					CountSinceLastMeasurement = conn.CountSinceLastMeasurement,
+					AvailableSlots = conn.AvailableSlots,
+					InFlightMessages = conn.InFlightMessages,
+					ConnectionName = conn.ConnectionName
+				};
+				connInfo.ObservedMeasurements.AddRange(
+					conn.ObservedMeasurements.Select(x => new SubscriptionInfo.Types.Measurement
+						{Key = x.Key, Value = x.Value}));
+				connectionInfo.Add(connInfo);
+			}
+
+			var subscriptionInfo = new SubscriptionInfo {
+				EventSource = input.EventSource,
+				GroupName = input.GroupName,
+				Status = input.Status,
+				AveragePerSecond = input.AveragePerSecond,
+				TotalItems = input.TotalItems,
+				CountSinceLastMeasurement = input.CountSinceLastMeasurement,
+				LastCheckpointedEventPosition = input.LastCheckpointedEventPosition ?? string.Empty,
+				LastKnownEventPosition = input.LastKnownEventPosition ?? string.Empty,
+				ResolveLinkTos = input.ResolveLinktos,
+				StartFrom = input.StartFrom,
+				MessageTimeoutMilliseconds = input.MessageTimeoutMilliseconds,
+				ExtraStatistics = input.ExtraStatistics,
+				MaxRetryCount = input.MaxRetryCount,
+				LiveBufferSize = input.LiveBufferSize,
+				BufferSize = input.BufferSize,
+				ReadBatchSize = input.ReadBatchSize,
+				CheckPointAfterMilliseconds = input.CheckPointAfterMilliseconds,
+				MinCheckPointCount = input.MinCheckPointCount,
+				MaxCheckPointCount = input.MaxCheckPointCount,
+				ReadBufferCount = input.ReadBufferCount,
+				LiveBufferCount = input.LiveBufferCount,
+				RetryBufferCount = input.RetryBufferCount,
+				TotalInFlightMessages = input.TotalInFlightMessages,
+				OutstandingMessagesCount = input.OutstandingMessagesCount,
+				NamedConsumerStrategy = input.NamedConsumerStrategy,
+				MaxSubscriberCount = input.MaxSubscriberCount,
+				ParkedMessageCount = input.ParkedMessageCount,
+			};
+			subscriptionInfo.Connections.AddRange(connectionInfo);
+			return subscriptionInfo;
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.ReplayParked.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.ReplayParked.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading.Tasks;
+using EventStore.Client.PersistentSubscriptions;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Plugins.Authorization;
+using Grpc.Core;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	internal partial class PersistentSubscriptions {
+		private static readonly Operation ReplayParkedOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.ReplayParked);
+		public override async Task<ReplayParkedResp> ReplayParked(ReplayParkedReq request, ServerCallContext context) {
+			var replayParkedMessagesSource = new TaskCompletionSource<ReplayParkedResp>();
+			var correlationId = Guid.NewGuid();
+
+			var user = context.GetHttpContext().User;
+
+			if (!await _authorizationProvider.CheckAccessAsync(user,
+				ReplayParkedOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw RpcExceptions.AccessDenied();
+			}
+
+			string streamId = request.Options.StreamOptionCase switch {
+				ReplayParkedReq.Types.Options.StreamOptionOneofCase.All => "$all",
+				ReplayParkedReq.Types.Options.StreamOptionOneofCase.StreamIdentifier => request.Options.StreamIdentifier,
+				_ => throw new InvalidOperationException()
+			};
+
+			long? stopAt = request.Options.StopAtOptionCase switch {
+				ReplayParkedReq.Types.Options.StopAtOptionOneofCase.StopAt => request.Options.StopAt,
+				ReplayParkedReq.Types.Options.StopAtOptionOneofCase.NoLimit => null,
+				_ => throw new InvalidOperationException()
+			};
+
+			_publisher.Publish(new ClientMessage.ReplayParkedMessages(
+				correlationId,
+				correlationId,
+				new CallbackEnvelope(HandleReplayParkedMessagesCompleted),
+				streamId,
+				request.Options.GroupName,
+				stopAt,
+				user));
+			return await replayParkedMessagesSource.Task.ConfigureAwait(false);
+
+			void HandleReplayParkedMessagesCompleted(Message message) {
+				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+					replayParkedMessagesSource.TrySetException(ex);
+					return;
+				}
+
+				if (message is ClientMessage.ReplayMessagesReceived completed) {
+					switch (completed.Result) {
+						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Success:
+							replayParkedMessagesSource.TrySetResult(new ReplayParkedResp());
+							return;
+						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.DoesNotExist:
+							replayParkedMessagesSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionDoesNotExist(streamId,
+									request.Options.GroupName));
+							return;
+						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.AccessDenied:
+							replayParkedMessagesSource.TrySetException(
+								RpcExceptions.AccessDenied());
+							return;
+						case ClientMessage.ReplayMessagesReceived.ReplayMessagesReceivedResult.Fail:
+							replayParkedMessagesSource.TrySetException(
+								RpcExceptions.PersistentSubscriptionFailed(streamId, request.Options.GroupName,
+									completed.Reason));
+							return;
+
+						default:
+							replayParkedMessagesSource.TrySetException(
+								RpcExceptions.UnknownError(completed.Result));
+							return;
+					}
+				}
+				replayParkedMessagesSource.TrySetException(
+					RpcExceptions.UnknownMessage<ClientMessage.ReplayMessagesReceived>(
+						message));
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.RestartSubsystem.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.RestartSubsystem.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Plugins.Authorization;
+using Grpc.Core;
+
+namespace EventStore.Core.Services.Transport.Grpc {
+	internal partial class PersistentSubscriptions {
+		private static readonly Operation RestartOperation = new Operation(Plugins.Authorization.Operations.Subscriptions.Restart);
+
+		public override async Task<Empty> RestartSubsystem(Empty request, ServerCallContext context) {
+			var restartSubsystemSource = new TaskCompletionSource<Empty>();
+
+			var user = context.GetHttpContext().User;
+
+			if (!await _authorizationProvider.CheckAccessAsync(user,
+				RestartOperation, context.CancellationToken).ConfigureAwait(false)) {
+				throw RpcExceptions.AccessDenied();
+			}
+
+			_publisher.Publish(new SubscriptionMessage.PersistentSubscriptionsRestart(
+				new CallbackEnvelope(HandleRestartSubsystemCompleted)));
+			return await restartSubsystemSource.Task.ConfigureAwait(false);
+
+			void HandleRestartSubsystemCompleted(Message message) {
+				if (message is ClientMessage.NotHandled notHandled &&
+				    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+					restartSubsystemSource.TrySetException(ex);
+					return;
+				}
+
+				switch (message) {
+					case SubscriptionMessage.PersistentSubscriptionsRestarting _:
+						restartSubsystemSource.TrySetResult(new Empty());
+						return;
+					case SubscriptionMessage.InvalidPersistentSubscriptionsRestart fail:
+						restartSubsystemSource.TrySetException(
+							RpcExceptions.PersistentSubscriptionFailed("", "",
+								$"Persistent Subscriptions cannot be restarted as it is in the wrong state."));
+						return;
+					default:
+						restartSubsystemSource.TrySetException(
+							RpcExceptions.UnknownMessage<SubscriptionMessage.PersistentSubscriptionsRestarting>(message));
+						return;
+				}
+			}
+		}
+	}
+}

--- a/src/Protos/Grpc/persistent.proto
+++ b/src/Protos/Grpc/persistent.proto
@@ -9,6 +9,10 @@ service PersistentSubscriptions {
 	rpc Update (UpdateReq) returns (UpdateResp);
 	rpc Delete (DeleteReq) returns (DeleteResp);
 	rpc Read (stream ReadReq) returns (stream ReadResp);
+	rpc GetInfo (GetInfoReq) returns (GetInfoResp);
+	rpc ReplayParked (ReplayParkedReq) returns (ReplayParkedResp);
+	rpc List (ListReq) returns (ListResp);
+	rpc RestartSubsystem (event_store.client.Empty) returns (event_store.client.Empty);
 }
 
 message ReadReq {
@@ -155,7 +159,7 @@ message CreateReq {
 		int32 live_buffer_size = 10;
 		int32 read_batch_size = 11;
 		int32 history_buffer_size = 12;
-		ConsumerStrategy named_consumer_strategy = 13;
+		ConsumerStrategy named_consumer_strategy = 13 [deprecated = true];
 		oneof message_timeout {
 			int64 message_timeout_ticks = 4;
 			int32 message_timeout_ms = 14;
@@ -164,6 +168,7 @@ message CreateReq {
 			int64 checkpoint_after_ticks = 6;
 			int32 checkpoint_after_ms = 15;
 		}
+		string consumer_strategy = 16;
 	}
 
 	enum ConsumerStrategy {
@@ -257,4 +262,109 @@ message DeleteReq {
 }
 
 message DeleteResp {
+}
+
+message GetInfoReq {
+	Options options = 1;
+
+	message Options {
+		oneof stream_option {
+			event_store.client.StreamIdentifier stream_identifier = 1;
+			event_store.client.Empty all = 2;
+		}
+
+		string group_name = 3;
+	}
+}
+
+message GetInfoResp {
+	SubscriptionInfo subscription_info = 1;
+}
+
+message SubscriptionInfo {
+	string event_source = 1;
+	string group_name = 2;
+	string status = 3;
+	repeated ConnectionInfo connections = 4;
+	int32 average_per_second = 5;
+	int64 total_items = 6;
+	int64 count_since_last_measurement = 7;
+	string last_checkpointed_event_position = 8;
+	string last_known_event_position = 9;
+	bool resolve_link_tos = 10;
+	string start_from = 11;
+	int32 message_timeout_milliseconds = 12;
+	bool extra_statistics = 13;
+	int32 max_retry_count = 14;
+	int32 live_buffer_size = 15;
+	int32 buffer_size = 16;
+	int32 read_batch_size = 17;
+	int32 check_point_after_milliseconds = 18;
+	int32 min_check_point_count = 19;
+	int32 max_check_point_count = 20;
+	int32 read_buffer_count = 21;
+	int64 live_buffer_count = 22;
+	int32 retry_buffer_count = 23;
+	int32 total_in_flight_messages = 24;
+	int32 outstanding_messages_count = 25;
+	string named_consumer_strategy = 26;
+	int32 max_subscriber_count = 27;
+	int64 parked_message_count = 28;
+
+	message ConnectionInfo {
+		string from = 1;
+		string username = 2;
+		int32 average_items_per_second = 3;
+		int64 total_items = 4;
+		int64 count_since_last_measurement = 5;
+		repeated Measurement observed_measurements = 6;
+		int32 available_slots = 7;
+		int32 in_flight_messages = 8;
+		string connection_name = 9;
+	}
+
+	message Measurement {
+		string key = 1;
+		int64 value = 2;
+	}
+}
+
+message ReplayParkedReq {
+	Options options = 1;
+
+	message Options {
+		string group_name = 1;
+		oneof stream_option {
+			event_store.client.StreamIdentifier stream_identifier = 2;
+			event_store.client.Empty all = 3;
+		}
+		oneof stop_at_option {
+			int64 stop_at = 4;
+			event_store.client.Empty no_limit = 5;
+		}
+	}
+}
+
+message ReplayParkedResp {
+}
+
+message ListReq {
+	Options options = 1;
+
+	message Options {
+		oneof list_option {
+			event_store.client.Empty list_all_subscriptions = 1;
+			StreamOption list_for_stream = 2;
+		}
+	}
+	message StreamOption {
+		oneof stream_option {
+			event_store.client.StreamIdentifier stream = 1;
+			event_store.client.Empty all = 2;
+		}
+	}
+}
+
+message ListResp {
+	repeated SubscriptionInfo subscriptions = 1;
 }


### PR DESCRIPTION
Added: GetInfo, ReplayParked, List, RestartSubsystem operations to persistent subscription gRPC proto
Added: String ConsumerStrategy property when creating persistent subscriptions over gRPC
Changed: Deprecate NamedConsumerStrategy when creating persistent subscriptions over gRPC

Fixes https://github.com/eventstore/eventstore/issues/3108