### PR TITLE
Add Max Queue Durations Over Period

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -1,4 +1,7 @@
 {
+	// must be 0, 1, 5, 10 or a multiple of 15
+	"ExpectedScrapeIntervalSeconds": 15,
+
 	"Meters": [
 		"EventStore.Core"
 	],
@@ -22,5 +25,50 @@
 		"StreamBatchAppend": "append",
 		"StreamDelete": "",
 		"StreamTombstone": ""
-	}
+	},
+
+	// this specifies what name to track each queue under, according to regular expressions to
+	// match the queue names against
+	"Queues": [
+		{
+			"Regex": "MainQueue",
+			"Label": "Main Queue"
+		},
+		{
+			"Regex": "MonitoringQueue",
+			"Label": "Monitoring Queue"
+		},
+		{
+			"Regex": "StorageReaderQueue #.*",
+			"Label": "Reader Queue"
+		},
+		{
+			"Regex": "StorageWriterQueue",
+			"Label": "Writer Queue"
+		},
+		{
+			"Regex": "Subscriptions",
+			"Label": "Subscriptions Queue"
+		},
+		{
+			"Regex": "PersistentSubscriptions",
+			"Label": "Persistent Subscriptions Queue"
+		},
+		{
+			"Regex": "Projections Leader",
+			"Label": "Projections Leader Queue"
+		},
+		{
+			"Regex": "Projection Core #.*",
+			"Label": "Projections Core Queue"
+		},
+		{
+			"Regex": "Worker #.*",
+			"Label": "Worker Queue"
+		},
+		{
+			"Regex": ".*",
+			"Label": "Other Queue"
+		}
+	]
 }

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -57,6 +57,11 @@ namespace EventStore.Common.Configuration {
 			StreamTombstone,
 		}
 
+		public class LabelMappingCase {
+			public string Regex { get; set; }
+			public string Label { get; set; }
+		}
+
 		public string[] Meters { get; set; } = Array.Empty<string>();
 
 		public StatusTracker[] StatusTrackers { get; set; } = Array.Empty<StatusTracker>();
@@ -64,5 +69,10 @@ namespace EventStore.Common.Configuration {
 		public Checkpoint[] Checkpoints { get; set; } = Array.Empty<Checkpoint>();
 
 		public Dictionary<GrpcMethod, string> GrpcMethods { get; set; } = new();
+
+		// must be 0, 1, 5, 10 or a multiple of 15
+		public int ExpectedScrapeIntervalSeconds { get; set; }
+
+		public LabelMappingCase[] Queues { get; set; } = Array.Empty<LabelMappingCase>();
 	}
 }

--- a/src/EventStore.Core.Tests/Bus/QueueSpeedTest.cs
+++ b/src/EventStore.Core.Tests/Bus/QueueSpeedTest.cs
@@ -124,7 +124,7 @@ namespace EventStore.Core.Tests.Bus {
 		public void mres_queued_handler_2_producers_50mln_messages() {
 			QueuedHandlerMRES queue = null;
 			SpeedTest(consumer => {
-				queue = new QueuedHandlerMRES(consumer, "Queue",  new QueueStatsManager(),false);
+				queue = new QueuedHandlerMRES(consumer, "Queue",  new QueueStatsManager(), new(), watchSlowMsg: false);
 				queue.Start();
 				return queue;
 			}, 2, 50000000);
@@ -135,7 +135,7 @@ namespace EventStore.Core.Tests.Bus {
 		public void mres_queued_handler_10_producers_50mln_messages() {
 			QueuedHandlerMRES queue = null;
 			SpeedTest(consumer => {
-				queue = new QueuedHandlerMRES(consumer, "Queue", new QueueStatsManager(), false);
+				queue = new QueuedHandlerMRES(consumer, "Queue", new QueueStatsManager(), new(), watchSlowMsg: false);
 				queue.Start();
 				return queue;
 			}, 10, 50000000);

--- a/src/EventStore.Core.Tests/Bus/queued_handler_should.cs
+++ b/src/EventStore.Core.Tests/Bus/queued_handler_should.cs
@@ -14,13 +14,13 @@ namespace EventStore.Core.Tests.Bus {
 		[Test]
 		public void throw_if_handler_is_null() {
 			Assert.Throws<ArgumentNullException>(
-				() => QueuedHandler.CreateQueuedHandler(null, "throwing", new QueueStatsManager(), watchSlowMsg: false));
+				() => QueuedHandler.CreateQueuedHandler(null, "throwing", new QueueStatsManager(), new(), watchSlowMsg: false));
 		}
 
 		[Test]
 		public void throw_if_name_is_null() {
 			Assert.Throws<ArgumentNullException>(
-				() => QueuedHandler.CreateQueuedHandler(Consumer, null, new QueueStatsManager(), watchSlowMsg: false));
+				() => QueuedHandler.CreateQueuedHandler(Consumer, null, new QueueStatsManager(), new(), watchSlowMsg: false));
 		}
 	}
 
@@ -56,7 +56,7 @@ namespace EventStore.Core.Tests.Bus {
 	[TestFixture]
 	public class queued_handler_threadpool_should : queued_handler_should {
 		public queued_handler_threadpool_should()
-			: base((consumer, name, timeout) => new QueuedHandlerThreadPool(consumer, name, new QueueStatsManager(),false, null, timeout)) {
+			: base((consumer, name, timeout) => new QueuedHandlerThreadPool(consumer, name, new QueueStatsManager(), new(), false, null, timeout)) {
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Bus/when_publishing_to_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_publishing_to_queued_handler.cs
@@ -110,7 +110,7 @@ namespace EventStore.Core.Tests.Bus {
 	[TestFixture, Category("LongRunning")]
 	public class when_publishing_to_queued_handler_threadpool : when_publishing_to_queued_handler {
 		public when_publishing_to_queued_handler_threadpool()
-			: base((consumer, name, timeout) => new QueuedHandlerThreadPool(consumer, name, new QueueStatsManager(),false, null, timeout)) {
+			: base((consumer, name, timeout) => new QueuedHandlerThreadPool(consumer, name, new QueueStatsManager(), new(), false, null, timeout)) {
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
+++ b/src/EventStore.Core.Tests/Bus/when_stopping_queued_handler.cs
@@ -59,7 +59,7 @@ namespace EventStore.Core.Tests.Bus {
 		[Test]
 		public void while_queue_is_busy_should_crash_with_timeout() {
 			var consumer = new WaitingConsumer(1);
-			var busyQueue = QueuedHandler.CreateQueuedHandler(consumer, "busy_test_queue", new QueueStatsManager(), watchSlowMsg: false,
+			var busyQueue = QueuedHandler.CreateQueuedHandler(consumer, "busy_test_queue", new QueueStatsManager(), new(), watchSlowMsg: false,
 				threadStopWaitTimeout: TimeSpan.FromMilliseconds(100));
 			var waitHandle = new ManualResetEvent(false);
 			var handledEvent = new ManualResetEvent(false);
@@ -116,7 +116,7 @@ namespace EventStore.Core.Tests.Bus {
 	[TestFixture]
 	public class when_stopping_queued_handler_threadpool : when_stopping_queued_handler {
 		public when_stopping_queued_handler_threadpool()
-			: base((consumer, name, timeout) => new QueuedHandlerThreadPool(consumer, name, new QueueStatsManager(),false, null, timeout)) {
+			: base((consumer, name, timeout) => new QueuedHandlerThreadPool(consumer, name, new QueueStatsManager(), new(), false, null, timeout)) {
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/with_read_io_dispatcher.cs
+++ b/src/EventStore.Core.Tests/Helpers/IODispatcherTests/ReadEventsTests/with_read_io_dispatcher.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Helpers.IODispatcherTests.ReadEventsTests {
 
 		[OneTimeSetUp]
 		public virtual void TestFixtureSetUp() {
-			var _queue = QueuedHandler.CreateQueuedHandler(_bus,"TestQueuedHandler", new QueueStatsManager());
+			var _queue = QueuedHandler.CreateQueuedHandler(_bus,"TestQueuedHandler", new QueueStatsManager(), new());
 			_ioDispatcher = new IODispatcher(_bus, new PublishEnvelope(_queue));
 			IODispatcherTestHelpers.SubscribeIODispatcher(_ioDispatcher, _bus);
 			_bus.Subscribe<ClientMessage.ReadStreamEventsForward>(this);

--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -50,7 +50,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 		public void SetUp(Action<IHttpService> bootstrap = null) {
 			_bus = new InMemoryBus($"bus_{_serverEndPoint.Port}");
 			var pipelineBus = InMemoryBus.CreateTest();
-			var queue = new QueuedHandlerThreadPool(pipelineBus, "Test", new QueueStatsManager(), true, TimeSpan.FromMilliseconds(50));
+			var queue = new QueuedHandlerThreadPool(pipelineBus, "Test", new QueueStatsManager(), new(), true, TimeSpan.FromMilliseconds(50));
 			_multiQueuedHandler = new MultiQueuedHandler(new IQueuedHandler[] {queue}, null);
 			_multiQueuedHandler.Start();
 

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/DurationMaxTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/DurationMaxTrackerTests.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using EventStore.Core.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public class DurationMaxTrackerTests : IDisposable {
+	private readonly TestMeterListener<double> _listener;
+	private readonly FakeClock _clock = new();
+	private readonly DurationMaxTracker _sut;
+
+	public DurationMaxTrackerTests() {
+		var meter = new Meter($"{typeof(DurationMaxTrackerTests)}");
+		_listener = new TestMeterListener<double>(meter);
+		var metric = new DurationMaxMetric(meter, "the-metric");
+		_sut = new DurationMaxTracker(
+			metric: metric,
+			name: "the-tracker",
+			expectedScrapeIntervalSeconds: 15,
+			clock: _clock);
+	}
+
+	public void Dispose() {
+		_listener.Dispose();
+	}
+
+	[Fact]
+	public void throws_with_invalid_period_configuration() {
+		var ex = Assert.Throws<ArgumentException>(() => {
+			var sut = new DurationMaxTracker(
+				metric: null,
+				name: "the-tracker",
+				expectedScrapeIntervalSeconds: 16,
+				clock: _clock);
+		});
+
+		Assert.Equal(
+			"ExpectedScrapeIntervalSeconds must be 0, 1, 5, 10 or a multiple of 15, but was 16",
+			ex.Message);
+
+	}
+	[Fact]
+	public void no_records() {
+		AssertMeasurements(0);
+	}
+
+	[Fact]
+	public void one_record() {
+		AssertMeasurements(0);
+		_clock.SecondsSinceEpoch = 500;
+		var start = _clock.Now;
+		_clock.SecondsSinceEpoch = 501;
+		_sut.RecordNow(start);
+		AssertMeasurements(1);
+	}
+
+	[Fact]
+	public void two_records_ascending() {
+		AssertMeasurements(0);
+		_clock.SecondsSinceEpoch = 500;
+		var start1 = _clock.Now;
+		var start2 = _clock.Now;
+		_clock.SecondsSinceEpoch = 501;
+		_sut.RecordNow(start1); // record a 1s duration
+		AssertMeasurements(1);
+		_clock.SecondsSinceEpoch = 502;
+		_sut.RecordNow(start2); // record a 2s duration
+		AssertMeasurements(2);
+	}
+
+	[Fact]
+	public void two_records_descending() {
+		AssertMeasurements(0);
+		_clock.SecondsSinceEpoch = 500;
+		var start2 = _clock.Now;
+		_clock.SecondsSinceEpoch = 502;
+		_sut.RecordNow(start2); // record a 2s duration
+		var start1 = _clock.Now;
+		AssertMeasurements(2);
+		_clock.SecondsSinceEpoch = 503;
+		_sut.RecordNow(start1); // record a 1s duration
+		AssertMeasurements(2);
+	}
+
+	[Fact]
+	public void removes_stale_data() {
+		_clock.SecondsSinceEpoch = 500;
+		var start = _clock.Now;
+		_clock.SecondsSinceEpoch = 501;
+		_sut.RecordNow(start);
+		_clock.SecondsSinceEpoch = 510;
+		AssertMeasurements(1);
+		_clock.SecondsSinceEpoch = 522;
+		AssertMeasurements(0);
+	}
+
+	[Fact]
+	public void removes_stale_data_incrementally() {
+		_clock.SecondsSinceEpoch = 500;
+		var start10 = _clock.Now;
+
+		_clock.SecondsSinceEpoch = 505;
+		var start9 = _clock.Now;
+
+		_clock.SecondsSinceEpoch = 510;
+		var start8 = _clock.Now;
+
+		_clock.SecondsSinceEpoch = 515;
+		var start7 = _clock.Now;
+
+		_clock.SecondsSinceEpoch = 520;
+		var start6 = _clock.Now;
+
+		_clock.SecondsSinceEpoch = 525;
+		var start5 = _clock.Now;
+
+		// record a series of durations, each 4s apart (so in a different bucket)
+		// there are 5 buckets
+		AssertMeasurements(0);
+
+		_clock.SecondsSinceEpoch = 510;
+		_sut.RecordNow(start10); // record a 10s duration
+		AssertMeasurements(10);
+
+		_clock.SecondsSinceEpoch = 514;
+		_sut.RecordNow(start9); // record a 9s duration
+		AssertMeasurements(10);
+
+		_clock.SecondsSinceEpoch = 518;
+		_sut.RecordNow(start8); // record a 8s duration
+		AssertMeasurements(10);
+
+		_clock.SecondsSinceEpoch = 522;
+		_sut.RecordNow(start7); // record a 7s duration
+		AssertMeasurements(10);
+
+		_clock.SecondsSinceEpoch = 526;
+		_sut.RecordNow(start6); // record a 6s duration
+		AssertMeasurements(10);
+
+		_clock.SecondsSinceEpoch = 530;
+		_sut.RecordNow(start5); // record a 5s duration
+		// original measurement has become stale
+		AssertMeasurements(9);
+	}
+
+	void AssertMeasurements(double expectedValue) {
+		_listener.Observe();
+
+		Assert.Collection(
+			_listener.RetrieveMeasurements("the-metric"),
+			m => {
+				Assert.Equal(expectedValue, m.Value);
+				Assert.Collection(
+					m.Tags.ToArray(),
+					t => {
+						Assert.Equal("name", t.Key);
+						Assert.Equal("the-tracker", t.Value);
+					},
+					t => {
+						Assert.Equal("range", t.Key);
+						Assert.Equal("16-20 seconds", t.Value);
+					});
+			});
+	}
+
+	public class BucketCalculatorTests {
+		private readonly DurationMaxTracker.BucketCalculator _sut = new();
+
+		[Theory]
+		[InlineData(0, 1, 1, 0, 1)]
+		[InlineData(1, 3, 1, 2, 3)]
+		[InlineData(5, 4, 2, 6, 8)]
+		[InlineData(10, 5, 3, 12, 15)]
+		[InlineData(15, 5, 4, 16, 20)]
+		[InlineData(30, 5, 8, 32, 40)]
+		[InlineData(45, 5, 12, 48, 60)]
+		[InlineData(60, 5, 16, 64, 80)]
+		[InlineData(75, 5, 20, 80, 100)]
+		[InlineData(90, 5, 24, 96, 120)]
+		[InlineData(105, 5, 28, 112, 140)]
+		[InlineData(120, 5, 32, 128, 160)]
+		public void calculates_happy_path(
+			int scrapeIntervalSeconds,
+			int expectedNumBuckets,
+			int expectedSecondsPerBucket,
+			int expectedMinPeriodSeconds,
+			int expectedMaxPeriodSeconds) {
+
+			_sut.Calculate(
+				scrapeIntervalSeconds,
+				out var actualNumBuckets,
+				out var actualSecondsPerBucket,
+				out var actualMinPeriodSeconds,
+				out var actualMaxPeriodSeconds);
+
+			Assert.Equal(expectedNumBuckets, actualNumBuckets);
+			Assert.Equal(expectedSecondsPerBucket, actualSecondsPerBucket);
+			Assert.Equal(expectedMinPeriodSeconds, actualMinPeriodSeconds);
+			Assert.Equal(expectedMaxPeriodSeconds, actualMaxPeriodSeconds);
+		}
+
+		[Fact]
+		public void throws() {
+			var ex = Assert.Throws<ArgumentException>(() => {
+				_sut.Calculate(16, out _, out _, out _, out _);
+			});
+
+			Assert.Equal(
+				"ExpectedScrapeIntervalSeconds must be 0, 1, 5, 10 or a multiple of 15, but was 16",
+				ex.Message);
+		}
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/QueueTrackersTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/QueueTrackersTests.cs
@@ -1,0 +1,94 @@
+﻿using EventStore.Core.Telemetry;
+using Xunit;
+using Conf = EventStore.Common.Configuration.TelemetryConfiguration;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry {
+	public class QueueTrackersTests {
+		[Fact]
+		public void default_trackers_yields_noop_tracker() {
+			var sut = new QueueTrackers();
+			var tracker = sut.GetTrackerForQueue("MainQueue");
+			Assert.Equal("NoOp", tracker.Name);
+		}
+
+		[Fact]
+		public void not_matched_yields_noop_tracker() {
+			var sut = GenSut(
+				new Conf.LabelMappingCase {
+					Regex = "MainQueue",
+					Label = "MainQueue",
+				});
+
+
+			var tracker = sut.GetTrackerForQueue("MainQueue");
+			Assert.Equal("MainQueue", tracker.Name);
+
+			tracker = sut.GetTrackerForQueue("WriterQueue");
+			Assert.Equal("NoOp", tracker.Name);
+		}
+
+		[Fact]
+		public void empty_tracker_yields_no_op() {
+			var sut = GenSut(
+				new Conf.LabelMappingCase {
+					Regex = "MainQueue",
+					Label = "",
+				},
+				new Conf.LabelMappingCase {
+					Regex = "WriterQueue",
+					Label = "WriterQueue",
+				});
+
+
+			var tracker = sut.GetTrackerForQueue("WriterQueue");
+			Assert.Equal("WriterQueue", tracker.Name);
+
+			tracker = sut.GetTrackerForQueue("MainQueue");
+			Assert.Equal("NoOp", tracker.Name);
+		}
+
+		[Fact]
+		public void patterns_applied_in_order() {
+			var sut = GenSut(
+				new Conf.LabelMappingCase {
+					Regex = "MainQueue",
+					Label = "MainQueue",
+				},
+				new Conf.LabelMappingCase {
+					Regex = ".*",
+					Label = "OtherQueue",
+				});
+
+			var tracker = sut.GetTrackerForQueue("MainQueue");
+			Assert.Equal("MainQueue", tracker.Name);
+
+			tracker = sut.GetTrackerForQueue("WriterQueue");
+			Assert.Equal("OtherQueue", tracker.Name);
+		}
+
+		[Fact]
+		public void matches_groups() {
+			var sut = GenSut(
+				new Conf.LabelMappingCase {
+					Regex = "Worker #(.*)",
+					Label = "Worker Queue $1",
+				});
+
+			var tracker = sut.GetTrackerForQueue("Worker #3");
+			Assert.Equal("Worker Queue 3", tracker.Name);
+		}
+
+		QueueTrackers GenSut(params Conf.LabelMappingCase[] map) =>
+			new(map, x => {
+				var tracker = new FakeTracker { Name = x };
+				return new QueueTracker(x, tracker);
+			});
+
+		class FakeTracker : IDurationMaxTracker {
+			public string Name { get; init; }
+
+			public void RecordNow(Instant start) {
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Bus/QueueItem.cs
+++ b/src/EventStore.Core/Bus/QueueItem.cs
@@ -1,0 +1,14 @@
+﻿using EventStore.Core.Messaging;
+using EventStore.Core.Telemetry;
+
+namespace EventStore.Core.Bus;
+
+public struct QueueItem {
+	public QueueItem(Instant enqueuedAt, Message message) {
+		EnqueuedAt = enqueuedAt;
+		Message = message;
+	}
+
+	public Instant EnqueuedAt { get; }
+	public Message Message { get; }
+}

--- a/src/EventStore.Core/Bus/QueuedHandler.cs
+++ b/src/EventStore.Core/Bus/QueuedHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using EventStore.Core.Messaging;
+using EventStore.Core.Telemetry;
 
 namespace EventStore.Core.Bus {
 	// on Windows AutoReset version is much slower, but on Linux ManualResetEventSlim version is much slower
@@ -8,6 +9,7 @@ namespace EventStore.Core.Bus {
 		IQueuedHandler {
 		public static IQueuedHandler CreateQueuedHandler(IHandle<Message> consumer, string name,
 			QueueStatsManager queueStatsManager,
+			QueueTrackers trackers,
 			bool watchSlowMsg = true,
 			TimeSpan? slowMsgThreshold = null, TimeSpan? threadStopWaitTimeout = null, string groupName = null) {
 			//if (IntPtr.Size == 8)
@@ -16,7 +18,7 @@ namespace EventStore.Core.Bus {
 			//    return new QueueHandlerUsingMpsc(consumer, name, watchSlowMsg, slowMsgThreshold, threadStopWaitTimeout,
 			//        groupName);
 			//}
-			return new QueuedHandler(consumer, name, queueStatsManager, watchSlowMsg, slowMsgThreshold, threadStopWaitTimeout, groupName);
+			return new QueuedHandler(consumer, name, queueStatsManager, trackers, watchSlowMsg, slowMsgThreshold, threadStopWaitTimeout, groupName);
 		}
 
 		public static readonly TimeSpan DefaultStopWaitTimeout = TimeSpan.FromSeconds(10);
@@ -25,12 +27,13 @@ namespace EventStore.Core.Bus {
 		QueuedHandler(IHandle<Message> consumer,
 			string name,
 			QueueStatsManager queueStatsManager,
+			QueueTrackers trackers,
 			bool watchSlowMsg = true,
 			TimeSpan? slowMsgThreshold = null,
 			TimeSpan? threadStopWaitTimeout = null,
 			string groupName = null)
 			: base(
-				consumer, name, queueStatsManager, watchSlowMsg, slowMsgThreshold, threadStopWaitTimeout ?? DefaultStopWaitTimeout,
+				consumer, name, queueStatsManager, trackers, watchSlowMsg, slowMsgThreshold, threadStopWaitTimeout ?? DefaultStopWaitTimeout,
 				groupName) {
 		}
 

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -12,6 +12,7 @@ using EventStore.Core.Services.Replication;
 using EventStore.Core.Services.Storage;
 using EventStore.Core.Services.Storage.EpochManager;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Telemetry;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
@@ -49,9 +50,10 @@ namespace EventStore.Core.Services {
 			ISystemStreamLookup<TStreamId> systemStreams,
 			IEpochManager epochManager,
 			QueueStatsManager queueStatsManager,
+			QueueTrackers trackers,
 			Func<long> getLastIndexedPosition)
 			: base(bus, subscribeToBus, minFlushDelay, db, writer, indexWriter, recordFactory, streamNameIndex,
-				eventTypeIndex, emptyEventTypeId, systemStreams, epochManager, queueStatsManager) {
+				eventTypeIndex, emptyEventTypeId, systemStreams, epochManager, queueStatsManager, trackers) {
 			Ensure.NotNull(getLastIndexedPosition, "getLastCommitPosition");
 
 			_getLastIndexedPosition = getLastIndexedPosition;

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -6,6 +6,7 @@ using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Telemetry;
 using EventStore.Core.TransactionLog.Checkpoint;
 using ILogger = Serilog.ILogger;
 
@@ -31,7 +32,9 @@ namespace EventStore.Core.Services.Storage {
 			ISystemStreamLookup<TStreamId> systemStreams,
 			int threadCount,
 			IReadOnlyCheckpoint writerCheckpoint, 
-			QueueStatsManager queueStatsManager) {
+			QueueStatsManager queueStatsManager,
+			QueueTrackers trackers) {
+
 			Ensure.NotNull(bus, "bus");
 			Ensure.NotNull(subscriber, "subscriber");
 			Ensure.NotNull(readIndex, "readIndex");
@@ -64,6 +67,7 @@ namespace EventStore.Core.Services.Storage {
 				queueNum => new QueuedHandlerThreadPool(storageReaderBuses[queueNum],
 					string.Format("StorageReaderQueue #{0}", queueNum + 1),
 					queueStatsManager,
+					trackers,
 					groupName: "StorageReaderQueue",
 					watchSlowMsg: true,
 					slowMsgThreshold: TimeSpan.FromMilliseconds(200)));

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -16,6 +16,7 @@ using EventStore.Core.Services.Histograms;
 using EventStore.Core.Services.Monitoring.Stats;
 using EventStore.Core.Services.Storage.EpochManager;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Telemetry;
 using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.LogRecords;
 using Newtonsoft.Json;
@@ -98,7 +99,9 @@ namespace EventStore.Core.Services.Storage {
 			TStreamId emptyEventTypeId,
 			ISystemStreamLookup<TStreamId> systemStreams,
 			IEpochManager epochManager,
-			QueueStatsManager queueStatsManager) {
+			QueueStatsManager queueStatsManager,
+			QueueTrackers trackers) {
+
 			Ensure.NotNull(bus, "bus");
 			Ensure.NotNull(subscribeToBus, "subscribeToBus");
 			Ensure.NotNull(db, "db");
@@ -135,6 +138,7 @@ namespace EventStore.Core.Services.Storage {
 			StorageWriterQueue = QueuedHandler.CreateQueuedHandler(new AdHocHandler<Message>(CommonHandle),
 				"StorageWriterQueue",
 				queueStatsManager,
+				trackers,
 				true,
 				TimeSpan.FromMilliseconds(500));
 			_tasks.Add(StorageWriterQueue.Start());

--- a/src/EventStore.Core/StandardComponents.cs
+++ b/src/EventStore.Core/StandardComponents.cs
@@ -1,6 +1,7 @@
 using EventStore.Core.Bus;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.Transport.Http;
+using EventStore.Core.Telemetry;
 using EventStore.Core.TransactionLog.Chunks;
 
 namespace EventStore.Core {
@@ -24,7 +25,8 @@ namespace EventStore.Core {
 			IHttpForwarder httpForwarder,
 			IHttpService[] httpServices,
 			IPublisher networkSendService,
-			QueueStatsManager queueStatsManager) {
+			QueueStatsManager queueStatsManager,
+			QueueTrackers trackers) {
 			_db = db;
 			_mainQueue = mainQueue;
 			_mainBus = mainBus;
@@ -34,6 +36,7 @@ namespace EventStore.Core {
 			_httpServices = httpServices;
 			_networkSendService = networkSendService;
 			_queueStatsManager = queueStatsManager;
+			QueueTrackers = trackers;
 		}
 
 		public TFChunkDb Db {
@@ -71,5 +74,7 @@ namespace EventStore.Core {
 		public QueueStatsManager QueueStatsManager {
 			get { return _queueStatsManager; }
 		}
+
+		public QueueTrackers QueueTrackers { get; private set; }
 	}
 }

--- a/src/EventStore.Core/Telemetry/Duration.cs
+++ b/src/EventStore.Core/Telemetry/Duration.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 
 namespace EventStore.Core.Telemetry {
+	// This represents an activity that can fail
 	public struct Duration : IDisposable {
 		private readonly DurationMetric _metric;
 		private readonly string _name;

--- a/src/EventStore.Core/Telemetry/DurationMaxMetric.cs
+++ b/src/EventStore.Core/Telemetry/DurationMaxMetric.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace EventStore.Core.Telemetry;
+
+public class DurationMaxMetric {
+	private readonly List<DurationMaxTracker> _trackers = new();
+
+	public DurationMaxMetric(Meter meter, string name) {
+		meter.CreateObservableGauge(name, Observe, "seconds");
+	}
+
+	public void Add(DurationMaxTracker tracker) {
+		lock (_trackers) {
+			_trackers.Add(tracker);
+		}
+	}
+
+	private IEnumerable<Measurement<double>> Observe() {
+		lock (_trackers) {
+			foreach (var tracker in _trackers) {
+				yield return tracker.Observe();
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/DurationMaxTracker.cs
+++ b/src/EventStore.Core/Telemetry/DurationMaxTracker.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+
+namespace EventStore.Core.Telemetry;
+
+public interface IDurationMaxTracker {
+	void RecordNow(Instant start);
+}
+
+// When observed, this returns the max duration that it has been asked to record over the last x
+// seconds, where x is not exact, but within a known range.
+// The idea is, if we expect to take an observation every e.g. ~15 seconds, and that observation
+// contains the max duration over the last 16-20 seconds, then every duration will be captured
+// at least once (although, some of them will be captured twice, which isn't as bad as missing them).
+//
+// It is useful for observing values with high volatility that may spike up significantly and then
+// return to normal between scrapes and therefore the spike would otherwise be missing from the metrics.
+//
+// It works by recording max values in buckets, each bucket representing one sub-period.
+// The max value for the period is then the max across all the buckets.
+// This keeps resource consumption low even when there are a lot of durations recorded.
+// On recording/observing, buckets that contain data that is old enough to not be relevant are reset.
+//
+// Multiple threads can RecordNow and Observe concurrently.
+public class DurationMaxTracker : IDurationMaxTracker {
+	private readonly long _ticksPerBucket;
+	private readonly int _numBuckets;
+	private readonly IClock _clock;
+	private readonly KeyValuePair<string, object>[] _maxTags;
+	private readonly double[] _maxBuckets;
+	private readonly object _lock = new();
+
+	// the sub period when this was last accessed (for recording or observation)
+	// we use this to determine what data (buckets) have become stale in the mean time
+	private long _lastSubPeriod;
+
+	public DurationMaxTracker(
+		DurationMaxMetric metric,
+		string name,
+		int expectedScrapeIntervalSeconds,
+		IClock clock = null,
+		IBucketCalculator bucketCalculator = null) {
+
+		_clock = clock ?? Clock.Instance;
+		bucketCalculator ??= new BucketCalculator();
+
+		bucketCalculator.Calculate(
+			expectedScrapeIntervalSeconds: expectedScrapeIntervalSeconds,
+			numBuckets: out _numBuckets,
+			secondsPerBucket: out var secondsPerBucket,
+			minPeriodSeconds: out var minPeriodSeconds,
+			maxPeriodSeconds: out var maxPeriodSeconds);
+
+		_ticksPerBucket = secondsPerBucket * Instant.TicksPerSecond;
+
+		_maxTags = new KeyValuePair<string, object>[] {
+			new("name", name),
+			new("range", $"{minPeriodSeconds}-{maxPeriodSeconds} seconds"),
+		};
+
+		_maxBuckets = new double[_numBuckets];
+
+		metric.Add(this);
+	}
+
+	public void RecordNow(Instant start) {
+		var now = _clock.Now;
+		var currentSubPeriod = now.Ticks / _ticksPerBucket;
+
+		ResetStaleBuckets(currentSubPeriod);
+
+		var elapsedSeconds = now.ElapsedSecondsSince(start);
+		var currentIndex = (int)(currentSubPeriod % _numBuckets);
+		_maxBuckets[currentIndex] = Math.Max(_maxBuckets[currentIndex], elapsedSeconds);
+	}
+
+	public Measurement<double> Observe() {
+		ResetStaleBuckets(_clock.Now.Ticks / _ticksPerBucket);
+		return new Measurement<double>(_maxBuckets.Max(), _maxTags.AsSpan());
+	}
+
+	private void ResetStaleBuckets(long currentSubPeriod) {
+		lock (_lock) {
+			// reset from the _lastSubPeriod (exclusive) to the currentSubPeriod (inclusive)
+			// which means we need to reset n buckets starting from the bucket after the
+			// _lastSubPeriod where n is currentSubPeriod - _lastSubPeriod, but at most _numBuckets.
+			var numBucketsToReset = Math.Min(currentSubPeriod - _lastSubPeriod, _numBuckets);
+			var targetBucket = (_lastSubPeriod + 1) % _numBuckets;
+			for (var n = 0; n < numBucketsToReset; n++) {
+				_maxBuckets[targetBucket] = 0;
+				targetBucket = (targetBucket + 1) % _numBuckets;
+			}
+
+			_lastSubPeriod = currentSubPeriod;
+		}
+	}
+
+	public interface IBucketCalculator {
+		void Calculate(
+			int expectedScrapeIntervalSeconds,
+			out int numBuckets,
+			out int secondsPerBucket,
+			out int minPeriodSeconds,
+			out int maxPeriodSeconds);
+	}
+
+	// calculates the number of buckets and the length of time each bucket represents. we calculate
+	// these such that the amount of time that observations cover is more than the expected scrape
+	// interval, so that we are likely to capture all the spikes even if a scape is a little late.
+	// if a scrape is _really_ late, e.g. because a blocking GC pauses all the threads for a long
+	// time, then some datapoints to be missed because they have become stale - but they will be
+	// the datapoints immediately before the GC, not the spike from the GC itself.
+	// we can't improve on this by comparing the time of the scrape with the time of the previous
+	// scrape because there might be multiple scrapers.
+	public class BucketCalculator : IBucketCalculator {
+		public void Calculate(
+			int expectedScrapeIntervalSeconds,
+			out int numBuckets,
+			out int secondsPerBucket,
+			out int minPeriodSeconds,
+			out int maxPeriodSeconds) {
+
+			if (expectedScrapeIntervalSeconds == 0) {
+				// observed durations in the range 0-1s
+				numBuckets = 1;
+				secondsPerBucket = 1;
+			} else if (expectedScrapeIntervalSeconds == 1) {
+				// observed durations in the range 2-3s
+				numBuckets = 3;
+				secondsPerBucket = 1;
+			} else if (expectedScrapeIntervalSeconds == 5) {
+				// observed durations in the range 6-8s
+				numBuckets = 4;
+				secondsPerBucket = 2;
+			} else if (expectedScrapeIntervalSeconds == 10) {
+				// observed durations in the range 12-15s
+				numBuckets = 5;
+				secondsPerBucket = 3;
+			} else if (expectedScrapeIntervalSeconds % 15 == 0) {
+				numBuckets = 5;
+				secondsPerBucket = expectedScrapeIntervalSeconds / 15 * 4;
+			} else {
+				throw new ArgumentException(
+					$"ExpectedScrapeIntervalSeconds must be 0, 1, 5, 10 or a multiple of 15, " +
+					$"but was {expectedScrapeIntervalSeconds}");
+			}
+
+			maxPeriodSeconds = numBuckets * secondsPerBucket;
+			minPeriodSeconds = maxPeriodSeconds - secondsPerBucket;
+		}
+	}
+
+	public class NoOp : IDurationMaxTracker {
+		public void RecordNow(Instant start) {
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/Instant.cs
+++ b/src/EventStore.Core/Telemetry/Instant.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 
 namespace EventStore.Core.Telemetry;
@@ -6,10 +6,12 @@ namespace EventStore.Core.Telemetry;
 // this provides stronger typing than just passing a long representing the number of ticks
 // and provides us a place to change the resolution and size if long ticks is overkill.
 public struct Instant {
-	private static readonly double _secondsPerTick = 1 / (double)Stopwatch.Frequency;
+	public static long TicksPerSecond { get; } = Stopwatch.Frequency;
+
+	private static readonly double _secondsPerTick = 1 / (double)TicksPerSecond;
 
 	public static Instant Now => new(Stopwatch.GetTimestamp());
-	public static Instant FromSeconds(long seconds) => new(stopwatchTicks: seconds * Stopwatch.Frequency);
+	public static Instant FromSeconds(long seconds) => new(stopwatchTicks: seconds * TicksPerSecond);
 
 	public static bool operator ==(Instant x, Instant y) => x._ticks == y._ticks;
 	public static bool operator !=(Instant x, Instant y) => x._ticks != y._ticks;
@@ -22,6 +24,8 @@ public struct Instant {
 	private Instant(long stopwatchTicks) {
 		_ticks = stopwatchTicks;
 	}
+
+	public long Ticks => _ticks;
 
 	public double ElapsedSecondsSince(Instant start) => TicksToSeconds(ElapsedTicksSince(start));
 

--- a/src/EventStore.Core/Telemetry/QueueTracker.cs
+++ b/src/EventStore.Core/Telemetry/QueueTracker.cs
@@ -1,0 +1,30 @@
+﻿namespace EventStore.Core.Telemetry {
+	// Composite tracker for tracking the various things that queues want to track.
+	public class QueueTracker {
+		private readonly string _name;
+		private readonly IDurationMaxTracker _queueingDurationTracker;
+		private readonly IClock _clock;
+
+		public QueueTracker(
+			string name,
+			IDurationMaxTracker queueingDurationTracker,
+			IClock clock = null) {
+
+			_name = name;
+			_queueingDurationTracker = queueingDurationTracker;
+			_clock = clock ?? Clock.Instance;
+		}
+
+		public static QueueTracker NoOp { get; } = new(
+			name: "NoOp",
+			new DurationMaxTracker.NoOp());
+
+		public string Name => _name;
+
+		public Instant Now => _clock.Now;
+
+		public void RecordMessageDequeued(Instant enqueuedAt) {
+			_queueingDurationTracker.RecordNow(enqueuedAt);
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/QueueTrackers.cs
+++ b/src/EventStore.Core/Telemetry/QueueTrackers.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using Serilog;
+using Conf = EventStore.Common.Configuration.TelemetryConfiguration;
+
+namespace EventStore.Core.Telemetry;
+
+public class QueueTrackers {
+	private static readonly ILogger Log = Serilog.Log.ForContext<QueueTrackers>();
+
+	private readonly Dictionary<string, QueueTracker> _trackers = new();
+	private readonly QueueTracker _noOp = QueueTracker.NoOp;
+	private readonly Conf.LabelMappingCase[] _cases;
+	private readonly Func<string, QueueTracker> _trackerFactory;
+
+	public QueueTrackers() {
+		_cases = Array.Empty<Conf.LabelMappingCase>();
+		_trackerFactory = _ => _noOp;
+	}
+
+	public QueueTrackers(
+		Conf.LabelMappingCase[] cases,
+		Func<string, QueueTracker> trackerFactory) {
+
+		_cases = cases;
+		_trackerFactory = trackerFactory;
+	}
+
+	public QueueTracker GetTrackerForQueue(string queueName) {
+		foreach (var @case in _cases) {
+			var pattern = $"^{@case.Regex}$";
+			var match = Regex.Match(input: queueName, pattern: pattern);
+			if (match.Success) {
+				var label = Regex.Replace(
+					input: queueName,
+					pattern: pattern,
+					replacement: @case.Label);
+
+				if (string.IsNullOrWhiteSpace(label))
+					return _noOp;
+
+				Log.Information(
+					"Telemetry matched queue {queueName} with pattern {pattern}. Label: {label}",
+					queueName, @case.Regex, label);
+
+				return GetTrackerByName(label);
+			}
+		}
+
+		Log.Information("Telemetry did not match queue {queueName}. Metrics will not be collected", queueName);
+		return _noOp;
+	}
+
+	private QueueTracker GetTrackerByName(string trackerName) {
+		if (!_trackers.TryGetValue(trackerName, out var tracker)) {
+			tracker = _trackerFactory(trackerName);
+			_trackers[trackerName] = tracker;
+		}
+
+		return tracker;
+	}
+}

--- a/src/EventStore.Core/Telemetry/StatusSubMetric.cs
+++ b/src/EventStore.Core/Telemetry/StatusSubMetric.cs
@@ -12,6 +12,8 @@ namespace EventStore.Core.Telemetry {
 	//
 	// The component name and status are stored in tags
 	// The value contains time in seconds since epoch so we can tell which status is active
+	//
+	// Multiple threads can SetStatus and Observe concurrently
 	public class StatusSubMetric {
 		private readonly KeyValuePair<string, object>[] _tags;
 		private string _status;

--- a/src/EventStore.Core/TransactionLog/Checkpoint/CheckpointMetric.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/CheckpointMetric.cs
@@ -22,7 +22,7 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 				};
 			}
 
-			// we could consider using ObservableUpDownCounter, but ICheckpoint does allow the values to
+			// we could consider using ObservableCounter, but ICheckpoint does allow the values to
 			// go down as well as up, so we are currently supporting that here.
 			meter.CreateObservableUpDownCounter(name, Observe);
 		}

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/ProjectionRuntimeScenario.cs
@@ -29,7 +29,7 @@ namespace EventStore.Projections.Core.Javascript.Tests.Integration
 			var ts = new TimerService(new TimerBasedScheduler(new RealTimer(),
 				timeProvider));
 			
-			var sc = new StandardComponents(db, mainQueue, mainBus, ts, timeProvider, null, new IHttpService[] { }, mainBus, qs);
+			var sc = new StandardComponents(db, mainQueue, mainBus, ts, timeProvider, null, new IHttpService[] { }, mainBus, qs, new());
 			runtime.Register(sc);
 			runtime.Start();
 			return (runtime.Stop, runtime.LeaderQueue);

--- a/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
+++ b/src/EventStore.Projections.Core.Javascript.Tests/Integration/SubsystemScenario.cs
@@ -36,7 +36,7 @@ namespace EventStore.Projections.Core.Javascript.Tests.Integration {
 
 		protected SubsystemScenario(Func<InMemoryBus, IQueuedHandler, ICheckpoint, (Action stopAction, IPublisher subsystemCommands)> createSubsystem, string readyStream, CancellationToken testTimeout) {
 			_mainBus = new InMemoryBus("main");
-			_mainQueue = QueuedHandler.CreateQueuedHandler(_mainBus, "bossQ", new QueueStatsManager());
+			_mainQueue = QueuedHandler.CreateQueuedHandler(_mainBus, "bossQ", new QueueStatsManager(), new());
 			_writerCheckpoint = new InMemoryCheckpoint(0);
 			_miniStore = new MiniStore(_writerCheckpoint, _mainBus);
 			TestTimeout = testTimeout;

--- a/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
@@ -31,14 +31,15 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 			var mainQueue = QueuedHandler.CreateQueuedHandler
 			(new AdHocHandler<Message>(msg => {
 				/* Ignore messages */
-			}), "MainQueue", new QueueStatsManager());
+			}), "MainQueue", new QueueStatsManager(), new());
 			var mainBus = new InMemoryBus("mainBus");
 			var threadBasedScheduler = new ThreadBasedScheduler(new RealTimeProvider(), new QueueStatsManager());
 			var timerService = new TimerService(threadBasedScheduler);
 
 			return new StandardComponents(db, mainQueue, mainBus,
 				timerService, timeProvider: null, httpForwarder: null, httpServices: new IHttpService[] { },
-				networkSendService: null, queueStatsManager: new QueueStatsManager());
+				networkSendService: null, queueStatsManager: new QueueStatsManager(),
+				trackers: new());
 		}
 
 		[OneTimeSetUp]

--- a/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionCoreWorkersNode.cs
@@ -28,6 +28,7 @@ namespace EventStore.Projections.Core {
 				var coreQueue = QueuedHandler.CreateQueuedHandler(coreInputBus,
 					"Projection Core #" + coreQueues.Count,
 					standardComponents.QueueStatsManager,
+					standardComponents.QueueTrackers,
 					groupName: "Projection Core");
 				var workerId = Guid.NewGuid();
 				var projectionNode = new ProjectionWorkerNode(

--- a/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
+++ b/src/EventStore.Projections.Core/ProjectionsSubsystem.cs
@@ -111,7 +111,7 @@ namespace EventStore.Projections.Core {
 
 		public void Register(StandardComponents standardComponents) {
 			_leaderInputQueue = QueuedHandler.CreateQueuedHandler(_leaderMainBus, "Projections Leader",
-				standardComponents.QueueStatsManager);
+				standardComponents.QueueStatsManager, standardComponents.QueueTrackers);
 			_leaderOutputBus = new InMemoryBus("ProjectionManagerAndCoreCoordinatorOutput");
 			
 			_leaderMainBus.Subscribe<ProjectionSubsystemMessage.RestartSubsystem>(this);


### PR DESCRIPTION
Added: Max queue durations over period per queue 

- This does its best to capture spikes in queue length without consuming many resources
- Queues can be grouped together in a configurable way by matching regular expressions and replacing placeholders by captures
- Set ExpectedScrapeIntervalSeconds according to how often the metrics endpoint will be scraped

![image](https://user-images.githubusercontent.com/2587665/213225975-f76af9c3-41e9-464b-a849-839fca594585.png)
