### PR TITLE
Fix chunk end number not being set correctly

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -154,7 +154,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					_chunks[i] = chunk;
 				}
 
-				_chunksCount = chunk.ChunkHeader.ChunkEndNumber + 1;
+				_chunksCount = Math.Max(chunk.ChunkHeader.ChunkEndNumber + 1, _chunksCount);
 
 				TryCacheChunk(chunk);
 			}


### PR DESCRIPTION
Fixed: Set chunk end number to the max between current end number and the added chunk number

This can cause an issue when multiple initialization threads are being used.