### PR TITLE
Update tracing packages and fix memory leak

### DIFF
--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -27,8 +27,8 @@
 		<PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
 		<PackageReference Include="System.Linq.Async" Version="5.0.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
-		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.57" />
+		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.328102" />
+		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.3" />
 		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 		<PackageReference Include="HostStat.NET" Version="1.0.2" />
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.1" />


### PR DESCRIPTION
Fixed: Memory leak caused by EventPipeEventSource

When doing some performance analysis I found that memory was growing at a rate of about ~4mb/hr

Example ES left running over a weekend (57 hours)
image

Example ES that I pulled from a UAT box (long uptime)
image

Tested locally after upgrading packages finding after 16 hours of running under load that EventPipeEventSource had used 8mb, this was still climbing at a rate of 0.5mb/hr

It was caused by AddCallbackOnDotNetRuntimeLoad that was only used to count gc collections. This in itself was actually incorrect as it would count a generation 2 gc but dismissed the fact that ment there was a generation 0 and 1 gc. I have replaced this in place with gen-x-gc-count from dotnet-counters that counts this over a time interval. This means the stat wont be as responsive (as its counted over an interval) but realistically not an issue for this stat.

If we want the stat to use the "old" values I am happy to change GetGcStats so the counter will negate higher levels gcs e.g. gen 0 = gen 0 - gen 1 - gen2