### PR TITLE
[release/oss-v20.10] Want to make reads that are after the LastEventNumber efficient

### DIFF
--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReadStreamResult.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReadStreamResult.cs
@@ -17,6 +17,9 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		public readonly EventRecord[] Records;
 		public readonly StreamMetadata Metadata;
 
+		/// <summary>
+		/// Failure Constructor
+		/// </summary>
 		public IndexReadStreamResult(long fromEventNumber, int maxCount, ReadStreamResult result,
 			StreamMetadata metadata, long lastEventNumber) {
 			if (result == ReadStreamResult.Success)
@@ -34,13 +37,29 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			Metadata = metadata;
 		}
 
-		public IndexReadStreamResult(long fromEventNumber,
+		/// <summary>
+		/// Success Constructor
+		/// </summary>
+		/// <param name="fromEventNumber">
+		///     EventNumber that the read starts from. Usually as specified in the request.
+		///     Sometimes resolved (e.g. from EndOfStream to the actual lastEventNumber)
+		///     This is not returned to the client when reading forwards, only backwards.
+		/// </param>
+		/// <param name="maxCount">The maximum number of events requested</param>
+		/// <param name="records"></param>
+		/// <param name="metadata"></param>
+		/// <param name="nextEventNumber">The event number to start the next _request_</param>
+		/// <param name="lastEventNumber">The last event number of the _stream_</param>
+		/// <param name="isEndOfStream"></param>
+		public IndexReadStreamResult(
+			long fromEventNumber,
 			int maxCount,
 			EventRecord[] records,
 			StreamMetadata metadata,
 			long nextEventNumber,
 			long lastEventNumber,
 			bool isEndOfStream) {
+
 			Ensure.NotNull(records, "records");
 
 			FromEventNumber = fromEventNumber;

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -236,7 +236,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				if (records.Length > 0)
 					nextEventNumber = records[records.Length - 1].EventNumber + 1;
 				var isEndOfStream = endEventNumber >= lastEventNumber;
-				return new IndexReadStreamResult(endEventNumber, maxCount, records, metadata,
+				return new IndexReadStreamResult(fromEventNumber, maxCount, records, metadata,
 					nextEventNumber, lastEventNumber, isEndOfStream);
 			}
 		}

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -205,15 +205,32 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 				long startEventNumber = fromEventNumber;
 				long endEventNumber = Math.Min(long.MaxValue, fromEventNumber + maxCount - 1);
 
+				// calculate minEventNumber, which is the lower bound that we are allowed to read
+				// according to the MaxCount and TruncateBefore
 				long minEventNumber = 0;
 				if (metadata.MaxCount.HasValue)
 					minEventNumber = Math.Max(minEventNumber, lastEventNumber - metadata.MaxCount.Value + 1);
 				if (metadata.TruncateBefore.HasValue)
 					minEventNumber = Math.Max(minEventNumber, metadata.TruncateBefore.Value);
+
+				// early return if we are trying to read events that are all below the lower bound
 				if (endEventNumber < minEventNumber)
 					return new IndexReadStreamResult(fromEventNumber, maxCount, IndexReadStreamResult.EmptyRecords,
 						metadata, minEventNumber, lastEventNumber, isEndOfStream: false);
+
+				// start our read at the lower bound if we were going to start it before hand.
 				startEventNumber = Math.Max(startEventNumber, minEventNumber);
+
+				// early return if we are trying to read events that are all above the upper bound
+				if (startEventNumber > lastEventNumber)
+					return new IndexReadStreamResult(
+						fromEventNumber: fromEventNumber,
+						maxCount: maxCount,
+						records: IndexReadStreamResult.EmptyRecords,
+						metadata: metadata,
+						nextEventNumber: lastEventNumber + 1,
+						lastEventNumber: lastEventNumber,
+						isEndOfStream: true);
 
 				if (metadata.MaxAge.HasValue) {
 					return ForStreamWithMaxAge(streamId,


### PR DESCRIPTION
Added: Fast path for forward reads that start after the LastEventNumber

Cherry picked from https://github.com/EventStore/EventStore/pull/3474

The initial cherry pick [failed](https://github.com/EventStore/EventStore/pull/3474#pullrequestreview-952317376), this is the manual resolved version of that PR.