### PR TITLE
Exit application when hosted service shuts down

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -198,6 +198,8 @@ namespace EventStore.ClusterNode {
 								.ConfigureServices(services => hostedService.Node.Startup.ConfigureServices(services))
 								.Configure(hostedService.Node.Startup.Configure))
 							.RunConsoleAsync(options => options.SuppressStatusMessages = true, cts.Token);
+
+						exitCodeSource.TrySetResult(0);
 					} catch (Exception ex) {
 						Log.Fatal("Error occurred during setup: {e}", ex);
 						exitCodeSource.TrySetResult(1);


### PR DESCRIPTION
Fixed: Exit application when hosted service shuts down

@timothycoleman noticed that SIGTERM wasn't properly being handled in the 22.10 draft release on linux. After receiving the signal, the node would just "hang" after printing "[node endpoint] IS SHUT DOWN"

It would cause docker client tests to take ~10 seconds longer: https://github.com/EventStore/EventStore-Client-Dotnet/actions/runs/3263348304/jobs/5364079792 (after a timeout of 10 seconds SIGKILL is sent to the root process)

It occurs due to this PR: https://github.com/dotnet/runtime/pull/56057 which is part of .net 6

Previously nothing was handling SIGTERM and the default behaviour of the signal handler was to exit the application. But now, the default behaviour of the handler is [being canceled](https://github.com/dotnet/runtime/pull/56057/files#diff-a284d832522ea68b2d33b2c96a332ff19324eb0995611442d16e6c3f5909e4eaR28) which means that the application continues executing normally after the hosted service stops.

It's not a bug in the runtime but more on our side - we were not explicitly exiting the process when the node is running normally (i.e not in tests).