### PR TITLE
Allow loading trusted root certificate from the Windows cert store

### DIFF
--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -247,7 +247,7 @@ namespace EventStore.Core {
 			[Description("The certificate store location name.")]
 			public string CertificateStoreLocation { get; init; } = string.Empty;
 
-			[Description("The certificate store location name.")]
+			[Description("The certificate store name.")]
 			public string CertificateStoreName { get; init; } = string.Empty;
 
 			[Description("The certificate store subject name.")]
@@ -256,11 +256,27 @@ namespace EventStore.Core {
 			[Description("The certificate fingerprint/thumbprint.")]
 			public string CertificateThumbprint { get; init; } = string.Empty;
 
+			[Description("The name of the certificate store that contains the trusted root certificate.")]
+			public string TrustedRootCertificateStoreName { get; init; } = string.Empty;
+
+			[Description("The certificate store location that contains the trusted root certificate.")]
+			public string TrustedRootCertificateStoreLocation { get; init; } = string.Empty;
+
+			[Description("The trusted root certificate subject name.")]
+			public string TrustedRootCertificateSubjectName { get; init; } = string.Empty;
+
+			[Description("The trusted root certificate fingerprint/thumbrint.")]
+			public string TrustedRootCertificateThumbprint { get; init; } = string.Empty;
+
 			internal static CertificateStoreOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				CertificateStoreLocation = configurationRoot.GetValue<string>(nameof(CertificateStoreLocation)),
 				CertificateStoreName = configurationRoot.GetValue<string>(nameof(CertificateStoreName)),
 				CertificateSubjectName = configurationRoot.GetValue<string>(nameof(CertificateSubjectName)),
-				CertificateThumbprint = configurationRoot.GetValue<string>(nameof(CertificateThumbprint))
+				CertificateThumbprint = configurationRoot.GetValue<string>(nameof(CertificateThumbprint)),
+				TrustedRootCertificateStoreLocation = configurationRoot.GetValue<string>(nameof(TrustedRootCertificateStoreLocation)),
+				TrustedRootCertificateStoreName = configurationRoot.GetValue<string>(nameof(TrustedRootCertificateStoreName)),
+				TrustedRootCertificateThumbprint = configurationRoot.GetValue<string>(nameof(TrustedRootCertificateThumbprint)),
+				TrustedRootCertificateSubjectName = configurationRoot.GetValue<string>(nameof(TrustedRootCertificateSubjectName))
 			};
 		}
 


### PR DESCRIPTION
added: `TrustedRootCertificateStoreName`, `TrustedRootCertificateStoreLocation`, `TrustedRootCertificateSubjectName` and `TrustedRootCertificateThumbprint` certificate options.
added: Allow loading trusted root certificates from the Windows cert store.

Fixes https://github.com/EventStore/EventStore/issues/3068

This is just a simple fix for loading trusted root certificates from the windows cert store.
If  `TrustedRootCertificateStoreName` or `TrustedRootCertificateStoreLocation` is specified, then the trusted root certificates are loaded from the cert store. Otherwise they are loaded from the `TrustedRootCertificatesPath`.

## Example setup:

1. Create a ca certificate using [es-gencert-cli](https://github.com/EventStore/es-gencert-cli/releases).
2. Create a node certificate using [es-gencert-cli](https://github.com/EventStore/es-gencert-cli/releases).
3. Combine the private and public keys for the node certirficates into a pfx file using openssl:

```
openssl pkcs12 -export -out node1.pfx -inkey node1.key -in node1.crt -certfile ../ca/ca.crt
```

4. Import the CA certificate to the windows cert store under `Trusted Root Certification Authorities`
5. Import the pfx node certificates generated in step 3 to the windows cert store under `Personal`
6. Configure the node with one of the following sets of certificate settings:

Using Thumbprints:
```
TrustedRootCertificateStoreLocation: LocalMachine
TrustedRootCertificateStoreName: Root
TrustedRootCertificateThumbprint: {thumbprint}
CertificateStoreLocation: LocalMachine
CertificateStoreName: My
CertificateThumbprint: {thumbprint}
```

Using SubjectName (this will match any certificate that contains the subject name) :
```
TrustedRootCertificateStoreLocation: LocalMachine
TrustedRootCertificateStoreName: Root
TrustedRootCertificateSubjectName: EventStoreDB CA
CertificateStoreLocation: LocalMachine
CertificateStoreName: My
CertificateSubjectName: eventstoredb-node
```

(*Note: Change LocalMachine to CurrentUser if you imported the certificates to the user cert store.*)

### Rolling certificates

1. Set up the node using the SubjectName configuration.
2. Create a new CA and node certificate in the same manner as above, ensuring that the subject names match the subject names in the configuration.
3. Import the new CA and node certificate into the cert store in the same manner as above.
4. On each node in the cluster, issue a request to reload the configuration using curl:

```
curl -i -X POST https://{node_address}/admin/reloadconfig -u admin:changeit -H "Content-Length:0" -k
```


