### PR TITLE
Fix projections subsystem getting stuck in a stopping state when reads timeout

### DIFF
--- a/src/EventStore.Core/Helpers/IODispatcher.cs
+++ b/src/EventStore.Core/Helpers/IODispatcher.cs
@@ -271,7 +271,6 @@ namespace EventStore.Core.Helpers {
 			Guid? corrId = null) {
 			if (!corrId.HasValue)
 				corrId = Guid.NewGuid();
-			AddPendingRequest(corrId.Value);
 			return
 				BackwardReader.Publish(
 					new ClientMessage.ReadStreamEventsBackward(
@@ -285,10 +284,7 @@ namespace EventStore.Core.Helpers {
 						false,
 						null,
 						principal),
-					res => {
-						RemovePendingRequest(res.CorrelationId);
-						action(res);
-					});
+					action);
 		}
 
 		public Guid ReadBackward(
@@ -337,7 +333,6 @@ namespace EventStore.Core.Helpers {
 			Guid? corrId = null) {
 			if (!corrId.HasValue)
 				corrId = Guid.NewGuid();
-			AddPendingRequest(corrId.Value);
 			return
 				ForwardReader.Publish(
 					new ClientMessage.ReadStreamEventsForward(
@@ -351,10 +346,7 @@ namespace EventStore.Core.Helpers {
 						false,
 						null,
 						principal),
-					res => {
-						RemovePendingRequest(res.CorrelationId);
-						action(res);
-					});
+					action);
 		}
 
 		public Guid ReadForward(
@@ -400,7 +392,6 @@ namespace EventStore.Core.Helpers {
 			Action<ClientMessage.ReadEventCompleted> action,
 			Guid? corrId = null) {
 			corrId ??= Guid.NewGuid();
-			AddPendingRequest(corrId.Value);
 			return
 				EventReader.Publish(
 					new ClientMessage.ReadEvent(
@@ -411,10 +402,8 @@ namespace EventStore.Core.Helpers {
 						fromEventNumber,
 						false,
 						false,
-						principal), res => {
-						RemovePendingRequest(res.CorrelationId);
-						action(res);
-					});
+						principal),
+					action);
 		}
 
 		public Guid ReadAllForward(

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -12,19 +12,13 @@ using EventStore.Core.Services;
 using EventStore.Core.Services.UserManagement;
 using EventStore.Projections.Core.Messages;
 using Newtonsoft.Json.Linq;
-using EventStore.Core.Services.TimerService;
-using EventStore.Core.Settings;
 using Serilog;
 
 namespace EventStore.Projections.Core.Services.Processing {
 	public class EmittedStream : IDisposable,
-		IHandle<CoreProjectionProcessingMessage.EmittedStreamWriteCompleted>,
-		IHandle<ProjectionManagementMessage.Internal.ReadTimeout> {
-		private const string ReadUpTo = "upTo";
-		private const string ReadFromEventNumber = "readFromEventNumber";
+		IHandle<CoreProjectionProcessingMessage.EmittedStreamWriteCompleted> {
 		private readonly IODispatcher _ioDispatcher;
 		private readonly IPublisher _publisher;
-
 
 		private readonly ILogger _logger;
 		private readonly string _streamId;
@@ -400,32 +394,17 @@ namespace EventStore.Projections.Core.Services.Processing {
 			_ioDispatcher.ReadBackward(
 				_streamId, fromEventNumber, 1, resolveLinks: false, principal: SystemAccounts.System,
 				action: completed => ReadStreamEventsBackwardCompleted(completed, upTo),
-				corrId: _pendingRequestCorrelationId);
-			ScheduleReadTimeoutMessage(_pendingRequestCorrelationId, _streamId, upTo, fromEventNumber);
+				corrId: _pendingRequestCorrelationId,
+				timeoutAction: CreateReadTimeoutAction(_pendingRequestCorrelationId, upTo, fromEventNumber));
 		}
 
-		private void ScheduleReadTimeoutMessage(Guid correlationId, string streamId, CheckpointTag upTo,
-			long fromEventNumber) {
-			_publisher.Publish(CreateReadTimeoutMessage(correlationId, streamId, new Dictionary<string, object> {
-				{ReadUpTo, upTo},
-				{ReadFromEventNumber, fromEventNumber}
-			}));
-		}
-
-		private Message CreateReadTimeoutMessage(Guid correlationId, string streamId,
-			Dictionary<string, object> parameters) {
-			return TimerMessage.Schedule.Create(
-				TimeSpan.FromMilliseconds(ESConsts.ReadRequestTimeout),
-				new SendToThisEnvelope(this),
-				new ProjectionManagementMessage.Internal.ReadTimeout(correlationId, streamId, parameters));
-		}
-
-		public void Handle(ProjectionManagementMessage.Internal.ReadTimeout message) {
-			if (message.CorrelationId != _pendingRequestCorrelationId) return;
-			_pendingRequestCorrelationId = Guid.Empty;
-			_awaitingListEventsCompleted = false;
-			SubmitListEvents((CheckpointTag)message.Parameters[ReadUpTo],
-				(long)message.Parameters[ReadFromEventNumber]);
+		private Action CreateReadTimeoutAction(Guid correlationId, CheckpointTag upTo, long fromEventNumber) {
+			return () => {
+				if (correlationId != _pendingRequestCorrelationId) return;
+				_pendingRequestCorrelationId = Guid.Empty;
+				_awaitingListEventsCompleted = false;
+				SubmitListEvents(upTo, fromEventNumber);
+			};
 		}
 
 		private void SubmitWriteMetadata() {

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -685,8 +685,11 @@ namespace EventStore.Projections.Core.Services.Processing {
 					_awaitingLinkToResolution = true;
 					_ioDispatcher.ReadEvent(resolution.StreamId, resolution.Revision, _writeAs, resp => {
 						OnEmittedLinkEventResolved(anyFound, eventToWrite, resolution.TopCommitted, resp);
-					});
-					
+					}, () => {
+						Log.Warning(
+							"Timed out reading original event for emitted event at revision {eventNumber} in stream '{streamName}'.",
+							resolution.Revision, resolution.StreamId);
+					}, Guid.NewGuid());
 					break;
 				}
 			}

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsTracker.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsTracker.cs
@@ -52,7 +52,11 @@ namespace EventStore.Projections.Core.Services.Processing {
 					if (!x.IsEndOfStream) {
 						ReadEmittedStreamStreamIdsIntoCache(x.NextEventNumber);
 					}
-				});
+				}, () => {
+					Log.Error(
+						"Timed out reading emitted stream ids into cache from {streamName} at position {position}.",
+						_projectionNamesBuilder.GetEmittedStreamsName(), position);
+				}, Guid.NewGuid());
 		}
 
 		public void TrackEmittedStream(EmittedEvent[] emittedEvents) {


### PR DESCRIPTION
Fixed: Prevent projections subsystem from getting stuck in a stopping state due to read timeouts
Changed: Reads operations in IODispatcher are no longer tracked if they don't have a timeoutAction
Added: Logging around read timeouts in projection emitted streams and emitted stream trackers

Fixes https://github.com/EventStore/EventStore/issues/3431

- Use the timeout functionality from the `IODispatcher` when recovering a projection from a checkpoint so that the reads can be properly tracked.
- Add `timeoutAction` to `ReadEvent` in the `IODispatcher`.
- Log an error when reads time out while reading linked events in emitted streams.
- Log an error when reads time out while emitted streams into the cache of the emitted stream tracker on timeout.