### PR TITLE
Revert "Prevent one slow subscription from slowing down others"

### DIFF
--- a/src/EventStore.Core/Messaging/ContinuationEnvelope.cs
+++ b/src/EventStore.Core/Messaging/ContinuationEnvelope.cs
@@ -20,8 +20,6 @@ namespace EventStore.Core.Messaging {
 		private readonly SemaphoreSlim _semaphore;
 		private readonly CancellationToken _cancellationToken;
 
-		private int _stopped;
-
 		public ContinuationEnvelope(Func<Message, CancellationToken, Task> onMessage, SemaphoreSlim semaphore,
 			CancellationToken cancellationToken) {
 			_onMessage = onMessage;
@@ -29,16 +27,9 @@ namespace EventStore.Core.Messaging {
 			_cancellationToken = cancellationToken;
 		}
 
-		public void StopReplies() {
-			Interlocked.Or(ref _stopped, 1);
-		}
-
 		public void ReplyWith<T>(T message) where T : Message {
 			try {
-				do {
-					if (Interlocked.And(ref _stopped, 1) == 1)
-						return;
-				} while (!_semaphore.Wait(50, _cancellationToken));
+				_semaphore.Wait(_cancellationToken);
 				_onMessage(message, _cancellationToken).ContinueWith(_ => _semaphore.Release(), _cancellationToken);
 			}
 			catch (ObjectDisposedException) {}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
@@ -210,10 +210,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					"Live subscription {subscriptionId} to $all running from {position}...",
 					_subscriptionId, startPosition);
 
-				ContinuationEnvelope envelope = null;
-				envelope = new ContinuationEnvelope(OnSubscriptionMessage, _semaphore, _cancellationToken);
 				_bus.Publish(new ClientMessage.SubscribeToStream(Guid.NewGuid(), _subscriptionId,
-					envelope, _subscriptionId,
+					new ContinuationEnvelope(OnSubscriptionMessage, _semaphore, _cancellationToken), _subscriptionId,
 					string.Empty, _resolveLinks, _user));
 
 				Task.Factory.StartNew(PumpLiveMessages, _cancellationToken);
@@ -352,18 +350,22 @@ namespace EventStore.Core.Services.Transport.Grpc {
 								return;
 							}
 
-							Log.Verbose(
-								"Live subscription {subscriptionId} to $all enqueuing live message {position}.",
-								_subscriptionId, appeared.Event.OriginalPosition);
+							using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+							try {
+								Log.Verbose(
+									"Live subscription {subscriptionId} to $all enqueuing live message {position}.",
+									_subscriptionId, appeared.Event.OriginalPosition);
 
-							if (!liveEvents.Writer.TryWrite(appeared.Event)) {
+								await liveEvents.Writer.WriteAsync(appeared.Event, cts.Token)
+									.ConfigureAwait(false);
+							} catch (Exception e) {
 								if (Interlocked.Exchange(ref liveMessagesCancelled, 1) != 0) return;
 
 								Log.Verbose(
+									e,
 									"Live subscription {subscriptionId} to $all timed out at {position}; unsubscribing...",
 									_subscriptionId, appeared.Event.OriginalPosition.GetValueOrDefault());
 
-								envelope.StopReplies();
 								Unsubscribe();
 
 								liveEvents.Writer.Complete();


### PR DESCRIPTION
Fixed: Revert: Prevent one slow gRPC subscription from slowing down others. Incomplete fix.

This reverts commit 17344a39086c4f638359ede489588bc2eeefa5d1.

https://github.com/EventStore/EventStore/pull/3538

It was a fix, but not a whole fix. It is also possible to hit the contention while doing the final catchups during the transition to live.