### PR TITLE
Backport additional fixes to 21.10

### DIFF
--- a/src/EventStore.Core/Messages/MergeIndexesResultDto.cs
+++ b/src/EventStore.Core/Messages/MergeIndexesResultDto.cs
@@ -8,5 +8,6 @@
 		public MergeIndexesResultDto(string mergeIndexesId) {
 			MergeIndexesId = mergeIndexesId;
 		}
+		public override string ToString() => $"MergeIndexesId: {MergeIndexesId}";
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -69,13 +69,14 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 
 		public static RpcException WrongExpectedVersion(
+			string operation,
 			string streamName,
 			long expectedVersion,
 			long? actualVersion = default) =>
 			new(
 				new Status(
 					StatusCode.FailedPrecondition,
-					$"Append failed due to WrongExpectedVersion. Stream: {streamName}, Expected version: {expectedVersion}, Actual version: {actualVersion}"),
+					$"{operation} failed due to WrongExpectedVersion. Stream: {streamName}, Expected version: {expectedVersion}, Actual version: {actualVersion}"),
 				new Metadata {
 					{Constants.Exceptions.ExceptionKey, Constants.Exceptions.WrongExpectedVersion},
 					{Constants.Exceptions.StreamName, streamName},

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -132,8 +132,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						deleteResponseSource.TrySetException(RpcExceptions.Timeout(completed.Message));
 						return;
 					case OperationResult.WrongExpectedVersion:
-						deleteResponseSource.TrySetException(RpcExceptions.WrongExpectedVersion(streamName,
-							expectedVersion, completed.CurrentVersion));
+						deleteResponseSource.TrySetException(RpcExceptions.WrongExpectedVersion("Delete",
+							streamName, expectedVersion, completed.CurrentVersion));
 						return;
 					case OperationResult.StreamDeleted:
 						deleteResponseSource.TrySetException(RpcExceptions.StreamDeleted(streamName));


### PR DESCRIPTION
Fixed: Make MergeIndexes endpoint return proper result.
Fixed: Incorrect error message when deleting a stream using gRPC.
Fixed: https://github.com/EventStore/EventStore/issues/3512 duplicate PS in the EventStoreDB UI

Cherry-picks the following PRs to 21.10:
- https://github.com/EventStore/EventStore/pull/3573
- https://github.com/EventStore/EventStore/pull/3583
- https://github.com/EventStore/EventStore/pull/3533