### PR TITLE
[release/oss-v20.10] Bump NewtonSoft to 13.0.2

### DIFF
--- a/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
+++ b/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
+++ b/src/EventStore.ClientAPI.Embedded/EventStore.ClientAPI.Embedded.csproj
@@ -42,7 +42,7 @@
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
 		<PackageReference Include="protobuf-net" Version="2.4.0" />
 		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
-		<PackageReference Include="newtonsoft.json" Version="13.0.1" />
+		<PackageReference Include="newtonsoft.json" Version="13.0.2" />
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.57" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />

--- a/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
+++ b/src/EventStore.ClientAPI/EventStore.ClientAPI.csproj
@@ -21,7 +21,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageReference Include="protobuf-net" Version="2.4.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -17,7 +17,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.5" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="3.1.5" />
 		<PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="3.1.5" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageReference Include="Serilog" Version="2.10.0" />
 		<PackageReference Include="Serilog.Enrichers.Process" Version="2.0.1" />
 		<PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -12,7 +12,7 @@
 		<Compile Remove="Playground\LaunchpadBase.cs" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -14,7 +14,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />


### PR DESCRIPTION
Fixed: Patch Newtonsoft from 13.0.1 to 13.0.2

Cherry picked from https://github.com/EventStore/EventStore/pull/3677