### PR TITLE
Matsientst/invalid config closest match

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -84,11 +84,15 @@ namespace EventStore.ClusterNode {
 					? LogEventLevel.Information
 					: LogEventLevel.Fatal;
 
-				foreach (var key in options.Unknown.Keys) {
-					Log.Write(level, "The option {key} is not a known option.", key);
+				foreach (var (option, suggestion) in options.Unknown.Options) {
+					if (string.IsNullOrEmpty(suggestion)) {
+						Log.Write(level, "The option {option} is not a known option.", option);	
+					} else {
+						Log.Write(level, "The option {option} is not a known option. Did you mean {suggestion}?", option, suggestion);
+					}
 				}
 
-				if (options.Unknown.Keys.Any() && !options.Application.AllowUnknownOptions) {
+				if (options.Unknown.Options.Any() && !options.Application.AllowUnknownOptions) {
 					Log.Fatal(
 						$"Found unknown options. To continue anyway, set {nameof(ClusterVNodeOptions.ApplicationOptions.AllowUnknownOptions)} to true.");
 					Log.Information($"Options:{Environment.NewLine}{ClusterVNodeOptions.HelpText}");

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -66,7 +66,7 @@ namespace EventStore.Core.Tests {
 				nameof(ClusterVNodeOptions.Cluster.PrepareAckCount),
 				nameof(ClusterVNodeOptions.Database.ChunkSize),
 				nameof(ClusterVNodeOptions.Database.StatsStorage),
-				nameof(ClusterVNodeOptions.Unknown.Keys),
+				nameof(ClusterVNodeOptions.Unknown.Options),
 			};
 			var actual = new List<string>();
 			ClusterVNodeOptions.FromConfiguration(new FakeConfigurationRoot(

--- a/src/EventStore.Core.XUnit.Tests/ClusterVNodeOptionsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/ClusterVNodeOptionsTests.cs
@@ -1,0 +1,44 @@
+using Xunit;
+namespace EventStore.Core.Tests;
+
+public class ClusterVNodeOptionsTests {
+	private static ClusterVNodeOptions BuildConfiguration(string args) {
+		var sut = ClusterVNodeOptions.FromConfiguration(args.Split(), System.Environment.GetEnvironmentVariables());
+		return sut;
+	}
+
+	[Fact]
+	public void confirm_suggested_option() {
+		var c = BuildConfiguration("--cluster-sze 3");
+
+		var (key, value) = c.Unknown.Options[0];
+		Assert.Equal("ClusterSze", key);
+		Assert.Equal("ClusterSize", value);
+	}
+
+	[Fact]
+	public void when_we_dont_have_that_option() {
+		var c = BuildConfiguration("--something-that-is-wildly-off 3");
+
+		var (key, value) = c.Unknown.Options[0];
+		Assert.Equal("SomethingThatIsWildlyOff", key);
+		Assert.Equal("", value);
+	}
+
+	[Fact]
+	public void valid_parameters() {
+		var c = BuildConfiguration("--cluster-size 3");
+
+		var values = c.Unknown.Options;
+		Assert.Equal(0, values.Count);
+	}
+
+	[Fact]
+	public void four_characters_off() {
+		var c = BuildConfiguration("--cluse-ie 3");
+
+		var (key, value) = c.Unknown.Options[0];
+		Assert.Equal("CluseIe", key);
+		Assert.Equal("ClusterSize", value);
+	}
+}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -25,6 +25,7 @@
 		<PackageReference Include="Microsoft.FASTER.Core" Version="1.9.5" />
 		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.1" />
 		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.1" />
+		<PackageReference Include="Quickenshtein" Version="1.5.1" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.1" />
 		<PackageReference Include="System.IO.Pipelines" Version="6.0.3" />


### PR DESCRIPTION
Added: Suggestions for unknown/invalid configuration parameters (#3784)

This PR adds the feature to suggest a parameter when the user passes an incorrect parameter. For example, if the user passes a parameter like: `--cluster-sze` the system would suggest:
`The option "ClusterSze" is not a known option. Did you mean "ClusterSize"`


