### PR TITLE
Add check for config file not found at EventStoreDB start up

### DIFF
--- a/src/EventStore.Common.Tests/Configuration/ConfigurationRootExtensionsTest.cs
+++ b/src/EventStore.Common.Tests/Configuration/ConfigurationRootExtensionsTest.cs
@@ -1,10 +1,13 @@
+using System.Collections;
+using EventStore.Common.Configuration;
 using Microsoft.Extensions.Configuration;
 
 namespace EventStore.Common.Tests.Configuration;
 
 public class ConfigurationRootExtensionsTest {
-	private static string GOSSIP_SEED = "GossipSeed";
-
+	private const string GOSSIP_SEED = "GossipSeed";
+	private const string CONFIG_FILE_KEY = "Config";
+	
 	[Fact]
 	public void successful_comma_separated_value() {
 		var config = new Dictionary<string, string> {
@@ -46,5 +49,46 @@ public class ConfigurationRootExtensionsTest {
 		Assert.Throws<ArgumentException>(() =>
 			EventStore.Common.Configuration.ConfigurationRootExtensions.GetCommaSeparatedValueAsArray(
 				configuration, "GossipSeed"));
+	}
+
+	[Fact]
+	public void user_specified_config_file_through_environment_variables_returns_true() {
+		IDictionary environmentVariables = new Dictionary<string, string>();
+		environmentVariables.Add("EVENTSTORE_CONFIG", "pathToConfigFileOnMachine");
+
+		var configurationRoot = new ConfigurationBuilder()
+			.Add(new EnvironmentVariablesSource(environmentVariables))
+			.Build();
+
+		var result = configurationRoot.IsUserSpecified(CONFIG_FILE_KEY);
+
+		Assert.True(result);
+	}
+	
+	[Fact]
+	public void user_specified_config_file_through_command_line_returns_true() {
+		var args = new string[] {
+			"--config=pathToConfigFileOnMachine"
+		};
+
+		var configurationRoot = new ConfigurationBuilder()
+			.Add(new CommandLineSource(args))
+			.Build();
+
+		var result = configurationRoot.IsUserSpecified(CONFIG_FILE_KEY);
+
+		Assert.True(result);
+	}
+
+	[Fact]
+	public void user_did_not_specified_config_file_returns_false() {
+		var configurationRoot = new ConfigurationBuilder()
+			.Add(new DefaultSource(new Dictionary<string, object> {
+			}))
+			.Build();
+
+		var result = configurationRoot.IsUserSpecified(CONFIG_FILE_KEY);
+
+		Assert.False(result);
 	}
 }

--- a/src/EventStore.Common/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationBuilderExtensions.cs
@@ -6,19 +6,21 @@ using Microsoft.Extensions.Configuration;
 namespace EventStore.Common.Configuration {
 	public static class ConfigurationBuilderExtensions {
 		public static IConfigurationBuilder AddEventStore(this IConfigurationBuilder configurationBuilder,
-			string[] args, IDictionary environment, IEnumerable<KeyValuePair<string, object?>> defaultValues) {
+			string configFileKey,
+			string[] args, 
+			IDictionary environment, 
+			IEnumerable<KeyValuePair<string, object?>> defaultValues) {
+			
 			var builder = configurationBuilder
 				.Add(new DefaultSource(defaultValues))
 				.Add(new EnvironmentVariablesSource(environment))
 				.Add(new CommandLineSource(args));
 
 			var root = builder.Build(); // need to build twice as on disk config is configurable
-
-			var configurationPath = root.GetValue<string>("Config");
-
+			
 			var yamlSource = new YamlSource {
-				Path = configurationPath,
-				Optional = true,
+				Path = root.GetValue<string>(configFileKey),
+				Optional = !root.IsUserSpecified(configFileKey),
 				ReloadOnChange = true
 			};
 			yamlSource.ResolveFileProvider();

--- a/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
@@ -25,6 +25,21 @@ namespace EventStore.Common.Configuration {
 			return value.Split(',', StringSplitOptions.RemoveEmptyEntries);
 		}
 		
+		// has the user specified what they want, or left it up to the default.
+		// specifying the same value as the default still counts as being used specified.
+		public static bool IsUserSpecified(this IConfigurationRoot configurationRoot, string key) {
+			foreach (var provider in configurationRoot.Providers) {
+				if (provider.GetType() == typeof(Default))
+					continue;
+
+				if (provider.TryGet(key, out _)) {
+					return true;
+				}
+			}
+
+			return false;
+		}
+
 		public static string? CheckProvidersForEnvironmentVariables(IConfigurationRoot? configurationRoot, IEnumerable<Type> OptionSections) {
 			if (configurationRoot != null) {
 				var environmentOptionsOnly = OptionSections.SelectMany(section => section.GetProperties())

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -135,7 +135,7 @@ namespace EventStore.Core.Tests {
 				await writer.WriteAsync(configurationFileContent);
 				await writer.FlushAsync();
 				var options = ClusterVNodeOptions.FromConfiguration(new ConfigurationBuilder()
-					.AddEventStore(args, environment, defaultValues.Concat(new[] {
+					.AddEventStore(nameof(ClusterVNodeOptions.ApplicationOptions.Config), args, environment, defaultValues.Concat(new[] {
 						new KeyValuePair<string, object>(nameof(ClusterVNodeOptions.Application.Config),
 							configurationFile.FullName)
 					}))

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using EventStore.Common;
 using EventStore.Common.Configuration;
+using EventStore.Common.Exceptions;
 using EventStore.Common.Options;
 using EventStore.Common.Utils;
 using EventStore.Core.Services.Monitoring;
@@ -57,12 +58,15 @@ namespace EventStore.Core {
 		public static ClusterVNodeOptions FromConfiguration(string[] args, IDictionary environment) {
 			if (args == null) throw new ArgumentNullException(nameof(args));
 			if (environment == null) throw new ArgumentNullException(nameof(environment));
-
-			var configurationRoot = new ConfigurationBuilder()
-				.AddEventStore(args, environment, DefaultValues)
-				.Build();
-
-			return FromConfiguration(configurationRoot);
+			
+			try {
+				var configurationRoot = new ConfigurationBuilder()
+					.AddEventStore(nameof(ApplicationOptions.Config), args, environment, DefaultValues)
+					.Build();
+				return FromConfiguration(configurationRoot);
+			} catch (Exception e) {
+				throw new InvalidConfigurationException(e.Message);
+			}
 		}
 
 		public static ClusterVNodeOptions FromConfiguration(IConfigurationRoot configurationRoot) {


### PR DESCRIPTION
Changed: Ensure the config file is found on startup if it has been specified

Fixed: #3534 

This PR added a check for the config file path at EventStoreDB start up. 