### PR TITLE
Ensure no pending writes can be incorrectly acked or published when going offline for truncation. 

### DIFF
--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/RequestManagerServiceSpecification.cs
@@ -56,6 +56,7 @@ namespace EventStore.Core.Tests.Services.RequestManagement.Service {
 			Dispatcher.Subscribe<StorageMessage.CommitIndexed>(Service);
 			Dispatcher.Subscribe<ReplicationTrackingMessage.IndexedTo>(Service);
 			Dispatcher.Subscribe<ReplicationTrackingMessage.ReplicatedTo>(Service);
+			Dispatcher.Subscribe<SystemMessage.StateChangeMessage>(Service);
 		}
 		[OneTimeSetUp]
 		public virtual void Setup() {

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/when_writing_and_deposed_as_leader.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/when_writing_and_deposed_as_leader.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Net;
+using EventStore.Core.Cluster;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.RequestManagement.Service {
+	[TestFixture]
+	public class when_writing_and_deposed_as_leader : RequestManagerServiceSpecification{
+		
+		protected override void Given() {
+			Dispatcher.Publish(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Dispatcher.Publish(new ClientMessage.WriteEvents(InternalCorrId, ClientCorrId, Envelope, true, StreamId, ExpectedVersion.Any, new[] { DummyEvent() }, null));
+		}
+
+		protected override Message When() {
+			return new SystemMessage.BecomePreReplica(Guid.NewGuid(), Guid.NewGuid(), FakeMemberInfo());
+		}
+	
+		[Test]
+		public void the_envelope_is_replied_to_with_commit_timeout() {
+			Assert.AreEqual(1, Envelope.Replies.Count);
+			Assert.IsInstanceOf<ClientMessage.WriteEventsCompleted>(Envelope.Replies[0]);
+			var response = (ClientMessage.WriteEventsCompleted)Envelope.Replies[0];
+			Assert.AreEqual(OperationResult.CommitTimeout, response.Result);
+			Assert.AreEqual("Request canceled by server", response.Message);
+		}
+
+		private static MemberInfo FakeMemberInfo() {
+			var ipAddress = "127.0.0.1";
+			var port = 1113;
+			return EventStore.Core.Cluster.MemberInfo.Initial(Guid.Empty, DateTime.UtcNow,
+				VNodeState.Unknown, true,
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				null, 0, 0, 0, false);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/RequestManagement/Service/when_writing_and_deposed_as_leader_and_replica_moves_forward.cs
+++ b/src/EventStore.Core.Tests/Services/RequestManagement/Service/when_writing_and_deposed_as_leader_and_replica_moves_forward.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Net;
+using EventStore.Core.Cluster;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.RequestManagement.Service
+{
+	[TestFixture]
+	public class when_writing_and_deposed_as_leader_and_replica_moves_forward : RequestManagerServiceSpecification {
+		
+		protected override void Given() {
+			Dispatcher.Publish(new SystemMessage.BecomeLeader(Guid.NewGuid()));
+			Dispatcher.Publish(new ClientMessage.WriteEvents(InternalCorrId, ClientCorrId, Envelope, true, StreamId, ExpectedVersion.Any, new[] { DummyEvent() }, null));
+			Dispatcher.Publish(new SystemMessage.BecomePreReplica(Guid.NewGuid(), Guid.NewGuid(), FakeMemberInfo()));
+		}
+
+		protected override Message When() {
+			return new ReplicationTrackingMessage.IndexedTo(LogPosition);
+		}
+	
+		[Test]
+		public void the_old_write_is_not_acknowledged() {
+			Assert.AreEqual(0, Envelope.Replies.Count);
+		}
+
+		private static MemberInfo FakeMemberInfo() {
+			var ipAddress = "127.0.0.1";
+			var port = 1113;
+			return EventStore.Core.Cluster.MemberInfo.Initial(Guid.Empty, DateTime.UtcNow,
+				VNodeState.Unknown, true,
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				new IPEndPoint(IPAddress.Parse(ipAddress), port),
+				null, 0, 0, 0, false);
+		}
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -766,7 +766,7 @@ namespace EventStore.Core {
 			_mainBus.Subscribe<ReplicationTrackingMessage.WriterCheckpointFlushed>(replicationTracker);
 			_mainBus.Subscribe<ReplicationTrackingMessage.LeaderReplicatedTo>(replicationTracker);
 			_mainBus.Subscribe<SystemMessage.VNodeConnectionLost>(replicationTracker);
-
+			_mainBus.Subscribe<ReplicationMessage.ReplicaSubscribed>(replicationTracker);
 			var indexCommitterService = new IndexCommitterService<TStreamId>(readIndex.IndexCommitter, _mainQueue,
 				Db.Config.WriterCheckpoint.AsReadOnly(),
 				Db.Config.ReplicationCheckpoint.AsReadOnly(),

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -88,8 +88,7 @@ namespace EventStore.Core.Services {
 
 			_subscriptionId = message.SubscriptionId;
 			_ackedSubscriptionPos = _subscriptionPos = message.SubscriptionPosition;
-			Bus.Publish(new ReplicationMessage.AckLogPosition(_subscriptionId, _ackedSubscriptionPos));
-
+			
 			Log.Information(
 				"=== SUBSCRIBED to [{leaderEndPoint},{leaderId:B}] at {subscriptionPosition} (0x{subscriptionPosition:X}). SubscriptionId: {subscriptionId:B}.",
 				message.LeaderEndPoint, message.LeaderId, message.SubscriptionPosition, message.SubscriptionPosition,
@@ -174,6 +173,7 @@ namespace EventStore.Core.Services {
 
 			// subscription position == writer checkpoint
 			// everything is ok
+			Bus.Publish(new ReplicationMessage.AckLogPosition(_subscriptionId, _ackedSubscriptionPos));
 		}
 
 		private bool AreAnyCommittedRecordsTruncatedWithLastEpoch(long subscriptionPosition, EpochRecord lastEpoch,

--- a/src/EventStore.Core/Services/Replication/ReplicationTrackingService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicationTrackingService.cs
@@ -20,7 +20,8 @@ namespace EventStore.Core.Services.Replication {
 		IHandle<ReplicationTrackingMessage.ReplicaWriteAck>,
 		IHandle<ReplicationTrackingMessage.WriterCheckpointFlushed>,
 		IHandle<ReplicationTrackingMessage.LeaderReplicatedTo>,
-		IHandle<SystemMessage.VNodeConnectionLost> {
+		IHandle<SystemMessage.VNodeConnectionLost>,
+		IHandle<ReplicationMessage.ReplicaSubscribed> {
 		private readonly ILogger _log = Serilog.Log.ForContext<ReplicationTrackingService>();
 		private readonly IPublisher _publisher;
 		private readonly ICheckpoint _replicationCheckpoint;
@@ -88,15 +89,12 @@ namespace EventStore.Core.Services.Replication {
 				_tcs.TrySetException(exc);
 				Application.Exit(ExitCode.Error,
 					$"Error in {nameof(ReplicationTrackingService)}. Terminating...\nError: " + exc.Message);
-				//TODO(clc): is this right, are we waiting for someone to clean us up???
-				while (!_stop) {
-					Thread.Sleep(100);
-				}
 			}
 			_publisher.Publish(new SystemMessage.ServiceShutdown(nameof(ReplicationTrackingService)));
 		}
 
 		public void Handle(ReplicationTrackingMessage.LeaderReplicatedTo message) {
+			if (_stop) return;
 			if (_state != VNodeState.Leader && _state != VNodeState.PreLeader && message.LogPosition > _replicationCheckpoint.Read()) {
 				_replicationCheckpoint.Write(message.LogPosition);
 				_replicationCheckpoint.Flush();
@@ -171,5 +169,12 @@ namespace EventStore.Core.Services.Replication {
 		}
 
 
+		public void Handle(ReplicationMessage.ReplicaSubscribed message) {
+			if (message.SubscriptionPosition < _writerCheckpoint.ReadNonFlushed()) {
+				//Going offline for truncation
+				_log.Information("Offline truncation will happen, shutting down {service}",nameof(ReplicationTrackingService));
+				Stop();
+			}
+		}
 	}
 }

--- a/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
+++ b/src/EventStore.Core/Services/RequestManager/Managers/RequestManagerBase.cs
@@ -205,7 +205,7 @@ namespace EventStore.Core.Services.RequestManager.Managers {
 						if (Interlocked.Read(ref _complete) != 1) {
 							//todo (clc) need a better Result here, but need to see if this will impact the client API
 							var result = !_allPreparesWritten ? OperationResult.PrepareTimeout : OperationResult.CommitTimeout;
-							var msg = "Request canceled by server, likely deposed leader";
+							var msg = "Request canceled by server";
 							CompleteFailedRequest(result, msg);
 						}
 					} catch { /*don't throw in disposed*/}

--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -167,7 +167,15 @@ namespace EventStore.Core.Services.RequestManager {
 		
 		
 		public void Handle(SystemMessage.StateChangeMessage message) {
-			//TODO(clc): if we have become resigning leader should all requests be actively disposed?
+			
+			if (_nodeState == VNodeState.Leader && message.State is not VNodeState.Leader or VNodeState.ResigningLeader) {
+				var keys = _currentRequests.Keys;
+				foreach (var key in keys) {
+					if (_currentRequests.Remove(key, out var manager)) {
+						manager.Dispose();
+					}
+				}
+			}
 			_nodeState = message.State;
 		}
 


### PR DESCRIPTION
Fixed: Ensure no pending writes can be incorrectly acked or published when going offline for truncation. 

This is sent back to the client as a WriteTimeout or CommitTimeout which indicates that the client should retry the request with the exact same values.

Fixes #3472 