### PR TITLE
Cancel reads already in the reader queues when the gRPC call is cancelled

### DIFF
--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -81,9 +81,11 @@ namespace EventStore.Core.Messages {
 			public readonly ClaimsPrincipal User;
 
 			public readonly DateTime Expires;
+			public readonly CancellationToken CancellationToken;
 
 			protected ReadRequestMessage(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
-				ClaimsPrincipal user, DateTime? expires) {
+				ClaimsPrincipal user, DateTime? expires,
+				CancellationToken cancellationToken = default) {
 				Ensure.NotEmptyGuid(internalCorrId, "internalCorrId");
 				Ensure.NotEmptyGuid(correlationId, "correlationId");
 				Ensure.NotNull(envelope, "envelope");
@@ -94,6 +96,7 @@ namespace EventStore.Core.Messages {
 
 				User = user;
 				Expires = expires ?? DateTime.UtcNow.AddMilliseconds(ESConsts.ReadRequestTimeout);
+				CancellationToken = cancellationToken;
 			}
 
 			public override string ToString() =>
@@ -475,8 +478,9 @@ namespace EventStore.Core.Messages {
 
 			public ReadEvent(Guid internalCorrId, Guid correlationId, IEnvelope envelope, string eventStreamId,
 				long eventNumber,
-				bool resolveLinkTos, bool requireLeader, ClaimsPrincipal user, DateTime? expires = null)
-				: base(internalCorrId, correlationId, envelope, user, expires) {
+				bool resolveLinkTos, bool requireLeader, ClaimsPrincipal user, DateTime? expires = null,
+				CancellationToken cancellationToken = default)
+				: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken) {
 				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
 				if (eventNumber < -1) throw new ArgumentOutOfRangeException(nameof(eventNumber));
 
@@ -537,8 +541,9 @@ namespace EventStore.Core.Messages {
 				string eventStreamId, long fromEventNumber, int maxCount, bool resolveLinkTos,
 				bool requireLeader, long? validationStreamVersion, ClaimsPrincipal user,
 				bool replyOnExpired,
-				TimeSpan? longPollTimeout = null, DateTime? expires = null)
-				: base(internalCorrId, correlationId, envelope, user, expires) {
+				TimeSpan? longPollTimeout = null, DateTime? expires = null,
+				CancellationToken cancellationToken = default)
+				: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken) {
 				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
 				if (fromEventNumber < -1) throw new ArgumentOutOfRangeException(nameof(fromEventNumber));
 
@@ -623,8 +628,9 @@ namespace EventStore.Core.Messages {
 
 			public ReadStreamEventsBackward(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 				string eventStreamId, long fromEventNumber, int maxCount, bool resolveLinkTos,
-				bool requireLeader, long? validationStreamVersion, ClaimsPrincipal user, DateTime? expires = null)
-				: base(internalCorrId, correlationId, envelope, user, expires) {
+				bool requireLeader, long? validationStreamVersion, ClaimsPrincipal user, DateTime? expires = null,
+				CancellationToken cancellationToken = default)
+				: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken) {
 				Ensure.NotNullOrEmpty(eventStreamId, "eventStreamId");
 				if (fromEventNumber < -1) throw new ArgumentOutOfRangeException(nameof(fromEventNumber));
 
@@ -716,8 +722,9 @@ namespace EventStore.Core.Messages {
 				long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos,
 				bool requireLeader, long? validationTfLastCommitPosition, ClaimsPrincipal user,
 				bool replyOnExpired,
-				TimeSpan? longPollTimeout = null, DateTime? expires = null)
-				: base(internalCorrId, correlationId, envelope, user, expires) {
+				TimeSpan? longPollTimeout = null, DateTime? expires = null,
+				CancellationToken cancellationToken = default)
+				: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken) {
 				CommitPosition = commitPosition;
 				PreparePosition = preparePosition;
 				MaxCount = maxCount;
@@ -793,8 +800,9 @@ namespace EventStore.Core.Messages {
 			public ReadAllEventsBackward(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 				long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos,
 				bool requireLeader, long? validationTfLastCommitPosition, ClaimsPrincipal user,
-				DateTime? expires = null)
-				: base(internalCorrId, correlationId, envelope, user, expires) {
+				DateTime? expires = null,
+				CancellationToken cancellationToken = default)
+				: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken) {
 				CommitPosition = commitPosition;
 				PreparePosition = preparePosition;
 				MaxCount = maxCount;
@@ -871,8 +879,9 @@ namespace EventStore.Core.Messages {
 				long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos, bool requireLeader,
 				int maxSearchWindow, long? validationTfLastCommitPosition, IEventFilter eventFilter, ClaimsPrincipal user,
 				bool replyOnExpired,
-				TimeSpan? longPollTimeout = null, DateTime? expires = null)
-				: base(internalCorrId, correlationId, envelope, user, expires) {
+				TimeSpan? longPollTimeout = null, DateTime? expires = null,
+				CancellationToken cancellationToken = default)
+				: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken) {
 				CommitPosition = commitPosition;
 				PreparePosition = preparePosition;
 				MaxCount = maxCount;
@@ -956,8 +965,9 @@ namespace EventStore.Core.Messages {
 			public FilteredReadAllEventsBackward(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 				long commitPosition, long preparePosition, int maxCount, bool resolveLinkTos, bool requireLeader,
 				int maxSearchWindow, long? validationTfLastCommitPosition, IEventFilter eventFilter, ClaimsPrincipal user,
-				TimeSpan? longPollTimeout = null, DateTime? expires = null)
-				: base(internalCorrId, correlationId, envelope, user, expires) {
+				TimeSpan? longPollTimeout = null, DateTime? expires = null,
+				CancellationToken cancellationToken = default)
+				: base(internalCorrId, correlationId, envelope, user, expires, cancellationToken) {
 				CommitPosition = commitPosition;
 				PreparePosition = preparePosition;
 				MaxCount = maxCount;

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
@@ -419,7 +419,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					correlationId, correlationId, new ContinuationEnvelope(onMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, ReadBatchSize, _resolveLinks, _requiresLeader, null, _user,
 					replyOnExpired: true,
-					expires: _expiryStrategy.GetExpiry()));
+					expires: _expiryStrategy.GetExpiry(),
+					cancellationToken: _cancellationToken));
 			}
 
 			private void Unsubscribe() => _bus.Publish(new ClientMessage.UnsubscribeFromStream(Guid.NewGuid(),

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -500,7 +500,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					commitPosition, preparePosition, ReadBatchSize, _resolveLinks, _requiresLeader,
 					(int)_maxSearchWindow, null, _eventFilter, _user,
 					replyOnExpired: true,
-					expires: _expiryStrategy.GetExpiry()));
+					expires: _expiryStrategy.GetExpiry(),
+					cancellationToken: _cancellationToken));
 			}
 
 			private void Unsubscribe() => _bus.Publish(new ClientMessage.UnsubscribeFromStream(Guid.NewGuid(),

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwards.cs
@@ -78,7 +78,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.ReadAllEventsBackward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, default, _user, _deadline));
+					_requiresLeader, default, _user, _deadline,
+					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllBackwardsFiltered.cs
@@ -100,7 +100,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.FilteredReadAllEventsBackward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user, expires: _deadline));
+					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user, expires: _deadline,
+					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwards.cs
@@ -78,7 +78,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.ReadAllEventsForward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, default, _user, replyOnExpired: false, expires: _deadline));
+					_requiresLeader, default, _user, replyOnExpired: false, expires: _deadline,
+					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadAllForwardsFiltered.cs
@@ -102,7 +102,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					commitPosition, preparePosition, (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
 					_requiresLeader, (int)_maxSearchWindow, null, _eventFilter, _user,
 					replyOnExpired: false,
-					expires: _deadline));
+					expires: _deadline,
+					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamBackwards.cs
@@ -78,7 +78,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.ReadStreamEventsBackward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					_streamName, startRevision.ToInt64(), (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, null, _user, _deadline));
+					_requiresLeader, null, _user, _deadline,
+					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.ReadStreamForwards.cs
@@ -78,7 +78,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				_bus.Publish(new ClientMessage.ReadStreamEventsForward(
 					correlationId, correlationId, new ContinuationEnvelope(OnMessage, _semaphore, _cancellationToken),
 					_streamName, startRevision.ToInt64(), (int)Math.Min(ReadBatchSize, _maxCount), _resolveLinks,
-					_requiresLeader, null, _user, replyOnExpired: false, expires: _deadline));
+					_requiresLeader, null, _user, replyOnExpired: false, expires: _deadline,
+					cancellationToken: _cancellationToken));
 
 				async Task OnMessage(Message message, CancellationToken ct) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.StreamSubscription.cs
@@ -432,7 +432,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_streamName, startRevision.ToInt64(), ReadBatchSize, _resolveLinks, _requiresLeader, null,
 					_user,
 					replyOnExpired: true,
-					expires: _expiryStrategy.GetExpiry()));
+					expires: _expiryStrategy.GetExpiry(),
+					cancellationToken: _cancellationToken));
 			}
 
 			private void Unsubscribe() => _bus.Publish(new ClientMessage.UnsubscribeFromStream(Guid.NewGuid(),


### PR DESCRIPTION
Fixed: Cancel reads already in the reader queues when the gRPC call is cancelled

Before this commit cancelling the gRPC call would prevent it issuing additional reads but would not cancel the read that is already in the queue. If the queue is long this can be an important difference.