### PR TITLE
Improve API response for bad requests

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -235,6 +235,54 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 			Assert.IsNotNull(dto, "DTO is null");
 			Assert.AreEqual(long.MaxValue, dto.LastEventNumber, "Last event number");
 		}
+		
+		[Test]
+		public void 
+			when_wrapping_scavenge_started_response_should_return_result_and_scavengeId_for_v2_clients() {
+			var scavengeId = Guid.NewGuid().ToString();
+			var msg = new ClientMessage.ScavengeDatabaseStartedResponse(Guid.NewGuid(), scavengeId);
+
+			var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+			Assert.IsNotNull(package, "Package is null");
+			Assert.AreEqual(TcpCommand.ScavengeDatabaseResponse, package.Value.Command, "TcpCommand");
+
+			var dto = package.Value.Data.Deserialize<ScavengeDatabaseResponse>();
+			Assert.IsNotNull(dto, "DTO is null");
+			Assert.AreEqual(dto.Result, ScavengeDatabaseResponse.Types.ScavengeResult.Started);
+			Assert.AreEqual(dto.ScavengeId, scavengeId);
+		}
+		
+		[Test]
+		public void 
+			when_wrapping_scavenge_inprogress_response_should_return_result_and_scavengeId_for_v2_clients() {
+			var scavengeId = Guid.NewGuid().ToString();
+			var msg = new ClientMessage.ScavengeDatabaseInProgressResponse(Guid.NewGuid(), scavengeId, reason:"In Progress");
+
+			var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+			Assert.IsNotNull(package, "Package is null");
+			Assert.AreEqual(TcpCommand.ScavengeDatabaseResponse, package.Value.Command, "TcpCommand");
+			
+			var dto = package.Value.Data.Deserialize<ScavengeDatabaseResponse>();
+			Assert.IsNotNull(dto, "DTO is null");
+			Assert.AreEqual(dto.Result, ScavengeDatabaseResponse.Types.ScavengeResult.InProgress);
+			Assert.AreEqual(dto.ScavengeId, scavengeId);
+		}
+
+		[Test]
+		public void 
+			when_wrapping_scavenge_unauthorized_response_should_return_result_and_scavengeId_for_v2_clients() {
+			var scavengeId = Guid.NewGuid().ToString();
+			var msg = new ClientMessage.ScavengeDatabaseUnauthorizedResponse(Guid.NewGuid(), scavengeId,"Unauthorized" );
+
+			var package = _dispatcher.WrapMessage(msg, (byte)ClientVersion.V2);
+			Assert.IsNotNull(package, "Package is null");
+			Assert.AreEqual(TcpCommand.ScavengeDatabaseResponse, package.Value.Command, "TcpCommand");
+
+			var dto = package.Value.Data.Deserialize<ScavengeDatabaseResponse>();
+			Assert.IsNotNull(dto, "DTO is null");
+			Assert.AreEqual(dto.Result, ScavengeDatabaseResponse.Types.ScavengeResult.Unauthorized);
+			Assert.AreEqual(dto.ScavengeId, scavengeId);
+		}
 
 		private EventRecord CreateDeletedEventRecord() {
 			return new EventRecord(long.MaxValue,

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1805,29 +1805,93 @@ namespace EventStore.Core.Messages {
 		}
 
 		[DerivedMessage]
-		public partial class ScavengeDatabaseResponse : Message {
+		public partial class ScavengeDatabaseGetResponse : Message {
 			public readonly Guid CorrelationId;
 			public readonly ScavengeResult Result;
 			public readonly string ScavengeId;
 
-			public ScavengeDatabaseResponse(Guid correlationId,
+			public ScavengeDatabaseGetResponse(Guid correlationId, 
 				ScavengeResult result, string scavengeId) {
 				CorrelationId = correlationId;
 				Result = result;
 				ScavengeId = scavengeId;
 			}
 
-			public override string ToString() {
-				return String.Format("Result: {0}, ScavengeId: {1}", Result, ScavengeId);
+			public override string ToString() => $"Result: {Result}, ScavengeId: {ScavengeId}";
+			public enum ScavengeResult {
+				InProgress,
+				Stopped
+			}
+		}
+		
+		[DerivedMessage]
+		public partial class ScavengeDatabaseStartedResponse : Message {
+			public readonly Guid CorrelationId;
+			public readonly string ScavengeId;
+
+			public ScavengeDatabaseStartedResponse(Guid correlationId, string scavengeId) {
+				CorrelationId = correlationId;
+				ScavengeId = scavengeId;
+			}
+			public override string ToString() => $"ScavengeId: {ScavengeId}";
+		}
+		
+		[DerivedMessage]
+		public partial class ScavengeDatabaseInProgressResponse : Message {
+			public readonly Guid CorrelationId;
+			public readonly string ScavengeId;
+			public readonly string Reason;
+
+			public ScavengeDatabaseInProgressResponse(Guid correlationId, string scavengeId, string reason) {
+				CorrelationId = correlationId;
+				ScavengeId = scavengeId;
+				Reason = reason;
 			}
 
-			public enum ScavengeResult {
-				Started,
-				Unauthorized,
-				InProgress,
-				Stopped,
-				InvalidScavengeId
+			public override string ToString() => $"ScavengeId: {ScavengeId}, Reason: {Reason}";
+		}
+
+		[DerivedMessage]
+		public partial class ScavengeDatabaseStoppedResponse : Message {
+			public readonly Guid CorrelationId;
+			public readonly string ScavengeId;
+
+			public ScavengeDatabaseStoppedResponse(Guid correlationId, string scavengeId) {
+				CorrelationId = correlationId;
+				ScavengeId = scavengeId;
 			}
+
+			public override string ToString() => $"ScavengeId: {ScavengeId}";
+		}
+		
+		[DerivedMessage]
+		public partial class ScavengeDatabaseNotFoundResponse : Message {
+			public readonly Guid CorrelationId;
+			public readonly string ScavengeId;
+			public readonly string Reason;
+
+			public ScavengeDatabaseNotFoundResponse(Guid correlationId, string scavengeId, string reason) {
+				CorrelationId = correlationId;
+				ScavengeId = scavengeId;
+				Reason = reason;
+			}
+
+			public override string ToString() => $"ScavengeId: {ScavengeId}, Reason: {Reason}";
+			
+		}
+		
+		[DerivedMessage]
+		public partial class ScavengeDatabaseUnauthorizedResponse : Message {
+			public readonly Guid CorrelationId;
+			public readonly string ScavengeId;
+			public readonly string Reason;
+
+			public ScavengeDatabaseUnauthorizedResponse(Guid correlationId, string scavengeId, string reason) {
+				CorrelationId = correlationId;
+				ScavengeId = scavengeId;
+				Reason = reason;
+			}
+			public override string ToString() => $"ScavengeId: {ScavengeId}, Reason: {Reason}";
 		}
 
 		[DerivedMessage]

--- a/src/EventStore.Core/Messages/SubscriptionMessage.cs
+++ b/src/EventStore.Core/Messages/SubscriptionMessage.cs
@@ -50,6 +50,11 @@ namespace EventStore.Core.Messages {
 
 		[DerivedMessage]
 		public partial class InvalidPersistentSubscriptionsRestart : Message {
+			public readonly string Reason;
+
+			public InvalidPersistentSubscriptionsRestart(string reason) {
+				Reason = reason;
+			}
 		}
 	
 		[DerivedMessage]

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -101,7 +101,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		
 		public void Handle(SubscriptionMessage.PersistentSubscriptionsRestart message) {
 			if (!_started) {
-				message.ReplyEnvelope.ReplyWith(new SubscriptionMessage.InvalidPersistentSubscriptionsRestart());
+				message.ReplyEnvelope.ReplyWith(new SubscriptionMessage.InvalidPersistentSubscriptionsRestart("The Persistent Subscriptions subsystem cannot be restarted because it is not started."));
 				return;
 			}
 			

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/CommunicationController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messaging;
@@ -34,9 +35,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		protected abstract void SubscribeCore(IHttpService service);
 
 		protected RequestParams SendBadRequest(HttpEntityManager httpEntityManager, string reason) {
-			httpEntityManager.ReplyStatus(HttpStatusCode.BadRequest,
-				reason,
+			httpEntityManager.ReplyContent(Encoding.ASCII.GetBytes(reason), HttpStatusCode.BadRequest,
+				"Bad Request",type: "text/plain", headers:null,
 				e => Log.Debug("Error while closing HTTP connection (bad request): {e}.", e.Message));
+ 
 			return new RequestParams(done: true);
 		}
 

--- a/src/EventStore.Projections.Core/Messages/ProjectionSubsystemMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionSubsystemMessage.cs
@@ -15,9 +15,11 @@ namespace EventStore.Projections.Core.Messages {
 		[DerivedMessage]
 		public partial class InvalidSubsystemRestart : Message {
 			public string SubsystemState { get; }
+			public string Reason { get; }
 
-			public InvalidSubsystemRestart(string subsystemState) {
+			public InvalidSubsystemRestart(string subsystemState, string reason) {
 				SubsystemState = subsystemState;
+				Reason = reason;
 			}
 		}
 

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -214,16 +214,17 @@ namespace EventStore.Projections.Core {
 		
 		public void Handle(ProjectionSubsystemMessage.RestartSubsystem message) {
 			if (_restarting) {
-				_logger.Information("PROJECTIONS SUBSYSTEM: Not restarting because the subsystem is already being restarted.");
-				message.ReplyEnvelope.ReplyWith(new ProjectionSubsystemMessage.InvalidSubsystemRestart("Restarting"));
+				var info = "PROJECTIONS SUBSYSTEM: Not restarting because the subsystem is already being restarted.";
+				_logger.Information(info);
+				message.ReplyEnvelope.ReplyWith(new ProjectionSubsystemMessage.InvalidSubsystemRestart("Restarting", info));
 				return;
 			}
 
 			if (_subsystemState != SubsystemState.Started) {
-				_logger.Information(
-					"PROJECTIONS SUBSYSTEM: Not restarting because the subsystem is not started. Current subsystem state: {state}",
-					_subsystemState);
-				message.ReplyEnvelope.ReplyWith(new ProjectionSubsystemMessage.InvalidSubsystemRestart(_subsystemState.ToString()));
+				var info =
+					$"PROJECTIONS SUBSYSTEM: Not restarting because the subsystem is not started. Current subsystem state: {_subsystemState}";
+				_logger.Information(info);
+				message.ReplyEnvelope.ReplyWith(new ProjectionSubsystemMessage.InvalidSubsystemRestart(_subsystemState.ToString(), info));
 				return;
 			}
 


### PR DESCRIPTION
Fixes: #https://github.com/EventStore/home/issues/884

Attached the sample results from Scavenge and persistent subscription bad API requests.

![FailedToCreateSubscription](https://user-images.githubusercontent.com/25709924/210901659-8c09c12d-6551-4374-a714-19fd6cf37dde.png)
<img width="938" alt="ScavengeCurrentlyRunning" src="https://user-images.githubusercontent.com/25709924/210901664-3f51bb7c-d4c4-47f1-934e-a6586e3468b8.png">
