### PR TITLE
Fix edge cases in maxage read fast path

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeInMemoryTableIndex.cs
@@ -124,5 +124,9 @@ namespace EventStore.Core.Tests.Services.Storage {
 		{
 			throw new NotImplementedException();
 		}
+
+		public void WaitForBackgroundTasks(int millisecondsTimeout) {
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/FakeTableIndex.cs
@@ -97,6 +97,10 @@ namespace EventStore.Core.Tests.Services.Storage {
 			return Task.CompletedTask;
 		}
 
+		public void WaitForBackgroundTasks(int millisecondsTimeout) {
+			throw new NotImplementedException();
+		}
+
 		public bool IsBackgroundTaskRunning {
 			get { return false; }
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/AfterScavenge/FilteredTableIndex.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/AfterScavenge/FilteredTableIndex.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Core.Index;
+
+namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.AfterScavenge {
+	// simulates particular entries having been removed from the index by scavenge
+	public class FilteredTableIndex<TStreamId> : ITableIndex<TStreamId> {
+		private readonly ITableIndex<TStreamId> _wrapped;
+		private readonly Func<IndexEntry, bool> _condition;
+		public FilteredTableIndex(ITableIndex<TStreamId> wrapped, Func<IndexEntry, bool> condition) {
+			_wrapped = wrapped;
+			_condition = condition;
+		}
+
+		public long CommitCheckpoint => _wrapped.CommitCheckpoint;
+
+		public long PrepareCheckpoint => _wrapped.PrepareCheckpoint;
+
+		public bool IsBackgroundTaskRunning => _wrapped.IsBackgroundTaskRunning;
+
+		public void Add(long commitPos, TStreamId streamId, long version, long position) {
+			_wrapped.Add(commitPos, streamId, version, position);
+		}
+
+		public void AddEntries(long commitPos, IList<IndexKey<TStreamId>> entries) {
+			_wrapped.AddEntries(commitPos, entries);
+		}
+
+		public void Close(bool removeFiles = true) {
+			_wrapped.Close(removeFiles);
+		}
+
+		public IReadOnlyList<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion, int? limit = null) {
+			return _wrapped
+				.GetRange(streamId, startVersion, endVersion, limit)
+				.Where(_condition)
+				.ToList();
+		}
+
+		public IReadOnlyList<IndexEntry> GetRange(ulong stream, long startVersion, long endVersion, int? limit = null) {
+			return _wrapped
+				.GetRange(stream, startVersion, endVersion, limit)
+				.Where(_condition)
+				.ToList();
+		}
+
+		public void Initialize(long chaserCheckpoint) {
+			_wrapped.Initialize(chaserCheckpoint);
+		}
+
+		public IEnumerable<ISearchTable> IterateAllInOrder() {
+			return _wrapped.IterateAllInOrder();
+		}
+
+		public Task MergeIndexes() {
+			return _wrapped.MergeIndexes();
+		}
+
+		public void Scavenge(IIndexScavengerLog log, CancellationToken ct) {
+			throw new NotImplementedException();
+		}
+
+		public void Scavenge(Func<IndexEntry, bool> shouldKeep, IIndexScavengerLog log, CancellationToken ct) {
+			throw new NotImplementedException();
+		}
+
+		public bool TryGetLatestEntry(TStreamId streamId, out IndexEntry entry) {
+			var got = _wrapped.TryGetLatestEntry(streamId, out entry);
+			if (!got)
+				return false;
+			if (_condition(entry))
+				return true;
+
+			// we got the latest entry from the wrapped but it doesn't pass our condition
+			var range = GetRange(streamId, 0, long.MaxValue);
+			if (range.Count == 0)
+				return false;
+			entry = range[0];
+			return true;
+		}
+
+		public bool TryGetLatestEntry(ulong stream, long beforePosition, Func<IndexEntry, bool> isForThisStream, out IndexEntry entry) {
+			throw new NotImplementedException();
+		}
+
+		public bool TryGetLatestEntry(TStreamId streamId, long beforePosition, Func<IndexEntry, bool> isForThisStream, out IndexEntry entry) {
+			throw new NotImplementedException();
+		}
+
+		public bool TryGetNextEntry(TStreamId streamId, long afterVersion, out IndexEntry entry) {
+			var got = _wrapped.TryGetNextEntry(streamId, afterVersion, out entry);
+			if (!got)
+				return false;
+			if (_condition(entry))
+				return true;
+
+			// we got the next entry from wrapped but it doesn't pass our condition
+			var range = GetRange(streamId, afterVersion, long.MaxValue);
+			if (range.Count == 0)
+				return false;
+			entry = range[^1];
+			return true;
+		}
+
+		public bool TryGetNextEntry(ulong stream, long afterVersion, out IndexEntry entry) {
+			var got = _wrapped.TryGetNextEntry(stream, afterVersion, out entry);
+			if (!got)
+				return false;
+			if (_condition(entry))
+				return true;
+
+			// we got the next entry from wrapped but it doesn't pass our condition
+			var range = GetRange(stream, afterVersion, long.MaxValue);
+			if (range.Count == 0)
+				return false;
+			entry = range[^1];
+			return true;
+		}
+
+		public bool TryGetOldestEntry(TStreamId streamId, out IndexEntry entry) {
+			var got = _wrapped.TryGetOldestEntry(streamId, out entry);
+			if (!got)
+				return false;
+			if (_condition(entry))
+				return true;
+
+			// we got the oldest entry from the wrapped but it doesn't pass our condition
+			var range = GetRange(streamId, 0, long.MaxValue);
+			if (range.Count == 0)
+				return false;
+			entry = range[^1];
+			return true;
+		}
+
+		public bool TryGetOneValue(TStreamId streamId, long version, out long position) {
+			throw new NotImplementedException();
+		}
+
+		public bool TryGetPreviousEntry(TStreamId streamId, long beforeVersion, out IndexEntry entry) {
+			throw new NotImplementedException();
+		}
+
+		public bool TryGetPreviousEntry(ulong stream, long beforeVersion, out IndexEntry entry) {
+			throw new NotImplementedException();
+		}
+
+		public void WaitForBackgroundTasks(int millisecondsTimeout) {
+			_wrapped.WaitForBackgroundTasks(millisecondsTimeout);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/AfterScavenge/when_having_gaps_in_index.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/MaxAgeMaxCount/AfterScavenge/when_having_gaps_in_index.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.MaxAgeMaxCount.AfterScavenge {
+	public abstract class MaxAgeIterationTests : ReadIndexTestScenario<LogFormat.V2, string> {
+		public ulong _esHash;
+
+		protected abstract long[] ExtantIndexEntries { get; }
+
+		protected override void WriteTestScenario() {
+			var now = DateTime.UtcNow;
+			var expired = now.AddMinutes(-50);
+
+			var metadata = string.Format(@"{{""$maxAge"":{0}}}", (int)TimeSpan.FromMinutes(10).TotalSeconds);
+
+			WriteStreamMetadata("ES", 0, metadata);
+
+			// the stream had ten events in it but 8 of them have expired leaving only the last two.
+			WriteSingleEvent("ES", 0, "data", expired);
+			WriteSingleEvent("ES", 1, "data", expired);
+			WriteSingleEvent("ES", 2, "data", expired);
+			WriteSingleEvent("ES", 3, "data", expired);
+			WriteSingleEvent("ES", 4, "data", expired);
+			WriteSingleEvent("ES", 5, "data", expired);
+			WriteSingleEvent("ES", 6, "data", expired);
+			WriteSingleEvent("ES", 7, "data", expired);
+			WriteSingleEvent("ES", 8, "data", now);
+			WriteSingleEvent("ES", 9, "data", now);
+			_esHash = Hasher.Hash("ES");
+
+			// dont scavenge the index because we want to keep most of the entries
+			// simulate removal by using FilteredTableIndex
+			Scavenge(completeLast: true, mergeChunks: false, scavengeIndex: false);
+		}
+
+		protected override ITableIndex<string> TransformTableIndex(ITableIndex<string> tableIndex) {
+			return new FilteredTableIndex<string>(
+				tableIndex,
+				// keep everything from other streams, but only the ExtantEntries of "ES"
+				entry => entry.Stream != _esHash || ExtantIndexEntries.Contains(entry.Version));
+		}
+
+		// repeatedly issue reads, each one starting from the previous `nextEventNumber`
+		// until we find the event we are looking for.
+		protected void ReadOneStartingFrom(long fromEventNumber, long expectedEventNumber) {
+			var attempts = new List<long>();
+			for (int i = 0; i < 20; i++) {
+				attempts.Add(fromEventNumber);
+				var result = ReadIndex.ReadStreamEventsForward("ES", fromEventNumber, maxCount: 1);
+
+				if (result.Records.Length != 0) {
+					Assert.AreEqual(expectedEventNumber, result.Records[0].EventNumber);
+					return;
+				}
+
+				fromEventNumber = result.NextEventNumber;
+			}
+
+			throw new Exception("iterated too many times. infinite loop?");
+		}
+
+		protected void ReadOneStartingFromEach() {
+			ReadOneStartingFrom(0, 8);
+			ReadOneStartingFrom(1, 8);
+			ReadOneStartingFrom(2, 8);
+			ReadOneStartingFrom(3, 8);
+			ReadOneStartingFrom(4, 8);
+			ReadOneStartingFrom(5, 8);
+			ReadOneStartingFrom(6, 8);
+			ReadOneStartingFrom(7, 8);
+			ReadOneStartingFrom(8, 8);
+			ReadOneStartingFrom(9, 9);
+		}
+	}
+
+	public class when_having_gaps_in_index_on_maxage_fast_path : MaxAgeIterationTests {
+		protected override long[] ExtantIndexEntries { get; } = new long[] { 0, 1, 2, 3, 4, 5, 6, 8, 9 };
+		
+		[Test]
+		public void works() => ReadOneStartingFromEach();
+	}
+
+	public class when_having_gaps_in_index_on_maxage_fast_path2 : MaxAgeIterationTests {
+		protected override long[] ExtantIndexEntries { get; } = new long[] { 0, 8, 9 };
+
+		[Test]
+		public void works() => ReadOneStartingFromEach();
+	}
+
+	public class when_having_gaps_in_index_on_maxage_fast_path3 : MaxAgeIterationTests {
+		protected override long[] ExtantIndexEntries { get; } = new long[] { 2, 8, 9 };
+
+		[Test]
+		public void works() => ReadOneStartingFromEach();
+	}
+
+	public class when_having_gaps_in_index_on_maxage_fast_path4 : MaxAgeIterationTests {
+		protected override long[] ExtantIndexEntries { get; } = new long[] { 1, 3, 5, 7, 8, 9 };
+
+		[Test]
+		public void works() => ReadOneStartingFromEach();
+	}
+
+	public class when_having_gaps_in_index_on_maxage_fast_path5 : MaxAgeIterationTests {
+		protected override long[] ExtantIndexEntries { get; } = new long[] { 0, 2, 4, 6, 8, 9 };
+
+		[Test]
+		public void works() => ReadOneStartingFromEach();
+	}
+}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_chunck_scavenged.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_chunck_scavenged.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 			var cancellationTokenSource = new CancellationTokenSource();
 
 			Log.ChunkScavenged += (sender, args) => cancellationTokenSource.Cancel();
-			await TfChunkScavenger.Scavenge(true, true, 0, cancellationTokenSource.Token);
+			await TfChunkScavenger.Scavenge(true, true, 0, ct: cancellationTokenSource.Token);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_completed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_completed.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 			var cancellationTokenSource = new CancellationTokenSource();
 
 			Log.CompletedCallback += (sender, args) => cancellationTokenSource.Cancel();
-			await TfChunkScavenger.Scavenge(true, true, 0, cancellationTokenSource.Token);
+			await TfChunkScavenger.Scavenge(true, true, 0, ct: cancellationTokenSource.Token);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_started.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_after_started.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 			var cancellationTokenSource = new CancellationTokenSource();
 
 			Log.StartedCallback += (sender, args) => cancellationTokenSource.Cancel();
-			await TfChunkScavenger.Scavenge(false, true, 0, cancellationTokenSource.Token);
+			await TfChunkScavenger.Scavenge(false, true, 0, ct: cancellationTokenSource.Token);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_before_started.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_cancelled_before_started.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 		protected override async Task When() {
 			var cancellationTokenSource = new CancellationTokenSource();
 			cancellationTokenSource.Cancel();
-			await TfChunkScavenger.Scavenge(false, true, 0, cancellationTokenSource.Token);
+			await TfChunkScavenger.Scavenge(false, true, 0, ct: cancellationTokenSource.Token);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_from_chunk_number.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_from_chunk_number.cs
@@ -10,7 +10,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 	public class when_scavenge_from_chunk_number<TLogFormat, TStreamId> : ScavengeLifeCycleScenario<TLogFormat, TStreamId> {
 		protected override Task When() {
 			var cancellationTokenSource = new CancellationTokenSource();
-			return TfChunkScavenger.Scavenge(true, true, 1, cancellationTokenSource.Token);
+			return TfChunkScavenger.Scavenge(true, true, 1, ct: cancellationTokenSource.Token);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_succeeds_without_error.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_succeeds_without_error.cs
@@ -10,7 +10,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 	public class when_scavenge_succeeds_without_error<TLogFormat, TStreamId> : ScavengeLifeCycleScenario<TLogFormat, TStreamId> {
 		protected override Task When() {
 			var cancellationTokenSource = new CancellationTokenSource();
-			return TfChunkScavenger.Scavenge(true, true, 0, cancellationTokenSource.Token);
+			return TfChunkScavenger.Scavenge(true, true, 0, ct: cancellationTokenSource.Token);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_on_completed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_on_completed.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 			var cancellationTokenSource = new CancellationTokenSource();
 
 			Log.CompletedCallback += (sender, args) => { throw new Exception("Expected exception."); };
-			return TfChunkScavenger.Scavenge(true, true, 0, cancellationTokenSource.Token);
+			return TfChunkScavenger.Scavenge(true, true, 0, ct: cancellationTokenSource.Token);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_processing_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/when_scavenge_throws_exception_processing_chunk.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 					throw new Exception("Expected exception.");
 			};
 
-			return TfChunkScavenger.Scavenge(true, true, 0, cancellationTokenSource.Token);
+			return TfChunkScavenger.Scavenge(true, true, 0, ct: cancellationTokenSource.Token);
 		}
 
 		[Test]

--- a/src/EventStore.Core/Index/ITableIndex.cs
+++ b/src/EventStore.Core/Index/ITableIndex.cs
@@ -36,5 +36,7 @@ namespace EventStore.Core.Index {
 
 		IReadOnlyList<IndexEntry> GetRange(TStreamId streamId, long startVersion, long endVersion, int? limit = null);
 		IReadOnlyList<IndexEntry> GetRange(ulong stream, long startVersion, long endVersion, int? limit = null);
+
+		void WaitForBackgroundTasks(int millisecondsTimeout);
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -80,6 +80,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		}
 
 		public Task Scavenge(bool alwaysKeepScavenged, bool mergeChunks, int startFromChunk = 0,
+			bool scavengeIndex = true,
 			CancellationToken ct = default(CancellationToken)) {
 			Ensure.Nonnegative(startFromChunk, nameof(startFromChunk));
 
@@ -95,7 +96,9 @@ namespace EventStore.Core.TransactionLog.Chunks {
 
 					ScavengeInternal(alwaysKeepScavenged, mergeChunks, startFromChunk, ct);
 
-					_tableIndex.Scavenge(_scavengerLog, ct);
+					if (scavengeIndex) {
+						_tableIndex.Scavenge(_scavengerLog, ct);
+					}
 				} catch (OperationCanceledException) {
 					Log.Information("SCAVENGING: Scavenge cancelled.");
 					result = ScavengeResult.Stopped;


### PR DESCRIPTION
Fixed: Edge cases in maxage read fast path.

These could result in the nextEventNumber being set incorrectly, leading to gRPC reads going into an infinite loop reading from e.g. 5 then 7 then 5, looking for events, for as long as the client keept the gRPC call open.

Two places relied on the index entries not having gaps in the version numbers for a particular streamhash, but it is possible for this to happen:

Old scavenge:
- During the course of a regular index scavenge, since it starts with the newest tables and works backwards
- If you scavenge starting from a chunk > 0, removing some records, then scavenge the index, it removes from the index whatever is no longer present in the log
- If there is a hash collision between two streams and the union of version numbers has gaps in

New scavenge:
- If the stream has a maybeDiscardPoint due to maxage, keeping some entries in the index that are not in the log, but some later entries are not kept because the node is restarted while they are still in the memtables