### PR TITLE
Filter out the LogV3 version of tests that run against both log formats from CI

### DIFF
--- a/ci/ci.runsettings
+++ b/ci/ci.runsettings
@@ -4,4 +4,7 @@
 		<DefaultTestNamePattern>{C}.{m}</DefaultTestNamePattern>
 		<DefaultTimeout>20000</DefaultTimeout>
 	</NUnit>
+	<RunConfiguration>
+		<TestCaseFilter>FullyQualifiedName!~EventStore.Core.Tests.LogFormat+V3</TestCaseFilter>
+	</RunConfiguration>
 </RunSettings>


### PR DESCRIPTION
Changed: CI Unit test settings

Keeping the LogV3 specific tests active, this just filters out the ones that run the tests of the other components against both log versions.