### PR TITLE
Add Queue and Processing time tracking for Timer service

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -32,43 +32,47 @@
 	"Queues": [
 		{
 			"Regex": "MainQueue",
-			"Label": "Main Queue"
+			"Label": "Main"
 		},
 		{
 			"Regex": "MonitoringQueue",
-			"Label": "Monitoring Queue"
+			"Label": "Monitoring"
+		},
+		{
+			"Regex": "Timer",
+			"Label": "Timer"
 		},
 		{
 			"Regex": "StorageReaderQueue #.*",
-			"Label": "Reader Queue"
+			"Label": "Readers"
 		},
 		{
 			"Regex": "StorageWriterQueue",
-			"Label": "Writer Queue"
+			"Label": "Writer"
 		},
 		{
 			"Regex": "Subscriptions",
-			"Label": "Subscriptions Queue"
+			"Label": "Subscriptions"
 		},
 		{
 			"Regex": "PersistentSubscriptions",
-			"Label": "Persistent Subscriptions Queue"
+			"Label": "Persistent Subscriptions"
 		},
 		{
 			"Regex": "Projections Leader",
-			"Label": "Projections Leader Queue"
+			"Label": "Projections Leader"
 		},
 		{
 			"Regex": "Projection Core #.*",
-			"Label": "Projections Core Queue"
+			"Label": "Projections Core"
 		},
 		{
 			"Regex": "Worker #.*",
-			"Label": "Worker Queue"
+			"Label": "Workers"
 		},
 		{
 			"Regex": ".*",
-			"Label": "Other Queue"
+			"Label": "Others"
 		}
 	],
 

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/FakeClock.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/FakeClock.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using EventStore.Core.Telemetry;
+using EventStore.Core.Time;
 
 namespace EventStore.Core.XUnit.Tests.Telemetry {
 	internal class FakeClock : IClock {

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/InstantTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/InstantTests.cs
@@ -1,4 +1,4 @@
-﻿using EventStore.Core.Telemetry;
+﻿using EventStore.Core.Time;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Telemetry;

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/InstantTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/InstantTests.cs
@@ -1,4 +1,5 @@
-﻿using EventStore.Core.Time;
+﻿using System;
+using EventStore.Core.Time;
 using Xunit;
 
 namespace EventStore.Core.XUnit.Tests.Telemetry;
@@ -9,5 +10,52 @@ public class InstantTests {
 		var x = Instant.FromSeconds(4);
 		var y = Instant.FromSeconds(6);
 		Assert.Equal(2, y.ElapsedSecondsSince(x));
+	}
+
+	[Fact]
+	public void add() {
+		Assert.Equal(
+			Instant.FromSeconds(4),
+			Instant.FromSeconds(3).Add(TimeSpan.FromSeconds(1)));
+	}
+
+	[Fact]
+	public void equal_to() {
+		Assert.False(Instant.FromSeconds(3) == Instant.FromSeconds(4));
+		Assert.True(Instant.FromSeconds(3) == Instant.FromSeconds(3));
+	}
+
+	[Fact]
+	public void not_equal_to() {
+		Assert.True(Instant.FromSeconds(3) != Instant.FromSeconds(4));
+		Assert.False(Instant.FromSeconds(3) != Instant.FromSeconds(3));
+	}
+
+	[Fact]
+	public void less_than() {
+		Assert.True(Instant.FromSeconds(3) < Instant.FromSeconds(4));
+		Assert.False(Instant.FromSeconds(3) < Instant.FromSeconds(3));
+		Assert.False(Instant.FromSeconds(3) < Instant.FromSeconds(2));
+	}
+
+	[Fact]
+	public void greater_than() {
+		Assert.False(Instant.FromSeconds(3) > Instant.FromSeconds(4));
+		Assert.False(Instant.FromSeconds(3) > Instant.FromSeconds(3));
+		Assert.True(Instant.FromSeconds(3) > Instant.FromSeconds(2));
+	}
+
+	[Fact]
+	public void less_than_or_equal_to() {
+		Assert.True(Instant.FromSeconds(3) <= Instant.FromSeconds(4));
+		Assert.True(Instant.FromSeconds(3) <= Instant.FromSeconds(3));
+		Assert.False(Instant.FromSeconds(3) <= Instant.FromSeconds(2));
+	}
+
+	[Fact]
+	public void greater_than_or_equal_to() {
+		Assert.False(Instant.FromSeconds(3) >= Instant.FromSeconds(4));
+		Assert.True(Instant.FromSeconds(3) >= Instant.FromSeconds(3));
+		Assert.True(Instant.FromSeconds(3) >= Instant.FromSeconds(2));
 	}
 }

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/QueueTrackersTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/QueueTrackersTests.cs
@@ -1,4 +1,5 @@
 using EventStore.Core.Telemetry;
+using EventStore.Core.Time;
 using Xunit;
 using Conf = EventStore.Common.Configuration.TelemetryConfiguration;
 

--- a/src/EventStore.Core/Bus/QueueItem.cs
+++ b/src/EventStore.Core/Bus/QueueItem.cs
@@ -1,5 +1,5 @@
 ﻿using EventStore.Core.Messaging;
-using EventStore.Core.Telemetry;
+using EventStore.Core.Time;
 
 namespace EventStore.Core.Bus;
 

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1431,7 +1431,7 @@ namespace EventStore.Core {
 
 			// TIMER
 			_timeProvider = new RealTimeProvider();
-			var threadBasedScheduler = new ThreadBasedScheduler(_timeProvider, _queueStatsManager);
+			var threadBasedScheduler = new ThreadBasedScheduler(_queueStatsManager, trackers.QueueTrackers);
 			AddTask(threadBasedScheduler.Task);
 			_timerService = new TimerService(threadBasedScheduler);
 			_mainBus.Subscribe<SystemMessage.BecomeShutdown>(_timerService);

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -51,7 +51,7 @@ public static class MetricsBootstrapper {
 		var coreMeter = new Meter("EventStore.Core", version: "0.0.1");
 		var statusMetric = new StatusMetric(coreMeter, "eventstore-statuses");
 		var durationMetric = new DurationMetric(coreMeter, "eventstore-duration");
-		var durationMaxMetric = new DurationMaxMetric(coreMeter, "eventstore-duration-max");
+		var queueQueueingDurationMaxMetric = new DurationMaxMetric(coreMeter, "eventstore-queue-queueing-duration-max");
 		var queueProcessingDurationMetric = new DurationMetric(coreMeter, "eventstore-queue-processing-duration");
 
 		// checkpoints
@@ -95,7 +95,7 @@ public static class MetricsBootstrapper {
 				name: name,
 				new DurationMaxTracker(
 					name: name,
-					metric: durationMaxMetric,
+					metric: queueQueueingDurationMaxMetric,
 					expectedScrapeIntervalSeconds: conf.ExpectedScrapeIntervalSeconds),
 				new QueueProcessingTracker(
 					metric: queueProcessingDurationMetric,

--- a/src/EventStore.Core/Telemetry/Duration.cs
+++ b/src/EventStore.Core/Telemetry/Duration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using EventStore.Core.Time;
 
 namespace EventStore.Core.Telemetry {
 	// This represents an activity that can fail

--- a/src/EventStore.Core/Telemetry/DurationMaxTracker.cs
+++ b/src/EventStore.Core/Telemetry/DurationMaxTracker.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
 using System.Linq;
+using EventStore.Core.Time;
 
 namespace EventStore.Core.Telemetry;
 

--- a/src/EventStore.Core/Telemetry/DurationMetric.cs
+++ b/src/EventStore.Core/Telemetry/DurationMetric.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using EventStore.Core.Time;
 
 namespace EventStore.Core.Telemetry {
 	public class DurationMetric {

--- a/src/EventStore.Core/Telemetry/QueueProcessingTracker.cs
+++ b/src/EventStore.Core/Telemetry/QueueProcessingTracker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using EventStore.Core.Time;
 
 namespace EventStore.Core.Telemetry {
 	public interface IQueueProcessingTracker {

--- a/src/EventStore.Core/Telemetry/QueueTracker.cs
+++ b/src/EventStore.Core/Telemetry/QueueTracker.cs
@@ -1,3 +1,5 @@
+using EventStore.Core.Time;
+
 namespace EventStore.Core.Telemetry {
 	// Composite tracker for tracking the various things that queues want to track.
 	// i.e.

--- a/src/EventStore.Core/Telemetry/StatusMetric.cs
+++ b/src/EventStore.Core/Telemetry/StatusMetric.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using EventStore.Core.Time;
 
 namespace EventStore.Core.Telemetry {
 	// A metric that tracks the statuses of multiple components.

--- a/src/EventStore.Core/Time/Clock.cs
+++ b/src/EventStore.Core/Time/Clock.cs
@@ -7,7 +7,7 @@ namespace EventStore.Core.Time {
 	}
 
 	public class Clock : IClock {
-		public static readonly Clock Instance = new();
+		public static Clock Instance { get; } = new();
 		private Clock() { }
 		public Instant Now => Instant.Now;
 		public long SecondsSinceEpoch => DateTimeOffset.UtcNow.ToUnixTimeSeconds();

--- a/src/EventStore.Core/Time/Clock.cs
+++ b/src/EventStore.Core/Time/Clock.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace EventStore.Core.Telemetry {
+namespace EventStore.Core.Time {
 	public interface IClock {
 		Instant Now { get; }
 		long SecondsSinceEpoch { get; }

--- a/src/EventStore.Core/Time/Instant.cs
+++ b/src/EventStore.Core/Time/Instant.cs
@@ -5,7 +5,7 @@ namespace EventStore.Core.Time;
 
 // this provides stronger typing than just passing a long representing the number of ticks
 // and provides us a place to change the resolution and size if long ticks is overkill.
-public struct Instant {
+public struct Instant : IEquatable<Instant> {
 	public static long TicksPerSecond { get; } = Stopwatch.Frequency;
 
 	private static readonly double _secondsPerTick = 1 / (double)TicksPerSecond;
@@ -15,6 +15,10 @@ public struct Instant {
 
 	public static bool operator ==(Instant x, Instant y) => x._ticks == y._ticks;
 	public static bool operator !=(Instant x, Instant y) => x._ticks != y._ticks;
+	public static bool operator <=(Instant x, Instant y) => x._ticks <= y._ticks;
+	public static bool operator >=(Instant x, Instant y) => x._ticks >= y._ticks;
+	public static bool operator <(Instant x, Instant y) => x._ticks < y._ticks;
+	public static bool operator >(Instant x, Instant y) => x._ticks > y._ticks;
 
 	private static double TicksToSeconds(long ticks) => ticks * _secondsPerTick;
 
@@ -29,9 +33,16 @@ public struct Instant {
 
 	public double ElapsedSecondsSince(Instant start) => TicksToSeconds(ElapsedTicksSince(start));
 
+	public Instant Add(TimeSpan timeSpan) {
+		return new(_ticks + (long)(timeSpan.TotalSeconds * TicksPerSecond));
+	}
+
 	// something has gone wrong if we call this
 	public override bool Equals(object obj) =>
 		throw new InvalidOperationException();
+
+	public bool Equals(Instant that) =>
+		this == that;
 
 	public override int GetHashCode() =>
 		_ticks.GetHashCode();

--- a/src/EventStore.Core/Time/Instant.cs
+++ b/src/EventStore.Core/Time/Instant.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Diagnostics;
 
-namespace EventStore.Core.Telemetry;
+namespace EventStore.Core.Time;
 
 // this provides stronger typing than just passing a long representing the number of ticks
 // and provides us a place to change the resolution and size if long ticks is overkill.

--- a/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
+++ b/src/EventStore.Projections.Core.Tests/Subsystem/TestFixtureWithProjectionSubsystem.cs
@@ -33,7 +33,7 @@ namespace EventStore.Projections.Core.Tests.Subsystem {
 				/* Ignore messages */
 			}), "MainQueue", new QueueStatsManager(), new());
 			var mainBus = new InMemoryBus("mainBus");
-			var threadBasedScheduler = new ThreadBasedScheduler(new RealTimeProvider(), new QueueStatsManager());
+			var threadBasedScheduler = new ThreadBasedScheduler(new QueueStatsManager(), new());
 			var timerService = new TimerService(threadBasedScheduler);
 
 			return new StandardComponents(db, mainQueue, mainBus,


### PR DESCRIPTION
Added: Queue and Processing time tracking for Timer service

It's not literally a queue but can be treated as such. Queue length is how long callbacks are waiting after they are due

![image](https://user-images.githubusercontent.com/2587665/217793677-392443ef-e8ee-49d2-90a3-45e0ee2d3618.png)
![image](https://user-images.githubusercontent.com/2587665/217793756-66520f5b-9006-437e-aebf-ecc0de6a38d0.png)
![image](https://user-images.githubusercontent.com/2587665/217793842-0ee8c8d4-f2fb-45b3-b592-7c4a0f3af744.png)


