### PR TITLE
Update to Grpc 2.41.0 & Protobuf 3.18.0

### DIFF
--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -9,16 +9,16 @@
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
 		<PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
-		<PackageReference Include="Grpc.Core" Version="2.39.1" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
+		<PackageReference Include="Grpc.Core" Version="2.41.0" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.41.0" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.6" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 		<PackageReference Include="CompareNETObjects" Version="4.65.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.15.8" />
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Google.Protobuf" Version="3.18.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.41.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -15,9 +15,9 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="EventStore.Plugins" Version="21.2.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.15.8" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.39.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Google.Protobuf" Version="3.18.0" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.41.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.41.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.LogV3/EventStore.LogV3.csproj
+++ b/src/EventStore.LogV3/EventStore.LogV3.csproj
@@ -7,8 +7,8 @@
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Protobuf" Version="3.15.8" />
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Google.Protobuf" Version="3.18.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.41.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -30,7 +30,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Grpc.Tools" Version="2.41.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -14,9 +14,9 @@
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
 		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="21.2.0" />
 		<PackageReference Include="EventStore.Plugins" Version="21.2.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.15.8" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Google.Protobuf" Version="3.18.0" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.41.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.41.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
Changed: Updated gRPC to include fix for flaky tests