### PR TITLE
[20.10] Use follower writer checkpoint for replication tracking

### DIFF
--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_non_promotable_replica_sends_replica_log_position_ack.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_non_promotable_replica_sends_replica_log_position_ack.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 		
 		public override void When() {
 			_logPosition = 4000;
-			Service.Handle(new ReplicationMessage.ReplicaLogPositionAck(ReadOnlyReplicaId, _logPosition));
+			Service.Handle(new ReplicationMessage.ReplicaLogPositionAck(ReadOnlyReplicaId, _logPosition, _logPosition));
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replication_service_has_replica_disconnected.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replication_service_has_replica_disconnected.cs
@@ -26,7 +26,8 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 		[Test]
 		public void post_disconnect_replica_Log_written_to_should_not_be_published() {
 			AssertEx.IsOrBecomesTrue(() => ReplicaLostMessages.Count == 1, msg: "ReplicaLost msg not received");
-			Service.Handle(new ReplicationMessage.ReplicaLogPositionAck(ReplicaId, DbConfig.WriterCheckpoint.Read() + 200));
+			var replicationLogPosition = DbConfig.WriterCheckpoint.Read() + 200;
+			Service.Handle(new ReplicationMessage.ReplicaLogPositionAck(ReplicaId, replicationLogPosition, replicationLogPosition));
 			
 			Assert.True(ReplicaWriteAcks.Count == 0, $"Got unexpected ReplicaLogAck Message");
 		}

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replication_service_recieves_leader_log_commited_to.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replication_service_recieves_leader_log_commited_to.cs
@@ -16,11 +16,11 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 		public void replicated_to_should_be_sent_to_subscriptions() {
 			AssertEx.IsOrBecomesTrue(() => TcpSends.Count > 4, msg:"TcpSend msg not recieved");
 			var sends = TcpSends.Where(tcpSend => tcpSend.Message is ReplicationTrackingMessage.ReplicatedTo).ToList();
-			Assert.AreEqual(3 * 2,sends.Count); //one ReplicatedTo message in sent when the subscription is added and the second one in When()
-			Assert.AreEqual(2, sends.Count( msg=> msg.ConnectionManager.ConnectionId == ReplicaSubscriptionId));
-			Assert.AreEqual(2, sends.Count( msg=> msg.ConnectionManager.ConnectionId == ReplicaSubscriptionId2));
-			Assert.AreEqual(2, sends.Count( msg=> msg.ConnectionManager.ConnectionId == ReadOnlyReplicaSubscriptionId));
-			
+			Assert.AreEqual(4 * 2, sends.Count); //one ReplicatedTo message in sent when the subscription is added and the second one in When()
+			Assert.AreEqual(2, sends.Count(msg => msg.ConnectionManager.ConnectionId == ReplicaSubscriptionId));
+			Assert.AreEqual(2, sends.Count(msg => msg.ConnectionManager.ConnectionId == ReplicaSubscriptionId2));
+			Assert.AreEqual(2, sends.Count(msg => msg.ConnectionManager.ConnectionId == ReadOnlyReplicaSubscriptionId));
+			Assert.AreEqual(2, sends.Count(msg => msg.ConnectionManager.ConnectionId == ReplicaSubscriptionIdV0));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replication_service_recieves_replica_log_position_ack.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replication_service_recieves_replica_log_position_ack.cs
@@ -3,21 +3,44 @@ using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 	[TestFixture]
-	public class when_replication_service_receives_replica_log_position_ack : with_replication_service {
-		private long _logPosition;
-		
-		public override void When() {			
-			_logPosition = 4000;
-			Service.Handle(new ReplicationMessage.ReplicaLogPositionAck(ReplicaId, _logPosition));
+	public class when_replication_service_receives_replica_log_position_ack_subscription_v0 : with_replication_service {
+		private long _replicationLogPosition;
+		private long _writerLogPosition;
+
+		public override void When() {
+			_replicationLogPosition = 4000;
+			_writerLogPosition = 3000;
+			Service.Handle(new ReplicationMessage.ReplicaLogPositionAck(ReplicaIdV0, _replicationLogPosition, _writerLogPosition));
 		}
 
 		[Test]
 		public void replica_Log_written_to_should_be_published() {
-			AssertEx.IsOrBecomesTrue(() => ReplicaWriteAcks.Count == 1, msg:"ReplicaLogWrittenTo msg not received");
+			AssertEx.IsOrBecomesTrue(() => ReplicaWriteAcks.Count == 1, msg: "ReplicaLogWrittenTo msg not received");
+			Assert.True(ReplicaWriteAcks.TryDequeue(out var commit));
+
+			Assert.AreEqual(ReplicaIdV0, commit.SubscriptionId);
+			Assert.AreEqual(_replicationLogPosition, commit.ReplicationLogPosition);
+		}
+	}
+
+	[TestFixture]
+	public class when_replication_service_receives_replica_log_position_ack_subscription_v1 : with_replication_service {
+		private long _replicationLogPosition;
+		private long _writerLogPosition;
+
+		public override void When() {
+			_replicationLogPosition = 4000;
+			_writerLogPosition = 3000;
+			Service.Handle(new ReplicationMessage.ReplicaLogPositionAck(ReplicaId, _replicationLogPosition, _writerLogPosition));
+		}
+
+		[Test]
+		public void replica_Log_written_to_should_be_published() {
+			AssertEx.IsOrBecomesTrue(() => ReplicaWriteAcks.Count == 1, msg: "ReplicaLogWrittenTo msg not received");
 			Assert.True(ReplicaWriteAcks.TryDequeue(out var commit));
 
 			Assert.AreEqual(ReplicaId, commit.SubscriptionId);
-			Assert.AreEqual(_logPosition, commit.ReplicationLogPosition);
+			Assert.AreEqual(_writerLogPosition, commit.ReplicationLogPosition);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -36,14 +36,17 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 		protected Guid ReplicaId = Guid.NewGuid();
 		protected Guid ReplicaId2 = Guid.NewGuid();
 		protected Guid ReadOnlyReplicaId = Guid.NewGuid();
+		protected Guid ReplicaIdV0 = Guid.NewGuid();
 
 		protected Guid ReplicaSubscriptionId;
 		protected Guid ReplicaSubscriptionId2;
 		protected Guid ReadOnlyReplicaSubscriptionId;
+		protected Guid ReplicaSubscriptionIdV0;
 
 		protected TcpConnectionManager ReplicaManager1;
 		protected TcpConnectionManager ReplicaManager2;
 		protected TcpConnectionManager ReadOnlyReplicaManager;
+		protected TcpConnectionManager ReplicaManagerV0;
 
 		protected TFChunkDbConfig DbConfig;
 
@@ -70,10 +73,10 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Service.Handle(new SystemMessage.SystemStart());
 			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 
-			ReplicaSubscriptionId = AddSubscription(ReplicaId, true, out ReplicaManager1);
-			ReplicaSubscriptionId2 = AddSubscription(ReplicaId2, true, out ReplicaManager2);
-			ReadOnlyReplicaSubscriptionId = AddSubscription(ReadOnlyReplicaId, false, out ReadOnlyReplicaManager);
-
+			ReplicaSubscriptionId = AddSubscription(ReplicaId, ReplicationSubscriptionVersions.V1, true, out ReplicaManager1);
+			ReplicaSubscriptionId2 = AddSubscription(ReplicaId2, ReplicationSubscriptionVersions.V1, true, out ReplicaManager2);
+			ReadOnlyReplicaSubscriptionId = AddSubscription(ReadOnlyReplicaId, ReplicationSubscriptionVersions.V1, false, out ReadOnlyReplicaManager);
+			ReplicaSubscriptionIdV0 = AddSubscription(ReplicaIdV0, ReplicationSubscriptionVersions.V0, true, out ReplicaManagerV0);
 
 			When();
 		}
@@ -84,7 +87,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Service.Handle(new SystemMessage.BecomeShuttingDown(Guid.NewGuid(), true, true));
 		}
 
-		private Guid AddSubscription(Guid replicaId, bool isPromotable, out TcpConnectionManager manager) {
+		private Guid AddSubscription(Guid replicaId, int version, bool isPromotable, out TcpConnectionManager manager) {
 			var tcpConn = new DummyTcpConnection() { ConnectionId = replicaId };
 
 			manager = new TcpConnectionManager(
@@ -100,6 +103,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				Guid.NewGuid(),
 				new NoopEnvelope(),
 				manager,
+				version,
 				0,
 				Guid.NewGuid(),
 				new Epoch[0],

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -104,6 +104,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				Guid.NewGuid(),
 				new NoopEnvelope(),
 				manager,
+				ReplicationSubscriptionVersions.V1,
 				logPosition,
 				Guid.NewGuid(),
 				epochs,

--- a/src/EventStore.Core/Messages/ReplicationMessageDto.cs
+++ b/src/EventStore.Core/Messages/ReplicationMessageDto.cs
@@ -67,11 +67,13 @@ namespace EventStore.Core.Messages {
 
 			[ProtoMember(8)] public bool IsPromotable { get; set; }
 
+			[ProtoMember(9)] public int Version { get; set; }
+
 			public SubscribeReplica() {
 			}
 
 			public SubscribeReplica(long logPosition, byte[] chunkId, Epoch[] lastEpochs, byte[] ip, int port,
-				byte[] leaderId, byte[] subscriptionId, bool isPromotable) {
+				byte[] leaderId, byte[] subscriptionId, bool isPromotable, int version) {
 				LogPosition = logPosition;
 				ChunkId = chunkId;
 				LastEpochs = lastEpochs;
@@ -81,6 +83,7 @@ namespace EventStore.Core.Messages {
 				LeaderId = leaderId;
 				SubscriptionId = subscriptionId;
 				IsPromotable = isPromotable;
+				Version = version;
 			}
 		}
 
@@ -129,13 +132,19 @@ namespace EventStore.Core.Messages {
 			[ProtoMember(1)] public byte[] SubscriptionId { get; set; }
 
 			[ProtoMember(2)] public long ReplicationLogPosition { get; set; }
+			[ProtoMember(3)] public long WriterLogPosition { get; set; }
 
 			public ReplicaLogPositionAck() {
 			}
 
-			public ReplicaLogPositionAck(byte[] subscriptionId, long replicationLogPosition) {
+			public ReplicaLogPositionAck(
+				byte[] subscriptionId,
+				long replicationLogPosition,
+				long writerLogPosition) {
+
 				SubscriptionId = subscriptionId;
 				ReplicationLogPosition = replicationLogPosition;
+				WriterLogPosition = writerLogPosition;
 			}
 		}
 

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -130,7 +130,10 @@ namespace EventStore.Core.Services {
 
 			// subscription position == writer checkpoint
 			// everything is ok
-			Bus.Publish(new ReplicationMessage.AckLogPosition(_subscriptionId, _ackedSubscriptionPos));
+			Bus.Publish(new ReplicationMessage.AckLogPosition(
+				subscriptionId: _subscriptionId,
+				replicationLogPosition: _ackedSubscriptionPos,
+				writerLogPosition: writerCheck));
 		}
 
 		private bool AreAnyCommittedRecordsTruncatedWithLastEpoch(long subscriptionPosition, EpochRecord lastEpoch,
@@ -165,7 +168,10 @@ namespace EventStore.Core.Services {
 
 			_subscriptionPos = message.ChunkHeader.ChunkStartPosition;
 			_ackedSubscriptionPos = _subscriptionPos;
-			Bus.Publish(new ReplicationMessage.AckLogPosition(_subscriptionId, _ackedSubscriptionPos));
+			Bus.Publish(new ReplicationMessage.AckLogPosition(
+				subscriptionId: _subscriptionId,
+				replicationLogPosition: _ackedSubscriptionPos,
+				writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
 		}
 
 		public void Handle(ReplicationMessage.RawChunkBulk message) {
@@ -213,7 +219,10 @@ namespace EventStore.Core.Services {
 
 			if (message.CompleteChunk || _subscriptionPos > _ackedSubscriptionPos) {
 				_ackedSubscriptionPos = _subscriptionPos;
-				Bus.Publish(new ReplicationMessage.AckLogPosition(_subscriptionId, _ackedSubscriptionPos));
+				Bus.Publish(new ReplicationMessage.AckLogPosition(
+					subscriptionId: _subscriptionId,
+					replicationLogPosition: _ackedSubscriptionPos,
+					writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
 			}
 		}
 
@@ -268,7 +277,11 @@ namespace EventStore.Core.Services {
 
 			if (message.CompleteChunk || _subscriptionPos > _ackedSubscriptionPos) {
 				_ackedSubscriptionPos = _subscriptionPos;
-				Bus.Publish(new ReplicationMessage.AckLogPosition(_subscriptionId, _ackedSubscriptionPos));
+				Bus.Publish(new ReplicationMessage.AckLogPosition(
+					subscriptionId: _subscriptionId,
+					replicationLogPosition: _ackedSubscriptionPos,
+					// we leave it up to the Flush call above whether to truly flush or not
+					writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
 			}
 		}
 

--- a/src/EventStore.Core/Services/Replication/ReplicaService.cs
+++ b/src/EventStore.Core/Services/Replication/ReplicaService.cs
@@ -227,6 +227,7 @@ namespace EventStore.Core.Services.Replication {
 				throw new Exception(string.Format("Chunk was null during subscribing at {0} (0x{0:X}).", logPosition));
 			SendTcpMessage(_connection,
 				new ReplicationMessage.SubscribeReplica(
+					version: ReplicationSubscriptionVersions.V1,
 					logPosition, chunk.ChunkHeader.ChunkId, epochs, _internalTcp,
 					message.LeaderId, message.SubscriptionId, isPromotable: !_isReadOnlyReplica));
 		}

--- a/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/InternalTcpDispatcher.cs
@@ -57,6 +57,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			return new ReplicationMessage.ReplicaSubscriptionRequest(package.CorrelationId,
 				envelope,
 				connection,
+				dto.Version,
 				dto.LogPosition,
 				new Guid(dto.ChunkId),
 				lastEpochs,
@@ -76,7 +77,8 @@ namespace EventStore.Core.Services.Transport.Tcp {
 				msg.ReplicaEndPoint.GetPort(),
 				msg.LeaderId.ToByteArray(),
 				msg.SubscriptionId.ToByteArray(),
-				msg.IsPromotable);
+				msg.IsPromotable,
+				msg.Version);
 			return new TcpPackage(TcpCommand.SubscribeReplica, Guid.NewGuid(), dto.Serialize());
 		}
 
@@ -84,12 +86,14 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			IEnvelope envelope, TcpConnectionManager connection) {
 			var dto = package.Data.Deserialize<ReplicationMessageDto.ReplicaLogPositionAck>();
 			return new ReplicationMessage.ReplicaLogPositionAck(new Guid(dto.SubscriptionId),
-				dto.ReplicationLogPosition);
+				dto.ReplicationLogPosition,
+				dto.WriterLogPosition);
 		}
 
 		private TcpPackage WrapAckLogPosition(ReplicationMessage.AckLogPosition msg) {
 			var dto = new ReplicationMessageDto.ReplicaLogPositionAck(msg.SubscriptionId.ToByteArray(),
-				msg.ReplicationLogPosition);
+				msg.ReplicationLogPosition,
+				msg.WriterLogPosition);
 			return new TcpPackage(TcpCommand.ReplicaLogPositionAck, Guid.NewGuid(), dto.Serialize());
 		}
 


### PR DESCRIPTION
Backport of https://github.com/EventStore/EventStore/pull/3527