### PR TITLE
Add track_emitted_streams feature to Projections.Create

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/ServerFeatures.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/ServerFeatures.cs
@@ -36,6 +36,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						method.Features.AddRange(new[] {"position", "events"});
 					} else if (x.Method.ServiceName.Contains("Streams") && x.Method.Name.Contains("BatchAppend")) {
 						method.Features.Add("deadline_duration");
+					} else if (x.Method.ServiceName.Contains("Projections") && x.Method.Name.Contains("Create")) {
+						method.Features.Add("track_emitted_streams");
 					}
 
 					return method;

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -26,12 +26,21 @@
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 		<PackageReference Include="Serilog.Sinks.TextWriter" Version="2.1.0" />
+		<PackageReference Include="Google.Protobuf" Version="3.18.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.41.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Core.Tests\EventStore.Core.Tests.csproj" />
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		<ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+		<Protobuf Include="..\Protos\Grpc\projections.proto" Link="Protos\projections.proto" GrpcServices="Client" ProtoRoot="../Protos/Grpc" Access="Internal" />
+		<Protobuf Include="..\Protos\Grpc\serverfeatures.proto" Link="Protos\serverfeatures.proto" GrpcServices="Client" ProtoRoot="../Protos/Grpc" Access="Internal" />
 	</ItemGroup>
 	<ItemGroup>
 		<Content Include="Queries\1Query.js">

--- a/src/EventStore.Projections.Core.Tests/Services/grpc_service/ServerFeaturesTests.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/grpc_service/ServerFeaturesTests.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using EventStore.Client;
+using EventStore.Client.ServerFeatures;
+using EventStore.Core.Tests;
+using EventStore.Projections.Core.Tests.ClientAPI.projectionsManager;
+using Google.Protobuf.Reflection;
+using Grpc.Net.Client;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.grpc_service {
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class ServerFeaturesTests<TLogFormat, TStreamId>: SpecificationWithNodeAndProjectionsManager<TLogFormat, TStreamId> {
+		private List<SupportedMethod> _supportedEndPoints = new ();
+		private List<SupportedMethod> _expectedEndPoints = new ();
+
+		public override Task Given() {
+			_expectedEndPoints.AddRange(GetEndPoints(Client.Projections.Projections.Descriptor));
+			var createEndPoint = _expectedEndPoints.FirstOrDefault(ep => ep.MethodName.Contains("create"));
+			createEndPoint?.Features.Add("track_emitted_streams");
+
+			return Task.CompletedTask;
+		}
+
+		public override async Task When() {
+			using var channel = GrpcChannel.ForAddress(new Uri($"https://{_node.HttpEndPoint}"),
+			new GrpcChannelOptions {
+				HttpClient = new HttpClient(new SocketsHttpHandler {
+					SslOptions = {
+							RemoteCertificateValidationCallback = delegate { return true; }
+					}
+				}, true)
+			});
+			var client = new ServerFeatures.ServerFeaturesClient(channel);
+
+			var resp = await client.GetSupportedMethodsAsync(new Empty());
+			_supportedEndPoints = resp.Methods.Where(x => x.ServiceName.Contains("projections")).ToList();
+		}
+
+		private SupportedMethod[] GetEndPoints(ServiceDescriptor desc) =>
+			desc.Methods.Select(x => new SupportedMethod {
+				MethodName = x.Name.ToLower(),
+				ServiceName = x.Service.FullName.ToLower()
+			}).ToArray();
+
+		[Test]
+		public void should_receive_expected_endpoints() {
+			CollectionAssert.AreEquivalent(_expectedEndPoints, _supportedEndPoints);
+		}
+	}
+}


### PR DESCRIPTION
Added: `track_emitted_streams` feature to Projections.Create gRPC method.
