### PR TITLE
Fix persistent subscription race condition

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStreamReader.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStreamReader.cs
@@ -119,9 +119,14 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			public void FetchCompleted(ClientMessage.ReadStreamEventsForwardCompleted msg) {
 				switch (msg.Result) {
 					case ReadStreamResult.Success:
-					case ReadStreamResult.NoStream:
 						_onFetchCompleted(_skipFirstEvent ? msg.Events.Skip(1).ToArray() : msg.Events,
 							new PersistentSubscriptionSingleStreamPosition(msg.NextEventNumber), msg.IsEndOfStream);
+						break;
+					case ReadStreamResult.NoStream:
+						_onFetchCompleted(
+							Array.Empty<ResolvedEvent>(),
+							new PersistentSubscriptionSingleStreamPosition(0),
+							msg.IsEndOfStream);
 						break;
 					case ReadStreamResult.AccessDenied:
 						_onError($"Read access denied for stream: {msg.EventStreamId}");


### PR DESCRIPTION
Fixed: Race condition when creating a persistent subscription to a stream at the same time as creating that stream.

A read result of 'NoStream' comes with a NextEventNumber of -1. If there happens to have been an event written since the read, the PersistentSubscription will issue another read starting from the NextEventNumber But -1 is not a valid event number to read from, which results in an error.

Instead, if there is NoStream, issue the read from 0.


