### PR TITLE
Fix incorrect error message when deleting a stream using gRPC

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -70,13 +70,14 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 
 		public static RpcException WrongExpectedVersion(
+			string operation,
 			string streamName,
 			long expectedVersion,
 			long? actualVersion = default) =>
 			new(
 				new Status(
 					StatusCode.FailedPrecondition,
-					$"Append failed due to WrongExpectedVersion. Stream: {streamName}, Expected version: {expectedVersion}, Actual version: {actualVersion}"),
+					$"{operation} failed due to WrongExpectedVersion. Stream: {streamName}, Expected version: {expectedVersion}, Actual version: {actualVersion}"),
 				new Metadata {
 					{Constants.Exceptions.ExceptionKey, Constants.Exceptions.WrongExpectedVersion},
 					{Constants.Exceptions.StreamName, streamName},

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -132,8 +132,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						deleteResponseSource.TrySetException(RpcExceptions.Timeout(completed.Message));
 						return;
 					case OperationResult.WrongExpectedVersion:
-						deleteResponseSource.TrySetException(RpcExceptions.WrongExpectedVersion(streamName,
-							expectedVersion, completed.CurrentVersion));
+						deleteResponseSource.TrySetException(RpcExceptions.WrongExpectedVersion("Delete",
+							streamName, expectedVersion, completed.CurrentVersion));
 						return;
 					case OperationResult.StreamDeleted:
 						deleteResponseSource.TrySetException(RpcExceptions.StreamDeleted(streamName));


### PR DESCRIPTION
Fixed: Incorrect error message when deleting a stream using gRPC. Fixes issue #3547