### PR TITLE
Silence warning when failing to find a log record that was present in the index

### DIFF
--- a/src/EventStore.Core.Tests/Fakes/FakeTfReader.cs
+++ b/src/EventStore.Core.Tests/Fakes/FakeTfReader.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Fakes {
 			throw new NotImplementedException();
 		}
 
-		public RecordReadResult TryReadAt(long position) {
+		public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
 			throw new NotImplementedException();
 		}
 

--- a/src/EventStore.Core.Tests/Index/FakeIndexReader.cs
+++ b/src/EventStore.Core.Tests/Index/FakeIndexReader.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.Fakes {
 			throw new NotImplementedException();
 		}
 
-		public RecordReadResult TryReadAt(long position) {
+		public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
 			var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				position.ToString(), -1, DateTime.UtcNow, PrepareFlags.None, "type", new byte[0], null);
 			return new RecordReadResult(true, position + 1, record, 1);

--- a/src/EventStore.Core.Tests/Index/IndexV2/table_index_hash_collision_when_upgrading_to_64bit.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/table_index_hash_collision_when_upgrading_to_64bit.cs
@@ -158,7 +158,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 			throw new NotImplementedException();
 		}
 
-		public RecordReadResult TryReadAt(long position) {
+		public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
 			var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				position % 2 == 0 ? "account--696193173" : "LPN-FC002_LPK51001", -1, DateTime.UtcNow, PrepareFlags.None,
 				"type", new byte[0], null);

--- a/src/EventStore.Core.Tests/Index/IndexV2/table_index_when_merging_upgrading_to_64bit_if_entry_doesnt_exist_drops_entry_and_carries_on.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV2/table_index_when_merging_upgrading_to_64bit_if_entry_doesnt_exist_drops_entry_and_carries_on.cs
@@ -147,7 +147,7 @@ namespace EventStore.Core.Tests.Index.IndexV2 {
 				throw new NotImplementedException();
 			}
 
-			public RecordReadResult TryReadAt(long position) {
+			public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
 				TStreamId streamId;
 				switch (position) {
 					case 1:

--- a/src/EventStore.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV3/when_upgrading_index_to_64bit_stream_version.cs
@@ -139,7 +139,7 @@ namespace EventStore.Core.Tests.Index.IndexV3 {
 			throw new NotImplementedException();
 		}
 
-		public RecordReadResult TryReadAt(long position) {
+		public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
 			var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				position % 2 == 0 ? "testStream-2" : "testStream-1", -1, DateTime.UtcNow, PrepareFlags.None, "type",
 				new byte[0], null);

--- a/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTFReader.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTFReader.cs
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			throw new NotImplementedException();
 		}
 
-		public RecordReadResult TryReadAt(long position) {
+		public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
 			NumReads++;
 			if (_records.ContainsKey(position)){
 				return new RecordReadResult(true, 0, _records[position], 0);

--- a/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/HashCollisions/with_hash_collisions.cs
@@ -474,7 +474,7 @@ namespace EventStore.Core.Tests.Services.Storage.HashCollisions {
 			throw new NotImplementedException();
 		}
 
-		public RecordReadResult TryReadAt(long position) {
+		public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
 			var record = (LogRecord)new PrepareLogRecord(position, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				position % 2 == 0 ? "account--696193173" : "LPN-FC002_LPK51001", -1, DateTime.UtcNow, PrepareFlags.None,
 				"type", new byte[0], null);

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_deleting_single_stream_spanning_through_2_chunks_in_2nd_chunk__in_db_with_3_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_deleting_single_stream_spanning_through_2_chunks_in_2nd_chunk__in_db_with_3_chunks.cs
@@ -93,7 +93,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 
 			var chunk = Db.Manager.GetChunk(1);
 			var chunkPos = (int)(_event7.LogPosition % Db.Config.ChunkSize);
-			var res = chunk.TryReadAt(chunkPos);
+			var res = chunk.TryReadAt(chunkPos, couldBeScavenged: false);
 
 			Assert.IsTrue(res.Success);
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
@@ -61,12 +61,12 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		public void all_chunks_are_merged_and_scavenged() {
 			foreach (var rec in _scavenged) {
 				var chunk = Db.Manager.GetChunkFor(rec.LogPosition);
-				Assert.IsFalse(chunk.TryReadAt(rec.LogPosition).Success);
+				Assert.IsFalse(chunk.TryReadAt(rec.LogPosition, couldBeScavenged: true).Success);
 			}
 
 			foreach (var rec in _survivors) {
 				var chunk = Db.Manager.GetChunkFor(rec.LogPosition);
-				var res = chunk.TryReadAt(rec.LogPosition);
+				var res = chunk.TryReadAt(rec.LogPosition, couldBeScavenged: false);
 				Assert.IsTrue(res.Success);
 				Assert.AreEqual(rec, res.LogRecord);
 			}

--- a/src/EventStore.Core.Tests/TransactionLog/when_appending_to_a_tfchunk_and_flushing.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_appending_to_a_tfchunk_and_flushing.cs
@@ -60,7 +60,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void the_record_can_be_read_at_exact_position() {
-			var res = _chunk.TryReadAt(0);
+			var res = _chunk.TryReadAt(0, couldBeScavenged: false);
 			Assert.IsTrue(res.Success);
 			Assert.AreEqual(_record, res.LogRecord);
 			Assert.AreEqual(_result.OldPosition, res.LogRecord.LogPosition);

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_tfchunk_from_empty_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_tfchunk_from_empty_file.cs
@@ -43,7 +43,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void there_is_no_record_at_pos_zero() {
-			var res = _chunk.TryReadAt(0);
+			var res = _chunk.TryReadAt(0, couldBeScavenged: true);
 			Assert.IsFalse(res.Success);
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -116,37 +116,37 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void prepare1_cant_be_read_at_position() {
-			var res = _scavengedChunk.TryReadAt((int)_p1.LogPosition);
+			var res = _scavengedChunk.TryReadAt((int)_p1.LogPosition, couldBeScavenged: true);
 			Assert.IsFalse(res.Success);
 		}
 
 		[Test]
 		public void commit1_cant_be_read_at_position() {
-			var res = _scavengedChunk.TryReadAt((int)_c1.LogPosition);
+			var res = _scavengedChunk.TryReadAt((int)_c1.LogPosition, couldBeScavenged: true);
 			Assert.IsFalse(res.Success);
 		}
 
 		[Test]
 		public void prepare2_cant_be_read_at_position() {
-			var res = _scavengedChunk.TryReadAt((int)_p2.LogPosition);
+			var res = _scavengedChunk.TryReadAt((int)_p2.LogPosition, couldBeScavenged: true);
 			Assert.IsFalse(res.Success);
 		}
 
 		[Test]
 		public void commit2_cant_be_read_at_position() {
-			var res = _scavengedChunk.TryReadAt((int)_c2.LogPosition);
+			var res = _scavengedChunk.TryReadAt((int)_c2.LogPosition, couldBeScavenged: true);
 			Assert.IsFalse(res.Success);
 		}
 
 		[Test]
 		public void prepare3_cant_be_read_at_position() {
-			var res = _scavengedChunk.TryReadAt((int)_p3.LogPosition);
+			var res = _scavengedChunk.TryReadAt((int)_p3.LogPosition, couldBeScavenged: true);
 			Assert.IsFalse(res.Success);
 		}
 
 		[Test]
 		public void commit3_cant_be_read_at_position() {
-			var res = _scavengedChunk.TryReadAt((int)_c3.LogPosition);
+			var res = _scavengedChunk.TryReadAt((int)_c3.LogPosition, couldBeScavenged: true);
 			Assert.IsFalse(res.Success);
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_a_single_record.cs
@@ -86,7 +86,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			RecordReadResult res;
 			for (var i = 0; i < RecordsCount; i++) {
 				var rec = _records[i];
-				res = reader.TryReadAt(rec.LogPosition);
+				res = reader.TryReadAt(rec.LogPosition, couldBeScavenged: true);
 
 				Assert.IsTrue(res.Success);
 				Assert.AreEqual(rec, res.LogRecord);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_cached_empty_scavenged_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_cached_empty_scavenged_tfchunk.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void no_record_at_exact_position_can_be_read() {
-			Assert.IsFalse(_chunk.TryReadAt(0).Success);
+			Assert.IsFalse(_chunk.TryReadAt(0, couldBeScavenged: true).Success);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -54,7 +54,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void the_record_can_be_read_at_exact_position() {
-			var res = _cachedChunk.TryReadAt(0);
+			var res = _cachedChunk.TryReadAt(0, couldBeScavenged: true);
 			Assert.IsTrue(res.Success);
 			Assert.AreEqual(_record, res.LogRecord);
 			Assert.AreEqual(_result.OldPosition, res.LogRecord.LogPosition);

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_uncached_empty_scavenged_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_uncached_empty_scavenged_tfchunk.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void no_record_at_exact_position_can_be_read() {
-			Assert.IsFalse(_chunk.TryReadAt(0).Success);
+			Assert.IsFalse(_chunk.TryReadAt(0, couldBeScavenged: true).Success);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -65,7 +65,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void the_record_can_be_read() {
-			var res = _uncachedChunk.TryReadAt(0);
+			var res = _uncachedChunk.TryReadAt(0, couldBeScavenged: true);
 			Assert.IsTrue(res.Success);
 			Assert.AreEqual(_record, res.LogRecord);
 			Assert.AreEqual(_result.OldPosition, res.LogRecord.LogPosition);

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
@@ -66,7 +66,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void trying_to_read_past_writer_checksum_returns_false() {
 			var reader = new TFChunkReader(_db, _writerCheckpoint);
-			Assert.IsFalse(reader.TryReadAt(_writerCheckpoint.Read()).Success);
+			Assert.IsFalse(reader.TryReadAt(_writerCheckpoint.Read(), couldBeScavenged: true).Success);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_multiple_records_to_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_multiple_records_to_a_tfchunk.cs
@@ -66,7 +66,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void the_first_record_can_be_read_at_position() {
-			var res = _chunk.TryReadAt((int)_position1);
+			var res = _chunk.TryReadAt((int)_position1, couldBeScavenged: true);
 			Assert.IsTrue(res.Success);
 			Assert.IsTrue(res.LogRecord is IPrepareLogRecord<TStreamId>);
 			Assert.AreEqual(_prepare1, res.LogRecord);
@@ -74,7 +74,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void the_second_record_can_be_read_at_position() {
-			var res = _chunk.TryReadAt((int)_position2);
+			var res = _chunk.TryReadAt((int)_position2, couldBeScavenged: true);
 			Assert.IsTrue(res.Success);
 			Assert.IsTrue(res.LogRecord is IPrepareLogRecord<TStreamId>);
 			Assert.AreEqual(_prepare2, res.LogRecord);

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
@@ -94,7 +94,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void trying_to_read_past_writer_checksum_returns_false() {
 			var reader = new TFChunkReader(_db, _writerCheckpoint);
-			Assert.IsFalse(reader.TryReadAt(_writerCheckpoint.Read()).Success);
+			Assert.IsFalse(reader.TryReadAt(_writerCheckpoint.Read(), couldBeScavenged: true).Success);
 		}
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
@@ -220,7 +220,7 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 			throw new NotImplementedException();
 		}
 
-		public RecordReadResult TryReadAt(long position) {
+		public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
 			throw new NotImplementedException();
 		}
 

--- a/src/EventStore.Core/Index/TableIndex.cs
+++ b/src/EventStore.Core/Index/TableIndex.cs
@@ -513,7 +513,7 @@ namespace EventStore.Core.Index {
 		}
 
 		private Tuple<TStreamId, bool> ReadEntry(TFReaderLease reader, long position) {
-			RecordReadResult result = reader.TryReadAt(position);
+			RecordReadResult result = reader.TryReadAt(position, couldBeScavenged: true);
 			if (!result.Success)
 				return new Tuple<TStreamId, bool>(_emptyStreamId, false);
 			if (result.LogRecord.RecordType != LogRecordType.Prepare)

--- a/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -147,7 +147,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 			}
 		}
 		private EpochRecord ReadEpochAt(ITransactionFileReader reader, long epochPos) {
-			var result = reader.TryReadAt(epochPos);
+			var result = reader.TryReadAt(epochPos, couldBeScavenged: false);
 			if (!result.Success)
 				throw new Exception($"Could not find Epoch record at LogPosition {epochPos}.");
 			if (result.LogRecord.RecordType != LogRecordType.System)
@@ -201,7 +201,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 				try {
 					epoch = firstEpoch;
 					do {
-						var result = reader.TryReadAt(epoch.PrevEpochPosition);
+						var result = reader.TryReadAt(epoch.PrevEpochPosition, couldBeScavenged: false);
 						if (!result.Success)
 							throw new Exception(
 								$"Could not find Epoch record at LogPosition {epoch.PrevEpochPosition}.");
@@ -255,7 +255,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 			// epochNumber < _minCachedEpochNumber
 			var reader = _readers.Get();
 			try {
-				var res = reader.TryReadAt(epochPosition);
+				var res = reader.TryReadAt(epochPosition, couldBeScavenged: false);
 				if (!res.Success || res.LogRecord.RecordType != LogRecordType.System)
 					return false;
 				var sysRec = (ISystemLogRecord)res.LogRecord;

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -510,7 +510,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 
 		private static IPrepareLogRecord<TStreamId> GetPrepare(TFReaderLease reader, long logPosition) {
-			RecordReadResult result = reader.TryReadAt(logPosition);
+			RecordReadResult result = reader.TryReadAt(logPosition, couldBeScavenged: true);
 			if (!result.Success)
 				return null;
 			if (result.LogRecord.RecordType != LogRecordType.Prepare)

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexReader.cs
@@ -202,7 +202,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 
 		protected static IPrepareLogRecord<TStreamId> ReadPrepareInternal(TFReaderLease reader, long logPosition) {
-			RecordReadResult result = reader.TryReadAt(logPosition);
+			RecordReadResult result = reader.TryReadAt(logPosition, couldBeScavenged: true);
 			if (!result.Success)
 				return null;
 

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexWriter.cs
@@ -152,7 +152,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		}
 
 		private static IPrepareLogRecord<TStreamId> GetPrepare(TFReaderLease reader, long logPosition) {
-			RecordReadResult result = reader.TryReadAt(logPosition);
+			RecordReadResult result = reader.TryReadAt(logPosition, couldBeScavenged: true);
 			if (!result.Success)
 				return null;
 			if (result.LogRecord.RecordType != LogRecordType.Prepare)

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -706,8 +706,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			((TFChunkReadSideScavenged)_readSide).DeOptimizeExistsAt();
 		}
 
-		public RecordReadResult TryReadAt(long logicalPosition) {
-			return _readSide.TryReadAt(logicalPosition);
+		public RecordReadResult TryReadAt(long logicalPosition, bool couldBeScavenged) {
+			return _readSide.TryReadAt(logicalPosition, couldBeScavenged);
 		}
 
 		public RecordReadResult TryReadFirst() {

--- a/src/EventStore.Core/TransactionLog/ITransactionFileReader.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileReader.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.TransactionLog {
 		SeqReadResult TryReadNext();
 		SeqReadResult TryReadPrev();
 
-		RecordReadResult TryReadAt(long position);
+		RecordReadResult TryReadAt(long position, bool couldBeScavenged);
 		bool ExistsAt(long position);
 	}
 
@@ -47,8 +47,8 @@ namespace EventStore.Core.TransactionLog {
 			return Reader.ExistsAt(position);
 		}
 
-		public RecordReadResult TryReadAt(long position) {
-			return Reader.TryReadAt(position);
+		public RecordReadResult TryReadAt(long position, bool couldBeScavenged) {
+			return Reader.TryReadAt(position, couldBeScavenged);
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkReaderForIndexExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkReaderForIndexExecutor.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 		public bool TryGetStreamId(long position, out TStreamId streamId) {
 			using (var reader = _tfReaderFactory()) {
-				var result = reader.TryReadAt(position);
+				var result = reader.TryReadAt(position, couldBeScavenged: true);
 				if (!result.Success) {
 					streamId = default;
 					return false;

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/IndexReaderForCalculator.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/IndexReaderForCalculator.cs
@@ -67,7 +67,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 		public bool IsTombstone(long logPosition) {
 			using (var reader = _tfReaderFactory()) {
-				var result = reader.TryReadAt(logPosition);
+				var result = reader.TryReadAt(logPosition, couldBeScavenged: true);
 
 				if (!result.Success)
 					return false;


### PR DESCRIPTION
Fixed: Silenced warning `Tried to read actual position -1` when it does not represent a suspicious occurrence. 

All the epochs should be there, so we still warn for those. But lookups from the index may not be because the records may have been scavenged.

An entry may be in the index but not in the log when:
- Scavenge (old or new) has been run on the log but not on the index (it is in progress still or perhaps it was stopped).
- Scavenge (old or new) has been run to completion but entries for scavenged events are still in the mem tables.
- New scavenge has been run and retained entries in the index due to uncertain max-age.