### PR TITLE
Publish AckLogPosition on ReplicaSubscribed

### DIFF
--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -88,6 +88,7 @@ namespace EventStore.Core.Services {
 
 			_subscriptionId = message.SubscriptionId;
 			_ackedSubscriptionPos = _subscriptionPos = message.SubscriptionPosition;
+			Bus.Publish(new ReplicationMessage.AckLogPosition(_subscriptionId, _ackedSubscriptionPos));
 
 			Log.Information(
 				"=== SUBSCRIBED to [{leaderEndPoint},{leaderId:B}] at {subscriptionPosition} (0x{subscriptionPosition:X}). SubscriptionId: {subscriptionId:B}.",


### PR DESCRIPTION
Fixed: Risk of PreLeader not successfully transitioning to Leader if a TCP disconnect occurs at just the right time.

So that the Leader/Preleader is notified, when the follower subscribes, of where the follower is replicated up to.
The leader could infer this from the subscription request, but this would mean adding a new mechanism that produces the ack messages. This solution fits neatly with what is already present.

Without this change there is a risk that the preleader would replicate its epoch to the follower, the follower acks, but the ack never makes it to the leader due to a dropped tcp connection.
In that case, when the follower resubscribes, it would be seen to be already up to date, no replication would occur, and so no ack sent, so the preleader would not find out that the replication
was successful, and therefore it would not transition to leader.