### PR TITLE
Backport v21.2: Fix overwriting CI container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         registry: https://docker.pkg.github.com
     - name: Docker Push CI
       uses: jen20/action-docker-build@v1
-      if: github.event_name == 'push' && matrix.container-runtime == 'focal'
+      if: github.event_name == 'push' && matrix.container-runtime == 'focal' && github.ref == 'refs/heads/master'
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixed: Only build CI container on master branch

The CI build on `release/oss-v21.2` is getting triggered and also needs the above fix.

Backport of #3378