### PR TITLE
Expose emitEnabled on create projection request

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -4099,6 +4099,11 @@
                         "id": 2,
                         "name": "track_emitted_streams",
                         "type": "bool"
+                      },
+                      {
+                        "id": 3,
+                        "name": "emit_enabled",
+                        "type": "bool"
                       }
                     ]
                   }

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
@@ -35,7 +35,11 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				_ => throw new InvalidOperationException()
 			};
 			var emitEnabled = options.ModeCase switch {
-				ModeOneofCase.Continuous => options.Continuous.TrackEmittedStreams,
+				ModeOneofCase.Continuous => options.Continuous.EmitEnabled,
+				_ => false
+			};
+			var trackEmittedStreams = (options.ModeCase, emitEnabled) switch {
+				(ModeOneofCase.Continuous, true) => options.Continuous.TrackEmittedStreams,
 				_ => false
 			};
 			var checkpointsEnables = options.ModeCase switch {
@@ -45,10 +49,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				_ => throw new InvalidOperationException()
 			};
 			var enabled = true;
-			var trackEmittedStreams = (options.ModeCase, emitEnabled) switch {
-				(ModeOneofCase.Continuous, false) => true,
-				_ => false
-			};
+
 			var runAs = new ProjectionManagementMessage.RunAs(user);
 
 			var envelope = new CallbackEnvelope(OnMessage);

--- a/src/Protos/Grpc/projections.proto
+++ b/src/Protos/Grpc/projections.proto
@@ -35,6 +35,7 @@ message CreateReq {
 		message Continuous {
 			string name = 1;
 			bool track_emitted_streams = 2;
+			bool emit_enabled = 3;
 		}
 	}
 }


### PR DESCRIPTION
Added: Expose `emitEnabled` on creation of continuous projection.

Closes #2735