### PR TITLE
Prevent gRPC subscriptions from hanging while catching up

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/isjson_flag_on_event.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/isjson_flag_on_event.cs
@@ -78,7 +78,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 						Assert.IsTrue(msg.Events.All(x => (x.OriginalEvent.Flags & PrepareFlags.IsJson) != 0));
 
 						done.Set();
-					}), stream, 0, 100, false, false, null, null));
+					}), stream, 0, 100, false, false, null, null, replyOnExpired: false));
 				Assert.IsTrue(done.Wait(10000), "Read was not completed in time.");
 			}
 		}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -25,6 +25,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.AspNetCore.TestHost;
 using ILogger = Serilog.ILogger;
+using EventStore.Core.Services.Storage.ReaderIndex;
 
 namespace EventStore.Core.Tests.Helpers {
 	public class MiniClusterNode<TLogFormat, TStreamId> {
@@ -66,7 +67,8 @@ namespace EventStore.Core.Tests.Helpers {
 		public MiniClusterNode(string pathname, int debugIndex, IPEndPoint internalTcp, IPEndPoint externalTcp,
 			IPEndPoint httpEndPoint, EndPoint[] gossipSeeds, ISubsystem[] subsystems = null, int? chunkSize = null,
 			int? cachedChunkSize = null, bool enableTrustedAuth = false, int memTableSize = 1000, bool inMemDb = true,
-			bool disableFlushToDisk = false, bool readOnlyReplica = false, int nodePriority = 0, string intHostAdvertiseAs = null) {
+			bool disableFlushToDisk = false, bool readOnlyReplica = false, int nodePriority = 0, string intHostAdvertiseAs = null,
+			IExpiryStrategy expiryStrategy = null) {
 
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
 				AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport",
@@ -174,7 +176,9 @@ namespace EventStore.Core.Tests.Helpers {
 					new InternalAuthenticationProviderFactory(components)),
 				new AuthorizationProviderFactory(components =>
 					new LegacyAuthorizationProviderFactory(components.MainQueue)),
-				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>(), Guid.NewGuid(), debugIndex);
+				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>(),
+				expiryStrategy,
+				Guid.NewGuid(), debugIndex);
 			Node.HttpService.SetupController(new TestController(Node.MainQueue));
 
 			_host = new WebHostBuilder()

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
 using EventStore.Common.Utils;
 using EventStore.Core.Services.Monitoring;
+using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Tests.Http;
 using EventStore.Core.Tests.Services.Transport.Tcp;
 using EventStore.Core.TransactionLog.Chunks;
@@ -64,7 +65,8 @@ namespace EventStore.Core.Tests.Helpers {
 			string dbPath = "", bool isReadOnlyReplica = false,
 			long streamExistenceFilterSize = Util.Opts.StreamExistenceFilterSizeDefault,
 			int streamExistenceFilterCheckpointIntervalMs = 30_000,
-			int streamExistenceFilterCheckpointDelayMs = 5_000) {
+			int streamExistenceFilterCheckpointDelayMs = 5_000,
+			IExpiryStrategy expiryStrategy = null) {
 			RunningTime.Start();
 			RunCount += 1;
 
@@ -156,7 +158,8 @@ namespace EventStore.Core.Tests.Helpers {
 					streamExistenceFilterCheckpointDelayMs: streamExistenceFilterCheckpointDelayMs));
 			Node = new ClusterVNode<TStreamId>(options, logFormatFactory,
 				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
-				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)));
+				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
+				expiryStrategy: expiryStrategy);
 			Db = Node.Db;
 
 			Node.HttpService.SetupController(new TestController(Node.MainQueue));

--- a/src/EventStore.Core.Tests/Services/Replication/ReplicationTestHelper.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/ReplicationTestHelper.cs
@@ -47,7 +47,7 @@ namespace EventStore.Core.Tests.Replication.ReadStream {
 							readResult = (ClientMessage.ReadAllEventsForwardCompleted)msg;
 							readEvent.Set();
 						}),
-					0, 0, 100, false, false, null, SystemAccounts.System);
+					0, 0, 100, false, false, null, SystemAccounts.System, replyOnExpired: false);
 				node.Node.MainQueue.Publish(read);
 
 				if (!readEvent.Wait(_timeout)) {
@@ -109,7 +109,7 @@ namespace EventStore.Core.Tests.Replication.ReadStream {
 						readResult = (ClientMessage.ReadStreamEventsForwardCompleted)msg;
 						resetEvent.Set();
 					}), streamId, 0, 10,
-				false, false, null, SystemAccounts.System);
+				false, false, null, SystemAccounts.System, replyOnExpired: false);
 			node.Node.MainQueue.Publish(read);
 
 			if (!resetEvent.Wait(_timeout)) {

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/LotsOfExpiriesStrategy.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/LotsOfExpiriesStrategy.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using EventStore.Core.Services.Storage.ReaderIndex;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
+	public class LotsOfExpiriesStrategy : IExpiryStrategy {
+		private int _counter;
+
+		public DateTime? GetExpiry() {
+			_counter++;
+			if (_counter % 10 == 0) {
+				// ok
+				return null;
+			} else {
+				// expired already
+				return DateTime.UtcNow - TimeSpan.FromSeconds(1);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/SubscribeToStreamTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/SubscribeToStreamTests.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Client.Streams;
+using EventStore.Core.Services.Transport.Grpc;
+using Google.Protobuf;
+using Grpc.Core;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
+	[TestFixture]
+	public class SubscribeToStreamTests {
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class when_subscribing_to_stream<TLogFormat, TStreamId> : GrpcSpecification<TLogFormat, TStreamId> {
+			private const string StreamId = nameof(when_subscribing_to_stream<TLogFormat, TStreamId>);
+			private readonly List<ReadResp> _responses = new();
+			private ulong _positionOfLastWrite;
+
+			public when_subscribing_to_stream() : base(new LotsOfExpiriesStrategy()) {
+			}
+
+			protected override async Task Given() {
+				var response = await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamId) },
+						Any = new(),
+					},
+					CorrelationId = Uuid.NewUuid().ToDto(),
+					IsFinal = true,
+					ProposedMessages = { CreateEvents(120) }
+				});
+				_positionOfLastWrite = response.Success.CurrentRevision;
+			}
+
+			protected override async Task When() {
+				using var call = StreamsClient.Read(new() {
+					Options = new() {
+						Subscription = new(),
+						NoFilter = new(),
+						ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards,
+						UuidOption = new() { Structured = new() },
+						Stream = new() {
+							Start = new(),
+							StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamId) },
+						},
+					}
+				}, GetCallOptions(AdminCredentials));
+
+				while (await call.ResponseStream.MoveNext()) {
+					var response = call.ResponseStream.Current;
+					if (response.ContentCase == ReadResp.ContentOneofCase.Event &&
+						_positionOfLastWrite == response.Event.Event.StreamRevision) {
+							break;
+					}
+
+					_responses.Add(response);
+				}
+
+				// caught up, now add one more event
+
+				await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamId) },
+						Any = new(),
+					},
+					CorrelationId = Uuid.NewUuid().ToDto(),
+					IsFinal = true,
+					ProposedMessages = { CreateEvents(1) }
+				});
+
+				// and consume it. this makes sure we didnt fail while transitioning to live
+				Assert.True(await call.ResponseStream.MoveNext());
+			}
+
+			[Test]
+			public void subscription_confirmed() {
+				Assert.AreEqual(ReadResp.ContentOneofCase.Confirmation, _responses[0].ContentCase);
+				Assert.NotNull(_responses[0].Confirmation.SubscriptionId);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 							new AnonymousHttpAuthenticationProvider(),
 						}, new TestAuthorizationProvider(),
 						new FakeReadIndex<LogFormat.V2, string>(_ => false, new LogV2SystemStreams()),
-						1024 * 1024, _timeout, _service, null)));
+						1024 * 1024, _timeout, expiryStrategy: null, _service, null)));
 			_httpMessageHandler = _server.CreateHandler();
 			_client = new HttpAsyncClient(_timeout, _httpMessageHandler);
 			

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -79,8 +79,8 @@ namespace EventStore.Core {
 				authenticationProviderFactory,
 				authorizationProviderFactory,
 				factories,
-				instanceId,
-				debugIndex);
+				instanceId: instanceId,
+				debugIndex: debugIndex);
 		}
 
 		abstract public TFChunkDb Db { get; }
@@ -217,6 +217,7 @@ namespace EventStore.Core {
 			AuthorizationProviderFactory authorizationProviderFactory = null,
 			IReadOnlyList<IPersistentSubscriptionConsumerStrategyFactory>
 				additionalPersistentSubscriptionConsumerStrategyFactories = null,
+			IExpiryStrategy expiryStrategy = null,
 			Guid? instanceId = null, int debugIndex = 0) {
 
 			if (options == null) {
@@ -1346,6 +1347,7 @@ namespace EventStore.Core {
 			_startup = new ClusterVNodeStartup<TStreamId>(_subsystems, _mainQueue, monitoringQueue, _mainBus, _workersHandler,
 				_authenticationProvider, httpAuthenticationProviders, _authorizationProvider, _readIndex,
 				options.Application.MaxAppendSize, TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs),
+				expiryStrategy ?? new DefaultExpiryStrategy(),
 				_httpService, options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null);
 			_mainBus.Subscribe<SystemMessage.SystemReady>(_startup);
 			_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_startup);

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -43,6 +43,7 @@ namespace EventStore.Core {
 		private readonly IReadIndex<TStreamId> _readIndex;
 		private readonly int _maxAppendSize;
 		private readonly TimeSpan _writeTimeout;
+		private readonly IExpiryStrategy _expiryStrategy;
 		private readonly KestrelHttpService _httpService;
 		private readonly StatusCheck _statusCheck;
 
@@ -62,6 +63,7 @@ namespace EventStore.Core {
 			IReadIndex<TStreamId> readIndex,
 			int maxAppendSize,
 			TimeSpan writeTimeout,
+			IExpiryStrategy expiryStrategy,
 			KestrelHttpService httpService,
 			string clusterDns) {
 			if (subsystems == null) {
@@ -107,6 +109,7 @@ namespace EventStore.Core {
 			_readIndex = readIndex;
 			_maxAppendSize = maxAppendSize;
 			_writeTimeout = writeTimeout;
+			_expiryStrategy = expiryStrategy;
 			_httpService = httpService;
 			_clusterDns = clusterDns;
 
@@ -160,7 +163,7 @@ namespace EventStore.Core {
 						.AddSingleton(new KestrelToInternalBridgeMiddleware(_httpService.UriRouter, _httpService.LogHttpRequests, _httpService.AdvertiseAsHost, _httpService.AdvertiseAsPort))
 						.AddSingleton(_readIndex)
 						.AddSingleton(new Streams<TStreamId>(_mainQueue, _readIndex, _maxAppendSize,
-							_writeTimeout, _authorizationProvider))
+							_writeTimeout, _expiryStrategy, _authorizationProvider))
 						.AddSingleton(new PersistentSubscriptions(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Users(_mainQueue, _authorizationProvider))
 						.AddSingleton(new Operations(_mainQueue, _authorizationProvider))

--- a/src/EventStore.Core/Data/FilteredReadAllResult.cs
+++ b/src/EventStore.Core/Data/FilteredReadAllResult.cs
@@ -5,6 +5,7 @@ namespace EventStore.Core.Data
         Success = 0,
         NotModified = 1,
         Error = 2,
-        AccessDenied = 3
+        AccessDenied = 3,
+        Expired = 4,
     }
 }

--- a/src/EventStore.Core/Data/ReadAllResult.cs
+++ b/src/EventStore.Core/Data/ReadAllResult.cs
@@ -3,6 +3,7 @@ namespace EventStore.Core.Data {
 		Success = 0,
 		NotModified = 1,
 		Error = 2,
-		AccessDenied = 3
+		AccessDenied = 3,
+		Expired = 4,
 	}
 }

--- a/src/EventStore.Core/Data/ReadStreamResult.cs
+++ b/src/EventStore.Core/Data/ReadStreamResult.cs
@@ -5,6 +5,7 @@ namespace EventStore.Core.Data {
 		StreamDeleted = 2,
 		NotModified = 3,
 		Error = 4,
-		AccessDenied = 5
+		AccessDenied = 5,
+		Expired = 6,
 	}
 }

--- a/src/EventStore.Core/Helpers/IODispatcher.cs
+++ b/src/EventStore.Core/Helpers/IODispatcher.cs
@@ -345,7 +345,8 @@ namespace EventStore.Core.Helpers {
 						resolveLinks,
 						false,
 						null,
-						principal),
+						principal,
+						replyOnExpired: false),
 					action);
 		}
 
@@ -371,7 +372,8 @@ namespace EventStore.Core.Helpers {
 					resolveLinks,
 					false,
 					null,
-					principal),
+					principal,
+					replyOnExpired: false),
 				res => {
 					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
 						action(res);
@@ -443,7 +445,8 @@ namespace EventStore.Core.Helpers {
 					requireLeader,
 					validationTfLastCommitPosition,
 					user,
-					longPollTimeout
+					replyOnExpired: false,
+					longPollTimeout: longPollTimeout
 					),
 				res => {
 					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {
@@ -528,7 +531,8 @@ namespace EventStore.Core.Helpers {
 					validationTfLastCommitPosition,
 					eventFilter,
 					user,
-					longPollTimeout
+					replyOnExpired: false,
+					longPollTimeout: longPollTimeout
 				),
 				res => {
 					if (_requestTracker.RemovePendingRead(res.CorrelationId)) {

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -581,10 +581,12 @@ namespace EventStore.Core.Messages {
 
 			public readonly long? ValidationStreamVersion;
 			public readonly TimeSpan? LongPollTimeout;
+			public readonly bool ReplyOnExpired;
 
 			public ReadStreamEventsForward(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 				string eventStreamId, long fromEventNumber, int maxCount, bool resolveLinkTos,
 				bool requireLeader, long? validationStreamVersion, ClaimsPrincipal user,
+				bool replyOnExpired,
 				TimeSpan? longPollTimeout = null, DateTime? expires = null)
 				: base(internalCorrId, correlationId, envelope, user, expires) {
 				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
@@ -597,6 +599,7 @@ namespace EventStore.Core.Messages {
 				RequireLeader = requireLeader;
 				ValidationStreamVersion = validationStreamVersion;
 				LongPollTimeout = longPollTimeout;
+				ReplyOnExpired = replyOnExpired;
 			}
 
 			public override string ToString() {
@@ -637,7 +640,7 @@ namespace EventStore.Core.Messages {
 				long tfLastCommitPosition) {
 				Ensure.NotNull(events, "events");
 
-				if (result != ReadStreamResult.Success) {
+				if (result != ReadStreamResult.Success && result != ReadStreamResult.Expired) {
 					Ensure.Equal(nextEventNumber, -1, "nextEventNumber");
 					Ensure.Equal(isEndOfStream, true, "isEndOfStream");
 				}
@@ -771,10 +774,12 @@ namespace EventStore.Core.Messages {
 
 			public readonly long? ValidationTfLastCommitPosition;
 			public readonly TimeSpan? LongPollTimeout;
+			public readonly bool ReplyOnExpired;
 
 			public ReadAllEventsForward(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 				long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos,
 				bool requireLeader, long? validationTfLastCommitPosition, ClaimsPrincipal user,
+				bool replyOnExpired,
 				TimeSpan? longPollTimeout = null, DateTime? expires = null)
 				: base(internalCorrId, correlationId, envelope, user, expires) {
 				CommitPosition = commitPosition;
@@ -784,6 +789,7 @@ namespace EventStore.Core.Messages {
 				RequireLeader = requireLeader;
 				ValidationTfLastCommitPosition = validationTfLastCommitPosition;
 				LongPollTimeout = longPollTimeout;
+				ReplyOnExpired = replyOnExpired;
 			}
 		}
 
@@ -919,6 +925,7 @@ namespace EventStore.Core.Messages {
 			public readonly bool RequireLeader;
 			public readonly int MaxSearchWindow;
 			public readonly IEventFilter EventFilter;
+			public readonly bool ReplyOnExpired;
 
 			public readonly long? ValidationTfLastCommitPosition;
 			public readonly TimeSpan? LongPollTimeout;
@@ -926,6 +933,7 @@ namespace EventStore.Core.Messages {
 			public FilteredReadAllEventsForward(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 				long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos, bool requireLeader,
 				int maxSearchWindow, long? validationTfLastCommitPosition, IEventFilter eventFilter, ClaimsPrincipal user,
+				bool replyOnExpired,
 				TimeSpan? longPollTimeout = null, DateTime? expires = null)
 				: base(internalCorrId, correlationId, envelope, user, expires) {
 				CommitPosition = commitPosition;
@@ -937,6 +945,7 @@ namespace EventStore.Core.Messages {
 				LongPollTimeout = longPollTimeout;
 				MaxSearchWindow = maxSearchWindow;
 				EventFilter = eventFilter;
+				ReplyOnExpired = replyOnExpired;
 			}
 		}
 

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/ExpiryStrategies.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/ExpiryStrategies.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace EventStore.Core.Services.Storage.ReaderIndex {
+	public interface IExpiryStrategy {
+		public DateTime? GetExpiry();
+	}
+
+	// Generates null expiry. Default expiry of now + ESConsts.ReadRequestTimeout will be in effect.
+	public class DefaultExpiryStrategy : IExpiryStrategy {
+		public DateTime? GetExpiry() => null;
+	}
+}

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -76,6 +76,11 @@ namespace EventStore.Core.Services.Storage {
 
 		void IHandle<ClientMessage.ReadStreamEventsForward>.Handle(ClientMessage.ReadStreamEventsForward msg) {
 			if (msg.Expires < DateTime.UtcNow) {
+				if (msg.ReplyOnExpired) {
+					msg.Envelope.ReplyWith(new ClientMessage.ReadStreamEventsForwardCompleted(
+						msg.CorrelationId, msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, ReadStreamResult.Expired,
+						ResolvedEvent.EmptyArray, default, default, default, default, default, default, default));
+				}
 				if (LogExpiredMessage(msg.Expires))
 					Log.Debug(
 						"Read Stream Events Forward operation has expired for Stream: {stream}, From Event Number: {fromEventNumber}, Max Count: {maxCount}. Operation Expired at {expiryDateTime}",
@@ -124,6 +129,13 @@ namespace EventStore.Core.Services.Storage {
 
 		void IHandle<ClientMessage.ReadAllEventsForward>.Handle(ClientMessage.ReadAllEventsForward msg) {
 			if (msg.Expires < DateTime.UtcNow) {
+				if (msg.ReplyOnExpired) {
+					msg.Envelope.ReplyWith(new ClientMessage.ReadAllEventsForwardCompleted(
+						msg.CorrelationId, ReadAllResult.Expired,
+						default, ResolvedEvent.EmptyArray, default, default, default,
+						currentPos: new TFPos(msg.CommitPosition, msg.PreparePosition),
+						TFPos.Invalid, TFPos.Invalid, default));
+				}
 				if (LogExpiredMessage(msg.Expires))
 					Log.Debug(
 						"Read All Stream Events Forward operation has expired for C:{commitPosition}/P:{preparePosition}. Operation Expired at {expiryDateTime}",
@@ -177,6 +189,13 @@ namespace EventStore.Core.Services.Storage {
 
 		void IHandle<ClientMessage.FilteredReadAllEventsForward>.Handle(ClientMessage.FilteredReadAllEventsForward msg) {
 			if (msg.Expires < DateTime.UtcNow) {
+				if (msg.ReplyOnExpired) {
+					msg.Envelope.ReplyWith(new ClientMessage.FilteredReadAllEventsForwardCompleted(
+						msg.CorrelationId, FilteredReadAllResult.Expired,
+						default, ResolvedEvent.EmptyArray, default, default, default,
+						currentPos: new TFPos(msg.CommitPosition, msg.PreparePosition),
+						TFPos.Invalid, TFPos.Invalid, default, default, default));
+				}
 				Log.Debug(
 					"Read All Stream Events Forward Filtered operation has expired for C:{0}/P:{1}. Operation Expired at {2}",
 					msg.CommitPosition, msg.PreparePosition, msg.Expires);

--- a/src/EventStore.Core/Services/SubscriptionsService.cs
+++ b/src/EventStore.Core/Services/SubscriptionsService.cs
@@ -249,14 +249,16 @@ namespace EventStore.Core.Services {
 				return new ClientMessage.ReadStreamEventsForward(
 					streamReq.InternalCorrId, streamReq.CorrelationId, streamReq.Envelope,
 					streamReq.EventStreamId, streamReq.FromEventNumber, streamReq.MaxCount, streamReq.ResolveLinkTos,
-					streamReq.RequireLeader, streamReq.ValidationStreamVersion, streamReq.User);
+					streamReq.RequireLeader, streamReq.ValidationStreamVersion, streamReq.User,
+					replyOnExpired: streamReq.ReplyOnExpired);
 
 			var allReq = originalRequest as ClientMessage.ReadAllEventsForward;
 			if (allReq != null)
 				return new ClientMessage.ReadAllEventsForward(
 					allReq.InternalCorrId, allReq.CorrelationId, allReq.Envelope,
 					allReq.CommitPosition, allReq.PreparePosition, allReq.MaxCount, allReq.ResolveLinkTos,
-					allReq.RequireLeader, allReq.ValidationTfLastCommitPosition, allReq.User);
+					allReq.RequireLeader, allReq.ValidationTfLastCommitPosition, allReq.User,
+					replyOnExpired: allReq.ReplyOnExpired);
 
 			throw new Exception(string.Format("Unexpected read request of type {0} for long polling: {1}.",
 				originalRequest.GetType(), originalRequest));

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
@@ -78,7 +78,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.ReadAllEventsForward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, default, _user, expires: _deadline));
+					_requiresLeader, default, _user, replyOnExpired: false, expires: _deadline));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
@@ -100,7 +100,9 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.FilteredReadAllEventsForward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user, expires: _deadline));
+					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user,
+					replyOnExpired: false,
+					expires: _deadline));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
@@ -78,7 +78,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.ReadStreamEventsForward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					_streamName, startRevision.ToInt64(), (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, null, _user, expires: _deadline));
+					_requiresLeader, null, _user, replyOnExpired: false, expires: _deadline));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -144,6 +144,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						ReadDirection.Forwards,
 						FilterOptionOneofCase.NoFilter) => new Enumerators.StreamSubscription<TStreamId>(
 							_publisher,
+							_expiryStrategy,
 							request.Options.Stream.StreamIdentifier,
 							request.Options.Stream.ToSubscriptionStreamRevision(),
 							request.Options.ResolveLinks,
@@ -156,6 +157,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						ReadDirection.Forwards,
 						FilterOptionOneofCase.NoFilter) => new Enumerators.AllSubscription(
 							_publisher,
+							_expiryStrategy,
 							request.Options.All.ToSubscriptionPosition(),
 							request.Options.ResolveLinks,
 							user,
@@ -168,6 +170,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						ReadDirection.Forwards,
 						FilterOptionOneofCase.Filter) => new Enumerators.AllSubscriptionFiltered(
 							_publisher,
+							_expiryStrategy,
 							request.Options.All.ToSubscriptionPosition(),
 							request.Options.ResolveLinks,
 							ConvertToEventFilter(true, request.Options.Filter),

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
@@ -9,18 +9,21 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		private readonly IReadIndex<TStreamId> _readIndex;
 		private readonly int _maxAppendSize;
 		private readonly TimeSpan _writeTimeout;
+		private readonly IExpiryStrategy _expiryStrategy;
 		private readonly IAuthorizationProvider _provider;
 		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Streams.Read);
 		private static readonly Operation WriteOperation = new Operation(Plugins.Authorization.Operations.Streams.Write);
 		private static readonly Operation DeleteOperation = new Operation(Plugins.Authorization.Operations.Streams.Delete);
 
 		public Streams(IPublisher publisher, IReadIndex<TStreamId> readIndex, int maxAppendSize, TimeSpan writeTimeout,
+			IExpiryStrategy expiryStrategy,
 			IAuthorizationProvider provider) {
 			if (publisher == null) throw new ArgumentNullException(nameof(publisher));
 			_publisher = publisher;
 			_readIndex = readIndex;
 			_maxAppendSize = maxAppendSize;
 			_writeTimeout = writeTimeout;
+			_expiryStrategy = expiryStrategy;
 			_provider = provider;
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/AtomController.cs
@@ -759,7 +759,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			Publish(new ClientMessage.ReadAllEventsForward(corrId, corrId, envelope,
 				position.CommitPosition, position.PreparePosition, count, resolveLinkTos,
 				requireLeader, GetETagTFPosition(manager), manager.User,
-				longPollTimeout));
+				replyOnExpired: false,
+				longPollTimeout: longPollTimeout));
 			return new RequestParams((longPollTimeout ?? TimeSpan.Zero) + ESConsts.HttpTimeout);
 		}
 
@@ -795,7 +796,8 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 			Publish(new ClientMessage.FilteredReadAllEventsForward(corrId, corrId, envelope,
 				position.CommitPosition, position.PreparePosition, count, true,
 				requireLeader, 1000, GetETagTFPosition(manager), filter, manager.User,
-				longPollTimeout));
+				replyOnExpired: false,
+				longPollTimeout: longPollTimeout));
 			return new RequestParams((longPollTimeout ?? TimeSpan.Zero) + ESConsts.HttpTimeout);
 		}
 
@@ -1008,7 +1010,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				Configure.GetStreamEventsForward);
 			var corrId = Guid.NewGuid();
 			Publish(new ClientMessage.ReadStreamEventsForward(corrId, corrId, envelope, stream, eventNumber, count,
-				resolveLinkTos, requireLeader, etag, manager.User, longPollTimeout));
+				resolveLinkTos, requireLeader, etag, manager.User,
+				replyOnExpired: false,
+				longPollTimeout: longPollTimeout));
 		}
 
 		private long? GetETagStreamVersion(HttpEntityManager manager) {

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -131,7 +131,9 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 				Configure.GetStreamEventsForward);
 			var corrId = Guid.NewGuid();
 			Publish(new ClientMessage.ReadStreamEventsForward(corrId, corrId, envelope, stream, eventNumber, count,
-				resolveLinkTos, requireLeader, etag, manager.User, longPollTimeout));
+				resolveLinkTos, requireLeader, etag, manager.User,
+				replyOnExpired: false,
+				longPollTimeout: longPollTimeout));
 		}
 		private void ViewParkedMessagesBackward(HttpEntityManager http, UriTemplateMatch match) {
 			var stream = match.BoundVariables["stream"];

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -151,7 +151,8 @@ namespace EventStore.Core.Services.Transport.Tcp {
 			if (dto == null) return null;
 			return new ClientMessage.ReadStreamEventsForward(Guid.NewGuid(), package.CorrelationId, envelope,
 				dto.EventStreamId, dto.FromEventNumber, dto.MaxCount,
-				dto.ResolveLinkTos, dto.RequireLeader, null, user);
+				dto.ResolveLinkTos, dto.RequireLeader, null, user,
+				replyOnExpired: false);
 		}
 
 		private static TcpPackage WrapReadStreamEventsForwardCompleted(
@@ -198,7 +199,9 @@ namespace EventStore.Core.Services.Transport.Tcp {
 
 			return new ClientMessage.ReadAllEventsForward(Guid.NewGuid(), package.CorrelationId, envelope,
 				dto.CommitPosition, dto.PreparePosition, dto.MaxCount,
-				dto.ResolveLinkTos, dto.RequireLeader, null, user, null);
+				dto.ResolveLinkTos, dto.RequireLeader, null, user,
+				replyOnExpired: false,
+				longPollTimeout: null);
 		}
 
 
@@ -241,7 +244,9 @@ namespace EventStore.Core.Services.Transport.Tcp {
 
 			return new ClientMessage.FilteredReadAllEventsForward(Guid.NewGuid(), package.CorrelationId, envelope,
 				dto.CommitPosition, dto.PreparePosition, dto.MaxCount,
-				dto.ResolveLinkTos, dto.RequireLeader, maxSearchWindow, null, eventFilter, user, null);
+				dto.ResolveLinkTos, dto.RequireLeader, maxSearchWindow, null, eventFilter, user,
+				replyOnExpired: false,
+				longPollTimeout: null);
 		}
 
 		private static TcpPackage WrapFilteredReadAllEventsForwardCompleted(

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
@@ -84,7 +84,7 @@ namespace EventStore.Projections.Core.Javascript.Tests.Integration {
 			var tmwid = new TellMeWhenItsDone(TestTimeout);
 			_mainQueue.Publish(new ClientMessage.ReadStreamEventsForward(Guid.NewGuid(),
 				Guid.NewGuid(), tmwid, stream, from, 100, true, false, null,
-				ClaimsPrincipal.Current, null, null));
+				ClaimsPrincipal.Current, replyOnExpired: false, null, null));
 			var msg = await tmwid.Task.WaitAsync(TestTimeout);
 			var rr = Assert.IsType<ClientMessage.ReadStreamEventsForwardCompleted>(msg);
 			return rr.Events;

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -693,7 +693,8 @@ namespace EventStore.Projections.Core.Services.Management {
 					resolveLinkTos: false,
 					requireLeader: false,
 					validationStreamVersion: null,
-					user: SystemAccounts.System),
+					user: SystemAccounts.System,
+					replyOnExpired: false),
 				m => OnProjectionsListReadCompleted(m, registeredProjections, from, completedAction));
 		}
 

--- a/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventByTypeIndexEventReader.cs
@@ -457,7 +457,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				} else {
 					readRequest = new ClientMessage.ReadStreamEventsForward(
 						pendingRequestCorrelationId, pendingRequestCorrelationId, new SendToThisEnvelope(this), "$et",
-						_lastKnownIndexCheckpointEventNumber + 1, 100, false, false, null, _readAs);
+						_lastKnownIndexCheckpointEventNumber + 1, 100, false, false, null, _readAs, replyOnExpired: false);
 				}
 
 				var timeoutMessage = TimerMessage.Schedule.Create(
@@ -492,7 +492,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 					corrId, corrId, new SendToThisEnvelope(this), stream,
 					_reader._fromPositions[stream], EventByTypeIndexEventReader.MaxReadCount, _reader._resolveLinkTos,
 					false, null,
-					_readAs);
+					_readAs,
+					replyOnExpired: false);
 
 				var timeoutMessage = TimerMessage.Schedule.Create(
 					TimeSpan.FromMilliseconds(ESConsts.ReadRequestTimeout),
@@ -662,7 +663,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					_fromTfPosition.CommitPosition,
 					_fromTfPosition.PreparePosition == -1 ? 0 : _fromTfPosition.PreparePosition,
 					EventByTypeIndexEventReader.MaxReadCount,
-					true, false, null, _readAs);
+					true, false, null, _readAs, replyOnExpired: false);
 
 				var timeoutMessage = TimerMessage.Schedule.Create(
 					TimeSpan.FromMilliseconds(ESConsts.ReadRequestTimeout),

--- a/src/EventStore.Projections.Core/Services/Processing/MultiStreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/MultiStreamEventReader.cs
@@ -266,7 +266,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			var readEventsForward = new ClientMessage.ReadStreamEventsForward(
 				Guid.NewGuid(), pendingRequestCorrelationId, new SendToThisEnvelope(this), stream,
 				_fromPositions.Streams[stream],
-				_maxReadCount, _resolveLinkTos, false, null, ReadAs);
+				_maxReadCount, _resolveLinkTos, false, null, ReadAs, replyOnExpired: false);
 			if (delay) {
 				_publisher.Publish(
 					new AwakeServiceMessage.SubscribeAwake(

--- a/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/RequestResponseQueueForwarder.cs
@@ -55,7 +55,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				new ClientMessage.ReadStreamEventsForward(
 					msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
 					msg.EventStreamId, msg.FromEventNumber, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
-					msg.ValidationStreamVersion, msg.User));
+					msg.ValidationStreamVersion, msg.User, replyOnExpired: false));
 		}
 
 		public void Handle(ClientMessage.ReadAllEventsForward msg) {
@@ -63,7 +63,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				new ClientMessage.ReadAllEventsForward(
 					msg.InternalCorrId, msg.CorrelationId, new PublishToWrapEnvelop(_inputQueue, msg.Envelope),
 					msg.CommitPosition, msg.PreparePosition, msg.MaxCount, msg.ResolveLinkTos, msg.RequireLeader,
-					msg.ValidationTfLastCommitPosition, msg.User));
+					msg.ValidationTfLastCommitPosition, msg.User, replyOnExpired: false));
 		}
 
 		public void Handle(SystemMessage.SubSystemInitialized msg) {

--- a/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/StreamEventReader.cs
@@ -186,7 +186,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		private Message CreateReadEventsMessage(Guid readCorrelationId) {
 			return new ClientMessage.ReadStreamEventsForward(
 				readCorrelationId, readCorrelationId, new SendToThisEnvelope(this), _streamName, _fromSequenceNumber,
-				_maxReadCount, _resolveLinkTos, false, null, ReadAs);
+				_maxReadCount, _resolveLinkTos, false, null, ReadAs, replyOnExpired: false);
 		}
 
 		private void DeliverSafeJoinPosition(long? safeJoinPosition) {

--- a/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/TransactionFileEventReader.cs
@@ -143,7 +143,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 			return new ClientMessage.ReadAllEventsForward(
 				correlationId, correlationId, new SendToThisEnvelope(this), _from.CommitPosition,
 				_from.PreparePosition == -1 ? _from.CommitPosition : _from.PreparePosition, _maxReadCount,
-				_resolveLinkTos, false, null, ReadAs);
+				_resolveLinkTos, false, null, ReadAs, replyOnExpired: false);
 		}
 
 		private void DeliverLastCommitPosition(TFPos lastPosition) {


### PR DESCRIPTION
Fixed: Prevent gRPC subscriptions from hanging while catching up

Stream subscriptions, $all subscriptions, and filtered $all subscriptions issue reads while they are catching up. Before this fix, if any of those reads were discarded because they had expired (i.e. were already 10s old by the time they reached the front of the queue), no further read would be attempted and the subscription would stall.

This change causes a reply to be sent back with status Expired if the read is being discarded due to expiry, and the subscription will retry the read.

The gRPC subscription explicitly opts in to this reply behaviour. For everything else no reply is sent back to make load shedding as quick as possible. Other callers manage their own retries.