### PR TITLE
Fix projection progress report.

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/FakeReaderSubscription.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/event_reader/heading_event_reader/FakeReaderSubscription.cs
@@ -93,6 +93,10 @@ namespace EventStore.Projections.Core.Tests.Services.event_reader.heading_event_
 			//ignore
 		}
 
+		public void Handle(ReaderSubscriptionMessage.ReportProgress message) {
+			//ignore
+		}
+
 		public string Tag {
 			get { return "FakeReaderSubscription"; }
 		}

--- a/src/EventStore.Projections.Core/Messages/ReaderSubscriptionMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ReaderSubscriptionMessage.cs
@@ -273,7 +273,7 @@ namespace EventStore.Projections.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public ReportProgress(Guid correlationId, object source = null) : base(correlation, null, source) { }
+			public ReportProgress(Guid correlationId, object source = null) : base(correlationId, null, source) { }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Messages/ReaderSubscriptionMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ReaderSubscriptionMessage.cs
@@ -216,7 +216,7 @@ namespace EventStore.Projections.Core.Messages {
 			private readonly long? _safeTransactionFileReaderJoinPosition;
 			private readonly float _progress;
 
-			//NOTE: committed event with null event _data means - end of the source reached.  
+			//NOTE: committed event with null event _data means - end of the source reached.
 			// Current last available TF commit position is in _position.CommitPosition
 			// TODO: separate message?
 
@@ -264,6 +264,16 @@ namespace EventStore.Projections.Core.Messages {
 			public string Reason {
 				get { return _reason; }
 			}
+		}
+
+		public class ReportProgress : SubscriptionMessage {
+			private static readonly int TypeId = System.Threading.Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public ReportProgress(Guid correlation, object source = null) : base(correlation, null, source) { }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Messages/ReaderSubscriptionMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ReaderSubscriptionMessage.cs
@@ -273,7 +273,7 @@ namespace EventStore.Projections.Core.Messages {
 				get { return TypeId; }
 			}
 
-			public ReportProgress(Guid correlation, object source = null) : base(correlation, null, source) { }
+			public ReportProgress(Guid correlationId, object source = null) : base(correlation, null, source) { }
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionWorkerNode.cs
@@ -40,7 +40,7 @@ namespace EventStore.Projections.Core {
 
 			_coreOutput = new InMemoryBus("Core Output");
 			_leaderOutputBus = leaderOutputBus;
-			
+
 			IPublisher publisher = CoreOutput;
 			_subscriptionDispatcher = new ReaderSubscriptionDispatcher(publisher);
 
@@ -62,7 +62,7 @@ namespace EventStore.Projections.Core {
 					_subscriptionDispatcher,
 					timeProvider,
 					_ioDispatcher,
-					timeoutScheduler, 
+					timeoutScheduler,
 					configuration);
 			}
 		}
@@ -148,6 +148,7 @@ namespace EventStore.Projections.Core {
 			coreInputBus.Subscribe<ReaderSubscriptionMessage.EventReaderPartitionDeleted>(_eventReaderCoreService);
 			coreInputBus.Subscribe<ReaderSubscriptionMessage.EventReaderNotAuthorized>(_eventReaderCoreService);
 			coreInputBus.Subscribe<ReaderSubscriptionMessage.Faulted>(_eventReaderCoreService);
+			coreInputBus.Subscribe<ReaderSubscriptionMessage.ReportProgress>(_eventReaderCoreService);
 			//NOTE: message forwarding is set up outside (for Read/Write events)
 		}
 	}

--- a/src/EventStore.Projections.Core/Services/Processing/EventReorderingReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EventReorderingReaderSubscription.cs
@@ -53,7 +53,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		}
 
 		private void ProcessAllFor(DateTime maxTimestamp) {
-			//NOTE: this is the most straightforward implementation 
+			//NOTE: this is the most straightforward implementation
 			//TODO: build proper data structure when the approach is finalized
 			bool processed;
 			do {
@@ -90,6 +90,10 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 		public void Handle(ReaderSubscriptionMessage.EventReaderPartitionDeleted message) {
 			throw new NotSupportedException();
+		}
+
+		public void Handle(ReaderSubscriptionMessage.ReportProgress message) {
+			NotifyProgress();
 		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Processing/IReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/IReaderSubscription.cs
@@ -10,7 +10,8 @@ namespace EventStore.Projections.Core.Services.Processing {
 		IHandle<ReaderSubscriptionMessage.EventReaderEof>,
 		IHandle<ReaderSubscriptionMessage.EventReaderPartitionEof>,
 		IHandle<ReaderSubscriptionMessage.EventReaderPartitionDeleted>,
-		IHandle<ReaderSubscriptionMessage.EventReaderNotAuthorized> {
+		IHandle<ReaderSubscriptionMessage.EventReaderNotAuthorized>,
+		IHandle<ReaderSubscriptionMessage.ReportProgress> {
 		string Tag { get; }
 		Guid SubscriptionId { get; }
 		IEventReader CreatePausedEventReader(IPublisher publisher, IODispatcher ioDispatcher, Guid forkedEventReaderId);

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
@@ -47,5 +47,9 @@ namespace EventStore.Projections.Core.Services.Processing {
 			var deletePosition = _positionTagger.MakeCheckpointTag(_positionTracker.LastTag, message);
 			PublishPartitionDeleted(message.Partition, deletePosition);
 		}
+
+		public void Handle(ReaderSubscriptionMessage.ReportProgress message) {
+			NotifyProgress();
+		}
 	}
 }

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscription.cs
@@ -38,7 +38,7 @@ namespace EventStore.Projections.Core.Services.Processing {
 		}
 
 		public void Handle(ReaderSubscriptionMessage.EventReaderIdle message) {
-			// ignore
+			ForceProgressValue(100);
 		}
 
 		public void Handle(ReaderSubscriptionMessage.EventReaderPartitionDeleted message) {

--- a/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/ReaderSubscriptionBase.cs
@@ -160,6 +160,14 @@ namespace EventStore.Projections.Core.Services.Processing {
 				_subscriptionMessageSequenceNumber++));
 		}
 
+		/// <summary>
+		/// Forces a progression value.
+		/// </summary>
+		/// <param name="value">a percentage rate. For example if the progress is 42%, value parameter must be 42</param>
+		protected void ForceProgressValue(float value) {
+			_progress = value;
+		}
+
 		protected void PublishPartitionDeleted(string partition, CheckpointTag deletePosition) {
 			_publisher.Publish(
 				new EventReaderSubscriptionMessage.PartitionDeleted(


### PR DESCRIPTION
Fixed: Fix projection progress report.

The issue was about how `ReaderSubscriptionBase` reported progression. `ReaderSubscriptionBase` uses a time window to decide if we should report progress downstream. If that time windows was missed, progression was not reported.

The new solution reports progression asynchronously, every 500ms, to match previous time window.

Fixes #2820 