### PR TITLE
Add better error messages for the gossip seed configuration

### DIFF
--- a/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
@@ -60,11 +60,18 @@ namespace EventStore.Core {
 			return builder.Length != 0 ? builder.ToString() : null;
 		}
 
-		private static EndPoint ParseEndPoint(string val) {
+		private static EndPoint ParseGossipEndPoint(string val) {
 			var parts = val.Split(':', 2);
+			
+			if (parts.Length != 2)
+				throw new Exception("You must specify the ports in the gossip seed");
+
+			if (!int.TryParse(parts[1], out var port))
+				throw new Exception($"Invalid format for gossip seed port: {parts[1]}");
+
 			return IPAddress.TryParse(parts[0], out var ip)
-				? new IPEndPoint(ip, int.Parse(parts[1]))
-				: new DnsEndPoint(parts[0], int.Parse(parts[1]));
+				? new IPEndPoint(ip, port)
+				: new DnsEndPoint(parts[0], port);
 		}
 
 		private static string GetHelpText() {

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -338,7 +338,7 @@ namespace EventStore.Core {
 
 			internal static ClusterOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				GossipSeed = Array.ConvertAll(configurationRoot.GetCommaSeparatedValueAsArray(nameof(GossipSeed)),
-					ParseEndPoint),
+					ParseGossipEndPoint),
 				DiscoverViaDns = configurationRoot.GetValue<bool>(nameof(DiscoverViaDns)),
 				ClusterSize = configurationRoot.GetValue<int>(nameof(ClusterSize)),
 				NodePriority = configurationRoot.GetValue<int>(nameof(NodePriority)),


### PR DESCRIPTION
Displays a human readable error when the port is missing
Displays a human readable error when the port is not a valid int

Also updated the name of ParseEndPoint to ParseGossipEndPoint as
the error messages created are specific to the Gossip seed.

Proposed fix for: https://github.com/EventStore/EventStore/issues/3565