### PR TITLE
[Backport 22.10] Out of space fix

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
@@ -1,0 +1,92 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
+using EventStore.Core.TransactionLog.LogRecords;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.TransactionLog {
+	[TestFixture(typeof(LogFormat.V2), typeof(string))]
+	[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+	public class when_closing_the_database<TLogFormat, TStreamId> : SpecificationWithDirectory {
+
+		private TFChunkDb _db;
+
+		private static void CreateChunk(string path, int size) {
+			var chunkHeader = new ChunkHeader(TFChunk.CurrentChunkVersion, size, 0, 0, false, Guid.NewGuid());
+			var chunkBytes = chunkHeader.AsByteArray();
+			var buf = new byte[ChunkHeader.Size + ChunkFooter.Size + chunkHeader.ChunkSize];
+			Buffer.BlockCopy(chunkBytes, 0, buf, 0, chunkBytes.Length);
+			File.WriteAllBytes(path, buf);
+		}
+
+		private static IPrepareLogRecord<TStreamId> CreateRecord() {
+			var recordFactory = LogFormatHelper<TLogFormat, TStreamId>.RecordFactory;
+			var streamId = LogFormatHelper<TLogFormat, TStreamId>.StreamId;
+			var eventTypeId = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
+
+			return LogRecord.Prepare(
+				factory: recordFactory,
+				logPosition: 0,
+				correlationId: Guid.NewGuid(),
+				eventId: Guid.NewGuid(),
+				transactionPos: 0,
+				transactionOffset: 0,
+				eventStreamId: streamId,
+				expectedVersion: -1,
+				timeStamp: new DateTime(2012, 12, 21),
+				flags: PrepareFlags.SingleWrite,
+				eventType: eventTypeId,
+				data: new byte[123],
+				metadata: new byte[] {0x13, 0x37});
+		}
+
+		private static ICheckpoint OpenCheckpoint(string path) =>
+			new FileCheckpoint(path, Path.GetFileName(path));
+
+		[SetUp]
+		public override Task SetUp() {
+			base.SetUp();
+
+			CreateChunk(GetFilePathFor("chunk-000000.000000"), 10_000);
+
+			_db = new TFChunkDb(TFChunkHelper.CreateDbConfig(
+				PathName,
+				OpenCheckpoint(GetFilePathFor("writer.chk")),
+				OpenCheckpoint(GetFilePathFor("chaser.chk")),
+				10_000));
+			_db.Open();
+
+			return Task.CompletedTask;
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		public void checkpoints_should_be_flushed_only_when_chunks_are_properly_closed(bool chunksClosed) {
+			if (!chunksClosed) {
+				// acquire a reader to prevent the chunk from being properly closed
+				_db.Manager.GetChunk(0).AcquireReader();
+			}
+
+			var writer = new TFChunkWriter(_db);
+			Assert.IsTrue(writer.Write(CreateRecord(), out _));
+			_db.Config.ChaserCheckpoint.Write(_db.Config.WriterCheckpoint.ReadNonFlushed());
+
+			_db.Close();
+
+			// reopen the checkpoints
+			var writerChk = OpenCheckpoint(GetFilePathFor("writer.chk"));
+			var chaserChk = OpenCheckpoint(GetFilePathFor("chaser.chk"));
+
+			if (chunksClosed) {
+				Assert.Greater(writerChk.Read(), 0L);
+				Assert.Greater(chaserChk.Read(), 0L);
+			} else {
+				Assert.AreEqual(0L, writerChk.Read());
+				Assert.AreEqual(0L, chaserChk.Read());
+			}
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_file_checkpoints.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_file_checkpoints.cs
@@ -9,12 +9,11 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void mem_mapped_file_checkpoint_can_be_read_as_file_checkpoint() {
 			var memoryMapped = new MemoryMappedFileCheckpoint(Filename);
 			memoryMapped.Write(0xDEAD);
-			memoryMapped.Flush();
-			memoryMapped.Dispose();
+			memoryMapped.Close(flush: true);
 
 			var fileCheckpoint = new FileCheckpoint(Filename);
 			var read = fileCheckpoint.Read();
-			fileCheckpoint.Dispose();
+			fileCheckpoint.Close(flush: true);
 			Assert.AreEqual(0xDEAD, read);
 		}
 
@@ -22,12 +21,11 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void file_checkpoint_can_be_read_as_mem_mapped_file_checkpoint() {
 			var fileCheckpoint = new FileCheckpoint(Filename);
 			fileCheckpoint.Write(0xDEAD);
-			fileCheckpoint.Flush();
-			fileCheckpoint.Dispose();
+			fileCheckpoint.Close(flush: true);
 
 			var memoryMapped = new MemoryMappedFileCheckpoint(Filename);
 			var read = memoryMapped.Read();
-			memoryMapped.Dispose();
+			memoryMapped.Close(flush: true);
 			Assert.AreEqual(0xDEAD, read);
 		}
 	}

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_a_file_checksum_to_a_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_a_file_checksum_to_a_file.cs
@@ -16,7 +16,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void name_is_set() {
 			var checksum = new FileCheckpoint(HelperExtensions.GetFilePathFromAssembly("filename"), "test");
 			Assert.AreEqual("test", checksum.Name);
-			checksum.Close();
+			checksum.Close(flush: true);
 		}
 
 		[Test]
@@ -25,7 +25,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			checkSum.Write(0xDEAD);
 			checkSum.Flush();
 			var read = checkSum.Read();
-			checkSum.Close();
+			checkSum.Close(flush: true);
 			Assert.AreEqual(0xDEAD, read);
 		}
 
@@ -33,10 +33,10 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void can_read_existing_checksum() {
 			var checksum = new FileCheckpoint(Filename);
 			checksum.Write(0xDEAD);
-			checksum.Close();
+			checksum.Close(flush: true);
 			checksum = new FileCheckpoint(Filename);
 			var val = checksum.Read();
-			checksum.Close();
+			checksum.Close(flush: true);
 			Assert.AreEqual(0xDEAD, val);
 		}
 
@@ -47,8 +47,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 			checkSum.Write(1011);
 			await Task.Delay(200);
 			Assert.AreEqual(0, readChecksum.Read());
-			checkSum.Close();
-			readChecksum.Close();
+			checkSum.Close(flush: true);
+			readChecksum.Close(flush: true);
 		}
 
 		[Test]
@@ -58,8 +58,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 			checkSum.Write(1011);
 			checkSum.Flush();
 			Assert.AreEqual(1011, readChecksum.Read());
-			checkSum.Close();
-			readChecksum.Close();
+			checkSum.Close(flush: true);
+			readChecksum.Close(flush: true);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_a_memorymappedpoint_to_a_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_a_memorymappedpoint_to_a_file.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void name_is_set() {
 			var checksum = new MemoryMappedFileCheckpoint(Filename, "test", false);
 			Assert.AreEqual("test", checksum.Name);
-			checksum.Close();
+			checksum.Close(flush: true);
 		}
 
 		[Test]
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			checkSum.Write(0xDEAD);
 			checkSum.Flush();
 			var read = checkSum.Read();
-			checkSum.Close();
+			checkSum.Close(flush: true);
 			Assert.AreEqual(0xDEAD, read);
 		}
 
@@ -41,10 +41,10 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public void can_read_existing_checksum() {
 			var checksum = new MemoryMappedFileCheckpoint(Filename);
 			checksum.Write(0xDEAD);
-			checksum.Close();
+			checksum.Close(flush: true);
 			checksum = new MemoryMappedFileCheckpoint(Filename);
 			var val = checksum.Read();
-			checksum.Close();
+			checksum.Close(flush: true);
 			Assert.AreEqual(0xDEAD, val);
 		}
 
@@ -55,8 +55,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 			checkSum.Write(1011);
 			await Task.Delay(200);
 			Assert.AreEqual(0, readChecksum.Read());
-			checkSum.Close();
-			readChecksum.Close();
+			checkSum.Close(flush: true);
+			readChecksum.Close(flush: true);
 		}
 
 		[Test]
@@ -66,8 +66,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 			checkSum.Write(1011);
 			checkSum.Flush();
 			Assert.AreEqual(1011, readChecksum.Read());
-			checkSum.Close();
-			readChecksum.Close();
+			checkSum.Close(flush: true);
+			readChecksum.Close(flush: true);
 			await Task.Delay(100);
 		}
 	}

--- a/src/EventStore.Core.XUnit.Tests/Helpers/FakeDisposable.cs
+++ b/src/EventStore.Core.XUnit.Tests/Helpers/FakeDisposable.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace EventStore.Core.XUnit.Tests.Helpers {
+	public class FakeDisposable: IDisposable {
+		private readonly Action _disposeAction;
+
+		public FakeDisposable(Action disposeAction) {
+			_disposeAction = disposeAction;
+		}
+
+		public void Dispose() => _disposeAction?.Invoke();
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/LogAbstraction/Common/StreamExistenceFilterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogAbstraction/Common/StreamExistenceFilterTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using EventStore.Core.LogAbstraction;
 using EventStore.Core.LogAbstraction.Common;
 using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.XUnit.Tests.Helpers;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.LogAbstraction.Common {
@@ -37,7 +38,7 @@ namespace EventStore.Core.XUnit.Tests.LogAbstraction.Common {
 				checkpointInterval: checkpointInterval.Value,
 				checkpointDelay: TimeSpan.Zero,
 				hasher: useHasher ? Hasher : null);
-			DisposeLater(checkpoint);
+			DisposeLater(new FakeDisposable(() => checkpoint.Close(flush: true)));
 			DisposeLater(filter);
 			return filter;
 		}

--- a/src/EventStore.Core/TransactionLog/Checkpoint/FileCheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/FileCheckpoint.cs
@@ -47,8 +47,10 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 			return _reader.ReadInt64();
 		}
 
-		public void Close() {
-			Flush();
+		public void Close(bool flush) {
+			if (flush)
+				Flush();
+
 			_reader.Close();
 			_writer.Close();
 			_fileStream.Close();
@@ -86,10 +88,6 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 		}
 
 		public event Action<long> Flushed;
-
-		public void Dispose() {
-			Close();
-		}
 
 		protected virtual void OnFlushed(long obj) {
 			var onFlushed = Flushed;

--- a/src/EventStore.Core/TransactionLog/Checkpoint/ICheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/ICheckpoint.cs
@@ -1,10 +1,10 @@
 using System;
 
 namespace EventStore.Core.TransactionLog.Checkpoint {
-	public interface ICheckpoint : IReadOnlyCheckpoint, IDisposable {
+	public interface ICheckpoint : IReadOnlyCheckpoint {
 		void Write(long checkpoint);
 		void Flush();
-		void Close();
+		void Close(bool flush);
 		IReadOnlyCheckpoint AsReadOnly() => this;
 	}
 

--- a/src/EventStore.Core/TransactionLog/Checkpoint/InMemoryCheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/InMemoryCheckpoint.cs
@@ -53,12 +53,9 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 				onFlushed.Invoke(obj);
 		}
 
-		public void Close() {
-			//NOOP
-		}
-
-		public void Dispose() {
-			//NOOP
+		public void Close(bool flush) {
+			if (flush)
+				Flush();
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Checkpoint/MemoryMappedFileCheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/MemoryMappedFileCheckpoint.cs
@@ -49,8 +49,9 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 			}
 		}
 
-		public void Close() {
-			Flush();
+		public void Close(bool flush) {
+			if (flush)
+				Flush();
 			_accessor.Dispose();
 			_file.Dispose();
 		}
@@ -92,10 +93,6 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 			var onFlushed = Flushed;
 			if (onFlushed != null)
 				onFlushed.Invoke(obj);
-		}
-
-		public void Dispose() {
-			Close();
 		}
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/TFChunk.cs
@@ -930,10 +930,14 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			writerWorkItem.Dispose();
 		}
 
-		public void Dispose() {
+		public void Dispose() => TryClose();
+
+		public bool TryClose() {
 			_selfdestructin54321 = true;
-			TryDestructFileStreams();
-			TryDestructMemStreams();
+			bool closed = true;
+			closed &= TryDestructFileStreams();
+			closed &= TryDestructMemStreams();
+			return closed;
 		}
 
 		public void MarkForDeletion() {
@@ -943,8 +947,8 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			TryDestructMemStreams();
 		}
 
-		private void TryDestructFileStreams() {
-			int fileStreamCount = int.MaxValue;
+		private bool TryDestructFileStreams() {
+			int fileStreamCount = Interlocked.CompareExchange(ref _fileStreamCount, 0, 0);
 
 			ReaderWorkItem workItem;
 			while (_fileStreams.TryDequeue(out workItem)) {
@@ -954,8 +958,13 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 
 			if (fileStreamCount < 0)
 				throw new Exception("Count of file streams reduced below zero.");
-			if (fileStreamCount == 0) // we are the last who should "turn the light off" for file streams
+
+			if (fileStreamCount == 0) { // we are the last who should "turn the light off" for file streams
 				CleanUpFileStreamDestruction();
+				return true;
+			}
+
+			return false;
 		}
 
 		private void CleanUpFileStreamDestruction() {
@@ -984,7 +993,7 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			if (writerWorkItem != null)
 				writerWorkItem.DisposeMemStream();
 
-			int memStreamCount = int.MaxValue;
+			int memStreamCount = Interlocked.CompareExchange(ref _memStreamCount, 0, 0);
 
 			ReaderWorkItem workItem;
 			while (_memStreams.TryDequeue(out workItem)) {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -13,6 +13,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		public readonly TFChunkManager Manager;
 
 		private readonly ILogger _log;
+		private int _closed;
 
 		public TFChunkDb(TFChunkDbConfig config, ILogger log = null) {
 			Ensure.NotNull(config, "config");
@@ -292,6 +293,9 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		}
 
 		public void Close() {
+			if (Interlocked.CompareExchange(ref _closed, 1, 0) != 0)
+				return;
+
 			Manager?.Dispose();
 			Config.WriterCheckpoint.Close();
 			Config.ChaserCheckpoint.Close();

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using ILogger = Serilog.ILogger;
 
 namespace EventStore.Core.TransactionLog.Chunks {
-	public class TFChunkManager : IDisposable {
+	public class TFChunkManager {
 		private static readonly ILogger Log = Serilog.Log.ForContext<TFChunkManager>();
 
 		public const int MaxChunksCount = 400_000; 
@@ -317,13 +317,16 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			return _chunks != null ? _chunks.FirstOrDefault(c => c != null && c.FileName == path) : null;
 		}
 
-		public void Dispose() {
+		public bool TryClose() {
+			var allChunksClosed = true;
 			lock (_chunksLocker) {
 				for (int i = 0; i < _chunksCount; ++i) {
 					if (_chunks[i] != null)
-						_chunks[i].Dispose();
+						allChunksClosed &= _chunks[i].TryClose();
 				}
 			}
+
+			return allChunksClosed;
 		}
 	}
 }


### PR DESCRIPTION
Fixed: Database checkpoints becomes inconsistent when running out of disk space

Backport of https://github.com/EventStore/EventStore/pull/3669