### PR TITLE
[22.10] Add `AllowUnknownOptions` configuration option

### DIFF
--- a/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
@@ -1,25 +1,9 @@
 using System;
-using System.Linq;
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 
 #nullable enable
 namespace EventStore.Common.Configuration {
 	public static class ConfigurationRootExtensions {
-		public static void Validate<TOptions>(this IConfigurationRoot configurationRoot) {
-			var options = typeof(TOptions).GetProperties()
-				.SelectMany(
-					property => property.PropertyType.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-				.Select(x => x.Name)
-				.ToHashSet(StringComparer.OrdinalIgnoreCase);
-
-			foreach (var (key, _) in configurationRoot.AsEnumerable()) {
-				if (!options.Contains(key)) {
-					throw new ArgumentException($"The option {key} is not a known option.", key);
-				}
-			}
-		}
-
 		public static string[] GetCommaSeparatedValueAsArray(this IConfigurationRoot configurationRoot, string key) =>
 			configurationRoot.GetValue<string?>(key)?.Split(',', StringSplitOptions.RemoveEmptyEntries) ??
 			Array.Empty<string>();

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -66,6 +66,7 @@ namespace EventStore.Core.Tests {
 				nameof(ClusterVNodeOptions.Cluster.PrepareAckCount),
 				nameof(ClusterVNodeOptions.Database.ChunkSize),
 				nameof(ClusterVNodeOptions.Database.StatsStorage),
+				nameof(ClusterVNodeOptions.Unknown.Keys),
 			};
 			var actual = new List<string>();
 			ClusterVNodeOptions.FromConfiguration(new FakeConfigurationRoot(

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -3,7 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using EventStore.Common;
 using EventStore.Common.Configuration;
@@ -34,6 +36,7 @@ namespace EventStore.Core {
 		[OptionGroup] public GrpcOptions Grpc { get; init; } = new();
 		[OptionGroup] public InterfaceOptions Interface { get; init; } = new();
 		[OptionGroup] public ProjectionOptions Projections { get; init; } = new();
+		public UnknownOptions Unknown { get; init; } = new(Array.Empty<string>());
 
 		public byte IndexBitnessVersion { get; init; } = Index.PTableVersions.IndexV4;
 
@@ -61,8 +64,6 @@ namespace EventStore.Core {
 		}
 
 		public static ClusterVNodeOptions FromConfiguration(IConfigurationRoot configurationRoot) {
-			configurationRoot.Validate<ClusterVNodeOptions>();
-
 			return new ClusterVNodeOptions {
 				Application = ApplicationOptions.FromConfiguration(configurationRoot),
 				DevMode = DevModeOptions.FromConfiguration(configurationRoot),
@@ -76,6 +77,7 @@ namespace EventStore.Core {
 				Grpc = GrpcOptions.FromConfiguration(configurationRoot),
 				Interface = InterfaceOptions.FromConfiguration(configurationRoot),
 				Projections = ProjectionOptions.FromConfiguration(configurationRoot),
+				Unknown = UnknownOptions.FromConfiguration(configurationRoot),
 				ConfigurationRoot = configurationRoot,
 			};
 		}
@@ -108,6 +110,9 @@ namespace EventStore.Core {
 
 			[Description("Print effective configuration to console and then exit.")]
 			public bool WhatIf { get; init; } = false;
+
+			[Description("Allows EventStoreDB to run with unknown configuration options present.")]
+			public bool AllowUnknownOptions { get; init; } = false;
 
 			[Description("Disable HTTP caching.")] public bool DisableHttpCaching { get; init; } = false;
 
@@ -143,6 +148,7 @@ namespace EventStore.Core {
 				Version = configurationRoot.GetValue<bool>(nameof(Version)),
 				EnableHistograms = configurationRoot.GetValue<bool>(nameof(EnableHistograms)),
 				WhatIf = configurationRoot.GetValue<bool>(nameof(WhatIf)),
+				AllowUnknownOptions = configurationRoot.GetValue<bool>(nameof(AllowUnknownOptions)),
 				WorkerThreads = configurationRoot.GetValue<int>(nameof(WorkerThreads)),
 				DisableHttpCaching = configurationRoot.GetValue<bool>(nameof(DisableHttpCaching)),
 				LogHttpRequests = configurationRoot.GetValue<bool>(nameof(LogHttpRequests)),
@@ -750,6 +756,31 @@ namespace EventStore.Core {
 				ProjectionCompilationTimeout = configurationRoot.GetValue<int>(nameof(ProjectionCompilationTimeout)),
 				ProjectionExecutionTimeout = configurationRoot.GetValue<int>(nameof(ProjectionExecutionTimeout))
 			};
+		}
+
+		public record UnknownOptions {
+			public IReadOnlyList<string> Keys { get; init; }
+
+			public UnknownOptions(IReadOnlyList<string> keys) {
+				Keys = keys;
+			}
+
+			internal static UnknownOptions FromConfiguration(IConfigurationRoot configurationRoot) {
+				var allKnownKeys = typeof(ClusterVNodeOptions).GetProperties()
+					.SelectMany(property => property
+						.PropertyType
+						.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+					.Select(x => x.Name)
+					.ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+				var unknownKeys = configurationRoot
+					.AsEnumerable()
+					.Select(kvp => kvp.Key)
+					.Where(key => !allKnownKeys.Contains(key))
+					.ToList();
+
+				return new UnknownOptions(unknownKeys);
+			}
 		}
 	}
 }


### PR DESCRIPTION
Added: AllowUnknownOptions option that allows EventStoreDB to start when unknown options are present (default: false)

cherry pick of https://github.com/EventStore/EventStore/pull/3652
