### PR TITLE
Downgrade GitInfo due to breaking change

### DIFF
--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -13,7 +13,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="GitInfo" Version="2.2.0">
+		<PackageReference Include="GitInfo" Version="2.0.26">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
Fixed: Downgrade GitInfo due to breaking change

With previous GitInfo, --version returns:
```
EventStoreDB version 22.10.0.0 (tags/oss-v22.10.0/24ec44693, Unknown)
```

With upgraded GitInfo, --version returns:
```
EventStoreDB version 22.10.0.0 (release/oss-v22.10/24ec44693, Unknown)                                                                                                                                      
```