### PR TITLE
Improve new scavenge based on cloud testing

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/CancellationAndContinuationTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/CancellationAndContinuationTests.cs
@@ -182,9 +182,6 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					Tracer.Line("    Begin"),
 					Tracer.Line("        Checkpoint: Calculating SP-0 done None"),
 					Tracer.Line("    Commit"),
-					Tracer.Line("    Begin"),
-					Tracer.Line("        Checkpoint: Calculating SP-0 done None"),
-					Tracer.Line("    Commit"),
 					Tracer.Line("Done"),
 
 					Tracer.Line("Executing chunks for SP-0"),
@@ -243,9 +240,6 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					Tracer.Line("Done"),
 
 					Tracer.Line("Calculating SP-0"),
-					Tracer.Line("    Begin"),
-					Tracer.Line("        Checkpoint: Calculating SP-0 done None"),
-					Tracer.Line("    Commit"),
 					Tracer.Line("    Begin"),
 					Tracer.Line("        Checkpoint: Calculating SP-0 done None"),
 					Tracer.Line("    Commit"),
@@ -357,9 +351,6 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					Tracer.Line("    Begin"),
 					Tracer.Line("        SetDiscardPoints(98, Active, Discard before 1, Discard before 1)"),
 					Tracer.Line("        SetDiscardPoints(100, Spent, Keep all, Keep all)"),
-					Tracer.Line("        Checkpoint: Calculating SP-0 done Hash: 100"),
-					Tracer.Line("    Commit"),
-					Tracer.Line("    Begin"),
 					Tracer.Line("        Checkpoint: Calculating SP-0 done Hash: 100"),
 					Tracer.Line("    Commit"),
 					Tracer.Line("Done"),
@@ -489,9 +480,6 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					Tracer.Line("        SetDiscardPoints(98, Active, Discard before 2, Discard before 2)"),
 					Tracer.Line("        Checkpoint: Calculating SP-0 done Hash: 100"),
 					Tracer.Line("    Commit"),
-					Tracer.Line("    Begin"),
-					Tracer.Line("        Checkpoint: Calculating SP-0 done Hash: 100"),
-					Tracer.Line("    Commit"),
 					Tracer.Line("Done"),
 
 					// the rest is fresh for SP-0
@@ -591,9 +579,6 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					Tracer.Line("    Begin"),
 					Tracer.Line("        SetDiscardPoints(ab-1, Active, Discard before 1, Discard before 1)"),
 					// no discard points to set for ab-2
-					Tracer.Line("        Checkpoint: Calculating SP-0 done Id: ab-2"),
-					Tracer.Line("    Commit"),
-					Tracer.Line("    Begin"),
 					Tracer.Line("        Checkpoint: Calculating SP-0 done Id: ab-2"),
 					Tracer.Line("    Commit"),
 					Tracer.Line("Done"),

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/ScavengeStateBuilder.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/ScavengeStateBuilder.cs
@@ -60,6 +60,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 
 		public ScavengeState<TStreamId> Build() {
 			var state = BuildInternal();
+			state.Init();
 			_mutateState(state);
 			return state;
 		}
@@ -113,7 +114,8 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 			var scavengeState = new ScavengeState<TStreamId>(
 				_hasher,
 				_metastreamLookup,
-				backendPool);
+				backendPool,
+				100_000);
 
 			return scavengeState;
 		}

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -374,7 +374,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					index: calculatorIndexReader,
 					chunkSize: dbConfig.ChunkSize,
 					cancellationCheckPeriod: cancellationCheckPeriod,
-					checkpointPeriod: checkpointPeriod,
+					buffer: new(checkpointPeriod),
 					throttle: throttle);
 
 				IChunkExecutor<TStreamId> chunkExecutor = new ChunkExecutor<TStreamId, ILogRecord>(

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/SubsequentScavengeTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/SubsequentScavengeTests.cs
@@ -360,9 +360,6 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					Tracer.Line("    Begin"),
 					Tracer.Line("        Checkpoint: Calculating SP-1 done None"),
 					Tracer.Line("    Commit"),
-					Tracer.Line("    Begin"),
-					Tracer.Line("        Checkpoint: Calculating SP-1 done None"),
-					Tracer.Line("    Commit"),
 					Tracer.Line("Done"),
 
 					Tracer.Line("Executing chunks for SP-1"),
@@ -434,9 +431,6 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					Tracer.Line("Done"),
 
 					Tracer.Line("Calculating SP-3"),
-					Tracer.Line("    Begin"),
-					Tracer.Line("        Checkpoint: Calculating SP-3 done None"),
-					Tracer.Line("    Commit"),
 					Tracer.Line("    Begin"),
 					Tracer.Line("        Checkpoint: Calculating SP-3 done None"),
 					Tracer.Line("    Commit"),

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -503,8 +503,14 @@ namespace EventStore.Core {
 			             "Use 0 to disable the filter. Resizing the filter will cause a full rebuild.")]
 			public long StreamExistenceFilterSize { get; init; } = Opts.StreamExistenceFilterSizeDefault;
 
+			[Description("The page size of the scavenge database.")]
+			public int ScavengeBackendPageSize { get; init; } = Opts.ScavengeBackendPageSizeDefault;
+
 			[Description("The amount of memory to use for backend caching in bytes.")]
 			public long ScavengeBackendCacheSize { get; init; } = Opts.ScavengeBackendCacheSizeDefault;
+
+			[Description("The number of stream hashes to remember when checking for collisions.")]
+			public int ScavengeHashUsersCacheCapacity { get; init; } = Opts.ScavengeHashUsersCacheCapacityDefault;
 
 			public static int GetPTableMaxReaderCount(int readerThreadsCount) {
 				var ptableMaxReaderCount = 1 /* StorageWriter */
@@ -562,7 +568,9 @@ namespace EventStore.Core {
 				MaxTruncation = configurationRoot.GetValue<long>(nameof(MaxTruncation)),
 				DbLogFormat = configurationRoot.GetValue<DbLogFormat>(nameof(DbLogFormat)),
 				StreamExistenceFilterSize = configurationRoot.GetValue<long>(nameof(StreamExistenceFilterSize)),
+				ScavengeBackendPageSize = configurationRoot.GetValue<int>(nameof(ScavengeBackendPageSize)),
 				ScavengeBackendCacheSize = configurationRoot.GetValue<long>(nameof(ScavengeBackendCacheSize)),
+				ScavengeHashUsersCacheCapacity = configurationRoot.GetValue<int>(nameof(ScavengeHashUsersCacheCapacity)),
 			};
 		}
 		

--- a/src/EventStore.Core/TransactionLog/Scavenging/Data/StreamHandle.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Data/StreamHandle.cs
@@ -40,7 +40,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		public override string ToString() {
 			switch (Kind) {
 				case StreamHandle.Kind.Hash:
-					return $"Hash: {StreamHash}";
+					return $"Hash: {StreamHash:N0}";
 				case StreamHandle.Kind.Id:
 					return $"Id: {StreamId}";
 				case StreamHandle.Kind.None:

--- a/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IScavengeState.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Interfaces/IScavengeState.cs
@@ -12,6 +12,8 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		IScavengeStateForCleaner,
 		IDisposable {
 
+		void Init();
+
 		bool TryGetCheckpoint(out ScavengeCheckpoint checkpoint);
 
 		IEnumerable<TStreamId> AllCollisions();
@@ -67,6 +69,8 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		void SetChunkTimeStampRange(int logicalChunkNumber, ChunkTimeStampRange range);
 
 		StreamHandle<TStreamId> GetStreamHandle(TStreamId streamId);
+
+		void LogAccumulationStats();
 	}
 
 	public interface IScavengeStateForCalculatorReadOnly<TStreamId> {

--- a/src/EventStore.Core/TransactionLog/Scavenging/LruCachingScavengeMap.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/LruCachingScavengeMap.cs
@@ -7,6 +7,8 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 	public class LruCachingScavengeMap<TKey, TValue> : IScavengeMap<TKey, TValue> {
 		private readonly LRUCache<TKey, TValue> _cache;
 		private readonly IScavengeMap<TKey, TValue> _wrapped;
+		private long _hits;
+		private long _misses;
 
 		public LruCachingScavengeMap(string name, IScavengeMap<TKey, TValue> wrapped, int cacheMaxCount) {
 			_wrapped = wrapped;
@@ -24,8 +26,12 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			_wrapped.AllRecords();
 
 		public bool TryGetValue(TKey key, out TValue value) {
-			if (_cache.TryGet(key, out value))
+			if (_cache.TryGet(key, out value)) {
+				_hits++;
 				return true;
+			}
+
+			_misses++;
 
 			if (_wrapped.TryGetValue(key, out value)) {
 				_cache.Put(key, value);
@@ -41,6 +47,13 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		public bool TryRemove(TKey key, out TValue value) {
 			_cache.Remove(key);
 			return _wrapped.TryRemove(key, out value);
+		}
+
+		public void GetStats(out long hits, out long misses) {
+			hits = _hits;
+			misses = _misses;
+			_hits = 0;
+			_misses = 0;
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Scavenging/ScavengeState.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/ScavengeState.cs
@@ -20,21 +20,22 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 	}
 
 	public class ScavengeState<TStreamId> : ScavengeState, IScavengeState<TStreamId> {
-		private readonly IScavengeStateBackend<TStreamId> _backend;
+		private bool _initialized;
+		private IScavengeStateBackend<TStreamId> _backend;
 		private readonly ObjectPool<IScavengeStateBackend<TStreamId>> _backendPool;
-
-		private readonly CollisionDetector<TStreamId> _collisionDetector;
+		private readonly int _hashUsersCacheCapacity;
+		private CollisionDetector<TStreamId> _collisionDetector;
 
 		// data stored keyed against metadata streams
-		private readonly MetastreamCollisionMap<TStreamId> _metastreamDatas;
+		private MetastreamCollisionMap<TStreamId> _metastreamDatas;
 
 		// data stored keyed against original (non-metadata) streams
-		private readonly OriginalStreamCollisionMap<TStreamId> _originalStreamDatas;
+		private OriginalStreamCollisionMap<TStreamId> _originalStreamDatas;
 
-		private readonly IScavengeMap<int, ChunkTimeStampRange> _chunkTimeStampRanges;
-		private readonly IChunkWeightScavengeMap _chunkWeights;
-		private readonly IScavengeMap<Unit, ScavengeCheckpoint> _checkpointStorage;
-		private readonly ITransactionManager _transactionManager;
+		private IScavengeMap<int, ChunkTimeStampRange> _chunkTimeStampRanges;
+		private IChunkWeightScavengeMap _chunkWeights;
+		private IScavengeMap<Unit, ScavengeCheckpoint> _checkpointStorage;
+		private ITransactionManager _transactionManager;
 
 		private readonly ILongHasher<TStreamId> _hasher;
 		private readonly IMetastreamLookup<TStreamId> _metastreamLookup;
@@ -42,9 +43,20 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		public ScavengeState(
 			ILongHasher<TStreamId> hasher,
 			IMetastreamLookup<TStreamId> metastreamLookup,
-			ObjectPool<IScavengeStateBackend<TStreamId>> backendPool) {
+			ObjectPool<IScavengeStateBackend<TStreamId>> backendPool,
+			int hashUsersCacheCapacity) {
 
+			_hasher = hasher;
+			_metastreamLookup = metastreamLookup;
 			_backendPool = backendPool;
+			_hashUsersCacheCapacity = hashUsersCacheCapacity;
+		}
+
+		public void Init() {
+			if (_initialized)
+				return;
+
+			_initialized = true;
 			_backend = _backendPool.Get();
 
 			// todo: in log v3 inject an implementation that doesn't store hash users
@@ -53,12 +65,10 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				hashUsers: new LruCachingScavengeMap<ulong, TStreamId>(
 					"HashUsers",
 					_backend.Hashes,
-					cacheMaxCount: 100_000),
+					cacheMaxCount: _hashUsersCacheCapacity),
 				collisionStorage: _backend.CollisionStorage,
-				hasher: hasher);
+				hasher: _hasher);
 
-			_hasher = hasher;
-			_metastreamLookup = metastreamLookup;
 			_checkpointStorage = _backend.CheckpointStorage;
 
 			_metastreamDatas = new MetastreamCollisionMap<TStreamId>(
@@ -81,8 +91,9 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		}
 
 		public void Dispose() {
-			_transactionManager.UnregisterOnRollback();
-			_backendPool.Return(_backend);
+			_transactionManager?.UnregisterOnRollback();
+			if (_backend != null)
+				_backendPool.Return(_backend);
 			_backendPool.Dispose();
 		}
 
@@ -163,6 +174,11 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			_collisionDetector.IsCollision(streamId) ?
 				StreamHandle.ForStreamId(streamId) :
 				StreamHandle.ForHash<TStreamId>(_hasher.Hash(streamId));
+
+		public void LogAccumulationStats() {
+			LogStats();
+			_collisionDetector.LogStats();
+		}
 
 		//
 		// FOR CALCULATOR

--- a/src/EventStore.Core/TransactionLog/Scavenging/Scavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Scavenger.cs
@@ -67,17 +67,21 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			_state.Dispose();
 		}
 
+		// following old scavenging design the returned task must complete successfully
 		public async Task ScavengeAsync(CancellationToken cancellationToken) {
 			await Task.Yield(); // get off the main queue
-			Log.Debug("SCAVENGING: started scavenging DB.");
-			LogCollisions();
 
 			_recordedTimes.Clear();
 			var stopwatch = Stopwatch.StartNew();
-
 			var result = ScavengeResult.Success;
 			string error = null;
 			try {
+				Log.Debug("SCAVENGING: initializing scavenge state.");
+				_state.Init();
+				_state.LogStats();
+				Log.Debug("SCAVENGING: started scavenging DB.");
+				LogCollisions();
+
 				_scavengerLogger.ScavengeStarted();
 
 				await RunInternal(_scavengerLogger, stopwatch, cancellationToken).ConfigureAwait(false);
@@ -94,10 +98,10 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				Log.Error(exc, "SCAVENGING: error while scavenging DB.");
 				error = string.Format("Error while scavenging DB: {0}.", exc.Message);
 			} finally {
-				LogCollisions();
-				LogTimes();
 				try {
 					_scavengerLogger.ScavengeCompleted(result, error, stopwatch.Elapsed);
+					LogCollisions();
+					LogTimes();
 				} catch (Exception ex) {
 					Log.Error(
 						ex,

--- a/src/EventStore.Core/TransactionLog/Scavenging/Sqlite/SqliteScavengeBackend.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Sqlite/SqliteScavengeBackend.cs
@@ -18,8 +18,11 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 		//    persisted checkpoint.
 		private const string SqliteWalJournalMode = "wal";
 		private const int SqliteNormalSynchronousValue = 1;
+		private const int WalAutocheckpointDisabled = 0;
+
 		private const int DefaultSqliteCacheSize = 2 * 1024 * 1024;
-		private const int SqlitePageSize = 16 * 1024;
+		private const int DefaultSqlitePageSize = 16 * 1024;
+		private readonly int _pageSizeInBytes;
 		private readonly long _cacheSizeInBytes;
 		private SqliteBackend _sqliteBackend;
 
@@ -37,8 +40,12 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 		public ITransactionFactory<SqliteTransaction> TransactionFactory { get; private set; }
 		public ITransactionManager TransactionManager { get; private set; }
 
-		public SqliteScavengeBackend(long cacheSizeInBytes = DefaultSqliteCacheSize) {
+		public SqliteScavengeBackend(
+			int pageSizeInBytes = DefaultSqlitePageSize,
+			long cacheSizeInBytes = DefaultSqliteCacheSize) {
+			Ensure.Positive(pageSizeInBytes, nameof(pageSizeInBytes));
 			Ensure.Positive(cacheSizeInBytes, nameof(cacheSizeInBytes));
+			_pageSizeInBytes = pageSizeInBytes;
 			_cacheSizeInBytes = cacheSizeInBytes;
 		}
 
@@ -55,16 +62,19 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 			var collisionStorage = new SqliteCollisionScavengeMap<TStreamId>();
 			CollisionStorage = collisionStorage;
 
-			var hashes = new SqliteScavengeMap<ulong, TStreamId>("HashUsers");
+			var hashes = new SqliteScavengeMap<ulong, TStreamId>("HashUsers", "INT");
 			Hashes = hashes;
 
-			var metaStorage = new SqliteMetastreamScavengeMap<ulong>("MetastreamDatas");
+			// passing "INT" could increase the speed of the accumulation when the database becomes large
+			var metaStorage = new SqliteMetastreamScavengeMap<ulong>("MetastreamDatas"/*, "INT"*/);
 			MetaStorage = metaStorage;
 			
 			var metaCollisionStorage = new SqliteMetastreamScavengeMap<TStreamId>("MetastreamDataCollisions");
 			MetaCollisionStorage = metaCollisionStorage;
-			
-			var originalStorage = new SqliteOriginalStreamScavengeMap<ulong>("OriginalStreamDatas");
+
+			// passing "INT" could increase the speed of the accumulation when the database becomes large
+			// but may slow down calculation and require adjustments to the iteration queries / indexes
+			var originalStorage = new SqliteOriginalStreamScavengeMap<ulong>("OriginalStreamDatas"/*, "INT"*/);
 			OriginalStorage = originalStorage;
 			
 			var originalCollisionStorage = new SqliteOriginalStreamScavengeMap<TStreamId>("OriginalStreamDataCollisions");
@@ -94,11 +104,15 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 		}
 
 		private void ConfigureFeatures() {
-			_sqliteBackend.SetPragmaValue(SqliteBackend.PageSize, SqlitePageSize.ToString());
+			Log.Debug("SCAVENGING: Setting page size to {pageSize:N0} bytes.", _pageSizeInBytes);
+			_sqliteBackend.SetPragmaValue(SqliteBackend.PageSize, _pageSizeInBytes.ToString());
 			var pageSize = int.Parse(_sqliteBackend.GetPragmaValue(SqliteBackend.PageSize));
-			if (pageSize != SqlitePageSize) {
+			if (pageSize != _pageSizeInBytes) {
 				// note we will fail to set it if the database already exists with a different page size
-				throw new Exception($"Failed to configure page size to {SqlitePageSize}. Actually {pageSize}");
+				// the page size could be changed if the vacuumed the database
+				throw new Exception(
+					$"Failed to configure page size to {_pageSizeInBytes}. Actually {pageSize}. " +
+					$"This is probably a pre-existing database with a different page size.");
 			}
 			
 			_sqliteBackend.SetPragmaValue(SqliteBackend.JournalMode, SqliteWalJournalMode);
@@ -106,7 +120,15 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 			if (journalMode.ToLower() != SqliteWalJournalMode) {
 				throw new Exception($"Failed to configure journal mode, unexpected value: {journalMode}");
 			}
-			
+
+#if MANUAL_SQLITE_CHECKPOINT
+			_sqliteBackend.SetPragmaValue(SqliteBackend.WalAutocheckpoint, WalAutocheckpointDisabled.ToString());
+			var autocheckpoint = int.Parse(_sqliteBackend.GetPragmaValue(SqliteBackend.WalAutocheckpoint));
+			if (autocheckpoint != WalAutocheckpointDisabled) {
+				throw new Exception($"Failed to configure wal autocheckpoint, unexpected value: {autocheckpoint}");
+			}
+#endif
+
 			_sqliteBackend.SetPragmaValue(SqliteBackend.Synchronous, SqliteNormalSynchronousValue.ToString());
 			var synchronousMode = int.Parse(_sqliteBackend.GetPragmaValue(SqliteBackend.Synchronous));
 			if (synchronousMode != SqliteNormalSynchronousValue) {

--- a/src/EventStore.Core/TransactionLog/Scavenging/Sqlite/SqliteScavengeMap.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Sqlite/SqliteScavengeMap.cs
@@ -18,11 +18,13 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 			{typeof(ulong), nameof(SqliteType.Integer)},
 			{typeof(string), nameof(SqliteType.Text)},
 		};
+		private readonly string _keyTypeOverride;
 
 		protected string TableName { get; }
 		
-		public SqliteScavengeMap(string name) {
+		public SqliteScavengeMap(string name, string keyTypeOverride = null) {
 			TableName = name;
+			_keyTypeOverride = keyTypeOverride;
 			AssertTypesAreSupported();
 		}
 
@@ -43,7 +45,7 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 		}
 
 		public virtual void Initialize(SqliteBackend sqlite) {
-			var keyType = SqliteTypeMapping.GetTypeName<TKey>();
+			var keyType = _keyTypeOverride ?? SqliteTypeMapping.GetTypeName<TKey>();
 			var valueType = SqliteTypeMapping.GetTypeName<TValue>();
 			var createSql = $@"
 				CREATE TABLE IF NOT EXISTS {TableName} (

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/Accumulator.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/Accumulator.cs
@@ -119,6 +119,9 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					tombStoneRecord,
 					cancellationToken,
 					out var countAccumulatedRecords,
+					out var countOriginalStreamRecords,
+					out var countMetaStreamRecords,
+					out var countTombstoneRecords,
 					out var chunkMinTimeStamp,
 					out var chunkMaxTimeStamp);
 
@@ -136,20 +139,35 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				var rate = countAccumulatedRecords / accumulationElapsed.TotalSeconds;
 
 				weights.Flush();
+				var weightsElapsed = stopwatch.Elapsed;
+
 				transaction.Commit(new ScavengeCheckpoint.Accumulating(
 					scavengePoint,
 					doneLogicalChunkNumber: logicalChunkNumber));
 
+				var commitElapsed = stopwatch.Elapsed;
+
 				Log.Debug(
-					"SCAVENGING: Accumulated {countAccumulatedRecords:N0} records in chunk {chunk} in {elapsed}. " +
+					"SCAVENGING: Accumulated {countAccumulatedRecords:N0} records " +
+					"({originals:N0} originals, {metadatas:N0} metadatas, {tombstones:N0} tombstones) " +
+					"in chunk {chunk} in {elapsed}. " +
 					"{rate:N2} records per second. " +
+					"Commit: {commitElapsed}. " +
 					"Chunk total: {chunkTotalElapsed}",
-					countAccumulatedRecords, logicalChunkNumber, accumulationElapsed,
+					countAccumulatedRecords,
+					countOriginalStreamRecords, countMetaStreamRecords, countTombstoneRecords,
+					logicalChunkNumber, accumulationElapsed,
 					rate,
+					commitElapsed - weightsElapsed,
 					stopwatch.Elapsed);
 
+				state.LogAccumulationStats();
+
 				return ret;
-			} catch {
+			} catch (Exception ex) {
+				if (ex is not OperationCanceledException) {
+					Log.Error(ex, "SCAVENGING: Rolling back");
+				}
 				// invariant: there is always an open transaction whenever an exception can be thrown
 				transaction.Rollback();
 				throw;
@@ -168,10 +186,16 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			RecordForAccumulator<TStreamId>.TombStoneRecord tombStoneRecord,
 			CancellationToken cancellationToken,
 			out int countAccumulatedRecords,
+			out int countOriginalStreamRecords,
+			out int countMetaStreamRecords,
+			out int countTombstoneRecords,
 			out DateTime chunkMinTimeStamp,
 			out DateTime chunkMaxTimeStamp) {
 
 			countAccumulatedRecords = 0;
+			countOriginalStreamRecords = 0;
+			countMetaStreamRecords = 0;
+			countTombstoneRecords = 0;
 			// start with empty range and expand it as we discover records.
 			chunkMinTimeStamp = DateTime.MaxValue;
 			chunkMaxTimeStamp = DateTime.MinValue;
@@ -196,14 +220,17 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					case AccumulatorRecordType.OriginalStreamRecord:
 						ProcessOriginalStreamRecord(originalStreamRecord, state);
 						record = originalStreamRecord;
+						countOriginalStreamRecords++;
 						break;
 					case AccumulatorRecordType.MetadataStreamRecord:
 						ProcessMetastreamRecord(metadataStreamRecord, scavengePoint, state, weights);
 						record = metadataStreamRecord;
+						countMetaStreamRecords++;
 						break;
 					case AccumulatorRecordType.TombstoneRecord:
 						ProcessTombstone(tombStoneRecord, scavengePoint, state, weights);
 						record = tombStoneRecord;
+						countTombstoneRecords++;
 						break;
 					default:
 						throw new InvalidOperationException($"Unexpected recordType: {recordType}");

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/Calculator.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/Calculator.cs
@@ -5,27 +5,35 @@ using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
 	public class Calculator {
-		protected static ILogger Log { get; } = Serilog.Log.ForContext<Accumulator>();
+		protected static ILogger Log { get; } = Serilog.Log.ForContext<Calculator>();
 	}
 
 	public class Calculator<TStreamId> : Calculator, ICalculator<TStreamId> {
 		private readonly IIndexReaderForCalculator<TStreamId> _index;
 		private readonly int _chunkSize;
 		private readonly int _cancellationCheckPeriod;
-		private readonly int _checkpointPeriod;
+		private readonly Buffer _buffer;
 		private readonly Throttle _throttle;
+
+		public class Buffer {
+			public Buffer(int size) {
+				Array = new(StreamHandle<TStreamId>, OriginalStreamData)[size];
+			}
+
+			public (StreamHandle<TStreamId>, OriginalStreamData)[] Array { get; init; }
+		}
 
 		public Calculator(
 			IIndexReaderForCalculator<TStreamId> index,
 			int chunkSize,
 			int cancellationCheckPeriod,
-			int checkpointPeriod,
+			Buffer buffer,
 			Throttle throttle) {
 
 			_index = index;
 			_chunkSize = chunkSize;
 			_cancellationCheckPeriod = cancellationCheckPeriod;
-			_checkpointPeriod = checkpointPeriod;
+			_buffer = buffer;
 			_throttle = throttle;
 		}
 
@@ -57,7 +65,6 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			var streamCalc = new StreamCalculator<TStreamId>(_index, scavengePoint);
 			var eventCalc = new EventCalculator<TStreamId>(_chunkSize, _index, state, scavengePoint, streamCalc);
 
-			var checkpointCounter = 0;
 			var cancellationCheckCounter = 0;
 			var periodStart = stopwatch.Elapsed;
 			var totalCounter = 0;
@@ -70,89 +77,101 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			// there are limited scenarios when we do want to do this, (metadata streams when the main
 			// stream is tombstoned, and when UnsafeIgnoreHardDeletes is true) and they are governed by
 			// the IsTombstoned flags.
-			var originalStreamsToCalculate = state.OriginalStreamsToCalculate(
-				checkpoint: checkpoint?.DoneStreamHandle ?? default);
 
-			// for determinism it is important that IncreaseChunkWeight is called in a transaction with
-			// its calculation and checkpoint, otherwise the weight could be increased again on recovery
-			var transaction = state.BeginTransaction();
-			try {
-				foreach (var (originalStreamHandle, originalStreamData) in originalStreamsToCalculate) {
-					if (originalStreamData.Status != CalculationStatus.Active)
-						throw new InvalidOperationException(
-							$"Attempted to calculate a {originalStreamData.Status} record: {originalStreamData}");
+			// we read a batch of streams at a time so that each time we commit there is no active read
+			// prevents any risk of the WAL not being able to reset.
+			static bool TryPopulateBuffer(
+				IScavengeStateForCalculator<TStreamId> state,
+				StreamHandle<TStreamId> checkpoint,
+				(StreamHandle<TStreamId>, OriginalStreamData)[] buffer,
+				out int count) {
 
-					// todo: if sqlite lets us update the 'current' row before continuing on to the next
-					// then this could take advantage of that.
-
-					streamCalc.SetStream(originalStreamHandle, originalStreamData);
-					var newStatus = streamCalc.CalculateStatus();
-
-					CalculateDiscardPointsForOriginalStream(
-						eventCalc,
-						weights,
-						originalStreamHandle,
-						scavengePoint,
-						cancellationToken,
-						ref cancellationCheckCounter,
-						out var newDiscardPoint,
-						out var newMaybeDiscardPoint);
-
-					// don't allow the discard point to move backwards
-					if (newDiscardPoint < originalStreamData.DiscardPoint) {
-						newDiscardPoint = originalStreamData.DiscardPoint;
-					}
-
-					// don't allow the maybe discard point to move backwards
-					if (newMaybeDiscardPoint < originalStreamData.MaybeDiscardPoint) {
-						newMaybeDiscardPoint = originalStreamData.MaybeDiscardPoint;
-					}
-
-					if (newStatus == originalStreamData.Status &&
-						newDiscardPoint == originalStreamData.DiscardPoint &&
-						newMaybeDiscardPoint == originalStreamData.MaybeDiscardPoint) {
-
-						// nothing to update for this stream
-					} else {
-						state.SetOriginalStreamDiscardPoints(
-							streamHandle: originalStreamHandle,
-							status: newStatus,
-							discardPoint: newDiscardPoint,
-							maybeDiscardPoint: newMaybeDiscardPoint);
-					}
-
-					totalCounter++;
-
-					// Checkpoint occasionally
-					if (++checkpointCounter == _checkpointPeriod) {
-						checkpointCounter = 0;
-						weights.Flush();
-						transaction.Commit(new ScavengeCheckpoint.Calculating<TStreamId>(
-							scavengePoint,
-							originalStreamHandle));
-						transaction = state.BeginTransaction();
-
-						var elapsed = stopwatch.Elapsed;
-						LogRate("period", _checkpointPeriod, elapsed - periodStart);
-						LogRate("total", totalCounter, elapsed);
-
-						periodStart = stopwatch.Elapsed;
-					}
+				count = 0;
+				var streams = state.OriginalStreamsToCalculate(checkpoint);
+				foreach (var stream in streams) {
+					buffer[count++] = stream;
+					if (count == buffer.Length)
+						break;
 				}
 
-				// if we processed some streams, the last one is in the calculator
-				// if we didn't process any streams, the calculator contains the default
-				// none handle, which is probably appropriate to commit in that case
-				weights.Flush();
-				transaction.Commit(new ScavengeCheckpoint.Calculating<TStreamId>(
-					scavengePoint,
-					streamCalc.OriginalStreamHandle));
-				LogRate("grand total (including rests)", totalCounter, stopwatch.Elapsed);
-			} catch {
-				// invariant: there is always an open transaction whenever an exception can be thrown
-				transaction.Rollback();
-				throw;
+				return count > 0;
 			}
+
+			var buffer = _buffer.Array;
+			var cp = checkpoint?.DoneStreamHandle ?? default;
+			while (TryPopulateBuffer(state, cp, buffer, out var countInBatch)) {
+				// for determinism it is important that IncreaseChunkWeight is called in a transaction with
+				// its calculation and checkpoint, otherwise the weight could be increased again on recovery
+				var transaction = state.BeginTransaction();
+				try {
+					for (int i = 0; i < countInBatch; i++) {
+						var (originalStreamHandle, originalStreamData) = buffer[i];
+						if (originalStreamData.Status != CalculationStatus.Active)
+							throw new InvalidOperationException(
+								$"Attempted to calculate a {originalStreamData.Status} record: {originalStreamData}");
+
+						streamCalc.SetStream(originalStreamHandle, originalStreamData);
+						var newStatus = streamCalc.CalculateStatus();
+
+						CalculateDiscardPointsForOriginalStream(
+							eventCalc,
+							weights,
+							originalStreamHandle,
+							scavengePoint,
+							cancellationToken,
+							ref cancellationCheckCounter,
+							out var newDiscardPoint,
+							out var newMaybeDiscardPoint);
+
+						// don't allow the discard point to move backwards
+						if (newDiscardPoint < originalStreamData.DiscardPoint) {
+							newDiscardPoint = originalStreamData.DiscardPoint;
+						}
+
+						// don't allow the maybe discard point to move backwards
+						if (newMaybeDiscardPoint < originalStreamData.MaybeDiscardPoint) {
+							newMaybeDiscardPoint = originalStreamData.MaybeDiscardPoint;
+						}
+
+						if (newStatus == originalStreamData.Status &&
+							newDiscardPoint == originalStreamData.DiscardPoint &&
+							newMaybeDiscardPoint == originalStreamData.MaybeDiscardPoint) {
+
+							// nothing to update for this stream
+						} else {
+							state.SetOriginalStreamDiscardPoints(
+								streamHandle: originalStreamHandle,
+								status: newStatus,
+								discardPoint: newDiscardPoint,
+								maybeDiscardPoint: newMaybeDiscardPoint);
+						}
+
+						totalCounter++;
+					}
+
+					// the last stream we processed is in the calculator
+					cp = streamCalc.OriginalStreamHandle;
+					weights.Flush();
+					transaction.Commit(new ScavengeCheckpoint.Calculating<TStreamId>(
+						scavengePoint,
+						cp));
+
+					var elapsed = stopwatch.Elapsed;
+					LogRate($"period", countInBatch, elapsed - periodStart);
+					LogRate("total", totalCounter, elapsed);
+
+					periodStart = stopwatch.Elapsed;
+				} catch (Exception ex) {
+					if (ex is not OperationCanceledException) {
+						Log.Error(ex, "SCAVENGING: Rolling back");
+					}
+					// invariant: there is always an open transaction whenever an exception can be thrown
+					transaction.Rollback();
+					throw;
+				}
+			}
+
+			LogRate("grand total (including rests)", totalCounter, stopwatch.Elapsed);
 			_throttle.Rest(cancellationToken);
 		}
 

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -27,6 +27,12 @@ namespace EventStore.Core.Util {
 
 		public const long StreamExistenceFilterSizeDefault = 256_000_000;
 
-		public static readonly int ScavengeBackendCacheSizeDefault = 32 * 1024 * 1024;
+		public const int ScavengeBackendPageSizeDefault = 16 * 1024;
+
+		public const int ScavengeBackendCacheSizeDefault = 64 * 1024 * 1024;
+
+		public const int ScavengeHashUsersCacheCapacityDefault = 100_000;
+
+
 	}
 }


### PR DESCRIPTION
Added: Tuning new scavenge based on cloud tests

Performance
- Configurable page size
- Configurable hash users lru cache size
- ensure WAL stays small during Calculation by not having open reads while writing
- Cluster the HashUsers table by ROWID instead of hash to speed up inserts
- Connect to the db off of the main queue

Logging
- extra stats logging
- extra error logging
- log the cache size correctly when it is >2gb