### PR TITLE
Avoid a gen2 allocation when scheduling a timer message

### DIFF
--- a/src/EventStore.Core/Services/TimerService/TimerService.cs
+++ b/src/EventStore.Core/Services/TimerService/TimerService.cs
@@ -23,7 +23,10 @@ namespace EventStore.Core.Services.TimerService {
 		}
 
 		public void Handle(TimerMessage.Schedule message) {
-			_scheduler.Schedule(message.TriggerAfter, OnTimerCallback, message);
+			_scheduler.Schedule(
+				message.TriggerAfter,
+				static (scheduler, state) => OnTimerCallback(scheduler, state),
+				message);
 		}
 
 		private static void OnTimerCallback(IScheduler scheduler, object state) {


### PR DESCRIPTION
Changed: Adjustments to reduce allocations