### PR TITLE
Add first Meter and Metric: Checkpoints

### DIFF
--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.Composition;
 using System.ComponentModel.Composition.Hosting;
 using System.IO;
 using System.Threading;
+using EventStore.Common.Configuration;
 using EventStore.Common.Exceptions;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
@@ -34,7 +35,11 @@ namespace EventStore.ClusterNode {
 
 		public ClusterVNode Node { get; }
 
-		public ClusterVNodeHostedService(ClusterVNodeOptions options, CertificateProvider certificateProvider) {
+		public ClusterVNodeHostedService(
+			ClusterVNodeOptions options,
+			CertificateProvider certificateProvider,
+			TelemetryConfiguration telemetryConfiguration) {
+
 			if (options == null) throw new ArgumentNullException(nameof(options));
 			var projectionMode = options.DevMode.Dev && options.Projections.RunProjections == ProjectionType.None
 				? ProjectionType.System
@@ -81,11 +86,13 @@ namespace EventStore.ClusterNode {
 			if (_options.Database.DbLogFormat == DbLogFormat.V2) {
 				var logFormatFactory = new LogV2FormatAbstractorFactory();
             	Node = ClusterVNode.Create(_options, logFormatFactory, GetAuthenticationProviderFactory(),
-	                GetAuthorizationProviderFactory(), GetPersistentSubscriptionConsumerStrategyFactories(), certificateProvider);
+	                GetAuthorizationProviderFactory(), GetPersistentSubscriptionConsumerStrategyFactories(), certificateProvider,
+					telemetryConfiguration);
 			} else if (_options.Database.DbLogFormat == DbLogFormat.ExperimentalV3) {
 				var logFormatFactory = new LogV3FormatAbstractorFactory();
 				Node = ClusterVNode.Create(_options, logFormatFactory, GetAuthenticationProviderFactory(),
-					GetAuthorizationProviderFactory(), GetPersistentSubscriptionConsumerStrategyFactories(), certificateProvider);
+					GetAuthorizationProviderFactory(), GetPersistentSubscriptionConsumerStrategyFactories(), certificateProvider,
+					telemetryConfiguration);
 			} else {
 				throw new ArgumentOutOfRangeException("Unexpected log format specified.");
 			}

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -22,6 +22,9 @@
 			<Link>logconfig.json</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
+		<None Update="telemetryconfig.json">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Update="kestrelsettings.json">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -166,7 +166,9 @@ namespace EventStore.ClusterNode {
 				Console.CancelKeyPress += delegate {
 					Application.Exit(0, "Cancelled.");
 				};
-				using (var hostedService = new ClusterVNodeHostedService(options, certificateProvider)) {
+
+				var telemetryConfiguration = TelemetryConfiguration.FromFile();
+				using (var hostedService = new ClusterVNodeHostedService(options, certificateProvider, telemetryConfiguration.Get<TelemetryConfiguration>())) {
 					using var signal = new ManualResetEventSlim(false);
 					_ = Run(hostedService, signal);
 					// ReSharper disable MethodSupportsCancellation
@@ -187,6 +189,7 @@ namespace EventStore.ClusterNode {
 							.ConfigureLogging(logging => logging.AddSerilog())
 							.ConfigureServices(services => services.Configure<KestrelServerOptions>(
 								EventStoreKestrelConfiguration.GetConfiguration()))
+							.ConfigureServices(services => services.Configure<TelemetryConfiguration>(telemetryConfiguration))
 							.ConfigureWebHostDefaults(builder => builder
 								.UseKestrel(server => {
 									server.Limits.Http2.KeepAlivePingDelay =

--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -1,0 +1,11 @@
+{
+	"Meters": [
+		"EventStore.Core"
+	],
+
+	"Checkpoints": [
+		"Writer",
+		"Index",
+		"Replication"
+	]
+}

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using EventStore.Common.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+
+namespace EventStore.Common.Configuration {
+	public class TelemetryConfiguration {
+		public static IConfiguration FromFile(string telemetryConfig = "telemetryconfig.json") {
+			var configurationDirectory = Path.IsPathRooted(telemetryConfig)
+				? Path.GetDirectoryName(telemetryConfig)
+				: Locations
+					.GetPotentialConfigurationDirectories()
+					.FirstOrDefault(directory => File.Exists(Path.Combine(directory, telemetryConfig)));
+
+			if (configurationDirectory == null) {
+				throw new FileNotFoundException(
+					$"Could not find {telemetryConfig} in the following directories: {string.Join(", ", Locations.GetPotentialConfigurationDirectories())}");
+			}
+
+			var configurationRoot = new ConfigurationBuilder()
+				.AddJsonFile(config => {
+					config.Optional = false;
+					config.FileProvider = new PhysicalFileProvider(configurationDirectory);
+					config.OnLoadException = context => Serilog.Log.Error(context.Exception, "err");
+					config.Path = Path.GetFileName(telemetryConfig);
+				})
+				.Build();
+
+			return configurationRoot;
+		}
+
+		public enum Checkpoint {
+			Chaser = 1,
+			Epoch,
+			Index,
+			Proposal,
+			Replication,
+			StreamExistenceFilter,
+			Truncate,
+			Writer,
+		}
+
+		public string[] Meters { get; set; } = Array.Empty<string>();
+
+		public Checkpoint[] Checkpoints { get; set; } = Array.Empty<Checkpoint>();
+	}
+}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -179,6 +179,7 @@ namespace EventStore.Core.Tests.Helpers {
 					new LegacyAuthorizationProviderFactory(components.MainQueue)),
 				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>(),
 				new OptionsCertificateProvider(options),
+				telemetryConfiguration: null,
 				expiryStrategy,
 				Guid.NewGuid(), debugIndex);
 			Node.HttpService.SetupController(new TestController(Node.MainQueue));

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -163,6 +163,7 @@ namespace EventStore.Core.Tests.Helpers {
 			Node = new ClusterVNode<TStreamId>(options, logFormatFactory,
 				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
+				telemetryConfiguration: null,
 				expiryStrategy: expiryStrategy,
 				certificateProvider: new OptionsCertificateProvider(options));
 			Db = Node.Db;

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Checkpoint/CheckpointMetricTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Checkpoint/CheckpointMetricTests.cs
@@ -1,0 +1,32 @@
+﻿using System.Diagnostics.Metrics;
+using System.Linq;
+using EventStore.Core.TransactionLog.Checkpoint;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.TransactionLog.Checkpoint {
+	public class CheckpointMetricTests {
+		[Fact]
+		public void can_collect() {
+			var metric = new CheckpointMetric(
+				new Meter("Eventstore.Core.XUnit.Tests"),
+				"eventstore-checkpoints",
+				new InMemoryCheckpoint("checkpoint", 5));
+
+			Assert.Collection(
+				metric.Observe().ToArray(),
+				measurement => {
+					Assert.Equal(5, measurement.Value);
+					Assert.Collection(
+						measurement.Tags.ToArray(),
+						tag => {
+							Assert.Equal("name", tag.Key);
+							Assert.Equal("checkpoint", tag.Value);
+						},
+						tag => {
+							Assert.Equal("read", tag.Key);
+							Assert.Equal("non-flushed", tag.Value);
+						});
+				});
+		}
+	}
+}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -23,6 +23,9 @@
 		</PackageReference>
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
 		<PackageReference Include="Microsoft.FASTER.Core" Version="1.9.5" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.1" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.1" />
+		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
 		<PackageReference Include="System.IO.Pipelines" Version="6.0.3" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using EventStore.Common.Configuration;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.Checkpoint;
+using System.Diagnostics.Metrics;
+
+namespace EventStore.Core;
+
+public static class MetricsBootstrapper {
+	public static void Bootstrap(
+		TelemetryConfiguration telemetryConfiguration,
+		TFChunkDbConfig dbConfig) {
+
+		var coreMeter = new Meter("EventStore.Core");
+
+		_ = new CheckpointMetric(
+			coreMeter,
+			"eventstore-checkpoints",
+			telemetryConfiguration.Checkpoints.Select(x => x switch {
+				TelemetryConfiguration.Checkpoint.Chaser => dbConfig.ChaserCheckpoint,
+				TelemetryConfiguration.Checkpoint.Epoch => dbConfig.EpochCheckpoint,
+				TelemetryConfiguration.Checkpoint.Index => dbConfig.IndexCheckpoint,
+				TelemetryConfiguration.Checkpoint.Proposal => dbConfig.ProposalCheckpoint,
+				TelemetryConfiguration.Checkpoint.Replication => dbConfig.ReplicationCheckpoint,
+				TelemetryConfiguration.Checkpoint.StreamExistenceFilter => dbConfig.StreamExistenceFilterCheckpoint,
+				TelemetryConfiguration.Checkpoint.Truncate => dbConfig.TruncateCheckpoint,
+				TelemetryConfiguration.Checkpoint.Writer => dbConfig.WriterCheckpoint,
+				_ => throw new Exception(
+					$"Unknown checkpoint in TelemetryConfiguration. Valid values are " +
+					$"{string.Join(", ", Enum.GetValues<TelemetryConfiguration.Checkpoint>())}"),
+			}).ToArray());
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/MetricsController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/MetricsController.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using EventStore.Common.Utils;
+using EventStore.Core.Bus;
+using EventStore.Core.Messaging;
+using EventStore.Plugins.Authorization;
+using EventStore.Transport.Http;
+using EventStore.Transport.Http.Codecs;
+
+namespace EventStore.Core.Services.Transport.Http.Controllers {
+	public class MetricsController : CommunicationController {
+		private static readonly ICodec[] SupportedCodecs = new ICodec[] {
+			Codec.CreateCustom(Codec.Text, "application/openmetrics-text", Helper.UTF8NoBom, false, false),
+		};
+
+		public MetricsController() : base(new NoOpPublisher()) {
+		}
+
+		protected override void SubscribeCore(IHttpService service) {
+			Ensure.NotNull(service, "service");
+
+			// this exists only to specify the permissions required for the /metrics endpoint
+			service.RegisterAction(new ControllerAction("/metrics", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs,
+				new Operation(Operations.Node.Statistics.Read)),
+				(x, y) => {
+					// the PrometheusExporterMiddleware handles the request itself, this will not be called
+					throw new InvalidOperationException();
+				});
+		}
+
+		class NoOpPublisher : IPublisher {
+			public void Publish(Message message) {
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Checkpoint/CheckpointMetric.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/CheckpointMetric.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace EventStore.Core.TransactionLog.Checkpoint {
+	// For now reading 'nonflushed' because the flushed values may give the impression
+	// of the checkpoints being further behind than they really are.
+	public class CheckpointMetric {
+		private readonly IReadOnlyCheckpoint[] _checkpoints;
+		private readonly Measurement<long>[] _measurements;
+		private readonly KeyValuePair<string, object>[][] _tagss;
+
+		public CheckpointMetric(Meter meter, string name, params IReadOnlyCheckpoint[] checkpoints) {
+			_checkpoints = checkpoints;
+			_measurements = new Measurement<long>[checkpoints.Length];
+			_tagss = new KeyValuePair<string, object>[checkpoints.Length][];
+
+			for (var i = 0; i < checkpoints.Length; i++) {
+				_tagss[i] = new KeyValuePair<string, object>[] {
+					new("name", checkpoints[i].Name),
+					new("read", "non-flushed"),
+				};
+			}
+
+			// we could consider using ObservableUpDownCounter, but ICheckpoint does allow the values to
+			// go down as well as up, so we are currently supporting that here.
+			meter.CreateObservableUpDownCounter(name, Observe);
+		}
+
+		public IEnumerable<Measurement<long>> Observe() {
+			for (var i = 0; i < _checkpoints.Length; i++) {
+				// looks like the Measurement constructor will allocate an array for the tags but the
+				// other constructor overloads appear to allocate two
+				_measurements[i] = new Measurement<long>(
+					value: _checkpoints[i].ReadNonFlushed(),
+					tags: _tagss[i].AsSpan());
+			}
+
+			return _measurements;
+		}
+	}
+}


### PR DESCRIPTION
Added: checkpoints metric

- checkpoints available in the Meter 'EventStore.Core' under the metric 'eventstore-checkpoints`
- Exposed on `/metrics` endpoint for collection by Prometheus
- Respects same authorisation required to view `/stats`
- Configurable in telemetryconfig.json

