### PR TITLE
remove transform from init function

### DIFF
--- a/src/EventStore.Projections.Core.Javascript.Tests/Specs/event-data-spec.json
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Specs/event-data-spec.json
@@ -80,7 +80,7 @@
 			"allStreams": true,
 			"events": ["baz"] ,
 			"partitioned": false,
-			"definesStateTransform": true,
+			"definesStateTransform": false,
 			"handlesDeletedNotifications": false,
 			"producesResults": false,
 			"definesFold": true,

--- a/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
+++ b/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs
@@ -655,7 +655,6 @@ namespace EventStore.Projections.Core.Services.Interpreted {
 				switch (name) {
 					case "$init":
 						_init = handler;
-						_definitionBuilder.SetDefinesStateTransform();
 						break;
 					case "$initShared":
 						_definitionBuilder.SetIsBiState(true);


### PR DESCRIPTION
Fixed: Double serialization of projections using $init function

Results of benchmarking

System projection and empty events:
V5.0.9 = Task Run system projections took 00:00:12.8476297
V21.10.7 = Task Run system projections took 00:00:13.8375754

Custom projection and empty events
V5.0.9 = Task Run large state user projections took 00:00:07.9944697
V21.10.2 = Task Run large state user projections took 00:00:07.9215283
V21.10.7 = Task Run large state user projections took 00:00:07.9377514

System projection and big events:
V5.0.9 = Task Run system projections took 00:00:13.2253495
V21.10.7 = Task Run system projections took 00:00:12.4902357

Custom projection and big events: (creates a large projection state)
V5.0.9 = Task Run system projections took 00:01:30.4
v21.10.2 = Not even comparable as it just took too long
V21.10.7 = Task Run system projections took 00:02:07.3

This then made me look into what was happening here so I started profiling

I found that in v21.10.7 the projection was being serialized twice:
Once processing, and the second doing a transformation. But I wasnt doing any transforms as far as I was aware

This led me to this line (attached profiler snaps):
https://github.com/EventStore/EventStore/blob/master/src/EventStore.Projections.Core/Services/Interpreted/JintProjectionStateHandler.cs#L658

I dont believe this line is required as it doesnt seem anything is added to _transforms list from it. So it just results in iterating over an empty list and then serializing the result again

Our projection was using $init and so a transform was being applied. Upon removing this line and running a custom ES build the results were as follows.
V5.0.9 = 1:28.000
V21.10.Custom = 1:20.000