### PR TITLE
Do not throw if entry is missing from _currentRequests

### DIFF
--- a/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
+++ b/src/EventStore.Core/Services/RequestManager/RequestManagementService.cs
@@ -203,8 +203,11 @@ namespace EventStore.Core.Services.RequestManager {
 				_currentTimedRequests.Remove(message.CorrelationId);
 			}
 
-			if (!_currentRequests.Remove(message.CorrelationId))
-				throw new InvalidOperationException("Should never complete request twice.");
+			if (!_currentRequests.Remove(message.CorrelationId)) {
+				// noop. RequestManager guarantees not complete twice now.
+				// and we will legitimately get in here when StateChangeMessage removes
+				// entries from _currentRequests
+			}
 		}
 		
 		public void Handle(ReplicationTrackingMessage.ReplicatedTo message) => _commitSource.Handle(message);


### PR DESCRIPTION
Fixed: Removed unnecessary `Should never complete request twice` error

This is a legit case because we remove them when handling StateChangeMessage to minimise the possibility of any subsequent acking when transitioning out of leader.

Making sure the request does not complete twice is now guaranteed by the RequestManger itself