### PR TITLE
Retry establishing a TCP connection to the leader

### DIFF
--- a/src/EventStore.Core/Messages/ReplicationMessage.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessage.cs
@@ -139,12 +139,30 @@ namespace EventStore.Core.Messages {
 			}
 
 			public readonly MemberInfo Leader;
-			public readonly Guid StateCorrelationId;
+			public readonly Guid ConnectionCorrelationId;
 
-			public ReconnectToLeader(Guid stateCorrelationId, MemberInfo leader) {
-				Ensure.NotEmptyGuid(stateCorrelationId, "stateCorrelationId");
-				Ensure.NotNull(leader, "leader");
-				StateCorrelationId = stateCorrelationId;
+			public ReconnectToLeader(Guid connectionCorrelationId, MemberInfo leader) {
+				Ensure.NotEmptyGuid(connectionCorrelationId, nameof(connectionCorrelationId));
+				Ensure.NotNull(leader, nameof(leader));
+				ConnectionCorrelationId = connectionCorrelationId;
+				Leader = leader;
+			}
+		}
+
+		public class LeaderConnectionFailed : Message {
+			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public readonly MemberInfo Leader;
+			public readonly Guid LeaderConnectionCorrelationId;
+
+			public LeaderConnectionFailed(Guid leaderConnectionCorrelationId, MemberInfo leader) {
+				Ensure.NotEmptyGuid(leaderConnectionCorrelationId, nameof(leaderConnectionCorrelationId));
+				Ensure.NotNull(leader, nameof(leader));
+				LeaderConnectionCorrelationId = leaderConnectionCorrelationId;
 				Leader = leader;
 			}
 		}

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -227,8 +227,11 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public BecomePreReplica(Guid correlationId, MemberInfo leader) : base(correlationId, VNodeState.PreReplica,
-				leader) {
+			public readonly Guid LeaderConnectionCorrelationId;
+
+			public BecomePreReplica(Guid correlationId, Guid leaderConnectionCorrelationId, MemberInfo leader)
+				: base(correlationId, VNodeState.PreReplica, leader) {
+				LeaderConnectionCorrelationId = leaderConnectionCorrelationId;
 			}
 		}
 
@@ -286,8 +289,11 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public BecomePreReadOnlyReplica(Guid correlationId, MemberInfo leader)
+			public readonly Guid LeaderConnectionCorrelationId;
+
+			public BecomePreReadOnlyReplica(Guid correlationId, Guid leaderConnectionCorrelationId, MemberInfo leader)
 				: base(correlationId, VNodeState.PreReadOnlyReplica, leader) {
+				LeaderConnectionCorrelationId = leaderConnectionCorrelationId;
 			}
 		}
 


### PR DESCRIPTION
Fixed: Attempt to reconnect to the leader every second if the node fails to establish a connection (for example due to DNS lookup timeout).

Fixes https://github.com/EventStore/home/issues/723

To reproduce the original issue, edit the code to throw an exception in [ResolveDnsToIpAddress](https://github.com/EventStore/EventStore/blob/master/src/EventStore.Common/Utils/EndpointExtensions.cs#L37) and then try and have the node subscribe to the leader. The follower will fail to subscribe and will get stuck in a state where it does not replicate from the leader.

- Catch exceptions when calling `ConnectToLeader` in `ReplicaService` and publish a `ReplicaMessage.LeaderConnectionFailed` message.
- Handle `LeaderConnectionFailed` in the `VNodeController` by attempting to `ReconnectToLeader`.
- Create a separate `ConnectionCorrelationId`, which covers establishing the connection to the leader. This is separate to the `StateCorrelationId` because subscriptions need to be retried independently of connections.
- Only attempt to create a subscription if the connection is not null.