### PR TITLE
Improve nunit test logging

### DIFF
--- a/src/EventStore.Core.Tests/AssertEx.cs
+++ b/src/EventStore.Core.Tests/AssertEx.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using KellermanSoftware.CompareNetObjects;
 using NUnit.Framework;
 
+//poke
+
 namespace EventStore.Core.Tests {
 	public static class AssertEx {
 		private static ComparisonConfig Configuration = new ComparisonConfig {

--- a/src/EventStore.Core.Tests/AssertEx.cs
+++ b/src/EventStore.Core.Tests/AssertEx.cs
@@ -79,6 +79,18 @@ namespace EventStore.Core.Tests {
 			Assert.Fail($"{msg} in {memberName} {sourceFilePath}:{sourceLineNumber}");
 		}
 
+		public static void IsOrBecomesTrue(Func<bool> func, TimeSpan? timeout,
+			Func<string> genMsg, bool yieldThread = false,
+			[CallerMemberName] string memberName = "",
+			[CallerFilePath] string sourceFilePath = "",
+			[CallerLineNumber] int sourceLineNumber = 0) {
+
+			if (IsOrBecomesTrueImpl(func, timeout, yieldThread))
+				return;
+
+			Assert.Fail($"{genMsg()} in {memberName} {sourceFilePath}:{sourceLineNumber}");
+		}
+
 		// shared between xunit and nunit
 		public static bool IsOrBecomesTrueImpl(
 			Func<bool> func,

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -55,7 +55,7 @@ namespace EventStore.Core.Tests.Helpers {
 		public Task Started => _started.Task;
 		public Task AdminUserCreated => _adminUserCreated.Task;
 
-		public VNodeState NodeState = VNodeState.Unknown;
+		public VNodeState NodeState { get; private set; }
 		private readonly IWebHost _host;
 
 		private readonly TestServer _kestrelTestServer;
@@ -159,7 +159,7 @@ namespace EventStore.Core.Tests.Helpers {
 
 			_isReadOnlyReplica = readOnlyReplica;
 
-			Log.Information(
+			Log.Verbose(
 				"\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"
 				+ "{11,-25} {12}\n" + "{13,-25} {14}\n" + "{15,-25} {16}\n" + "{17,-25} {18}\n\n",
 				"ES VERSION:", VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp,
@@ -215,6 +215,8 @@ namespace EventStore.Core.Tests.Helpers {
 
 			Node.MainBus.Subscribe(
 				new AdHocHandler<SystemMessage.StateChangeMessage>(m => {
+					Log.Debug("MiniClusterNode {path} index {index} at port {port} changed state from {oldState} to {state}",
+						_dbPath, DebugIndex, HttpEndPoint.Port, NodeState, m.State);
 					NodeState = m.State;
 				}));
 			if (!_isReadOnlyReplica) {

--- a/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
+++ b/src/EventStore.Core.Tests/Integration/specification_with_cluster.cs
@@ -114,13 +114,13 @@ namespace EventStore.Core.Tests.Integration {
 			// wait for cluster to be fully operational, tests depend on leader and followers
 			AssertEx.IsOrBecomesTrue(() => _nodes.Any(x => x.NodeState == Data.VNodeState.Leader),
 				timeout: TimeSpan.FromSeconds(30),
-				msg: "Waiting for leader timed out!");
+				genMsg: () => $"Waiting for leader timed out! States={string.Join(", ", _nodes.Select(n => n.NodeState))}");
 
 			//flaky: most tests only need 1 follower, waiting for 2 causes timeouts 
 			AssertEx.IsOrBecomesTrue(() =>
 					_nodes.Any(x => x.NodeState is VNodeState.Follower or VNodeState.ReadOnlyReplica),
 				timeout: TimeSpan.FromSeconds(90),
-				msg: $"Waiting for followers timed out! States={string.Join(", ", _nodes.Select(n => n.NodeState))}");
+				genMsg: () => $"Waiting for followers timed out! States={string.Join(", ", _nodes.Select(n => n.NodeState))}");
 
 			_conn = CreateConnection();
 			await _conn.ConnectAsync();

--- a/src/EventStore.Core.Tests/SpecificationWithDirectory.cs
+++ b/src/EventStore.Core.Tests/SpecificationWithDirectory.cs
@@ -2,9 +2,11 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Serilog;
 
 namespace EventStore.Core.Tests {
 	public class SpecificationWithDirectory {
+		private static readonly ILogger Log = Serilog.Log.ForContext<SpecificationWithDirectory>();
 		protected string PathName;
 
 		protected string GetTempFilePath() {
@@ -21,6 +23,8 @@ namespace EventStore.Core.Tests {
 			PathName = Path.Combine(Path.GetTempPath(), string.Format("ES-{0}-{1}", Guid.NewGuid(), typeName));
 			Directory.CreateDirectory(PathName);
 
+			Log.Debug("SpecificationWithDirectory SetUp done: {path}", PathName);
+
 			return Task.CompletedTask;
 		}
 
@@ -28,6 +32,8 @@ namespace EventStore.Core.Tests {
 		public virtual async Task TearDown() {
 			// kill whole tree
 			await DirectoryDeleter.TryForceDeleteDirectoryAsync(PathName, retries: 10);
+
+			Log.Debug("SpecificationWithDirectory TearDown done: {path}", PathName);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/SpecificationWithDirectoryPerTestFixture.cs
+++ b/src/EventStore.Core.Tests/SpecificationWithDirectoryPerTestFixture.cs
@@ -3,9 +3,11 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Serilog;
 
 namespace EventStore.Core.Tests {
 	public class SpecificationWithDirectoryPerTestFixture {
+		private static readonly ILogger Log = Serilog.Log.ForContext<SpecificationWithDirectoryPerTestFixture>();
 		protected internal string PathName;
 
 		protected string GetTempFilePath() {
@@ -24,6 +26,8 @@ namespace EventStore.Core.Tests {
 			PathName = Path.Combine(Path.GetTempPath(), string.Format("ES-{0}-{1}", Guid.NewGuid(), typeName));
 			Directory.CreateDirectory(PathName);
 
+			Log.Debug("SpecificationWithDirectoryPerTestFixture SetUp done: {path}", PathName);
+
 			return Task.CompletedTask;
 		}
 
@@ -31,6 +35,8 @@ namespace EventStore.Core.Tests {
 		public virtual async Task TestFixtureTearDown() {
 			// kill whole tree
 			await DirectoryDeleter.TryForceDeleteDirectoryAsync(PathName, retries: 10);
+
+			Log.Debug("SpecificationWithDirectoryPerTestFixture TearDown done: {path}", PathName);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TestsInitFixture.cs
+++ b/src/EventStore.Core.Tests/TestsInitFixture.cs
@@ -4,18 +4,35 @@ using System.Runtime.InteropServices;
 using EventStore.Common.Utils;
 using EventStore.Core.Tests.Helpers;
 using NUnit.Framework;
+using Serilog;
 
 namespace EventStore.Core.Tests {
 	[SetUpFixture]
 	public class TestsInitFixture {
 		[OneTimeSetUp]
 		public void SetUp() {
+			SetUp(Serilog.Events.LogEventLevel.Warning);
+		}
+
+		public void SetUp(Serilog.Events.LogEventLevel minimumLevel) {
 			ServicePointManager.DefaultConnectionLimit = 1000;
+
+			// https://github.com/nunit/nunit/issues/1062#issuecomment-259589577
+			// Standard output is produced using Console.Write and TextContext.Write. The text is attached to the test result.
+			// Immediate output is produced by Console.Error, TextContext.Error and TextContext.Progress. It is displayed immediately when received.
+			// Normally, the console only displays info from the fixture if the OneTimeSetUp fails.
+			//
+			// Therefore, here we set up the logger to log whatever we want to see to the console error output
+			Log.Logger = new LoggerConfiguration()
+				.MinimumLevel.Is(minimumLevel)
+				.MinimumLevel.Override("EventStore.Core.Tests", Serilog.Events.LogEventLevel.Debug)
+				.WriteTo.Console(standardErrorFromLevel: Serilog.Events.LogEventLevel.Verbose)
+				.CreateLogger();
 			LogEnvironmentInfo();
 		}
 
 		private void LogEnvironmentInfo() {
-			var log = Serilog.Log.ForContext<TestsInitFixture>();
+			var log = Log.ForContext<TestsInitFixture>();
 
 			log.Information("\n{0,-25} {1} ({2}/{3}, {4})\n"
 					 + "{5,-25} {6} ({7})\n"
@@ -32,30 +49,34 @@ namespace EventStore.Core.Tests {
 
 		[OneTimeTearDown]
 		public void TearDown() {
+			var log = Log.ForContext<TestsInitFixture>();
 			var runCount = Math.Max(1, MiniNode<LogFormat.V2,string>.RunCount);
-			var msg = string.Format("Total running time of MiniNode (Log V2): {0} (mean {1})\n" +
-									"Total starting time of MiniNode (Log V2): {2} (mean {3})\n" +
-									"Total stopping time of MiniNode (Log V2): {4} (mean {5})\n" +
-									"Total run count (Log V2): {6}",
-				MiniNode<LogFormat.V2,string>.RunningTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V2,string>.RunningTime.Elapsed.Ticks / runCount),
-				MiniNode<LogFormat.V2,string>.StartingTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V2,string>.StartingTime.Elapsed.Ticks / runCount),
-				MiniNode<LogFormat.V2,string>.StoppingTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V2,string>.StoppingTime.Elapsed.Ticks / runCount),
-				MiniNode<LogFormat.V2,string>.RunCount);
+			var msg = string.Format(
+				"\n" +
+				"Total running  time of MiniNode (Log V2): {0} (mean {1})\n" +
+				"Total starting time of MiniNode (Log V2): {2} (mean {3})\n" +
+				"Total stopping time of MiniNode (Log V2): {4} (mean {5})\n" +
+				"Total run count (Log V2): {6}",
+				MiniNode<LogFormat.V2, string>.RunningTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V2, string>.RunningTime.Elapsed.Ticks / runCount),
+				MiniNode<LogFormat.V2, string>.StartingTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V2, string>.StartingTime.Elapsed.Ticks / runCount),
+				MiniNode<LogFormat.V2, string>.StoppingTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V2, string>.StoppingTime.Elapsed.Ticks / runCount),
+				MiniNode<LogFormat.V2, string>.RunCount);
 
-			Console.WriteLine(msg);
-			Console.WriteLine();
+			log.Information(msg);
 
-			runCount = Math.Max(1, MiniNode<LogFormat.V3,long>.RunCount);
-			msg = string.Format("Total running time of MiniNode (Log V3): {0} (mean {1})\n" +
-			                        "Total starting time of MiniNode (Log V3): {2} (mean {3})\n" +
-			                        "Total stopping time of MiniNode (Log V3): {4} (mean {5})\n" +
-			                        "Total run count (Log V3): {6}",
-				MiniNode<LogFormat.V3,long>.RunningTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V3,long>.RunningTime.Elapsed.Ticks / runCount),
-				MiniNode<LogFormat.V3,long>.StartingTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V3,long>.StartingTime.Elapsed.Ticks / runCount),
-				MiniNode<LogFormat.V3,long>.StoppingTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V3,long>.StoppingTime.Elapsed.Ticks / runCount),
-				MiniNode<LogFormat.V3,long>.RunCount);
+			runCount = Math.Max(1, MiniNode<LogFormat.V3, uint>.RunCount);
+			msg = string.Format(
+				"\n" +
+				"Total running  time of MiniNode (Log V3): {0} (mean {1})\n" +
+				"Total starting time of MiniNode (Log V3): {2} (mean {3})\n" +
+				"Total stopping time of MiniNode (Log V3): {4} (mean {5})\n" +
+				"Total run count (Log V3): {6}",
+				MiniNode<LogFormat.V3, uint>.RunningTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V3, uint>.RunningTime.Elapsed.Ticks / runCount),
+				MiniNode<LogFormat.V3, uint>.StartingTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V3, uint>.StartingTime.Elapsed.Ticks / runCount),
+				MiniNode<LogFormat.V3, uint>.StoppingTime.Elapsed, TimeSpan.FromTicks(MiniNode<LogFormat.V3, uint>.StoppingTime.Elapsed.Ticks / runCount),
+				MiniNode<LogFormat.V3, uint>.RunCount);
 
-			Console.WriteLine(msg);
+			log.Information(msg);
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1522,7 +1522,10 @@ namespace EventStore.Core {
 
 			var cts = new CancellationTokenSource();
 
-			await using var _ = cts.Token.Register(() => _shutdownSource.TrySetCanceled(cancellationToken)).ConfigureAwait(false);
+			await using var _ = cts.Token.Register(() => {
+				Log.Warning("Shutdown timed out after {timeout}", timeout.Value);
+				_shutdownSource.TrySetCanceled(cancellationToken);
+			}).ConfigureAwait(false);
 
 			cts.CancelAfter(timeout.Value);
 			await _shutdownSource.Task.ConfigureAwait(false);

--- a/src/EventStore.Projections.Core.Tests/TestsInitFixture.cs
+++ b/src/EventStore.Projections.Core.Tests/TestsInitFixture.cs
@@ -8,7 +8,7 @@ namespace EventStore.Projections.Core.Tests {
 
 		[OneTimeSetUp]
 		public void SetUp() {
-			_initFixture.SetUp();
+			_initFixture.SetUp(Serilog.Events.LogEventLevel.Fatal);
 		}
 
 		[OneTimeTearDown]


### PR DESCRIPTION
Changed: Improved unit test logging 

- Configure logger to output Warnings from the production code to the console, and Debug messages from the test code.
- Log a warning if node shutdown times out
- Add overload of IsOrBecomesTrue that can generate the message upon giving up
- MiniNode and MiniClusterNode (debug) log on state change
- SpecificationWithDirectory(PerTestFixture) debug logs on setup/teardown, makes it easier to tell which test is actually running

Significant advantage here is that if the mininode experiences an error we will be able to see it and which test it is associated with in the test output.