### PR TITLE
Add duration histograms for gRPC reads and writes

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -13,5 +13,14 @@
 		"Writer",
 		"Index",
 		"Replication"
-	]
+	],
+
+	// maps grpc methods to labels that they are to be recorded under
+	"GrpcMethods": {
+		"StreamRead": "read",
+		"StreamAppend": "append",
+		"StreamBatchAppend": "append",
+		"StreamDelete": "",
+		"StreamTombstone": ""
+	}
 }

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using EventStore.Common.Utils;
@@ -48,10 +49,20 @@ namespace EventStore.Common.Configuration {
 			Writer,
 		}
 
+		public enum GrpcMethod {
+			StreamRead = 1,
+			StreamAppend,
+			StreamBatchAppend,
+			StreamDelete,
+			StreamTombstone,
+		}
+
 		public string[] Meters { get; set; } = Array.Empty<string>();
 
 		public StatusTracker[] StatusTrackers { get; set; } = Array.Empty<StatusTracker>();
 
 		public Checkpoint[] Checkpoints { get; set; } = Array.Empty<Checkpoint>();
+
+		public Dictionary<GrpcMethod, string> GrpcMethods { get; set; } = new();
 	}
 }

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -2,6 +2,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Threading;
+using EventStore.Common.Configuration;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.LogV2;
@@ -68,7 +69,10 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 							new AnonymousHttpAuthenticationProvider(),
 						}, new TestAuthorizationProvider(),
 						new FakeReadIndex<LogFormat.V2, string>(_ => false, new LogV2SystemStreams()),
-						1024 * 1024, _timeout, expiryStrategy: null, _service, null)));
+						1024 * 1024, _timeout, expiryStrategy: null, _service,
+						new TelemetryConfiguration(),
+						new Trackers(),
+						null)));
 			_httpMessageHandler = _server.CreateHandler();
 			_client = new HttpAsyncClient(_timeout, _httpMessageHandler);
 			

--- a/src/EventStore.Core.XUnit.Tests/Services/VNode/NodeStatusTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/VNode/NodeStatusTrackerTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Diagnostics.Metrics;
 using System.Linq;
 using EventStore.Core.Services.VNode;
@@ -7,39 +7,45 @@ using EventStore.Core.XUnit.Tests.Telemetry;
 using Xunit;
 
 namespace EventStore.Core.TransactionLog.Services.VNode {
-	public class NodeStatusTrackerTests {
+	public class NodeStatusTrackerTests : IDisposable {
+		private readonly TestMeterListener<long> _listener;
 		private readonly FakeClock _clock = new();
 		private readonly StatusMetric _metric;
 		private readonly NodeStatusTracker _sut;
 
 		public NodeStatusTrackerTests() {
+			var meter = new Meter($"{typeof(NodeStatusTrackerTests)}");
+			_listener = new TestMeterListener<long>(meter);
 			_metric = new StatusMetric(
-				new Meter($"Eventstore.Core.XUnit.Tests.{nameof(NodeStatusTrackerTests)}"),
+				meter,
 				"eventstore-statuses",
 				_clock);
 			_sut = new NodeStatusTracker(_metric);
 		}
 
+		public void Dispose() {
+			_listener?.Dispose();
+		}
+
 		[Fact]
 		public void can_observe_state_change() {
 			_clock.SecondsSinceEpoch = 500;
-			AssertMeasurements("Initializing", 500, _metric.Observe());
+			AssertMeasurements("Initializing", 500);
 
 			_sut.OnStateChange(Data.VNodeState.PreReplica);
 			_clock.SecondsSinceEpoch = 501;
-			AssertMeasurements("PreReplica", 501, _metric.Observe());
+			AssertMeasurements("PreReplica", 501);
 
 			_sut.OnStateChange(Data.VNodeState.Follower);
 			_clock.SecondsSinceEpoch = 502;
-			AssertMeasurements("Follower", 502, _metric.Observe());
+			AssertMeasurements("Follower", 502);
 		}
 
-		static void AssertMeasurements(
-			string expectedStatus,
-			int expectedValue,
-			IEnumerable<Measurement<long>> measurements) {
+		void AssertMeasurements(string expectedStatus, int expectedValue) {
+			_listener.Observe();
 
-			Assert.Collection(measurements.ToArray(),
+			Assert.Collection(
+				_listener.RetrieveMeasurements("eventstore-statuses"),
 				m => {
 					Assert.Equal(expectedValue, m.Value);
 					Assert.Collection(

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/DurationTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/DurationTrackerTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using EventStore.Core.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry {
+	public class DurationTrackerTests : IDisposable {
+		private readonly TestMeterListener<double> _listener;
+		private readonly FakeClock _clock = new();
+		private readonly DurationTracker _sut;
+
+		public DurationTrackerTests() {
+			var meter = new Meter($"{typeof(DurationTrackerTests)}");
+			_listener = new TestMeterListener<double>(meter);
+			var durationMetric = new DurationMetric(meter, "the-histogram", _clock);
+			_sut = new DurationTracker(durationMetric, "the-duration");
+		}
+
+		public void Dispose() {
+			_listener.Dispose();
+		}
+
+		[Fact]
+		public void records_success() {
+			_clock.SecondsSinceEpoch = 500;
+			using (_sut.Start()) {
+				_clock.SecondsSinceEpoch = 501;
+			}
+
+			AssertMeasurements("successful", 1);
+		}
+
+		[Fact]
+		public void records_failure() {
+			_clock.SecondsSinceEpoch = 500;
+			using (var duration = _sut.Start()) {
+				_clock.SecondsSinceEpoch = 501;
+				duration.SetException(new Exception("failed"));
+			}
+
+			AssertMeasurements("failed", 1);
+		}
+
+		void AssertMeasurements(
+			string expectedStatus,
+			int expectedValue) {
+
+			Assert.Collection(
+				_listener.RetrieveMeasurements("the-histogram"),
+				m => {
+					Assert.Equal(expectedValue, m.Value);
+					Assert.Collection(
+						m.Tags,
+						t => {
+							Assert.Equal("activity", t.Key);
+							Assert.Equal("the-duration", t.Value);
+						},
+						t => {
+							Assert.Equal("status", t.Key);
+							Assert.Equal(expectedStatus, t.Value);
+						});
+				});
+		}
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/FakeClock.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/FakeClock.cs
@@ -1,7 +1,9 @@
-﻿using EventStore.Core.Telemetry;
+﻿using System;
+using EventStore.Core.Telemetry;
 
 namespace EventStore.Core.XUnit.Tests.Telemetry {
 	internal class FakeClock : IClock {
+		public DateTime UtcNow => DateTimeOffset.FromUnixTimeSeconds(SecondsSinceEpoch).UtcDateTime;
 		public long SecondsSinceEpoch { get; set; }
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/TestMeterListener.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/TestMeterListener.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry {
+	public class TestMeterListener<T> : IDisposable where T : struct {
+		private readonly MeterListener _listener;
+		private readonly Dictionary<string, List<TestMeasurement>> _measurementsByInstrument;
+
+		public TestMeterListener(Meter meter) {
+			_measurementsByInstrument = new();
+			_listener = new MeterListener {
+				InstrumentPublished = (instrument, listener) => {
+					if (instrument.Meter == meter) {
+						listener.EnableMeasurementEvents(instrument);
+					}
+				}
+			};
+			_listener.SetMeasurementEventCallback<T>(OnMeasurement);
+			_listener.Start();
+		}
+
+		public void Dispose() {
+			_listener?.Dispose();
+		}
+
+		public void Observe() {
+			_listener.RecordObservableInstruments();
+		}
+
+		// gets the measurements for a given instrument and clears them
+		public IReadOnlyList<TestMeasurement> RetrieveMeasurements(string instrumentName) {
+			if (!_measurementsByInstrument.Remove(instrumentName, out var measurements)) {
+				return Array.Empty<TestMeasurement>();
+			}
+
+			return measurements;
+		}
+
+		private void OnMeasurement(
+			Instrument instrument,
+			T value,
+			ReadOnlySpan<KeyValuePair<string, object>> tags,
+			object state) {
+
+			if (!_measurementsByInstrument.TryGetValue(instrument.Name, out var measurements)) {
+				measurements = new();
+				_measurementsByInstrument[instrument.Name] = measurements;
+			}
+
+			measurements.Add(new TestMeasurement {
+				Value = value,
+				Tags = tags.ToArray(),
+			});
+		}
+
+		public class TestMeasurement {
+			public T Value { get; init; }
+			public KeyValuePair<string, object>[] Tags { get; init; }
+		}
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Checkpoint/CheckpointMetricTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Checkpoint/CheckpointMetricTests.cs
@@ -1,19 +1,23 @@
 ﻿using System.Diagnostics.Metrics;
 using System.Linq;
 using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.XUnit.Tests.Telemetry;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.TransactionLog.Checkpoint {
 	public class CheckpointMetricTests {
 		[Fact]
 		public void can_collect() {
+			var meter = new Meter($"{typeof(CheckpointMetricTests)}");
+			using var listener = new TestMeterListener<long>(meter);
 			var metric = new CheckpointMetric(
-				new Meter("Eventstore.Core.XUnit.Tests"),
+				meter,
 				"eventstore-checkpoints",
 				new InMemoryCheckpoint("checkpoint", 5));
 
+			listener.Observe();
 			Assert.Collection(
-				metric.Observe().ToArray(),
+				listener.RetrieveMeasurements("eventstore-checkpoints"),
 				measurement => {
 					Assert.Equal(5, measurement.Value);
 					Assert.Collection(

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -378,11 +378,9 @@ namespace EventStore.Core {
 				out var readerThreadsCount,
 				out var workerThreadsCount));
 
+			telemetryConfiguration ??= new();
 			var trackers = new Trackers();
-
-			if (telemetryConfiguration is not null) {
-				MetricsBootstrapper.Bootstrap(telemetryConfiguration, Db.Config, trackers);
-			}
+			MetricsBootstrapper.Bootstrap(telemetryConfiguration, Db.Config, trackers);
 
 			TFChunkDbConfig CreateDbConfig(
 				out SystemStatsHelper statsHelper,
@@ -1559,7 +1557,10 @@ namespace EventStore.Core {
 				_authenticationProvider, httpAuthenticationProviders, _authorizationProvider, _readIndex,
 				options.Application.MaxAppendSize, TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs),
 				expiryStrategy ?? new DefaultExpiryStrategy(),
-				_httpService, options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null);
+				_httpService,
+				telemetryConfiguration,
+				trackers,
+				options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null);
 			_mainBus.Subscribe<SystemMessage.SystemReady>(_startup);
 			_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_startup);
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -13,176 +13,183 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		public override async Task<AppendResp> Append(
 			IAsyncStreamReader<AppendReq> requestStream,
 			ServerCallContext context) {
-			if (!await requestStream.MoveNext().ConfigureAwait(false))
-				throw new InvalidOperationException();
 
-			if (requestStream.Current.ContentCase != AppendReq.ContentOneofCase.Options)
-				throw new InvalidOperationException();
-
-			var options = requestStream.Current.Options;
-			var streamName = options.StreamIdentifier;
-
-			var expectedVersion = options.ExpectedStreamRevisionCase switch {
-				AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.Revision => new StreamRevision(
-					options.Revision).ToInt64(),
-				AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.Any => AnyStreamRevision.Any.ToInt64(),
-				AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.StreamExists => AnyStreamRevision.StreamExists
-					.ToInt64(),
-				AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream =>
-					AnyStreamRevision.NoStream.ToInt64(),
-				_ => throw RpcExceptions.InvalidArgument(options.ExpectedStreamRevisionCase)
-			};
-
-			var requiresLeader = GetRequiresLeader(context.RequestHeaders);
-
-			var user = context.GetHttpContext().User;
-			var op = WriteOperation.WithParameter(
-				Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
-			if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
-				throw RpcExceptions.AccessDenied();
-			}
-
-			var correlationId = Guid.NewGuid(); // TODO: JPB use request id?
-
-			var events = new List<Event>();
-
-			var size = 0;
-			while (await requestStream.MoveNext().ConfigureAwait(false)) {
-				if (requestStream.Current.ContentCase != AppendReq.ContentOneofCase.ProposedMessage)
+			using var duration = _appendTracker.Start();
+			try {
+				if (!await requestStream.MoveNext().ConfigureAwait(false))
 					throw new InvalidOperationException();
 
-				var proposedMessage = requestStream.Current.ProposedMessage;
-				var data = proposedMessage.Data.ToByteArray();
-				var metadata = proposedMessage.CustomMetadata.ToByteArray();
+				if (requestStream.Current.ContentCase != AppendReq.ContentOneofCase.Options)
+					throw new InvalidOperationException();
 
-				if (!proposedMessage.Metadata.TryGetValue(Constants.Metadata.Type, out var eventType)) {
-					throw RpcExceptions.RequiredMetadataPropertyMissing(Constants.Metadata.Type);
+				var options = requestStream.Current.Options;
+				var streamName = options.StreamIdentifier;
+
+				var expectedVersion = options.ExpectedStreamRevisionCase switch {
+					AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.Revision => new StreamRevision(
+						options.Revision).ToInt64(),
+					AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.Any => AnyStreamRevision.Any.ToInt64(),
+					AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.StreamExists => AnyStreamRevision.StreamExists
+						.ToInt64(),
+					AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream =>
+						AnyStreamRevision.NoStream.ToInt64(),
+					_ => throw RpcExceptions.InvalidArgument(options.ExpectedStreamRevisionCase)
+				};
+
+				var requiresLeader = GetRequiresLeader(context.RequestHeaders);
+
+				var user = context.GetHttpContext().User;
+				var op = WriteOperation.WithParameter(
+					Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
+				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
+					throw RpcExceptions.AccessDenied();
 				}
 
-				if (!proposedMessage.Metadata.TryGetValue(Constants.Metadata.ContentType, out var contentType)) {
-					throw RpcExceptions.RequiredMetadataPropertyMissing(Constants.Metadata.ContentType);
+				var correlationId = Guid.NewGuid(); // TODO: JPB use request id?
+
+				var events = new List<Event>();
+
+				var size = 0;
+				while (await requestStream.MoveNext().ConfigureAwait(false)) {
+					if (requestStream.Current.ContentCase != AppendReq.ContentOneofCase.ProposedMessage)
+						throw new InvalidOperationException();
+
+					var proposedMessage = requestStream.Current.ProposedMessage;
+					var data = proposedMessage.Data.ToByteArray();
+					var metadata = proposedMessage.CustomMetadata.ToByteArray();
+
+					if (!proposedMessage.Metadata.TryGetValue(Constants.Metadata.Type, out var eventType)) {
+						throw RpcExceptions.RequiredMetadataPropertyMissing(Constants.Metadata.Type);
+					}
+
+					if (!proposedMessage.Metadata.TryGetValue(Constants.Metadata.ContentType, out var contentType)) {
+						throw RpcExceptions.RequiredMetadataPropertyMissing(Constants.Metadata.ContentType);
+					}
+
+					size += Event.SizeOnDisk(eventType, data, metadata);
+
+					if (size > _maxAppendSize) {
+						throw RpcExceptions.MaxAppendSizeExceeded(_maxAppendSize);
+					}
+
+					events.Add(new Event(
+						Uuid.FromDto(proposedMessage.Id).ToGuid(),
+						eventType,
+						contentType == Constants.Metadata.ContentTypes.ApplicationJson,
+						data,
+						metadata));
 				}
 
-				size += Event.SizeOnDisk(eventType, data, metadata);
+				var appendResponseSource = new TaskCompletionSource<AppendResp>(TaskCreationOptions.RunContinuationsAsynchronously);
 
-				if (size > _maxAppendSize) {
-					throw RpcExceptions.MaxAppendSizeExceeded(_maxAppendSize);
+				var envelope = new CallbackEnvelope(HandleWriteEventsCompleted);
+
+				_publisher.Publish(new ClientMessage.WriteEvents(
+					correlationId,
+					correlationId,
+					envelope,
+					requiresLeader,
+					streamName,
+					expectedVersion,
+					events.ToArray(),
+					user,
+					cancellationToken: context.CancellationToken));
+
+				return await appendResponseSource.Task.ConfigureAwait(false);
+
+				void HandleWriteEventsCompleted(Message message) {
+					if (message is ClientMessage.NotHandled notHandled &&
+						RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
+						appendResponseSource.TrySetException(ex);
+						return;
+					}
+
+					if (!(message is ClientMessage.WriteEventsCompleted completed)) {
+						appendResponseSource.TrySetException(
+							RpcExceptions.UnknownMessage<ClientMessage.WriteEventsCompleted>(message));
+						return;
+					}
+
+					var response = new AppendResp();
+					switch (completed.Result) {
+						case OperationResult.Success:
+							response.Success = new AppendResp.Types.Success();
+							if (completed.LastEventNumber == -1) {
+								response.Success.NoStream = new Empty();
+							} else {
+								response.Success.CurrentRevision = StreamRevision.FromInt64(completed.LastEventNumber);
+							}
+
+							if (completed.CommitPosition == -1) {
+								response.Success.NoPosition = new Empty();
+							} else {
+								var position = Position.FromInt64(completed.CommitPosition, completed.PreparePosition);
+								response.Success.Position = new AppendResp.Types.Position {
+									CommitPosition = position.CommitPosition,
+									PreparePosition = position.PreparePosition
+								};
+							}
+
+							appendResponseSource.TrySetResult(response);
+							return;
+						case OperationResult.PrepareTimeout:
+						case OperationResult.CommitTimeout:
+						case OperationResult.ForwardTimeout:
+							appendResponseSource.TrySetException(RpcExceptions.Timeout(completed.Message));
+							return;
+						case OperationResult.WrongExpectedVersion:
+							response.WrongExpectedVersion = new AppendResp.Types.WrongExpectedVersion();
+
+							switch (options.ExpectedStreamRevisionCase) {
+								case AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.Any:
+									response.WrongExpectedVersion.ExpectedAny = new Empty();
+									response.WrongExpectedVersion.Any2060 = new Empty();
+									break;
+								case AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.StreamExists:
+									response.WrongExpectedVersion.ExpectedStreamExists = new Empty();
+									response.WrongExpectedVersion.StreamExists2060 = new Empty();
+									break;
+								case AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream:
+									response.WrongExpectedVersion.ExpectedNoStream = new Empty();
+									response.WrongExpectedVersion.ExpectedRevision2060 = ulong.MaxValue;
+									break;
+								case AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.Revision:
+									response.WrongExpectedVersion.ExpectedRevision =
+										StreamRevision.FromInt64(expectedVersion);
+									response.WrongExpectedVersion.ExpectedRevision2060 =
+										StreamRevision.FromInt64(expectedVersion);
+									break;
+							}
+
+							if (completed.CurrentVersion == -1) {
+								response.WrongExpectedVersion.CurrentNoStream = new Empty();
+								response.WrongExpectedVersion.NoStream2060 = new Empty();
+							} else {
+								response.WrongExpectedVersion.CurrentRevision =
+									StreamRevision.FromInt64(completed.CurrentVersion);
+								response.WrongExpectedVersion.CurrentRevision2060 =
+									StreamRevision.FromInt64(completed.CurrentVersion);
+							}
+
+							appendResponseSource.TrySetResult(response);
+							return;
+						case OperationResult.StreamDeleted:
+							appendResponseSource.TrySetException(RpcExceptions.StreamDeleted(streamName));
+							return;
+						case OperationResult.InvalidTransaction:
+							appendResponseSource.TrySetException(RpcExceptions.InvalidTransaction());
+							return;
+						case OperationResult.AccessDenied:
+							appendResponseSource.TrySetException(RpcExceptions.AccessDenied());
+							return;
+						default:
+							appendResponseSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
+							return;
+					}
 				}
-
-				events.Add(new Event(
-					Uuid.FromDto(proposedMessage.Id).ToGuid(),
-					eventType,
-					contentType == Constants.Metadata.ContentTypes.ApplicationJson,
-					data,
-					metadata));
-			}
-
-			var appendResponseSource = new TaskCompletionSource<AppendResp>(TaskCreationOptions.RunContinuationsAsynchronously);
-
-			var envelope = new CallbackEnvelope(HandleWriteEventsCompleted);
-
-			_publisher.Publish(new ClientMessage.WriteEvents(
-				correlationId,
-				correlationId,
-				envelope,
-				requiresLeader,
-				streamName,
-				expectedVersion,
-				events.ToArray(),
-				user,
-				cancellationToken: context.CancellationToken));
-
-			return await appendResponseSource.Task.ConfigureAwait(false);
-
-			void HandleWriteEventsCompleted(Message message) {
-				if (message is ClientMessage.NotHandled notHandled &&
-				    RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
-					appendResponseSource.TrySetException(ex);
-					return;
-				}
-
-				if (!(message is ClientMessage.WriteEventsCompleted completed)) {
-					appendResponseSource.TrySetException(
-						RpcExceptions.UnknownMessage<ClientMessage.WriteEventsCompleted>(message));
-					return;
-				}
-
-				var response = new AppendResp();
-				switch (completed.Result) {
-					case OperationResult.Success:
-						response.Success = new AppendResp.Types.Success();
-						if (completed.LastEventNumber == -1) {
-							response.Success.NoStream = new Empty();
-						} else {
-							response.Success.CurrentRevision = StreamRevision.FromInt64(completed.LastEventNumber);
-						}
-
-						if (completed.CommitPosition == -1) {
-							response.Success.NoPosition = new Empty();
-						} else {
-							var position = Position.FromInt64(completed.CommitPosition, completed.PreparePosition);
-							response.Success.Position = new AppendResp.Types.Position {
-								CommitPosition = position.CommitPosition,
-								PreparePosition = position.PreparePosition
-							};
-						}
-
-						appendResponseSource.TrySetResult(response);
-						return;
-					case OperationResult.PrepareTimeout:
-					case OperationResult.CommitTimeout:
-					case OperationResult.ForwardTimeout:
-						appendResponseSource.TrySetException(RpcExceptions.Timeout(completed.Message));
-						return;
-					case OperationResult.WrongExpectedVersion:
-						response.WrongExpectedVersion = new AppendResp.Types.WrongExpectedVersion();
-
-						switch (options.ExpectedStreamRevisionCase) {
-							case AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.Any:
-								response.WrongExpectedVersion.ExpectedAny = new Empty();
-								response.WrongExpectedVersion.Any2060 = new Empty();
-								break;
-							case AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.StreamExists:
-								response.WrongExpectedVersion.ExpectedStreamExists = new Empty();
-								response.WrongExpectedVersion.StreamExists2060 = new Empty();
-								break;
-							case AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream:
-								response.WrongExpectedVersion.ExpectedNoStream = new Empty();
-								response.WrongExpectedVersion.ExpectedRevision2060 = ulong.MaxValue;
-								break;
-							case AppendReq.Types.Options.ExpectedStreamRevisionOneofCase.Revision:
-								response.WrongExpectedVersion.ExpectedRevision =
-									StreamRevision.FromInt64(expectedVersion);
-								response.WrongExpectedVersion.ExpectedRevision2060 =
-									StreamRevision.FromInt64(expectedVersion);
-								break;
-						}
-
-						if (completed.CurrentVersion == -1) {
-							response.WrongExpectedVersion.CurrentNoStream = new Empty();
-							response.WrongExpectedVersion.NoStream2060 = new Empty();
-						} else {
-							response.WrongExpectedVersion.CurrentRevision =
-								StreamRevision.FromInt64(completed.CurrentVersion);
-							response.WrongExpectedVersion.CurrentRevision2060 =
-								StreamRevision.FromInt64(completed.CurrentVersion);
-						}
-
-						appendResponseSource.TrySetResult(response);
-						return;
-					case OperationResult.StreamDeleted:
-						appendResponseSource.TrySetException(RpcExceptions.StreamDeleted(streamName));
-						return;
-					case OperationResult.InvalidTransaction:
-						appendResponseSource.TrySetException(RpcExceptions.InvalidTransaction());
-						return;
-					case OperationResult.AccessDenied:
-						appendResponseSource.TrySetException(RpcExceptions.AccessDenied());
-						return;
-					default:
-						appendResponseSource.TrySetException(RpcExceptions.UnknownError(completed.Result));
-						return;
-				}
+			} catch (Exception ex) {
+				duration.SetException(ex);
+				throw;
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -11,79 +11,91 @@ using Grpc.Core;
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal partial class Streams<TStreamId> {
 		public override async Task<DeleteResp> Delete(DeleteReq request, ServerCallContext context) {
-			var options = request.Options;
-			var streamName = options.StreamIdentifier;
-			var expectedVersion = options.ExpectedStreamRevisionCase switch {
-				DeleteReq.Types.Options.ExpectedStreamRevisionOneofCase.Revision =>
-				new StreamRevision(options.Revision).ToInt64(),
-				DeleteReq.Types.Options.ExpectedStreamRevisionOneofCase.Any =>
-				AnyStreamRevision.Any.ToInt64(),
-				DeleteReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream =>
-				AnyStreamRevision.NoStream.ToInt64(),
-				DeleteReq.Types.Options.ExpectedStreamRevisionOneofCase.StreamExists =>
-				AnyStreamRevision.StreamExists.ToInt64(),
-				_ => throw RpcExceptions.InvalidArgument(options.ExpectedStreamRevisionCase)
-			};
-
-			var user = context.GetHttpContext().User;
-			var op = DeleteOperation.WithParameter(Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
-			if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
-				throw RpcExceptions.AccessDenied();
-			}
-			var requiresLeader = GetRequiresLeader(context.RequestHeaders);
-
-			var position = await DeleteInternal(streamName, expectedVersion, user, false, requiresLeader,
-				context.CancellationToken).ConfigureAwait(false);
-
-			return position.HasValue
-				? new DeleteResp {
-					Position = new DeleteResp.Types.Position {
-						CommitPosition = position.Value.CommitPosition,
-						PreparePosition = position.Value.PreparePosition
-					}
-				}
-				: new DeleteResp {
-					NoPosition = new Empty()
+			using var duration = _deleteTracker.Start();
+			try {
+				var options = request.Options;
+				var streamName = options.StreamIdentifier;
+				var expectedVersion = options.ExpectedStreamRevisionCase switch {
+					DeleteReq.Types.Options.ExpectedStreamRevisionOneofCase.Revision =>
+					new StreamRevision(options.Revision).ToInt64(),
+					DeleteReq.Types.Options.ExpectedStreamRevisionOneofCase.Any =>
+					AnyStreamRevision.Any.ToInt64(),
+					DeleteReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream =>
+					AnyStreamRevision.NoStream.ToInt64(),
+					DeleteReq.Types.Options.ExpectedStreamRevisionOneofCase.StreamExists =>
+					AnyStreamRevision.StreamExists.ToInt64(),
+					_ => throw RpcExceptions.InvalidArgument(options.ExpectedStreamRevisionCase)
 				};
+
+				var user = context.GetHttpContext().User;
+				var op = DeleteOperation.WithParameter(Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
+				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
+					throw RpcExceptions.AccessDenied();
+				}
+				var requiresLeader = GetRequiresLeader(context.RequestHeaders);
+
+				var position = await DeleteInternal(streamName, expectedVersion, user, false, requiresLeader,
+					context.CancellationToken).ConfigureAwait(false);
+
+				return position.HasValue
+					? new DeleteResp {
+						Position = new DeleteResp.Types.Position {
+							CommitPosition = position.Value.CommitPosition,
+							PreparePosition = position.Value.PreparePosition
+						}
+					}
+					: new DeleteResp {
+						NoPosition = new Empty()
+					};
+			} catch (Exception ex) {
+				duration.SetException(ex);
+				throw;
+			}
 		}
 
 		public override async Task<TombstoneResp> Tombstone(TombstoneReq request, ServerCallContext context) {
-			var options = request.Options;
-			var streamName = options.StreamIdentifier;
+			using var duration = _tombstoneTracker.Start();
+			try {
+				var options = request.Options;
+				var streamName = options.StreamIdentifier;
 
-			var expectedVersion = options.ExpectedStreamRevisionCase switch {
-				TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.Revision =>
-				new StreamRevision(options.Revision).ToInt64(),
-				TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.Any =>
-				AnyStreamRevision.Any.ToInt64(),
-				TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream =>
-				AnyStreamRevision.NoStream.ToInt64(),
-				TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.StreamExists =>
-				AnyStreamRevision.StreamExists.ToInt64(),
-				_ => throw RpcExceptions.InvalidArgument(options.ExpectedStreamRevisionCase)
-			};
-
-			var requiresLeader = GetRequiresLeader(context.RequestHeaders);
-			
-			var user = context.GetHttpContext().User;
-			var op = DeleteOperation.WithParameter(Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
-			if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
-				throw RpcExceptions.AccessDenied();
-			}
-
-			var position = await DeleteInternal(streamName, expectedVersion, user, true, requiresLeader,
-				context.CancellationToken).ConfigureAwait(false);
-
-			return position.HasValue
-				? new TombstoneResp {
-					Position = new TombstoneResp.Types.Position {
-						CommitPosition = position.Value.CommitPosition,
-						PreparePosition = position.Value.PreparePosition
-					}
-				}
-				: new TombstoneResp {
-					NoPosition = new Empty()
+				var expectedVersion = options.ExpectedStreamRevisionCase switch {
+					TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.Revision =>
+					new StreamRevision(options.Revision).ToInt64(),
+					TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.Any =>
+					AnyStreamRevision.Any.ToInt64(),
+					TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.NoStream =>
+					AnyStreamRevision.NoStream.ToInt64(),
+					TombstoneReq.Types.Options.ExpectedStreamRevisionOneofCase.StreamExists =>
+					AnyStreamRevision.StreamExists.ToInt64(),
+					_ => throw RpcExceptions.InvalidArgument(options.ExpectedStreamRevisionCase)
 				};
+
+				var requiresLeader = GetRequiresLeader(context.RequestHeaders);
+			
+				var user = context.GetHttpContext().User;
+				var op = DeleteOperation.WithParameter(Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
+				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
+					throw RpcExceptions.AccessDenied();
+				}
+
+				var position = await DeleteInternal(streamName, expectedVersion, user, true, requiresLeader,
+					context.CancellationToken).ConfigureAwait(false);
+
+				return position.HasValue
+					? new TombstoneResp {
+						Position = new TombstoneResp.Types.Position {
+							CommitPosition = position.Value.CommitPosition,
+							PreparePosition = position.Value.PreparePosition
+						}
+					}
+					: new TombstoneResp {
+						NoPosition = new Empty()
+					};
+			} catch (Exception ex) {
+				duration.SetException(ex);
+				throw;
+			}
 		}
 
 		private async Task<Position?> DeleteInternal(string streamName, long expectedVersion,

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,200 +16,208 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			ReadReq request,
 			IServerStreamWriter<ReadResp> responseStream,
 			ServerCallContext context) {
-			var options = request.Options;
-			var countOptionsCase = options.CountOptionCase;
-			var streamOptionsCase = options.StreamOptionCase;
-			var readDirection = options.ReadDirection;
-			var filterOptionsCase = options.FilterOptionCase;
-			var compatibility = options.ControlOption?.Compatibility ?? 0;
 
-			var user = context.GetHttpContext().User;
-			var requiresLeader = GetRequiresLeader(context.RequestHeaders);
+			var trackDuration = request.Options.CountOptionCase != CountOptionOneofCase.Subscription;
+			using var duration = trackDuration ? _readTracker.Start() : new();
+			try {
+				var options = request.Options;
+				var countOptionsCase = options.CountOptionCase;
+				var streamOptionsCase = options.StreamOptionCase;
+				var readDirection = options.ReadDirection;
+				var filterOptionsCase = options.FilterOptionCase;
+				var compatibility = options.ControlOption?.Compatibility ?? 0;
 
-			var op = streamOptionsCase switch {
-				StreamOptionOneofCase.Stream => ReadOperation.WithParameter(
-					Plugins.Authorization.Operations.Streams.Parameters.StreamId(
-						request.Options.Stream.StreamIdentifier)),
-				StreamOptionOneofCase.All => ReadOperation.WithParameter(
-					Plugins.Authorization.Operations.Streams.Parameters.StreamId(SystemStreams.AllStream)),
-				_ => throw RpcExceptions.InvalidArgument(streamOptionsCase)
-			};
+				var user = context.GetHttpContext().User;
+				var requiresLeader = GetRequiresLeader(context.RequestHeaders);
 
-			if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
-				throw RpcExceptions.AccessDenied();
-			}
-
-			var enumerator =
-				(streamOptionsCase, countOptionsCase, readDirection, filterOptionsCase) switch {
-					(StreamOptionOneofCase.Stream,
-						CountOptionOneofCase.Count,
-						ReadDirection.Forwards,
-						FilterOptionOneofCase.NoFilter) => (IAsyncEnumerator<ReadResp>)
-						new Enumerators.ReadStreamForwards(
-							_publisher,
-							request.Options.Stream.StreamIdentifier,
-							request.Options.Stream.ToStreamRevision(),
-							request.Options.Count,
-							request.Options.ResolveLinks,
-							user,
-							requiresLeader,
-							context.Deadline,
-							options.UuidOption,
-							compatibility,
-							context.CancellationToken),
-					(StreamOptionOneofCase.Stream,
-						CountOptionOneofCase.Count,
-						ReadDirection.Backwards,
-						FilterOptionOneofCase.NoFilter) => new Enumerators.ReadStreamBackwards(
-							_publisher,
-							request.Options.Stream.StreamIdentifier,
-							request.Options.Stream.ToStreamRevision(),
-							request.Options.Count,
-							request.Options.ResolveLinks,
-							user,
-							requiresLeader,
-							context.Deadline,
-							options.UuidOption,
-							compatibility,
-							context.CancellationToken),
-					(StreamOptionOneofCase.All,
-						CountOptionOneofCase.Count,
-						ReadDirection.Forwards,
-						FilterOptionOneofCase.NoFilter) => new Enumerators.ReadAllForwards(
-							_publisher,
-							request.Options.All.ToPosition(),
-							request.Options.Count,
-							request.Options.ResolveLinks,
-							user,
-							requiresLeader,
-							context.Deadline,
-							options.UuidOption,
-							context.CancellationToken),
-					(StreamOptionOneofCase.All,
-						CountOptionOneofCase.Count,
-						ReadDirection.Forwards,
-						FilterOptionOneofCase.Filter) => new Enumerators.ReadAllForwardsFiltered(
-							_publisher,
-							request.Options.All.ToPosition(),
-							request.Options.Count,
-							request.Options.ResolveLinks,
-							ConvertToEventFilter(true, request.Options.Filter),
-							user,
-							requiresLeader,
-							_readIndex,
-							request.Options.Filter.WindowCase switch {
-								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
-								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
-									.Max,
-								_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
-							},
-							context.Deadline,
-							options.UuidOption,
-							context.CancellationToken),
-					(StreamOptionOneofCase.All,
-						CountOptionOneofCase.Count,
-						ReadDirection.Backwards,
-						FilterOptionOneofCase.NoFilter) => new Enumerators.ReadAllBackwards(
-							_publisher,
-							request.Options.All.ToPosition(),
-							request.Options.Count,
-							request.Options.ResolveLinks,
-							user,
-							requiresLeader,
-							context.Deadline,
-							options.UuidOption,
-							context.CancellationToken),
-					(StreamOptionOneofCase.All,
-						CountOptionOneofCase.Count,
-						ReadDirection.Backwards,
-						FilterOptionOneofCase.Filter) => new Enumerators.ReadAllBackwardsFiltered(
-							_publisher,
-							request.Options.All.ToPosition(),
-							request.Options.Count,
-							request.Options.ResolveLinks,
-							ConvertToEventFilter(true, request.Options.Filter),
-							user,
-							requiresLeader,
-							_readIndex,
-							request.Options.Filter.WindowCase switch {
-								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
-								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
-									.Max,
-								_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
-							},
-							context.Deadline,
-							options.UuidOption,
-							context.CancellationToken),
-					(StreamOptionOneofCase.Stream,
-						CountOptionOneofCase.Subscription,
-						ReadDirection.Forwards,
-						FilterOptionOneofCase.NoFilter) => new Enumerators.StreamSubscription<TStreamId>(
-							_publisher,
-							_expiryStrategy,
-							request.Options.Stream.StreamIdentifier,
-							request.Options.Stream.ToSubscriptionStreamRevision(),
-							request.Options.ResolveLinks,
-							user,
-							requiresLeader,
-							options.UuidOption,
-							context.CancellationToken),
-					(StreamOptionOneofCase.All,
-						CountOptionOneofCase.Subscription,
-						ReadDirection.Forwards,
-						FilterOptionOneofCase.NoFilter) => new Enumerators.AllSubscription(
-							_publisher,
-							_expiryStrategy,
-							request.Options.All.ToSubscriptionPosition(),
-							request.Options.ResolveLinks,
-							user,
-							requiresLeader,
-							_readIndex,
-							options.UuidOption,
-							context.CancellationToken),
-					(StreamOptionOneofCase.All,
-						CountOptionOneofCase.Subscription,
-						ReadDirection.Forwards,
-						FilterOptionOneofCase.Filter) => new Enumerators.AllSubscriptionFiltered(
-							_publisher,
-							_expiryStrategy,
-							request.Options.All.ToSubscriptionPosition(),
-							request.Options.ResolveLinks,
-							ConvertToEventFilter(true, request.Options.Filter),
-							user,
-							requiresLeader,
-							_readIndex,
-							request.Options.Filter.WindowCase switch {
-								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
-								ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
-									.Max,
-								_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
-							},
-							request.Options.Filter.CheckpointIntervalMultiplier,
-							options.UuidOption,
-							context.CancellationToken),
-					_ => throw RpcExceptions.InvalidCombination((streamOptionsCase, countOptionsCase, readDirection,
-						filterOptionsCase))
+				var op = streamOptionsCase switch {
+					StreamOptionOneofCase.Stream => ReadOperation.WithParameter(
+						Plugins.Authorization.Operations.Streams.Parameters.StreamId(
+							request.Options.Stream.StreamIdentifier)),
+					StreamOptionOneofCase.All => ReadOperation.WithParameter(
+						Plugins.Authorization.Operations.Streams.Parameters.StreamId(SystemStreams.AllStream)),
+					_ => throw RpcExceptions.InvalidArgument(streamOptionsCase)
 				};
 
-			await using (enumerator.ConfigureAwait(false))
-			await using (context.CancellationToken.Register(() => enumerator.DisposeAsync()).ConfigureAwait(false)) {
-				while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
-					await responseStream.WriteAsync(enumerator.Current).ConfigureAwait(false);
+				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
+					throw RpcExceptions.AccessDenied();
 				}
-			}
 
-			IEventFilter ConvertToEventFilter(bool isAllStream, ReadReq.Types.Options.Types.FilterOptions filter) =>
-				filter.FilterCase switch {
-					ReadReq.Types.Options.Types.FilterOptions.FilterOneofCase.EventType => (
-						string.IsNullOrEmpty(filter.EventType.Regex)
-							? EventFilter.EventType.Prefixes(isAllStream, filter.EventType.Prefix.ToArray())
-							: EventFilter.EventType.Regex(isAllStream, filter.EventType.Regex)),
-					ReadReq.Types.Options.Types.FilterOptions.FilterOneofCase.StreamIdentifier => (
-						string.IsNullOrEmpty(filter.StreamIdentifier.Regex)
-							? EventFilter.StreamName.Prefixes(isAllStream, filter.StreamIdentifier.Prefix.ToArray())
-							: EventFilter.StreamName.Regex(isAllStream, filter.StreamIdentifier.Regex)),
-					_ => throw RpcExceptions.InvalidArgument(filter)
-				};
+				var enumerator =
+					(streamOptionsCase, countOptionsCase, readDirection, filterOptionsCase) switch {
+						(StreamOptionOneofCase.Stream,
+							CountOptionOneofCase.Count,
+							ReadDirection.Forwards,
+							FilterOptionOneofCase.NoFilter) => (IAsyncEnumerator<ReadResp>)
+							new Enumerators.ReadStreamForwards(
+								_publisher,
+								request.Options.Stream.StreamIdentifier,
+								request.Options.Stream.ToStreamRevision(),
+								request.Options.Count,
+								request.Options.ResolveLinks,
+								user,
+								requiresLeader,
+								context.Deadline,
+								options.UuidOption,
+								compatibility,
+								context.CancellationToken),
+						(StreamOptionOneofCase.Stream,
+							CountOptionOneofCase.Count,
+							ReadDirection.Backwards,
+							FilterOptionOneofCase.NoFilter) => new Enumerators.ReadStreamBackwards(
+								_publisher,
+								request.Options.Stream.StreamIdentifier,
+								request.Options.Stream.ToStreamRevision(),
+								request.Options.Count,
+								request.Options.ResolveLinks,
+								user,
+								requiresLeader,
+								context.Deadline,
+								options.UuidOption,
+								compatibility,
+								context.CancellationToken),
+						(StreamOptionOneofCase.All,
+							CountOptionOneofCase.Count,
+							ReadDirection.Forwards,
+							FilterOptionOneofCase.NoFilter) => new Enumerators.ReadAllForwards(
+								_publisher,
+								request.Options.All.ToPosition(),
+								request.Options.Count,
+								request.Options.ResolveLinks,
+								user,
+								requiresLeader,
+								context.Deadline,
+								options.UuidOption,
+								context.CancellationToken),
+						(StreamOptionOneofCase.All,
+							CountOptionOneofCase.Count,
+							ReadDirection.Forwards,
+							FilterOptionOneofCase.Filter) => new Enumerators.ReadAllForwardsFiltered(
+								_publisher,
+								request.Options.All.ToPosition(),
+								request.Options.Count,
+								request.Options.ResolveLinks,
+								ConvertToEventFilter(true, request.Options.Filter),
+								user,
+								requiresLeader,
+								_readIndex,
+								request.Options.Filter.WindowCase switch {
+									ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
+									ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
+										.Max,
+									_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
+								},
+								context.Deadline,
+								options.UuidOption,
+								context.CancellationToken),
+						(StreamOptionOneofCase.All,
+							CountOptionOneofCase.Count,
+							ReadDirection.Backwards,
+							FilterOptionOneofCase.NoFilter) => new Enumerators.ReadAllBackwards(
+								_publisher,
+								request.Options.All.ToPosition(),
+								request.Options.Count,
+								request.Options.ResolveLinks,
+								user,
+								requiresLeader,
+								context.Deadline,
+								options.UuidOption,
+								context.CancellationToken),
+						(StreamOptionOneofCase.All,
+							CountOptionOneofCase.Count,
+							ReadDirection.Backwards,
+							FilterOptionOneofCase.Filter) => new Enumerators.ReadAllBackwardsFiltered(
+								_publisher,
+								request.Options.All.ToPosition(),
+								request.Options.Count,
+								request.Options.ResolveLinks,
+								ConvertToEventFilter(true, request.Options.Filter),
+								user,
+								requiresLeader,
+								_readIndex,
+								request.Options.Filter.WindowCase switch {
+									ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
+									ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
+										.Max,
+									_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
+								},
+								context.Deadline,
+								options.UuidOption,
+								context.CancellationToken),
+						(StreamOptionOneofCase.Stream,
+							CountOptionOneofCase.Subscription,
+							ReadDirection.Forwards,
+							FilterOptionOneofCase.NoFilter) => new Enumerators.StreamSubscription<TStreamId>(
+								_publisher,
+								_expiryStrategy,
+								request.Options.Stream.StreamIdentifier,
+								request.Options.Stream.ToSubscriptionStreamRevision(),
+								request.Options.ResolveLinks,
+								user,
+								requiresLeader,
+								options.UuidOption,
+								context.CancellationToken),
+						(StreamOptionOneofCase.All,
+							CountOptionOneofCase.Subscription,
+							ReadDirection.Forwards,
+							FilterOptionOneofCase.NoFilter) => new Enumerators.AllSubscription(
+								_publisher,
+								_expiryStrategy,
+								request.Options.All.ToSubscriptionPosition(),
+								request.Options.ResolveLinks,
+								user,
+								requiresLeader,
+								_readIndex,
+								options.UuidOption,
+								context.CancellationToken),
+						(StreamOptionOneofCase.All,
+							CountOptionOneofCase.Subscription,
+							ReadDirection.Forwards,
+							FilterOptionOneofCase.Filter) => new Enumerators.AllSubscriptionFiltered(
+								_publisher,
+								_expiryStrategy,
+								request.Options.All.ToSubscriptionPosition(),
+								request.Options.ResolveLinks,
+								ConvertToEventFilter(true, request.Options.Filter),
+								user,
+								requiresLeader,
+								_readIndex,
+								request.Options.Filter.WindowCase switch {
+									ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
+									ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
+										.Max,
+									_ => throw RpcExceptions.InvalidArgument(request.Options.Filter.WindowCase)
+								},
+								request.Options.Filter.CheckpointIntervalMultiplier,
+								options.UuidOption,
+								context.CancellationToken),
+						_ => throw RpcExceptions.InvalidCombination((streamOptionsCase, countOptionsCase, readDirection,
+							filterOptionsCase))
+					};
+
+				await using (enumerator.ConfigureAwait(false))
+				await using (context.CancellationToken.Register(() => enumerator.DisposeAsync()).ConfigureAwait(false)) {
+					while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+						await responseStream.WriteAsync(enumerator.Current).ConfigureAwait(false);
+					}
+				}
+
+				IEventFilter ConvertToEventFilter(bool isAllStream, ReadReq.Types.Options.Types.FilterOptions filter) =>
+					filter.FilterCase switch {
+						ReadReq.Types.Options.Types.FilterOptions.FilterOneofCase.EventType => (
+							string.IsNullOrEmpty(filter.EventType.Regex)
+								? EventFilter.EventType.Prefixes(isAllStream, filter.EventType.Prefix.ToArray())
+								: EventFilter.EventType.Regex(isAllStream, filter.EventType.Regex)),
+						ReadReq.Types.Options.Types.FilterOptions.FilterOneofCase.StreamIdentifier => (
+							string.IsNullOrEmpty(filter.StreamIdentifier.Regex)
+								? EventFilter.StreamName.Prefixes(isAllStream, filter.StreamIdentifier.Prefix.ToArray())
+								: EventFilter.StreamName.Regex(isAllStream, filter.StreamIdentifier.Regex)),
+						_ => throw RpcExceptions.InvalidArgument(filter)
+					};
+			} catch (Exception ex) {
+				duration.SetException(ex);
+				throw;
+			}
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
@@ -1,6 +1,8 @@
 using System;
+using EventStore.Common.Configuration;
 using EventStore.Core.Bus;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Telemetry;
 using EventStore.Plugins.Authorization;
 
 namespace EventStore.Core.Services.Transport.Grpc {
@@ -10,6 +12,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		private readonly int _maxAppendSize;
 		private readonly TimeSpan _writeTimeout;
 		private readonly IExpiryStrategy _expiryStrategy;
+		private readonly IDurationTracker _readTracker;
+		private readonly IDurationTracker _appendTracker;
+		private readonly IDurationTracker _batchAppendTracker;
+		private readonly IDurationTracker _deleteTracker;
+		private readonly IDurationTracker _tombstoneTracker;
 		private readonly IAuthorizationProvider _provider;
 		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Streams.Read);
 		private static readonly Operation WriteOperation = new Operation(Plugins.Authorization.Operations.Streams.Write);
@@ -17,13 +24,20 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 		public Streams(IPublisher publisher, IReadIndex<TStreamId> readIndex, int maxAppendSize, TimeSpan writeTimeout,
 			IExpiryStrategy expiryStrategy,
+			GrpcTrackers trackers,
 			IAuthorizationProvider provider) {
+	
 			if (publisher == null) throw new ArgumentNullException(nameof(publisher));
 			_publisher = publisher;
 			_readIndex = readIndex;
 			_maxAppendSize = maxAppendSize;
 			_writeTimeout = writeTimeout;
 			_expiryStrategy = expiryStrategy;
+			_readTracker = trackers[TelemetryConfiguration.GrpcMethod.StreamRead];
+			_appendTracker = trackers[TelemetryConfiguration.GrpcMethod.StreamAppend];
+			_batchAppendTracker = trackers[TelemetryConfiguration.GrpcMethod.StreamBatchAppend];
+			_deleteTracker = trackers[TelemetryConfiguration.GrpcMethod.StreamDelete];
+			_tombstoneTracker = trackers[TelemetryConfiguration.GrpcMethod.StreamTombstone];
 			_provider = provider;
 		}
 	}

--- a/src/EventStore.Core/Telemetry/Clock.cs
+++ b/src/EventStore.Core/Telemetry/Clock.cs
@@ -2,11 +2,13 @@
 
 namespace EventStore.Core.Telemetry {
 	public interface IClock {
+		DateTime UtcNow { get; }
 		long SecondsSinceEpoch { get; }
 	}
 
 	public class Clock : IClock {
 		public static readonly Clock Instance = new();
+		public DateTime UtcNow => DateTime.UtcNow;
 		public long SecondsSinceEpoch => DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 	}
 }

--- a/src/EventStore.Core/Telemetry/Duration.cs
+++ b/src/EventStore.Core/Telemetry/Duration.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EventStore.Core.Telemetry {
+	public struct Duration : IDisposable {
+		private readonly DurationMetric _metric;
+		private readonly string _name;
+		private readonly DateTime _start;
+		private bool _failed;
+
+		public Duration(DurationMetric metric, string name, DateTime start) {
+			_metric = metric;
+			_name = name;
+			_start = start;
+			_failed = false;
+		}
+
+		public void SetException(Exception ex) {
+			_failed = true;
+		}
+
+		public void Dispose() {
+			_metric?.Record(
+				_start,
+				new KeyValuePair<string, object>("activity", _name),
+				new KeyValuePair<string, object>("status", _failed ? "failed" : "successful"));
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/DurationMetric.cs
+++ b/src/EventStore.Core/Telemetry/DurationMetric.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace EventStore.Core.Telemetry {
+	public class DurationMetric {
+		private readonly Histogram<double> _histogram;
+		private readonly IClock _clock;
+
+		public DurationMetric(Meter meter, string name, IClock clock = null) {
+			_clock = clock ?? Clock.Instance;
+			_histogram = meter.CreateHistogram<double>(name, "seconds");
+		}
+
+		public Duration Start(string durationName) =>
+			new(this, durationName, _clock.UtcNow);
+
+		public void Record(
+			DateTime start,
+			KeyValuePair<string, object> tag1,
+			KeyValuePair<string, object> tag2) {
+
+			var elapsed = _clock.UtcNow - start;
+			_histogram.Record(elapsed.TotalSeconds, tag1, tag2);
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/DurationTracker.cs
+++ b/src/EventStore.Core/Telemetry/DurationTracker.cs
@@ -1,0 +1,22 @@
+﻿namespace EventStore.Core.Telemetry {
+
+	public interface IDurationTracker {
+		Duration Start();
+	}
+
+	public class DurationTracker : IDurationTracker {
+		private readonly DurationMetric _metric;
+		private readonly string _durationName;
+
+		public DurationTracker(DurationMetric metric, string durationName) {
+			_metric = metric;
+			_durationName = durationName;
+		}
+
+		public Duration Start() => _metric.Start(_durationName);
+
+		public class NoOp : IDurationTracker {
+			public Duration Start() => new();
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/StatusMetric.cs
+++ b/src/EventStore.Core/Telemetry/StatusMetric.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.Telemetry {
 			}
 		}
 
-		public IEnumerable<Measurement<long>> Observe() {
+		private IEnumerable<Measurement<long>> Observe() {
 			var secondsSinceEpoch = _clock.SecondsSinceEpoch;
 			lock (_subMetrics) {
 				foreach (var instance in _subMetrics) {

--- a/src/EventStore.Core/TransactionLog/Checkpoint/CheckpointMetric.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/CheckpointMetric.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 			meter.CreateObservableUpDownCounter(name, Observe);
 		}
 
-		public IEnumerable<Measurement<long>> Observe() {
+		private IEnumerable<Measurement<long>> Observe() {
 			for (var i = 0; i < _checkpoints.Length; i++) {
 				// looks like the Measurement constructor will allocate an array for the tags but the
 				// other constructor overloads appear to allocate two


### PR DESCRIPTION
Added: Histograms for gRPC reads and appends

The changes in the gRPC services are only wrapping existing code with the timing mechanism. No changes to the logic.