### PR TITLE
Add support for DNS discovery with a secure cluster having only DNS SANs (including wildcard SANs)

### DIFF
--- a/src/EventStore.Common/Utils/CertificateDelegates.cs
+++ b/src/EventStore.Common/Utils/CertificateDelegates.cs
@@ -1,0 +1,9 @@
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EventStore.Common.Utils {
+	public static class CertificateDelegates {
+		public delegate (bool, string) ServerCertificateValidator(X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors);
+		public delegate (bool, string) ClientCertificateValidator(X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors);
+	}
+}

--- a/src/EventStore.Common/Utils/CertificateDelegates.cs
+++ b/src/EventStore.Common/Utils/CertificateDelegates.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace EventStore.Common.Utils {
 	public static class CertificateDelegates {
-		public delegate (bool, string) ServerCertificateValidator(X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors);
+		public delegate (bool, string) ServerCertificateValidator(X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors, string[] otherNames);
 		public delegate (bool, string) ClientCertificateValidator(X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors);
 	}
 }

--- a/src/EventStore.Common/Utils/CertificateExtensions.cs
+++ b/src/EventStore.Common/Utils/CertificateExtensions.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Formats.Asn1;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace EventStore.Common.Utils {
+	public static class CertificateExtensions {
+		public static IEnumerable<(string name, string type)> GetSubjectAlternativeNames(this X509Certificate certificate) {
+			// Implemented based on RFC 5280 (https://datatracker.ietf.org/doc/html/rfc5280)
+			// - Reads IP addresses and DNS names from the Subject Alternative Names extension
+			// - Does not support other name types yet
+
+			if (certificate is not X509Certificate2 certificate2) {
+				using var c2 = new X509Certificate2(certificate);
+				certificate2 = c2;
+			}
+
+			X509ExtensionCollection extensions;
+			try {
+				extensions = certificate2.Extensions;
+			} catch (CryptographicException) {
+				return null;
+			}
+
+			var sans = new List<(string, string)>();
+			foreach (var extension in extensions) {
+				if (extension.Oid?.Value != "2.5.29.17") continue; // Oid for Subject Alternative Names extension
+				var asnReader = new AsnReader(extension.RawData, AsnEncodingRules.DER).ReadSequence();
+				while (asnReader.HasData) {
+					Asn1Tag tag;
+					try {
+						tag = asnReader.PeekTag();
+					} catch (AsnContentException) {
+						break;
+					}
+
+					switch (tag.TagValue) {
+						case 2: // dNSName [2] IA5String
+							sans.Add((asnReader.ReadCharacterString(UniversalTagNumber.IA5String, tag), CertificateNameType.DnsName));
+							break;
+						case 7: // iPAddress [7] OCTET STRING
+							sans.Add((new IPAddress(asnReader.ReadOctetString(tag)).ToString(), CertificateNameType.IpAddress));
+							break;
+						default:
+							asnReader.ReadEncodedValue();
+							break;
+					}
+				}
+			}
+
+			return sans;
+		}
+
+		public static bool MatchesName(this X509Certificate certificate, string name) {
+			// Implemented based on RFC 6125 (https://datatracker.ietf.org/doc/html/rfc6125) with the following changes:
+			// - Does not support SRV-ID and URI-ID identifier types yet
+			// - Partial wildcard support is not implemented since it has been deprecated in most major browsers
+
+			if (certificate is not X509Certificate2 certificate2) {
+				using var c2 = new X509Certificate2(certificate);
+				certificate2 = c2;
+			}
+
+			var sans = GetSubjectAlternativeNames(certificate2).ToArray();
+			if (sans.Length > 0)
+				return sans.Any(san => MatchesName(san.name, san.type, name));
+
+			var cn = GetCommonName(certificate2);
+			return cn != null && MatchesName(cn, CertificateNameType.DnsName, name);
+		}
+
+		private static string GetCommonName(X509Certificate2 certificate) => certificate.GetNameInfo(X509NameType.SimpleName, false);
+
+		private static bool HasNonAsciiChars(string s) => s.Any(t => t > 127);
+
+		private static bool IsInternationalizedDomainNameLabel(string s) {
+			const string ACEPrefix = "xn--";
+			return HasNonAsciiChars(s) || s.StartsWith(ACEPrefix, StringComparison.OrdinalIgnoreCase);
+		}
+
+		// Based on RFC 952
+		private static bool IsValidDnsNameLabel(string label) =>
+			label.All(x => x is >= '0' and <= '9' or >= 'a' and <= 'z' or >= 'A' and <= 'Z' or '-');
+
+		// Based on RFC 6125 (without support for partial wildcard DNS labels
+		// since it has been deprecated by most major browsers)
+		private static bool IsValidCertificateNameFirstLabel(string label) =>
+			label == "*" || IsValidDnsNameLabel(label);
+
+		private static bool MatchesName(string certName, string certNameType, string name) {
+			const char Wildcard = '*';
+			const char Delimiter = '.';
+
+			if (string.IsNullOrEmpty(certName) ||
+			    string.IsNullOrEmpty(name))
+				return false;
+
+			// if at least one of the names is an IP address, do an exact match
+			if (certNameType == CertificateNameType.IpAddress ||
+			    IPAddress.TryParse(certName, out _) ||
+			    IPAddress.TryParse(name, out _))
+				return name.EqualsOrdinalIgnoreCase(certName);
+
+			Debug.Assert(certNameType == CertificateNameType.DnsName);
+
+			var certNameLabels = certName.Split(Delimiter);
+			var dnsNameLabels = name.Split(Delimiter);
+
+			if (certNameLabels.Length != dnsNameLabels.Length)
+				return false;
+
+			if (certNameLabels.Any(string.IsNullOrEmpty) ||
+			    dnsNameLabels.Any(string.IsNullOrEmpty))
+				return false;
+
+			if (certNameLabels.Any(IsInternationalizedDomainNameLabel) ||
+			    dnsNameLabels.Any(IsInternationalizedDomainNameLabel)) {
+				var idnMapping = new IdnMapping();
+				dnsNameLabels = dnsNameLabels.Select(x => idnMapping.GetAscii(x)).ToArray();
+				certNameLabels = certNameLabels.Select(x => idnMapping.GetAscii(x)).ToArray();
+			}
+
+			if (!IsValidCertificateNameFirstLabel(certNameLabels.First()) ||
+			    !certNameLabels.Skip(1).All(IsValidDnsNameLabel) ||
+			    !dnsNameLabels.All(IsValidDnsNameLabel))
+				return false;
+
+			// if first label is not a wildcard, check for an exact match
+			if (certNameLabels.First() != Wildcard.ToString())
+				return certNameLabels.EqualsOrdinalIgnoreCase(dnsNameLabels);
+
+			// first label is wildcard, compare the other labels
+			return certNameLabels.Skip(1).EqualsOrdinalIgnoreCase(dnsNameLabels.Skip(1));
+		}
+	}
+}

--- a/src/EventStore.Common/Utils/CertificateNameType.cs
+++ b/src/EventStore.Common/Utils/CertificateNameType.cs
@@ -1,0 +1,7 @@
+namespace EventStore.Common.Utils {
+	public static class CertificateNameType {
+		// Based on RFC 5280 (https://datatracker.ietf.org/doc/html/rfc5280)
+		public const string IpAddress = "iPAddress";
+		public const string DnsName = "dNSName";
+	}
+}

--- a/src/EventStore.Common/Utils/IPWithClusterDnsEndPoint.cs
+++ b/src/EventStore.Common/Utils/IPWithClusterDnsEndPoint.cs
@@ -1,0 +1,15 @@
+using System.Net;
+
+namespace EventStore.Common.Utils {
+	public class IPWithClusterDnsEndPoint : IPEndPoint {
+		public string ClusterDnsName { get; }
+
+		public IPWithClusterDnsEndPoint(IPAddress address, string clusterDns, int port) : base(address, port) {
+			Ensure.NotNull(clusterDns, "clusterDns");
+			Ensure.NotNull(address, "address");
+			ClusterDnsName = clusterDns;
+		}
+
+		public override string ToString() => $"{base.ToString()}/{ClusterDnsName}";
+	}
+}

--- a/src/EventStore.Common/Utils/StringExtensions.cs
+++ b/src/EventStore.Common/Utils/StringExtensions.cs
@@ -1,4 +1,8 @@
-﻿namespace EventStore.Common.Utils {
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EventStore.Common.Utils {
 	public static class StringExtensions {
 		public static bool IsEmptyString(this string s) {
 			return string.IsNullOrEmpty(s);
@@ -7,5 +11,11 @@
 		public static bool IsNotEmptyString(this string s) {
 			return !string.IsNullOrEmpty(s);
 		}
+
+		public static bool EqualsOrdinalIgnoreCase(this string a, string b) =>
+			string.Compare(a, b, StringComparison.OrdinalIgnoreCase) == 0;
+
+		public static bool EqualsOrdinalIgnoreCase(this IEnumerable<string> a, IEnumerable<string> b) =>
+			a.SequenceEqual(b, StringComparer.OrdinalIgnoreCase);
 	}
 }

--- a/src/EventStore.Core.Tests/Certificates/name_matching.cs
+++ b/src/EventStore.Core.Tests/Certificates/name_matching.cs
@@ -1,0 +1,299 @@
+using System;
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Common.Utils;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Certificates {
+	public class name_matching {
+		private X509Certificate GenSut(string subjectName, (string name, string type)[] sans)  {
+			using (RSA rsa = RSA.Create())
+			{
+				var certReq = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+				var sanBuilder = new SubjectAlternativeNameBuilder();
+				foreach (var (name, type) in sans) {
+					switch (type) {
+						case CertificateNameType.IpAddress:
+							sanBuilder.AddIpAddress(IPAddress.Parse(name));
+							break;
+						case CertificateNameType.DnsName:
+							sanBuilder.AddDnsName(name);
+							break;
+					}
+				}
+
+				certReq.CertificateExtensions.Add(sanBuilder.Build());
+				return certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddMonths(-1), DateTimeOffset.UtcNow.AddMonths(1));
+			}
+		}
+
+		[Test]
+		public void ip_address_matches_ip_san() {
+			var sut = GenSut("CN=test", new [] {
+					("10.123.45.6", CertificateNameType.IpAddress)
+			});
+
+			Assert.True(sut.MatchesName("10.123.45.6"));
+			Assert.False(sut.MatchesName("10.13.45.6"));
+		}
+
+		[Test]
+		public void dns_name_matches_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("subdomain.domain.com", CertificateNameType.DnsName)
+			});
+
+			Assert.True(sut.MatchesName("subdomain.domain.com"));
+
+			Assert.False(sut.MatchesName("com"));
+			Assert.False(sut.MatchesName("domain.com"));
+			Assert.False(sut.MatchesName("subdomain"));
+			Assert.False(sut.MatchesName("subdomain.domain"));
+			Assert.False(sut.MatchesName("subdomain.domain.coms"));
+			Assert.False(sut.MatchesName("1subdomain.domain.com"));
+			Assert.False(sut.MatchesName("sub.subdomain.domain.com"));
+		}
+
+		[Test]
+		public void dns_name_matches_dns_san_case_insensitive() {
+			var sut = GenSut("CN=test", new [] {
+				("website.tld", CertificateNameType.DnsName)
+			});
+
+			Assert.True(sut.MatchesName("WeBsIte.tLd"));
+		}
+
+		[Test]
+		public void cn_is_ignored_when_dns_san_is_present() {
+			var sut = GenSut("CN=test", new [] {
+				("website.tld", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("test"));
+		}
+
+		[Test]
+		public void cn_is_ignored_when_ip_san_is_present() {
+			var sut = GenSut("CN=test", new [] {
+				("127.0.0.1", CertificateNameType.IpAddress)
+			});
+
+			Assert.False(sut.MatchesName("test"));
+		}
+
+		[Test]
+		public void cn_is_considered_when_no_san_is_present() {
+			var sut = GenSut("CN=test", Array.Empty<(string name, string type)>());
+			Assert.True(sut.MatchesName("test"));
+		}
+
+		[Test]
+		public void dns_name_matches_cn_case_insensitive() {
+			var sut = GenSut("CN=subdomain.domain.com", Array.Empty<(string name, string type)>());
+			Assert.True(sut.MatchesName("SubDomain.DoMaiN.COm"));
+		}
+
+		[Test]
+		public void cn_matches_when_subject_name_contains_other_fields() {
+			var sut = GenSut("CN=a.b.c,OU=Engineering,O=Company, C=Country", Array.Empty<(string name, string type)>());
+			Assert.True(sut.MatchesName("a.b.c"));
+			Assert.False(sut.MatchesName("a.b.c,OU"));
+		}
+
+		[Test]
+		public void dns_name_matches_wildcard_cn() {
+			var sut = GenSut("CN=*.example.com", Array.Empty<(string name, string type)>());
+
+			Assert.True(sut.MatchesName("foo.example.com"));
+
+			Assert.False(sut.MatchesName(".example.com"));
+			Assert.False(sut.MatchesName("bar.foo.example.com"));
+			Assert.False(sut.MatchesName("foo"));
+			Assert.False(sut.MatchesName("foo.example"));
+		}
+
+		[Test]
+		public void dns_name_matches_wildcard_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("*.example.com", CertificateNameType.DnsName)
+			});
+
+			Assert.True(sut.MatchesName("foo.example.com"));
+
+			Assert.False(sut.MatchesName(".example.com"));
+			Assert.False(sut.MatchesName("bar.foo.example.com"));
+			Assert.False(sut.MatchesName("foo"));
+			Assert.False(sut.MatchesName("foo.example"));
+		}
+
+		[Test]
+		public void dns_name_matches_wildcard_dns_san_case_insensitive() {
+			var sut = GenSut("CN=test", new [] {
+				("*.example.com", CertificateNameType.DnsName)
+			});
+
+			Assert.True(sut.MatchesName("ABcdEF.ExAmPle.CoM"));
+		}
+
+		[Test]
+		public void dns_name_does_not_match_partial_wildcard_prefix_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("*s.abcd", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("s.abcd"));
+			Assert.False(sut.MatchesName("tests.abcd"));
+		}
+
+		[Test]
+		public void dns_name_does_not_match_partial_wildcard_suffix_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("t*.abc", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("t.abc"));
+			Assert.False(sut.MatchesName("test.abc"));
+		}
+
+		[Test]
+		public void dns_name_does_not_match_partial_wildcard_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("abc*def.tld", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("abcdef.tld"));
+			Assert.False(sut.MatchesName("abcHELLOdef.tld"));
+		}
+
+		[Test]
+		public void dns_name_does_not_match_wildcard_in_non_first_dns_san_label() {
+			var sut = GenSut("CN=test", new [] {
+				("hello.*.com", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("hello.test.com"));
+			Assert.False(sut.MatchesName("hello.*.com"));
+		}
+
+		[Test]
+		public void dns_name_does_not_match_multiple_wildcards_in_first_dns_san_label() {
+			var sut = GenSut("CN=test", new [] {
+				("a*bc*d.test.com", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("a*bc*d.test.com"));
+			Assert.False(sut.MatchesName("abcd.test.com"));
+			Assert.False(sut.MatchesName("a1bc2d.test.com"));
+		}
+
+		[Test]
+		public void invalid_dns_name_does_not_match_wildcard_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("*.example.com", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("*.example.com"));
+			Assert.False(sut.MatchesName("te+st.example.com"));
+			Assert.False(sut.MatchesName("te$st.example.com"));
+			Assert.False(sut.MatchesName("te=st.example.com"));
+		}
+
+		[Test]
+		public void ip_address_does_not_match_wildcard_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("*", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("127.0.0.1"));
+		}
+
+		[Test]
+		public void ip_address_does_not_match_wildcard_cn() {
+			var sut = GenSut("CN=*", Array.Empty<(string name, string type)>());
+			Assert.False(sut.MatchesName("127.0.0.1"));
+		}
+
+		[Test]
+		public void dns_name_matches_internationalized_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("سلام", CertificateNameType.DnsName),
+				("和平.tld", CertificateNameType.DnsName),
+				("world.สันติภาพ.com", CertificateNameType.DnsName)
+			});
+
+			Assert.True(sut.MatchesName("سلام"));
+			Assert.True(sut.MatchesName("xn--mgbx5cf"));
+
+			Assert.True(sut.MatchesName("和平.tld"));
+			Assert.True(sut.MatchesName("xn--0tr63u.tld"));
+
+			Assert.True(sut.MatchesName("world.สันติภาพ.com"));
+			Assert.True(sut.MatchesName("world.xn--m3chqh1c2bko.com"));
+		}
+
+		[Test]
+		public void dns_name_matches_internationalized_dns_san_with_ace_prefix() {
+			var sut = GenSut("CN=test", new [] {
+				("xn--mgbx5cf", CertificateNameType.DnsName),
+				("xn--0tr63u.tld", CertificateNameType.DnsName),
+				("world.xn--m3chqh1c2bko.com", CertificateNameType.DnsName)
+			});
+
+			Assert.True(sut.MatchesName("سلام"));
+			Assert.True(sut.MatchesName("xn--mgbx5cf"));
+
+			Assert.True(sut.MatchesName("和平.tld"));
+			Assert.True(sut.MatchesName("xn--0tr63u.tld"));
+
+			Assert.True(sut.MatchesName("world.สันติภาพ.com"));
+			Assert.True(sut.MatchesName("world.xn--m3chqh1c2bko.com"));
+		}
+
+		[Test]
+		public void dns_name_matches_internationalized_dns_san_case_insensitive() {
+			var sut = GenSut("CN=test", new [] {
+				("سلام", CertificateNameType.DnsName)
+			});
+
+			Assert.True(sut.MatchesName("Xn--MgBx5Cf"));
+		}
+
+		[Test]
+		public void dns_name_matches_internationalized_cn() {
+			var sut = GenSut("CN=xn--mgbx5cf", Array.Empty<(string name, string type)>());
+			Assert.True(sut.MatchesName("سلام"));
+			Assert.True(sut.MatchesName("xn--mgbx5cf"));
+		}
+
+		[Test]
+		public void dns_name_matches_internationalized_cn_case_insensitive() {
+			var sut = GenSut("CN=xn--mgbx5cf", Array.Empty<(string name, string type)>());
+			Assert.True(sut.MatchesName("Xn--MgBx5Cf"));
+		}
+
+		[Test]
+		public void dns_name_matches_wildcard_internationalized_dns_san() {
+			var sut = GenSut("CN=test", new [] {
+				("*.สันติภาพ.com", CertificateNameType.DnsName)
+			});
+
+			Assert.True(sut.MatchesName("world.สันติภาพ.com"));
+			Assert.True(sut.MatchesName("world.xn--m3chqh1c2bko.com"));
+
+			Assert.True(sut.MatchesName("สันติภาพ.สันติภาพ.com"));
+			Assert.True(sut.MatchesName("xn--m3chqh1c2bko.xn--m3chqh1c2bko.com"));
+		}
+
+		[Test]
+		public void dns_name_does_not_match_internationalized_dns_san_with_illegal_wildcard_characters() {
+			var sut = GenSut("CN=test", new [] {
+				("*.สันติภาพ*.com", CertificateNameType.DnsName),
+				("*.xn--*-yxflvj1d7blq.com", CertificateNameType.DnsName)
+			});
+
+			Assert.False(sut.MatchesName("world.สันติภาพ*.com"));
+			Assert.False(sut.MatchesName("world.xn--*-yxflvj1d7blq.com"));
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Certificates/subject_alternative_names.cs
+++ b/src/EventStore.Core.Tests/Certificates/subject_alternative_names.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Common.Utils;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Certificates {
+	public class subject_alternative_names {
+		private X509Certificate GenSut((string name, string type)[] sans)  {
+			using (RSA rsa = RSA.Create())
+			{
+				var certReq = new CertificateRequest("CN=hello", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+				var sanBuilder = new SubjectAlternativeNameBuilder();
+				foreach (var (name, type) in sans) {
+					switch (type) {
+						case CertificateNameType.IpAddress:
+							sanBuilder.AddIpAddress(IPAddress.Parse(name));
+							break;
+						case CertificateNameType.DnsName:
+							sanBuilder.AddDnsName(name);
+							break;
+						case "email":
+							sanBuilder.AddEmailAddress(name);
+							break;
+						case "uri":
+							sanBuilder.AddUri(new Uri(name));
+							break;
+						case "upn":
+							sanBuilder.AddUserPrincipalName(name);
+							break;
+					}
+				}
+
+				certReq.CertificateExtensions.Add(sanBuilder.Build());
+				return certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddMonths(-1), DateTimeOffset.UtcNow.AddMonths(1));
+			}
+		}
+
+		[Test]
+		public void can_read_one_ip_address_from_san() {
+			var sut = GenSut(new [] { ("127.0.0.1", CertificateNameType.IpAddress) });
+			var sans = sut.GetSubjectAlternativeNames().ToArray();
+			Assert.AreEqual(1, sans.Length);
+			Assert.AreEqual("127.0.0.1", sans[0].name);
+			Assert.AreEqual(CertificateNameType.IpAddress, sans[0].type);
+		}
+
+		[Test]
+		public void can_read_one_dns_name_from_san() {
+			var sut = GenSut(new [] { ("hello.world", CertificateNameType.DnsName) });
+			var sans = sut.GetSubjectAlternativeNames().ToArray();
+			Assert.AreEqual(1, sans.Length);
+			Assert.AreEqual("hello.world", sans[0].name);
+			Assert.AreEqual(CertificateNameType.DnsName, sans[0].type);
+		}
+
+		[Test]
+		public void can_read_multiple_ips_and_dns_names_from_san() {
+			var sut = GenSut(new [] {
+				("127.0.0.1", CertificateNameType.IpAddress),
+				("hello.world", CertificateNameType.DnsName),
+				("10.0.0.2", CertificateNameType.IpAddress),
+				("good.bye.world", CertificateNameType.DnsName)
+			});
+			var sans = sut.GetSubjectAlternativeNames().ToArray();
+			Assert.AreEqual(4, sans.Length);
+			Assert.AreEqual(new [] {"10.0.0.2", "127.0.0.1"},
+				sans.Where(san => san.type == CertificateNameType.IpAddress)
+					.Select(x => x.name)
+					.OrderBy(x => x).ToArray());
+			Assert.AreEqual(new [] {"good.bye.world", "hello.world"},
+				sans.Where(san => san.type == CertificateNameType.DnsName)
+					.Select(x => x.name)
+					.OrderBy(x => x).ToArray());
+		}
+
+		[Test]
+		public void can_read_multiple_ips_and_dns_names_from_san_with_other_name_types() {
+			var sut = GenSut(new [] {
+				("https://uritest/path", "uri"),
+				("127.0.0.1", CertificateNameType.IpAddress),
+				("test@test.com", "email"),
+				("hello.world", CertificateNameType.DnsName),
+				("https://hello.com/test", "uri"),
+				("10.0.0.2", CertificateNameType.IpAddress),
+				("user@domain.com", "upn"),
+				("good.bye.world", CertificateNameType.DnsName),
+				("test2@test2.com", "email"),
+			});
+			var sans = sut.GetSubjectAlternativeNames().ToArray();
+			Assert.AreEqual(4, sans.Length);
+			Assert.AreEqual(new [] {"10.0.0.2", "127.0.0.1"},
+				sans.Where(san => san.type == CertificateNameType.IpAddress)
+					.Select(x => x.name)
+					.OrderBy(x => x).ToArray());
+			Assert.AreEqual(new [] {"good.bye.world", "hello.world"},
+				sans.Where(san => san.type == CertificateNameType.DnsName)
+					.Select(x => x.name)
+					.OrderBy(x => x).ToArray());
+		}
+
+	}
+
+}

--- a/src/EventStore.Core.Tests/Cluster/EventStoreClientCacheTests.cs
+++ b/src/EventStore.Core.Tests/Cluster/EventStoreClientCacheTests.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Cluster {
 		private static readonly Func<EndPoint, IPublisher, EventStoreClusterClient> EventStoreClusterClientFactory =
 			(endpoint, bus) =>
 				new EventStoreClusterClient(
-					new UriBuilder(Uri.UriSchemeHttps, endpoint.GetHost(), endpoint.GetPort()).Uri, bus,
+					Uri.UriSchemeHttps, endpoint, null, bus,
 					delegate { return (true, null); }, null);
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 							new AnonymousHttpAuthenticationProvider(),
 						}, new TestAuthorizationProvider(),
 						new FakeReadIndex<LogFormat.V2, string>(_ => false, new LogV2SystemStreams()),
-						1024 * 1024, _timeout, _service)));
+						1024 * 1024, _timeout, _service, null)));
 			_httpMessageHandler = _server.CreateHandler();
 			_client = new HttpAsyncClient(_timeout, _httpMessageHandler);
 			

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
@@ -38,6 +38,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				var clientTcpConnection = TcpConnectionSsl.CreateConnectingConnection(
 					Guid.NewGuid(),
 					listeningSocket.LocalEndPoint.GetHost(),
+					null,
 					(IPEndPoint)listeningSocket.LocalEndPoint,
 					delegate { return (true, null); },
 					null,
@@ -102,6 +103,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 					clientTcpConnection = TcpConnectionSsl.CreateConnectingConnection(
 						Guid.NewGuid(),
 						listeningSocket.LocalEndPoint.GetHost(),
+						null,
 						(IPEndPoint)listeningSocket.LocalEndPoint,
 						delegate { return (true, null); },
 						null,

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
@@ -68,6 +68,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			var clientSsl = TcpConnectionSsl.CreateConnectingConnection(
 				Guid.NewGuid(),
 				serverEndPoint.GetHost(),
+				null,
 				serverEndPoint,
 				delegate { return (true, null); },
 				null,

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
@@ -99,8 +99,9 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			var clientSsl = TcpConnectionSsl.CreateConnectingConnection(
 				Guid.NewGuid(),
 				serverEndPoint.GetHost(),
+				null,
 				serverEndPoint,
-				(cert, chain, err) => validateServerCertificate ? ClusterVNode<string>.ValidateServerCertificate(cert, chain, err, () => null, () => rootCertificates) : (true, null),
+				(cert, chain, err, _) => validateServerCertificate ? ClusterVNode<string>.ValidateServerCertificate(cert, chain, err, () => null, () => rootCertificates, null) : (true, null),
 				() => new X509CertificateCollection{clientCertificate},
 				new TcpClientConnector(),
 				TcpConnectionManager.ConnectionTimeout,

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
@@ -36,6 +36,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				connection = TcpConnectionSsl.CreateConnectingConnection(
 					Guid.NewGuid(),
 					endpoint.GetHost(),
+					null,
 					endpoint,
 					delegate { return (true, null); },
 					null,

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/with_intermediate_certificates.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/with_intermediate_certificates.cs
@@ -49,8 +49,9 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			_client = TcpConnectionSsl.CreateConnectingConnection(
 				Guid.NewGuid(),
 				_serverEndPoint.GetHost(),
+				null,
 				_serverEndPoint,
-				(certificate, chain, _) => {
+				(certificate, chain, _, _) => {
 					gotLeaf = _leaf.Equals(certificate);
 					foreach (var chainElement in chain.ChainElements) {
 						if (chainElement.Certificate.Equals(_intermediate)) {
@@ -99,8 +100,9 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				_client = TcpConnectionSsl.CreateConnectingConnection(
 					Guid.NewGuid(),
 					_serverEndPoint.GetHost(),
+					null,
 					_serverEndPoint,
-					(_, _, _) => (true, null),
+					(_, _, _, _) => (true, null),
 					() => new X509Certificate2Collection(_cert),
 					new TcpClientConnector(),
 					TcpConnectionManager.ConnectionTimeout,

--- a/src/EventStore.Core/Cluster/ClusterInfo.cs
+++ b/src/EventStore.Core/Cluster/ClusterInfo.cs
@@ -46,20 +46,20 @@ namespace EventStore.Core.Cluster {
 			return false;
 		}
 		
-		internal static ClusterInfo FromGrpcClusterInfo(EventStore.Cluster.ClusterInfo grpcCluster) {
+		internal static ClusterInfo FromGrpcClusterInfo(EventStore.Cluster.ClusterInfo grpcCluster, string clusterDns) {
 			var receivedMembers = Array.ConvertAll(grpcCluster.Members.ToArray(), x =>
 				new MemberInfo(
 					Uuid.FromDto(x.InstanceId).ToGuid(), x.TimeStamp.FromTicksSinceEpoch(), (VNodeState)x.State,
 					x.IsAlive,
-					!x.InternalTcpUsesTls ? new DnsEndPoint(x.InternalTcp.Address, (int)x.InternalTcp.Port) : null,
-					x.InternalTcpUsesTls ? new DnsEndPoint(x.InternalTcp.Address, (int)x.InternalTcp.Port) : null,
+					!x.InternalTcpUsesTls ? new DnsEndPoint(x.InternalTcp.Address, (int)x.InternalTcp.Port).WithClusterDns(clusterDns) : null,
+					x.InternalTcpUsesTls ? new DnsEndPoint(x.InternalTcp.Address, (int)x.InternalTcp.Port).WithClusterDns(clusterDns) : null,
 					!x.ExternalTcpUsesTls && x.ExternalTcp != null
-						? new DnsEndPoint(x.ExternalTcp.Address, (int)x.ExternalTcp.Port)
+						? new DnsEndPoint(x.ExternalTcp.Address, (int)x.ExternalTcp.Port).WithClusterDns(clusterDns)
 						: null,
 					x.ExternalTcpUsesTls && x.ExternalTcp != null
-						? new DnsEndPoint(x.ExternalTcp.Address, (int)x.ExternalTcp.Port)
+						? new DnsEndPoint(x.ExternalTcp.Address, (int)x.ExternalTcp.Port).WithClusterDns(clusterDns)
 						: null,
-					new DnsEndPoint(x.HttpEndPoint.Address, (int)x.HttpEndPoint.Port),
+					new DnsEndPoint(x.HttpEndPoint.Address, (int)x.HttpEndPoint.Port).WithClusterDns(clusterDns),
 					x.AdvertiseHostToClientAs, (int)x.AdvertiseHttpPortToClientAs, (int)x.AdvertiseTcpPortToClientAs,
 					x.LastCommitPosition, x.WriterCheckpoint, x.ChaserCheckpoint,
 					x.EpochPosition, x.EpochNumber, Uuid.FromDto(x.EpochId).ToGuid(), x.NodePriority,

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.Gossip.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.Gossip.cs
@@ -44,12 +44,12 @@ namespace EventStore.Core.Cluster {
 				Server = new GossipEndPoint(server.GetHost(), (uint)server.GetPort())
 			};
 			var clusterInfoDto = await _gossipClient.UpdateAsync(request, deadline: deadline.ToUniversalTime());
-			return ClusterInfo.FromGrpcClusterInfo(clusterInfoDto);
+			return ClusterInfo.FromGrpcClusterInfo(clusterInfoDto, _clusterDns);
 		}
 
 		private async Task<ClusterInfo> GetGossipAsync(DateTime deadline) {
 			var clusterInfoDto = await _gossipClient.ReadAsync(new Empty(), deadline: deadline.ToUniversalTime());
-			return ClusterInfo.FromGrpcClusterInfo(clusterInfoDto);
+			return ClusterInfo.FromGrpcClusterInfo(clusterInfoDto, _clusterDns);
 		}
 	}
 }

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Cluster {
 		private readonly IPublisher _bus;
 		public bool Disposed { get; private set; }
 
-		public EventStoreClusterClient(Uri address, IPublisher bus, Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> serverCertValidator, Func<X509Certificate> clientCertificateSelector) {
+		public EventStoreClusterClient(string uriScheme, EndPoint endpoint, IPublisher bus, CertificateDelegates.ServerCertificateValidator serverCertValidator, Func<X509Certificate> clientCertificateSelector) {
 			HttpMessageHandler httpMessageHandler = null;
 			if (address.Scheme == Uri.UriSchemeHttps){
 				var socketsHttpHandler = new SocketsHttpHandler {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -94,7 +94,7 @@ namespace EventStore.Core {
 		abstract public AuthorizationGateway AuthorizationGateway { get; }
 		abstract public IHttpService HttpService { get; }
 		abstract public VNodeInfo NodeInfo { get; }
-		abstract public Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> InternalClientCertificateValidator { get; }
+		abstract public CertificateDelegates.ClientCertificateValidator InternalClientCertificateValidator { get; }
 		abstract public Func<X509Certificate2> CertificateSelector { get; }
 		abstract public Func<X509Certificate2Collection> IntermediateCertificatesSelector { get; }
 		abstract public bool DisableHttps { get; }
@@ -180,10 +180,10 @@ namespace EventStore.Core {
 		private readonly Func<X509Certificate2> _certificateSelector;
 		private readonly Func<X509Certificate2Collection> _trustedRootCertsSelector;
 		private readonly Func<X509Certificate2Collection> _intermediateCertsSelector;
-		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _internalServerCertificateValidator;
-		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _internalClientCertificateValidator;
-		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _externalClientCertificateValidator;
-		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _externalServerCertificateValidator;
+		private readonly CertificateDelegates.ServerCertificateValidator _internalServerCertificateValidator;
+		private readonly CertificateDelegates.ClientCertificateValidator _internalClientCertificateValidator;
+		private readonly CertificateDelegates.ClientCertificateValidator _externalClientCertificateValidator;
+		private readonly CertificateDelegates.ServerCertificateValidator _externalServerCertificateValidator;
 
 		private readonly ClusterVNodeStartup<TStreamId> _startup;
 		private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
@@ -195,7 +195,7 @@ namespace EventStore.Core {
 			get { return _tasks; }
 		}
 
-		public override Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> InternalClientCertificateValidator => _internalClientCertificateValidator;
+		public override CertificateDelegates.ClientCertificateValidator InternalClientCertificateValidator => _internalClientCertificateValidator;
 		public override Func<X509Certificate2> CertificateSelector => _certificateSelector;
 		public override Func<X509Certificate2Collection> IntermediateCertificatesSelector => _intermediateCertsSelector;
 		public override bool DisableHttps => _disableHttps;

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -49,6 +49,7 @@ namespace EventStore.Core {
 		private bool _ready;
 		private readonly IAuthorizationProvider _authorizationProvider;
 		private readonly MultiQueuedHandler _httpMessageHandler;
+		private readonly string _clusterDns;
 
 		public ClusterVNodeStartup(ISubsystem[] subsystems,
 			IPublisher mainQueue,
@@ -61,7 +62,8 @@ namespace EventStore.Core {
 			IReadIndex<TStreamId> readIndex,
 			int maxAppendSize,
 			TimeSpan writeTimeout,
-			KestrelHttpService httpService) {
+			KestrelHttpService httpService,
+			string clusterDns) {
 			if (subsystems == null) {
 				throw new ArgumentNullException(nameof(subsystems));
 			}
@@ -106,6 +108,7 @@ namespace EventStore.Core {
 			_maxAppendSize = maxAppendSize;
 			_writeTimeout = writeTimeout;
 			_httpService = httpService;
+			_clusterDns = clusterDns;
 
 			_statusCheck = new StatusCheck(this);
 		}
@@ -161,8 +164,8 @@ namespace EventStore.Core {
 						.AddSingleton(new PersistentSubscriptions(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Users(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Operations(_mainQueue, _authorizationProvider))
-						.AddSingleton(new ClusterGossip(_mainQueue, _authorizationProvider))
-						.AddSingleton(new Elections(_mainQueue, _authorizationProvider))
+						.AddSingleton(new ClusterGossip(_mainQueue, _authorizationProvider, _clusterDns))
+						.AddSingleton(new Elections(_mainQueue, _authorizationProvider, _clusterDns))
 						.AddSingleton(new ClientGossip(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Monitoring(_monitoringQueue))
 						.AddSingleton<ServerFeatures>()

--- a/src/EventStore.Core/Services/Gossip/DnsGossipSeedSource.cs
+++ b/src/EventStore.Core/Services/Gossip/DnsGossipSeedSource.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Net;
+using EventStore.Common.Utils;
 
 namespace EventStore.Core.Services.Gossip {
 	public class DnsGossipSeedSource : IGossipSeedSource {
@@ -19,7 +20,7 @@ namespace EventStore.Core.Services.Gossip {
 		public EndPoint[] EndGetHostEndpoints(IAsyncResult asyncResult) {
 			var addresses = Dns.EndGetHostAddresses(asyncResult);
 
-			return addresses.Select(address => new IPEndPoint(address, _managerHttpPort)).ToArray();
+			return addresses.Select(address => new IPEndPoint(address, _managerHttpPort).WithClusterDns(_hostname)).ToArray();
 		}
 	}
 }

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -30,7 +30,7 @@ namespace EventStore.Core.Services {
 		private const string _httpSendHistogram = "http-send";
 		private MemberInfo _leaderInfo;
 
-		public HttpSendService(HttpMessagePipe httpPipe, bool forwardRequests, Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> externServerCertValidator) {
+		public HttpSendService(HttpMessagePipe httpPipe, bool forwardRequests, CertificateDelegates.ServerCertificateValidator externServerCertValidator) {
 			Ensure.NotNull(httpPipe, "httpPipe");
 			_httpPipe = httpPipe;
 			_forwardRequests = forwardRequests;

--- a/src/EventStore.Core/Services/HttpSendService.cs
+++ b/src/EventStore.Core/Services/HttpSendService.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Services {
 				SslOptions = {
 					CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
 					RemoteCertificateValidationCallback = (sender, certificate, chain, errors) => {
-						var (isValid, error) = externServerCertValidator(certificate, chain, errors);
+						var (isValid, error) = externServerCertValidator(certificate, chain, errors, _leaderInfo?.HttpEndPoint.GetOtherNames());
 						if (!isValid && error != null) {
 							Log.Error("Server certificate validation error: {e}", error);
 						}

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -166,6 +166,7 @@ namespace EventStore.Core.Services.Replication {
 				_tcpDispatcher,
 				_publisher,
 				leaderEndPoint.GetHost(),
+				leaderEndPoint.GetOtherNames(),
 				leaderEndPoint,
 				_connector,
 				_useSsl,

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.Services.Replication {
 		private readonly EndPoint _internalTcp;
 		private readonly bool _isReadOnlyReplica;
 		private readonly bool _useSsl;
-		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _sslServerCertValidator;
+		private readonly CertificateDelegates.ServerCertificateValidator _sslServerCertValidator;
 		private readonly Func<X509Certificate> _sslClientCertificateSelector;
 		private readonly TimeSpan _heartbeatTimeout;
 		private readonly TimeSpan _heartbeatInterval;
@@ -58,7 +58,7 @@ namespace EventStore.Core.Services.Replication {
 			EndPoint internalTcp,
 			bool isReadOnlyReplica,
 			bool useSsl,
-			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> sslServerCertValidator,
+			CertificateDelegates.ServerCertificateValidator sslServerCertValidator,
 			Func<X509Certificate> sslClientCertificateSelector,
 			TimeSpan heartbeatTimeout,
 			TimeSpan heartbeatInterval,

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -134,7 +134,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			EndPoint remoteEndPoint,
 			TcpClientConnector connector,
 			bool useSsl,
-			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> sslServerCertValidator,
+			CertificateDelegates.ServerCertificateValidator sslServerCertValidator,
 			Func<X509CertificateCollection> sslClientCertificatesSelector,
 			IPublisher networkSendQueue,
 			IAuthenticationProvider authProvider,

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -131,6 +131,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			ITcpDispatcher dispatcher,
 			IPublisher publisher,
 			string targetHost,
+			string[] otherNames,
 			EndPoint remoteEndPoint,
 			TcpClientConnector connector,
 			bool useSsl,
@@ -174,7 +175,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 
 			RemoteEndPoint = remoteEndPoint;
 			_connection = useSsl
-				? connector.ConnectSslTo(ConnectionId, targetHost, remoteEndPoint.ResolveDnsToIPAddress(), ConnectionTimeout,
+				? connector.ConnectSslTo(ConnectionId, targetHost, otherNames, remoteEndPoint.ResolveDnsToIPAddress(), ConnectionTimeout,
 					sslServerCertValidator, sslClientCertificatesSelector, OnConnectionEstablished, OnConnectionFailed)
 				: connector.ConnectTo(ConnectionId, remoteEndPoint.ResolveDnsToIPAddress(), ConnectionTimeout, OnConnectionEstablished,
 					OnConnectionFailed);

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpService.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpService.cs
@@ -36,9 +36,9 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private readonly TimeSpan _heartbeatInterval;
 		private readonly TimeSpan _heartbeatTimeout;
 		private readonly IAuthenticationProvider _authProvider;
-		private readonly Func<X509Certificate2> _certificateSelector;
+		private readonly Func<X509Certificate> _certificateSelector;
 		private readonly Func<X509Certificate2Collection> _intermediatesSelector;
-		private readonly Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _sslClientCertValidator;
+		private readonly CertificateDelegates.ClientCertificateValidator _sslClientCertValidator;
 		private readonly int _connectionPendingSendBytesThreshold;
 		private readonly int _connectionQueueSizeThreshold;
 		private readonly AuthorizationGateway _authorizationGateway;
@@ -53,9 +53,9 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			TimeSpan heartbeatTimeout,
 			IAuthenticationProvider authProvider,
 			AuthorizationGateway authorizationGateway,
-			Func<X509Certificate2> certificateSelector,
+			Func<X509Certificate> certificateSelector,
 			Func<X509Certificate2Collection> intermediatesSelector,
-			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> sslClientCertValidator,
+			CertificateDelegates.ClientCertificateValidator sslClientCertValidator,
 			int connectionPendingSendBytesThreshold,
 			int connectionQueueSizeThreshold)
 			: this(publisher, serverEndPoint, networkSendQueue, serviceType, securityType, (_, __) => dispatcher,
@@ -72,9 +72,9 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			TimeSpan heartbeatTimeout,
 			IAuthenticationProvider authProvider,
 			AuthorizationGateway authorizationGateway,
-			Func<X509Certificate2> certificateSelector,
+			Func<X509Certificate> certificateSelector,
 			Func<X509Certificate2Collection> intermediatesSelector,
-			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> sslClientCertValidator,
+			CertificateDelegates.ClientCertificateValidator sslClientCertValidator,
 			int connectionPendingSendBytesThreshold,
 			int connectionQueueSizeThreshold) {
 			Ensure.NotNull(publisher, "publisher");

--- a/src/EventStore.Core/Services/Transport/Tcp/TcpService.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpService.cs
@@ -36,7 +36,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 		private readonly TimeSpan _heartbeatInterval;
 		private readonly TimeSpan _heartbeatTimeout;
 		private readonly IAuthenticationProvider _authProvider;
-		private readonly Func<X509Certificate> _certificateSelector;
+		private readonly Func<X509Certificate2> _certificateSelector;
 		private readonly Func<X509Certificate2Collection> _intermediatesSelector;
 		private readonly CertificateDelegates.ClientCertificateValidator _sslClientCertValidator;
 		private readonly int _connectionPendingSendBytesThreshold;
@@ -53,7 +53,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			TimeSpan heartbeatTimeout,
 			IAuthenticationProvider authProvider,
 			AuthorizationGateway authorizationGateway,
-			Func<X509Certificate> certificateSelector,
+			Func<X509Certificate2> certificateSelector,
 			Func<X509Certificate2Collection> intermediatesSelector,
 			CertificateDelegates.ClientCertificateValidator sslClientCertValidator,
 			int connectionPendingSendBytesThreshold,
@@ -72,7 +72,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			TimeSpan heartbeatTimeout,
 			IAuthenticationProvider authProvider,
 			AuthorizationGateway authorizationGateway,
-			Func<X509Certificate> certificateSelector,
+			Func<X509Certificate2> certificateSelector,
 			Func<X509Certificate2Collection> intermediatesSelector,
 			CertificateDelegates.ClientCertificateValidator sslClientCertValidator,
 			int connectionPendingSendBytesThreshold,

--- a/src/EventStore.TestClient/TcpTestClient.cs
+++ b/src/EventStore.TestClient/TcpTestClient.cs
@@ -103,9 +103,10 @@ namespace EventStore.TestClient {
 				connection = _connector.ConnectSslTo(
 					Guid.NewGuid(),
 					endpoint.GetHost(),
+					endpoint.GetOtherNames(),
 					endpoint.ResolveDnsToIPAddress(),
 					TcpConnectionManager.ConnectionTimeout,
-					(cert, chain, err) => (err == SslPolicyErrors.None || !_validateServer, err.ToString()),
+					(_, _, err, _) => (err == SslPolicyErrors.None || !_validateServer, err.ToString()),
 					() => null,
 					onConnectionEstablished,
 					onConnectionFailed,

--- a/src/EventStore.Transport.Tcp/TcpClientConnector.cs
+++ b/src/EventStore.Transport.Tcp/TcpClientConnector.cs
@@ -50,7 +50,7 @@ namespace EventStore.Transport.Tcp {
 			string targetHost,
 			IPEndPoint remoteEndPoint,
 			TimeSpan connectionTimeout,
-			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> sslServerCertValidator,
+			CertificateDelegates.ServerCertificateValidator sslServerCertValidator,
 			Func<X509CertificateCollection> clientCertificatesSelector,
 			Action<ITcpConnection> onConnectionEstablished = null,
 			Action<ITcpConnection, SocketError> onConnectionFailed = null,

--- a/src/EventStore.Transport.Tcp/TcpClientConnector.cs
+++ b/src/EventStore.Transport.Tcp/TcpClientConnector.cs
@@ -48,6 +48,7 @@ namespace EventStore.Transport.Tcp {
 
 		public ITcpConnection ConnectSslTo(Guid connectionId,
 			string targetHost,
+			string[] otherNames,
 			IPEndPoint remoteEndPoint,
 			TimeSpan connectionTimeout,
 			CertificateDelegates.ServerCertificateValidator sslServerCertValidator,
@@ -56,7 +57,7 @@ namespace EventStore.Transport.Tcp {
 			Action<ITcpConnection, SocketError> onConnectionFailed = null,
 			bool verbose = true) {
 			Ensure.NotNull(remoteEndPoint, "remoteEndPoint");
-			return TcpConnectionSsl.CreateConnectingConnection(connectionId, targetHost, remoteEndPoint, sslServerCertValidator,
+			return TcpConnectionSsl.CreateConnectingConnection(connectionId, targetHost, otherNames, remoteEndPoint, sslServerCertValidator,
 				clientCertificatesSelector, this, connectionTimeout, onConnectionEstablished, onConnectionFailed, verbose);
 		}
 

--- a/src/EventStore.Transport.Tcp/TcpConnectionBase.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionBase.cs
@@ -114,7 +114,7 @@ namespace EventStore.Transport.Tcp {
 		}
 
 		private Socket _socket;
-		private readonly IPEndPoint _remoteEndPoint;
+		protected readonly IPEndPoint _remoteEndPoint;
 		private IPEndPoint _localEndPoint;
 
 		private long _lastSendStarted = -1;

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -18,7 +18,7 @@ namespace EventStore.Transport.Tcp {
 		public static ITcpConnection CreateConnectingConnection(Guid connectionId,
 			string targetHost,
 			IPEndPoint remoteEndPoint,
-			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> serverCertValidator,
+			CertificateDelegates.ServerCertificateValidator serverCertValidator,
 			Func<X509CertificateCollection> clientCertificatesSelector,
 			TcpClientConnector connector,
 			TimeSpan connectionTimeout,
@@ -47,9 +47,9 @@ namespace EventStore.Transport.Tcp {
 		public static ITcpConnection CreateServerFromSocket(Guid connectionId,
 			IPEndPoint remoteEndPoint,
 			Socket socket,
-			Func<X509Certificate2> serverCertificateSelector,
+			Func<X509Certificate> serverCertificateSelector,
 			Func<X509Certificate2Collection> intermediatesSelector,
-			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> clientCertValidator,
+			CertificateDelegates.ClientCertificateValidator clientCertValidator,
 			bool verbose) {
 			var connection = new TcpConnectionSsl(connectionId, remoteEndPoint, verbose);
 			connection.InitServerSocket(socket, serverCertificateSelector, intermediatesSelector, clientCertValidator, verbose);
@@ -97,8 +97,8 @@ namespace EventStore.Transport.Tcp {
 		private SslStream _sslStream;
 		private bool _isAuthenticated;
 		private int _sendingBytes;
-		private Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _serverCertValidator;
-		private Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> _clientCertValidator;
+		private CertificateDelegates.ServerCertificateValidator _serverCertValidator;
+		private CertificateDelegates.ClientCertificateValidator _clientCertValidator;
 		private readonly byte[] _receiveBuffer = new byte[TcpConnection.BufferManager.ChunkSize];
 
 		private TcpConnectionSsl(Guid connectionId, IPEndPoint remoteEndPoint, bool verbose) : base(remoteEndPoint) {
@@ -112,7 +112,7 @@ namespace EventStore.Transport.Tcp {
 			Socket socket,
 			Func<X509Certificate2> serverCertificateSelector,
 			Func<X509Certificate2Collection> intermediatesSelector,
-			Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> clientCertValidator,
+			CertificateDelegates.ClientCertificateValidator clientCertValidator,
 			bool verbose) {
 			InitConnectionBase(socket);
 			if (verbose)
@@ -190,7 +190,7 @@ namespace EventStore.Transport.Tcp {
 			_socket = socket;
 		}
 
-		private void InitSslStream(string targetHost, Func<X509Certificate, X509Chain, SslPolicyErrors, ValueTuple<bool, string>> serverCertValidator, Func<X509CertificateCollection> clientCertificatesSelector, bool verbose) {
+		private void InitSslStream(string targetHost, CertificateDelegates.ServerCertificateValidator serverCertValidator, Func<X509CertificateCollection> clientCertificatesSelector, bool verbose) {
 			Ensure.NotNull(targetHost, "targetHost");
 			InitConnectionBase(_socket);
 			if (verbose)


### PR DESCRIPTION
Added: Support for DNS discovery with a secure cluster having only DNS SANs (including wildcard SANs)

### Summary:
- The PR adds support for DNS discovery with a secure cluster having only DNS SANs, basically:
```
DiscoverViaDns: True
ClusterDns: test.cluster.dns
Insecure: False
+ Certificate containing DNS SAN (test.cluster.dns) or wildcard DNS SAN (*.cluster.dns) but no IP SAN
```
-  This is useful for situations where certificates are generated by a public certificate authority (which cannot easily contain IP SANs).
- There still needs to be a DNS A record pointing towards the IP addresses of each node. We do not yet support full hostname DNS discovery (e.g via DNS SRV records) which would eliminate the need to configure the IP addresses.

### Fix description:
- The fix works by adding flexibility to support validation of multiple names against a certificate (instead of a single one - usually the target host used in a HTTP URI) when connecting to a TLS-enabled endpoint.
- The cluster DNS name is then supplied as an additional name used for validation.
- By default, hostname validation against a certificate will still be done by the .NET libraries but when it fails, we do some additional validation of "extra" hostnames with our own implementation.
- The PR should not cause any breaking changes since it is only additive.

This required implementation of:
- our own hostname validation logic based on [RFC 6125](https://tools.ietf.org/html/rfc6125) since there is currently no such API in .NET 5 - probably because it depends on the system's libraries (e.g openssl on linux) for name validation.
- our own SAN parsing logic from ASN.1 encoded data based on [RFC 5280](https://datatracker.ietf.org/doc/html/rfc5280). The existing code for SAN parsing depends on the ASNEncodedData.Format() function which is not ideal since this method should in principle be used only for pretty-printing.

### Scenarios tested
The following settings were common across all scenarios:
- DiscoverViaDns: True
- ClusterDns: test.esdb-qa.eventstore.com
- DNS A Record for `test.esdb-qa.eventstore.com` which points to 127.0.0.1, 127.0.0.2, 127.0.0.3

### Insecure cluster :heavy_check_mark: 

### Certificate with DNS SAN only :heavy_check_mark: 
- CN=eventstoredb-node
- DNS SAN = test.esdb-qa.eventstore.com

### Certificate with wildcard DNS SAN only :heavy_check_mark: 
- CN=eventstoredb-node
- DNS SAN = *.esdb-qa.eventstore.com

### Certificate with IP SAN only :heavy_check_mark: 
- CN=eventstoredb-node
- IP SAN = 127.0.0.1 / 127.0.0.2 / 127.0.0.3 respectively

### Certificate with CN and no DNS SAN :x:
- CN=test.esdb-qa.eventstore.com
- DNS SAN = `none`
- CertificateReservedNodeCommonName: `test.esdb-qa.eventstore.com`
- Although it is a valid certificate, this does not work since we currently [require at least one DNS SAN or IP address in the certificate.](https://github.com/EventStore/EventStore/blob/bd962bcddbf524bccb03166dd431f5b59a84c5a2/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs#L53) However this should not be a problem since the use of CNs has been deprecated since a long time ago in RFC 2818: `Although the use of the Common Name is existing practice, it is deprecated and Certification Authorities are encouraged to use the dNSName instead.`

### Certificate with both CN / SAN  :heavy_check_mark: 
- In situations where there are both a CN and SAN, the SAN takes precedence and the CN should be ignored. ([extract from RFC 6125](https://datatracker.ietf.org/doc/html/rfc6125#section-6.4.4))

### Rolling upgrade - setting DiscoverViaDns to True when it was previously False :heavy_check_mark: 
- Rolling upgrades will work but the node being upgraded will still need to have an IP SAN
- Rolling upgrades to a certificate with no IP SAN will require two steps (suggested by @hayley-jean):
  - First do a rolling upgrade of each node to a certificate with `<IP SAN, Cluster DNS SAN>`
  - Do a second rolling upgrade of each node to a certificate having only the `<Cluster DNS SAN>`

