### PR TITLE
Add deprecation warnings

### DIFF
--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -452,6 +452,7 @@ namespace EventStore.Core {
 			}
 
 			[Description("Disables Hard Deletes. (UNSAFE: use to remove hard deletes)")]
+			[Deprecated("This setting is unsafe and not recommended")]
 			public bool UnsafeIgnoreHardDelete { get; init; } = false;
 
 			[Description("Bypasses the checking of file hashes of indexes during startup and after index merges " +
@@ -462,9 +463,11 @@ namespace EventStore.Core {
 			public int IndexCacheDepth { get; init; } = 16;
 
 			[Description("Makes index merges faster and reduces disk pressure during merges.")]
+			[Deprecated("This setting is ignored by the new scavenge algorithm and will be removed in future versions.")]
 			public bool OptimizeIndexMerge { get; init; } = false;
 
 			[Description("Always keeps the newer chunks from a scavenge operation.")]
+			[Deprecated("This setting is ignored by the new scavenge algorithm and will be removed in future versions.")]
 			public bool AlwaysKeepScavenged { get; init; } = false;
 
 			[Description("Change the way the DB files are opened to reduce their stickiness in the system file cache.")]


### PR DESCRIPTION
Added: Deprecation warnings for UnsafeIgnoreHardDeletes and AlwaysKeepsScavenged

- AlwaysKeepScavenged is effectively always on for new scavenge. Although which chunks _get scavenged_ is configurable by setting a Threshold.
- UnsafeIgnoreHardDeletes is a bit fiddly to use, customers are probably off the beaten track if they want to use it. Removing it from docs and deprecating it to reduce visibility

Particular danger for UnsafeIgnoreHardDeletes (old scavenge)

1. Write some data to stream S and then tombstone it. Write enough data to complete the chunk.
2. Scavenge Node A with UnsafeIgnoreHardDeletes on. S and its tombstone is removed entirely from node A.
3. Restart Node A, make it the leader, write more data (S`) to stream S, successful.

Now node A contains only S', so all is well.
but node B contains S, S' and the Tombstone, so the stream is still considered deleted there. Presumably scavenging node B now would (to the surprise of the user) scavenge S' as well as S