### PR TITLE
Log warnings and errors when close to the max chunk number limit

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -9,6 +9,9 @@ namespace EventStore.Core.TransactionLog.Chunks {
 	public class TFChunkManager : IDisposable {
 		private static readonly ILogger Log = Serilog.Log.ForContext<TFChunkManager>();
 
+		// MaxChunksCount is currently capped at 400,000 since:
+		// - the chunk file naming strategy supports only up to 6 digits for the chunk number.
+		// - this class uses a fixed size array to keep the chunk list
 		public const int MaxChunksCount = 400_000; 
 
 		public int ChunksCount {


### PR DESCRIPTION
Changed: Log warnings and errors when close to the max chunk number limit