### PR TITLE
Update Jint to version 3.0.0-beta-2048

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/Jint/Serialization/when_serializing_state.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/Jint/Serialization/when_serializing_state.cs
@@ -124,7 +124,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint.Serialization {
 
 		[Test]
 		public void undefined_property() {
-			var instance = new ObjectInstance(_engine);
+			var instance = new JsObject(_engine);
 			instance.Set("foo", JsValue.Undefined);
 			instance.Set("bar", "baz");
 			var serialized = _sut.Serialize(instance);
@@ -153,7 +153,7 @@ namespace EventStore.Projections.Core.Tests.Services.Jint.Serialization {
 				).SingleOrDefault();
 			if(streamName == null) throw new InvalidOperationException($"Could not find {filename}");
 			using var stream = assembly.GetManifestResourceStream(streamName);
-			
+
 			var doc = JsonDocument.Parse(stream);
 			using var ms = new MemoryStream();
 			var writer = new Utf8JsonWriter(ms);

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -37,7 +37,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Jint" Version="3.0.0-beta-2038" />
+		<PackageReference Include="Jint" Version="3.0.0-beta-2048" />
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		<ProjectReference Include="..\EventStore.Transport.Http\EventStore.Transport.Http.csproj" />


### PR DESCRIPTION
Changed: Jint library version to 3.0.0-beta-2048

* required API changes
* instead of removing `eval` from Global, now using new option to prevent dynamic script parsing (you missed that code parsing can also happen via `Function` constructor
* note that Jint's `JsonParser` [has been improved](https://github.com/sebastienros/jint/pull/1485) and it has default maximum recursion of 64
* replaced `IReadOnlyDictionary` field type with concrete to prevent interface dispatch penalty