### PR TITLE
Implement gossip-read processing time tracking.

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -28,6 +28,15 @@
 		"StreamTombstone": ""
 	},
 
+	"GossipTrackers": [
+//		"PullFromPeer",
+		"PushToPeer",
+		"ProcessingPushFromPeer"
+//		"ProcessingRequestFromPeer",
+//		"ProcessingRequestFromGrpcClient",
+//		"ProcessingRequestFromHttpClient"
+	],
+
 	// this specifies what name to track each queue under, according to regular expressions to
 	// match the queue names against
 	"Queues": [

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -58,6 +58,15 @@ namespace EventStore.Common.Configuration {
 			StreamTombstone,
 		}
 
+		public enum Gossip {
+			PullFromPeer = 1,
+			PushToPeer,
+			ProcessingPushFromPeer,
+			ProcessingRequestFromPeer,
+			ProcessingRequestFromGrpcClient,
+			ProcessingRequestFromHttpClient,
+		}
+
 		public class LabelMappingCase {
 			public string Regex { get; set; }
 			public string Label { get; set; }
@@ -70,6 +79,8 @@ namespace EventStore.Common.Configuration {
 		public Checkpoint[] Checkpoints { get; set; } = Array.Empty<Checkpoint>();
 
 		public Dictionary<GrpcMethod, string> GrpcMethods { get; set; } = new();
+
+		public Gossip[] GossipTrackers { get; set; } = Array.Empty<Gossip>();
 
 		// must be 0, 1, 5, 10 or a multiple of 15
 		public int ExpectedScrapeIntervalSeconds { get; set; }

--- a/src/EventStore.Core.Tests/Cluster/EventStoreClientCacheTests.cs
+++ b/src/EventStore.Core.Tests/Cluster/EventStoreClientCacheTests.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Cluster;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.TimerService;
+using EventStore.Core.Telemetry;
 using EventStore.Core.Tests.Fakes;
 using NUnit.Framework;
 
@@ -16,7 +17,9 @@ namespace EventStore.Core.Tests.Cluster {
 			(endpoint, bus) =>
 				new EventStoreClusterClient(
 					Uri.UriSchemeHttps, endpoint, null, bus,
-					delegate { return (true, null); }, null);
+					delegate { return (true, null); }, null,
+					new DurationTracker.NoOp(),
+					new DurationTracker.NoOp());
 
 		[Test]
 		public void BusShouldNotBeNull() {

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -590,7 +590,9 @@ namespace EventStore.Core {
 					new EventStoreClusterClient(
 						options.Application.Insecure ? Uri.UriSchemeHttp : Uri.UriSchemeHttps,
 						endpoint, options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null,
-						publisher, _internalServerCertificateValidator, _certificateSelector));
+						publisher, _internalServerCertificateValidator, _certificateSelector,
+						gossipSendTracker: trackers.GossipTrackers.PushToPeer,
+						gossipGetTracker: trackers.GossipTrackers.PullFromPeer));
 
 			_mainBus.Subscribe<ClusterClientMessage.CleanCache>(_eventStoreClusterClientCache);
 			_mainBus.Subscribe<SystemMessage.SystemInit>(_eventStoreClusterClientCache);
@@ -1087,7 +1089,8 @@ namespace EventStore.Core {
 			var metricsController = new MetricsController();
 			var atomController = new AtomController(_mainQueue, _workersHandler,
 				options.Application.DisableHttpCaching, TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs));
-			var gossipController = new GossipController(_mainQueue, _workersHandler);
+			var gossipController = new GossipController(_mainQueue, _workersHandler,
+				trackers.GossipTrackers.ProcessingRequestFromHttpClient);
 			var persistentSubscriptionController =
 				new PersistentSubscriptionController(httpSendService, _mainQueue, _workersHandler);
 			var infoController = new InfoController(options, new Dictionary<string, bool> {

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
@@ -6,6 +6,7 @@ using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Telemetry;
 using EventStore.Plugins.Authorization;
 using Grpc.Core;
 using Empty = EventStore.Client.Empty;
@@ -15,13 +16,20 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 		private readonly IPublisher _bus;
 		private readonly IAuthorizationProvider _authorizationProvider;
 		private readonly string _clusterDns;
+		private readonly IDurationTracker _updateTracker;
+		private readonly IDurationTracker _readTracker;
 		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.Read);
 		private static readonly Operation UpdateOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.Update);
 
-		public Gossip(IPublisher bus, IAuthorizationProvider authorizationProvider, string clusterDns) {
+		public Gossip(IPublisher bus, IAuthorizationProvider authorizationProvider, string clusterDns,
+			IDurationTracker updateTracker,
+			IDurationTracker readTracker) {
+
 			_bus = bus;
 			_authorizationProvider = authorizationProvider ?? throw new ArgumentNullException(nameof(authorizationProvider));
 			_clusterDns = clusterDns;
+			_updateTracker = updateTracker;
+			_readTracker = readTracker;
 		}
 
 		public override async Task<ClusterInfo> Update(GossipRequest request, ServerCallContext context) {
@@ -31,7 +39,8 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 			}
 			var clusterInfo = EventStore.Core.Cluster.ClusterInfo.FromGrpcClusterInfo(request.Info, _clusterDns);
 			var tcs = new TaskCompletionSource<ClusterInfo>();
-			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs)),
+			var duration = _updateTracker.Start();
+			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration)),
 				clusterInfo, new DnsEndPoint(request.Server.Address, (int)request.Server.Port).WithClusterDns(_clusterDns)));
 			return await tcs.Task.ConfigureAwait(false);
 		}
@@ -42,13 +51,15 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 				throw RpcExceptions.AccessDenied();
 			}
 			var tcs = new TaskCompletionSource<ClusterInfo>();
-			_bus.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs))));
+			var duration = _readTracker.Start();
+			_bus.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration))));
 			return await tcs.Task.ConfigureAwait(false);
 		}
 
-		private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs) {
+		private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs, Duration duration) {
 			if (msg is GossipMessage.SendGossip received) {
 				tcs.TrySetResult(EventStore.Core.Cluster.ClusterInfo.ToGrpcClusterInfo(received.ClusterInfo));
+				duration.Dispose();
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Grpc/Gossip.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Gossip.cs
@@ -1,15 +1,19 @@
 using System;
 using EventStore.Core.Bus;
+using EventStore.Core.Telemetry;
 using EventStore.Plugins.Authorization;
 
 namespace EventStore.Core.Services.Transport.Grpc {
 	partial class Gossip : EventStore.Client.Gossip.Gossip.GossipBase  {
 		private readonly IPublisher _bus;
 		private readonly IAuthorizationProvider _authorizationProvider;
-		public Gossip(IPublisher bus, IAuthorizationProvider authorizationProvider) {
+		private readonly IDurationTracker _tracker;
+
+		public Gossip(IPublisher bus, IAuthorizationProvider authorizationProvider, IDurationTracker tracker) {
 			_bus = bus;
 			_authorizationProvider =
 				authorizationProvider ?? throw new ArgumentNullException(nameof(authorizationProvider));
+			_tracker = tracker;
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using EventStore.Client.Streams;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.Telemetry;
 using Grpc.Core;
 using CountOptionOneofCase = EventStore.Client.Streams.ReadReq.Types.Options.CountOptionOneofCase;
 using FilterOptionOneofCase = EventStore.Client.Streams.ReadReq.Types.Options.FilterOptionOneofCase;
@@ -18,7 +19,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			ServerCallContext context) {
 
 			var trackDuration = request.Options.CountOptionCase != CountOptionOneofCase.Subscription;
-			using var duration = trackDuration ? _readTracker.Start() : new();
+			using var duration = trackDuration ? _readTracker.Start() : Duration.Nil;
 			try {
 				var options = request.Options;
 				var countOptionsCase = options.CountOptionCase;

--- a/src/EventStore.Core/Telemetry/Duration.cs
+++ b/src/EventStore.Core/Telemetry/Duration.cs
@@ -10,6 +10,8 @@ namespace EventStore.Core.Telemetry {
 		private readonly Instant _start;
 		private bool _failed;
 
+		public static Duration Nil { get; } = new();
+
 		public Duration(DurationMetric metric, string name, Instant start) {
 			_metric = metric;
 			_name = name;

--- a/src/EventStore.Core/Telemetry/DurationTracker.cs
+++ b/src/EventStore.Core/Telemetry/DurationTracker.cs
@@ -16,7 +16,7 @@
 		public Duration Start() => _metric.Start(_durationName);
 
 		public class NoOp : IDurationTracker {
-			public Duration Start() => new();
+			public Duration Start() => Duration.Nil;
 		}
 	}
 }


### PR DESCRIPTION
Added:  Metrics for gossip

- PullFromPeer (off by default) tracks the time it takes the node to get gossip from another. this is uncommon and only used when tcp connections drop.
- PushToPeer (on by default) tracks the time it takes the node to push gossip to another. this is the common gossip-sharing mechanism.
- ProcessingPushFromPeer (on by default) is how long it takes the node to process the gossip pushed to it from another.
- ProcessingRequestFromPeer (off by default) is how long it takes the node to respond to the request for gossip from another.
- ProcessingRequestFromHttpClient (off by default) is how long it takes the node to respond to the request for gossip from the http endpoint.
- ProcessingRequestFromGrpcClient (off by default) is how long it takes the node to respond to the request for gossip from the grpc client endpoint.

All are histograms. The general idea is to be able to tell how effectively the nodes are able to gossip with each other. are they in danger of timing out.
