### PR TITLE
[Cherry-pick oss-v21.10] Add Current Stream Version to DeleteStreamCompleted

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -549,6 +549,11 @@
                 "id": 4,
                 "name": "commit_position",
                 "type": "int64"
+              },
+              {
+                "id": 5,
+                "name": "current_version",
+                "type": "int64"
               }
             ]
           },

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithExistingEvents.cs
@@ -450,14 +450,14 @@ namespace EventStore.Core.Tests.Helpers {
 			List<EventRecord> list;
 			if (_deletedStreams.Contains(message.EventStreamId)) {
 				message.Envelope.ReplyWith(new ClientMessage.DeleteStreamCompleted(message.CorrelationId,
-					OperationResult.StreamDeleted, string.Empty, -1, -1));
+					OperationResult.StreamDeleted, string.Empty, -1, -1, -1));
 				return;
 			}
 
 			if (!_streams.TryGetValue(message.EventStreamId, out list) || list == null) {
 				if (message.ExpectedVersion == ExpectedVersion.Any) {
 					message.Envelope.ReplyWith(new ClientMessage.DeleteStreamCompleted(message.CorrelationId,
-						OperationResult.StreamDeleted, string.Empty, -1, -1));
+						OperationResult.StreamDeleted, string.Empty, -1, -1, -1));
 					_deletedStreams.Add(message.EventStreamId);
 					return;
 				}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_wrong_expected_version.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/DeleteMgr/when_delete_stream_completes_wrong_expected_version.cs
@@ -3,16 +3,17 @@ using System.Collections.Generic;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services.RequestManager.Managers;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
-using EventStore.Core.Services.RequestManager.Managers;
 
 namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 	[TestFixture]
-	public class when_delete_stream_completes_successfully : RequestManagerSpecification<DeleteStream> {
+	public class when_delete_stream_completes_wrong_expected_version : RequestManagerSpecification<DeleteStream> {
 		private long commitPosition = 1000;
 		private readonly string _streamId = $"DeleteTest-{Guid.NewGuid()}";
+
 		protected override DeleteStream OnManager(FakePublisher publisher) {
 			return new DeleteStream(
 				publisher,
@@ -20,8 +21,8 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 				Envelope,
 				InternalCorrId,
 				ClientCorrId,
-			   	streamId: _streamId,
-				expectedVersion: ExpectedVersion.Any,
+				streamId: _streamId,
+				expectedVersion: 10,
 				hardDelete: false,
 				commitSource: CommitSource);
 		}
@@ -31,19 +32,21 @@ namespace EventStore.Core.Tests.Services.RequestManagement.DeleteMgr {
 		}
 
 		protected override Message When() {
-			return new ReplicationTrackingMessage.IndexedTo(commitPosition);
+			return new StorageMessage.WrongExpectedVersion(InternalCorrId, 3);
 		}
 
 		[Test]
-		public void successful_request_message_is_published() {
+		public void failed_request_message_is_published() {
 			Assert.That(Produced.ContainsSingle<StorageMessage.RequestCompleted>(
-				x => x.CorrelationId == InternalCorrId && x.Success));
+				x => x.CorrelationId == InternalCorrId && !x.Success));
 		}
 
 		[Test]
-		public void the_envelope_is_replied_to_with_success() {
+		public void the_envelope_is_replied_to_with_wrong_expected_version() {
 			Assert.That(Envelope.Replies.ContainsSingle<ClientMessage.DeleteStreamCompleted>(
-				x => x.CorrelationId == ClientCorrId && x.Result == OperationResult.Success && x.CurrentVersion == 3));
+				x => x.CorrelationId == ClientCorrId &&
+				     x.Result == OperationResult.WrongExpectedVersion &&
+				     x.CurrentVersion == 3));
 		}
 	}
 }

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -487,23 +487,25 @@ namespace EventStore.Core.Messages {
 			public readonly string Message;
 			public readonly long PreparePosition;
 			public readonly long CommitPosition;
+			public readonly long CurrentVersion;
 
 			public DeleteStreamCompleted(Guid correlationId, OperationResult result, string message,
-				long preparePosition, long commitPosition) {
+				long currentVersion, long preparePosition, long commitPosition) {
 				CorrelationId = correlationId;
 				Result = result;
 				Message = message;
+				CurrentVersion = currentVersion;
 				PreparePosition = preparePosition;
 				CommitPosition = commitPosition;
 			}
 
-			public DeleteStreamCompleted(Guid correlationId, OperationResult result, string message) : this(
-				correlationId, result, message, -1, -1) {
+			public DeleteStreamCompleted(Guid correlationId, OperationResult result, string message,
+				long currentVersion = -1L) : this(correlationId, result, message, currentVersion, -1, -1) {
 			}
 
-
 			public DeleteStreamCompleted WithCorrelationId(Guid newCorrId) {
-				return new DeleteStreamCompleted(newCorrId, Result, Message, PreparePosition, CommitPosition);
+				return new DeleteStreamCompleted(newCorrId, Result, Message, CurrentVersion, PreparePosition,
+					CommitPosition);
 			}
 		}
 

--- a/src/EventStore.Core/Messages/TcpClientMessageDto.cs
+++ b/src/EventStore.Core/Messages/TcpClientMessageDto.cs
@@ -249,13 +249,17 @@ namespace EventStore.Core.Messages
   
     [ProtoMember(4, IsRequired = false, Name=@"commit_position", DataFormat = DataFormat.TwosComplement)]
     public readonly long? CommitPosition;
+
+    [ProtoMember(5, IsRequired = false, Name=@"current_version", DataFormat = DataFormat.TwosComplement)]
+    public readonly long? CurrentVersion;
   
     private DeleteStreamCompleted() {}
   
-    public DeleteStreamCompleted(OperationResult result, string message, long? preparePosition, long? commitPosition)
+    public DeleteStreamCompleted(OperationResult result, string message, long? currentVersion, long? preparePosition, long? commitPosition)
     {
         Result = result;
         Message = message;
+        CurrentVersion = currentVersion;
         PreparePosition = preparePosition;
         CommitPosition = commitPosition;
     }

--- a/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/DeleteStream.cs
@@ -50,10 +50,11 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 				 ClientCorrId,
 				 OperationResult.Success,
 				 null,
+				 LastEventNumber,
 				 CommitPosition,  //not technically correct, but matches current behavior correctly
 				 CommitPosition);
 
 		protected override Message ClientFailMsg =>
-			new ClientMessage.DeleteStreamCompleted(ClientCorrId, Result, FailureMessage);
+			new ClientMessage.DeleteStreamCompleted(ClientCorrId, Result, FailureMessage, FailureCurrentVersion);
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -113,7 +113,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					return;
 				}
 
-				if (!(message is ClientMessage.DeleteStreamCompleted completed)) {
+				if (message is not ClientMessage.DeleteStreamCompleted completed) {
 					deleteResponseSource.TrySetException(
 						RpcExceptions.UnknownMessage<ClientMessage.DeleteStreamCompleted>(message));
 					return;
@@ -133,7 +133,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						return;
 					case OperationResult.WrongExpectedVersion:
 						deleteResponseSource.TrySetException(RpcExceptions.WrongExpectedVersion(streamName,
-							expectedVersion));
+							expectedVersion, completed.CurrentVersion));
 						return;
 					case OperationResult.StreamDeleted:
 						deleteResponseSource.TrySetException(RpcExceptions.StreamDeleted(streamName));

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -409,7 +409,10 @@ namespace EventStore.Core.Services.Transport.Http {
 					case OperationResult.ForwardTimeout:
 						return InternalServerError("Delete timeout");
 					case OperationResult.WrongExpectedVersion:
-						return BadRequest("Wrong expected EventNumber");
+						return new ResponseConfiguration(HttpStatusCode.BadRequest, "Wrong expected EventNumber",
+							"text/plain", Helper.UTF8NoBom,
+							new KeyValuePair<string, string>(SystemHeaders.CurrentVersion,
+								msg.CurrentVersion.ToString()));
 					case OperationResult.StreamDeleted:
 						return Gone("Stream deleted");
 					case OperationResult.InvalidTransaction:

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientWriteTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientWriteTcpDispatcher.cs
@@ -284,6 +284,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			if (dto == null) return null;
 			return new ClientMessage.DeleteStreamCompleted(package.CorrelationId, (OperationResult)dto.Result,
 				dto.Message,
+				dto.CurrentVersion ?? -1,
 				dto.PreparePosition ?? -1,
 				dto.CommitPosition ?? -1);
 		}
@@ -291,6 +292,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private static TcpPackage WrapDeleteStreamCompleted(ClientMessage.DeleteStreamCompleted msg) {
 			var dto = new TcpClientMessageDto.DeleteStreamCompleted((TcpClientMessageDto.OperationResult)msg.Result,
 				msg.Message,
+				msg.CurrentVersion,
 				msg.PreparePosition,
 				msg.CommitPosition);
 			return new TcpPackage(TcpCommand.DeleteStreamCompleted, msg.CorrelationId, dto.Serialize());

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -812,7 +812,7 @@ namespace EventStore.Core.Services.VNode {
 			}
 
 			var timeoutMessage = new ClientMessage.DeleteStreamCompleted(
-				message.CorrelationId, OperationResult.ForwardTimeout, "Forwarding timeout", -1, -1);
+				message.CorrelationId, OperationResult.ForwardTimeout, "Forwarding timeout", -1, -1, -1);
 			ForwardRequest(message, timeoutMessage);
 		}
 
@@ -934,7 +934,7 @@ namespace EventStore.Core.Services.VNode {
 				return;
 			}
 			var timeoutMessage = new ClientMessage.DeleteStreamCompleted(
-				message.CorrelationId, OperationResult.ForwardTimeout, "Forwarding timeout", -1, -1);
+				message.CorrelationId, OperationResult.ForwardTimeout, "Forwarding timeout", -1, -1, -1);
 			ForwardRequest(message, timeoutMessage);
 		}
 

--- a/src/Protos/ClientAPI/ClientMessageDtos.proto
+++ b/src/Protos/ClientAPI/ClientMessageDtos.proto
@@ -77,6 +77,7 @@ message DeleteStreamCompleted {
 	optional string message = 2;
 	optional int64 prepare_position = 3;
 	optional int64 commit_position = 4;
+	optional int64 current_version = 5;
 }
 
 message TransactionStart {


### PR DESCRIPTION
Fixed: include current stream revision on internal delete messages

Cherry picks https://github.com/EventStore/EventStore/pull/3401 to oss-v21.10