### PR TITLE
Downgrade error to debug

### DIFF
--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -305,7 +305,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			}
 
 			if (!chunksClosed)
-				_log.Error("Failed to properly close all chunk files - checkpoints will not be flushed.");
+				_log.Debug("One or more chunks are still open; skipping checkpoint flush.");
 
 			Config.WriterCheckpoint.Close(flush: chunksClosed);
 			Config.ChaserCheckpoint.Close(flush: chunksClosed);


### PR DESCRIPTION
Fixed: downgraded an error log message that is not really and error to debug level

It's common for Replication to still be holding a reader from TFChunk.AcquireReader at this point in the shutdown It is not anything that the user needs to be concerned with, the usual operation of the database while it is running will have made sure that any necessary checkpoint flushes have been performed