### PR TITLE
Use a stopwatch instead of DateTime.UtcNow for durations

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Telemetry/DurationTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/DurationTrackerTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using EventStore.Core.Telemetry;
 using Xunit;

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/FakeClock.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/FakeClock.cs
@@ -3,7 +3,7 @@ using EventStore.Core.Telemetry;
 
 namespace EventStore.Core.XUnit.Tests.Telemetry {
 	internal class FakeClock : IClock {
-		public DateTime UtcNow => DateTimeOffset.FromUnixTimeSeconds(SecondsSinceEpoch).UtcDateTime;
+		public Instant Now => Instant.FromSeconds(SecondsSinceEpoch);
 		public long SecondsSinceEpoch { get; set; }
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/InstantTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/InstantTests.cs
@@ -1,0 +1,13 @@
+﻿using EventStore.Core.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public class InstantTests {
+	[Fact]
+	public void can_measure_elapsed() {
+		var x = Instant.FromSeconds(4);
+		var y = Instant.FromSeconds(6);
+		Assert.Equal(2, y.ElapsedSecondsSince(x));
+	}
+}

--- a/src/EventStore.Core/Telemetry/Clock.cs
+++ b/src/EventStore.Core/Telemetry/Clock.cs
@@ -2,13 +2,14 @@
 
 namespace EventStore.Core.Telemetry {
 	public interface IClock {
-		DateTime UtcNow { get; }
+		Instant Now { get; }
 		long SecondsSinceEpoch { get; }
 	}
 
 	public class Clock : IClock {
 		public static readonly Clock Instance = new();
-		public DateTime UtcNow => DateTime.UtcNow;
+		private Clock() { }
+		public Instant Now => Instant.Now;
 		public long SecondsSinceEpoch => DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 	}
 }

--- a/src/EventStore.Core/Telemetry/Duration.cs
+++ b/src/EventStore.Core/Telemetry/Duration.cs
@@ -5,10 +5,10 @@ namespace EventStore.Core.Telemetry {
 	public struct Duration : IDisposable {
 		private readonly DurationMetric _metric;
 		private readonly string _name;
-		private readonly DateTime _start;
+		private readonly Instant _start;
 		private bool _failed;
 
-		public Duration(DurationMetric metric, string name, DateTime start) {
+		public Duration(DurationMetric metric, string name, Instant start) {
 			_metric = metric;
 			_name = name;
 			_start = start;

--- a/src/EventStore.Core/Telemetry/DurationMetric.cs
+++ b/src/EventStore.Core/Telemetry/DurationMetric.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 
 namespace EventStore.Core.Telemetry {
@@ -13,15 +12,15 @@ namespace EventStore.Core.Telemetry {
 		}
 
 		public Duration Start(string durationName) =>
-			new(this, durationName, _clock.UtcNow);
+			new(this, durationName, _clock.Now);
 
 		public void Record(
-			DateTime start,
+			Instant start,
 			KeyValuePair<string, object> tag1,
 			KeyValuePair<string, object> tag2) {
 
-			var elapsed = _clock.UtcNow - start;
-			_histogram.Record(elapsed.TotalSeconds, tag1, tag2);
+			var elapsedSeconds = _clock.Now.ElapsedSecondsSince(start);
+			_histogram.Record(elapsedSeconds, tag1, tag2);
 		}
 	}
 }

--- a/src/EventStore.Core/Telemetry/Instant.cs
+++ b/src/EventStore.Core/Telemetry/Instant.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace EventStore.Core.Telemetry;
+
+// this provides stronger typing than just passing a long representing the number of ticks
+// and provides us a place to change the resolution and size if long ticks is overkill.
+public struct Instant {
+	private static readonly double _secondsPerTick = 1 / (double)Stopwatch.Frequency;
+
+	public static Instant Now => new(Stopwatch.GetTimestamp());
+	public static Instant FromSeconds(long seconds) => new(stopwatchTicks: seconds * Stopwatch.Frequency);
+
+	public static bool operator ==(Instant x, Instant y) => x._ticks == y._ticks;
+	public static bool operator !=(Instant x, Instant y) => x._ticks != y._ticks;
+
+	private static double TicksToSeconds(long ticks) => ticks * _secondsPerTick;
+
+	private readonly long _ticks;
+
+	// Stopwatch Ticks, not DateTime Ticks - these can be different.
+	private Instant(long stopwatchTicks) {
+		_ticks = stopwatchTicks;
+	}
+
+	public double ElapsedSecondsSince(Instant start) => TicksToSeconds(ElapsedTicksSince(start));
+
+	// something has gone wrong if we call this
+	public override bool Equals(object obj) =>
+		throw new InvalidOperationException();
+
+	public override int GetHashCode() =>
+		_ticks.GetHashCode();
+
+	private long ElapsedTicksSince(Instant since) => _ticks - since._ticks;
+}


### PR DESCRIPTION
Added: a process-wide stopwatch for measuring durations

- The stopwatch won't be affected by system clock changes
- The stopwatch is 1/3 faster
- The stopwatch can be used by other parts of the system that need to time things, too