### PR TITLE
Enable standard projections and atompub when running in dev mode.

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1074,10 +1074,10 @@ namespace EventStore.Core {
 			var persistentSubscriptionController =
 				new PersistentSubscriptionController(httpSendService, _mainQueue, _workersHandler);
 			var infoController = new InfoController(options, new Dictionary<string, bool> {
-				["projections"] = options.Projections.RunProjections != ProjectionType.None,
+				["projections"] = options.Projections.RunProjections != ProjectionType.None || options.DevMode.Dev,
 				["userManagement"] = options.Auth.AuthenticationType == Opts.AuthenticationTypeDefault &&
 				                     !options.Application.Insecure,
-				["atomPub"] = options.Interface.EnableAtomPubOverHttp
+				["atomPub"] = options.Interface.EnableAtomPubOverHttp || options.DevMode.Dev
 
 			}, _authenticationProvider);
 
@@ -1090,7 +1090,7 @@ namespace EventStore.Core {
 			_httpService.SetupController(infoController);
 			if (!options.Interface.DisableStatsOnHttp)
 				_httpService.SetupController(statController);
-			if (options.Interface.EnableAtomPubOverHttp)
+			if (options.Interface.EnableAtomPubOverHttp || options.DevMode.Dev)
 				_httpService.SetupController(atomController);
 			if (!options.Interface.DisableGossipOnHttp)
 				_httpService.SetupController(gossipController);

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -84,7 +84,7 @@ namespace EventStore.Core {
 
 		[Description("Dev mode Options")]
 		public record DevModeOptions {
-			[Description("Runs EventStoreDB in dev mode. This will create and add dev certificates to your certificate store.")]
+			[Description("Runs EventStoreDB in dev mode. This will create and add dev certificates to your certificate store, enable atompub over http, and run standard projections.")]
 			public bool Dev { get; init; } = false;
 
 			[Description("Removes any dev certificates installed on this computer without starting EventStoreDB.")]


### PR DESCRIPTION
Changed: Start standard projections and atompub over http when running in dev mode

Running with `--dev` will now do the following:
- Generate and trust dev certs
- Enable atompub over http
- Start the Projection subsystem with `ProjectionType.System` unless specified otherwise
- Run the standard projections automatically