### PR TITLE
Adding fix to allow for command line arguments  --cluster-size=3 and …

### DIFF
--- a/src/EventStore.Common.Tests/Configuration/CommandLineSourceTest.cs
+++ b/src/EventStore.Common.Tests/Configuration/CommandLineSourceTest.cs
@@ -1,0 +1,49 @@
+using Microsoft.Extensions.Configuration;
+using EventStore.Common.Configuration;
+
+namespace EventStore.Common.Tests.Configuration;
+
+public class CommandLineSourceTest {
+	private static IConfigurationRoot BuildConfiguration(string args) {
+		var sut = new CommandLineSource(args.Split());
+		var configurationRoot = new ConfigurationBuilder().Add(sut).Build();
+		return configurationRoot;
+	}
+
+	[Fact]
+	public void normalize_keys() {
+		var c = BuildConfiguration("--cluster-size 3 --log /tmp/eventstore/logs");
+		Assert.Equal(3, c.GetValue<int>("ClusterSize"));
+		Assert.Equal("/tmp/eventstore/logs", c.GetValue<string>("Log"));
+	}
+
+	[Fact]
+	public void normalize_keys_boolean_plus_sign() {
+		var c = BuildConfiguration("--whatever+");
+		Assert.Equal("true", c.GetValue<string>("Whatever"));
+	}
+
+	[Fact]
+	public void normalize_keys_boolean_negative_sign() {
+		var c = BuildConfiguration("--whatever-");
+		Assert.Equal("false", c.GetValue<string>("Whatever"));
+	}
+
+	[Fact]
+	public void normalize_keys_boolean_no_value() {
+		var c = BuildConfiguration("--whatever");
+		Assert.Equal("true", c.GetValue<string>("Whatever"));
+	}
+	
+	[Fact]
+	public void normalize_keys_equals() {
+		var c = BuildConfiguration("--cluster-size=3");
+		Assert.Equal(3, c.GetValue<int>("ClusterSize"));
+	}
+	
+	[Fact]
+	public void normalize_keys_one_dash() {
+		var c = BuildConfiguration("-cluster-size=3");
+		Assert.Equal(3, c.GetValue<int>("ClusterSize"));
+	}
+}

--- a/src/EventStore.Common.Tests/Configuration/ConfigurationRootExtensionsTest.cs
+++ b/src/EventStore.Common.Tests/Configuration/ConfigurationRootExtensionsTest.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Configuration;
+
+namespace EventStore.Common.Tests.Configuration;
+
+public class ConfigurationRootExtensionsTest {
+	private static string GOSSIP_SEED = "GossipSeed";
+
+	[Fact]
+	public void successful_comma_separated_value() {
+		var config = new Dictionary<string, string> {
+			{ GOSSIP_SEED, "nodeb.eventstore.test:2113,nodec.eventstore.test:3113" }
+		};
+		IConfigurationRoot configuration = MemoryConfigurationBuilderExtensions
+			.AddInMemoryCollection(new ConfigurationBuilder(), config)
+			.Build();
+		var values =
+			EventStore.Common.Configuration.ConfigurationRootExtensions.GetCommaSeparatedValueAsArray(
+				configuration, "GossipSeed");
+		Assert.Equal(2, values.Length);
+	}
+
+	[Fact]
+	public void invalid_delimiter() {
+		var config = new Dictionary<string, string> {
+			{ GOSSIP_SEED, "nodeb.eventstore.test:2113;nodec.eventstore.test:3113" }
+		};
+		IConfigurationRoot configuration = MemoryConfigurationBuilderExtensions
+			.AddInMemoryCollection(new ConfigurationBuilder(), config)
+			.Build();
+
+		Assert.Throws<ArgumentException>(() =>
+			EventStore.Common.Configuration.ConfigurationRootExtensions.GetCommaSeparatedValueAsArray(
+				configuration, "GossipSeed"));
+	}
+	
+	[Fact]
+	public void mixed_invalid_delimiter() {
+		var config = new Dictionary<string, string> {
+			{ GOSSIP_SEED, "nodea.eventstore.test:2113,nodeb.eventstore.test:2113;nodec.eventstore.test:3113" }
+		};
+
+		var configuration = MemoryConfigurationBuilderExtensions
+			.AddInMemoryCollection(new ConfigurationBuilder(), config)
+			.Build();
+
+		Assert.Throws<ArgumentException>(() =>
+			EventStore.Common.Configuration.ConfigurationRootExtensions.GetCommaSeparatedValueAsArray(
+				configuration, "GossipSeed"));
+	}
+}

--- a/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
+++ b/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+		<Platforms>x64;ARM64</Platforms>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="GitHubActionsTestLogger" Version="2.0.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/EventStore.Common.Tests/Usings.cs
+++ b/src/EventStore.Common.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/src/EventStore.Common/Configuration/CommandLineSource.cs
+++ b/src/EventStore.Common/Configuration/CommandLineSource.cs
@@ -11,14 +11,24 @@ namespace EventStore.Common.Configuration {
 
 			static string NormalizeKeys(string x) => x[0] == '-' && x[1] != '-' ? $"-{x}" : x;
 
-			string NormalizeBooleans(string x, int i) => (x[..2] == "--", x[^1]) switch {
-				(true, '+') => $"{x[..^1]}=true",
-				(true, '-') => $"{x[..^1]}=false",
-				(true, _) => !x.Contains("=") && (i == args.Length - 1 || args[i + 1][..2] == "--")
-					? $"{x}=true"
-					: x,
-				_ => x
-			};
+			string NormalizeBooleans(string x, int i) {
+				if (!x.StartsWith("--"))
+					return x;
+
+				if (x.EndsWith('+'))
+					return $"{x[..^1]}=true";
+
+				if (x.EndsWith('-'))
+					return $"{x[..^1]}=false";
+
+				if (x.Contains('='))
+					return x;
+				
+				if (i != args.Length - 1 && !args[i + 1].StartsWith("--"))
+					return x;
+
+				return $"{x}=true";
+			}
 		}
 
 		public IConfigurationProvider Build(IConfigurationBuilder builder) => new CommandLine(_args);

--- a/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
@@ -4,8 +4,21 @@ using Microsoft.Extensions.Configuration;
 #nullable enable
 namespace EventStore.Common.Configuration {
 	public static class ConfigurationRootExtensions {
-		public static string[] GetCommaSeparatedValueAsArray(this IConfigurationRoot configurationRoot, string key) =>
-			configurationRoot.GetValue<string?>(key)?.Split(',', StringSplitOptions.RemoveEmptyEntries) ??
-			Array.Empty<string>();
+		private static string[] INVALID_DELIMITERS = new[] { ";", "\t" };
+
+		public static string[] GetCommaSeparatedValueAsArray(this IConfigurationRoot configurationRoot, string key) {
+			string? value = configurationRoot.GetValue<string?>(key);
+			if (string.IsNullOrEmpty(value)) {
+				return Array.Empty<string>();
+			}
+
+			foreach (var invalidDelimiter in INVALID_DELIMITERS) {
+				if (value.Contains(invalidDelimiter)) {
+					throw new ArgumentException($"Invalid delimiter {invalidDelimiter} for {key}");
+				}
+			}
+
+			return value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+		}
 	}
 }

--- a/src/EventStore.sln
+++ b/src/EventStore.sln
@@ -55,9 +55,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.Projections.Core
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.MicroBenchmarks", "EventStore.MicroBenchmarks\EventStore.MicroBenchmarks.csproj", "{87F81751-192B-4263-A658-6DFC51EA557C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EventStore.SourceGenerators", "EventStore.SourceGenerators\EventStore.SourceGenerators.csproj", "{24BA3208-F690-4DD4-AECB-E339DEE0C69E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.SourceGenerators", "EventStore.SourceGenerators\EventStore.SourceGenerators.csproj", "{24BA3208-F690-4DD4-AECB-E339DEE0C69E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.SourceGenerators.Tests", "EventStore.SourceGenerators.Tests\EventStore.SourceGenerators.Tests.csproj", "{3C9DCA10-0006-4FA5-88CB-9CCEC1B2C522}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EventStore.Common.Tests", "EventStore.Common.Tests\EventStore.Common.Tests.csproj", "{58219323-BD46-4F67-A83A-410F56F84EE3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -345,6 +347,18 @@ Global
 		{3C9DCA10-0006-4FA5-88CB-9CCEC1B2C522}.Release|ARM64.Build.0 = Release|ARM64
 		{3C9DCA10-0006-4FA5-88CB-9CCEC1B2C522}.Release|x64.ActiveCfg = Release|x64
 		{3C9DCA10-0006-4FA5-88CB-9CCEC1B2C522}.Release|x64.Build.0 = Release|x64
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Debug|x64.Build.0 = Debug|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Release|ARM64.Build.0 = Release|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Release|x64.ActiveCfg = Release|Any CPU
+		{58219323-BD46-4F67-A83A-410F56F84EE3}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Fixed: Don't require an equals sign when parsing a command line argument followed by an integer
Added: Improved warning when using an invalid delimiter in gossip seed

Fixed: #3753, #3756

This PR fixes an issue where the command line arguments if followed by an integer throw an `ArgumentOutOfRangeException`.
When starting the application like:
`./src/EventStore.ClusterNode/bin/x64/Release/net6.0/EventStore.ClusterNode --cluster-size 3`
The result is an exception:
```
mattmacchia@Matt-Personal-Mac EventStore % ./src/EventStore.ClusterNode/bin/x64/Release/net6.0/EventStore.ClusterNode --cluster-size 3
[62777, 1,14:34:39.767,FTL] Host terminated unexpectedly.
System.ArgumentOutOfRangeException: Index and length must refer to a location within the string. (Parameter 'length')
   at System.String.Substring(Int32 startIndex, Int32 length)
   at EventStore.Common.Configuration.CommandLineSource.<>c__DisplayClass1_0.<.ctor>g__NormalizeBooleans|1(String x, Int32 i) in /Users/mattmacchia/Documents/dev/eventstore/EventStore/src/EventStore.Common/Configuration/CommandLineSource.cs:line 17
   at System.Linq.Enumerable.SelectIterator[TSource,TResult](IEnumerable`1 source, Func`3 selector)+MoveNext()
   at Microsoft.Extensions.Configuration.CommandLine.CommandLineConfigurationProvider.Load()
   at EventStore.Common.Configuration.CommandLine.Load() in /Users/mattmacchia/Documents/dev/eventstore/EventStore/src/EventStore.Common/Configuration/CommandLine.cs:line 13
   at Microsoft.Extensions.Configuration.ConfigurationRoot..ctor(IList`1 providers)
   at Microsoft.Extensions.Configuration.ConfigurationBuilder.Build()
   at EventStore.Common.Configuration.ConfigurationBuilderExtensions.AddEventStore(IConfigurationBuilder configurationBuilder, String[] args, IDictionary environment, IEnumerable`1 defaultValues) in /Users/mattmacchia/Documents/dev/eventstore/EventStore/src/EventStore.Common/Configuration/ConfigurationBuilderExtensions.cs:line 10
   at EventStore.Core.ClusterVNodeOptions.FromConfiguration(String[] args, IDictionary environment) in /Users/mattmacchia/Documents/dev/eventstore/EventStore/src/EventStore.Core/ClusterVNodeOptions.cs:line 59
   at EventStore.ClusterNode.Program.Main(String[] args) in /Users/mattmacchia/Documents/dev/eventstore/EventStore/src/EventStore.ClusterNode/Program.cs:line 36
```


This PR also includes a feature to specifically alert you if you're using an invalid delimiter. For example, if you have this in your config:
`GossipSeed: nodeb.eventstore.test:2113;nodec.eventstore.test:3113` (invalid delimiter of ;)
This would throw an `ArgumentException` with a message like:
`System.ArgumentException: Invalid delimiter ; for GossipSeed`

