### PR TITLE
Scope RetryInterceptor to  be a singleton

### DIFF
--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -194,6 +194,7 @@ namespace EventStore.Core {
 						.Services
 
 						// gRPC
+						.AddSingleton<RetryInterceptor>()
 						.AddGrpc(options => {
 							options.Interceptors.Add<RetryInterceptor>();
 						})


### PR DESCRIPTION
Removed: Unnecessary allocation on read

No need to allocate a new one on every request, it contains no state.