### PR TITLE
Want to make reads that are after the LastEventNumber efficient

### DIFF
--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReadStreamResult.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReadStreamResult.cs
@@ -17,6 +17,9 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		public readonly EventRecord[] Records;
 		public readonly StreamMetadata Metadata;
 
+		/// <summary>
+		/// Failure Constructor
+		/// </summary>
 		public IndexReadStreamResult(long fromEventNumber, int maxCount, ReadStreamResult result,
 			StreamMetadata metadata, long lastEventNumber) {
 			if (result == ReadStreamResult.Success)
@@ -34,13 +37,29 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			Metadata = metadata;
 		}
 
-		public IndexReadStreamResult(long fromEventNumber,
+		/// <summary>
+		/// Success Constructor
+		/// </summary>
+		/// <param name="fromEventNumber">
+		///     EventNumber that the read starts from. Usually as specified in the request.
+		///     Sometimes resolved (e.g. from EndOfStream to the actual lastEventNumber)
+		///     This is not returned to the client when reading forwards, only backwards.
+		/// </param>
+		/// <param name="maxCount">The maximum number of events requested</param>
+		/// <param name="records"></param>
+		/// <param name="metadata"></param>
+		/// <param name="nextEventNumber">The event number to start the next _request_</param>
+		/// <param name="lastEventNumber">The last event number of the _stream_</param>
+		/// <param name="isEndOfStream"></param>
+		public IndexReadStreamResult(
+			long fromEventNumber,
 			int maxCount,
 			EventRecord[] records,
 			StreamMetadata metadata,
 			long nextEventNumber,
 			long lastEventNumber,
 			bool isEndOfStream) {
+
 			Ensure.NotNull(records, "records");
 
 			FromEventNumber = fromEventNumber;

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -234,15 +234,33 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				long startEventNumber = fromEventNumber;
 				long endEventNumber = Math.Min(long.MaxValue, fromEventNumber + maxCount - 1);
 
+				// calculate minEventNumber, which is the lower bound that we are allowed to read
+				// according to the MaxCount and TruncateBefore
 				long minEventNumber = 0;
 				if (metadata.MaxCount.HasValue)
 					minEventNumber = Math.Max(minEventNumber, lastEventNumber - metadata.MaxCount.Value + 1);
 				if (metadata.TruncateBefore.HasValue)
 					minEventNumber = Math.Max(minEventNumber, metadata.TruncateBefore.Value);
+
+				// early return if we are trying to read events that are all below the lower bound
 				if (endEventNumber < minEventNumber)
 					return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
 						metadata, minEventNumber, lastEventNumber, isEndOfStream: false);
+
+				// start our read at the lower bound if we were going to start it before hand.
 				startEventNumber = Math.Max(startEventNumber, minEventNumber);
+
+				// early return if we are trying to read events that are all above the upper bound
+				if (startEventNumber > lastEventNumber)
+					return new IndexReadStreamResult(
+						fromEventNumber: fromEventNumber,
+						maxCount: maxCount,
+						records: IndexReadStreamResult.EmptyRecords,
+						metadata: metadata,
+						nextEventNumber: lastEventNumber + 1,
+						lastEventNumber: lastEventNumber,
+						isEndOfStream: true);
+
 				if (metadata.MaxAge.HasValue) {
 					return ForStreamWithMaxAge(streamId, streamName,
 						fromEventNumber, maxCount,

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -264,7 +264,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				if (records.Length > 0)
 					nextEventNumber = records[records.Length - 1].EventNumber + 1;
 				var isEndOfStream = endEventNumber >= lastEventNumber;
-				return new IndexReadStreamResult(endEventNumber, maxCount, records, metadata,
+				return new IndexReadStreamResult(fromEventNumber, maxCount, records, metadata,
 					nextEventNumber, lastEventNumber, isEndOfStream);
 			}
 
@@ -324,7 +324,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 					Array.Reverse(resultsArray);
 
 					var isEndOfStream = endEventNumber >= lastEventNumber;
-					return new IndexReadStreamResult(endEventNumber, maxCount, resultsArray, metadata,
+					return new IndexReadStreamResult(fromEventNumber, maxCount, resultsArray, metadata,
 						nextEventNumber, lastEventNumber, isEndOfStream);
 				}
 
@@ -403,7 +403,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 							isEndOfStream = false;
 						}
 
-						return new IndexReadStreamResult(endEventNumber, maxCount, resultsList.ToArray(), metadata,
+						return new IndexReadStreamResult(fromEventNumber, maxCount, resultsList.ToArray(), metadata,
 							nextEventNumber, lastEventNumber, isEndOfStream);
 					}
 


### PR DESCRIPTION
Added: Fast path for forward reads that start after the LastEventNumber

Use case: Some clients want to be able to read a stream up to latest from a follower (say, receive events 0-100) but then do an additional read on the leader starting with event 101 in case the follower is stale.

This PR introduces a fast path for when a read starts after the LastEventNumber. We get the LastEventNumber (which may be cached anyway) and then there is no further need to query the index.

On my machine with (a fairly contrived) 100 ptables, this PR makes the ReadIndex access in this scenario 6000x faster

Note this only applies to reading streams forward. If reading backwards it is not clear that such an optimisation could apply since the maxcount would apply from the last actual event downwards, meaning we'd be returning events anyway.