### PR TITLE
Want to consider populating $all position for stream reads/subscriptions. gRPC & non-transaction only.

### DIFF
--- a/src/EventStore.Core/Data/EventRecord.cs
+++ b/src/EventStore.Core/Data/EventRecord.cs
@@ -9,6 +9,8 @@ namespace EventStore.Core.Data {
 			get { return (Flags & PrepareFlags.IsJson) == PrepareFlags.IsJson; }
 		}
 
+		public bool IsSelfCommitted => Flags.HasAnyOf(PrepareFlags.IsCommitted);
+
 		public readonly long EventNumber;
 		public readonly long LogPosition;
 		public readonly Guid CorrelationId;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.cs
@@ -47,10 +47,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		private static ReadResp.Types.ReadEvent ConvertToReadEvent(ReadReq.Types.Options.Types.UUIDOption uuidOption,
 			ResolvedEvent e) {
 			var readEvent = new ReadResp.Types.ReadEvent {
-				Link = ConvertToRecordedEvent(uuidOption, e.Link, e.OriginalPosition?.CommitPosition,
-					e.OriginalPosition?.PreparePosition),
-				Event = ConvertToRecordedEvent(uuidOption, e.Event, e.OriginalPosition?.CommitPosition,
-					e.OriginalPosition?.PreparePosition),
+				Link = ConvertToRecordedEvent(uuidOption, e.Link, e.LinkPosition?.CommitPosition,
+					e.LinkPosition?.PreparePosition),
+				Event = ConvertToRecordedEvent(uuidOption, e.Event, e.EventPosition?.CommitPosition,
+					e.EventPosition?.PreparePosition),
 			};
 			if (e.OriginalPosition.HasValue) {
 				var position = Position.FromInt64(


### PR DESCRIPTION
Added: Populate $all position for stream reads/subscriptions/persistent subscriptions. gRPC only. Non-transaction events only.

Currently the $all position (commit and prepare pair) is only provided to the client during $all reads/subscriptions, and not during stream reads/subscriptions. However, the user-facing datastructure does contain fields for this information.

This PR considers the possibility of populating the $all position for stream reads/subscriptions with the following caveats

- only for gRPC clients (the tcp wire datastructures do not have fields for this information)
- only for events that are not written in explicit transactions (we cannot efficiently determine the commit position for events in transactions)

todo: discuss pros (this is asked for from time to time. a bit odd that the fields are present but not currently populated) and cons (potential confusion with respect to transactions). does it need a server capability added? does it want backporting?

Client impact:
- dotnet, java, go, rust: most probably no changes necessary
- node: will not be broken by this change, but needs some work to plumb the data through to the user. can be written in a non-breaking way

Closes https://github.com/EventStore/EventStore-Client-Dotnet/issues/211.