### PR TITLE
Use the term "certificate signed by a private CA" instead of "self-signed certificates"

### DIFF
--- a/docs/clustering/README.md
+++ b/docs/clustering/README.md
@@ -46,7 +46,7 @@ Configure cluster nodes to discover other nodes in one of two ways:
 - [via a DNS entry](./using-dns.md) and a well-known [gossip port](./gossip.md#gossip-port)
 - [via a list of addresses](./using-ip-addresses.md) of other cluster nodes
 
-The multi-address DNS name cluster discovery only works for clusters that use self-signed SSL certificates, or run insecure. For other scenarios you need to provide the gossip seed using hostnames of other cluster nodes.
+The multi-address DNS name cluster discovery only works for clusters that use certificates signed by a private certificate authority, or run insecure. For other scenarios you need to provide the gossip seed using hostnames of other cluster nodes.
 
 ## Internal communication
 

--- a/docs/clustering/using-dns.md
+++ b/docs/clustering/using-dns.md
@@ -4,9 +4,9 @@ When you tell EventStoreDB to use DNS for its gossip, the server will resolve th
 
 To use the DNS discovery, you need to set the `ClusterDns` option to the DNS name that allows making an HTTP call to it. When the server starts, it will attempt to make a gRPC call using the `https://<cluster-dns>:<gossip-port>` URL (`http` if the cluster is insecure).
 
-When using a certificate signed by a trusted CA, you'd normally use the wildcard certificate. Ensure that the cluster DNS name fits the wildcard, otherwise the request will fail on SSL check.
+When using a certificate signed by a publicly trusted CA, you'd normally use the wildcard certificate. Ensure that the cluster DNS name fits the wildcard, otherwise the request will fail on SSL check.
 
-When using self-signed certificates, the cluster DNS name must be included to the certificate of each node as SAN (subject alternative name).
+When using certificates signed by a private CA, the cluster DNS name must be included to the certificate of each node as SAN (subject alternative name).
 
 You also need to have the `DiscoverViaDns` option to be set to `true` but it is its default value.
 

--- a/docs/installation/README.md
+++ b/docs/installation/README.md
@@ -8,7 +8,7 @@ EventStoreDB can run as a single node or as a highly-available cluster. For the 
 
 The installation procedure consists of the following steps:
 - Create a configuration file for each cluster node
-- Obtain SSL certificates, either signed by a trusted authority, or self-signed
+- Obtain SSL certificates, either signed by a publicly trusted or private certificate authority
 - Install EventStoreDB on each node using one of the available methods
 - Copy the configuration files and SSL certificates to each node
 - Start the EventStoreDB service on each node

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -88,8 +88,8 @@ You have tell your client to use secure connection for both TCP and gRPC.
 | TCP      | `GossipSeeds=localhost:1111,localhost:1112,localhost:1113;ValidateServer=False;UseSslConnection=True` |
 | gRPC     | `esdb://localhost:2111,localhost:2112,localhost:2113?tls=true&tlsVerifyCert=false`                    |
 
-As you might've noticed, both connection strings have a setting to disable the certificate validation (`ValidateServer=False` for `TCP` and `tlsVerifyCert=false` for `gRPC`). It would prevent the invalid certificate error since the cluster uses self-signed certificates. 
+As you might've noticed, both connection strings have a setting to disable the certificate validation (`ValidateServer=False` for `TCP` and `tlsVerifyCert=false` for `gRPC`). It would prevent the invalid certificate error since the cluster uses a private, auto-generated CA.
 
-However, **we do not recommend using this setting in production**. Instead, you can either add the CA certificated to the trusted root CA store or instruct your application to use such a certificate. See the [instruction of how to do it.](../security/configuration.md#certificate-installation-on-a-client-environment)
+However, **we do not recommend using this setting in production**. Instead, you can either add the CA certificate to the trusted root CA store or instruct your application to use such a certificate. See the [instruction of how to do it.](../security/configuration.md#certificate-installation-on-a-client-environment)
 
 

--- a/docs/security/configuration.md
+++ b/docs/security/configuration.md
@@ -53,7 +53,7 @@ Server certificates **must** have the internal and external IP addresses or DNS 
 
 When getting an incoming connection, the server needs to ensure if the certificate used for the connection can be trusted. For this to work, the server needs to know where trusted root certificates are located.
 
-EventStoreDB will not use the default trusted root certificates store location of the platform. So, even if you use a certificate signed by a public trusted CA, you'd need to explicitly tell the node to use the OS default root certificate store. For self-signed certificates, you just provide the path to the CA certificate file (but not the filename).
+EventStoreDB will not use the default trusted root certificates store location of the platform. So, even if you use a certificate signed by a publicly trusted CA, you'd need to explicitly tell the node to use the OS default root certificate store. For certificates signed by a private CA, you just provide the path to the CA certificate file (but not the filename).
 
 | Format               | Syntax |
 | :------------------- | :----- |
@@ -156,7 +156,7 @@ Import-Certificate -FilePath .\ca.crt -CertStoreLocation Cert:\LocalMachine\CA
 
 ## Certificate Generation CLI
 
-Event Store provides the interactive Certificate Generation CLI, which creates self-signed certificates for EventStoreDB. You can use the [configuration wizard](../installation/README.md), that will provide you exact CLI commands that you need to run to generates certificates matching your configuration. 
+Event Store provides the interactive Certificate Generation CLI, which creates certificates signed by a private, auto-generated CA for EventStoreDB. You can use the [configuration wizard](../installation/README.md), that will provide you exact CLI commands that you need to run to generates certificates matching your configuration. 
 
 ### Getting Started
 
@@ -217,7 +217,7 @@ Example:
 
 #### Generating the Node certificate
 
-You need to generate self-signed certificates for each node. They should be installed only on the specific node machine.
+You need to generate certificates signed by the CA for each node. They should be installed only on the specific node machine.
 
 By default, the tool will create the `ca` directory in the `certs` directory you created. Two keys will be generated:
 - `node.crt` - the public file that needs to be also used for the nodes and client configuration,
@@ -289,11 +289,11 @@ See more in the [complete sample of docker-compose secured cluster configuration
 
 ## Certificate installation on a client environment
 
-To connect to EventStoreDB, you need to install generated CA public certificate on the client machine (e.g. machine where the client is hosted, or your dev environment).
+To connect to EventStoreDB, you need to install the auto-generated CA certificate file on the client machine (e.g. machine where the client is hosted, or your dev environment).
 
 #### Linux (Ubuntu, Debian)
 
-1. Copy generated CA file to dir `/usr/local/share/ca-certificates/`, e.g. using command: 
+1. Copy auto-generated CA file to dir `/usr/local/share/ca-certificates/`, e.g. using command: 
   ```bash
   sudo cp ca.crt /usr/local/share/ca-certificates/event_store_ca.crt
   ```


### PR DESCRIPTION
Fixed: Use the term "certificate signed by a private CA" instead of "self-signed certificates"