### PR TITLE
Support specifying values with a metric prefix

### DIFF
--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using EventStore.Common.Utils;
 using EventStore.TestClient.Commands;
 using EventStore.TestClient.Commands.DvuBasic;
-using EventStore.TestClient.Statistics;
 using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
 using ILogger = Serilog.ILogger;
 #pragma warning disable 1591

--- a/src/EventStore.TestClient/ClientApiTcpCommands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/ClientApiTcpCommands/WriteFloodProcessor.cs
@@ -36,14 +36,14 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 					return false;
 
 				try {
-					clientsCnt = int.Parse(args[0]);
-					requestsCnt = long.Parse(args[1]);
+					clientsCnt = MetricPrefixValue.ParseInt(args[0]);
+					requestsCnt = MetricPrefixValue.ParseLong(args[1]);
 					if (args.Length >= 3)
-						streamsCnt = int.Parse(args[2]);
+						streamsCnt = MetricPrefixValue.ParseInt(args[2]);
 					if (args.Length >= 4)
-						size = int.Parse(args[3]);
+						size = MetricPrefixValue.ParseInt(args[3]);
 					if (args.Length >= 5)
-						batchSize = int.Parse(args[4]);
+						batchSize = MetricPrefixValue.ParseInt(args[4]);
 					if (args.Length >= 6)
 						streamPrefix = args[5];
 				} catch {

--- a/src/EventStore.TestClient/Commands/MultiWriteFloodWaiting.cs
+++ b/src/EventStore.TestClient/Commands/MultiWriteFloodWaiting.cs
@@ -2,11 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using EventStore.Client.Messages;
 using EventStore.Core.Data;
-using EventStore.Core.Messages;
 using EventStore.Core.Services.Transport.Tcp;
 using EventStore.Transport.Tcp;
 using OperationResult = EventStore.Client.Messages.OperationResult;
@@ -30,10 +28,10 @@ namespace EventStore.TestClient.Commands {
 				if (args.Length != 1 && args.Length != 3)
 					return false;
 				try {
-					writeCount = int.Parse(args[0]);
+					writeCount = MetricPrefixValue.ParseInt(args[0]);
 					if (args.Length > 1) {
-						clientsCnt = int.Parse(args[1]);
-						requestsCnt = long.Parse(args[2]);
+						clientsCnt = MetricPrefixValue.ParseInt(args[1]);
+						requestsCnt = MetricPrefixValue.ParseLong(args[2]);
 					}
 				} catch {
 					return false;

--- a/src/EventStore.TestClient/Commands/MultiWriteProcessor.cs
+++ b/src/EventStore.TestClient/Commands/MultiWriteProcessor.cs
@@ -1,19 +1,17 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using EventStore.Client.Messages;
 using EventStore.Common.Utils;
 using EventStore.Core.Data;
 using EventStore.Core.Services.Transport.Tcp;
-using OperationResult = EventStore.Core.Messages.OperationResult;
 
 namespace EventStore.TestClient.Commands {
 	internal class MultiWriteProcessor : ICmdProcessor {
 		public string Usage {
 			get { return "MWR [<write-count=10> [<stream=test-stream> [<expected-version=ANY>]]"; }
 		}
-
+		
 		public string Keyword {
 			get { return "MWR"; }
 		}
@@ -27,7 +25,7 @@ namespace EventStore.TestClient.Commands {
 			if (args.Length > 0) {
 				if (args.Length > 3)
 					return false;
-				writeCount = int.Parse(args[0]);
+				writeCount = MetricPrefixValue.ParseInt(args[0]);
 				if (args.Length >= 2)
 					eventStreamId = args[1];
 				if (args.Length >= 3)

--- a/src/EventStore.TestClient/Commands/PingFloodProcessor.cs
+++ b/src/EventStore.TestClient/Commands/PingFloodProcessor.cs
@@ -12,7 +12,7 @@ namespace EventStore.TestClient.Commands {
 		public string Usage {
 			get { return "PINGFL [<clients> <messages>]"; }
 		}
-
+		
 		public string Keyword {
 			get { return "PINGFL"; }
 		}
@@ -24,8 +24,8 @@ namespace EventStore.TestClient.Commands {
 				if (args.Length != 2)
 					return false;
 				try {
-					clientsCnt = int.Parse(args[0]);
-					requestsCnt = long.Parse(args[1]);
+					clientsCnt = MetricPrefixValue.ParseInt(args[0]);
+					requestsCnt = MetricPrefixValue.ParseLong(args[1]);
 				} catch {
 					return false;
 				}

--- a/src/EventStore.TestClient/Commands/PingFloodWaitingProcessor.cs
+++ b/src/EventStore.TestClient/Commands/PingFloodWaitingProcessor.cs
@@ -22,8 +22,8 @@ namespace EventStore.TestClient.Commands {
 				if (args.Length != 2)
 					return false;
 				try {
-					clientsCnt = int.Parse(args[0]);
-					requestsCnt = long.Parse(args[1]);
+					clientsCnt = MetricPrefixValue.ParseInt(args[0]);
+					requestsCnt = MetricPrefixValue.ParseLong(args[1]);
 				} catch {
 					return false;
 				}

--- a/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 using System.Text;
 using EventStore.Client.Messages;
 using EventStore.Common.Utils;
-using EventStore.Core.Messages;
 using EventStore.Core.Services.Transport.Tcp;
 
 namespace EventStore.TestClient.Commands {

--- a/src/EventStore.TestClient/Commands/ReadFloodProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadFloodProcessor.cs
@@ -13,7 +13,7 @@ namespace EventStore.TestClient.Commands {
 			//                     0          1           2               3                  4
 			get { return "RDFL [<clients> <requests> [<streams-cnt> [<stream-prefix> [<require-leader>]]]]"; }
 		}
-
+		
 		public string Keyword {
 			get { return "RDFL"; }
 		}
@@ -30,10 +30,10 @@ namespace EventStore.TestClient.Commands {
 					return false;
 
 				try {
-					clientsCnt = int.Parse(args[0]);
-					requestsCnt = long.Parse(args[1]);
+					clientsCnt = MetricPrefixValue.ParseInt(args[0]);
+					requestsCnt = MetricPrefixValue.ParseLong(args[1]);
 					if (args.Length >= 3)
-						streamsCnt = int.Parse(args[2]);
+						streamsCnt = MetricPrefixValue.ParseInt(args[2]);
 					if (args.Length >= 4)
 						streamPrefix = args[3];
 					if (args.Length >= 5)
@@ -86,13 +86,13 @@ namespace EventStore.TestClient.Commands {
 						} else {
 							if (Interlocked.Increment(ref fail) % 1000 == 0) Console.Write("#");
 						}
-
+						
 						Interlocked.Increment(ref received);
 						var localAll = Interlocked.Increment(ref all);
 						if (localAll % 100000 == 0) {
 							var elapsed = sw2.Elapsed;
 							sw2.Restart();
-							context.Log.Verbose("\nDONE TOTAL {reads} READS IN {elapsed} ({rate:0.0}/s).", localAll,
+							context.Log.Information("\nDONE TOTAL {reads} READS IN {elapsed} ({rate:0.0}/s).", localAll,
 								elapsed, 1000.0 * 100000 / elapsed.TotalMilliseconds);
 						}
 

--- a/src/EventStore.TestClient/Commands/ReadProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadProcessor.cs
@@ -2,8 +2,6 @@ using System;
 using System.Diagnostics;
 using EventStore.Client.Messages;
 using EventStore.Common.Utils;
-using EventStore.Core.Data;
-using EventStore.Core.Messages;
 using EventStore.Core.Services.Transport.Tcp;
 
 namespace EventStore.TestClient.Commands {
@@ -27,7 +25,7 @@ namespace EventStore.TestClient.Commands {
 					return false;
 				eventStreamId = args[0];
 				if (args.Length >= 2)
-					fromNumber = int.Parse(args[1]);
+					fromNumber = MetricPrefixValue.ParseInt(args[1]);
 				if (args.Length >= 3)
 					requireLeader = bool.Parse(args[2]);
 			}

--- a/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
+++ b/src/EventStore.TestClient/Commands/SubscriptionStressTestProcessor.cs
@@ -21,7 +21,7 @@ namespace EventStore.TestClient.Commands {
 			if (args.Length > 0) {
 				if (args.Length > 1)
 					return false;
-				subscriptionCount = int.Parse(args[0]);
+				subscriptionCount = MetricPrefixValue.ParseInt(args[0]);
 			}
 
 			context.IsAsync();

--- a/src/EventStore.TestClient/Commands/TransactionWriteProcessor.cs
+++ b/src/EventStore.TestClient/Commands/TransactionWriteProcessor.cs
@@ -29,7 +29,7 @@ namespace EventStore.TestClient.Commands {
 				if (args.Length > 1)
 					expectedVersion = args[1].ToUpper() == "ANY" ? ExpectedVersion.Any : int.Parse(args[1]);
 				if (args.Length > 2)
-					eventsCnt = int.Parse(args[1]);
+					eventsCnt = MetricPrefixValue.ParseInt(args[1]);
 			}
 
 			context.IsAsync();

--- a/src/EventStore.TestClient/Commands/WriteFloodClientApiProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodClientApiProcessor.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using EventStore.ClientAPI;
-using EventStore.ClientAPI.Common.Log;
 using EventStore.Common.Utils;
 using ExpectedVersion = EventStore.Core.Data.ExpectedVersion;
 
@@ -29,12 +27,12 @@ namespace EventStore.TestClient.Commands {
 					return false;
 
 				try {
-					clientsCnt = int.Parse(args[0]);
-					requestsCnt = long.Parse(args[1]);
+					clientsCnt = MetricPrefixValue.ParseInt(args[0]);
+					requestsCnt = MetricPrefixValue.ParseLong(args[1]);
 					if (args.Length >= 3)
-						streamsCnt = int.Parse(args[2]);
+						streamsCnt = MetricPrefixValue.ParseInt(args[2]);
 					if (args.Length >= 4)
-						size = int.Parse(args[3]);
+						size = MetricPrefixValue.ParseInt(args[3]);
 				} catch {
 					return false;
 				}

--- a/src/EventStore.TestClient/Commands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodProcessor.cs
@@ -32,14 +32,14 @@ namespace EventStore.TestClient.Commands {
 					return false;
 
 				try {
-					clientsCnt = int.Parse(args[0]);
-					requestsCnt = long.Parse(args[1]);
+					clientsCnt = MetricPrefixValue.ParseInt(args[0]);
+					requestsCnt = MetricPrefixValue.ParseLong(args[1]);
 					if (args.Length >= 3)
-						streamsCnt = int.Parse(args[2]);
+						streamsCnt = MetricPrefixValue.ParseInt(args[2]);
 					if (args.Length >= 4)
-						size = int.Parse(args[3]);
+						size = MetricPrefixValue.ParseInt(args[3]);
 					if (args.Length >= 5)
-						batchSize = int.Parse(args[4]);
+						batchSize = MetricPrefixValue.ParseInt(args[4]);
 					if (args.Length >= 6)
 						streamNamePrefix = args[5];
 				} catch {

--- a/src/EventStore.TestClient/Commands/WriteFloodWaitingProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodWaitingProcessor.cs
@@ -26,10 +26,10 @@ namespace EventStore.TestClient.Commands {
 					return false;
 
 				try {
-					clientsCnt = int.Parse(args[0]);
-					requestsCnt = int.Parse(args[1]);
+					clientsCnt = MetricPrefixValue.ParseInt(args[0]);
+					requestsCnt = MetricPrefixValue.ParseInt(args[1]);
 					if (args.Length == 3)
-						payloadSize = int.Parse(args[2]);
+						payloadSize = MetricPrefixValue.ParseInt(args[2]);
 				} catch {
 					return false;
 				}

--- a/src/EventStore.TestClient/Commands/WriteLongTermProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteLongTermProcessor.cs
@@ -36,10 +36,10 @@ namespace EventStore.TestClient.Commands {
 					return false;
 
 				try {
-					clientsCnt = int.Parse(args[0]);
-					minPerSecond = int.Parse(args[1]);
-					maxPerSecond = int.Parse(args[2]);
-					runTimeMinutes = int.Parse(args[3]);
+					clientsCnt = MetricPrefixValue.ParseInt(args[0]);
+					minPerSecond = MetricPrefixValue.ParseInt(args[1]);
+					maxPerSecond = MetricPrefixValue.ParseInt(args[2]);
+					runTimeMinutes = MetricPrefixValue.ParseInt(args[3]);
 					if (args.Length == 5)
 						eventStreamId = args[4];
 				} catch {

--- a/src/EventStore.TestClient/MetricPrefixValue.cs
+++ b/src/EventStore.TestClient/MetricPrefixValue.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace EventStore.TestClient;
+
+/// <summary>
+///	Helps making it easier to specify large values without making a mistake.
+/// With this we can write: WRFLGRPC 10 5M 500k 100 1 perftest
+/// instead of: WRFLGRPC 10 5000000 500000 100 1 perftest
+/// </summary>
+internal static class MetricPrefixValue {
+	private static readonly Dictionary<char, long> _metricPrefixes = new () {
+		{'k', 1_000},
+		{'m', 1_000_000},
+		{'g', 1_000_000_000},
+	};
+
+	public static int ParseInt(string value) => int.Parse(Expand(value));
+
+	public static long ParseLong(string value) => long.Parse(Expand(value));
+	
+	private static string Expand(string value) {
+		value = value.ToLower();
+		
+		if (!_metricPrefixes.Keys.Any(k => value.EndsWith(k))) {
+			return value;
+		}
+
+		var metricPrefix = value[^1];
+		var numericPart = value[..^1];
+		var v = double.Parse(numericPart) * _metricPrefixes[metricPrefix];
+		return ((long)v).ToString();
+	}
+}


### PR DESCRIPTION
Changed: Support specifying values with a metric prefix with the `testclient`.


Allows us to write `WRFLGRPC 10 5M 500k 100 1 perftest` instead of `WRFLGRPC 10 5000000 500000 100 1 perftest`.
Not too happy with the prefix used as a postfix situation, so happy to get better naming suggestions.

https://en.wikipedia.org/wiki/Metric_prefix