### PR TITLE
WIP: handle io dispatcher timeouts better

### DIFF
--- a/src/EventStore.Core.Tests/Authentication/with_internal_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Authentication/with_internal_authentication_provider.cs
@@ -14,7 +14,8 @@ namespace EventStore.Core.Tests.Authentication {
 
 		protected void SetUpProvider() {
 			_ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_bus));
-			_bus.Subscribe(_ioDispatcher.BackwardReader);
+			_bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+			_bus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher.BackwardReader);
 			_bus.Subscribe(_ioDispatcher.ForwardReader);
 			_bus.Subscribe(_ioDispatcher.Writer);
 			_bus.Subscribe(_ioDispatcher.StreamDeleter);

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/IODispatcherTestHelpers.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/IODispatcherTestHelpers.cs
@@ -26,7 +26,8 @@ namespace EventStore.Core.Tests.Helpers.IODispatcherTests {
 			bus.Subscribe<IODispatcherDelayedMessage>(ioDispatcher);
 			bus.Subscribe<ClientMessage.NotHandled>(ioDispatcher);
 			bus.Subscribe(ioDispatcher.ForwardReader);
-			bus.Subscribe(ioDispatcher.BackwardReader);
+			bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
+			bus.Subscribe<ClientMessage.NotHandled>(ioDispatcher.BackwardReader);
 			bus.Subscribe(ioDispatcher.Writer);
 			bus.Subscribe(ioDispatcher.Awaker);
 			bus.Subscribe(ioDispatcher.StreamDeleter);

--- a/src/EventStore.Core.Tests/Helpers/TestFixtureWithReadWriteDispatchers.cs
+++ b/src/EventStore.Core.Tests/Helpers/TestFixtureWithReadWriteDispatchers.cs
@@ -21,10 +21,7 @@ namespace EventStore.Core.Tests.Helpers {
 		protected RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted>
 			_writeDispatcher;
 
-		protected
-			RequestResponseDispatcher
-			<ClientMessage.ReadStreamEventsBackward, ClientMessage.ReadStreamEventsBackwardCompleted>
-			_readDispatcher;
+		protected ReadDispatcher _readDispatcher;
 
 		protected TestHandler<Message> _consumer;
 		protected IODispatcher _ioDispatcher;
@@ -60,7 +57,8 @@ namespace EventStore.Core.Tests.Helpers {
 			_streamDispatcher = _ioDispatcher.StreamDeleter;
 
 			_bus.Subscribe(_ioDispatcher.ForwardReader);
-			_bus.Subscribe(_ioDispatcher.BackwardReader);
+			_bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+			_bus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher.BackwardReader);
 			_bus.Subscribe(_ioDispatcher.ForwardReader);
 			_bus.Subscribe(_ioDispatcher.Writer);
 			_bus.Subscribe(_ioDispatcher.StreamDeleter);

--- a/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
@@ -58,13 +58,8 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 					maxCount: 1,
 					resolveLinks: false,
 					principal: SystemAccounts.System,
-					action: m => {
-						ReadUserDataCompleted(m, authenticationRequest);
-					},
-					timeoutAction: () => {
-						ReadUserDataTimedOut(authenticationRequest);
-					},
-					Guid.NewGuid());
+					handler: new AuthReadResponseHandler(this, authenticationRequest),
+					corrId: Guid.NewGuid());
 			}
 		}
 		public string Name => "internal";
@@ -78,52 +73,6 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 			return new [] {
 				"Basic"
 			};
-		}
-
-		private void ReadUserDataCompleted(ClientMessage.ReadStreamEventsBackwardCompleted completed,
-			AuthenticationRequest authenticationRequest) {
-			try {
-				if (completed.Result == ReadStreamResult.StreamDeleted ||
-				    completed.Result == ReadStreamResult.NoStream ||
-				    completed.Result == ReadStreamResult.AccessDenied) {
-					if (_logFailedAuthenticationAttempts)
-						Log.Warning("Authentication Failed for {id}: {reason}", authenticationRequest.Id, "Invalid user.");
-					authenticationRequest.Unauthorized();
-					return;
-				}
-
-				if (completed.Result == ReadStreamResult.Error) {
-					if (_logFailedAuthenticationAttempts)
-						Log.Warning("Authentication Failed for {id}: {reason}", authenticationRequest.Id,
-							"Unexpected error.");
-					authenticationRequest.Error();
-					return;
-				}
-
-				var userData = completed.Events[0].Event.Data.ParseJson<UserData>();
-				if (userData.LoginName != authenticationRequest.Name) {
-					authenticationRequest.Error();
-					return;
-				}
-
-				if (userData.Disabled) {
-					if (_logFailedAuthenticationAttempts)
-						Log.Warning("Authentication Failed for {id}: {reason}", authenticationRequest.Id,
-							"The account is disabled.");
-					authenticationRequest.Unauthorized();
-				} else {
-					AuthenticateWithPasswordHash(authenticationRequest, userData);
-				}
-			} catch {
-				authenticationRequest.Unauthorized();
-			}
-		}
-
-		private void ReadUserDataTimedOut(AuthenticationRequest authenticationRequest) {
-			if (_logFailedAuthenticationAttempts)
-				Log.Warning("Authentication Failed for {id}: {reason}", authenticationRequest.Id,
-					"The system is not ready.");
-			authenticationRequest.NotReady();
 		}
 
 		private void AuthenticateWithPasswordHash(AuthenticationRequest authenticationRequest, UserData userData) {
@@ -175,6 +124,73 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 
 		public Task Initialize() {
 			return _tcs.Task;
+		}
+
+		class AuthReadResponseHandler : IReadStreamEventsBackwardHandler {
+			private readonly InternalAuthenticationProvider _self;
+			private readonly AuthenticationRequest _authenticationRequest;
+
+			public AuthReadResponseHandler(InternalAuthenticationProvider self, AuthenticationRequest request) {
+				_self = self;
+				_authenticationRequest = request;
+			}
+
+			public bool HandlesAlt => true;
+			public bool HandlesTimeout => true;
+
+			public void Handle(ClientMessage.ReadStreamEventsBackwardCompleted completed) {
+				try {
+					if (completed.Result == ReadStreamResult.StreamDeleted ||
+						completed.Result == ReadStreamResult.NoStream ||
+						completed.Result == ReadStreamResult.AccessDenied) {
+						if (_self._logFailedAuthenticationAttempts)
+							Log.Warning("Authentication Failed for {id}: {reason}", _authenticationRequest.Id, "Invalid user.");
+						_authenticationRequest.Unauthorized();
+						return;
+					}
+
+					if (completed.Result == ReadStreamResult.Error) {
+						if (_self._logFailedAuthenticationAttempts)
+							Log.Warning("Authentication Failed for {id}: {reason}", _authenticationRequest.Id,
+								"Unexpected error.");
+						_authenticationRequest.Error();
+						return;
+					}
+
+					var userData = completed.Events[0].Event.Data.ParseJson<UserData>();
+					if (userData.LoginName != _authenticationRequest.Name) {
+						_authenticationRequest.Error();
+						return;
+					}
+
+					if (userData.Disabled) {
+						if (_self._logFailedAuthenticationAttempts)
+							Log.Warning("Authentication Failed for {id}: {reason}", _authenticationRequest.Id,
+								"The account is disabled.");
+						_authenticationRequest.Unauthorized();
+					} else {
+						_self.AuthenticateWithPasswordHash(_authenticationRequest, userData);
+					}
+				} catch {
+					_authenticationRequest.Unauthorized();
+				}
+			}
+
+			public void Handle(ClientMessage.NotHandled notHandled) {
+				if (_self._logFailedAuthenticationAttempts)
+					Log.Warning("Authentication Failed for {id}: {reason}. {description}",
+						_authenticationRequest.Id,
+						notHandled.Reason,
+						notHandled.Description);
+				_authenticationRequest.NotReady();
+			}
+
+			public void Timeout() {
+				if (_self._logFailedAuthenticationAttempts)
+					Log.Warning("Authentication Failed for {id}: {reason}", _authenticationRequest.Id,
+						"Timeout.");
+				_authenticationRequest.NotReady();
+			}
 		}
 	}
 }

--- a/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProviderFactory.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProviderFactory.cs
@@ -21,7 +21,8 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 
 			foreach (var bus in components.WorkerBuses) {
 				bus.Subscribe(_dispatcher.ForwardReader);
-				bus.Subscribe(_dispatcher.BackwardReader);
+				bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_dispatcher.BackwardReader);
+				bus.Subscribe<ClientMessage.NotHandled>(_dispatcher.BackwardReader);
 				bus.Subscribe(_dispatcher.Writer);
 				bus.Subscribe(_dispatcher.StreamDeleter);
 				bus.Subscribe(_dispatcher.Awaker);
@@ -45,7 +46,8 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 			_components.MainBus.Subscribe(provider);
 
 			var ioDispatcher = new IODispatcher(_components.MainQueue, new PublishEnvelope(_components.MainQueue));
-			_components.MainBus.Subscribe(ioDispatcher.BackwardReader);
+			_components.MainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
+			_components.MainBus.Subscribe<ClientMessage.NotHandled>(ioDispatcher.BackwardReader);
 			_components.MainBus.Subscribe(ioDispatcher.ForwardReader);
 			_components.MainBus.Subscribe(ioDispatcher.Writer);
 			_components.MainBus.Subscribe(ioDispatcher.StreamDeleter);

--- a/src/EventStore.Core/Bus/AdHocHandler.cs
+++ b/src/EventStore.Core/Bus/AdHocHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Common.Utils;
+using EventStore.Core.Helpers;
 using EventStore.Core.Messaging;
 
 namespace EventStore.Core.Bus {
@@ -13,6 +14,29 @@ namespace EventStore.Core.Bus {
 
 		public void Handle(T message) {
 			_handle(message);
+		}
+	}
+
+	public struct AdHocHandlerStruct<T> : IHandle<T>, IHandleTimeout where T : Message {
+		private readonly Action<T> _handle;
+		private readonly Action _timeout;
+
+		public AdHocHandlerStruct(Action<T> handle, Action timeout) {
+			Ensure.NotNull(handle, "handle");
+
+			HandlesTimeout = timeout is not null;
+			_handle = handle;
+			_timeout = timeout.OrNoOp();
+		}
+
+		public bool HandlesTimeout { get; }
+
+		public void Handle(T response) {
+			_handle(response);
+		}
+
+		public void Timeout() {
+			_timeout();
 		}
 	}
 }

--- a/src/EventStore.Core/Bus/IHandleAlt.cs
+++ b/src/EventStore.Core/Bus/IHandleAlt.cs
@@ -1,0 +1,7 @@
+﻿using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Bus {
+	public interface IHandleAlt<T> : IHandle<T> where T : Message {
+		bool HandlesAlt { get; }
+	}
+}

--- a/src/EventStore.Core/Bus/IHandleTimeout.cs
+++ b/src/EventStore.Core/Bus/IHandleTimeout.cs
@@ -1,0 +1,7 @@
+﻿namespace EventStore.Core.Bus {
+
+	public interface IHandleTimeout {
+		bool HandlesTimeout { get; }
+		void Timeout();
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1164,6 +1164,7 @@ namespace EventStore.Core {
 			// IO DISPATCHER
 			var ioDispatcher = new IODispatcher(_mainQueue, new PublishEnvelope(_mainQueue));
 			_mainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
+			_mainBus.Subscribe<ClientMessage.NotHandled>(ioDispatcher.BackwardReader);
 			_mainBus.Subscribe<ClientMessage.WriteEventsCompleted>(ioDispatcher.Writer);
 			_mainBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(ioDispatcher.ForwardReader);
 			_mainBus.Subscribe<ClientMessage.ReadAllEventsForwardCompleted>(ioDispatcher.AllForwardReader);

--- a/src/EventStore.Core/Helpers/IODispatcherAsync.cs
+++ b/src/EventStore.Core/Helpers/IODispatcherAsync.cs
@@ -189,7 +189,7 @@ namespace EventStore.Core.Helpers {
 			Action handler) {
 			return steps => ioDispatcher.Delay(
 				timeout,
-				() => {
+				_ => {
 					if (cancellationScope.Cancelled(Guid.Empty)) return;
 					handler();
 					Run(steps);
@@ -296,7 +296,7 @@ namespace EventStore.Core.Helpers {
 					if (ShouldRetry(result, retryExpectedVersion)) {
 						ioDispatcher.Delay(
 							timeout,
-							() => {
+							_ => {
 								if (timeout < TimeSpan.FromSeconds(10))
 									timeout += timeout;
 								PerformWithRetry(ioDispatcher, handler, steps, retryExpectedVersion, timeout, action);

--- a/src/EventStore.Core/Helpers/IODispatcherDelayedMessage.cs
+++ b/src/EventStore.Core/Helpers/IODispatcherDelayedMessage.cs
@@ -10,22 +10,22 @@ namespace EventStore.Core.Helpers {
 		}
 
 		private readonly Guid _correlationId;
-		private readonly Action _action;
+		private readonly ICorrelatedTimeout _timeout;
 		private readonly Guid? _messageCorrelationId;
 
-		public IODispatcherDelayedMessage(Guid correlationId, Action action) {
-			_action = action;
+		public IODispatcherDelayedMessage(Guid correlationId, ICorrelatedTimeout timeout) {
+			_timeout = timeout;
 			_correlationId = correlationId;
 		}
 
-		public IODispatcherDelayedMessage(Guid correlationId, Action action, Guid? messageCorrelationId) {
-			_action = action;
+		public IODispatcherDelayedMessage(Guid correlationId, ICorrelatedTimeout timeout, Guid messageCorrelationId) {
+			_timeout = timeout;
 			_correlationId = correlationId;
 			_messageCorrelationId = messageCorrelationId;
 		}
 
-		public Action Action {
-			get { return _action; }
+		public void Timeout() {
+			_timeout.Timeout(_messageCorrelationId ?? Guid.Empty);
 		}
 
 		public Guid CorrelationId {

--- a/src/EventStore.Core/Helpers/NoOpAction.cs
+++ b/src/EventStore.Core/Helpers/NoOpAction.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace EventStore.Core.Helpers {
+	public class NoOpAction {
+		public static Action Instance { get; } = () => { };
+	}
+
+	public class NoOpAction<T> {
+		public static Action<T> Instance { get; } = _ => { };
+	}
+
+	public static class ActionExtensions {
+		public static Action OrNoOp(this Action self) => self ?? NoOpAction.Instance;
+		public static Action<T> OrNoOp<T>(this Action<T> self) => self ?? NoOpAction<T>.Instance;
+	}
+}

--- a/src/EventStore.Core/Helpers/ReadStreamEventsBackwardHandlers.cs
+++ b/src/EventStore.Core/Helpers/ReadStreamEventsBackwardHandlers.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Common.Utils;
+using static EventStore.Core.Helpers.IODispatcher;
+
+namespace EventStore.Core.Helpers {
+	public interface IReadStreamEventsBackwardHandler :
+		IHandle<ClientMessage.ReadStreamEventsBackwardCompleted>,
+		IHandleAlt<ClientMessage.NotHandled>,
+		IHandleTimeout {
+	}
+
+	public static class ReadStreamEventsBackwardHandlers {
+		// Adds and removes from a tracker so it knows what is outstanding
+		public class Tracking : IReadStreamEventsBackwardHandler {
+			private readonly Guid _correlationId;
+			private readonly RequestTracking _requestTracker;
+			private readonly IReadStreamEventsBackwardHandler _wrapped;
+
+			public Tracking(
+				Guid correlationId,
+				RequestTracking requestTracker,
+				IReadStreamEventsBackwardHandler wrapped) {
+
+				Ensure.NotNull(requestTracker, nameof(requestTracker));
+				Ensure.NotNull(wrapped, nameof(wrapped));
+
+				_correlationId = correlationId;
+				_requestTracker = requestTracker;
+				_wrapped = wrapped;
+
+				_requestTracker.AddPendingRead(correlationId);
+			}
+
+			public bool HandlesAlt => _wrapped.HandlesAlt;
+			public bool HandlesTimeout => _wrapped.HandlesTimeout;
+
+			public void Handle(ClientMessage.ReadStreamEventsBackwardCompleted message) {
+				if (_requestTracker.RemovePendingRead(message.CorrelationId)) {
+					_wrapped.Handle(message);
+				}
+			}
+
+			public void Handle(ClientMessage.NotHandled message) {
+				if (_requestTracker.RemovePendingRead(message.CorrelationId)) {
+					_wrapped.Handle(message);
+				}
+			}
+
+			public void Timeout() {
+				if (_requestTracker.RemovePendingRead(_correlationId)) {
+					_wrapped.Timeout();
+				}
+			}
+		}
+
+		// todo: move away from this and towards bespoke implementations (like AuthReadResponseHandler) to avoid having to
+		// allocate all these delegates
+		public class AdHoc : IReadStreamEventsBackwardHandler {
+			private readonly Action<ClientMessage.ReadStreamEventsBackwardCompleted> _handled;
+			private readonly Action<ClientMessage.NotHandled> _notHandled;
+			private readonly Action _timedout;
+
+			public AdHoc(
+				Action<ClientMessage.ReadStreamEventsBackwardCompleted> handled,
+				Action<ClientMessage.NotHandled> notHandled,
+				Action timedout) {
+
+				Ensure.NotNull(handled, nameof(handled));
+
+				HandlesAlt = notHandled is not null;
+				HandlesTimeout = timedout is not null;
+				_handled = handled;
+				_notHandled = notHandled.OrNoOp();
+				_timedout = timedout.OrNoOp();
+			}
+
+			public bool HandlesAlt { get; }
+			public bool HandlesTimeout { get; }
+
+			public void Handle(ClientMessage.ReadStreamEventsBackwardCompleted message) {
+				_handled(message);
+			}
+
+			public void Handle(ClientMessage.NotHandled message) {
+				_notHandled(message);
+			}
+
+			public void Timeout() {
+				_timedout();
+			}
+		}
+
+		// Assumes the request will eventually receive a reponse of the expected type
+		// And not be dropped due to timeout or responded to with a different message
+		public class Optimistic : AdHoc {
+			public Optimistic(
+				Action<ClientMessage.ReadStreamEventsBackwardCompleted> handle) : base(
+					handle, null, null) {
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Messaging/AdHocCorrelatedTimeout.cs
+++ b/src/EventStore.Core/Messaging/AdHocCorrelatedTimeout.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace EventStore.Core.Messaging {
+	public struct AdHocCorrelatedTimeout : ICorrelatedTimeout {
+		private readonly Action<Guid> _timeout;
+
+		public AdHocCorrelatedTimeout(Action<Guid> timeout) {
+			_timeout = timeout;
+		}
+
+		public void Timeout(Guid correlationId) {
+			_timeout(correlationId);
+		}
+	}
+}

--- a/src/EventStore.Core/Messaging/ICorrelatedTimeout.cs
+++ b/src/EventStore.Core/Messaging/ICorrelatedTimeout.cs
@@ -1,0 +1,7 @@
+﻿using System;
+
+namespace EventStore.Core.Messaging {
+	public interface ICorrelatedTimeout {
+		void Timeout(Guid correlationId);
+	}
+}

--- a/src/EventStore.Core/Messaging/RequestResponseAltDispatcher.cs
+++ b/src/EventStore.Core/Messaging/RequestResponseAltDispatcher.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using EventStore.Core.Bus;
+using EventStore.Core.Helpers;
+using EventStore.Core.Messages;
+
+namespace EventStore.Core.Messaging {
+	// Just a typedef
+	public class ReadDispatcher :
+		RequestResponseAltDispatcher<
+			ClientMessage.ReadStreamEventsBackward,
+			ClientMessage.ReadStreamEventsBackwardCompleted,
+			ClientMessage.NotHandled,
+			IReadStreamEventsBackwardHandler> {
+		public ReadDispatcher(
+			IPublisher publisher,
+			Func<ClientMessage.ReadStreamEventsBackward, Guid> getRequestCorrelationId,
+			Func<ClientMessage.ReadStreamEventsBackwardCompleted, Guid> getResponseCorrelationId,
+			Func<ClientMessage.NotHandled, Guid> getResponseAltCorrelationId,
+			IEnvelope defaultReplyEnvelope,
+			Func<Guid, Message> cancelMessageFactory = null) :
+				base(publisher, getRequestCorrelationId, getResponseCorrelationId,
+					getResponseAltCorrelationId, defaultReplyEnvelope, cancelMessageFactory) {
+		}
+	}
+
+	// This derivation of RequestResponseDispatcher handles two different response messages
+	// Useful if the system might respond to the request with a message like NotHandled and we want to know about it.
+	public class RequestResponseAltDispatcher<TRequest, TResponse, TResponseAlt, THandler> :
+		RequestResponseDispatcher<TRequest, TResponse, THandler>,
+		IHandle<TResponseAlt>
+		where TRequest : Message
+		where TResponse : Message
+		where TResponseAlt : Message
+		where THandler : IHandle<TResponse>, IHandleAlt<TResponseAlt>, IHandleTimeout {
+
+		private readonly Func<TResponseAlt, Guid> _getResponseAltCorrelationId;
+
+		public RequestResponseAltDispatcher(
+			IPublisher publisher,
+			Func<TRequest, Guid> getRequestCorrelationId,
+			Func<TResponse, Guid> getResponseCorrelationId,
+			Func<TResponseAlt, Guid> getResponseAltCorrelationId,
+			IEnvelope defaultReplyEnvelope,
+			Func<Guid, Message> cancelMessageFactory = null) : base(
+				publisher,
+				getRequestCorrelationId,
+				getResponseCorrelationId,
+				defaultReplyEnvelope,
+				cancelMessageFactory) {
+			_getResponseAltCorrelationId = getResponseAltCorrelationId;
+		}
+
+		void IHandle<TResponseAlt>.Handle(TResponseAlt message) {
+			var correlationId = _getResponseAltCorrelationId(message);
+
+			// if we dont handle the alternative message, then dont remove the handler
+			// so that it can be called on timeout
+			var handlerExists = TryRemoveHandler(correlationId, static h => h.HandlesAlt, out var handler);
+
+			if (handlerExists) {
+				handler.Handle(message);
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -77,7 +77,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					metadata));
 			}
 
-			var appendResponseSource = new TaskCompletionSource<AppendResp>();
+			var appendResponseSource = new TaskCompletionSource<AppendResp>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 			var envelope = new CallbackEnvelope(HandleWriteEventsCompleted);
 

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/PasswordChangeNotificationReader.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/PasswordChangeNotificationReader.cs
@@ -60,19 +60,19 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 							_log.Error("Failed to read: {stream} completed.Result={e}",
 								UserManagementService.UserPasswordNotificationsStreamId, completed.Result.ToString());
 							_ioDispatcher.Delay(
-								TimeSpan.FromSeconds(10), () => ReadNotificationsFrom(fromEventNumber));
+								TimeSpan.FromSeconds(10), _ => ReadNotificationsFrom(fromEventNumber));
 							break;
 						case ReadStreamResult.NoStream:
 						case ReadStreamResult.StreamDeleted:
 							_ioDispatcher.Delay(
-								TimeSpan.FromSeconds(1), () => ReadNotificationsFrom(0));
+								TimeSpan.FromSeconds(1), _ => ReadNotificationsFrom(0));
 							break;
 						case ReadStreamResult.Success:
 							foreach (var @event in completed.Events)
 								PublishPasswordChangeNotificationFrom(@event);
 							if (completed.IsEndOfStream)
 								_ioDispatcher.Delay(
-									TimeSpan.FromSeconds(1), () => ReadNotificationsFrom(completed.NextEventNumber));
+									TimeSpan.FromSeconds(1), _ => ReadNotificationsFrom(completed.NextEventNumber));
 							else
 								ReadNotificationsFrom(completed.NextEventNumber);
 							break;
@@ -82,7 +82,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 				},
 				() => {
 					_log.Warning("Timeout reading stream: {stream}. Trying again in 10 seconds.", UserManagementService.UserPasswordNotificationsStreamId);
-					_ioDispatcher.Delay(TimeSpan.FromSeconds(10), () => ReadNotificationsFrom(fromEventNumber));
+					_ioDispatcher.Delay(TimeSpan.FromSeconds(10), _ => ReadNotificationsFrom(fromEventNumber));
 				},
 				Guid.NewGuid());
 		}

--- a/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/SpecificationWithEmittedStreamsTrackerAndDeleter.cs
@@ -18,7 +18,8 @@ namespace EventStore.Projections.Core.Tests.Services {
 
 		protected override Task Given() {
 			_ioDispatcher = new IODispatcher(_node.Node.MainQueue, new PublishEnvelope(_node.Node.MainQueue), true);
-			_node.Node.MainBus.Subscribe(_ioDispatcher.BackwardReader);
+			_node.Node.MainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+			_node.Node.MainBus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher.BackwardReader);
 			_node.Node.MainBus.Subscribe(_ioDispatcher.ForwardReader);
 			_node.Node.MainBus.Subscribe(_ioDispatcher.Writer);
 			_node.Node.MainBus.Subscribe(_ioDispatcher.StreamDeleter);

--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_starting_a_projection.cs
@@ -48,7 +48,8 @@ namespace EventStore.Projections.Core.Tests.Services.core_projection {
 			_bus.Subscribe(_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.NotAuthorized>());
 			_bus.Subscribe(
 				_subscriptionDispatcher.CreateSubscriber<EventReaderSubscriptionMessage.ReaderAssignedReader>());
-			_bus.Subscribe(_ioDispatcher.BackwardReader);
+			_bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+			_bus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher.BackwardReader);
 			_bus.Subscribe(_ioDispatcher.ForwardReader);
 			_bus.Subscribe(_ioDispatcher.Writer);
 			_bus.Subscribe<IODispatcherDelayedMessage>(_ioDispatcher);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/TestFixtureWithProjectionCoreAndManagementServices.cs
@@ -218,6 +218,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			bus.Subscribe<CoreProjectionProcessingMessage.Failed>(coreService);
 			bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(ioDispatcher.ForwardReader);
 			bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
+			bus.Subscribe<ClientMessage.NotHandled>(ioDispatcher.BackwardReader);
 			bus.Subscribe<ClientMessage.WriteEventsCompleted>(ioDispatcher.Writer);
 			bus.Subscribe<ClientMessage.DeleteStreamCompleted>(ioDispatcher.StreamDeleter);
 			bus.Subscribe<IODispatcherDelayedMessage>(ioDispatcher.Awaker);

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/specification_with_projection_management_service.cs
@@ -91,6 +91,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 
 			_bus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(ioDispatcher.ForwardReader);
 			_bus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
+			_bus.Subscribe<ClientMessage.NotHandled>(ioDispatcher.BackwardReader);
 			_bus.Subscribe<ClientMessage.WriteEventsCompleted>(ioDispatcher.Writer);
 			_bus.Subscribe<ClientMessage.DeleteStreamCompleted>(ioDispatcher.StreamDeleter);
 			_bus.Subscribe<IODispatcherDelayedMessage>(ioDispatcher.Awaker);

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -103,7 +103,8 @@ namespace EventStore.Projections.Core {
 			mainBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(projectionManager);
 
 			mainBus.Subscribe(ioDispatcher.Awaker);
-			mainBus.Subscribe(ioDispatcher.BackwardReader);
+			mainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
+			mainBus.Subscribe<ClientMessage.NotHandled>(ioDispatcher.BackwardReader);
 			mainBus.Subscribe(ioDispatcher.ForwardReader);
 			mainBus.Subscribe(ioDispatcher.StreamDeleter);
 			mainBus.Subscribe(ioDispatcher.Writer);

--- a/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
@@ -110,6 +110,7 @@ namespace EventStore.Projections.Core {
 				coreInputBus.Subscribe<CoreProjectionManagementMessage.GetResult>(_projectionCoreService);
 				coreInputBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(_ioDispatcher.ForwardReader);
 				coreInputBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(_ioDispatcher.BackwardReader);
+				coreInputBus.Subscribe<ClientMessage.NotHandled>(_ioDispatcher.BackwardReader);
 				coreInputBus.Subscribe<ClientMessage.ReadEventCompleted>(_ioDispatcher.EventReader);
 				coreInputBus.Subscribe<ClientMessage.WriteEventsCompleted>(_ioDispatcher.Writer);
 				coreInputBus.Subscribe<ClientMessage.DeleteStreamCompleted>(_ioDispatcher.StreamDeleter);

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -82,10 +82,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		private readonly RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted>
 			_writeDispatcher;
 
-		private readonly
-			RequestResponseDispatcher
-			<ClientMessage.ReadStreamEventsBackward, ClientMessage.ReadStreamEventsBackwardCompleted>
-			_readDispatcher;
+		private readonly ReadDispatcher _readDispatcher;
 
 		private readonly
 			RequestResponseDispatcher
@@ -138,9 +135,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			ILogger logger,
 			RequestResponseDispatcher<ClientMessage.DeleteStream, ClientMessage.DeleteStreamCompleted> streamDispatcher,
 			RequestResponseDispatcher<ClientMessage.WriteEvents, ClientMessage.WriteEventsCompleted> writeDispatcher,
-			RequestResponseDispatcher
-				<ClientMessage.ReadStreamEventsBackward, ClientMessage.ReadStreamEventsBackwardCompleted>
-				readDispatcher,
+			ReadDispatcher readDispatcher,
 			IPublisher output,
 			ITimeProvider timeProvider,
 			RequestResponseDispatcher<CoreProjectionManagementMessage.GetState, CoreProjectionStatusMessage.StateReport>
@@ -629,7 +624,7 @@ namespace EventStore.Projections.Core.Services.Management {
 					1,
 					resolveLinkTos: false, requireLeader: false, validationStreamVersion: null,
 					user: SystemAccounts.System),
-				PersistedStateReadCompleted);
+				new ReadStreamEventsBackwardHandlers.Optimistic(PersistedStateReadCompleted));
 		}
 
 		private void PersistedStateReadCompleted(ClientMessage.ReadStreamEventsBackwardCompleted completed) {

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -78,10 +78,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			<ClientMessage.ReadStreamEventsForward, ClientMessage.ReadStreamEventsForwardCompleted>
 			_readForwardDispatcher;
 
-		private readonly
-			RequestResponseDispatcher
-			<ClientMessage.ReadStreamEventsBackward, ClientMessage.ReadStreamEventsBackwardCompleted>
-			_readDispatcher;
+		private readonly ReadDispatcher _readDispatcher;
 
 		private int _readEventsBatchSize = 100;
 
@@ -136,13 +133,12 @@ namespace EventStore.Projections.Core.Services.Management {
 					v => v.CorrelationId,
 					v => v.CorrelationId,
 					new PublishEnvelope(_inputQueue));
-			_readDispatcher =
-				new RequestResponseDispatcher
-					<ClientMessage.ReadStreamEventsBackward, ClientMessage.ReadStreamEventsBackwardCompleted>(
-						publisher,
-						v => v.CorrelationId,
-						v => v.CorrelationId,
-						new PublishEnvelope(_inputQueue));
+			_readDispatcher = new ReadDispatcher(
+				publisher,
+				v => v.CorrelationId,
+				v => v.CorrelationId,
+				v => v.CorrelationId,
+				new PublishEnvelope(_inputQueue));
 			_readForwardDispatcher =
 				new RequestResponseDispatcher
 					<ClientMessage.ReadStreamEventsForward, ClientMessage.ReadStreamEventsForwardCompleted>(
@@ -1034,7 +1030,7 @@ namespace EventStore.Projections.Core.Services.Management {
 					requireLeader: false,
 					validationStreamVersion: null,
 					user: SystemAccounts.System),
-				onComplete);
+				new ReadStreamEventsBackwardHandlers.Optimistic(onComplete));
 		}
 
 		private void ReadProjectionPossibleStreamCompleted(

--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointWriter.cs
@@ -118,7 +118,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 				}
 				_ioDispatcher.Delay(
 					TimeSpan.FromSeconds(delayInSeconds),
-					PublishWriteStreamMetadataAndCheckpointEvent);
+					_ => PublishWriteStreamMetadataAndCheckpointEvent());
 			}
 		}
 

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStream.cs
@@ -442,7 +442,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					m => HandleMetadataWriteCompleted(m, retryCount));
 			} else {
 				_ioDispatcher.Delay(TimeSpan.FromSeconds(delayInSeconds),
-					() => _writerConfiguration.Writer.WriteEvents(
+					_ => _writerConfiguration.Writer.WriteEvents(
 						_metadataStreamId, ExpectedVersion.Any, new Event[] {_submittedWriteMetaStreamEvent}, _writeAs,
 						m => HandleMetadataWriteCompleted(m, retryCount)));
 			}
@@ -599,7 +599,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 					m => HandleWriteEventsCompleted(m, retryCount));
 			} else {
 				_ioDispatcher.Delay(TimeSpan.FromSeconds(delayInSeconds),
-					() => _writerConfiguration.Writer.WriteEvents(
+					_ => _writerConfiguration.Writer.WriteEvents(
 						_streamId, _lastKnownEventNumber, _submittedToWriteEvents, _writeAs,
 						m => HandleWriteEventsCompleted(m, retryCount)));
 			}


### PR DESCRIPTION
- handle timeouts via the RequestResponseDispatchers so they can tidy up the map
- pass the whole RequestResponseDispatcher in the schedule messages rather than allocating closures that will end up in gen2

needs some testing, will need rebasing (it is only the second commit not the first)