### PR TITLE
Do not allow anonymous user to access some endpoints and streams in EventStoreDB

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -75,6 +75,34 @@ For this to work, you can use the `DefaultOpsPassword` option:
 Due to security reasons the DefaultAdminPassword and DefaultOpsPassword options can only be set through environment variables. The user will receive the error message if they try to pass the options using command line or config file.
 :::
 
+### Allow anonymous access to some endpoints and streams
+
+Historically, anonymous users with network access have been allowed to read/write streams that do not have access control lists.
+
+This anonymous access to streams can be disabled, and in the future will likely be disabled by default.
+
+| Format               | Syntax                                     |
+|:---------------------|:-------------------------------------------|
+| Command line         | `--allow-anonymous-stream-access`          |
+| YAML                 | `AllowAnonymousStreamAccess`               |
+| Environment variable | `EVENTSTORE_ALLOW_ANONYMOUS_STREAM_ACCESS` |
+
+**Default**: `true`
+
+Similarly to streams above, anonymous access has historically been available to the `/stats` and `/gossip` endpoints, and the `HTTP OPTIONS` method.
+
+This can be disabled with the following option. Anonymous access will still be granted to `/ping`, `/info`, the static content of the UI, and http redirects
+
+For this to work, you can disable the `AllowAnonymousEndpointAccess` option:
+
+| Format               | Syntax                                       |
+|:---------------------|:---------------------------------------------|
+| Command line         | `--allow-anonymous-endpoint-access`          |
+| YAML                 | `AllowAnonymousEndpointAccess`               |
+| Environment variable | `EVENTSTORE_ALLOW_ANONYMOUS_ENDPOINT_ACCESS` |
+
+**Default**: `true`
+
 ### Certificates configuration
 
 In this section, you can find settings related to protocol security (HTTPS and TLS).

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -107,10 +107,13 @@ namespace EventStore.ClusterNode {
 				if (_options.Application.Insecure) {
 					return new AuthorizationProviderFactory(_ => new PassthroughAuthorizationProviderFactory());
 				}
+
 				var authorizationTypeToPlugin = new Dictionary<string, AuthorizationProviderFactory> {
 					{
 						"internal", new AuthorizationProviderFactory(components =>
-							new LegacyAuthorizationProviderFactory(components.MainQueue))
+							new LegacyAuthorizationProviderFactory(components.MainQueue,
+								_options.Application.AllowAnonymousEndpointAccess,
+								_options.Application.AllowAnonymousStreamAccess))
 					}
 				};
 

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -21,8 +21,10 @@ namespace EventStore.Core.Tests.ClientOperations {
 				.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 					ssl_connections.GetServerCertificate());
 			_node = new ClusterVNode<TStreamId>(options, logFormatFactory,
-				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
-				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
+				new AuthenticationProviderFactory(
+					c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
+				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
+					options.Application.AllowAnonymousEndpointAccess, options.Application.AllowAnonymousStreamAccess)),
 				certificateProvider: new OptionsCertificateProvider(options));
 			_node.StartAsync(true).Wait();
 		}

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
@@ -24,8 +24,11 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 					.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 						ssl_connections.GetServerCertificate()));
 			_node = new ClusterVNode<TStreamId>(_options, _logFormatFactory,
-				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c, _options.DefaultUser)),
-				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
+				new AuthenticationProviderFactory(c =>
+					new InternalAuthenticationProviderFactory(c, _options.DefaultUser)),
+				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
+					_options.Application.AllowAnonymousEndpointAccess,
+					_options.Application.AllowAnonymousStreamAccess)),
 				certificateProvider: new OptionsCertificateProvider(_options));
 			_node.Start();
 		}
@@ -56,8 +59,11 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 				.Secure(new X509Certificate2Collection(ssl_connections.GetRootCertificate()),
 					ssl_connections.GetServerCertificate()));
 			_node = new ClusterVNode<TStreamId>(_options, _logFormatFactory,
-				new AuthenticationProviderFactory(_ => new InternalAuthenticationProviderFactory(_, _options.DefaultUser)),
-				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
+				new AuthenticationProviderFactory(_ =>
+					new InternalAuthenticationProviderFactory(_, _options.DefaultUser)),
+				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
+					_options.Application.AllowAnonymousEndpointAccess,
+					_options.Application.AllowAnonymousStreamAccess)),
 				certificateProvider: new OptionsCertificateProvider(_options));
 			_node.Start();
 		}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -173,10 +173,13 @@ namespace EventStore.Core.Tests.Helpers {
 				HttpEndPoint);
 
 			var logFormatFactory = LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory;
-			Node = new ClusterVNode<TStreamId>(options, logFormatFactory, new AuthenticationProviderFactory(components =>
-					new InternalAuthenticationProviderFactory(components, options.DefaultUser)),
+			Node = new ClusterVNode<TStreamId>(options, logFormatFactory, new AuthenticationProviderFactory(
+					components =>
+						new InternalAuthenticationProviderFactory(components, options.DefaultUser)),
 				new AuthorizationProviderFactory(components =>
-					new LegacyAuthorizationProviderFactory(components.MainQueue)),
+					new LegacyAuthorizationProviderFactory(components.MainQueue,
+						options.Application.AllowAnonymousEndpointAccess,
+						options.Application.AllowAnonymousStreamAccess)),
 				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>(),
 				new OptionsCertificateProvider(options),
 				telemetryConfiguration: null,

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -161,8 +161,10 @@ namespace EventStore.Core.Tests.Helpers {
 					streamExistenceFilterCheckpointIntervalMs: streamExistenceFilterCheckpointIntervalMs,
 					streamExistenceFilterCheckpointDelayMs: streamExistenceFilterCheckpointDelayMs));
 			Node = new ClusterVNode<TStreamId>(options, logFormatFactory,
-				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
-				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
+				new AuthenticationProviderFactory(
+					c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
+				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
+					options.Application.AllowAnonymousEndpointAccess, options.Application.AllowAnonymousStreamAccess)),
 				telemetryConfiguration: null,
 				expiryStrategy: expiryStrategy,
 				certificateProvider: new OptionsCertificateProvider(options));

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -164,6 +164,12 @@ namespace EventStore.Core {
 			[Description("Disable Authentication, Authorization and TLS on all TCP/HTTP interfaces.")]
 			public bool Insecure { get; init; } = false;
 
+			[Description("Allow anonymous access to API end points")]
+			public bool AllowAnonymousEndpointAccess { get; init; } = true;
+
+			[Description("Allow anonymous access to streams")]
+			public bool AllowAnonymousStreamAccess { get; init; } = true;
+
 			internal static ApplicationOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				Config = configurationRoot.GetValue<string>(nameof(Config)),
 				Help = configurationRoot.GetValue<bool>(nameof(Help)),
@@ -180,6 +186,8 @@ namespace EventStore.Core {
 					configurationRoot.GetValue<bool>(nameof(LogFailedAuthenticationAttempts)),
 				SkipIndexScanOnReads = configurationRoot.GetValue<bool>(nameof(SkipIndexScanOnReads)),
 				Insecure = configurationRoot.GetValue<bool>(nameof(Insecure)),
+				AllowAnonymousEndpointAccess = configurationRoot.GetValue<bool>(key:nameof(AllowAnonymousEndpointAccess)),
+				AllowAnonymousStreamAccess = configurationRoot.GetValue<bool>(key:nameof(AllowAnonymousStreamAccess))
 			};
 		}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/GossipController.cs
@@ -34,7 +34,7 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 		}
 
 		protected override void SubscribeCore(IHttpService service) {
-			service.RegisterAction(new ControllerAction("/gossip", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Gossip.Read)),
+			service.RegisterAction(new ControllerAction("/gossip", HttpMethod.Get, Codec.NoCodecs, SupportedCodecs, new Operation(Operations.Node.Gossip.ClientRead)),
 				OnGetGossip);
 		}
 


### PR DESCRIPTION
Added: Options to restrict EventStoreDB access for anonymous users

Related to https://github.com/EventStore/home/issues/899
 
This PR adds a functionality to restrict the anonymous access to some endpoints and streams in EventStoreDB by setting the following options:- 
 

Format               | Syntax                                     |
|:---------------------|:-------------------------------------------|
| Command line         | `--allow-anonymous-stream-access`          |
| YAML                 | `AllowAnonymousStreamAccess`               |
| Environment variable | `EVENTSTORE_ALLOW_ANONYMOUS_STREAM_ACCESS`

Default: true

Note: In the future, the value will likely be disabled by default

Format               | Syntax                                       |
|:---------------------|:---------------------------------------------|
| Command line         | `--allow-anonymous-endpoint-access`          |
| YAML                 | `AllowAnonymousEndpointAccess`               |
| Environment variable | `EVENTSTORE_ALLOW_ANONYMOUS_ENDPOINT_ACCESS` |

Default: true