### PR TITLE
[Cherry-pick] Send full certificate chain (excluding root) from client and server side

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Net.Security;
 using System.Runtime.InteropServices;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Common.Configuration;
@@ -10,7 +14,6 @@ using EventStore.Core.Services.Transport.Http;
 using EventStore.Core;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
-using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -141,24 +144,7 @@ namespace EventStore.ClusterNode {
 												listenOptions.Use(next =>
 													new ClearTextHttpMultiplexingMiddleware(next).OnConnectAsync);
 											} else {
-												listenOptions.UseHttps(new HttpsConnectionAdapterOptions {
-													ServerCertificateSelector = delegate {
-														return hostedService.Node.CertificateSelector();
-													},
-													ClientCertificateMode = ClientCertificateMode.AllowCertificate,
-													ClientCertificateValidation = (certificate, chain, sslPolicyErrors) => {
-														var (isValid, error) =
-															hostedService.Node.InternalClientCertificateValidator(
-																certificate,
-																chain,
-																sslPolicyErrors);
-														if (!isValid && error != null) {
-															Log.Error("Client certificate validation error: {e}", error);
-														}
-
-														return isValid;
-													}
-												});
+												listenOptions.UseHttps(CreateServerOptionsSelectionCallback(hostedService), null);
 											}
 										});
 								})
@@ -183,6 +169,42 @@ namespace EventStore.ClusterNode {
 			} finally {
 				Log.CloseAndFlush();
 			}
+		}
+
+		private static ServerOptionsSelectionCallback CreateServerOptionsSelectionCallback(ClusterVNodeHostedService hostedService) {
+			return ((_, _, _, _) => {
+				var serverOptions = new SslServerAuthenticationOptions {
+					ServerCertificateContext = SslStreamCertificateContext.Create(
+						hostedService.Node.CertificateSelector(),
+						hostedService.Node.IntermediateCertificatesSelector(),
+						offline: true),
+					ClientCertificateRequired = true, // request a client certificate but it's not necessary for the client to supply one
+					RemoteCertificateValidationCallback = (_, certificate, chain, sslPolicyErrors) => {
+						if(certificate == null) // not necessary to have a client certificate
+							return true;
+
+						var (isValid, error) =
+							hostedService.Node.InternalClientCertificateValidator(
+								certificate,
+								chain,
+								sslPolicyErrors);
+						if (!isValid && error != null) {
+							Log.Error("Client certificate validation error: {e}", error);
+						}
+
+						return isValid;
+					},
+					CertificateRevocationCheckMode = X509RevocationMode.NoCheck,
+					EnabledSslProtocols = SslProtocols.None, // let the OS choose a secure TLS protocol
+					ApplicationProtocols = new List<SslApplicationProtocol> {
+						SslApplicationProtocol.Http2,
+						SslApplicationProtocol.Http11
+					},
+					AllowRenegotiation = false
+				};
+
+				return ValueTask.FromResult(serverOptions);
+			});
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionSslTests.cs
@@ -52,7 +52,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				var serverSocket = listeningSocket.Accept();
 				var serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
 					(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, ssl_connections.GetServerCertificate,
-					delegate { return (true, null); }, false);
+					null, delegate { return (true, null); }, false);
 
 				mre.Wait(TimeSpan.FromSeconds(3));
 				try {
@@ -118,7 +118,8 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 					serverSocket = listeningSocket.Accept();
 					clientTcpConnection.Close("Intentional close");
 					serverTcpConnection = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(),
-						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, ssl_connections.GetServerCertificate,delegate { return (true, null); }, false);
+						(IPEndPoint)serverSocket.RemoteEndPoint, serverSocket, ssl_connections.GetServerCertificate,
+						null, delegate { return (true, null); }, false);
 
 					mre.Wait(TimeSpan.FromSeconds(10));
 					SpinWait.SpinUntil(() => serverTcpConnection.IsClosed, TimeSpan.FromSeconds(10));

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connection.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 		[Test]
 		public void should_connect_to_each_other_and_send_data() {
 			var serverEndPoint = new IPEndPoint(_ip, _port);
-			X509Certificate cert = GetServerCertificate();
+			X509Certificate2 cert = GetServerCertificate();
 
 			var sent = new byte[1000];
 			new Random().NextBytes(sent);
@@ -39,7 +39,8 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 
 			var listener = new TcpServerListener(serverEndPoint);
 			listener.StartListening((endPoint, socket) => {
-				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, () => cert,delegate { return (true, null); },
+				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket,
+					() => cert, null, delegate { return (true, null); },
 					verbose: true);
 				ssl.ConnectionClosed += (x, y) => done.Set();
 				if (ssl.IsClosed)

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/ssl_connections_mutual_auth.cs
@@ -70,7 +70,8 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			var listener = new TcpServerListener(serverEndPoint);
 			listener.StartListening((endPoint, socket) => {
 				var ssl = TcpConnectionSsl.CreateServerFromSocket(Guid.NewGuid(), endPoint, socket, () => serverCertificate,
-					(cert, chain, err) => validateClientCertificate ? ClusterVNode<string>.ValidateClientCertificate(cert, chain, err, () => null, () => rootCertificates) : (true, null),
+					null, (cert, chain, err) => validateClientCertificate ?
+						ClusterVNode<string>.ValidateClientCertificate(cert, chain, err, () => null, () => rootCertificates) : (true, null),
 					verbose: true);
 				ssl.ConnectionClosed += (x, y) => done.Set();
 				if (ssl.IsClosed)

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/when_invalid_data_is_sent_over_tcp.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
 	public class when_invalid_data_is_sent_over_tcp<TLogFormat, TStreamId> : specification_with_cluster<TLogFormat, TStreamId> {
 
-		[Timeout(5000)]
+		[Timeout(15000)]
 		[TestCase("InternalTcpEndPoint", false)]
 		[TestCase("ExternalTcpEndPoint", false)]
 		public async Task connection_should_be_closed_by_remote_party(string endpointProperty, bool secure) {

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/with_intermediate_certificates.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/with_intermediate_certificates.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Net;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using EventStore.Common.Utils;
+using EventStore.Core.Services.Transport.Tcp;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.Certificates;
+using EventStore.Transport.Tcp;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Tcp {
+	[TestFixture]
+	public class with_intermediate_certificates : with_certificate_chain_of_length_3 {
+		private TcpServerListener _listener;
+		private IPEndPoint _serverEndPoint;
+		private ITcpConnection _client;
+		private Func<X509Certificate, X509Chain, SslPolicyErrors, (bool, string)> _clientCertValidator;
+		private X509Certificate2 _cert;
+
+		[SetUp]
+		public void SetUp() {
+			// certificate exported to PKCS #12 due to this issue on Windows: https://github.com/dotnet/runtime/issues/45680
+			_cert = new X509Certificate2(_leaf.Export(X509ContentType.Pkcs12));
+
+			_clientCertValidator = (_,_,_) => (true, null);
+			_serverEndPoint = new IPEndPoint(IPAddress.Loopback, PortsHelper.GetAvailablePort(IPAddress.Loopback));
+			_listener = new TcpServerListener(_serverEndPoint);
+			_listener.StartListening((endPoint, socket) => {
+				TcpConnectionSsl.CreateServerFromSocket(
+					Guid.NewGuid(),
+					endPoint,
+					socket,
+					() => _cert,
+					() => new X509Certificate2Collection(_intermediate),
+					(cert,chain,errors) => _clientCertValidator(cert, chain, errors),
+					verbose: true);
+			}, "Secure");
+		}
+
+		[Test]
+		public void server_should_send_intermediate_certificate_during_handshake() {
+			var done = new ManualResetEventSlim(false);
+
+			bool gotLeaf = false;
+			bool gotIntermediate = false;
+
+			_client = TcpConnectionSsl.CreateConnectingConnection(
+				Guid.NewGuid(),
+				_serverEndPoint.GetHost(),
+				_serverEndPoint,
+				(certificate, chain, _) => {
+					gotLeaf = _leaf.Equals(certificate);
+					foreach (var chainElement in chain.ChainElements) {
+						if (chainElement.Certificate.Equals(_intermediate)) {
+							gotIntermediate = true;
+						}
+					}
+
+					done.Set();
+					return (true, null);
+				},
+				null,
+				new TcpClientConnector(),
+				TcpConnectionManager.ConnectionTimeout,
+				conn => { },
+				(conn, err) => { },
+				verbose: true);
+
+			Assert.True(done.Wait(20000), "Took too long to receive completion.");
+			Assert.True(gotLeaf);
+			Assert.True(gotIntermediate);
+		}
+
+		[Test, Ignore("Skipped since it adds an intermediate certificate to the current user's store")]
+		public void client_should_send_intermediate_certificate_during_handshake() {
+			try {
+				// see: https://github.com/dotnet/runtime/issues/47680#issuecomment-771093045
+				AddIntermediateCertificateToStore();
+
+				var done = new ManualResetEventSlim(false);
+
+				bool gotLeaf = false;
+				bool gotIntermediate = false;
+
+				_clientCertValidator = (certificate, chain, _) => {
+					gotLeaf = _leaf.Equals(certificate);
+					foreach (var chainElement in chain.ChainElements) {
+						if (chainElement.Certificate.Equals(_intermediate)) {
+							gotIntermediate = true;
+						}
+					}
+
+					done.Set();
+					return (true, null);
+				};
+
+				_client = TcpConnectionSsl.CreateConnectingConnection(
+					Guid.NewGuid(),
+					_serverEndPoint.GetHost(),
+					_serverEndPoint,
+					(_, _, _) => (true, null),
+					() => new X509Certificate2Collection(_cert),
+					new TcpClientConnector(),
+					TcpConnectionManager.ConnectionTimeout,
+					conn => { },
+					(conn, err) => { },
+					verbose: true);
+
+				Assert.True(done.Wait(20000), "Took too long to receive completion.");
+				Assert.True(gotLeaf);
+				Assert.True(gotIntermediate);
+			} finally {
+				RemoveIntermediateCertificateFromStore();
+			}
+		}
+
+		private void AddIntermediateCertificateToStore() {
+			using var intermediateStore = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser);
+			intermediateStore.Open(OpenFlags.ReadWrite);
+			intermediateStore.Add(_intermediate);
+		}
+
+		private void RemoveIntermediateCertificateFromStore() {
+			using var intermediateStore = new X509Store(StoreName.CertificateAuthority, StoreLocation.CurrentUser);
+			intermediateStore.Open(OpenFlags.ReadWrite);
+			intermediateStore.Remove(_intermediate);
+		}
+
+		[TearDown]
+		public void TearDown() {
+			_listener.Stop();
+			_client.Close("Normal close.");
+		}
+	}
+}


### PR DESCRIPTION
Fixed: Send full certificate chain from both server and client side during TLS handshake (requires manually adding intermediate certificates to the store)

Cherry-picks https://github.com/EventStore/EventStore/pull/3398 to release 21.10