### PR TITLE
Parse custom password for admin and ops user through Environment Variables.

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -51,6 +51,30 @@ For this to work, you can use the `Insecure` option:
 When running with protocol security disabled, everything is sent unencrypted over the wire. In the previous version it included the server credentials. Sending username and password over the wire without encryption is not secure by definition, but it might give a false sense of security. In order to make things explicit, EventStoreDB v20 **does not use any authentication and authorisation** (including ACLs) when running insecure.
 :::
 
+### Running with default admin and ops password
+
+We are adding an ability to set default admin and ops passwords on first run of the database. It will not impact the existing credentials, the user can log into their accounts with exising passwords.
+
+For this to work, you can use the `DefaultAdminPassword` option:
+
+| Format               | Syntax                              |
+|:---------------------|:------------------------------------|
+| Environment variable | `EVENTSTORE_DEFAULT_ADMIN_PASSWORD` |
+
+**Default**: `changeit`
+
+For this to work, you can use the `DefaultOpsPassword` option:
+
+| Format               | Syntax                              |
+|:---------------------|:------------------------------------|
+| Environment variable | `EVENTSTORE_DEFAULT_OPS_PASSWORD`   |
+
+**Default**: `changeit`
+
+::: warning
+Due to security reasons the DefaultAdminPassword and DefaultOpsPassword options can only be set through environment variables. The user will receive the error message if they try to pass the options using command line or config file.
+:::
+
 ### Certificates configuration
 
 In this section, you can find settings related to protocol security (HTTPS and TLS).

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -190,7 +190,7 @@ namespace EventStore.ClusterNode {
 				var authenticationTypeToPlugin = new Dictionary<string, AuthenticationProviderFactory> {
 					{
 						"internal", new AuthenticationProviderFactory(components =>
-							new InternalAuthenticationProviderFactory(components))
+							new InternalAuthenticationProviderFactory(components, _options.DefaultUser))
 					}
 				};
 

--- a/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
@@ -1,4 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
 using Microsoft.Extensions.Configuration;
 
 #nullable enable
@@ -19,6 +23,45 @@ namespace EventStore.Common.Configuration {
 			}
 
 			return value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+		}
+		
+		public static string? CheckProvidersForEnvironmentVariables(IConfigurationRoot? configurationRoot, IEnumerable<Type> OptionSections) {
+			if (configurationRoot != null) {
+				var environmentOptionsOnly = OptionSections.SelectMany(section => section.GetProperties())
+					.Where(option => option.GetCustomAttribute<EnvironmentOnlyAttribute>() != null)
+					.Select(option => option)
+					.ToArray();
+
+				var errorBuilder = new StringBuilder();
+
+				foreach (var provider in configurationRoot.Providers) {
+					var source = provider.GetType();
+					
+					if (source == typeof(Default) || source == typeof(EnvironmentVariables)) continue;
+					
+					var errorDescriptions = from key in provider.GetChildKeys(Enumerable.Empty<string>(), default)
+						from property in environmentOptionsOnly
+						where string.Equals(property.Name, key, StringComparison.CurrentCultureIgnoreCase)
+						select property.GetCustomAttribute<EnvironmentOnlyAttribute>()?.Message;
+
+					var builder = errorDescriptions
+						.Aggregate(new StringBuilder(), (stringBuilder, errorDescription) => stringBuilder.AppendLine($"Provided by: {provider.GetType().Name}. {errorDescription}"));
+					errorBuilder.Append(builder);
+				}
+				return errorBuilder.Length != 0 ? errorBuilder.ToString() : null;
+			}
+			return null;
+		}
+
+		public static string GetEnvironmentOption(PropertyInfo property, int optionColumnWidth) {
+			var builder = new StringBuilder();
+			const string Prefix = "EVENTSTORE";
+
+			builder.Append($"{Prefix}_")
+				.Append(OptionsDumper.NameTranslators.CombineByPascalCase(property.Name, "_").ToUpper());
+			var description = property.GetCustomAttribute<EnvironmentOnlyAttribute>()?.Message;
+				
+			return builder.ToString().PadRight(optionColumnWidth, ' ') + description;
 		}
 	}
 }

--- a/src/EventStore.Common/Configuration/EnvironmentOnlyAttribute.cs
+++ b/src/EventStore.Common/Configuration/EnvironmentOnlyAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace EventStore.Common.Configuration {
+	[AttributeUsage(AttributeTargets.Property)]
+	public class EnvironmentOnlyAttribute : Attribute {
+		public string Message { get; }
+
+		public EnvironmentOnlyAttribute(string message) {
+			Message = message;
+		}
+	}
+}
+

--- a/src/EventStore.Core.Tests/Authentication/with_internal_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Authentication/with_internal_authentication_provider.cs
@@ -4,6 +4,7 @@ using EventStore.Core.Authentication.InternalAuthentication;
 using EventStore.Core.Helpers;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services;
 using EventStore.Core.Tests.Helpers;
 using EventStore.Plugins.Authentication;
 
@@ -25,7 +26,7 @@ namespace EventStore.Core.Tests.Authentication {
 
 			PasswordHashAlgorithm passwordHashAlgorithm = new StubPasswordHashAlgorithm();
 			_internalAuthenticationProvider =
-				new InternalAuthenticationProvider(_bus, _ioDispatcher, passwordHashAlgorithm, 1000, false);
+				new InternalAuthenticationProvider(_bus, _ioDispatcher, passwordHashAlgorithm, 1000, false, DefaultData.DefaultUserOptions);
 			_bus.Subscribe(_internalAuthenticationProvider);
 		}
 	}

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.ClientOperations {
 				.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 					ssl_connections.GetServerCertificate());
 			_node = new ClusterVNode<TStreamId>(options, logFormatFactory,
-				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
+				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
 				certificateProvider: new OptionsCertificateProvider(options));
 			_node.StartAsync(true).Wait();

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 					.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 						ssl_connections.GetServerCertificate()));
 			_node = new ClusterVNode<TStreamId>(_options, _logFormatFactory,
-				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
+				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c, _options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
 				certificateProvider: new OptionsCertificateProvider(_options));
 			_node.Start();
@@ -56,7 +56,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 				.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 					ssl_connections.GetServerCertificate()));
 			_node = new ClusterVNode<TStreamId>(_options, _logFormatFactory,
-				new AuthenticationProviderFactory(_ => new InternalAuthenticationProviderFactory(_)),
+				new AuthenticationProviderFactory(_ => new InternalAuthenticationProviderFactory(_, _options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
 				certificateProvider: new OptionsCertificateProvider(_options));
 			_node.Start();

--- a/src/EventStore.Core.Tests/DefaultData.cs
+++ b/src/EventStore.Core.Tests/DefaultData.cs
@@ -8,5 +8,9 @@ namespace EventStore.Core.Tests {
 		public static string AdminPassword = SystemUsers.DefaultAdminPassword;
 		public static UserCredentials AdminCredentials = new UserCredentials(AdminUsername, AdminPassword);
 		public static NetworkCredential AdminNetworkCredentials = new NetworkCredential(AdminUsername, AdminPassword);
+		public static ClusterVNodeOptions.DefaultUserOptions DefaultUserOptions = new ClusterVNodeOptions.DefaultUserOptions() {
+			DefaultAdminPassword = SystemUsers.DefaultAdminPassword,
+			DefaultOpsPassword = SystemUsers.DefaultOpsPassword
+		};
 	}
 }

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -174,7 +174,7 @@ namespace EventStore.Core.Tests.Helpers {
 
 			var logFormatFactory = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory;
 			Node = new ClusterVNode<TStreamId>(options, logFormatFactory, new AuthenticationProviderFactory(components =>
-					new InternalAuthenticationProviderFactory(components)),
+					new InternalAuthenticationProviderFactory(components, options.DefaultUser)),
 				new AuthorizationProviderFactory(components =>
 					new LegacyAuthorizationProviderFactory(components.MainQueue)),
 				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>(),

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -161,7 +161,7 @@ namespace EventStore.Core.Tests.Helpers {
 					streamExistenceFilterCheckpointIntervalMs: streamExistenceFilterCheckpointIntervalMs,
 					streamExistenceFilterCheckpointDelayMs: streamExistenceFilterCheckpointDelayMs));
 			Node = new ClusterVNode<TStreamId>(options, logFormatFactory,
-				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
+				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
 				telemetryConfiguration: null,
 				expiryStrategy: expiryStrategy,

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service.cs
@@ -95,7 +95,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				InMemoryBus.CreateTest(), tcpConn, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
-					new StubPasswordHashAlgorithm(), 1, false),
+					new StubPasswordHashAlgorithm(), 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -87,7 +87,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 			Service.Handle(new SystemMessage.SystemStart());
 			Service.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
-
+			
 			When();
 		}
 
@@ -114,7 +114,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 				InMemoryBus.CreateTest(), tcpConn, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
 					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
-					new StubPasswordHashAlgorithm(), 1, false),
+					new StubPasswordHashAlgorithm(), 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpClientDispatcherTests.cs
@@ -31,13 +31,13 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 		[OneTimeSetUp]
 		public void Setup() {
 			_dispatcher = new ClientTcpDispatcher(2000);
-
+			
 			var dummyConnection = new DummyTcpConnection();
 			_connection = new TcpConnectionManager(
 				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(), new InternalAuthenticationProvider(
 					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
-					new StubPasswordHashAlgorithm(), 1, false),
+					new StubPasswordHashAlgorithm(), 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				Opts.ConnectionPendingSendBytesThresholdDefault, Opts.ConnectionQueueSizeThresholdDefault);

--- a/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Tcp/TcpConnectionManagerTests.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 	public class TcpConnectionManagerTests {
 		private int _connectionPendingSendBytesThreshold = 10 * 1024;
 		private int _connectionQueueSizeThreshold = 50000;
-
+		
 		[Test]
 		public void when_handling_trusted_write_on_external_service() {
 			var package = new TcpPackage(TcpCommand.WriteEvents, TcpFlags.TrustedWrite, Guid.NewGuid(), null, null,
@@ -40,7 +40,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()),
-					new StubPasswordHashAlgorithm(), 1, false),
+					new StubPasswordHashAlgorithm(), 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
@@ -81,7 +81,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				Guid.NewGuid().ToString(), TcpServiceType.Internal, new ClientTcpDispatcher(2000),
 				publisher, dummyConnection, publisher,
 				new InternalAuthenticationProvider(publisher, new Core.Helpers.IODispatcher(publisher, new NoopEnvelope()),
-					new StubPasswordHashAlgorithm(), 1, false),
+					new StubPasswordHashAlgorithm(), 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
@@ -117,7 +117,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(
 					InMemoryBus.CreateTest(), new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(),
-						new NoopEnvelope()), null, 1, false),
+						new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { mre.Set(); },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
@@ -146,7 +146,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
-					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { },
 				_connectionPendingSendBytesThreshold, _connectionQueueSizeThreshold);
@@ -179,7 +179,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
-					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { mre.Set(); },
 				ESConsts.UnrestrictedPendingSendBytes, ESConsts.MaxConnectionQueueSize);
@@ -212,7 +212,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
-					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { mre.Set(); },
 				ESConsts.UnrestrictedPendingSendBytes, ESConsts.MaxConnectionQueueSize);
@@ -245,7 +245,7 @@ namespace EventStore.Core.Tests.Services.Transport.Tcp {
 				Guid.NewGuid().ToString(), TcpServiceType.External, new ClientTcpDispatcher(2000),
 				InMemoryBus.CreateTest(), dummyConnection, InMemoryBus.CreateTest(),
 				new InternalAuthenticationProvider(InMemoryBus.CreateTest(),
-					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false),
+					new Core.Helpers.IODispatcher(InMemoryBus.CreateTest(), new NoopEnvelope()), null, 1, false, DefaultData.DefaultUserOptions),
 				new AuthorizationGateway(new TestAuthorizationProvider()), 
 				TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10), (man, err) => { mre.Set(); },
 				ESConsts.UnrestrictedPendingSendBytes, ESConsts.MaxConnectionQueueSize);

--- a/src/EventStore.Core.Tests/Services/UserManagementService/user_management_service.cs
+++ b/src/EventStore.Core.Tests/Services/UserManagementService/user_management_service.cs
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Services.UserManagementService {
 
 				_users = new Core.Authentication.InternalAuthentication.UserManagementService(
 					_ioDispatcher, new StubPasswordHashAlgorithm(), skipInitializeStandardUsersCheck: true, 
-					new TaskCompletionSource<bool>());
+					new TaskCompletionSource<bool>(), DefaultData.DefaultUserOptions);
 
 				_bus.Subscribe<UserManagementMessage.Get>(_users);
 				_bus.Subscribe<UserManagementMessage.GetAll>(_users);

--- a/src/EventStore.Core.Tests/SpecificationWithDirectoryPerTestFixture.cs
+++ b/src/EventStore.Core.Tests/SpecificationWithDirectoryPerTestFixture.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests {
 			var typeName = GetType().Name.Length > 30 ? GetType().Name.Substring(0, 30) : GetType().Name;
 			PathName = Path.Combine(Path.GetTempPath(), string.Format("ES-{0}-{1}", Guid.NewGuid(), typeName));
 			Directory.CreateDirectory(PathName);
-
+			
 			return Task.CompletedTask;
 		}
 

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -207,7 +207,7 @@ namespace EventStore.Core.Tests {
 			Assert.False(certificatePasswordLine.Contains("123"));
 			Assert.True(certificatePasswordLine.Contains("****"));
 		}
-
+		
 		private class ParseCaseData {
 			public static IEnumerable TestCases() {
 				const string array = nameof(TestOptions.ArrayOfStrings);

--- a/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/InternalAuthenticationProvider.cs
@@ -23,16 +23,18 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 		private readonly bool _logFailedAuthenticationAttempts;
 		private readonly LRUCache<string, Tuple<string, ClaimsPrincipal>> _userPasswordsCache;
 		private readonly TaskCompletionSource<bool> _tcs = new TaskCompletionSource<bool>();
+		private readonly ClusterVNodeOptions.DefaultUserOptions _defaultUserOptions;
 
 		public InternalAuthenticationProvider(ISubscriber subscriber, IODispatcher ioDispatcher, PasswordHashAlgorithm passwordHashAlgorithm,
-			int cacheSize, bool logFailedAuthenticationAttempts) {
+			int cacheSize, bool logFailedAuthenticationAttempts, ClusterVNodeOptions.DefaultUserOptions defaultUserOptions) {
 			_ioDispatcher = ioDispatcher;
 			_passwordHashAlgorithm = passwordHashAlgorithm;
 			_userPasswordsCache = new LRUCache<string, Tuple<string, ClaimsPrincipal>>("UserPasswords", cacheSize);
 			_logFailedAuthenticationAttempts = logFailedAuthenticationAttempts;
+			_defaultUserOptions = defaultUserOptions;
 			
 			var userManagement = new UserManagementService(ioDispatcher, _passwordHashAlgorithm,
-				skipInitializeStandardUsersCheck: false, _tcs);
+				skipInitializeStandardUsersCheck: false, _tcs, _defaultUserOptions);
 			subscriber.Subscribe<UserManagementMessage.Create>(userManagement);
 			subscriber.Subscribe<UserManagementMessage.Update>(userManagement);
 			subscriber.Subscribe<UserManagementMessage.Enable>(userManagement);

--- a/src/EventStore.Core/Authentication/InternalAuthentication/UserManagementService.cs
+++ b/src/EventStore.Core/Authentication/InternalAuthentication/UserManagementService.cs
@@ -36,15 +36,17 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 		private readonly TaskCompletionSource<bool> _tcs;
 		private int _numberOfStandardUsersToBeCreated = 2;
 		private readonly ILogger _log;
+		private readonly ClusterVNodeOptions.DefaultUserOptions _defaultUserOptions;
 
 		public UserManagementService(IODispatcher ioDispatcher,
 			PasswordHashAlgorithm passwordHashAlgorithm, bool skipInitializeStandardUsersCheck,
-			TaskCompletionSource<bool> tcs) {
+			TaskCompletionSource<bool> tcs, ClusterVNodeOptions.DefaultUserOptions defaultUserOptions) {
 			_log = Serilog.Log.ForContext<UserManagementService>();
 			_ioDispatcher = ioDispatcher;
 			_passwordHashAlgorithm = passwordHashAlgorithm;
 			_skipInitializeStandardUsersCheck = skipInitializeStandardUsersCheck;
 			_tcs = tcs;
+			_defaultUserOptions = defaultUserOptions;
 		}
 
 		private bool VerifyPassword(string password, UserData userDetailsToVerify) {
@@ -480,7 +482,7 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 		private void CreateAdminUser() {
 			var userData = CreateUserData(
 				SystemUsers.Admin, "Event Store Administrator", new[] {SystemRoles.Admins},
-				SystemUsers.DefaultAdminPassword);
+				_defaultUserOptions.DefaultAdminPassword);
 			WriteStreamAcl(
 				SystemUsers.Admin, completed1 => {
 					switch (completed1.Result) {
@@ -527,7 +529,7 @@ namespace EventStore.Core.Authentication.InternalAuthentication {
 		private void CreateOperationsUser() {
 			var userData = CreateUserData(
 				SystemUsers.Operations, "Event Store Operations", new[] {SystemRoles.Operations},
-				SystemUsers.DefaultAdminPassword);
+				_defaultUserOptions.DefaultOpsPassword);
 			WriteStreamAcl(
 				SystemUsers.Operations, completed1 => {
 					switch (completed1.Result) {

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -26,6 +26,7 @@ namespace EventStore.Core {
 		internal IConfigurationRoot? ConfigurationRoot { get; init; }
 		[OptionGroup] public ApplicationOptions Application { get; init; } = new();
 		[OptionGroup] public DevModeOptions DevMode { get; init; } = new();
+		[OptionGroup] public DefaultUserOptions DefaultUser { get; init; } = new();
 		[OptionGroup] public LoggingOptions Log { get; init; } = new();
 		[OptionGroup] public AuthOptions Auth { get; init; } = new();
 		[OptionGroup] public CertificateOptions Certificate { get; init; } = new();
@@ -67,6 +68,7 @@ namespace EventStore.Core {
 			return new ClusterVNodeOptions {
 				Application = ApplicationOptions.FromConfiguration(configurationRoot),
 				DevMode = DevModeOptions.FromConfiguration(configurationRoot),
+				DefaultUser = DefaultUserOptions.FromConfiguration(configurationRoot),
 				Log = LoggingOptions.FromConfiguration(configurationRoot),
 				Auth = AuthOptions.FromConfiguration(configurationRoot),
 				Certificate = CertificateOptions.FromConfiguration(configurationRoot),
@@ -84,6 +86,21 @@ namespace EventStore.Core {
 
 		public ClusterVNodeOptions Reload() => ConfigurationRoot == null ? this : FromConfiguration(ConfigurationRoot);
 
+		[Description("Default User Options")]
+		public record DefaultUserOptions {
+			
+			[Description("Admin Default password"), Sensitive, EnvironmentOnly("The Admin user password can only be set using Environment Variables")]
+			public string DefaultAdminPassword { get; init; } = "changeit";
+			
+			[Description("Ops Default password"), Sensitive, EnvironmentOnly("The Ops user password can only be set using Environment Variables")] 
+			public string DefaultOpsPassword { get; init; } = "changeit";
+ 
+			internal static DefaultUserOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
+				DefaultAdminPassword = configurationRoot.GetValue<string>(nameof(DefaultAdminPassword)),
+				DefaultOpsPassword = configurationRoot.GetValue<string>(nameof(DefaultOpsPassword))
+			};
+		}
+		
 		[Description("Dev mode Options")]
 		public record DevModeOptions {
 			[Description("Runs EventStoreDB in dev mode. This will create and add dev certificates to your certificate store, enable atompub over http, and run standard projections.")]
@@ -101,7 +118,7 @@ namespace EventStore.Core {
 		[Description("Application Options")]
 		public record ApplicationOptions {
 			[Description("Show help.")] public bool Help { get; init; } = false;
-
+			
 			[Description("Show version.")] public bool Version { get; init; } = false;
 
 			[Description("Configuration files.")]

--- a/src/EventStore.Core/Services/SystemUsers.cs
+++ b/src/EventStore.Core/Services/SystemUsers.cs
@@ -4,5 +4,6 @@
 		public const string Admin = "admin";
 		public const string Operations = "ops";
 		public const string DefaultAdminPassword = "changeit";
+		public const string DefaultOpsPassword = "changeit";
 	}
 }


### PR DESCRIPTION
Added: The ability to set default admin and ops passwords on first run of the database

Fixes #https://github.com/EventStore/home/issues/897

Currently the user does not have any option to set the default password for Admin and Ops user. This PR provides the ability to set default admin and ops passwords on first run of the database. It will not impact the existing password for the admin and ops user. 


For this to work, you can set the `DefaultAdminPassword`  and `DefaultOpsPassword` option using environment variables:

| Format               | Syntax                |
| Environment variable | `EVENTSTORE_DEFAULT_ADMIN_PASSWORD` |
| Environment variable | `EVENTSTORE_DEFAULT_OPS_PASSWORD` |

**Default**: `changeit`

**Warning**
The above two options can only be set through environment variables due to security reasons. The user will receive the error message if they try to pass the options using command line or config file.