### PR TITLE
Manually Bump Version to 22.2

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,6 +13,7 @@
 		<LangVersion>9.0</LangVersion>
 		<IsPackable>false</IsPackable>
 		<MinVerTagPrefix>oss-v</MinVerTagPrefix>
+		<MinVerMinimumMajorMinor>22.2</MinVerMinimumMajorMinor>
 	</PropertyGroup>
 	<Target Name="UpdateAssemblyVersion" AfterTargets="MinVer">
   		<PropertyGroup>
@@ -24,7 +25,7 @@
 		<None Include="..\..\ouro.png" Pack="true" PackagePath="\"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="MinVer" Version="2.3.0">
+		<PackageReference Include="MinVer" Version="2.5.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
Changed: fixed Incorrect version number in CI build

The version number as reported by the container is incorrect, as the tag for the `21.10` release is not reachable from `master`. We therefore bump the version number manually.
