### PR TITLE
Implement Event/Byte read tracking.

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -18,6 +18,11 @@
 		"Replication"
 	],
 
+	"Events": {
+		"Read": true,
+		"Written": true
+	},
+
 	// maps grpc methods to labels that they are to be recorded under
 	"GrpcMethods": {
 		"StreamRead": "read",

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -66,6 +66,11 @@ namespace EventStore.Common.Configuration {
 			ProcessingRequestFromHttpClient,
 		}
 
+		public enum EventTracker {
+			Read = 1,
+			Written,
+		}
+
 		public class LabelMappingCase {
 			public string Regex { get; set; }
 			public string Label { get; set; }
@@ -80,6 +85,8 @@ namespace EventStore.Common.Configuration {
 		public Dictionary<GrpcMethod, string> GrpcMethods { get; set; } = new();
 
 		public Gossip[] GossipTrackers { get; set; } = Array.Empty<Gossip>();
+
+		public Dictionary<EventTracker, bool> Events { get; set; } = new();
 
 		// must be 0, 1, 5, 10 or a multiple of 15
 		public int ExpectedScrapeIntervalSeconds { get; set; }

--- a/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkFailureTests.cs
@@ -131,7 +131,8 @@ namespace EventStore.Core.Tests.Services.RedactionService {
 
 			newChunk = $"{nameof(cannot_switch_with_chunk_having_mismatched_range)}-chunk-0-2.tmp";
 			var chunkHeader = new ChunkHeader(1, 1024, 0, 2, true, Guid.NewGuid());
-			var chunk = TFChunk.CreateWithHeader(Path.Combine(PathName, newChunk), chunkHeader, 1024, false, false, false, 1, 1, false);
+			var chunk = TFChunk.CreateWithHeader(Path.Combine(PathName, newChunk), chunkHeader, 1024, false, false, false, 1, 1, false,
+				new TFChunkTracker.NoOp());
 			chunk.Dispose();
 			msg = await SwitchChunk(GetChunk(0, 0), newChunk);
 			Assert.AreEqual(SwitchChunkResult.ChunkRangeDoesNotMatch, msg.Result);

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -169,7 +169,8 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: _db.Config.ReplicationCheckpoint,
 				indexCheckpoint: _db.Config.IndexCheckpoint,
-				indexStatusTracker: new IndexStatusTracker.NoOp());
+				indexStatusTracker: new IndexStatusTracker.NoOp(),
+				indexTracker: new IndexTracker.NoOp());
 
 
 			readIndex.IndexCommitter.Init(chaserCheckpoint.Read());
@@ -215,7 +216,8 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: _db.Config.ReplicationCheckpoint,
 				indexCheckpoint: _db.Config.IndexCheckpoint,
-				indexStatusTracker: new IndexStatusTracker.NoOp());
+				indexStatusTracker: new IndexStatusTracker.NoOp(),
+				indexTracker: new IndexTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(chaserCheckpoint.Read());
 			ReadIndex = readIndex;

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -138,7 +138,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: Db.Config.ReplicationCheckpoint,
 				indexCheckpoint: Db.Config.IndexCheckpoint,
-				indexStatusTracker: new IndexStatusTracker.NoOp());
+				indexStatusTracker: new IndexStatusTracker.NoOp(),
+				indexTracker: new IndexTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(ChaserCheckpoint.Read());
 			ReadIndex = readIndex;

--- a/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/RepeatableDbTestScenario.cs
@@ -90,7 +90,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: DbRes.Db.Config.ReplicationCheckpoint,
 				indexCheckpoint: DbRes.Db.Config.IndexCheckpoint,
-				indexStatusTracker: new IndexStatusTracker.NoOp());
+				indexStatusTracker: new IndexStatusTracker.NoOp(),
+				indexTracker: new IndexTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
 			ReadIndex = readIndex;

--- a/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/SimpleDbTestScenario.cs
@@ -88,7 +88,8 @@ namespace EventStore.Core.Tests.Services.Storage {
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: DbRes.Db.Config.ReplicationCheckpoint,
 				indexCheckpoint: DbRes.Db.Config.IndexCheckpoint,
-				indexStatusTracker: new IndexStatusTracker.NoOp());
+				indexStatusTracker: new IndexStatusTracker.NoOp(),
+				indexTracker: new IndexTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(DbRes.Db.Config.ChaserCheckpoint.Read());
 			ReadIndex = readIndex;

--- a/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Transactions/when_rebuilding_index_for_partially_persisted_transaction.cs
@@ -59,7 +59,8 @@ namespace EventStore.Core.Tests.Services.Storage.Transactions {
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: Db.Config.ReplicationCheckpoint,
 				indexCheckpoint: Db.Config.IndexCheckpoint,
-				indexStatusTracker: new IndexStatusTracker.NoOp());
+				indexStatusTracker: new IndexStatusTracker.NoOp(),
+				indexTracker: new IndexTracker.NoOp());
 			readIndex.IndexCommitter.Init(ChaserCheckpoint.Read());
 			ReadIndex = readIndex;
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/WriteEventsToIndexScenario.cs
@@ -150,7 +150,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				_systemStreams, emptyStreamId, _sizer);
 			_indexCommitter = new IndexCommitter<TStreamId>(_publisher, _indexBackend, _indexReader, _tableIndex,
 				_logFormat.StreamNameIndexConfirmer, _streamNames, _logFormat.EventTypeIndexConfirmer, _logFormat.EventTypes,
-				_systemStreams, _logFormat.StreamExistenceFilter, _logFormat.StreamExistenceFilterInitializer, new InMemoryCheckpoint(-1), new IndexStatusTracker.NoOp(), false);
+				_systemStreams, _logFormat.StreamExistenceFilter, _logFormat.StreamExistenceFilterInitializer, new InMemoryCheckpoint(-1), new IndexStatusTracker.NoOp(), new IndexTracker.NoOp(), false);
 
 			WriteEvents();
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Optimization/tfchunkreader_existsat_optimizer_should.cs
@@ -91,7 +91,8 @@ namespace EventStore.Core.Tests.TransactionLog.Optimization {
 				chunkNumber, chunkNumber, scavenged, false, false, false,
 				Constants.TFChunkInitialReaderCountDefault,
 				Constants.TFChunkMaxReaderCountDefault,
-				false);
+				false,
+				new TFChunkTracker.NoOp());
 			long offset = chunkNumber * 1024 * 1024;
 			long logPos = 0 + offset;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeTestScenario.cs
@@ -84,7 +84,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 				new LRUCache<TStreamId, IndexBackend<TStreamId>.MetadataCached>("StreamMetadata", 100),
 				true, _metastreamMaxCount,
 				Opts.HashCollisionReadLimitDefault, Opts.SkipIndexScanOnReadsDefault,
-				_dbResult.Db.Config.ReplicationCheckpoint,_dbResult.Db.Config.IndexCheckpoint, new IndexStatusTracker.NoOp());
+				_dbResult.Db.Config.ReplicationCheckpoint,_dbResult.Db.Config.IndexCheckpoint, new IndexStatusTracker.NoOp(), new IndexTracker.NoOp());
 			readIndex.IndexCommitter.Init(_dbResult.Db.Config.WriterCheckpoint.Read());
 			ReadIndex = readIndex;
 

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/scavenged_chunk.cs
@@ -14,7 +14,8 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging {
 			var chunk = TFChunk.CreateNew(Filename, 1024 * 1024, 0, 0, true, false, false, false,
 				Constants.TFChunkInitialReaderCountDefault,
 				Constants.TFChunkMaxReaderCountDefault,
-				false);
+				false,
+				new TFChunkTracker.NoOp());
 			long logPos = 0;
 			for (int i = 0, n = ChunkFooter.Size / PosMap.FullSize + 1; i < n; ++i) {
 				map.Add(new PosMap(logPos, (int)logPos));

--- a/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/TFChunkHelper.cs
@@ -72,7 +72,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public static TFChunk CreateNewChunk(string fileName, int chunkSize = 4096, bool isScavenged = false) {
 			return TFChunk.CreateNew(fileName, chunkSize, 0, 0,
 				isScavenged: isScavenged, inMem: false, unbuffered: false,
-				writethrough: false, initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
+				writethrough: false, initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp());
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Truncation/TruncateAndReOpenDbScenario.cs
@@ -68,7 +68,8 @@ namespace EventStore.Core.Tests.TransactionLog.Truncation {
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: Db.Config.ReplicationCheckpoint,
 				indexCheckpoint: Db.Config.IndexCheckpoint,
-				indexStatusTracker: new IndexStatusTracker.NoOp());
+				indexStatusTracker: new IndexStatusTracker.NoOp(),
+				indexTracker: new IndexTracker.NoOp());
 			readIndex.IndexCommitter.Init(ChaserCheckpoint.Read());
 			ReadIndex = readIndex;
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
@@ -446,7 +446,7 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 				.WriteTo.Sink(sink)
 				.MinimumLevel.Verbose()
 				.CreateLogger())
-			using (var db = new TFChunkDb(config, log)) {
+			using (var db = new TFChunkDb(config, new TFChunkTracker.NoOp(), log)) {
 				byte[] contents = new byte[config.ChunkSize];
 				for (var i = 0; i < config.ChunkSize; i++) {
 					contents[i] = 0;

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_existing_tfchunk.cs
@@ -1,4 +1,5 @@
 using System;
+using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
@@ -17,7 +18,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_testChunk = TFChunk.FromCompletedFile(Filename, true, false,
 				Constants.TFChunkInitialReaderCountDefault,
 				Constants.TFChunkMaxReaderCountDefault,
-				reduceFileCachePressure: false);
+				reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp());
 		}
 
 		[TearDown]

--- a/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_opening_tfchunk_from_non_existing_file.cs
@@ -1,4 +1,5 @@
 using EventStore.Core.Exceptions;
+using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using NUnit.Framework;
 
@@ -8,7 +9,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public void it_should_throw_a_file_not_found_exception() {
 			Assert.Throws<CorruptDatabaseException>(() => TFChunk.FromCompletedFile(Filename, verifyHash: true,
-				unbufferedRead: false, initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false));
+				unbufferedRead: false, initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp()));
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_from_a_cached_tfchunk.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Core.TransactionLog;
+using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
@@ -29,7 +30,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Flush();
 			_chunk.Complete();
 			_cachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
-				initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
+				initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp());
 			_cachedChunk.CacheInMemory();
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_uncaching_a_tfchunk.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Core.TransactionLog;
+using EventStore.Core.TransactionLog.Chunks;
 using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using EventStore.Core.TransactionLog.LogRecords;
 using NUnit.Framework;
@@ -29,7 +30,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			_chunk.Flush();
 			_chunk.Complete();
 			_uncachedChunk = TFChunk.FromCompletedFile(Filename, verifyHash: true, unbufferedRead: false,
-				initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false);
+				initialReaderCount: Constants.TFChunkInitialReaderCountDefault, maxReaderCount: Constants.TFChunkMaxReaderCountDefault, reduceFileCachePressure: false, tracker: new TFChunkTracker.NoOp());
 			_uncachedChunk.CacheInMemory();
 			_uncachedChunk.UnCacheFromMemory();
 		}

--- a/src/EventStore.Core.XUnit.Tests/Index/IndexTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Index/IndexTrackerTests.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using EventStore.Core.Index;
+using EventStore.Core.Telemetry;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.XUnit.Tests.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Index;
+
+public class IndexTrackerTests : IDisposable {
+	private readonly TestMeterListener<long> _listener;
+	private readonly IndexTracker _sut;
+
+	public IndexTrackerTests() {
+		var meter = new Meter($"{typeof(IndexTrackerTests)}");
+		_listener = new TestMeterListener<long>(meter);
+
+		var eventMetric = meter.CreateCounter<long>("eventstore-io", unit: "events");
+		_sut = new IndexTracker(
+			new CounterSubMetric<long>(
+				eventMetric,
+				new KeyValuePair<string, object>("activity", "written")));
+	}
+
+	public void Dispose() {
+		_listener.Dispose();
+	}
+
+	[Fact]
+	public void can_observe_prepare_logs() {
+		var prepares = new List<IPrepareLogRecord<string>> {
+			CreatePrepare(),
+			CreatePrepare(),
+			CreatePrepare()
+		};
+
+		_sut.OnIndexed(prepares);
+		_listener.Observe();
+
+		AssertMeasurements(expectedEventsWritten: 3);
+	}
+
+	private static PrepareLogRecord CreatePrepare() {
+		return new PrepareLogRecord(42, Guid.NewGuid(), Guid.NewGuid(), 42, 42, "tests", 42, DateTime.Now,
+			PrepareFlags.Data, "type-test", Array.Empty<byte>(), Array.Empty<byte>());
+	}
+
+	private void AssertMeasurements(long expectedEventsWritten) {
+		_listener.Observe();
+
+		Assert.Collection(
+			_listener.RetrieveMeasurements("eventstore-io-events"),
+			m => {
+				Assert.Equal(expectedEventsWritten, m.Value);
+				Assert.Collection(m.Tags.ToArray(), t => {
+					Assert.Equal("activity", t.Key);
+					Assert.Equal("written", t.Value);
+				});
+			});
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -276,7 +276,8 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 				skipIndexScanOnReads: Opts.SkipIndexScanOnReadsDefault,
 				replicationCheckpoint: dbResult.Db.Config.ReplicationCheckpoint,
 				indexCheckpoint: dbResult.Db.Config.IndexCheckpoint,
-				indexStatusTracker: new IndexStatusTracker.NoOp());
+				indexStatusTracker: new IndexStatusTracker.NoOp(),
+				indexTracker: new IndexTracker.NoOp());
 
 			readIndex.IndexCommitter.Init(dbResult.Db.Config.WriterCheckpoint.Read());
 			// wait for tables to be merged. for one of the tests this takes a while

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/DurationMaxTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/DurationMaxTrackerTests.cs
@@ -160,7 +160,7 @@ public class DurationMaxTrackerTests : IDisposable {
 		_listener.Observe();
 
 		Assert.Collection(
-			_listener.RetrieveMeasurements("the-metric"),
+			_listener.RetrieveMeasurements("the-metric-seconds"),
 			m => {
 				Assert.Equal(expectedValue, m.Value);
 				Assert.Collection(

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/DurationTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/DurationTrackerTests.cs
@@ -46,7 +46,7 @@ namespace EventStore.Core.XUnit.Tests.Telemetry {
 			int expectedValue) {
 
 			Assert.Collection(
-				_listener.RetrieveMeasurements("the-histogram"),
+				_listener.RetrieveMeasurements("the-histogram-seconds"),
 				m => {
 					Assert.Equal(expectedValue, m.Value);
 					Assert.Collection(

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/QueueProcessingTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/QueueProcessingTrackerTests.cs
@@ -34,7 +34,7 @@ namespace EventStore.Core.XUnit.Tests.Telemetry {
 		void AssertMeasurements(int expectedValue) {
 
 			Assert.Collection(
-				_listener.RetrieveMeasurements("the-metric"),
+				_listener.RetrieveMeasurements("the-metric-seconds"),
 				m => {
 					Assert.Equal(expectedValue, m.Value);
 					Assert.Collection(

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/TestMeterListener.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/TestMeterListener.cs
@@ -43,9 +43,10 @@ namespace EventStore.Core.XUnit.Tests.Telemetry {
 			ReadOnlySpan<KeyValuePair<string, object>> tags,
 			object state) {
 
-			if (!_measurementsByInstrument.TryGetValue(instrument.Name, out var measurements)) {
+			var instrumentName = GenName(instrument);
+			if (!_measurementsByInstrument.TryGetValue(instrumentName, out var measurements)) {
 				measurements = new();
-				_measurementsByInstrument[instrument.Name] = measurements;
+				_measurementsByInstrument[instrumentName] = measurements;
 			}
 
 			measurements.Add(new TestMeasurement {
@@ -53,6 +54,11 @@ namespace EventStore.Core.XUnit.Tests.Telemetry {
 				Tags = tags.ToArray(),
 			});
 		}
+
+		private static string GenName(Instrument instrument) =>
+			string.IsNullOrWhiteSpace(instrument.Unit)
+			? instrument.Name
+			: instrument.Name + "-" + instrument.Unit;
 
 		public class TestMeasurement {
 			public T Value { get; init; }

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/TFChunkTrackerTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using EventStore.Core.Telemetry;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.LogRecords;
+using EventStore.Core.XUnit.Tests.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
+
+public class TFChunkTrackerTests : IDisposable {
+	private readonly TFChunkTracker _sut;
+	private readonly TestMeterListener<long> _listener;
+
+	public TFChunkTrackerTests() {
+		var meter = new Meter($"{typeof(TFChunkTrackerTests)}");
+		_listener = new TestMeterListener<long>(meter);
+		var byteMetric = meter.CreateCounter<long>("eventstore-io", unit: "bytes");
+		var eventMetric = meter.CreateCounter<long>("eventstore-io", unit: "events");
+
+		var readTag = new KeyValuePair<string, object>("activity", "read");
+		_sut = new TFChunkTracker(
+			readBytes: new CounterSubMetric<long>(byteMetric, readTag),
+			readEvents: new CounterSubMetric<long>(eventMetric, readTag));
+	}
+
+	public void Dispose() {
+		_listener.Dispose();
+	}
+
+	[Fact]
+	public void can_observe_prepare_log() {
+		var prepare = CreatePrepare(
+			data: new byte[5],
+			meta: new byte[5]);
+
+		_sut.OnRead(prepare);
+		_listener.Observe();
+
+		AssertEventsRead(1);
+		AssertBytesRead(10);
+	}
+
+	[Fact]
+	public void disregard_system_log() {
+		var system = CreateSystemRecord();
+		_sut.OnRead(system);
+		_listener.Observe();
+
+		AssertEventsRead(null);
+		AssertBytesRead(null);
+	}
+
+	[Fact]
+	public void disregard_commit_log() {
+		var system = CreateCommit();
+		_sut.OnRead(system);
+		_listener.Observe();
+
+		AssertEventsRead(null);
+		AssertBytesRead(null);
+	}
+
+	private void AssertEventsRead(long? expectedEventsRead) =>
+		AssertMeasurements("eventstore-io-events", expectedEventsRead);
+
+	private void AssertBytesRead(long? expectedBytesRead) =>
+		AssertMeasurements("eventstore-io-bytes", expectedBytesRead);
+
+	private void AssertMeasurements(string instrumentName, long? expectedValue) {
+		_listener.Observe();
+		var actual = _listener.RetrieveMeasurements(instrumentName);
+
+		if (expectedValue is null) {
+			Assert.Empty(actual);
+		} else {
+			Assert.Collection(
+				actual,
+				m => {
+					Assert.Equal(expectedValue, m.Value);
+					Assert.Collection(m.Tags.ToArray(), t => {
+						Assert.Equal("activity", t.Key);
+						Assert.Equal("read", t.Value);
+					});
+				});
+		}
+	}
+
+	private static PrepareLogRecord CreatePrepare(byte[] data, byte[] meta) {
+		return new PrepareLogRecord(42, Guid.NewGuid(), Guid.NewGuid(), 42, 42, "tests", 42, DateTime.Now,
+			PrepareFlags.Data, "type-test", data, meta);
+	}
+
+	private static SystemLogRecord CreateSystemRecord() {
+		return new SystemLogRecord(42, DateTime.Now, SystemRecordType.Epoch, SystemRecordSerialization.Binary, Array.Empty<byte>());
+	}
+
+	private static CommitLogRecord CreateCommit() {
+		return new CommitLogRecord(42, Guid.NewGuid(), 42, DateTime.Now, 42);
+	}
+}

--- a/src/EventStore.Core/Index/IndexTracker.cs
+++ b/src/EventStore.Core/Index/IndexTracker.cs
@@ -1,0 +1,27 @@
+﻿#nullable enable
+using System.Collections.Generic;
+using EventStore.Core.Telemetry;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.Index {
+	public interface IIndexTracker {
+		void OnIndexed<TStreamId>(List<IPrepareLogRecord<TStreamId>> prepares);
+	}
+
+	public class IndexTracker : IIndexTracker {
+		private readonly CounterSubMetric<long> _indexedEvents;
+
+		public IndexTracker(CounterSubMetric<long> indexedEvents) {
+			_indexedEvents = indexedEvents;
+		}
+
+		public void OnIndexed<TStreamId>(List<IPrepareLogRecord<TStreamId>> prepares) {
+			_indexedEvents.Add(prepares.Count);
+		}
+
+		public class NoOp : IIndexTracker {
+			public void OnIndexed<TStreamId>(List<IPrepareLogRecord<TStreamId>> record) {
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Services/RedactionService.cs
+++ b/src/EventStore.Core/Services/RedactionService.cs
@@ -250,7 +250,8 @@ namespace EventStore.Core.Services {
 					initialReaderCount: 1,
 					maxReaderCount: 1,
 					optimizeReadSideCache: false,
-					reduceFileCachePressure: true);
+					reduceFileCachePressure: true,
+					tracker: new TFChunkTracker.NoOp());
 			} catch (HashValidationException) {
 				failReason = SwitchChunkResult.NewChunkHashInvalid;
 				return false;

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -47,6 +47,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 		private readonly ISystemStreamLookup<TStreamId> _systemStreams;
 		private readonly INameExistenceFilter _streamExistenceFilter;
 		private readonly IIndexStatusTracker _statusTracker;
+		private readonly IIndexTracker _tracker;
 		private INameExistenceFilterInitializer _streamExistenceFilterInitializer;
 		private readonly bool _additionalCommitChecks;
 		private long _persistedPreparePos = -1;
@@ -68,6 +69,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			INameExistenceFilterInitializer streamExistenceFilterInitializer,
 			ICheckpoint indexChk,
 			IIndexStatusTracker statusTracker,
+			IIndexTracker tracker,
 			bool additionalCommitChecks) {
 			_bus = bus;
 			_backend = backend;
@@ -83,6 +85,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			_indexChk = indexChk;
 			_additionalCommitChecks = additionalCommitChecks;
 			_statusTracker = statusTracker;
+			_tracker = tracker;
 		}
 
 		public void Init(long buildToPosition) {
@@ -440,6 +443,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 							isTfEof && i == n - 1));
 				}
 			}
+
+			_tracker.OnIndexed(prepares);
 
 			return eventNumber;
 		}

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/ReadIndex.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/ReadIndex.cs
@@ -55,7 +55,8 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			bool skipIndexScanOnReads,
 			IReadOnlyCheckpoint replicationCheckpoint,
 			ICheckpoint indexCheckpoint,
-			IIndexStatusTracker indexStatusTracker) {
+			IIndexStatusTracker indexStatusTracker,
+			IIndexTracker indexTracker) {
 
 			Ensure.NotNull(bus, "bus");
 			Ensure.NotNull(readerPool, "readerPool");
@@ -88,7 +89,7 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 			_indexWriter = new IndexWriter<TStreamId>(indexBackend, _indexReader, _streamIds, _streamNames, systemStreams, emptyStreamName, sizer);
 			_indexCommitter = new IndexCommitter<TStreamId>(bus, indexBackend, _indexReader, tableIndex, streamNameIndex,
 				_streamNames, eventTypeIndex, eventTypeNames, systemStreams, streamExistenceFilter,
-				streamExistenceFilterInitializer, indexCheckpoint, indexStatusTracker, additionalCommitChecks);
+				streamExistenceFilterInitializer, indexCheckpoint, indexStatusTracker, indexTracker, additionalCommitChecks);
 			_allReader = new AllReader<TStreamId>(indexBackend, _indexCommitter, _streamNames, eventTypeNames);
 		}
 

--- a/src/EventStore.Core/Telemetry/CounterSubMetric.cs
+++ b/src/EventStore.Core/Telemetry/CounterSubMetric.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace EventStore.Core.Telemetry {
+	public class CounterSubMetric<T> where T : struct {
+		private readonly Counter<T> _metric;
+		private readonly KeyValuePair<string, object> _tag;
+
+		public CounterSubMetric(Counter<T> metric, KeyValuePair<string, object> tag) {
+			_metric = metric;
+			_tag = tag;
+		}
+
+		public void Add(T delta) {
+			_metric.Add(delta, _tag);
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkManager.cs
@@ -20,6 +20,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 
 		private readonly TFChunkDbConfig _config;
 		private readonly TFChunk.TFChunk[] _chunks = new TFChunk.TFChunk[MaxChunksCount];
+		private readonly ITransactionFileTracker _tracker;
 		private volatile int _chunksCount;
 		private volatile bool _cachingEnabled;
 
@@ -27,9 +28,10 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		private int _backgroundPassesRemaining;
 		private int _backgroundRunning;
 
-		public TFChunkManager(TFChunkDbConfig config) {
+		public TFChunkManager(TFChunkDbConfig config, ITransactionFileTracker tracker) {
 			Ensure.NotNull(config, "config");
 			_config = config;
+			_tracker = tracker;
 		}
 
 		public void EnableCaching() {
@@ -101,7 +103,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				_config.WriteThrough,
 				_config.InitialReaderCount,
 				_config.MaxReaderCount,
-				_config.ReduceFileCachePressure);
+				_config.ReduceFileCachePressure,
+				_tracker);
 		}
 
 		public TFChunk.TFChunk AddNewChunk() {
@@ -118,7 +121,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					writethrough: _config.WriteThrough,
 					initialReaderCount: _config.InitialReaderCount,
 					maxReaderCount: _config.MaxReaderCount,
-					reduceFileCachePressure: _config.ReduceFileCachePressure);
+					reduceFileCachePressure: _config.ReduceFileCachePressure,
+					tracker: _tracker);
 				AddChunk(chunk);
 				return chunk;
 			}
@@ -143,7 +147,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					writethrough: _config.WriteThrough,
 					initialReaderCount: _config.InitialReaderCount,
 					maxReaderCount: _config.MaxReaderCount,
-					reduceFileCachePressure: _config.ReduceFileCachePressure);
+					reduceFileCachePressure: _config.ReduceFileCachePressure,
+					tracker: _tracker);
 				AddChunk(chunk);
 				return chunk;
 			}
@@ -200,7 +205,7 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				}
 
 				newChunk = TFChunk.TFChunk.FromCompletedFile(newFileName, verifyHash, _config.Unbuffered,
-					_config.InitialReaderCount, _config.MaxReaderCount, _config.OptimizeReadSideCache, _config.ReduceFileCachePressure);
+					_config.InitialReaderCount, _config.MaxReaderCount, _tracker, _config.OptimizeReadSideCache, _config.ReduceFileCachePressure );
 			}
 
 			lock (_chunksLocker) {

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkScavenger.cs
@@ -195,7 +195,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					writethrough: _db.Config.WriteThrough,
 					initialReaderCount: _db.Config.InitialReaderCount,
 					maxReaderCount: _db.Config.MaxReaderCount,
-					reduceFileCachePressure: _db.Config.ReduceFileCachePressure);
+					reduceFileCachePressure: _db.Config.ReduceFileCachePressure,
+					tracker: new TFChunkTracker.NoOp());
 			} catch (IOException exc) {
 				_logger.Error(exc,
 					"IOException during creating new chunk for scavenging purposes. Stopping scavenging process...");
@@ -430,7 +431,8 @@ namespace EventStore.Core.TransactionLog.Chunks {
 					writethrough: db.Config.WriteThrough,
 					initialReaderCount: db.Config.InitialReaderCount,
 					maxReaderCount: db.Config.MaxReaderCount,
-					reduceFileCachePressure: db.Config.ReduceFileCachePressure);
+					reduceFileCachePressure: db.Config.ReduceFileCachePressure,
+					tracker: new TFChunkTracker.NoOp());
 			} catch (IOException exc) {
 				logger.Error(exc,
 					"IOException during creating new chunk for scavenging merge purposes. Stopping scavenging merge process...");

--- a/src/EventStore.Core/TransactionLog/Chunks/TransactionFileTracker.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TransactionFileTracker.cs
@@ -1,0 +1,31 @@
+#nullable enable
+using EventStore.Core.Telemetry;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.TransactionLog.Chunks;
+
+public class TFChunkTracker : ITransactionFileTracker {
+	private readonly CounterSubMetric<long> _readBytes;
+	private readonly CounterSubMetric<long> _readEvents;
+
+	public TFChunkTracker(
+		CounterSubMetric<long> readBytes,
+		CounterSubMetric<long> readEvents) {
+
+		_readBytes = readBytes;
+		_readEvents = readEvents;
+	}
+
+	public void OnRead(ILogRecord record) {
+		if (record is not PrepareLogRecord prepare)
+			return;
+
+		_readBytes.Add(prepare.Data.Length + prepare.Metadata.Length);
+		_readEvents.Add(1);
+	}
+
+	public class NoOp : ITransactionFileTracker {
+		public void OnRead(ILogRecord record) {
+		}
+	}
+}

--- a/src/EventStore.Core/TransactionLog/ITransactionFileTracker.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileTracker.cs
@@ -1,0 +1,7 @@
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.TransactionLog;
+
+public interface ITransactionFileTracker {
+	void OnRead(ILogRecord record);
+}

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ChunkWriterForExecutor.cs
@@ -44,7 +44,8 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 				writethrough: dbConfig.WriteThrough,
 				initialReaderCount: dbConfig.InitialReaderCount,
 				maxReaderCount: dbConfig.MaxReaderCount,
-				reduceFileCachePressure: dbConfig.ReduceFileCachePressure);
+				reduceFileCachePressure: dbConfig.ReduceFileCachePressure,
+				tracker: new TFChunkTracker.NoOp());
 		}
 
 		public string FileName { get; }


### PR DESCRIPTION
Added: Metrics for count of events being read/written and bytes being read

- bytes written can be inferred from the movement of the writer checkpoint
- events written works by counting the number of events indexed since (i) from the users perspective that is when the event is written in the sense that that is when it can be read and (ii) the mechanism can work the same on the leader and followers

![image](https://user-images.githubusercontent.com/2587665/229911374-851187f8-a541-455e-9595-82de8a1b4d91.png)
![image](https://user-images.githubusercontent.com/2587665/229911426-dc2f44e6-275b-46a1-ab6d-d2569a894700.png)
