### PR TITLE
Add `AllowUnknownOptions` configuration option

### DIFF
--- a/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
@@ -1,25 +1,9 @@
 using System;
-using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 
 #nullable enable
 namespace EventStore.Common.Configuration {
 	public static class ConfigurationRootExtensions {
-		public static void Validate<TOptions>(this IConfigurationRoot configurationRoot) {
-			var options = typeof(TOptions).GetProperties()
-				.SelectMany(
-					property => property.PropertyType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-				.Select(x => x.Name)
-				.ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-			foreach (var (key, _) in configurationRoot.AsEnumerable()) {
-				if (!options.Contains(key)) {
-					throw new ArgumentException($"The option {key} is not a known option.", key);
-				}
-			}
-		}
-
 		public static string[] GetCommaSeparatedValueAsArray(this IConfigurationRoot configurationRoot, string key) =>
 			configurationRoot.GetValue<string?>(key)?.Split(',', StringSplitOptions.RemoveEmptyEntries) ??
 			Array.Empty<string>();

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -66,6 +66,7 @@ namespace EventStore.Core.Tests {
 				nameof(ClusterVNodeOptions.Cluster.PrepareAckCount),
 				nameof(ClusterVNodeOptions.Database.ChunkSize),
 				nameof(ClusterVNodeOptions.Database.StatsStorage),
+				nameof(ClusterVNodeOptions.Unknown.Keys),
 			};
 			var actual = new List<string>();
 			ClusterVNodeOptions.FromConfiguration(new FakeConfigurationRoot(


### PR DESCRIPTION
Added: AllowUnknownOptions option that allows EventStoreDB to start when unknown options are present (default: false)

When enabled, unknown options are logged as information on startup rather than preventing startup

Useful when the same or similar configurations are used against multiple versions of ES:
- Customers doing side by side comparisons
- ES Cloud (configuring a new option that does not exist in previous versions)
- (dev/qa)

Also
- When existing due to unknown configuration options, log out all the options and where they came from first to help identify the source (env/file/commandline)