### PR TITLE
Backport v20.10: Fix dir enumerate performance regression

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_completed_chunk.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		public override async Task TestFixtureSetUp() {
 			await base.TestFixtureSetUp();
 
-			_config = TFChunkHelper.CreateDbConfigEx(PathName, 1711, 5500, 5500, -1, 1111, 1000, -1);
+			_config = TFChunkHelper.CreateDbConfigEx(PathName, 3711, 5500, 5500, -1, 1111, 1000, -1);
 
 			var rnd = new Random();
 			_file1Contents = new byte[_config.ChunkSize];
@@ -30,6 +30,8 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 
 			DbUtil.CreateSingleChunk(_config, 0, GetFilePathFor("chunk-000000.000001"), contents: _file1Contents);
 			DbUtil.CreateSingleChunk(_config, 1, GetFilePathFor("chunk-000001.000002"), contents: _file2Contents);
+			DbUtil.CreateSingleChunk(_config, 2, GetFilePathFor("chunk-000002.000000"));
+			DbUtil.CreateSingleChunk(_config, 3, GetFilePathFor("chunk-000003.000000"));
 
 			var truncator = new TFChunkDbTruncator(_config);
 			truncator.TruncateDb(_config.TruncateCheckpoint.ReadNonFlushed());
@@ -73,7 +75,7 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 		}
 
 		[Test]
-		public void all_chunks_are_preserved() {
+		public void chunks_after_truncation_point_are_deleted() {
 			Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000001")));
 			Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000001.000002")));
 			Assert.AreEqual(2, Directory.GetFiles(PathName, "*").Length);

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/when_truncating_into_the_middle_of_multichunk.cs
@@ -20,9 +20,13 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000001"));
 			DbUtil.CreateMultiChunk(_config, 0, 2, GetFilePathFor("chunk-000000.000002"));
+			DbUtil.CreateSingleChunk(_config, 3, GetFilePathFor("chunk-000003.000000"));
 			DbUtil.CreateMultiChunk(_config, 3, 10, GetFilePathFor("chunk-000003.000001"));
 			DbUtil.CreateMultiChunk(_config, 3, 10, GetFilePathFor("chunk-000003.000002"));
-			DbUtil.CreateMultiChunk(_config, 7, 8, GetFilePathFor("chunk-000007.000001"));
+			DbUtil.CreateSingleChunk(_config, 4, GetFilePathFor("chunk-000004.000000"));
+			DbUtil.CreateMultiChunk(_config, 4, 4, GetFilePathFor("chunk-000004.000002"));
+			DbUtil.CreateMultiChunk(_config, 5, 7, GetFilePathFor("chunk-000005.000001"));
+			DbUtil.CreateMultiChunk(_config, 8, 9, GetFilePathFor("chunk-000008.000001"));
 			DbUtil.CreateOngoingChunk(_config, 11, GetFilePathFor("chunk-000011.000000"));
 
 			var truncator = new TFChunkDbTruncator(_config);

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db_with_multi_chunks.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db_with_multi_chunks.cs
@@ -35,11 +35,11 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			var config = TFChunkHelper.CreateDbConfig(PathName, 30000);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
-				DbUtil.CreateMultiChunk(config, 1, 2, GetFilePathFor("chunk-000001.000000"));
+				DbUtil.CreateMultiChunk(config, 1, 2, GetFilePathFor("chunk-000001.000001"));
 				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
 
 				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000000")));
-				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000001.000000")));
+				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000001.000001")));
 				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000003.000000")));
 				Assert.AreEqual(3, Directory.GetFiles(PathName, "*").Length);
 			}
@@ -49,11 +49,11 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		public void allows_next_new_chunk_when_checksum_is_exactly_in_between_two_chunks_if_last_is_ongoing_chunk() {
 			var config = TFChunkHelper.CreateDbConfig(PathName, 20000);
 			using (var db = new TFChunkDb(config)) {
-				DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
+				DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000001"));
 				DbUtil.CreateOngoingChunk(config, 2, GetFilePathFor("chunk-000002.000000"));
 				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
 
-				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000000")));
+				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000001")));
 				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000002.000000")));
 				Assert.AreEqual(2, Directory.GetFiles(PathName, "*").Length);
 			}
@@ -78,16 +78,18 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			File.Create(GetFilePathFor("foo")).Close();
 			File.Create(GetFilePathFor("bla")).Close();
 
-			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 350, chunkSize: 100);
+			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 450, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000002"));
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000005"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000000"));
-				DbUtil.CreateMultiChunk(config, 1, 2, GetFilePathFor("chunk-000001.000001"));
+				DbUtil.CreateMultiChunk(config, 1, 3, GetFilePathFor("chunk-000001.000001"));
 				DbUtil.CreateSingleChunk(config, 2, GetFilePathFor("chunk-000002.000000"));
-				DbUtil.CreateSingleChunk(config, 3, GetFilePathFor("chunk-000003.000007"));
-				DbUtil.CreateOngoingChunk(config, 3, GetFilePathFor("chunk-000003.000008"));
+				DbUtil.CreateSingleChunk(config, 3, GetFilePathFor("chunk-000003.000000"));
+				DbUtil.CreateSingleChunk(config, 3, GetFilePathFor("chunk-000003.000001"));
+				DbUtil.CreateSingleChunk(config, 4, GetFilePathFor("chunk-000004.000007"));
+				DbUtil.CreateOngoingChunk(config, 4, GetFilePathFor("chunk-000004.000008"));
 
 				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
 
@@ -95,7 +97,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 				Assert.IsTrue(File.Exists(GetFilePathFor("bla")));
 				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000005")));
 				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000001.000001")));
-				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000003.000008")));
+				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000004.000008")));
 				Assert.AreEqual(5, Directory.GetFiles(PathName, "*").Length);
 			}
 		}
@@ -105,12 +107,12 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_not_present_but_should_be_created() {
 			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
-				DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
+				DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000001"));
 
 				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
 				Assert.IsNotNull(db.Manager.GetChunk(2));
 
-				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000000")));
+				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000001")));
 				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000002.000000")));
 				Assert.AreEqual(2, Directory.GetFiles(PathName, "*").Length);
 			}
@@ -120,13 +122,13 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		public void when_checkpoint_is_exactly_on_the_boundary_of_chunk_the_last_chunk_could_be_present() {
 			var config = TFChunkHelper.CreateSizedDbConfig(PathName, 200, chunkSize: 100);
 			using (var db = new TFChunkDb(config)) {
-				DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000000"));
+				DbUtil.CreateMultiChunk(config, 0, 1, GetFilePathFor("chunk-000000.000002"));
 				DbUtil.CreateOngoingChunk(config, 2, GetFilePathFor("chunk-000002.000001"));
 
 				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
 				Assert.IsNotNull(db.Manager.GetChunk(2));
 
-				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000000")));
+				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000000.000002")));
 				Assert.IsTrue(File.Exists(GetFilePathFor("chunk-000002.000001")));
 				Assert.AreEqual(2, Directory.GetFiles(PathName, "*").Length);
 			}

--- a/src/EventStore.Core.Tests/TransactionLog/versioned_pattern_filenaming_strategy.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/versioned_pattern_filenaming_strategy.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
 using NUnit.Framework;
@@ -140,6 +141,38 @@ namespace EventStore.Core.Tests.TransactionLog {
 			Assert.AreEqual(2, tempFiles.Length);
 			Assert.AreEqual(tmp[0], tempFiles[0]);
 			Assert.AreEqual(tmp[1], tempFiles[1]);
+		}
+
+		[Test]
+		public void returns_file_index_for_correctly_formatted_filename() {
+			var strategy = new VersionedPatternFileNamingStrategy(PathName, "chunk-");
+			Assert.AreEqual(0, strategy.GetIndexFor("chunk-000000.000000"));
+			Assert.AreEqual(1, strategy.GetIndexFor("chunk-000001.000000"));
+			Assert.AreEqual(999999, strategy.GetIndexFor("chunk-999999.000000"));
+		}
+
+		[Test]
+		public void returns_file_version_for_correctly_formatted_filename() {
+			var strategy = new VersionedPatternFileNamingStrategy(PathName, "chunk-");
+			Assert.AreEqual(0, strategy.GetVersionFor("chunk-000002.000000"));
+			Assert.AreEqual(1, strategy.GetVersionFor("chunk-000002.000001"));
+			Assert.AreEqual(999999, strategy.GetVersionFor("chunk-000002.999999"));
+		}
+
+		[Test]
+		public void throws_for_incorrectly_formatted_filename() {
+			var strategy = new VersionedPatternFileNamingStrategy(PathName, "chunk-");
+			Assert.Throws<ArgumentException>(() => strategy.GetIndexFor("chunk-000000.a"));
+			Assert.Throws<ArgumentException>(() => strategy.GetIndexFor("chunk-00000a.000000"));
+			Assert.Throws<ArgumentException>(() => strategy.GetIndexFor("chunk-a.000000"));
+			Assert.Throws<ArgumentException>(() => strategy.GetIndexFor("chunk-000000.00000a"));
+			Assert.Throws<ArgumentException>(() => strategy.GetIndexFor("chunks-000000.00000a"));
+			Assert.Throws<ArgumentException>(() => strategy.GetVersionFor("chunk-000000.a"));
+			Assert.Throws<ArgumentException>(() => strategy.GetVersionFor("chunk-00000a.000000"));
+			Assert.Throws<ArgumentException>(() => strategy.GetVersionFor("chunk-a.000000"));
+			Assert.Throws<ArgumentException>(() => strategy.GetVersionFor("chunk-000000.00000a"));
+			Assert.Throws<ArgumentException>(() => strategy.GetVersionFor("chunks-000000.00000a"));
+			Assert.Throws<ArgumentException>(() => strategy.GetVersionFor("chunks-000000.000000"));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/with_tfchunk_enumerator.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/with_tfchunk_enumerator.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog {
+	[TestFixture]
+	public class with_tfchunk_enumerator : SpecificationWithDirectory {
+
+		[Test]
+		public void iterates_chunks_with_correct_callback_order() {
+			File.Create(GetFilePathFor("foo")).Close(); // should be ignored
+			File.Create(GetFilePathFor("bla")).Close(); // should be ignored
+			File.Create(GetFilePathFor("chunk-000001.000000.tmp")).Close(); // should be ignored
+			File.Create(GetFilePathFor("chunk-001.000")).Close(); // should be ignored
+
+			// chunk 0 is missing
+			File.Create(GetFilePathFor("chunk-000001.000000")).Close(); // chunks 1 - 1 (latest)
+			File.Create(GetFilePathFor("chunk-000002.000001")).Close(); // chunks 2 - 2 (latest)
+			// chunks 3 & 4 are missing
+			File.Create(GetFilePathFor("chunk-000005.000000")).Close(); // chunks 5 - 5 (old)
+			File.Create(GetFilePathFor("chunk-000005.000001")).Close(); // chunks 5 - 6 (old)
+			File.Create(GetFilePathFor("chunk-000005.000002")).Close(); // chunks 5 - 7 (latest)
+			File.Create(GetFilePathFor("chunk-000006.000000")).Close(); // chunks 6 - 6 (old)
+			// chunk 7 is not missing - it's merged with chunk 5
+			File.Create(GetFilePathFor("chunk-000008.000007")).Close(); // chunks 8 - 8 (latest)
+			// chunk 9 is missing
+			File.Create(GetFilePathFor("chunk-000010.000005")).Close(); // chunks 10 - 14 (latest)
+			// chunks 15 & 16 are missing
+
+			var strategy = new VersionedPatternFileNamingStrategy(PathName, "chunk-");
+			var chunkEnumerator = new TFChunkEnumerator(strategy);
+			var result = new List<string>();
+			int GetNextFileNumber((string chunk, int chunkNumber, int chunkVersion) t) {
+				return Path.GetFileName(t.chunk) switch {
+					"chunk-000001.000000" => 2,
+					"chunk-000002.000001" => 3,
+					"chunk-000005.000000" => 6,
+					"chunk-000005.000001" => 7,
+					"chunk-000005.000002" => 8,
+					"chunk-000006.000000" => 7,
+					"chunk-000008.000007" => 9,
+					"chunk-000010.000005" => 15,
+					_ => throw new Exception($"Unexpected file: {t.chunk}")
+				};
+			}
+
+			foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(16, GetNextFileNumber)) {
+				switch (chunkInfo) {
+					case LatestVersion(var fileName, var start, var end):
+						result.Add($"latest {Path.GetFileName(fileName)} {start}-{end}");
+						break;
+					case OldVersion(var fileName, var start):
+						result.Add($"old {Path.GetFileName(fileName)} {start}");
+						break;
+					case MissingVersion(var fileName, var start):
+						result.Add($"missing {Path.GetFileName(fileName)} {start}");
+						break;
+					default:
+						throw new ArgumentOutOfRangeException(nameof(chunkInfo));
+				}
+			}
+
+			var expectedResult = new List<string> {
+				"missing chunk-000000.000000 0",
+				"latest chunk-000001.000000 1-1",
+				"latest chunk-000002.000001 2-2",
+				"missing chunk-000003.000000 3",
+				"missing chunk-000004.000000 4",
+				"old chunk-000005.000000 5",
+				"old chunk-000005.000001 5",
+				"latest chunk-000005.000002 5-7",
+				"old chunk-000006.000000 6",
+				"latest chunk-000008.000007 8-8",
+				"missing chunk-000009.000000 9",
+				"latest chunk-000010.000005 10-14",
+				"missing chunk-000015.000000 15",
+				"missing chunk-000016.000000 16"
+			};
+			Assert.AreEqual(expectedResult, result);
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbConfig.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly ICheckpoint TruncateCheckpoint;
 		public readonly ICheckpoint ReplicationCheckpoint;
 		public readonly ICheckpoint IndexCheckpoint;
-		public readonly IFileNamingStrategy FileNamingStrategy;
+		public readonly IVersionedFileNamingStrategy FileNamingStrategy;
 		public readonly bool InMemDb;
 		public readonly bool Unbuffered;
 		public readonly bool WriteThrough;
@@ -25,7 +25,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly long MaxTruncation;
 
 		public TFChunkDbConfig(string path,
-			IFileNamingStrategy fileNamingStrategy,
+			IVersionedFileNamingStrategy fileNamingStrategy,
 			int chunkSize,
 			long maxChunksCacheSize,
 			ICheckpoint writerCheckpoint,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkEnumerator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkEnumerator.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using EventStore.Core.Exceptions;
+using EventStore.Core.TransactionLog.FileNamingStrategy;
+
+namespace EventStore.Core.TransactionLog.Chunks {
+	public class TFChunkEnumerator {
+		private readonly IVersionedFileNamingStrategy _chunkFileNamingStrategy;
+		private string[] _allFiles;
+		private readonly Dictionary<string, int> _nextChunkNumber;
+
+		public TFChunkEnumerator(IVersionedFileNamingStrategy chunkFileNamingStrategy) {
+			_chunkFileNamingStrategy = chunkFileNamingStrategy;
+			_allFiles = null;
+			_nextChunkNumber = new Dictionary<string, int>();
+		}
+
+		public IEnumerable<TFChunkInfo> EnumerateChunks(int lastChunkNumber,
+			Func<(string fileName, int fileStartNumber, int fileVersion), int> getNextChunkNumber = null) {
+			getNextChunkNumber ??= GetNextChunkNumber;
+
+			if (_allFiles == null) {
+				var allFiles = _chunkFileNamingStrategy.GetAllPresentFiles();
+				Array.Sort(allFiles, StringComparer.CurrentCultureIgnoreCase);
+				_allFiles = allFiles;
+			}
+
+			int expectedChunkNumber = 0;
+			for (int i = 0; i < _allFiles.Length; i++) {
+				var chunkFileName = _allFiles[i];
+				var chunkNumber = _chunkFileNamingStrategy.GetIndexFor(Path.GetFileName(_allFiles[i]));
+				var nextChunkNumber = -1;
+				if (i + 1 < _allFiles.Length)
+					nextChunkNumber = _chunkFileNamingStrategy.GetIndexFor(Path.GetFileName(_allFiles[i+1]));
+
+				if (chunkNumber < expectedChunkNumber) { // present in an earlier, merged, chunk
+					yield return new OldVersion(chunkFileName, chunkNumber);
+					continue;
+				}
+
+				if (chunkNumber > expectedChunkNumber) { // one or more chunks are missing
+					for (int j = expectedChunkNumber; j < chunkNumber; j++) {
+						yield return new MissingVersion(_chunkFileNamingStrategy.GetFilenameFor(j, 0), j);
+					}
+					// set the expected chunk number to prevent calling onFileMissing() again for the same chunk numbers
+					expectedChunkNumber = chunkNumber;
+				}
+
+				if (chunkNumber == nextChunkNumber) { // there is a newer version of this chunk
+					yield return new OldVersion(chunkFileName, chunkNumber);
+				} else { // latest version of chunk with the expected chunk number
+					expectedChunkNumber = getNextChunkNumber((chunkFileName, chunkNumber, _chunkFileNamingStrategy.GetVersionFor(Path.GetFileName(chunkFileName))));
+					yield return new LatestVersion(chunkFileName, chunkNumber, expectedChunkNumber - 1);
+				}
+			}
+
+			for (int i = expectedChunkNumber; i <= lastChunkNumber; i++) {
+				yield return new MissingVersion(_chunkFileNamingStrategy.GetFilenameFor(i, 0), i);
+			}
+		}
+
+		private int GetNextChunkNumber((string chunkFileName, int chunkNumber, int chunkVersion) t) {
+			if (t.chunkVersion == 0)
+				return t.chunkNumber + 1;
+
+			// we only cache next chunk numbers for chunks having a non-zero version
+			if (_nextChunkNumber.TryGetValue(t.chunkFileName, out var nextChunkNumber))
+				return nextChunkNumber;
+
+			var header = ReadChunkHeader(t.chunkFileName);
+			_nextChunkNumber[t.chunkFileName] = header.ChunkEndNumber + 1;
+			return header.ChunkEndNumber + 1;
+		}
+
+		private static ChunkHeader ReadChunkHeader(string chunkFileName) {
+			ChunkHeader chunkHeader;
+			using (var fs = new FileStream(chunkFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite)) {
+				if (fs.Length < ChunkFooter.Size + ChunkHeader.Size) {
+					throw new CorruptDatabaseException(new BadChunkInDatabaseException(
+						$"Chunk file '{chunkFileName}' is bad. It does not have enough size for header and footer. File size is {fs.Length} bytes."));
+				}
+				chunkHeader = ChunkHeader.FromStream(fs);
+			}
+
+			return chunkHeader;
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkInfo.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkInfo.cs
@@ -1,0 +1,6 @@
+namespace EventStore.Core.TransactionLog.Chunks {
+	public record TFChunkInfo(string fileName);
+	public record LatestVersion(string fileName, int start, int end) : TFChunkInfo(fileName);
+	public record OldVersion(string fileName, int start) : TFChunkInfo(fileName);
+	public record MissingVersion(string fileName, int start) : TFChunkInfo(fileName);
+}

--- a/src/EventStore.Core/TransactionLog/FileNamingStrategy/IVersionedFileNamingStrategy.cs
+++ b/src/EventStore.Core/TransactionLog/FileNamingStrategy/IVersionedFileNamingStrategy.cs
@@ -1,11 +1,12 @@
 namespace EventStore.Core.TransactionLog.FileNamingStrategy {
-	public interface IFileNamingStrategy {
+	public interface IVersionedFileNamingStrategy {
 		string GetFilenameFor(int index, int version);
 		string DetermineBestVersionFilenameFor(int index);
 		string[] GetAllVersionsFor(int index);
 		string[] GetAllPresentFiles();
-
 		string GetTempFilename();
 		string[] GetAllTempFiles();
+		int GetIndexFor(string fileName);
+		int GetVersionFor(string fileName);
 	}
 }


### PR DESCRIPTION
Fixed: Directory.EnumerateFiles regression causing slower startup/truncation times on large databases

Backport of #3363