### PR TITLE
Return Error if TrackEmittedStreams and !EmitEnabled

### DIFF
--- a/proto.lock
+++ b/proto.lock
@@ -4097,12 +4097,12 @@
                       },
                       {
                         "id": 2,
-                        "name": "track_emitted_streams",
+                        "name": "emit_enabled",
                         "type": "bool"
                       },
                       {
                         "id": 3,
-                        "name": "emit_enabled",
+                        "name": "track_emitted_streams",
                         "type": "bool"
                       }
                     ]

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
@@ -38,31 +38,32 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				ModeOneofCase.Continuous => options.Continuous.EmitEnabled,
 				_ => false
 			};
-			var trackEmittedStreams = (options.ModeCase, emitEnabled) switch {
-				(ModeOneofCase.Continuous, true) => options.Continuous.TrackEmittedStreams,
+			var trackEmittedStreams = (options.ModeCase, emitEnabled, options.Continuous.TrackEmittedStreams) switch {
+				(ModeOneofCase.Continuous, true, true) => true,
+				(ModeOneofCase.Continuous, false, true) =>
+					throw new InvalidOperationException("EmitEnabled must be set to true to track emitted streams."),
 				_ => false
 			};
-			var checkpointsEnables = options.ModeCase switch {
+			var checkpointsEnabled = options.ModeCase switch {
 				ModeOneofCase.Continuous => true,
 				ModeOneofCase.OneTime => false,
 				ModeOneofCase.Transient => false,
 				_ => throw new InvalidOperationException()
 			};
-			var enabled = true;
 
 			var runAs = new ProjectionManagementMessage.RunAs(user);
 
 			var envelope = new CallbackEnvelope(OnMessage);
 
 			_queue.Publish(new ProjectionManagementMessage.Command.Post(envelope, projectionMode, name, runAs,
-				handlerType, options.Query, enabled, checkpointsEnables, emitEnabled, trackEmittedStreams, true));
+				handlerType, options.Query, true, checkpointsEnabled, emitEnabled, trackEmittedStreams, true));
 
 			await createdSource.Task.ConfigureAwait(false);
 
 			return new CreateResp();
 
 			void OnMessage(Message message) {
-				if (!(message is ProjectionManagementMessage.Updated)) {
+				if (message is not ProjectionManagementMessage.Updated) {
 					createdSource.TrySetException(UnknownMessage<ProjectionManagementMessage.Updated>(message));
 					return;
 				}

--- a/src/Protos/Grpc/projections.proto
+++ b/src/Protos/Grpc/projections.proto
@@ -34,8 +34,8 @@ message CreateReq {
 		}
 		message Continuous {
 			string name = 1;
-			bool track_emitted_streams = 2;
-			bool emit_enabled = 3;
+			bool emit_enabled = 2;
+			bool track_emitted_streams = 3;
 		}
 	}
 }


### PR DESCRIPTION
Changed: Reject gRPC call to create a projection if `TrackEmittedStreams=true` and `EmitEnabled=false`
Changed: Proto names of `emit_enabled` and `track_emitted_streams` swapped for backwards compatibility

This PR swaps the names of EmitEnabled and TrackEmittedStreams in the proto because what the server used to refer to as TrackEmittedStreams is, in fact, the correct behavior for EmitEnabled. This makes the recent change to 'Add EmitEnabled' really mean 'Add TrackEmittedStreams.'

Therefore clients that were relying on the old behavior and just sending `TrackEmittedStreams=true` to enable emitting when creating a projection, will continue to work after upgrading the server.

However, they will run into a change of behavior (because of the bug fix) when they upgrade the client library, so we have made the server throw in this case to make it more obvious that a code change is necessary.