### PR TITLE
Terminate live gRPC subscription if it falls behind

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.cs
@@ -6,7 +6,7 @@ using Google.Protobuf;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal static partial class Enumerators {
-		private const int MaxLiveEventBufferCount = 16;
+		private const int MaxLiveEventBufferCount = 32;
 		private const int ReadBatchSize = 32; // TODO  JPB make this configurable
 
 		private static readonly BoundedChannelOptions BoundedChannelOptions =


### PR DESCRIPTION
Fixed: Slow EventCommitted handling. Live gRPC subscriptions that fall behind are dropped and invited to resubscribe.

The client can resubscribe from where it received up to.
The slowness was due to lock contention.
Longer term the subscription will be able to correctly switch between catchup and live smoothly but this requires more thought.