### PR TITLE
Add system, process, and connection metrics. (DB-21)

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -59,6 +59,45 @@
 		"Chunk": false
 	},
 
+	"Kestrel": {
+		"ConnectionCount": true
+	},
+
+	"System": {
+		"Cpu": true,
+		"LoadAverage1m": true,
+		"LoadAverage5m": true,
+		"LoadAverage15m": true,
+		"FreeMem": true,
+		"TotalMem": true,
+		"DriveTotalBytes": true,
+		"DriveUsedBytes": true
+	},
+
+	"Process": {
+		"UpTime": true,
+		"Cpu": true,
+		"MemWorkingSet": true,
+		"ThreadCount": true,
+		"LockContentionCount": true,
+		"ExceptionCount": true,
+		"Gen0CollectionCount": true,
+		"Gen1CollectionCount": true,
+		"Gen2CollectionCount": true,
+		"Gen0Size": true,
+		"Gen1Size": true,
+		"Gen2Size": true,
+		"LohSize": true,
+		"TimeInGc": true,
+		"HeapSize": true,
+		"HeapFragmentation": true,
+		"TotalAllocatedBytes": true,
+		"DiskReadBytes": true,
+		"DiskReadOps": true,
+		"DiskWrittenBytes": true,
+		"DiskWrittenOps": true
+	},
+
 	// this specifies what name to track each queue under, according to regular expressions to
 	// match the queue names against
 	"Queues": [

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -89,6 +89,45 @@ namespace EventStore.Common.Configuration {
 			Chunk,
 		}
 
+		public enum KestrelTracker {
+			ConnectionCount = 1,
+		}
+
+		public enum SystemTracker {
+			Cpu = 1,
+			LoadAverage1m,
+			LoadAverage5m,
+			LoadAverage15m,
+			FreeMem,
+			TotalMem,
+			DriveTotalBytes,
+			DriveUsedBytes,
+		}
+
+		public enum ProcessTracker {
+			UpTime = 1,
+			Cpu,
+			MemWorkingSet,
+			ThreadCount,
+			LockContentionCount,
+			ExceptionCount,
+			Gen0CollectionCount,
+			Gen1CollectionCount,
+			Gen2CollectionCount,
+			Gen0Size,
+			Gen1Size,
+			Gen2Size,
+			LohSize,
+			TimeInGc,
+			HeapSize,
+			HeapFragmentation,
+			TotalAllocatedBytes,
+			DiskReadBytes,
+			DiskReadOps,
+			DiskWrittenBytes,
+			DiskWrittenOps,
+		}
+
 		public class LabelMappingCase {
 			public string Regex { get; set; }
 			public string Label { get; set; }
@@ -105,6 +144,12 @@ namespace EventStore.Common.Configuration {
 		public Dictionary<GrpcMethod, string> GrpcMethods { get; set; } = new();
 
 		public Gossip[] GossipTrackers { get; set; } = Array.Empty<Gossip>();
+
+		public Dictionary<KestrelTracker, bool> Kestrel { get; set; } = new();
+
+		public Dictionary<SystemTracker, bool> System { get; set; } = new();
+
+		public Dictionary<ProcessTracker, bool> Process { get; set; } = new();
 
 		public Dictionary<WriterTracker, bool> Writer { get; set; } = new();
 

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/ProcessMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/ProcessMetricsTests.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using EventStore.Common.Configuration;
+using EventStore.Core.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public class ProcessMetricsTests : IDisposable {
+	private readonly TestMeterListener<int> _intListener;
+	private readonly TestMeterListener<double> _doubleListener;
+	private readonly TestMeterListener<long> _longListener;
+	private readonly ProcessMetrics _sut;
+
+	public ProcessMetricsTests() {
+		var meter = new Meter($"{typeof(ProcessMetricsTests)}");
+		_intListener = new TestMeterListener<int>(meter);
+		_doubleListener = new TestMeterListener<double>(meter);
+		_longListener = new TestMeterListener<long>(meter);
+
+		var config = new Dictionary<TelemetryConfiguration.ProcessTracker, bool>();
+
+		foreach (var value in Enum.GetValues<TelemetryConfiguration.ProcessTracker>()) {
+			config[value] = true;
+		}
+
+		_sut = new ProcessMetrics(meter, TimeSpan.FromSeconds(42), config);
+		_sut.CreateObservableMetrics(new() {
+			{ TelemetryConfiguration.ProcessTracker.UpTime, "eventstore-proc-up-time" },
+			{ TelemetryConfiguration.ProcessTracker.Cpu, "eventstore-proc-cpu" },
+			{ TelemetryConfiguration.ProcessTracker.ThreadCount, "eventstore-proc-thread-count" },
+			{ TelemetryConfiguration.ProcessTracker.LockContentionCount, "eventstore-proc-contention-count" },
+			{ TelemetryConfiguration.ProcessTracker.ExceptionCount, "eventstore-proc-exception-count" },
+			{ TelemetryConfiguration.ProcessTracker.TimeInGc, "eventstore-gc-time-in-gc" },
+			{ TelemetryConfiguration.ProcessTracker.HeapSize, "eventstore-gc-heap-size" },
+			{ TelemetryConfiguration.ProcessTracker.HeapFragmentation, "eventstore-gc-heap-fragmentation" },
+			{ TelemetryConfiguration.ProcessTracker.TotalAllocatedBytes, "eventstore-gc-total-allocated" },
+		});
+
+		_sut.CreateMemoryMetric("eventstore-proc-mem", new() {
+			{ TelemetryConfiguration.ProcessTracker.MemWorkingSet, "working-set" },
+		});
+
+		_sut.CreateGcGenerationSizeMetric("eventstore-gc-generation-size", new() {
+			{ TelemetryConfiguration.ProcessTracker.Gen0Size, "gen0" },
+			{ TelemetryConfiguration.ProcessTracker.Gen1Size, "gen1" },
+			{ TelemetryConfiguration.ProcessTracker.Gen2Size, "gen2" },
+			{ TelemetryConfiguration.ProcessTracker.LohSize, "loh" },
+		});
+
+		_sut.CreateGcCollectionCountMetric("eventstore-gc-collection-count", new() {
+			{ TelemetryConfiguration.ProcessTracker.Gen0CollectionCount, "gen0" },
+			{ TelemetryConfiguration.ProcessTracker.Gen1CollectionCount, "gen1" },
+			{ TelemetryConfiguration.ProcessTracker.Gen2CollectionCount, "gen2" },
+		});
+
+		_sut.CreateDiskBytesMetric("eventstore-disk-io", new() {
+			{ TelemetryConfiguration.ProcessTracker.DiskReadBytes, "read" },
+			{ TelemetryConfiguration.ProcessTracker.DiskWrittenBytes, "written" },
+		});
+
+		_sut.CreateDiskOpsMetric("eventstore-disk-io", new() {
+			{ TelemetryConfiguration.ProcessTracker.DiskReadBytes, "read" },
+			{ TelemetryConfiguration.ProcessTracker.DiskWrittenBytes, "written" },
+		});
+
+		_intListener.Observe();
+		_doubleListener.Observe();
+		_longListener.Observe();
+	}
+
+	public void Dispose() {
+		_intListener.Dispose();
+		_doubleListener.Dispose();
+		_longListener.Dispose();
+	}
+
+	[Fact]
+	public void can_collect_proc_up_time() {
+		Assert.Collection(
+			_doubleListener.RetrieveMeasurements("eventstore-proc-up-time"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("pid", tag.Key);
+						Assert.NotNull(tag.Value);
+					});
+			});
+	}
+
+	[Fact]
+	public void can_collect_proc_cpu() {
+		Assert.Collection(
+			_intListener.RetrieveMeasurements("eventstore-proc-cpu"),
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_proc_contention_count() {
+		Assert.Collection(
+			_longListener.RetrieveMeasurements("eventstore-proc-contention-count"),
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_proc_exception_count() {
+		Assert.Collection(
+			_intListener.RetrieveMeasurements("eventstore-proc-exception-count"),
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_gc_total_allocated() {
+		Assert.Collection(
+			_longListener.RetrieveMeasurements("eventstore-gc-total-allocated"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_thread_count() {
+		Assert.Collection(
+			_intListener.RetrieveMeasurements("eventstore-proc-thread-count"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_gc_time_in_gc() {
+		Assert.Collection(
+			_intListener.RetrieveMeasurements("eventstore-gc-time-in-gc"),
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_gc_heap_size() {
+		Assert.Collection(
+			_longListener.RetrieveMeasurements("eventstore-gc-heap-size-bytes"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_gc_heap_fragmentation() {
+		Assert.Collection(
+			_doubleListener.RetrieveMeasurements("eventstore-gc-heap-fragmentation"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_proc_mem() {
+		Assert.Collection(
+			_longListener.RetrieveMeasurements("eventstore-proc-mem-bytes"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("kind", tag.Key);
+						Assert.Equal("working-set", tag.Value);
+					});
+			});
+	}
+
+	[Fact]
+	public void can_collect_gc_generation_size() {
+		Assert.Collection(
+			_longListener.RetrieveMeasurements("eventstore-gc-generation-size-bytes"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("generation", tag.Key);
+						Assert.Equal("gen0", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("generation", tag.Key);
+						Assert.Equal("gen1", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("generation", tag.Key);
+						Assert.Equal("gen2", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("generation", tag.Key);
+						Assert.Equal("loh", tag.Value);
+					});
+			});
+	}
+
+	[Fact]
+	public void can_collect_gc_collections_count() {
+		Assert.Collection(
+			_intListener.RetrieveMeasurements("eventstore-gc-collection-count"),
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("generation", tag.Key);
+						Assert.Equal("gen0", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("generation", tag.Key);
+						Assert.Equal("gen1", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("generation", tag.Key);
+						Assert.Equal("gen2", tag.Value);
+					});
+			});
+	}
+
+	[Fact]
+	public void can_collect_disk_io_bytes() {
+		Assert.Collection(
+			_longListener.RetrieveMeasurements("eventstore-disk-io-bytes"),
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("activity", tag.Key);
+						Assert.Equal("read", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("activity", tag.Key);
+						Assert.Equal("written", tag.Value);
+					});
+			});
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/SystemMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/SystemMetricsTests.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using EventStore.Common.Configuration;
+using EventStore.Common.Utils;
+using EventStore.Core.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public class SystemMetricsTests : IDisposable {
+	private readonly TestMeterListener<float> _floatListener;
+	private readonly TestMeterListener<double> _doubleListener;
+	private readonly TestMeterListener<long> _longListener;
+	private readonly FakeClock _clock = new();
+	private readonly SystemMetrics _sut;
+
+	public SystemMetricsTests() {
+		var meter = new Meter($"{typeof(ProcessMetricsTests)}");
+		_floatListener = new TestMeterListener<float>(meter);
+		_doubleListener = new TestMeterListener<double>(meter);
+		_longListener = new TestMeterListener<long>(meter);
+
+		var config = new Dictionary<TelemetryConfiguration.SystemTracker, bool>();
+
+		foreach (var value in Enum.GetValues<TelemetryConfiguration.SystemTracker>()) {
+			config[value] = true;
+		}
+		_sut = new SystemMetrics(meter, TimeSpan.FromSeconds(42), config);
+		_sut.CreateLoadAverageMetric("eventstore-sys-load-avg", new() {
+			{ TelemetryConfiguration.SystemTracker.LoadAverage1m, "1m" },
+			{ TelemetryConfiguration.SystemTracker.LoadAverage5m, "5m" },
+			{ TelemetryConfiguration.SystemTracker.LoadAverage15m, "15m" },
+		});
+
+		_sut.CreateCpuMetric("eventstore-sys-cpu");
+
+		_sut.CreateMemoryMetric("eventstore-sys-mem", new() {
+			{ TelemetryConfiguration.SystemTracker.FreeMem, "free" },
+			{ TelemetryConfiguration.SystemTracker.TotalMem, "total" },
+		});
+
+		_sut.CreateDiskMetric("eventstore-sys-disk", ".", new() {
+			{ TelemetryConfiguration.SystemTracker.DriveTotalBytes, "total" },
+			{ TelemetryConfiguration.SystemTracker.DriveUsedBytes, "used" },
+		});
+
+		_floatListener.Observe();
+		_doubleListener.Observe();
+		_longListener.Observe();
+	}
+
+	public void Dispose() {
+		_floatListener.Dispose();
+		_doubleListener.Dispose();
+		_longListener.Dispose();
+	}
+
+	[Fact]
+	public void can_collect_sys_load_avg() {
+		if (!OS.IsUnix)
+			return;
+
+		Assert.Collection(
+			_doubleListener.RetrieveMeasurements("eventstore-sys-load-avg"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("period", tag.Key);
+						Assert.Equal("1m", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("period", tag.Key);
+						Assert.Equal("5m", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("period", tag.Key);
+						Assert.Equal("15m", tag.Value);
+					});
+			});
+	}
+
+	[Fact]
+	public void can_collect_sys_cpu() {
+		if (OS.IsUnix)
+			return;
+
+		Assert.Collection(
+			_floatListener.RetrieveMeasurements("eventstore-sys-cpu"),
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Empty(m.Tags);
+			});
+	}
+
+	[Fact]
+	public void can_collect_sys_mem() {
+		Assert.Collection(
+			_longListener.RetrieveMeasurements("eventstore-sys-mem-bytes"),
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("kind", tag.Key);
+						Assert.Equal("free", tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value > 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("kind", tag.Key);
+						Assert.Equal("total", tag.Value);
+					});
+			});
+	}
+
+	[Fact]
+	public void can_collect_sys_disk() {
+		Assert.Collection(
+			_longListener.RetrieveMeasurements("eventstore-sys-disk-bytes"),
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("kind", tag.Key);
+						Assert.Equal("used", tag.Value);
+					},
+					tag => {
+						Assert.Equal("disk", tag.Key);
+						Assert.NotNull(tag.Value);
+					});
+			},
+			m => {
+				Assert.True(m.Value >= 0);
+				Assert.Collection(
+					m.Tags,
+					tag => {
+						Assert.Equal("kind", tag.Key);
+						Assert.Equal("total", tag.Value);
+					},
+					tag => {
+						Assert.Equal("disk", tag.Key);
+						Assert.NotNull(tag.Value);
+					});
+			});
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Util/FunctionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Util/FunctionsTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using EventStore.Core.Util;
+using EventStore.Core.XUnit.Tests.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Util;
+
+public class FunctionsTests {
+	[Fact]
+	public void sanity_check() {
+		var clock = new FakeClock();
+		clock.SecondsSinceEpoch = 12345;
+		var calls = 0;
+		var f = () => ++calls;
+		var debounced = f.Debounce(TimeSpan.FromSeconds(5), clock);
+
+		// no calls to begin with
+		Assert.Equal(0, calls);
+
+		// calls in the first place
+		Assert.Equal(1, debounced());
+
+
+		// cached for second call
+		Assert.Equal(1, debounced());
+
+		// still cached after some time has passed
+		clock.AdvanceSeconds(3);
+		Assert.Equal(1, debounced());
+
+		// called again after more time has passed.
+		clock.AdvanceSeconds(3);
+		Assert.Equal(2, debounced());
+	}
+}

--- a/src/EventStore.Core/Telemetry/ConnectionMetric.cs
+++ b/src/EventStore.Core/Telemetry/ConnectionMetric.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+
+namespace EventStore.Core.Telemetry;
+
+public class ConnectionMetric : EventListener {
+	private readonly UpDownCounter<long> _connectionsMetric;
+
+	public ConnectionMetric(Meter meter, string name) {
+		_connectionsMetric = meter.CreateUpDownCounter<long>(name);
+	}
+
+	protected override void OnEventSourceCreated(EventSource eventSource) {
+		if (eventSource.Name is not "Microsoft-AspNetCore-Server-Kestrel")
+			return;
+
+		EnableEvents(eventSource, EventLevel.Verbose);
+	}
+
+	protected override void OnEventWritten(EventWrittenEventArgs eventData) {
+		if (_connectionsMetric == null)
+			return;
+
+		switch (eventData.EventName) {
+			case "ConnectionStart": {
+				_connectionsMetric.Add(1);
+				break;
+			}
+			case "ConnectionStop": {
+				_connectionsMetric.Add(-1);
+				break;
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/Dimensions.cs
+++ b/src/EventStore.Core/Telemetry/Dimensions.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+
+namespace EventStore.Core.Telemetry;
+
+internal class Dimensions<TTracker, TData> where TTracker : notnull where TData : struct {
+	private readonly List<Func<Measurement<TData>>> _funcs = new();
+	private readonly Func<string, KeyValuePair<string, object>> _genTag;
+	private readonly Dictionary<TTracker, string> _enabledDimensions;
+
+	public Dimensions(
+		Dictionary<TTracker, bool> config,
+		Dictionary<TTracker, string> dimNames,
+		Func<string, KeyValuePair<string, object>> genTag) {
+
+		_enabledDimensions = dimNames
+			.Where(kvp => config.TryGetValue(kvp.Key, out var enabled) && enabled)
+			.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+		_genTag = genTag;
+	}
+
+	public bool AnyRegistered() => _funcs.Any();
+
+	public void Register(TTracker tracker, Func<TData> func) {
+		if (!_enabledDimensions.TryGetValue(tracker, out var dimension))
+			return;
+
+		var tags = new[] { _genTag(dimension) };
+		_funcs.Add(() => new(func(), tags.AsSpan()));
+	}
+
+	public void Register(TTracker tracker, Func<string, Measurement<TData>> func) {
+		if (!_enabledDimensions.TryGetValue(tracker, out var dimension))
+			return;
+
+		_funcs.Add(() => func(dimension));
+	}
+
+	public Func<IEnumerable<Measurement<TData>>> GenObserve() {
+		var measurements = new Measurement<TData>[_funcs.Count];
+
+		return () => {
+			for (var i = 0; i < measurements.Length; i++) {
+				measurements[i] = _funcs[i]();
+			}
+			return measurements;
+		};
+	}
+}

--- a/src/EventStore.Core/Telemetry/ProcessMetrics.cs
+++ b/src/EventStore.Core/Telemetry/ProcessMetrics.cs
@@ -1,0 +1,142 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using EventStore.Core.Services.Monitoring.Stats;
+using EventStore.Core.Util;
+using static EventStore.Common.Configuration.TelemetryConfiguration;
+
+namespace EventStore.Core.Telemetry;
+
+public class ProcessMetrics {
+	private static readonly Serilog.ILogger _log = Serilog.Log.ForContext<ProcessMetrics>();
+
+	private readonly Meter _meter;
+	private readonly TimeSpan _timeout;
+	private readonly Dictionary<ProcessTracker, bool> _config;
+	private readonly Func<DiskIo> _getDiskIo;
+	private readonly Func<Process> _getCurrentProc;
+
+	public ProcessMetrics(Meter meter, TimeSpan timeout, Dictionary<ProcessTracker, bool> config) {
+		_meter = meter;
+		_timeout = timeout;
+		_config = config;
+
+		_getDiskIo = Functions.Debounce(() => DiskIo.GetDiskIo(Environment.ProcessId, _log), timeout);
+		_getCurrentProc = Functions.Debounce(Process.GetCurrentProcess, _timeout);
+	}
+
+	public void CreateObservableMetrics(Dictionary<ProcessTracker, string> metricNames) {
+		var enabledNames = metricNames
+			.Where(kvp => _config.TryGetValue(kvp.Key, out var enabled) && enabled)
+			.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+		var getProcCpuUsage = typeof(GC)
+			.Assembly
+			.GetType("System.Diagnostics.Tracing.RuntimeEventSourceHelper")!
+			.GetMethod("GetCpuUsage", BindingFlags.Static | BindingFlags.NonPublic)!
+			.CreateDelegate<Func<int>>();
+
+		var getExceptionCount = typeof(Exception)
+			.GetMethod("GetExceptionCount", BindingFlags.Static | BindingFlags.NonPublic)!
+			.CreateDelegate<Func<uint>>();
+
+		var getPercentTimeInGc = typeof(GC)
+			.GetMethod("GetLastGCPercentTimeInGC", BindingFlags.Static | BindingFlags.NonPublic)!
+			.CreateDelegate<Func<int>>();
+
+		void CreateObservableUpDownCounter<T>(ProcessTracker tracker, Func<T> observe, string? unit = null)
+			where T : struct {
+
+			if (enabledNames.TryGetValue(tracker, out var name))
+				_meter.CreateObservableUpDownCounter(name, observe, unit);
+		}
+
+		void CreateObservableCounter<T>(ProcessTracker tracker, Func<T> observe, string? unit = null)
+			where T : struct {
+
+			if (enabledNames.TryGetValue(tracker, out var name))
+				_meter.CreateObservableCounter(name, observe);
+		}
+
+		if (enabledNames.TryGetValue(ProcessTracker.UpTime, out var upTimeName))
+			_meter.CreateObservableCounter(upTimeName, () => {
+				var process = _getCurrentProc();
+				var upTime = (DateTime.Now - process.StartTime).TotalSeconds;
+				return new Measurement<double>(upTime, new KeyValuePair<string, object?>("pid", process.Id));
+			});
+
+		CreateObservableCounter(ProcessTracker.Cpu, getProcCpuUsage);
+		CreateObservableCounter(ProcessTracker.LockContentionCount, () => Monitor.LockContentionCount);
+		CreateObservableCounter(ProcessTracker.ExceptionCount, () => (int)getExceptionCount());
+		CreateObservableCounter(ProcessTracker.TotalAllocatedBytes, () => GC.GetTotalAllocatedBytes(), "bytes");
+
+		CreateObservableUpDownCounter(ProcessTracker.ThreadCount, () => ThreadPool.ThreadCount);
+		CreateObservableUpDownCounter(ProcessTracker.TimeInGc, getPercentTimeInGc);
+		CreateObservableUpDownCounter(ProcessTracker.HeapSize, () => GC.GetGCMemoryInfo().HeapSizeBytes, "bytes");
+		CreateObservableUpDownCounter(ProcessTracker.HeapFragmentation, () => {
+			var info = GC.GetGCMemoryInfo();
+			return info.HeapSizeBytes != 0 ? info.FragmentedBytes * 100d / info.HeapSizeBytes : 0;
+		});
+	}
+
+	public void CreateMemoryMetric(string metricName, Dictionary<ProcessTracker, string> dimNames) {
+		var dims = new Dimensions<ProcessTracker, long>(_config, dimNames, tag => new("kind", tag));
+
+		dims.Register(ProcessTracker.MemWorkingSet, () => _getCurrentProc().WorkingSet64);
+
+		if (dims.AnyRegistered())
+			_meter.CreateObservableGauge(metricName, dims.GenObserve(), "bytes");
+	}
+
+	public void CreateGcGenerationSizeMetric(string metricName, Dictionary<ProcessTracker, string> dimNames) {
+		var dims = new Dimensions<ProcessTracker, long>(_config, dimNames, tag => new("generation", tag));
+
+		var getGcGenerationSize = typeof(GC)
+			.GetMethod("GetGenerationSize", BindingFlags.Static | BindingFlags.NonPublic)!
+			.CreateDelegate<Func<int, ulong>>();
+
+		dims.Register(ProcessTracker.Gen0Size, () => (long)getGcGenerationSize(0));
+		dims.Register(ProcessTracker.Gen1Size, () => (long)getGcGenerationSize(1));
+		dims.Register(ProcessTracker.Gen2Size, () => (long)getGcGenerationSize(2));
+		dims.Register(ProcessTracker.LohSize, () => (long)getGcGenerationSize(3));
+
+		if (dims.AnyRegistered())
+			_meter.CreateObservableUpDownCounter(metricName, dims.GenObserve(), "bytes");
+	}
+
+	public void CreateGcCollectionCountMetric(string metricName, Dictionary<ProcessTracker, string> dimNames) {
+		var dims = new Dimensions<ProcessTracker, int>(_config, dimNames, tag => new("generation", tag));
+
+		dims.Register(ProcessTracker.Gen0CollectionCount, () => GC.CollectionCount(0));
+		dims.Register(ProcessTracker.Gen1CollectionCount, () => GC.CollectionCount(1));
+		dims.Register(ProcessTracker.Gen2CollectionCount, () => GC.CollectionCount(2));
+
+		if (dims.AnyRegistered())
+			_meter.CreateObservableCounter(metricName, dims.GenObserve());
+	}
+
+	public void CreateDiskBytesMetric(string metricName, Dictionary<ProcessTracker, string> dimNames) {
+		var dims = new Dimensions<ProcessTracker, long>(_config, dimNames, tag => new("activity", tag));
+
+		dims.Register(ProcessTracker.DiskReadBytes, () => (long)(_getDiskIo()?.ReadBytes ?? 0));
+		dims.Register(ProcessTracker.DiskWrittenBytes, () => (long)(_getDiskIo()?.WrittenBytes ?? 0));
+
+		if (dims.AnyRegistered())
+			_meter.CreateObservableCounter(metricName, dims.GenObserve(), "bytes");
+	}
+
+	public void CreateDiskOpsMetric(string name, Dictionary<ProcessTracker, string> dimNames) {
+		var dims = new Dimensions<ProcessTracker, long>(_config, dimNames, tag => new("activity", tag));
+
+		dims.Register(ProcessTracker.DiskReadOps, () => (long)(_getDiskIo()?.ReadOps ?? 0));
+		dims.Register(ProcessTracker.DiskWrittenOps, () => (long)(_getDiskIo()?.WriteOps ?? 0));
+
+		if (dims.AnyRegistered())
+			_meter.CreateObservableCounter(name, dims.GenObserve(), "operations");
+	}
+}

--- a/src/EventStore.Core/Telemetry/SystemMetrics.cs
+++ b/src/EventStore.Core/Telemetry/SystemMetrics.cs
@@ -1,0 +1,96 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using EventStore.Common.Utils;
+using EventStore.Core.Services.Monitoring.Stats;
+using EventStore.Core.Services.Monitoring.Utils;
+using EventStore.Core.Util;
+using EventStore.Native.Monitoring;
+using static EventStore.Common.Configuration.TelemetryConfiguration;
+
+namespace EventStore.Core.Telemetry;
+
+public class SystemMetrics {
+	private static readonly Serilog.ILogger _log = Serilog.Log.ForContext<SystemMetrics>();
+
+	private readonly Meter _meter;
+	private readonly TimeSpan _timeout;
+	private readonly Dictionary<SystemTracker, bool> _config;
+	private readonly HostStat.HostStat _stats;
+	private readonly PerfCounterHelper _perfCounter;
+
+	public SystemMetrics(
+		Meter meter,
+		TimeSpan timeout,
+		Dictionary<SystemTracker, bool> config) {
+
+		_meter = meter;
+		_timeout = timeout;
+		_config = config;
+		_stats = new HostStat.HostStat();
+		_perfCounter = new PerfCounterHelper(_log);
+	}
+
+	public void CreateLoadAverageMetric(string metricName, Dictionary<SystemTracker, string> dimNames) {
+		if (!OS.IsUnix)
+			return;
+
+		var dims = new Dimensions<SystemTracker, double>(_config, dimNames, tag => new("period", tag));
+
+		var getLoadAverages = Functions.Debounce(_stats.GetLoadAverages, _timeout);
+		dims.Register(SystemTracker.LoadAverage1m, () => getLoadAverages().Average1m);
+		dims.Register(SystemTracker.LoadAverage5m, () => getLoadAverages().Average5m);
+		dims.Register(SystemTracker.LoadAverage15m, () => getLoadAverages().Average15m);
+
+		if (dims.AnyRegistered())
+			_meter.CreateObservableGauge(metricName, dims.GenObserve());
+	}
+
+	public void CreateCpuMetric(string name) {
+		if (OS.IsUnix || !_config.TryGetValue(SystemTracker.Cpu, out var enabled) || !enabled)
+			return;
+
+		_meter.CreateObservableUpDownCounter(name, _perfCounter.GetTotalCpuUsage);
+	}
+
+	public void CreateMemoryMetric(string metricName, Dictionary<SystemTracker, string> dimNames) {
+		var dims = new Dimensions<SystemTracker, long>(_config, dimNames, tag => new("kind", tag));
+
+		if (OS.IsUnix) {
+			dims.Register(SystemTracker.FreeMem, () => (long)_stats.GetFreeMemory());
+			dims.Register(SystemTracker.TotalMem, () => (long)_stats.GetTotalMemory());
+		} else {
+			dims.Register(SystemTracker.FreeMem, _perfCounter.GetFreeMemory);
+			dims.Register(SystemTracker.TotalMem, () => (long)WinNativeMemoryStatus.GetTotalMemory());
+		}
+
+		if (dims.AnyRegistered())
+			_meter.CreateObservableGauge(metricName, dims.GenObserve(), "bytes");
+	}
+
+	public void CreateDiskMetric(string metricName, string dbPath, Dictionary<SystemTracker, string> dimNames) {
+		var dims = new Dimensions<SystemTracker, long>(_config, dimNames, tag => new());
+
+		var getDriveInfo = Functions.Debounce(() => EsDriveInfo.FromDirectory(dbPath, _log), _timeout);
+
+		Func<string, Measurement<long>> GenMeasure(Func<EsDriveInfo, long> func) => tag => {
+			var info = getDriveInfo();
+			if (info is null)
+				return new();
+
+			return new(
+				func(info),
+				new KeyValuePair<string, object?>[] {
+					new("kind", tag),
+					new("disk", info.DiskName),
+				});
+		};
+
+		dims.Register(SystemTracker.DriveUsedBytes, GenMeasure(info => info.UsedBytes));
+		dims.Register(SystemTracker.DriveTotalBytes, GenMeasure(info => info.TotalBytes));
+
+		if (dims.AnyRegistered())
+			_meter.CreateObservableGauge(metricName, dims.GenObserve(), "bytes");
+	}
+}

--- a/src/EventStore.Core/Util/Functions.cs
+++ b/src/EventStore.Core/Util/Functions.cs
@@ -1,0 +1,24 @@
+#nullable enable
+using System;
+using EventStore.Core.Time;
+
+namespace EventStore.Core.Util;
+
+public static class Functions {
+	public static Func<T> Debounce<T>(this Func<T> func, TimeSpan timeout, IClock? clock = null) {
+		clock ??= Clock.Instance;
+		var seconds = timeout.TotalSeconds;
+		Instant lastCalled = default;
+		T? current = default;
+
+		return () => {
+			var now = clock.Now;
+			if (lastCalled == default || now.ElapsedSecondsSince(lastCalled) > seconds) {
+				current = func();
+				lastCalled = now;
+			}
+
+			return current!;
+		};
+	}
+}


### PR DESCRIPTION
Added: Add system, process, and connection metrics.

```
# TYPE eventstore_io_bytes counter
# UNIT eventstore_io_bytes bytes
eventstore_io_bytes{activity="read"} 1807752234 1683645023547

# TYPE eventstore_io_events counter
# UNIT eventstore_io_events events
eventstore_io_events{activity="read"} 1143984 1683645023547
eventstore_io_events{activity="written"} 42919 1683645023547

# TYPE eventstore_checkpoints gauge
eventstore_checkpoints{name="writer",read="non-flushed"} 74339121 1683645023547
eventstore_checkpoints{name="index",read="non-flushed"} 74338748 1683645023547
eventstore_checkpoints{name="replication",read="non-flushed"} 74339121 1683645023547

# TYPE eventstore_kestrel_connections gauge
eventstore_kestrel_connections 1 1683645023547

# TYPE eventstore_sys_load_avg gauge
eventstore_sys_load_avg{period="1m"} 2.80419921875 1683645023547
eventstore_sys_load_avg{period="5m"} 2.3447265625 1683645023547
eventstore_sys_load_avg{period="15m"} 1.9951171875 1683645023547

# TYPE eventstore_sys_mem_bytes gauge
# UNIT eventstore_sys_mem_bytes bytes
eventstore_sys_mem_bytes{kind="free"} 54807818240 1683645023547
eventstore_sys_mem_bytes{kind="total"} 67093868544 1683645023547

# TYPE eventstore_sys_disk_bytes gauge
# UNIT eventstore_sys_disk_bytes bytes
eventstore_sys_disk_bytes{disk="/home",kind="used"} 51155714048 1683645023547
eventstore_sys_disk_bytes{disk="/home",kind="total"} 2046687182848 1683645023547

# TYPE eventstore_proc_up_time counter
eventstore_proc_up_time{pid="15945"} 65.1388136 1683645023547

# TYPE eventstore_proc_cpu counter
eventstore_proc_cpu 0 1683645023547# TYPE eventstore_sys_loadavg1m gauge
eventstore_sys_loadavg1m 2.9140625 1682026870037

# TYPE eventstore_sys_loadavg5m gauge
eventstore_sys_loadavg5m 2.96728515625 1682026870037

# TYPE eventstore_sys_loadavg15m gauge
eventstore_sys_loadavg15m 2.46044921875 1682026870037

# TYPE eventstore_sys_free_mem gauge
eventstore_sys_free_mem 53533179904 1682026870037

# TYPE eventstore_sys_free_total_mem gauge
eventstore_sys_free_total_mem 67093852160 1682026870037

# TYPE eventstore_proc_cpu gauge
eventstore_proc_cpu{contentionRate="13",id="40691",mem="574603264",startTime="2023-04-20T21:40:53.3500000Z",threadsCount="20",thrownExceptionsRate="-1"} 0.0009885382050447734 1682026870037

# TYPE eventstore_driveio_read_bytes counter
eventstore_driveio_read_bytes 0 1682026870037

# TYPE eventstore_driveio_read_ops counter
eventstore_driveio_read_ops 9284 1682026870037

# TYPE eventstore_driveio_write_bytes counter
eventstore_driveio_write_bytes 311296 1682026870037

# TYPE eventstore_driveio_write_ops counter
eventstore_driveio_write_ops 50981 1682026870037

# TYPE eventstore_drive_total_bytes gauge
eventstore_drive_total_bytes 2046687182848 1682026870037

# TYPE eventstore_drive_used_bytes gauge
eventstore_drive_used_bytes 45369237504 1682026870037

# TYPE eventstore_gc_allocation_speed gauge
eventstore_gc_allocation_speed 182852456 1682026870037

# TYPE eventstore_gc_fragmentation gauge
eventstore_gc_fragmentation 23.041708602782393 1682026870037

# TYPE eventstore_gc_0_size gauge
eventstore_gc_0_size -1 1682026870037

# TYPE eventstore_gc_1_size gauge
eventstore_gc_1_size -1 1682026870037

# TYPE eventstore_gc_2_size gauge
eventstore_gc_2_size -1 1682026870037

# TYPE eventstore_gc_0_items_count gauge
eventstore_gc_0_items_count 19 1682026870037

# TYPE eventstore_gc_1_items_count gauge
eventstore_gc_1_items_count 12 1682026870037

# TYPE eventstore_gc_2_items_count gauge
eventstore_gc_2_items_count 6 1682026870037

# TYPE eventstore_gc_loh_size gauge
eventstore_gc_loh_size -1 1682026870037

# TYPE eventstore_gc_time_in_gc gauge
eventstore_gc_time_in_gc -1 1682026870037

# TYPE eventstore_gc_total_bytes_in_heaps gauge
eventstore_gc_total_bytes_in_heaps 120866384 1682026870037

# TYPE eventstore_gc_pauses_pauses counter
# UNIT eventstore_gc_pauses_pauses pauses
eventstore_gc_pauses_pauses 18 1682026870037

# TYPE eventstore_proc_contention_count counter
eventstore_proc_contention_count 447 1683645023547

# TYPE eventstore_proc_exception_count counter
eventstore_proc_exception_count 146 1683645023547

# TYPE eventstore_gc_total_allocated counter
eventstore_gc_total_allocated 33015596816 1683645023547

# TYPE eventstore_proc_thread_count gauge
eventstore_proc_thread_count 7 1683645023547

# TYPE eventstore_gc_time_in_gc gauge
eventstore_gc_time_in_gc 0 1683645023547

# TYPE eventstore_gc_heap_size_bytes gauge
# UNIT eventstore_gc_heap_size_bytes bytes
eventstore_gc_heap_size_bytes 592441832 1683645023547

# TYPE eventstore_gc_heap_fragmentation gauge
eventstore_gc_heap_fragmentation 69.36222288908188 1683645023547

# TYPE eventstore_proc_mem_bytes gauge
# UNIT eventstore_proc_mem_bytes bytes
eventstore_proc_mem_bytes{kind="working-set"} 1069105152 1683645023547

# TYPE eventstore_gc_generation_size_bytes gauge
# UNIT eventstore_gc_generation_size_bytes bytes
eventstore_gc_generation_size_bytes{generation="gen0"} 3784440 1683645023547
eventstore_gc_generation_size_bytes{generation="gen1"} 824232 1683645023547
eventstore_gc_generation_size_bytes{generation="gen2"} 244467016 1683645023547
eventstore_gc_generation_size_bytes{generation="loh"} 343056472 1683645023547

# TYPE eventstore_gc_collection_count counter
eventstore_gc_collection_count{generation="gen0"} 2930 1683645023547
eventstore_gc_collection_count{generation="gen1"} 1280 1683645023547
eventstore_gc_collection_count{generation="gen2"} 28 1683645023547

# TYPE eventstore_disk_io_bytes counter
# UNIT eventstore_disk_io_bytes bytes
eventstore_disk_io_bytes{activity="read"} 45846528 1683645023547
eventstore_disk_io_bytes{activity="written"} 733184 1683645023547

# TYPE eventstore_disk_io_operations counter
# UNIT eventstore_disk_io_operations operations
eventstore_disk_io_operations{activity="read"} 102232 1683645023547
eventstore_disk_io_operations{activity="written"} 60096 1683645023547
```
