### PR TITLE
TFChunk disposal synchronization improvements

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -934,6 +934,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 		public bool TryClose() {
 			_selfdestructin54321 = true;
+
+			Thread.MemoryBarrier();
+
 			bool closed = true;
 			closed &= TryDestructFileStreams();
 			closed &= TryDestructMemStreams();
@@ -943,6 +946,9 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 		public void MarkForDeletion() {
 			_selfdestructin54321 = true;
 			_deleteFile = true;
+
+			Thread.MemoryBarrier();
+
 			TryDestructFileStreams();
 			TryDestructMemStreams();
 		}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -354,6 +354,10 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 		private void CreateReaderStreams() {
 			Interlocked.Add(ref _fileStreamCount, _internalStreamsCount);
+
+			// should never happen in practice because this function is called from the static TFChunk constructors
+			Debug.Assert(!_selfdestructin54321);
+
 			for (int i = 0; i < _internalStreamsCount; i++) {
 				_fileStreams.Enqueue(CreateInternalReaderWorkItem());
 			}
@@ -403,6 +407,10 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 			// READER STREAMS
 			Interlocked.Add(ref _memStreamCount, _maxReaderCount);
+
+			// should never happen in practice because this function is called from the static TFChunk constructors
+			Debug.Assert(!_selfdestructin54321);
+
 			for (int i = 0; i < _maxReaderCount; i++) {
 				var stream = new UnmanagedMemoryStream((byte*)_cachedData, _cachedLength);
 				var reader = new BinaryReader(stream);


### PR DESCRIPTION
Fixed: Improved synchronization during TFChunk disposal

These are some small synchronization issues I've found in TFChunk disposal while implementing https://github.com/EventStore/EventStore/pull/3669

The most important one, which might have an impact in practice, is: b91a6c432fb68777603044d013ee169fa6657c13. From my understanding, writing to a `volatile` variable is equivalent to adding a barrier before the write ("release semantics" - https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/language-specification/classes#1454-volatile-fields), not after it.

Regarding 7f2ecca1048a30cd5df0205bf639217e7c40d70d, cleaning up twice may not actually have an impact in practice but the change makes the code more correct. A simpler alternative could be to make sure that CleanUpFileStreamDestruction() and FreeCachedData() are idempotent but it would require explaining it clearly in the comments.

39a9a9138d6a87356e7701204e7bcdcc19f751e5 does not have a big impact in practice since:
1. it applies only to mem db
2. the call to TFChunk.CompleteScavenge() and TFChunk.Dispose()/TryClose() are probably mutually exclusive in practice

but i added the change mainly for the sake of completeness.