### PR TITLE
Use the bloom filter of a scavenged ptable

### DIFF
--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -426,12 +426,11 @@ namespace EventStore.Core.Index {
 
 		private PersistentBloomFilter TryOpenBloomFilter() {
 			try {
-				// todo: if there is a bloom filter with a different size we could still use it
+				// use existing filter without specifying what size it needs to be
+				// for scavenged ptables in particular we do not know exactly what size the bloom filter
+				// is because it is based on the pre-scavenge size
 				var bloomFilter = new PersistentBloomFilter(
-					new FileStreamPersistence(
-						path: BloomFilterFilename,
-						create: false,
-						size: GenBloomFilterSizeBytes(_count)));
+					FileStreamPersistence.FromFile(BloomFilterFilename));
 
 				return bloomFilter;
 			} catch (FileNotFoundException) {

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -459,6 +459,14 @@ namespace EventStore.Core.Index {
 									outputFile);
 							}
 
+							var bloomFilterFile = GenBloomFilterFilename(outputFile);
+							try {
+								File.Delete(bloomFilterFile);
+							} catch (Exception ex) {
+								Log.Error(ex, "Unable to delete unwanted bloom filter: {bloomFilterFile}",
+									bloomFilterFile);
+							}
+
 							spaceSaved = 0;
 							return null;
 						}


### PR DESCRIPTION
Fixed: Can now use the ptable bloom filters after an index scavenge

Previously the bloom filter was not used for a scavenged ptable due to a size mismatch. An error was produced in the log. There were no adverse effects beyond the performance loss of not using the bloom filter.

This was because the bloom filter is sized according to the pre-scavenge table and populated as the scavenge progresses.
Now the scavenged ptable will use the bloom filter regardless of its size.

Also, delete bloom filter if deleting ptable due to no scavenged entries. This would have been cleaned up on next startup
anyway, but this is tidier.

Fixes #3487