### PR TITLE
[backport v20.10] Retry establishing a TCP connection to the leader

### DIFF
--- a/src/EventStore.Core/Messages/ReplicationMessage.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessage.cs
@@ -139,12 +139,30 @@ namespace EventStore.Core.Messages {
 			}
 
 			public readonly MemberInfo Leader;
-			public readonly Guid StateCorrelationId;
+			public readonly Guid ConnectionCorrelationId;
 
-			public ReconnectToLeader(Guid stateCorrelationId, MemberInfo leader) {
-				Ensure.NotEmptyGuid(stateCorrelationId, "stateCorrelationId");
-				Ensure.NotNull(leader, "leader");
-				StateCorrelationId = stateCorrelationId;
+			public ReconnectToLeader(Guid connectionCorrelationId, MemberInfo leader) {
+				Ensure.NotEmptyGuid(connectionCorrelationId, nameof(connectionCorrelationId));
+				Ensure.NotNull(leader, nameof(leader));
+				ConnectionCorrelationId = connectionCorrelationId;
+				Leader = leader;
+			}
+		}
+
+		public class LeaderConnectionFailed : Message {
+			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public readonly MemberInfo Leader;
+			public readonly Guid LeaderConnectionCorrelationId;
+
+			public LeaderConnectionFailed(Guid leaderConnectionCorrelationId, MemberInfo leader) {
+				Ensure.NotEmptyGuid(leaderConnectionCorrelationId, nameof(leaderConnectionCorrelationId));
+				Ensure.NotNull(leader, nameof(leader));
+				LeaderConnectionCorrelationId = leaderConnectionCorrelationId;
 				Leader = leader;
 			}
 		}

--- a/src/EventStore.Core/Messages/SystemMessage.cs
+++ b/src/EventStore.Core/Messages/SystemMessage.cs
@@ -227,8 +227,11 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public BecomePreReplica(Guid correlationId, MemberInfo leader) : base(correlationId, VNodeState.PreReplica,
-				leader) {
+			public readonly Guid LeaderConnectionCorrelationId;
+
+			public BecomePreReplica(Guid correlationId, Guid leaderConnectionCorrelationId, MemberInfo leader)
+				: base(correlationId, VNodeState.PreReplica, leader) {
+				LeaderConnectionCorrelationId = leaderConnectionCorrelationId;
 			}
 		}
 
@@ -286,8 +289,11 @@ namespace EventStore.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public BecomePreReadOnlyReplica(Guid correlationId, MemberInfo leader)
+			public readonly Guid LeaderConnectionCorrelationId;
+
+			public BecomePreReadOnlyReplica(Guid correlationId, Guid leaderConnectionCorrelationId, MemberInfo leader)
 				: base(correlationId, VNodeState.PreReadOnlyReplica, leader) {
+				LeaderConnectionCorrelationId = leaderConnectionCorrelationId;
 			}
 		}
 

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -108,12 +108,12 @@ namespace EventStore.Core.Services.Replication {
 				}
 				case VNodeState.PreReplica: {
 					var m = (SystemMessage.BecomePreReplica)message;
-					ConnectToLeader(m.Leader);
+					ConnectToLeader(m.LeaderConnectionCorrelationId, m.Leader);
 					break;
 				}
 				case VNodeState.PreReadOnlyReplica: {
 					var m = (SystemMessage.BecomePreReadOnlyReplica)message;
-					ConnectToLeader(m.Leader);
+					ConnectToLeader(m.LeaderConnectionCorrelationId, m.Leader);
 					break;
 				}
 				case VNodeState.CatchingUp:
@@ -145,10 +145,10 @@ namespace EventStore.Core.Services.Replication {
 		}
 
 		public void Handle(ReplicationMessage.ReconnectToLeader message) {
-			ConnectToLeader(message.Leader);
+			ConnectToLeader(message.ConnectionCorrelationId, message.Leader);
 		}
 
-		private void ConnectToLeader(MemberInfo leader) {
+		private void ConnectToLeader(Guid leaderConnectionCorrelationId, MemberInfo leader) {
 			Debug.Assert(_state == VNodeState.PreReplica || _state == VNodeState.PreReadOnlyReplica);
 
 			var leaderEndPoint = GetLeaderEndPoint(leader, _useSsl);
@@ -161,27 +161,32 @@ namespace EventStore.Core.Services.Replication {
 				_connection.Stop(string.Format("Reconnecting from old leader [{0}] to new leader: [{1}].",
 					_connection.RemoteEndPoint, leaderEndPoint));
 
-			_connection = new TcpConnectionManager(_useSsl ? "leader-secure" : "leader-normal",
-				Guid.NewGuid(),
-				_tcpDispatcher,
-				_publisher,
-				leaderEndPoint.GetHost(),
-				leaderEndPoint,
-				_connector,
-				_useSsl,
-				_sslServerCertValidator,
-				() => {
-					var cert = _sslClientCertificateSelector();
-					return new X509CertificateCollection{cert};
-				},
-				_networkSendQueue,
-				_authProvider,
-				_authorizationGateway,
-				_heartbeatInterval,
-				_heartbeatTimeout,
-				OnConnectionEstablished,
-				OnConnectionClosed);
-			_connection.StartReceiving();
+			try {
+				_connection = new TcpConnectionManager(_useSsl ? "leader-secure" : "leader-normal",
+					Guid.NewGuid(),
+					_tcpDispatcher,
+					_publisher,
+					leaderEndPoint.GetHost(),
+					leaderEndPoint,
+					_connector,
+					_useSsl,
+					_sslServerCertValidator,
+					() => {
+						var cert = _sslClientCertificateSelector();
+						return new X509CertificateCollection{cert};
+					},
+					_networkSendQueue,
+					_authProvider,
+					_authorizationGateway,
+					_heartbeatInterval,
+					_heartbeatTimeout,
+					OnConnectionEstablished,
+					OnConnectionClosed);
+				_connection.StartReceiving();
+			} catch (Exception ex) {
+				Log.Error(ex, "Failed to connect to leader [{leader}]. This will be retried.", leader);
+				_publisher.Publish(new ReplicationMessage.LeaderConnectionFailed(leaderConnectionCorrelationId, leader));
+			}
 		}
 
 		private static EndPoint GetLeaderEndPoint(MemberInfo leader, bool useSsl) {
@@ -201,6 +206,11 @@ namespace EventStore.Core.Services.Replication {
 			if (_state != VNodeState.PreReplica && _state != VNodeState.PreReadOnlyReplica)
 				throw new Exception(string.Format("_state is {0}, but is expected to be {1} or {2}", _state,
 					VNodeState.PreReplica, VNodeState.PreReadOnlyReplica));
+			if (_connection is null) {
+				Log.Warning(
+					"Attempted to subscribe to LEADER [{leaderId:B}], but no connection has been established. This will be retried.", message.LeaderId);
+				return;
+			}
 
 			var logPosition = _db.Config.WriterCheckpoint.ReadNonFlushed();
 			var epochs = _epochManager.GetLastEpochs(ClusterConsts.SubscriptionLastEpochCount).ToArray();

--- a/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
+++ b/src/EventStore.Core/Services/VNode/ClusterVNodeController.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Services.VNode {
 		private VNodeState _state = VNodeState.Initializing;
 		private MemberInfo _leader;
 		private Guid _stateCorrelationId = Guid.NewGuid();
+		private Guid _leaderConnectionCorrelationId = Guid.NewGuid();
 		private Guid _subscriptionId = Guid.Empty;
 		private readonly int _clusterSize;
 
@@ -232,12 +233,14 @@ namespace EventStore.Core.Services.VNode {
 				.When<SystemMessage.WaitForChaserToCatchUp>().Do(Handle)
 				.When<SystemMessage.ChaserCaughtUp>().Do(HandleAsPreReplica)
 				.When<ReplicationMessage.ReconnectToLeader>().Do(Handle)
+				.When<ReplicationMessage.LeaderConnectionFailed>().Do(Handle)
 				.When<ReplicationMessage.SubscribeToLeader>().Do(Handle)
 				.When<ReplicationMessage.ReplicaSubscriptionRetry>().Do(Handle)
 				.When<ReplicationMessage.ReplicaSubscribed>().Do(Handle)
 				.WhenOther().ForwardTo(_outputBus)
 				.InAllStatesExcept(VNodeState.PreReplica, VNodeState.PreReadOnlyReplica)
 				.When<ReplicationMessage.ReconnectToLeader>().Ignore()
+				.When<ReplicationMessage.LeaderConnectionFailed>().Ignore()
 				.When<ReplicationMessage.SubscribeToLeader>().Ignore()
 				.When<ReplicationMessage.ReplicaSubscriptionRetry>().Ignore()
 				.When<ReplicationMessage.ReplicaSubscribed>().Ignore()
@@ -528,11 +531,12 @@ namespace EventStore.Core.Services.VNode {
 			_leader = message.Leader;
 			_subscriptionId = Guid.NewGuid();
 			_stateCorrelationId = Guid.NewGuid();
+			_leaderConnectionCorrelationId = Guid.NewGuid();
 			_outputBus.Publish(message);
 			if (_leader.InstanceId == _nodeInfo.InstanceId)
 				_fsm.Handle(new SystemMessage.BecomePreLeader(_stateCorrelationId));
 			else
-				_fsm.Handle(new SystemMessage.BecomePreReplica(_stateCorrelationId, _leader));
+				_fsm.Handle(new SystemMessage.BecomePreReplica(_stateCorrelationId, _leaderConnectionCorrelationId, _leader));
 		}
 
 		private void Handle(SystemMessage.ServiceInitialized message) {
@@ -905,9 +909,10 @@ namespace EventStore.Core.Services.VNode {
 		private void Handle(SystemMessage.VNodeConnectionLost message) {
 			if (_leader != null && _leader.Is(message.VNodeEndPoint)) // leader connection failed
 			{
+				_leaderConnectionCorrelationId = Guid.NewGuid();
 				var msg = _state == VNodeState.PreReplica
-					? (Message)new ReplicationMessage.ReconnectToLeader(_stateCorrelationId, _leader)
-					: new SystemMessage.BecomePreReplica(_stateCorrelationId, _leader);
+					? (Message)new ReplicationMessage.ReconnectToLeader(_leaderConnectionCorrelationId, _leader)
+					: new SystemMessage.BecomePreReplica(_stateCorrelationId, _leaderConnectionCorrelationId, _leader);
 				_mainQueue.Publish(TimerMessage.Schedule.Create(LeaderReconnectionDelay, _publishEnvelope, msg));
 			}
 
@@ -917,9 +922,10 @@ namespace EventStore.Core.Services.VNode {
 		private void HandleAsReadOnlyReplica(SystemMessage.VNodeConnectionLost message) {
 			if (_leader != null && _leader.Is(message.VNodeEndPoint)) // leader connection failed
 			{
+				_leaderConnectionCorrelationId = Guid.NewGuid();
 				var msg = _state == VNodeState.PreReadOnlyReplica
-					? (Message)new ReplicationMessage.ReconnectToLeader(_stateCorrelationId, _leader)
-					: new SystemMessage.BecomePreReadOnlyReplica(_stateCorrelationId, _leader);
+					? (Message)new ReplicationMessage.ReconnectToLeader(_leaderConnectionCorrelationId, _leader)
+					: new SystemMessage.BecomePreReadOnlyReplica(_stateCorrelationId, _leaderConnectionCorrelationId, _leader);
 				_mainQueue.Publish(TimerMessage.Schedule.Create(LeaderReconnectionDelay, _publishEnvelope, msg));
 			}
 
@@ -950,6 +956,7 @@ namespace EventStore.Core.Services.VNode {
 				Log.Debug(
 					(noLeader ? "NO LEADER found" : "LEADER CHANGE detected") + " in READ ONLY PRE-REPLICA/READ ONLY REPLICA state. Proceeding to READ ONLY LEADERLESS STATE. CURRENT LEADER: [{leader}]",_leader);
 				_stateCorrelationId = Guid.NewGuid();
+				_leaderConnectionCorrelationId = Guid.NewGuid();
 				_fsm.Handle(new SystemMessage.BecomeReadOnlyLeaderless(_stateCorrelationId));
 			}
 
@@ -966,7 +973,8 @@ namespace EventStore.Core.Services.VNode {
 				_leader = aliveLeaders.First();
 				Log.Information("LEADER found in READ ONLY LEADERLESS state. LEADER: [{leader}]. Proceeding to READ ONLY PRE-REPLICA state.", _leader);
 				_stateCorrelationId = Guid.NewGuid();
-				_fsm.Handle(new SystemMessage.BecomePreReadOnlyReplica(_stateCorrelationId, _leader));
+				_leaderConnectionCorrelationId = Guid.NewGuid();
+				_fsm.Handle(new SystemMessage.BecomePreReadOnlyReplica(_stateCorrelationId, _leaderConnectionCorrelationId, _leader));
 			} else {
 				Log.Debug(
 					"{leadersFound} found in READ ONLY LEADERLESS state, making further attempts.",
@@ -1004,7 +1012,8 @@ namespace EventStore.Core.Services.VNode {
 				Log.Information("Existing LEADER found during LEADER DISCOVERY stage. LEADER: [{leader}]. Proceeding to PRE-REPLICA state.", _leader);
 				_mainQueue.Publish(new LeaderDiscoveryMessage.LeaderFound(_leader));
 				_stateCorrelationId = Guid.NewGuid();
-				_fsm.Handle(new SystemMessage.BecomePreReplica(_stateCorrelationId, _leader));
+				_leaderConnectionCorrelationId = Guid.NewGuid();
+				_fsm.Handle(new SystemMessage.BecomePreReplica(_stateCorrelationId, _leaderConnectionCorrelationId, _leader));
 			} else {
 				Log.Debug(
 					"{leadersFound} found during LEADER DISCOVERY stage, making further attempts.",
@@ -1050,9 +1059,18 @@ namespace EventStore.Core.Services.VNode {
 		}
 
 		private void Handle(ReplicationMessage.ReconnectToLeader message) {
-			if (_leader.InstanceId != message.Leader.InstanceId || _stateCorrelationId != message.StateCorrelationId)
+			if (_leader.InstanceId != message.Leader.InstanceId || _leaderConnectionCorrelationId != message.ConnectionCorrelationId)
 				return;
 			_outputBus.Publish(message);
+		}
+
+		private void Handle(ReplicationMessage.LeaderConnectionFailed message) {
+			if (_leader.InstanceId != message.Leader.InstanceId || _leaderConnectionCorrelationId != message.LeaderConnectionCorrelationId)
+				return;
+			_leaderConnectionCorrelationId = Guid.NewGuid();
+			var msg = new ReplicationMessage.ReconnectToLeader(_leaderConnectionCorrelationId, message.Leader);
+			// Attempt the connection again after a timeout
+			_outputBus.Publish(TimerMessage.Schedule.Create(LeaderSubscriptionTimeout, _publishEnvelope, msg));
 		}
 
 		private void Handle(ReplicationMessage.SubscribeToLeader message) {


### PR DESCRIPTION
Fixed: Attempt to reconnect to the leader every second if the node fails to establish a connection (for example due to DNS lookup timeout).

Cherry picked from https://github.com/EventStore/EventStore/pull/3458