### PR TITLE
Implement Init/Rebuild index status report.

### DIFF
--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -168,7 +168,8 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 				hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: _db.Config.ReplicationCheckpoint,
-				indexCheckpoint: _db.Config.IndexCheckpoint);
+				indexCheckpoint: _db.Config.IndexCheckpoint,
+				indexStatusTracker: new IndexStatusTracker.NoOp());
 
 
 			readIndex.IndexCommitter.Init(chaserCheckpoint.Read());
@@ -213,7 +214,8 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 				hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: _db.Config.ReplicationCheckpoint,
-				indexCheckpoint: _db.Config.IndexCheckpoint);
+				indexCheckpoint: _db.Config.IndexCheckpoint,
+				indexStatusTracker: new IndexStatusTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(chaserCheckpoint.Read());
 			ReadIndex = readIndex;

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -137,7 +137,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 				hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: Db.Config.ReplicationCheckpoint,
-				indexCheckpoint: Db.Config.IndexCheckpoint);
+				indexCheckpoint: Db.Config.IndexCheckpoint,
+				indexStatusTracker: new IndexStatusTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(ChaserCheckpoint.Read());
 			ReadIndex = readIndex;

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -89,7 +89,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 				hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: DbRes.Db.Config.ReplicationCheckpoint,
-				indexCheckpoint: DbRes.Db.Config.IndexCheckpoint);
+				indexCheckpoint: DbRes.Db.Config.IndexCheckpoint,
+				indexStatusTracker: new IndexStatusTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
 			ReadIndex = readIndex;

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -87,7 +87,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 				hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: DbRes.Db.Config.ReplicationCheckpoint,
-				indexCheckpoint: DbRes.Db.Config.IndexCheckpoint);
+				indexCheckpoint: DbRes.Db.Config.IndexCheckpoint,
+				indexStatusTracker: new IndexStatusTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
 			ReadIndex = readIndex;

--- a/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
@@ -58,7 +58,8 @@ namespace EventStore.Core.Tests.Services.Storage.Transactions {
 				hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: Db.Config.ReplicationCheckpoint,
-				indexCheckpoint: Db.Config.IndexCheckpoint);
+				indexCheckpoint: Db.Config.IndexCheckpoint,
+				indexStatusTracker: new IndexStatusTracker.NoOp());
 			readIndex.IndexCommitter.Init(ChaserCheckpoint.Read());
 			ReadIndex = readIndex;
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
@@ -150,7 +150,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				_systemStreams, emptyStreamId, _sizer);
 			_indexCommitter = new IndexCommitter<TStreamId>(_publisher, _indexBackend, _indexReader, _tableIndex,
 				_logFormat.StreamNameIndexConfirmer, _streamNames, _logFormat.EventTypeIndexConfirmer, _logFormat.EventTypes,
-				_systemStreams, _logFormat.StreamExistenceFilter, _logFormat.StreamExistenceFilterInitializer, new InMemoryCheckpoint(-1),  false);
+				_systemStreams, _logFormat.StreamExistenceFilter, _logFormat.StreamExistenceFilterInitializer, new InMemoryCheckpoint(-1), new IndexStatusTracker.NoOp(), false);
 
 			WriteEvents();
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -84,7 +84,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 				new LRUCache<TStreamId, IndexBackend<TStreamId>.MetadataCached>("StreamMetadata", 100),
 				true, _metastreamMaxCount,
 				Opts.HashCollisionReadLimitDefault, Opts.SkipIndexScanOnReadsDefault,
-				_dbResult.Db.Config.ReplicationCheckpoint,_dbResult.Db.Config.IndexCheckpoint);
+				_dbResult.Db.Config.ReplicationCheckpoint,_dbResult.Db.Config.IndexCheckpoint, new IndexStatusTracker.NoOp());
 			readIndex.IndexCommitter.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 			ReadIndex = readIndex;
 

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -67,7 +67,8 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 				hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: Db.Config.ReplicationCheckpoint,
-				indexCheckpoint: Db.Config.IndexCheckpoint);
+				indexCheckpoint: Db.Config.IndexCheckpoint,
+				indexStatusTracker: new IndexStatusTracker.NoOp());
 			readIndex.IndexCommitter.Init(ChaserCheckpoint.Read());
 			ReadIndex = readIndex;
 		}

--- a/src/EventStore.Core.XUnit.Tests/Index/IndexStatusTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Index/IndexStatusTrackerTests.cs
@@ -28,6 +28,48 @@ namespace EventStore.Core.XUnit.Tests.Index {
 		}
 
 		[Fact]
+		public void can_observe_opening() {
+			_clock.SecondsSinceEpoch = 500;
+			AssertMeasurements("Idle", 500);
+
+			using (_sut.StartOpening()) {
+				_clock.SecondsSinceEpoch = 501;
+				AssertMeasurements("Opening", 501);
+			}
+
+			_clock.SecondsSinceEpoch = 502;
+			AssertMeasurements("Idle", 502);
+		}
+
+		[Fact]
+		public void can_observe_rebuilding() {
+			_clock.SecondsSinceEpoch = 500;
+			AssertMeasurements("Idle", 500);
+
+			using (_sut.StartRebuilding()) {
+				_clock.SecondsSinceEpoch = 501;
+				AssertMeasurements("Rebuilding", 501);
+			}
+
+			_clock.SecondsSinceEpoch = 502;
+			AssertMeasurements("Idle", 502);
+		}
+
+		[Fact]
+		public void can_observe_initializing() {
+			_clock.SecondsSinceEpoch = 500;
+			AssertMeasurements("Idle", 500);
+
+			using (_sut.StartInitializing()) {
+				_clock.SecondsSinceEpoch = 501;
+				AssertMeasurements("Initializing", 501);
+			}
+
+			_clock.SecondsSinceEpoch = 502;
+			AssertMeasurements("Idle", 502);
+		}
+
+		[Fact]
 		public void can_observe_merging() {
 			_clock.SecondsSinceEpoch = 500;
 			AssertMeasurements("Idle", 500);

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -275,7 +275,8 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 				hashCollisionReadLimit: Opts.HashCollisionReadLimitDefault,
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: dbResult.Db.Config.ReplicationCheckpoint,
-				indexCheckpoint: dbResult.Db.Config.IndexCheckpoint);
+				indexCheckpoint: dbResult.Db.Config.IndexCheckpoint,
+				indexStatusTracker: new IndexStatusTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(dbResult.Db.Config.WriterCheckpoint.Read());
 			// wait for tables to be merged. for one of the tests this takes a while

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -742,7 +742,8 @@ namespace EventStore.Core {
 				options.Database.HashCollisionReadLimit,
 				options.Application.SkipIndexScanOnReads,
 				Db.Config.ReplicationCheckpoint.AsReadOnly(),
-				Db.Config.IndexCheckpoint);
+				Db.Config.IndexCheckpoint,
+				trackers.IndexStatusTracker);
 			_readIndex = readIndex;
 			var writer = new TFChunkWriter(Db);
 

--- a/src/EventStore.Core/Index/IndexStatusTracker.cs
+++ b/src/EventStore.Core/Index/IndexStatusTracker.cs
@@ -3,6 +3,9 @@ using EventStore.Core.Telemetry;
 
 namespace EventStore.Core.Index {
 	public interface IIndexStatusTracker {
+		IDisposable StartOpening();
+		IDisposable StartRebuilding();
+		IDisposable StartInitializing();
 		IDisposable StartMerging();
 		IDisposable StartScavenging();
 	}
@@ -14,12 +17,17 @@ namespace EventStore.Core.Index {
 			_metric = new("Index", metric);
 		}
 
+		public IDisposable StartOpening() => _metric.StartActivity("Opening");
+		public IDisposable StartRebuilding() => _metric.StartActivity("Rebuilding");
+		public IDisposable StartInitializing() => _metric.StartActivity("Initializing");
 		public IDisposable StartMerging() => _metric.StartActivity("Merging");
 		public IDisposable StartScavenging() => _metric.StartActivity("Scavenging");
 
 		public class NoOp : IIndexStatusTracker {
+			public IDisposable StartOpening() => null;
+			public IDisposable StartRebuilding() => null;
+			public IDisposable StartInitializing() => null;
 			public IDisposable StartMerging() => null;
-
 			public IDisposable StartScavenging() => null;
 		}
 	}

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/ReadIndex.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/ReadIndex.cs
@@ -54,7 +54,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			int hashCollisionReadLimit,
 			bool skipIndexScanOnReads,
 			IReadOnlyCheckpoint replicationCheckpoint,
-			ICheckpoint indexCheckpoint) {
+			ICheckpoint indexCheckpoint,
+			IIndexStatusTracker indexStatusTracker) {
 
 			Ensure.NotNull(bus, "bus");
 			Ensure.NotNull(readerPool, "readerPool");
@@ -87,7 +88,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			_indexWriter = new IndexWriter<TStreamId>(indexBackend, _indexReader, _streamIds, _streamNames, systemStreams, emptyStreamName, sizer);
 			_indexCommitter = new IndexCommitter<TStreamId>(bus, indexBackend, _indexReader, tableIndex, streamNameIndex,
 				_streamNames, eventTypeIndex, eventTypeNames, systemStreams, streamExistenceFilter,
-				streamExistenceFilterInitializer, indexCheckpoint, additionalCommitChecks);
+				streamExistenceFilterInitializer, indexCheckpoint, indexStatusTracker, additionalCommitChecks);
 			_allReader = new AllReader<TStreamId>(indexBackend, _indexCommitter, _streamNames, eventTypeNames);
 		}
 


### PR DESCRIPTION
Added: Implement Init/Rebuild index status report.

![image](https://user-images.githubusercontent.com/2587665/217227385-eaf89409-0283-43ea-9a61-47381394c142.png)

- `Opening` means loading the files, performing verification if it is enabled
- `Rebuilding` is rebuilding the memtables
- `Initializing` is initializing any other parts of the index (at the moment this is just the StreamExistenceFilter)