### PR TITLE
Handle redacted events in AtomPub

### DIFF
--- a/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AutoEventConverter.cs
@@ -25,6 +25,9 @@ namespace EventStore.Core.Services.Transport.Http {
 					return evnt.Event.Data.ToArray();
 				case ContentType.Xml:
 				case ContentType.ApplicationXml: {
+					if (evnt.Event.Data.IsEmpty)
+						return "<data />";
+
 					var serializeObject = JsonConvert.SerializeObject(dto.data);
 					var deserializeXmlNode = JsonConvert.DeserializeXmlNode(serializeObject, "data");
 					return deserializeXmlNode.InnerXml;

--- a/src/EventStore.Core/Services/Transport/Http/Convert.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Convert.cs
@@ -342,6 +342,7 @@ namespace EventStore.Core.Services.Transport.Http {
 				richEntry.PositionEventNumber = eventLinkPair.OriginalEvent.EventNumber;
 				richEntry.PositionStreamId = eventLinkPair.OriginalEvent.EventStreamId;
 				richEntry.IsJson = (evnt.Flags & PrepareFlags.IsJson) != 0;
+				richEntry.IsRedacted = (evnt.Flags & PrepareFlags.IsRedacted) != 0;
 
 				var data = evnt.Data.Span;
 

--- a/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
+++ b/src/EventStore.Core/TransactionLog/LogRecords/PrepareLogRecord.cs
@@ -107,7 +107,7 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 			CorrelationId = correlationId;
 			TimeStamp = timeStamp;
 			EventType = eventType ?? string.Empty;
-			Data = data;
+			Data = Flags.HasFlag(PrepareFlags.IsRedacted) ? NoData : data;
 			Metadata = metadata;
 			if (InMemorySize > TFConsts.MaxLogRecordSize) throw new Exception("Record too large.");
 		}
@@ -135,6 +135,8 @@ namespace EventStore.Core.TransactionLog.LogRecords {
 
 			var dataCount = reader.ReadInt32();
 			Data = dataCount == 0 ? NoData : reader.ReadBytes(dataCount);
+			if (Flags.HasFlag(PrepareFlags.IsRedacted))
+				Data = NoData;
 
 			var metadataCount = reader.ReadInt32();
 			Metadata = metadataCount == 0 ? NoData : reader.ReadBytes(metadataCount);

--- a/src/EventStore.Transport.Http/Atom/Feed.cs
+++ b/src/EventStore.Transport.Http/Atom/Feed.cs
@@ -242,6 +242,7 @@ namespace EventStore.Transport.Http.Atom {
 
 		public bool IsMetaData { get; set; }
 		public bool IsLinkMetaData { get; set; }
+		public bool IsRedacted { get; set; }
 
 		public long PositionEventNumber { get; set; }
 


### PR DESCRIPTION
Added: Handle redacted events in AtomPub

This PR needs to wait for https://github.com/EventStore/EventStore/pull/3713 to be merged.

UI part: https://github.com/EventStore/EventStore.UI/pull/352

The solution works as follows:
- Replace redacted data by `NoData` (an empty byte array) when reading the log record from disk (or when creating a redacted log record)
- We're essentially treating redacted events in the same way as events having data length = 0.
- An IsRedacted flag has been added to the AtomPub feed based on whether the IsRedacted PrepareFlag is set.
- The XMLCodec was also broken when serializing empty data and has been fixed

I initially took a different approach (see `simple-redaction-atompub2` branch) where I was trying to transform the redacted data to null and this causes several complications/many cases to handle. The current solution is more in line with how EventStoreDB represents empty data.