### PR TITLE
Update the epoch checkpoint with the proper position before going offline for truncation

### DIFF
--- a/src/EventStore.Core.Tests/Services/ElectionsService/FakeEpochManager.cs
+++ b/src/EventStore.Core.Tests/Services/ElectionsService/FakeEpochManager.cs
@@ -52,8 +52,6 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			}
 		}
 
-		
-
 		public bool IsCorrectEpochAt(long epochPosition, int epochNumber, Guid epochId) {
 			throw new NotImplementedException();
 		}
@@ -68,10 +66,8 @@ namespace EventStore.Core.Tests.Services.ElectionsService {
 			}
 		}
 
-		public IEnumerable<EpochRecord> GetCachedEpochs() {
-			lock (_epochs) {
-				return _epochs.AsReadOnly();
-			}
+		public bool TryTruncateBefore(long position, out EpochRecord epoch) {
+			throw new NotImplementedException();
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EventStore.Core.Bus;
+using EventStore.Core.LogAbstraction;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.Chunks;
+using NUnit.Framework;
+using EventStore.Core.Services.Storage.EpochManager;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.Tests.Services.Storage.EpochManager {
+	public abstract class
+		when_truncating_the_epoch_checkpoint<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
+		private TFChunkDb _db;
+		private EpochManager<TStreamId> _epochManager;
+		private LogFormatAbstractor<TStreamId> _logFormat;
+		private TFChunkWriter _writer;
+		private IBus _mainBus;
+		private List<EpochRecord> _epochs;
+		private readonly Guid _instanceId = Guid.NewGuid();
+		private readonly int _numEpochs;
+		private const int CachedEpochCount = 10;
+
+		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
+			long pos = _writer.Checkpoint.ReadNonFlushed();
+			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
+			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
+			_writer.Write(rec, out _);
+			_writer.Flush();
+			return epoch;
+		}
+
+		public when_truncating_the_epoch_checkpoint(int numEpochs) {
+			_numEpochs = numEpochs;
+		}
+
+		[SetUp]
+		public void SetUp() {
+			_mainBus = new InMemoryBus(nameof(when_having_an_epoch_manager_and_empty_tf_log<TLogFormat, TStreamId>));
+
+			var indexDirectory = GetFilePathFor("index");
+			_logFormat = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory.Create(new() {
+				IndexDirectory = indexDirectory,
+			});
+
+			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(PathName, 0));
+			_db.Open();
+			_writer = new TFChunkWriter(_db);
+			_epochManager = new EpochManager<TStreamId>(_mainBus,
+				CachedEpochCount,
+				_db.Config.EpochCheckpoint,
+				_writer,
+				initialReaderCount: 1,
+				maxReaderCount: 5,
+				readerFactory: () => new TFChunkReader(_db, _db.Config.WriterCheckpoint,
+					optimizeReadSideCache: _db.Config.OptimizeReadSideCache),
+				_logFormat.RecordFactory,
+				_logFormat.StreamNameIndex,
+				_logFormat.EventTypeIndex,
+				_logFormat.CreatePartitionManager(
+					reader: new TFChunkReader(_db, _db.Config.WriterCheckpoint),
+					writer: _writer),
+				_instanceId);
+
+			_epochManager.Init();
+			_epochs = new List<EpochRecord>();
+
+			var lastPos = 0L;
+			for (int i = 0; i < _numEpochs; i++) {
+				var epoch = WriteEpoch(i, lastPos, _instanceId);
+				_epochManager.AddEpochToCache(epoch);
+				_epochs.Add(epoch);
+				lastPos = epoch.EpochPosition;
+			}
+		}
+
+
+		[TearDown]
+		public void TearDown() {
+			try {
+				_logFormat?.Dispose();
+				_writer?.Dispose();
+			} catch {
+				//workaround for TearDown error
+			}
+
+			_db?.Dispose();
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class with_no_epochs : when_truncating_the_epoch_checkpoint<TLogFormat, TStreamId> {
+			public with_no_epochs() : base(0) { }
+
+			[Test]
+			public void cannot_truncate_before_any_position() {
+				Assert.False(_epochManager.TryTruncateBefore(0, out _));
+				Assert.False(_epochManager.TryTruncateBefore(12, out _));
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class with_two_epochs : when_truncating_the_epoch_checkpoint<TLogFormat, TStreamId> {
+			public with_two_epochs() : base(2) { }
+
+			[Test]
+			public void cannot_truncate_before_first_epoch_position() {
+				Assert.False(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition, out _));
+			}
+
+			[Test]
+			public void can_truncate_before_first_epoch_position_plus_one() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition + 1, out var epoch));
+				Assert.AreEqual(_epochs[0].EpochNumber, epoch.EpochNumber);
+			}
+
+			[Test]
+			public void can_truncate_before_second_epoch_position() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[1].EpochPosition, out var epoch));
+				Assert.AreEqual(_epochs[0].EpochNumber, epoch.EpochNumber);
+			}
+
+			[Test]
+			public void can_truncate_before_second_epoch_position_plus_one() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[1].EpochPosition + 1, out var epoch));
+				Assert.AreEqual(_epochs[1].EpochNumber, epoch.EpochNumber);
+			}
+
+			[Test]
+			public void checkpoint_is_changed_after_truncation() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition + 1, out _));
+				Assert.AreEqual(_epochs[0].EpochPosition, _db.Config.EpochCheckpoint.Read());
+			}
+
+			[Test]
+			public void checkpoint_is_unchanged_after_no_truncation() {
+				Assert.False(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition, out _));
+				Assert.AreEqual(_epochs[1].EpochPosition, _db.Config.EpochCheckpoint.Read());
+			}
+
+			[Test]
+			public void can_read_checkpoint_after_no_truncation() {
+				Assert.False(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition, out _));
+				Assert.DoesNotThrow(() => {
+					_epochManager.Init(); // triggers a checkpoint read internally
+				});
+			}
+
+			[Test]
+			public void cannot_read_checkpoint_after_truncation() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition + 1, out _));
+				Assert.Throws<InvalidOperationException>(() => {
+					_epochManager.Init(); // triggers a checkpoint read internally
+				});
+			}
+
+			[Test]
+			public void can_write_checkpoint_after_no_truncation() {
+				Assert.False(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition, out _));
+				Assert.DoesNotThrow(() => {
+					_epochManager.WriteNewEpoch(2); // triggers a checkpoint write internally
+				});
+			}
+
+			[Test]
+			public void cannot_write_checkpoint_after_truncation() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition + 1, out _));
+				Assert.Throws<InvalidOperationException>(() => {
+					_epochManager.WriteNewEpoch(2); // triggers a checkpoint write internally
+				});
+			}
+
+			[Test]
+			public void cannot_truncate_twice() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition + 1, out _));
+				Assert.Throws<InvalidOperationException>(() => {
+					_epochManager.TryTruncateBefore(_epochs[0].EpochPosition + 1, out _);
+				});
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class with_cache_size_minus_three_epochs : when_truncating_the_epoch_checkpoint<TLogFormat, TStreamId> {
+			public with_cache_size_minus_three_epochs() : base(CachedEpochCount - 3) { }
+
+			[Test]
+			public void cannot_truncate_before_first_epoch_position() {
+				Assert.False(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition, out _));
+			}
+
+			[Test]
+			public void can_truncate_before_first_epoch_position_plus_one() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition + 1, out var epoch));
+				Assert.AreEqual(_epochs[0].EpochNumber, epoch.EpochNumber);
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class with_cache_size_epochs : when_truncating_the_epoch_checkpoint<TLogFormat, TStreamId> {
+			public with_cache_size_epochs() : base(CachedEpochCount) { }
+			[Test]
+			public void cannot_truncate_before_first_epoch_position() {
+				Assert.False(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition, out _));
+			}
+
+			[Test]
+			public void can_truncate_before_first_epoch_position_plus_one() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition + 1, out var epoch));
+				Assert.AreEqual(_epochs[0].EpochNumber, epoch.EpochNumber);
+			}
+		}
+
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class with_cache_size_plus_two_epochs : when_truncating_the_epoch_checkpoint<TLogFormat, TStreamId> {
+			public with_cache_size_plus_two_epochs() : base(CachedEpochCount + 2) { }
+
+			[Test]
+			public void cannot_truncate_before_third_epoch_position() {
+				Assert.False(_epochManager.TryTruncateBefore(_epochs[2].EpochPosition, out _));
+			}
+
+			[Test]
+			public void can_truncate_before_third_epoch_position_plus_one() {
+				Assert.True(_epochManager.TryTruncateBefore(_epochs[2].EpochPosition + 1, out var epoch));
+				Assert.AreEqual(_epochs[2].EpochNumber, epoch.EpochNumber);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
@@ -94,8 +94,12 @@ namespace EventStore.Core.Tests.Services.Storage.EpochManager {
 			public with_no_epochs() : base(0) { }
 
 			[Test]
-			public void cannot_truncate_before_any_position() {
+			public void cannot_truncate_before_position_zero() {
 				Assert.False(_epochManager.TryTruncateBefore(0, out _));
+			}
+
+			[Test]
+			public void cannot_truncate_before_arbitrary_position() {
 				Assert.False(_epochManager.TryTruncateBefore(12, out _));
 			}
 		}
@@ -141,9 +145,9 @@ namespace EventStore.Core.Tests.Services.Storage.EpochManager {
 			}
 
 			[Test]
-			public void can_read_checkpoint_after_no_truncation() {
+			public void cannot_read_checkpoint_even_if_no_truncation() {
 				Assert.False(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition, out _));
-				Assert.DoesNotThrow(() => {
+				Assert.Throws<InvalidOperationException>(() => {
 					_epochManager.Init(); // triggers a checkpoint read internally
 				});
 			}
@@ -157,9 +161,9 @@ namespace EventStore.Core.Tests.Services.Storage.EpochManager {
 			}
 
 			[Test]
-			public void can_write_checkpoint_after_no_truncation() {
+			public void cannot_write_checkpoint_even_if_no_truncation() {
 				Assert.False(_epochManager.TryTruncateBefore(_epochs[0].EpochPosition, out _));
-				Assert.DoesNotThrow(() => {
+				Assert.Throws<InvalidOperationException>(() => {
 					_epochManager.WriteNewEpoch(2); // triggers a checkpoint write internally
 				});
 			}

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -141,11 +141,15 @@ namespace EventStore.Core.Services {
 				// when starting up for truncation
 				var oldEpoch = EpochManager.GetLastEpoch();
 				if (EpochManager.TryTruncateBefore(message.SubscriptionPosition, out var newEpoch)) {
-					Log.Information("Truncated epoch from "
-						+ "E{oldEpochNumber}@{oldEpochPosition}:{oldEpochId:B} to "
-						+ "E{newEpochNumber}@{newEpochPosition}:{newEpochId:B}",
-						oldEpoch.EpochNumber, oldEpoch.EpochPosition, oldEpoch.EpochId,
-						newEpoch.EpochNumber, newEpoch.EpochPosition, newEpoch.EpochId);
+					if (newEpoch.EpochId != oldEpoch.EpochId) {
+						Log.Information("Truncated epoch from "
+						                + "E{oldEpochNumber}@{oldEpochPosition}:{oldEpochId:B} to "
+						                + "E{newEpochNumber}@{newEpochPosition}:{newEpochId:B}",
+							oldEpoch.EpochNumber, oldEpoch.EpochPosition, oldEpoch.EpochId,
+							newEpoch.EpochNumber, newEpoch.EpochPosition, newEpoch.EpochId);
+					} else {
+						Log.Information("Truncation of epoch not required.");
+					}
 				} else {
 					Log.Information("Could not find a valid epoch to truncate to before position: {truncatePosition} (0x{truncatePosition:X})",
 						message.SubscriptionPosition, message.SubscriptionPosition);

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -131,8 +131,36 @@ namespace EventStore.Core.Services {
 						"ATTEMPT TO TRUNCATE EPOCH WITH COMMITTED RECORDS. THIS MAY BE BAD, BUT IT IS OK IF A NEWLY-ELECTED LEADER FAILS IMMEDIATELY AFTER ELECTION.");
 				}
 
+				Log.Information("Setting the truncate checkpoint to: {truncatePosition} (0x{truncatePosition:X})",
+					message.SubscriptionPosition, message.SubscriptionPosition);
 				Db.Config.TruncateCheckpoint.Write(message.SubscriptionPosition);
 				Db.Config.TruncateCheckpoint.Flush();
+
+				// try to write the new epoch position prior to shutting down to
+				// avoid scanning the transaction log to find a valid epoch
+				// when starting up for truncation
+				var oldEpoch = EpochManager.GetLastEpoch();
+				if (EpochManager.TryTruncateBefore(message.SubscriptionPosition, out var newEpoch)) {
+					Log.Information("Truncated epoch from "
+						+ "E{oldEpochNumber}@{oldEpochPosition}:{oldEpochId:B} to "
+						+ "E{newEpochNumber}@{newEpochPosition}:{newEpochId:B}",
+						oldEpoch.EpochNumber, oldEpoch.EpochPosition, oldEpoch.EpochId,
+						newEpoch.EpochNumber, newEpoch.EpochPosition, newEpoch.EpochId);
+				} else {
+					Log.Information("Could not find a valid epoch to truncate to before position: {truncatePosition} (0x{truncatePosition:X})",
+						message.SubscriptionPosition, message.SubscriptionPosition);
+					var epochs = EpochManager.GetLastEpochs(int.MaxValue);
+					if (epochs.Length > 0) {
+						Log.Debug("Displaying cached epochs:");
+						foreach (var epoch in epochs) {
+							Log.Debug(
+								"=== E{epochNumber}@{epochPosition}:{epochId:B}",
+								epoch.EpochNumber, epoch.EpochPosition, epoch.EpochId);
+						}
+					} else {
+						Log.Debug("No cached epochs were found");
+					}
+				}
 
 				BlockWriter = true;
 				Bus.Publish(new ClientMessage.RequestShutdown(exitProcess: true, shutdownHttp: true));

--- a/src/EventStore.Core/Services/Storage/EpochManager/IEpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/IEpochManager.cs
@@ -13,5 +13,6 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 		bool IsCorrectEpochAt(long epochPosition, int epochNumber, Guid epochId);
 		void WriteNewEpoch(int epochNumber);
 		void CacheEpoch(EpochRecord epoch);
+		bool TryTruncateBefore(long position, out EpochRecord epoch);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDbTruncator.cs
@@ -98,6 +98,10 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				}
 			}
 
+			// Note: Prior to going offline for truncation, we attempt to set the epoch checkpoint to an epoch record
+			// located before the truncate position (if such a record is present in the epoch cache).
+			// This saves us from resetting it to -1 here and also saves us from scanning the transaction log for
+			// a proper epoch record during startup.
 			if (_config.EpochCheckpoint.Read() >= truncateChk) {
 				var epochChk = _config.EpochCheckpoint.Read();
 				Log.Information("Truncating epoch from {epochFrom} (0x{epochFrom:X}) to {epochTo} (0x{epochTo:X}).", epochChk,


### PR DESCRIPTION
Fixed: Update the epoch checkpoint with the proper position before going offline for truncation

Fixes: #3286 