### PR TITLE
Scavenging Quality of Life improvements

### DIFF
--- a/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
+++ b/src/EventStore.Core.Tests/Authorization/LegacyPolicyVerification.cs
@@ -307,6 +307,7 @@ namespace EventStore.Core.Tests.Authorization {
 				yield return CreateOperation(Operations.Node.ReloadConfiguration);
 				yield return CreateOperation(Operations.Node.Scavenge.Start);
 				yield return CreateOperation(Operations.Node.Scavenge.Stop);
+				yield return CreateOperation(Operations.Node.Scavenge.Read);
 				yield return CreateOperation(Operations.Node.MergeIndexes);
 				yield return CreateOperation(Operations.Node.SetPriority);
 				yield return CreateOperation(Operations.Node.Resign);

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -149,7 +149,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			if (_scavenge) {
 				if (_completeLastChunkOnScavenge)
 					Db.Manager.GetChunk(Db.Manager.ChunksCount - 1).Complete();
-				_scavenger = new TFChunkScavenger<TStreamId>(Db, new FakeTFScavengerLog(), TableIndex, ReadIndex, _logFormat.Metastreams);
+				_scavenger = new TFChunkScavenger<TStreamId>(Serilog.Log.Logger, Db, new FakeTFScavengerLog(), TableIndex, ReadIndex, _logFormat.Metastreams);
 				await _scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: _mergeChunks,
 					scavengeIndex: _scavengeIndex);
 			}

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authorization/authorization_tests.cs
@@ -147,6 +147,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 				"/admin/shutdown;POST;Ops", /* this test is not executed for Ops and Admin to prevent the node from shutting down */
 				"/admin/scavenge?startFromChunk={startFromChunk}&threads={threads};POST;Ops",
 				"/admin/scavenge/{scavengeId};DELETE;Ops",
+				"/admin/scavenge/current;GET;Ops",
 				"/admin/mergeindexes;POST;Ops",
 				"/ping;GET;None",
 				"/info;GET;None",

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 
 			Log = new FakeTFScavengerLog();
 			FakeTableIndex = new FakeTableIndex<TStreamId>();
-			TfChunkScavenger = new TFChunkScavenger<TStreamId>(_dbResult.Db, Log, FakeTableIndex, new FakeReadIndex<TLogFormat, TStreamId>(_ => false, _logFormat.Metastreams),
+			TfChunkScavenger = new TFChunkScavenger<TStreamId>(Serilog.Log.Logger, _dbResult.Db, Log, FakeTableIndex, new FakeReadIndex<TLogFormat, TStreamId>(_ => false, _logFormat.Metastreams),
 				_logFormat.Metastreams);
 
 			try {

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -88,7 +88,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 			readIndex.IndexCommitter.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 			ReadIndex = readIndex;
 
-			var scavenger = new TFChunkScavenger<TStreamId>(_dbResult.Db, new FakeTFScavengerLog(), tableIndex, ReadIndex,
+			var scavenger = new TFChunkScavenger<TStreamId>(Serilog.Log.Logger, _dbResult.Db, new FakeTFScavengerLog(), tableIndex, ReadIndex,
 				_logFormat.Metastreams,
 				unsafeIgnoreHardDeletes: UnsafeIgnoreHardDelete());
 			await scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);

--- a/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_having_scavenged_tfchunk_with_all_records_removed.cs
@@ -81,7 +81,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_db.Config.ChaserCheckpoint.Write(chunk.ChunkHeader.ChunkEndPosition);
 			_db.Config.ChaserCheckpoint.Flush();
 
-			var scavenger = new TFChunkScavenger<TStreamId>(_db, new FakeTFScavengerLog(), new FakeTableIndex<TStreamId>(),
+			var scavenger = new TFChunkScavenger<TStreamId>(Serilog.Log.Logger, _db, new FakeTFScavengerLog(), new FakeTableIndex<TStreamId>(),
 				new FakeReadIndex<TLogFormat, TStreamId>(x => EqualityComparer<TStreamId>.Default.Equals(x, streamId), _logFormat.Metastreams),
 				_logFormat.Metastreams);
 			await scavenger.Scavenge(alwaysKeepScavenged: true, mergeChunks: false);

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/CollisionDetectorTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/CollisionDetectorTests.cs
@@ -104,6 +104,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 			collisions.Initialize(new SqliteBackend(Fixture.DbConnection));
 
 			var sut = new CollisionDetector<string>(
+				Serilog.Log.Logger,
 				new LruCachingScavengeMap<ulong, string>(
 					"HashUsers",
 					hashes,

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/ScavengeStateBuilder.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/ScavengeStateBuilder.cs
@@ -76,7 +76,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 				maxCount: TFChunkScavenger.MaxThreadCount + 1,
 				factory: () => {
 					var connection = _connectionPool.Get();
-					var sqlite = new SqliteScavengeBackend<TStreamId>();
+					var sqlite = new SqliteScavengeBackend<TStreamId>(Serilog.Log.Logger);
 					sqlite.Initialize(connection);
 
 					var backend = new AdHocScavengeBackendInterceptor<TStreamId>(sqlite);
@@ -112,6 +112,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 				dispose: backend => _connectionPool.Return(map[backend]));
 
 			var scavengeState = new ScavengeState<TStreamId>(
+				Serilog.Log.Logger,
 				_hasher,
 				_metastreamLookup,
 				backendPool,

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteScavengeBackendTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Sqlite/SqliteScavengeBackendTests.cs
@@ -16,14 +16,14 @@ namespace EventStore.Core.XUnit.Tests.Scavenge.Sqlite {
 
 		[Fact]
 		public void should_successfully_enable_features_on_initialization() {
-			var sut = new SqliteScavengeBackend<string>();
+			var sut = new SqliteScavengeBackend<string>(Serilog.Log.Logger);
 			var result = Record.Exception(() => sut.Initialize(Fixture.DbConnection));
 			Assert.Null(result);
 		}
 		
 		[Fact]
 		public void should_initialize_multiple_times_without_error() {
-			var sut = new SqliteScavengeBackend<string>();
+			var sut = new SqliteScavengeBackend<string>(Serilog.Log.Logger);
 			var result = Record.Exception(() => sut.Initialize(Fixture.DbConnection));
 			Assert.Null(result);
 			
@@ -33,7 +33,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge.Sqlite {
 
 		[Fact]
 		public void should_commit_and_read_in_a_transaction_successfully() {
-			var sut = new SqliteScavengeBackend<string>();
+			var sut = new SqliteScavengeBackend<string>(Serilog.Log.Logger);
 			sut.Initialize(Fixture.DbConnection);
 			
 			var add = sut.TransactionFactory.Begin();
@@ -70,7 +70,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge.Sqlite {
 
 		[Fact]
 		public void should_commit_and_read_all_in_a_transaction_successfully() {
-			var sut = new SqliteScavengeBackend<string>();
+			var sut = new SqliteScavengeBackend<string>(Serilog.Log.Logger);
 			sut.Initialize(Fixture.DbConnection);
 			
 			var add = sut.TransactionFactory.Begin();
@@ -104,7 +104,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge.Sqlite {
 		
 		[Fact]
 		public void should_commit_and_delete_in_a_transaction_successfully() {
-			var sut = new SqliteScavengeBackend<string>();
+			var sut = new SqliteScavengeBackend<string>(Serilog.Log.Logger);
 			sut.Initialize(Fixture.DbConnection);
 			
 			var checkpoint = new ScavengeCheckpoint.ExecutingIndex(new ScavengePoint(1,1, DateTime.UtcNow, 1));
@@ -142,7 +142,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge.Sqlite {
 		
 		[Fact]
 		public void should_restore_previous_state_on_rollback() {
-			var sut = new SqliteScavengeBackend<string>();
+			var sut = new SqliteScavengeBackend<string>(Serilog.Log.Logger);
 			sut.Initialize(Fixture.DbConnection);
 
 			// Setup
@@ -180,7 +180,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge.Sqlite {
 			const int collisionStorageCount = 5;
 			const int cacheSizeInBytes = 4 * 1024 * 1024;
 
-			var sut = new SqliteScavengeBackend<string>(cacheSizeInBytes);
+			var sut = new SqliteScavengeBackend<string>(Serilog.Log.Logger, cacheSizeInBytes);
 			sut.Initialize(Fixture.DbConnection);
 
 			var stopwatch = new Stopwatch();
@@ -239,7 +239,7 @@ namespace EventStore.Core.XUnit.Tests.Scavenge.Sqlite {
 			const int collisionStorageCount = 5;
 			const int cacheSizeInBytes = 4 * 1024 * 1024;
 
-			var sut = new SqliteScavengeBackend<string>(cacheSizeInBytes);
+			var sut = new SqliteScavengeBackend<string>(Serilog.Log.Logger, cacheSizeInBytes);
 			sut.Initialize(Fixture.DbConnection);
 
 			var insert = new Stopwatch();

--- a/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
+++ b/src/EventStore.Core/Authorization/LegacyAuthorizationProviderFactory.cs
@@ -64,6 +64,7 @@ namespace EventStore.Core.Authorization {
 			policy.RequireAuthenticated(Operations.Node.Login);
 			policy.AddMatchAnyAssertion(Operations.Node.Scavenge.Start, Grant.Allow, OperationsOrAdmins);
 			policy.AddMatchAnyAssertion(Operations.Node.Scavenge.Stop, Grant.Allow, OperationsOrAdmins);
+			policy.AddMatchAnyAssertion(Operations.Node.Scavenge.Read, Grant.Allow, OperationsOrAdmins);
 
 			var subscriptionAccess =
 				new AndAssertion(

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1393,6 +1393,7 @@ namespace EventStore.Core {
 			// ReSharper disable RedundantTypeArgumentsOfMethod
 			_mainBus.Subscribe<ClientMessage.ScavengeDatabase>(storageScavenger);
 			_mainBus.Subscribe<ClientMessage.StopDatabaseScavenge>(storageScavenger);
+			_mainBus.Subscribe<ClientMessage.GetDatabaseScavenge>(storageScavenger);
 			_mainBus.Subscribe<SystemMessage.StateChangeMessage>(storageScavenger);
 			// ReSharper restore RedundantTypeArgumentsOfMethod
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1244,9 +1244,10 @@ namespace EventStore.Core {
 				// reuse the same buffer; it's quite big.
 				var calculatorBuffer = new Calculator<TStreamId>.Buffer(32_768);
 
-				scavengerFactory = new ScavengerFactory((message, logger) => {
+				scavengerFactory = new ScavengerFactory((message, scavengerLogger, logger) => {
 					// currently on the main queue
 					var throttle = new Throttle(
+						logger: logger,
 						minimumRest: TimeSpan.FromMilliseconds(1000),
 						restLoggingThreshold: TimeSpan.FromMilliseconds(10_000),
 						activePercent: message.ThrottlePercent ?? 100);
@@ -1278,6 +1279,7 @@ namespace EventStore.Core {
 							Log.Information("Opened scavenging database {scavengeDatabase} with version {version}",
 								dbPath, connection.ServerVersion);
 							var sqlite = new SqliteScavengeBackend<TStreamId>(
+								logger: logger,
 								pageSizeInBytes: options.Database.ScavengeBackendPageSize,
 								cacheSizeInBytes: options.Database.ScavengeBackendCacheSize);
 							sqlite.Initialize(connection);
@@ -1286,12 +1288,14 @@ namespace EventStore.Core {
 						dispose: backend => backend.Dispose());
 
 					var state = new ScavengeState<TStreamId>(
+						logger,
 						longHasher,
 						logFormat.Metastreams,
 						backendPool,
 						options.Database.ScavengeHashUsersCacheCapacity);
 
 					var accumulator = new Accumulator<TStreamId>(
+						logger: logger,
 						chunkSize: TFConsts.ChunkSize,
 						metastreamLookup: logFormat.Metastreams,
 						chunkReader: new ChunkReaderForAccumulator<TStreamId>(
@@ -1305,6 +1309,7 @@ namespace EventStore.Core {
 						throttle: throttle);
 
 					var calculator = new Calculator<TStreamId>(
+						logger: logger,
 						new IndexReaderForCalculator<TStreamId>(
 							readIndex,
 							() => new TFReaderLease(readerPool),
@@ -1315,8 +1320,9 @@ namespace EventStore.Core {
 						throttle: throttle);
 
 					var chunkExecutor = new ChunkExecutor<TStreamId, ILogRecord>(
+						logger,
 						logFormat.Metastreams,
-						new ChunkManagerForExecutor<TStreamId>(Db.Manager, Db.Config),
+						new ChunkManagerForExecutor<TStreamId>(logger, Db.Manager, Db.Config),
 						chunkSize: Db.Config.ChunkSize,
 						unsafeIgnoreHardDeletes: options.Database.UnsafeIgnoreHardDelete,
 						cancellationCheckPeriod: cancellationCheckPeriod,
@@ -1324,11 +1330,13 @@ namespace EventStore.Core {
 						throttle: throttle);
 
 					var chunkMerger = new ChunkMerger(
+						logger: logger,
 						mergeChunks: !options.Database.DisableScavengeMerging,
-						backend: new OldScavengeChunkMergerBackend(db: Db),
+						backend: new OldScavengeChunkMergerBackend(logger, db: Db),
 						throttle: throttle);
 
 					var indexExecutor = new IndexExecutor<TStreamId>(
+						logger,
 						new IndexScavenger(tableIndex),
 						new ChunkReaderForIndexExecutor<TStreamId>(() => new TFReaderLease(readerPool)),
 						unsafeIgnoreHardDeletes: options.Database.UnsafeIgnoreHardDelete,
@@ -1336,11 +1344,13 @@ namespace EventStore.Core {
 						throttle: throttle);
 
 					var cleaner = new Cleaner(
+						logger: logger,
 						unsafeIgnoreHardDeletes: options.Database.UnsafeIgnoreHardDelete);
 
-					var scavengePointSource = new ScavengePointSource(ioDispatcher);
+					var scavengePointSource = new ScavengePointSource(logger, ioDispatcher);
 
 					return new Scavenger<TStreamId>(
+						logger: logger,
 						checkPreconditions: () => {
 							tableIndex.Visit(table => {
 								if (table.Version <= PTableVersions.IndexV1)
@@ -1356,7 +1366,7 @@ namespace EventStore.Core {
 						indexExecutor: indexExecutor,
 						cleaner: cleaner,
 						scavengePointSource: scavengePointSource,
-						scavengerLogger: logger,
+						scavengerLogger: scavengerLogger,
 						// threshold < 0: execute all chunks, even those with no weight
 						// threshold = 0: execute all chunks with weight greater than 0
 						// threshold > 0: execute all chunks above a certain weight
@@ -1366,14 +1376,15 @@ namespace EventStore.Core {
 				});
 
 			} else {
-				scavengerFactory = new ScavengerFactory((message, logger) =>
+				scavengerFactory = new ScavengerFactory((message, scavengerLogger, logger) =>
 					new OldScavenger<TStreamId>(
 						alwaysKeepScaveged: options.Database.AlwaysKeepScavenged,
 						mergeChunks: !options.Database.DisableScavengeMerging,
 						startFromChunk: message.StartFromChunk,
 						tfChunkScavenger: new TFChunkScavenger<TStreamId>(
+							logger: logger,
 							db: Db,
-							scavengerLog: logger,
+							scavengerLog: scavengerLogger,
 							tableIndex: tableIndex,
 							readIndex: readIndex,
 							metastreams: logFormat.SystemStreams,

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="EventStore.Plugins" Version="22.10.0" />
+		<PackageReference Include="EventStore.Plugins" Version="22.10.1" />
 		<PackageReference Include="Google.Protobuf" Version="3.21.6" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.49.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.49.1">

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -2041,6 +2041,26 @@ namespace EventStore.Core.Messages {
 			}
 		}
 
+		public class GetDatabaseScavenge : Message {
+			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
+
+			public override int MsgTypeId {
+				get { return TypeId; }
+			}
+
+			public readonly IEnvelope Envelope;
+			public readonly Guid CorrelationId;
+			public readonly ClaimsPrincipal User;
+			public readonly string ScavengeId;
+
+			public GetDatabaseScavenge(IEnvelope envelope, Guid correlationId, ClaimsPrincipal user) {
+				Ensure.NotNull(envelope, "envelope");
+				Envelope = envelope;
+				CorrelationId = correlationId;
+				User = user;
+			}
+		}
+
 		public class ScavengeDatabaseResponse : Message {
 			private static readonly int TypeId = Interlocked.Increment(ref NextMsgId);
 

--- a/src/EventStore.Core/Messages/ScavengeGetResultDto.cs
+++ b/src/EventStore.Core/Messages/ScavengeGetResultDto.cs
@@ -1,0 +1,10 @@
+﻿namespace EventStore.Core.Messages {
+	public class ScavengeGetResultDto {
+		public string ScavengeId { get; set; } = "";
+		public string ScavengeLink { get; set; } = "";
+
+		public override string ToString() =>
+			$"ScavengeId: {ScavengeId}, " +
+			$"ScavengeLink: {ScavengeLink}";
+	}
+}

--- a/src/EventStore.Core/Services/Storage/ScavengerFactory.cs
+++ b/src/EventStore.Core/Services/Storage/ScavengerFactory.cs
@@ -4,20 +4,21 @@ using System.Threading.Tasks;
 using EventStore.Core.Messages;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Scavenging;
+using Serilog;
 
 namespace EventStore.Core.Services.Storage {
 	// The resulting scavenger is used for one continuous run. If it is cancelled or
 	// completed then starting scavenge again will instantiate another scavenger
 	// with a different id.
 	public class ScavengerFactory {
-		private readonly Func<ClientMessage.ScavengeDatabase, ITFChunkScavengerLog, IScavenger> _create;
+		private readonly Func<ClientMessage.ScavengeDatabase, ITFChunkScavengerLog, ILogger, IScavenger> _create;
 
-		public ScavengerFactory(Func<ClientMessage.ScavengeDatabase, ITFChunkScavengerLog, IScavenger> create) {
+		public ScavengerFactory(Func<ClientMessage.ScavengeDatabase, ITFChunkScavengerLog, ILogger, IScavenger> create) {
 			_create = create;
 		}
 
-		public IScavenger Create(ClientMessage.ScavengeDatabase message, ITFChunkScavengerLog logger) =>
-			_create(message, logger);
+		public IScavenger Create(ClientMessage.ScavengeDatabase message, ITFChunkScavengerLog scavengerLogger, ILogger logger) =>
+			_create(message, scavengerLogger, logger);
 	}
 
 	public class OldScavenger<TStreamId> : IScavenger {

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -55,13 +55,14 @@ namespace EventStore.Core.Services.Storage {
 							_currentScavenge.ScavengeId));
 					} else {
 						var tfChunkScavengerLog = _logManager.CreateLog();
+						var logger = Log.ForContext("ScavengeId", tfChunkScavengerLog.ScavengeId);
 
 						_cancellationTokenSource = new CancellationTokenSource();
 
-						_currentScavenge = _scavengerFactory.Create(message, tfChunkScavengerLog);
+						_currentScavenge = _scavengerFactory.Create(message, tfChunkScavengerLog, logger);
 						_currentScavengeTask = _currentScavenge.ScavengeAsync(_cancellationTokenSource.Token);
 
-						HandleCleanupWhenFinished(_currentScavengeTask, _currentScavenge);
+						HandleCleanupWhenFinished(_currentScavengeTask, _currentScavenge, logger);
 
 						message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
 							ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started,
@@ -110,17 +111,17 @@ namespace EventStore.Core.Services.Storage {
 			}
 		}
 
-		private async void HandleCleanupWhenFinished(Task newScavengeTask, IScavenger newScavenge) {
+		private async void HandleCleanupWhenFinished(Task newScavengeTask, IScavenger newScavenge, ILogger logger) {
 			// Clean up the reference to the TfChunkScavenger once it's finished.
 			try {
 				await newScavengeTask.ConfigureAwait(false);
 			} catch (Exception ex) {
-				Log.Error(ex, "SCAVENGING: Unexpected error when scavenging");
+				logger.Error(ex, "SCAVENGING: Unexpected error when scavenging");
 			} finally {
 				try {
 					newScavenge.Dispose();
 				} catch (Exception ex) {
-					Log.Error(ex, "SCAVENGING: Unexpected error when disposing the scavenger");
+					logger.Error(ex, "SCAVENGING: Unexpected error when disposing the scavenger");
 				}
 			}
 

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -16,6 +16,7 @@ namespace EventStore.Core.Services.Storage {
 	public class StorageScavenger :
 		IHandle<ClientMessage.ScavengeDatabase>,
 		IHandle<ClientMessage.StopDatabaseScavenge>,
+		IHandle<ClientMessage.GetDatabaseScavenge>,
 		IHandle<SystemMessage.StateChangeMessage> {
 
 		protected static ILogger Log { get; } = Serilog.Log.ForContext<StorageScavenger>();
@@ -24,6 +25,8 @@ namespace EventStore.Core.Services.Storage {
 		private readonly object _lock = new object();
 
 		private IScavenger _currentScavenge;
+		// invariant: _currentScavenge is not null => _currentScavengeTask is the task of the current scavenge
+		private Task _currentScavengeTask;
 		private CancellationTokenSource _cancellationTokenSource;
 
 		public StorageScavenger(
@@ -55,10 +58,10 @@ namespace EventStore.Core.Services.Storage {
 
 						_cancellationTokenSource = new CancellationTokenSource();
 
-						var newScavenge = _currentScavenge = _scavengerFactory.Create(message, tfChunkScavengerLog);
-						var newScavengeTask = _currentScavenge.ScavengeAsync(_cancellationTokenSource.Token);
+						_currentScavenge = _scavengerFactory.Create(message, tfChunkScavengerLog);
+						_currentScavengeTask = _currentScavenge.ScavengeAsync(_cancellationTokenSource.Token);
 
-						HandleCleanupWhenFinished(newScavengeTask, newScavenge);
+						HandleCleanupWhenFinished(_currentScavengeTask, _currentScavenge);
 
 						message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
 							ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Started,
@@ -71,16 +74,37 @@ namespace EventStore.Core.Services.Storage {
 		public void Handle(ClientMessage.StopDatabaseScavenge message) {
 			if (IsAllowed(message.User, message.CorrelationId, message.Envelope)) {
 				lock (_lock) {
-					if (_currentScavenge != null && _currentScavenge.ScavengeId == message.ScavengeId) {
+					if (_currentScavenge != null &&
+						(_currentScavenge.ScavengeId == message.ScavengeId || message.ScavengeId == "current")) {
 						_cancellationTokenSource.Cancel();
 
-						message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
-							ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Stopped,
-							message.ScavengeId));
+						_currentScavengeTask.ContinueWith(_ => {
+							message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
+								ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Stopped,
+								_currentScavenge.ScavengeId));
+						});
 					} else {
 						message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(message.CorrelationId,
 							ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InvalidScavengeId,
 							_currentScavenge?.ScavengeId));
+					}
+				}
+			}
+		}
+
+		public void Handle(ClientMessage.GetDatabaseScavenge message) {
+			if (IsAllowed(message.User, message.CorrelationId, message.Envelope)) {
+				lock (_lock) {
+					if (_currentScavenge != null) {
+						message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(
+							message.CorrelationId,
+							ClientMessage.ScavengeDatabaseResponse.ScavengeResult.InProgress,
+							_currentScavenge.ScavengeId));
+					} else {
+						message.Envelope.ReplyWith(new ClientMessage.ScavengeDatabaseResponse(
+							message.CorrelationId,
+							ClientMessage.ScavengeDatabaseResponse.ScavengeResult.Stopped,
+							scavengeId: null));
 					}
 				}
 			}

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkManagerForExecutor.cs
@@ -2,13 +2,16 @@
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
+using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
 	public class ChunkManagerForExecutor<TStreamId> : IChunkManagerForChunkExecutor<TStreamId, ILogRecord> {
+		private readonly ILogger _logger;
 		private readonly TFChunkManager _manager;
 		private readonly TFChunkDbConfig _dbConfig;
 
-		public ChunkManagerForExecutor(TFChunkManager manager, TFChunkDbConfig dbConfig) {
+		public ChunkManagerForExecutor(ILogger logger, TFChunkManager manager, TFChunkDbConfig dbConfig) {
+			_logger = logger;
 			_manager = manager;
 			_dbConfig = dbConfig;
 		}
@@ -16,7 +19,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		public IChunkWriterForExecutor<TStreamId, ILogRecord> CreateChunkWriter(
 			IChunkReaderForExecutor<TStreamId, ILogRecord> sourceChunk) {
 
-			return new ChunkWriterForExecutor<TStreamId>(this, _dbConfig, sourceChunk);
+			return new ChunkWriterForExecutor<TStreamId>(_logger, this, _dbConfig, sourceChunk);
 		}
 
 		public IChunkReaderForExecutor<TStreamId, ILogRecord> GetChunkReaderFor(long position) {

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/OldScavengeChunkMergerBackend.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/OldScavengeChunkMergerBackend.cs
@@ -1,11 +1,14 @@
 ﻿using System.Threading;
 using EventStore.Core.TransactionLog.Chunks;
+using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
 	public class OldScavengeChunkMergerBackend : IChunkMergerBackend {
+		private readonly ILogger _logger;
 		private readonly TFChunkDb _db;
 
-		public OldScavengeChunkMergerBackend(TFChunkDb db) {
+		public OldScavengeChunkMergerBackend(ILogger logger, TFChunkDb db) {
+			_logger = logger;
 			_db = db;
 		}
 
@@ -21,6 +24,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			// todo: if time permits we could add some way of checkpointing during the merges
 			// todo: move MergePhase to non-generic TFChunkScavenger
 			TFChunkScavenger<string>.MergePhase(
+				logger: _logger,
 				db: _db,
 				maxChunkDataSize: _db.Config.ChunkSize,
 				scavengerLog: scavengerLogger,

--- a/src/EventStore.Core/TransactionLog/Scavenging/ScavengeState.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/ScavengeState.cs
@@ -15,11 +15,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 	// different data for each so we have two maps. we have one collision detector since
 	// we need to detect collisions between all of the streams.
 	// we don't need to store data for every original stream, only ones that need scavenging.
-	public class ScavengeState {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<ScavengeState>();
-	}
-
-	public class ScavengeState<TStreamId> : ScavengeState, IScavengeState<TStreamId> {
+	public class ScavengeState<TStreamId> : IScavengeState<TStreamId> {
 		private bool _initialized;
 		private IScavengeStateBackend<TStreamId> _backend;
 		private readonly ObjectPool<IScavengeStateBackend<TStreamId>> _backendPool;
@@ -37,15 +33,18 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		private IScavengeMap<Unit, ScavengeCheckpoint> _checkpointStorage;
 		private ITransactionManager _transactionManager;
 
+		private readonly ILogger _logger;
 		private readonly ILongHasher<TStreamId> _hasher;
 		private readonly IMetastreamLookup<TStreamId> _metastreamLookup;
 
 		public ScavengeState(
+			ILogger logger,
 			ILongHasher<TStreamId> hasher,
 			IMetastreamLookup<TStreamId> metastreamLookup,
 			ObjectPool<IScavengeStateBackend<TStreamId>> backendPool,
 			int hashUsersCacheCapacity) {
 
+			_logger = logger;
 			_hasher = hasher;
 			_metastreamLookup = metastreamLookup;
 			_backendPool = backendPool;
@@ -62,6 +61,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			// todo: in log v3 inject an implementation that doesn't store hash users
 			// since there are no collisions.
 			_collisionDetector = new CollisionDetector<TStreamId>(
+				logger: _logger,
 				hashUsers: new LruCachingScavengeMap<ulong, TStreamId>(
 					"HashUsers",
 					_backend.Hashes,
@@ -141,7 +141,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				out var collision);
 
 			if (collisionResult == CollisionResult.NewCollision) {
-				Log.Information(
+				_logger.Information(
 					"SCAVENGING: Detected collision between streams \"{streamId}\" and \"{previous}\"",
 					streamId, collision);
 

--- a/src/EventStore.Core/TransactionLog/Scavenging/Scavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Scavenger.cs
@@ -9,11 +9,8 @@ using EventStore.Core.TransactionLog.Chunks;
 using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
-	public class Scavenger {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<Scavenger>();
-	}
-
-	public class Scavenger<TStreamId> : Scavenger, IScavenger {
+	public class Scavenger<TStreamId> : IScavenger {
+		private readonly ILogger _logger;
 		private readonly Action _checkPreconditions;
 		private readonly IScavengeState<TStreamId> _state;
 		private readonly IAccumulator<TStreamId> _accumulator;
@@ -32,6 +29,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			new Dictionary<string, TimeSpan>();
 
 		public Scavenger(
+			ILogger logger,
 			Action checkPreconditions,
 			IScavengeState<TStreamId> state,
 			IAccumulator<TStreamId> accumulator,
@@ -46,6 +44,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			bool syncOnly,
 			Func<string> getThrottleStats) {
 
+			_logger = logger;
 			_checkPreconditions = checkPreconditions;
 			_state = state;
 			_accumulator = accumulator;
@@ -76,26 +75,28 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			var result = ScavengeResult.Success;
 			string error = null;
 			try {
-				Log.Debug("SCAVENGING: initializing scavenge state.");
+				_logger.Debug("SCAVENGING: Scavenge Initializing State.");
 				_state.Init();
 				_state.LogStats();
-				Log.Debug("SCAVENGING: started scavenging DB.");
+				_logger.Debug("SCAVENGING: Scavenge Started.");
 				LogCollisions();
 
 				_scavengerLogger.ScavengeStarted();
 
 				await RunInternal(_scavengerLogger, stopwatch, cancellationToken).ConfigureAwait(false);
 
-				Log.Debug(
-					"SCAVENGING: total time taken: {elapsed}, total space saved: {spaceSaved}.",
+				_logger.Debug(
+					"SCAVENGING: Scavenge Completed. Total time taken: {elapsed}. Total space saved: {spaceSaved}.",
 					stopwatch.Elapsed, _scavengerLogger.SpaceSaved);
 
 			} catch (OperationCanceledException) {
-				Log.Information("SCAVENGING: Scavenge cancelled.");
+				_logger.Information("SCAVENGING: Scavenge Stopped. Total time taken: {elapsed}.",
+					stopwatch.Elapsed);
 				result = ScavengeResult.Stopped;
 			} catch (Exception exc) {
 				result = ScavengeResult.Failed;
-				Log.Error(exc, "SCAVENGING: error while scavenging DB.");
+				_logger.Error(exc, "SCAVENGING: Scavenge Failed. Total time taken: {elapsed}.",
+					stopwatch.Elapsed);
 				error = string.Format("Error while scavenging DB: {0}.", exc.Message);
 			} finally {
 				try {
@@ -103,7 +104,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					LogCollisions();
 					LogTimes();
 				} catch (Exception ex) {
-					Log.Error(
+					_logger.Error(
 						ex,
 						"SCAVENGING: Error whilst recording scavenge completed. " +
 						"Scavenge result: {result}, Elapsed: {elapsed}, Original error: {e}",
@@ -114,10 +115,10 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 		private void LogCollisions() {
 			var collisions = _state.AllCollisions().ToArray();
-			Log.Debug("SCAVENGING: {count} KNOWN COLLISIONS", collisions.Length);
+			_logger.Debug("SCAVENGING: {count} KNOWN COLLISIONS", collisions.Length);
 
 			foreach (var collision in collisions) {
-				Log.Debug("SCAVENGING: KNOWN COLLISION: \"{collision}\"", collision);
+				_logger.Debug("SCAVENGING: KNOWN COLLISION: \"{collision}\"", collision);
 			}
 		}
 
@@ -141,7 +142,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				// there is no checkpoint, so this is the first scavenge of this scavenge state
 				// (not necessarily the first scavenge of this database, old scavenged may have been run
 				// or new scavenges run and the scavenge state deleted)
-				Log.Debug("SCAVENGING: Starting a new scavenge with no checkpoint");
+				_logger.Debug("SCAVENGING: Started a new scavenge with no checkpoint");
 				await StartNewAsync(
 					prevScavengePoint: null,
 					scavengerLogger,
@@ -150,7 +151,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 			} else if (checkpoint is ScavengeCheckpoint.Done done) {
 				// start of a subsequent scavenge.
-				Log.Debug("SCAVENGING: Starting a new scavenge after checkpoint {checkpoint}", checkpoint);
+				_logger.Debug("SCAVENGING: Started a new scavenge after checkpoint {checkpoint}", checkpoint);
 				await StartNewAsync(
 					prevScavengePoint: done.ScavengePoint,
 					scavengerLogger,
@@ -159,7 +160,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 			} else {
 				// the other cases are continuing an incomplete scavenge
-				Log.Debug("SCAVENGING: Continuing a scavenge from {checkpoint}", checkpoint);
+				_logger.Debug("SCAVENGING: Continuing a scavenge from {checkpoint}", checkpoint);
 
 				if (checkpoint is ScavengeCheckpoint.Accumulating accumulating) {
 					Time(stopwatch, "Accumulation", () =>
@@ -203,19 +204,19 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		}
 
 		private void Time(Stopwatch stopwatch, string name, Action f) {
+			_logger.Debug("SCAVENGING: Scavenge " + name + " Phase Started.");
 			var start = stopwatch.Elapsed;
 			f();
 			var elapsed = stopwatch.Elapsed - start;
 			_state.LogStats();
-			Log.Debug($"SCAVENGING: {_getThrottleStats()}");
-			Log.Debug("SCAVENGING: " + name + " took {elapsed}", elapsed);
-			Log.Debug("");
+			_logger.Debug($"SCAVENGING: {_getThrottleStats()}");
+			_logger.Debug("SCAVENGING: Scavenge " + name + " Phase Completed. Took {elapsed}.", elapsed);
 			_recordedTimes[name] = elapsed;
 		}
 
 		private void LogTimes() {
 			foreach (var key in _recordedTimes.Keys.OrderBy(x => x)) {
-				Log.Debug("SCAVENGING: {name} took {elapsed}", key, _recordedTimes[key]);
+				_logger.Debug("SCAVENGING: {name} took {elapsed}", key, _recordedTimes[key]);
 			}
 		}
 
@@ -235,10 +236,10 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				.ConfigureAwait(false);
 			if (latestScavengePoint == null) {
 				if (_syncOnly) {
-					Log.Debug("SCAVENGING: No existing scavenge point to sync with, nothing to do.");
+					_logger.Debug("SCAVENGING: No existing scavenge point to sync with, nothing to do.");
 					return;
 				} else {
-					Log.Debug("SCAVENGING: creating the first scavenge point.");
+					_logger.Debug("SCAVENGING: Creating the first scavenge point.");
 					// no latest scavenge point, create the first one
 					nextScavengePoint = await _scavengePointSource
 						.AddScavengePointAsync(
@@ -252,19 +253,19 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				if (prevScavengePoint == null ||
 					prevScavengePoint.EventNumber < latestScavengePoint.EventNumber) {
 					// the latest scavengepoint is suitable
-					Log.Debug(
-						"SCAVENGING: using existing scavenge point {scavengePointNumber}",
+					_logger.Debug(
+						"SCAVENGING: Using existing scavenge point {scavengePointNumber}",
 						latestScavengePoint.EventNumber);
 					nextScavengePoint = latestScavengePoint;
 				} else {
 					if (_syncOnly) {
-						Log.Debug("SCAVENGING: No existing scavenge point to sync with, nothing to do.");
+						_logger.Debug("SCAVENGING: No existing scavenge point to sync with, nothing to do.");
 						return;
 					} else {
 						// the latest scavengepoint is the prev scavenge point, so create a new one
 						var expectedVersion = prevScavengePoint.EventNumber;
-						Log.Debug(
-							"SCAVENGING: creating the next scavenge point: {scavengePointNumber}",
+						_logger.Debug(
+							"SCAVENGING: Creating the next scavenge point: {scavengePointNumber}",
 							expectedVersion + 1);
 
 						nextScavengePoint = await _scavengePointSource

--- a/src/EventStore.Core/TransactionLog/Scavenging/Sqlite/SqliteScavengeBackend.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Sqlite/SqliteScavengeBackend.cs
@@ -4,12 +4,8 @@ using Microsoft.Data.Sqlite;
 using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
-	public class SqliteScavengeBackend {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<SqliteScavengeBackend>();
-	}
-
 	// Encapsulates a connection to sqlite, complete with prepared statements and an API to access it
-	public class SqliteScavengeBackend<TStreamId> : SqliteScavengeBackend, IScavengeStateBackend<TStreamId> {
+	public class SqliteScavengeBackend<TStreamId> : IScavengeStateBackend<TStreamId> {
 		// WAL with SYNCHRONOUS NORMAL means that
 		//  - commiting a transaction does not wait to it to flush to disk
 		//  - which is nice and quick, but means in powerloss the last x transactions
@@ -22,6 +18,7 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 
 		private const int DefaultSqliteCacheSize = 2 * 1024 * 1024;
 		private const int DefaultSqlitePageSize = 16 * 1024;
+		private readonly ILogger _logger;
 		private readonly int _pageSizeInBytes;
 		private readonly long _cacheSizeInBytes;
 		private SqliteBackend _sqliteBackend;
@@ -41,10 +38,12 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 		public ITransactionManager TransactionManager { get; private set; }
 
 		public SqliteScavengeBackend(
+			ILogger logger,
 			int pageSizeInBytes = DefaultSqlitePageSize,
 			long cacheSizeInBytes = DefaultSqliteCacheSize) {
 			Ensure.Positive(pageSizeInBytes, nameof(pageSizeInBytes));
 			Ensure.Positive(cacheSizeInBytes, nameof(cacheSizeInBytes));
+			_logger = logger;
 			_pageSizeInBytes = pageSizeInBytes;
 			_cacheSizeInBytes = cacheSizeInBytes;
 		}
@@ -104,7 +103,7 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 		}
 
 		private void ConfigureFeatures() {
-			Log.Debug("SCAVENGING: Setting page size to {pageSize:N0} bytes.", _pageSizeInBytes);
+			_logger.Debug("SCAVENGING: Setting page size to {pageSize:N0} bytes.", _pageSizeInBytes);
 			_sqliteBackend.SetPragmaValue(SqliteBackend.PageSize, _pageSizeInBytes.ToString());
 			var pageSize = int.Parse(_sqliteBackend.GetPragmaValue(SqliteBackend.PageSize));
 			if (pageSize != _pageSizeInBytes) {
@@ -162,7 +161,7 @@ namespace EventStore.Core.TransactionLog.Scavenging.Sqlite {
 		}
 
 		public void LogStats() {
-			Log.Debug($"SCAVENGING: {GetStats().PrettyPrint()}");
+			_logger.Debug($"SCAVENGING: {GetStats().PrettyPrint()}");
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/Accumulator.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/Accumulator.cs
@@ -5,11 +5,8 @@ using EventStore.Core.LogAbstraction;
 using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
-	public class Accumulator {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<Accumulator>();
-	}
-
-	public class Accumulator<TStreamId> : Accumulator, IAccumulator<TStreamId> {
+	public class Accumulator<TStreamId> : IAccumulator<TStreamId> {
+		private readonly ILogger _logger;
 		private readonly int _chunkSize;
 		private readonly IMetastreamLookup<TStreamId> _metastreamLookup;
 		private readonly IChunkReaderForAccumulator<TStreamId> _chunkReader;
@@ -18,6 +15,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		private readonly Throttle _throttle;
 
 		public Accumulator(
+			ILogger logger,
 			int chunkSize,
 			IMetastreamLookup<TStreamId> metastreamLookup,
 			IChunkReaderForAccumulator<TStreamId> chunkReader,
@@ -25,6 +23,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			int cancellationCheckPeriod,
 			Throttle throttle) {
 
+			_logger = logger;
 			_chunkSize = chunkSize;
 			_metastreamLookup = metastreamLookup;
 			_chunkReader = chunkReader;
@@ -40,7 +39,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			IScavengeStateForAccumulator<TStreamId> state,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Starting new scavenge accumulation phase: {prevScavengePoint} to {scavengePoint}",
+			_logger.Debug("SCAVENGING: Started new scavenge accumulation phase: {prevScavengePoint} to {scavengePoint}",
 				prevScavengePoint?.GetName() ?? "beginning of log",
 				scavengePoint.GetName());
 
@@ -65,7 +64,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			IScavengeStateForAccumulator<TStreamId> state,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Accumulating from checkpoint: {checkpoint}", checkpoint);
+			_logger.Debug("SCAVENGING: Accumulating from checkpoint: {checkpoint}", checkpoint);
 			var stopwatch = new Stopwatch();
 
 			// bounds are ok because we wont try to read past the scavenge point
@@ -147,7 +146,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 				var commitElapsed = stopwatch.Elapsed;
 
-				Log.Debug(
+				_logger.Debug(
 					"SCAVENGING: Accumulated {countAccumulatedRecords:N0} records " +
 					"({originals:N0} originals, {metadatas:N0} metadatas, {tombstones:N0} tombstones) " +
 					"in chunk {chunk} in {elapsed}. " +
@@ -166,7 +165,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				return ret;
 			} catch (Exception ex) {
 				if (ex is not OperationCanceledException) {
-					Log.Error(ex, "SCAVENGING: Rolling back");
+					_logger.Error(ex, "SCAVENGING: Rolling back");
 				}
 				// invariant: there is always an open transaction whenever an exception can be thrown
 				transaction.Rollback();
@@ -311,7 +310,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			}
 
 			if (!isInOrder) {
-				Log.Information("SCAVENGING: Accumulator found out of order metadata: {stream}:{eventNumber}",
+				_logger.Information("SCAVENGING: Accumulator found out of order metadata: {stream}:{eventNumber}",
 					record.StreamId,
 					record.EventNumber);
 				return;

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkExecutor.cs
@@ -9,12 +9,8 @@ using EventStore.Core.TransactionLog.Chunks;
 using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
-	public class ChunkExecutor {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<ChunkExecutor>();
-	}
-
-	public class ChunkExecutor<TStreamId, TRecord> : ChunkExecutor, IChunkExecutor<TStreamId> {
-
+	public class ChunkExecutor<TStreamId, TRecord> : IChunkExecutor<TStreamId> {
+		private readonly ILogger _logger;
 		private readonly IMetastreamLookup<TStreamId> _metastreamLookup;
 		private readonly IChunkManagerForChunkExecutor<TStreamId, TRecord> _chunkManager;
 		private readonly long _chunkSize;
@@ -24,6 +20,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		private readonly Throttle _throttle;
 
 		public ChunkExecutor(
+			ILogger logger,
 			IMetastreamLookup<TStreamId> metastreamLookup,
 			IChunkManagerForChunkExecutor<TStreamId, TRecord> chunkManager,
 			long chunkSize,
@@ -32,6 +29,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			int threads,
 			Throttle throttle) {
 
+			_logger = logger;
 			_metastreamLookup = metastreamLookup;
 			_chunkManager = chunkManager;
 			_chunkSize = chunkSize;
@@ -47,7 +45,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			ITFChunkScavengerLog scavengerLogger,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Starting new scavenge chunk execution phase for {scavengePoint}",
+			_logger.Debug("SCAVENGING: Started new scavenge chunk execution phase for {scavengePoint}",
 				scavengePoint.GetName());
 
 			var checkpoint = new ScavengeCheckpoint.ExecutingChunks(
@@ -63,7 +61,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			ITFChunkScavengerLog scavengerLogger,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Executing chunks from checkpoint: {checkpoint}", checkpoint);
+			_logger.Debug("SCAVENGING: Executing chunks from checkpoint: {checkpoint}", checkpoint);
 
 			var startFromChunk = checkpoint?.DoneLogicalChunkNumber + 1 ?? 0;
 			var scavengePoint = checkpoint.ScavengePoint;
@@ -116,8 +114,8 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 								physicalChunk.ChunkStartNumber,
 								physicalChunk.ChunkEndNumber);
 						} else {
-							Log.Debug(
-								"SCAVENGING: skipped physical chunk: {oldChunkName} " +
+							_logger.Debug(
+								"SCAVENGING: Skipped physical chunk: {oldChunkName} " +
 								"with weight {physicalWeight:N0}. ",
 								physicalChunk.Name,
 								physicalWeight);
@@ -186,8 +184,8 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			long chunkEndPos = sourceChunk.ChunkEndPosition;
 			var oldChunkName = sourceChunk.Name;
 
-			Log.Debug(
-				"SCAVENGING: started to scavenge physical chunk: {oldChunkName} " +
+			_logger.Debug(
+				"SCAVENGING: Started to scavenge physical chunk: {oldChunkName} " +
 				"with weight {physicalWeight:N0}. " +
 				"{chunkStartNumber} => {chunkEndNumber} ({chunkStartPosition} => {chunkEndPosition})",
 				oldChunkName,
@@ -197,12 +195,12 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			IChunkWriterForExecutor<TStreamId, TRecord> outputChunk;
 			try {
 				outputChunk = _chunkManager.CreateChunkWriter(sourceChunk);
-				Log.Debug(
+				_logger.Debug(
 					"SCAVENGING: Resulting temp chunk file: {tmpChunkPath}.", 
 					Path.GetFileName(outputChunk.FileName));
 
 			} catch (IOException ex) {
-				Log.Error(ex,
+				_logger.Error(ex,
 					"IOException during creating new chunk for scavenging purposes. " +
 					"Stopping scavenging process...");
 				throw;
@@ -236,7 +234,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					}
 				}
 
-				Log.Debug(
+				_logger.Debug(
 					"SCAVENGING: Scavenging {oldChunkName} traversed {recordsCount:N0}. " +
 					" Kept {keptCount:N0}. Discarded {discardedCount:N0}",
 					oldChunkName, discardedCount + keptCount,
@@ -245,7 +243,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				outputChunk.Complete(out var newFileName, out var newFileSize);
 
 				var elapsed = sw.Elapsed;
-				Log.Debug(
+				_logger.Debug(
 					"SCAVENGING: Scavenging of chunks:"
 					+ "\n{oldChunkName}"
 					+ "\ncompleted in {elapsed}."
@@ -261,7 +259,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				scavengerLogger.ChunksScavenged(chunkStartNumber, chunkEndNumber, elapsed, spaceSaved);
 
 			} catch (FileBeingDeletedException exc) {
-				Log.Information(
+				_logger.Information(
 					"SCAVENGING: Got FileBeingDeletedException exception during scavenging, that probably means some chunks were re-replicated."
 					+ "\nStopping scavenging and removing temp chunk '{tmpChunkPath}'..."
 					+ "\nException message: {e}.",
@@ -272,12 +270,12 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				throw;
 
 			} catch (OperationCanceledException) {
-				Log.Information("SCAVENGING: Cancelled at: {oldChunkName}", oldChunkName);
+				_logger.Information("SCAVENGING: Cancelled at: {oldChunkName}", oldChunkName);
 				outputChunk.Abort(deleteImmediately: false);
 				throw;
 
 			} catch (Exception ex) {
-				Log.Information(
+				_logger.Information(
 					ex,
 					"SCAVENGING: Got exception while scavenging chunk: #{chunkStartNumber}-{chunkEndNumber}.",
 					chunkStartNumber, chunkEndNumber);
@@ -334,7 +332,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			if (details.IsTombstoned) {
 				if (_unsafeIgnoreHardDeletes) {
 					// remove _everything_ for metadata and original streams
-					Log.Information(
+					_logger.Information(
 						"SCAVENGING: Removing hard deleted stream tombstone for stream {stream} at position {transactionPosition}",
 						record.StreamId, record.LogPosition);
 					return true;

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkMerger.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/ChunkMerger.cs
@@ -4,17 +4,18 @@ using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
 	public class ChunkMerger : IChunkMerger {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<ChunkMerger>();
-
+		private readonly ILogger _logger;
 		private readonly bool _mergeChunks;
 		private readonly IChunkMergerBackend _backend;
 		private readonly Throttle _throttle;
 
 		public ChunkMerger(
+			ILogger logger,
 			bool mergeChunks,
 			IChunkMergerBackend backend,
 			Throttle throttle) {
 
+			_logger = logger;
 			_mergeChunks = mergeChunks;
 			_backend = backend;
 			_throttle = throttle;
@@ -26,7 +27,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			ITFChunkScavengerLog scavengerLogger,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Starting new scavenge chunk merging phase for {scavengePoint}",
+			_logger.Debug("SCAVENGING: Started new scavenge chunk merging phase for {scavengePoint}",
 				scavengePoint.GetName());
 
 			var checkpoint = new ScavengeCheckpoint.MergingChunks(scavengePoint);
@@ -41,10 +42,10 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			CancellationToken cancellationToken) {
 
 			if (_mergeChunks) {
-				Log.Debug("SCAVENGING: Merging chunks from checkpoint: {checkpoint}", checkpoint);
+				_logger.Debug("SCAVENGING: Merging chunks from checkpoint: {checkpoint}", checkpoint);
 				_backend.MergeChunks(scavengerLogger, _throttle, cancellationToken);
 			} else {
-				Log.Debug("SCAVENGING: Merging chunks is disabled");
+				_logger.Debug("SCAVENGING: Merging chunks is disabled");
 			}
 		}
 	}

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/Cleaner.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/Cleaner.cs
@@ -4,12 +4,13 @@ using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
 	public class Cleaner : ICleaner {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<Cleaner>();
-
+		private readonly ILogger _logger;
 		private readonly bool _unsafeIgnoreHardDeletes;
 
 		public Cleaner(
+			ILogger logger,
 			bool unsafeIgnoreHardDeletes) {
+			_logger = logger;
 			_unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
 		}
 
@@ -18,7 +19,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			IScavengeStateForCleaner state,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Starting new scavenge clean up phase for {scavengePoint}",
+			_logger.Debug("SCAVENGING: Started new scavenge clean up phase for {scavengePoint}",
 				scavengePoint.GetName());
 
 			var checkpoint = new ScavengeCheckpoint.Cleaning(scavengePoint);
@@ -31,7 +32,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			IScavengeStateForCleaner state,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Cleaning checkpoint: {checkpoint}", checkpoint);
+			_logger.Debug("SCAVENGING: Cleaning checkpoint: {checkpoint}", checkpoint);
 
 			cancellationToken.ThrowIfCancellationRequested();
 
@@ -55,12 +56,12 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			if (state.AllChunksExecuted()) {
 				// Now we know we have successfully executed every chunk with weight.
 
-				Log.Debug("SCAVENGING: Deleting metastream data");
+				_logger.Debug("SCAVENGING: Deleting metastream data");
 				state.DeleteMetastreamData();
 
 				cancellationToken.ThrowIfCancellationRequested();
 
-				Log.Debug("SCAVENGING: Deleting originalstream data. Deleting archived: {deleteArchived}",
+				_logger.Debug("SCAVENGING: Deleting originalstream data. Deleting archived: {deleteArchived}",
 					_unsafeIgnoreHardDeletes);
 				state.DeleteOriginalStreamData(deleteArchived: _unsafeIgnoreHardDeletes);
 
@@ -74,7 +75,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					throw new Exception(
 						"UnsafeIgnoreHardDeletes is true but not all chunks have been executed");
 				} else {
-					Log.Debug("SCAVENGING: Skipping cleanup because some chunks have not been executed");
+					_logger.Debug("SCAVENGING: Skipping cleanup because some chunks have not been executed");
 				}
 			}
 		}

--- a/src/EventStore.Core/TransactionLog/Scavenging/Stages/IndexExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Stages/IndexExecutor.cs
@@ -4,11 +4,8 @@ using EventStore.Core.Index;
 using Serilog;
 
 namespace EventStore.Core.TransactionLog.Scavenging {
-	public class IndexExecutor {
-		protected static readonly ILogger Log = Serilog.Log.ForContext<IndexExecutor>();
-	}
-
-	public class IndexExecutor<TStreamId> : IndexExecutor, IIndexExecutor<TStreamId> {
+	public class IndexExecutor<TStreamId> : IIndexExecutor<TStreamId> {
+		private readonly ILogger _logger;
 		private readonly IIndexScavenger _indexScavenger;
 		private readonly IChunkReaderForIndexExecutor<TStreamId> _streamLookup;
 		private readonly bool _unsafeIgnoreHardDeletes;
@@ -16,12 +13,14 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 		private readonly Throttle _throttle;
 
 		public IndexExecutor(
+			ILogger logger,
 			IIndexScavenger indexScavenger,
 			IChunkReaderForIndexExecutor<TStreamId> streamLookup,
 			bool unsafeIgnoreHardDeletes,
 			int restPeriod,
 			Throttle throttle) {
 
+			_logger = logger;
 			_indexScavenger = indexScavenger;
 			_streamLookup = streamLookup;
 			_unsafeIgnoreHardDeletes = unsafeIgnoreHardDeletes;
@@ -35,7 +34,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			IIndexScavengerLog scavengerLogger,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Starting new scavenge index execution phase for {scavengePoint}",
+			_logger.Debug("SCAVENGING: Started new scavenge index execution phase for {scavengePoint}",
 				scavengePoint.GetName());
 
 			var checkpoint = new ScavengeCheckpoint.ExecutingIndex(scavengePoint);
@@ -49,7 +48,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			IIndexScavengerLog scavengerLogger,
 			CancellationToken cancellationToken) {
 
-			Log.Debug("SCAVENGING: Executing indexes from checkpoint: {checkpoint}", checkpoint);
+			_logger.Debug("SCAVENGING: Executing indexes from checkpoint: {checkpoint}", checkpoint);
 
 			_indexScavenger.ScavengeIndex(
 				scavengePoint: checkpoint.ScavengePoint.Position,
@@ -148,7 +147,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 							// probably this isn't possible
 						}
 
-						Log.Debug(
+						_logger.Debug(
 							"SCAVENGING: Found out of order index entry. " +
 							"Stream \"{stream}\" has index entry {indexEntry} but " +
 							"previously saw index entry with position {previousPosition}.",

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -13,7 +13,7 @@
 	<ItemGroup>
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
 		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="22.0.0" />
-		<PackageReference Include="EventStore.Plugins" Version="22.10.0" />
+		<PackageReference Include="EventStore.Plugins" Version="22.10.1" />
 		<PackageReference Include="Google.Protobuf" Version="3.21.6" />
 		<PackageReference Include="Grpc.Net.Client" Version="2.49.0" />
 		<PackageReference Include="Grpc.Tools" Version="2.49.1">


### PR DESCRIPTION
Added: Improvements to Scavenge HTTP API (query if scavenge is running, stop any running scavenge)
Added: ScavengeId to log context

HTTP API:
- `GET` the current scavenge (id and link for deleting) if any, from `/admin/scavenge/current`
- `DELETE` `/admin/scavenge/current` to stop the current scavenge regardless of its id.
- Stopping a scavenge now waits for the scavenge to stop before responding to the request

Logging:
- Add `ScavengeId` to the log context