### PR TITLE
Upgrade sqlite to v3.39.2 for CVE-2022-35737

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1263,11 +1263,14 @@ namespace EventStore.Core {
 						factory: () => {
 							var scavengeDirectory = Path.Combine(indexPath, "scavenging");
 							Directory.CreateDirectory(scavengeDirectory);
+							var dbPath = Path.Combine(scavengeDirectory, "scavenging.db");
 							var connectionStringBuilder = new SqliteConnectionStringBuilder {
-								DataSource = Path.Combine(scavengeDirectory, "scavenging.db")
+								DataSource = dbPath,
 							};
 							var connection = new SqliteConnection(connectionStringBuilder.ConnectionString);
 							connection.Open();
+							Log.Information("Opened scavenging database {scavengeDatabase} with version {version}",
+								dbPath, connection.ServerVersion);
 							var sqlite = new SqliteScavengeBackend<TStreamId>(
 								cacheSizeInBytes: options.Database.ScavengeBackendCacheSize);
 							sqlite.Initialize(connection);

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -32,7 +32,10 @@
 		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 		<PackageReference Include="HostStat.NET" Version="1.0.2" />
 		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.1" />
-		<PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.9" />
+		<PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.10" />
+		<!-- CVE-2022-35737 -->
+		<PackageReference Include="SQLitePCLRaw.core" Version="2.1.2" />
+		<PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />


### PR DESCRIPTION
Fixed: Upgrade sqlite to v3.39.2 for CVE-2022-35737