### PR TITLE
No longer EXPOSE port 2112 in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ IntIp: 0.0.0.0" >> /etc/eventstore/eventstore.conf
 
 VOLUME /var/lib/eventstore /var/log/eventstore
 
-EXPOSE 1112/tcp 1113/tcp 2112/tcp 2113/tcp
+EXPOSE 1112/tcp 1113/tcp 2113/tcp
 
 HEALTHCHECK --interval=5s --timeout=5s --retries=24 \
     CMD curl --fail --insecure https://localhost:2113/health/live || curl --fail http://localhost:2113/health/live || exit 1


### PR DESCRIPTION
It used to be used for internal http but is no longer needed.