### PR TITLE
[Cherry-pick] Fix projections subsystem getting stuck in a stopping state when reads timeout

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsTracker.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsTracker.cs
@@ -52,7 +52,11 @@ namespace EventStore.Projections.Core.Services.Processing {
 					if (!x.IsEndOfStream) {
 						ReadEmittedStreamStreamIdsIntoCache(x.NextEventNumber);
 					}
-				});
+				}, () => {
+					Log.Error(
+						"Timed out reading emitted stream ids into cache from {streamName} at position {position}.",
+						_projectionNamesBuilder.GetEmittedStreamsName(), position);
+				}, Guid.NewGuid());
 		}
 
 		public void TrackEmittedStream(EmittedEvent[] emittedEvents) {


### PR DESCRIPTION
Fixed: Prevent projections subsystem from getting stuck in a stopping state due to read timeouts
Changed: Reads operations in IODispatcher are no longer tracked if they don't have a timeoutAction
Added: Logging around read timeouts in projection emitted streams and emitted stream trackers

Cherry-picks PR https://github.com/EventStore/EventStore/pull/3435 to release/oss-v21.10