### PR TITLE
Prevent torn implicit transactions (DB-64)

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -118,7 +118,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 			Guid eventId = default(Guid),
 			string eventType = "some-type") {
 
-			long pos = WriterCheckpoint.ReadNonFlushed();
+			long pos = Writer.LogPosition;
 			_logFormatFactory.StreamNameIndex.GetOrReserve(
 				_logFormatFactory.RecordFactory,
 				eventStreamName,

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -119,7 +119,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 			Guid eventId = default(Guid),
 			string eventType = "some-type") {
 
-			long pos = Writer.LogPosition;
+			long pos = Writer.NextRecordPosition;
 			_logFormatFactory.StreamNameIndex.GetOrReserve(
 				_logFormatFactory.RecordFactory,
 				eventStreamName,

--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -81,6 +81,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 
 			WriteTestScenario();
 
+			Writer.Commit();
 			Writer.Close();
 			Writer = null;
 			WriterCheckpoint.Flush();

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -200,7 +200,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(4), out _);
 			EpochManager.WriteNewEpoch(1);
 
-			var subscribePosition = Writer.LogPosition + 1000;
+			var subscribePosition = Writer.CommittedLogPosition + 1000;
 			_replicaEpochs = new List<Epoch> {
 				new Epoch(subscribePosition, 2, Guid.NewGuid()),
 			};
@@ -215,7 +215,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
 				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
 			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(Writer.LogPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(Writer.CommittedLogPosition, subscribed[0].SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
 		}
@@ -237,7 +237,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(4), out _);
 			EpochManager.WriteNewEpoch(4);
 
-			var subscribePosition = Writer.LogPosition + 1000;
+			var subscribePosition = Writer.CommittedLogPosition + 1000;
 			_replicaEpochs = new List<Epoch> {
 				new Epoch(subscribePosition, 2, Guid.NewGuid()),
 			};

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -200,7 +200,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(4), out _);
 			EpochManager.WriteNewEpoch(1);
 
-			var subscribePosition = Db.Config.WriterCheckpoint.ReadNonFlushed() + 1000;
+			var subscribePosition = Writer.LogPosition + 1000;
 			_replicaEpochs = new List<Epoch> {
 				new Epoch(subscribePosition, 2, Guid.NewGuid()),
 			};
@@ -215,7 +215,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
 				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
 			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(Db.Config.WriterCheckpoint.ReadNonFlushed(), subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(Writer.LogPosition, subscribed[0].SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
 		}
@@ -237,7 +237,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(4), out _);
 			EpochManager.WriteNewEpoch(4);
 
-			var subscribePosition = Db.Config.WriterCheckpoint.ReadNonFlushed() + 1000;
+			var subscribePosition = Writer.LogPosition + 1000;
 			_replicaEpochs = new List<Epoch> {
 				new Epoch(subscribePosition, 2, Guid.NewGuid()),
 			};

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -201,7 +201,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(4), out _);
 			EpochManager.WriteNewEpoch(1);
 
-			var subscribePosition = Writer.CommittedLogPosition + 1000;
+			var subscribePosition = Writer.CommittedPosition + 1000;
 			_replicaEpochs = new List<Epoch> {
 				new Epoch(subscribePosition, 2, Guid.NewGuid()),
 			};
@@ -216,7 +216,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
 				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
 			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(Writer.CommittedLogPosition, subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(Writer.CommittedPosition, subscribed[0].SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
 		}
@@ -238,7 +238,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(4), out _);
 			EpochManager.WriteNewEpoch(4);
 
-			var subscribePosition = Writer.CommittedLogPosition + 1000;
+			var subscribePosition = Writer.CommittedPosition + 1000;
 			_replicaEpochs = new List<Epoch> {
 				new Epoch(subscribePosition, 2, Guid.NewGuid()),
 			};

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -125,6 +125,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(5), out _);
 			Writer.Write(CreateLogRecord(6), out _);
 			Writer.Write(CreateLogRecord(7), out var lastWritePosition);
+			Writer.Commit();
 			Writer.Flush();
 
 			_replicaEpochs = new List<Epoch> {

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -101,7 +101,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 		public IPrepareLogRecord<TStreamId> CreateLogRecord(long eventNumber, string data = "*************") {
 			var tStreamId = LogFormatHelper<TLogFormat, TStreamId>.StreamId;
 			var eventType = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
-			return LogRecord.Prepare(_logFormat.RecordFactory, Db.Config.WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+			return LogRecord.Prepare(_logFormat.RecordFactory, Writer.LogPosition, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				tStreamId, eventNumber, PrepareFlags.None, eventType, Encoding.UTF8.GetBytes(data),
 				null, DateTime.UtcNow);
 		}

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -101,7 +101,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 		public IPrepareLogRecord<TStreamId> CreateLogRecord(long eventNumber, string data = "*************") {
 			var tStreamId = LogFormatHelper<TLogFormat, TStreamId>.StreamId;
 			var eventType = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
-			return LogRecord.Prepare(_logFormat.RecordFactory, Writer.LogPosition, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+			return LogRecord.Prepare(_logFormat.RecordFactory, Writer.NextRecordPosition, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				tStreamId, eventNumber, PrepareFlags.None, eventType, Encoding.UTF8.GetBytes(data),
 				null, DateTime.UtcNow);
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_disallowed_streams.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_disallowed_streams.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 				retryOnFail: true); //allowed
 
 			_forwardReadPos = new TFPos(firstEvent.LogPosition, firstEvent.LogPosition);
-			_backwardReadPos = new TFPos(WriterCheckpoint.ReadNonFlushed(), WriterCheckpoint.ReadNonFlushed());
+			_backwardReadPos = new TFPos(Writer.LogPosition, Writer.LogPosition);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_disallowed_streams.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_disallowed_streams.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 				retryOnFail: true); //allowed
 
 			_forwardReadPos = new TFPos(firstEvent.LogPosition, firstEvent.LogPosition);
-			_backwardReadPos = new TFPos(Writer.LogPosition, Writer.LogPosition);
+			_backwardReadPos = new TFPos(Writer.NextRecordPosition, Writer.NextRecordPosition);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 				retryOnFail: true);
 
 			_forwardReadPos = new TFPos(firstEvent.LogPosition, firstEvent.LogPosition);
-			_backwardReadPos = new TFPos(Writer.LogPosition, Writer.LogPosition);
+			_backwardReadPos = new TFPos(Writer.NextRecordPosition, Writer.NextRecordPosition);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 				retryOnFail: true);
 
 			_forwardReadPos = new TFPos(firstEvent.LogPosition, firstEvent.LogPosition);
-			_backwardReadPos = new TFPos(WriterCheckpoint.ReadNonFlushed(), WriterCheckpoint.ReadNonFlushed());
+			_backwardReadPos = new TFPos(Writer.LogPosition, Writer.LogPosition);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/BuildingIndex/when_building_an_index_off_tfile_with_duplicate_events_in_a_stream.cs
@@ -128,6 +128,7 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 			Writer = new TFChunkWriter(_db);
 			Writer.Open();
 			SetupDB();
+			Writer.Commit();
 			Writer.Close();
 			Writer = null;
 
@@ -180,6 +181,7 @@ namespace EventStore.Core.Tests.Services.Storage.BuildingIndex {
 			Writer = new TFChunkWriter(_db);
 			Writer.Open();
 			Given();
+			Writer.Commit();
 			Writer.Close();
 			Writer = null;
 

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_commit_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_commit_event.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 				data: new byte[] { 1, 2, 3, 4, 5 },
 				metadata: new byte[] { 7, 17 });
 			Assert.True(Writer.Write(record, out _logPosition));
+			Writer.Commit();
 			Writer.Flush();
 
 			IndexCommitter.AddPendingPrepare(new[]{ record},_logPosition);
@@ -44,6 +45,7 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 				firstEventNumber: 10);
 
 			Assert.True(Writer.Write(record2, out _logPosition));
+			Writer.Commit();
 			Writer.Flush();
 		}
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_committed_prepare_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_committed_prepare_event.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 				metadata: new byte[] { 7, 17 });
 
 			Assert.True(Writer.Write(record, out _));
+			Writer.Commit();
 			Writer.Flush();
 		}
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_prepare_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_prepare_event.cs
@@ -33,6 +33,7 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 				metadata: new byte[] { 7, 17 });
 
 			Assert.True(Writer.Write(record, out _));
+			Writer.Commit();
 			Writer.Flush();
 		}
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_system_event.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Chaser/when_chaser_reads_system_event.cs
@@ -17,6 +17,7 @@ namespace EventStore.Core.Tests.Services.Storage.Chaser {
 				SystemRecordSerialization.Json, epoch.AsSerialized());
 
 			Assert.True(Writer.Write(rec, out _));
+			Writer.Commit();
 			Writer.Flush();
 		}
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_and_committing_one.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_and_committing_one.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_2nd_prepare_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition,
-				WriterCheckpoint.ReadNonFlushed());
+				Writer.LogPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_3rd_prepare_should_return_wrong_expected_version() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition,
-				WriterCheckpoint.ReadNonFlushed());
+				Writer.LogPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_and_committing_one.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_and_committing_one.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_2nd_prepare_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition,
-				Writer.LogPosition);
+				Writer.CommittedLogPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_3rd_prepare_should_return_wrong_expected_version() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition,
-				Writer.LogPosition);
+				Writer.CommittedLogPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_and_committing_one.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_and_committing_one.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_2nd_prepare_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition,
-				Writer.CommittedLogPosition);
+				Writer.CommittedPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_3rd_prepare_should_return_wrong_expected_version() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition,
-				Writer.CommittedLogPosition);
+				Writer.CommittedPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void other_prepares_cannot_be_committed() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare0.LogPosition,
-				Writer.CommittedLogPosition);
+				Writer.CommittedPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.CommittedLogPosition);
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.CommittedPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void other_prepares_cannot_be_committed() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare0.LogPosition,
-				WriterCheckpoint.ReadNonFlushed());
+				Writer.LogPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, WriterCheckpoint.ReadNonFlushed());
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.LogPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_committing_one_of_them.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void other_prepares_cannot_be_committed() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare0.LogPosition,
-				Writer.LogPosition);
+				Writer.CommittedLogPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.LogPosition);
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.CommittedLogPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void every_prepare_can_be_commited() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare0.LogPosition,
-				WriterCheckpoint.ReadNonFlushed());
+				Writer.LogPosition);
 
 			var streamId = _logFormat.StreamIds.LookupValue("ES");
 
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition, WriterCheckpoint.ReadNonFlushed());
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition, Writer.LogPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual(streamId, res.EventStreamId);
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, WriterCheckpoint.ReadNonFlushed());
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.LogPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual(streamId, res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void every_prepare_can_be_commited() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare0.LogPosition,
-				Writer.LogPosition);
+				Writer.CommittedLogPosition);
 
 			var streamId = _logFormat.StreamIds.LookupValue("ES");
 
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition, Writer.LogPosition);
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition, Writer.CommittedLogPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual(streamId, res.EventStreamId);
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.LogPosition);
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.CommittedLogPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual(streamId, res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_few_prepares_with_same_expected_version_and_not_committing_them.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void every_prepare_can_be_commited() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare0.LogPosition,
-				Writer.CommittedLogPosition);
+				Writer.CommittedPosition);
 
 			var streamId = _logFormat.StreamIds.LookupValue("ES");
 
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition, Writer.CommittedLogPosition);
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition, Writer.CommittedPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual(streamId, res.EventStreamId);
@@ -37,7 +37,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 			Assert.AreEqual(-1, res.StartEventNumber);
 			Assert.AreEqual(-1, res.EndEventNumber);
 
-			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.CommittedLogPosition);
+			res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare2.LogPosition, Writer.CommittedPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual(streamId, res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_expected_prepare_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition,
-				Writer.CommittedLogPosition);
+				Writer.CommittedPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_not_expected_prepare_should_return_wrong_expected_version() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare4.LogPosition,
-				Writer.CommittedLogPosition);
+				Writer.CommittedPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_expected_prepare_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition,
-				Writer.LogPosition);
+				Writer.CommittedLogPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_not_expected_prepare_should_return_wrong_expected_version() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare4.LogPosition,
-				Writer.LogPosition);
+				Writer.CommittedLogPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_prepares_in_wrong_order_and_committing_in_right_order.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_expected_prepare_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare1.LogPosition,
-				WriterCheckpoint.ReadNonFlushed());
+				Writer.LogPosition);
 
 			Assert.AreEqual(CommitDecision.Ok, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);
@@ -38,7 +38,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_on_not_expected_prepare_should_return_wrong_expected_version() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare4.LogPosition,
-				WriterCheckpoint.ReadNonFlushed());
+				Writer.LogPosition);
 
 			Assert.AreEqual(CommitDecision.WrongExpectedVersion, res.Decision);
 			Assert.AreEqual("ES", res.EventStreamId);

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_single_prepare.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_single_prepare.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare.LogPosition,
-				Writer.LogPosition);
+				Writer.CommittedLogPosition);
 
 			var streamId = _logFormat.StreamIds.LookupValue("ES");
 

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_single_prepare.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_single_prepare.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare.LogPosition,
-				WriterCheckpoint.ReadNonFlushed());
+				Writer.LogPosition);
 
 			var streamId = _logFormat.StreamIds.LookupValue("ES");
 

--- a/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_single_prepare.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/CheckCommitStartingAt/when_writing_single_prepare.cs
@@ -15,7 +15,7 @@ namespace EventStore.Core.Tests.Services.Storage.CheckCommitStartingAt {
 		[Test]
 		public void check_commmit_should_return_ok_decision() {
 			var res = ReadIndex.IndexWriter.CheckCommitStartingAt(_prepare.LogPosition,
-				Writer.CommittedLogPosition);
+				Writer.CommittedPosition);
 
 			var streamId = _logFormat.StreamIds.LookupValue("ES");
 

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_hard_deleting_stream_with_log_version_0.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_hard_deleting_stream_with_log_version_0.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 
 		private void WriteV0HardDelete(string eventStreamId) {
 			long pos;
-			var logPosition = Writer.LogPosition;
+			var logPosition = Writer.NextRecordPosition;
 			var prepare = new PrepareLogRecord(logPosition, Guid.NewGuid(), Guid.NewGuid(), logPosition, 0,
 				eventStreamId,
 				int.MaxValue - 1, DateTime.UtcNow,
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 				prepareRecordVersion: LogRecordVersion.LogRecordV0);
 			Writer.Write(prepare, out pos);
 
-			var commit = new CommitLogRecord(Writer.LogPosition, prepare.CorrelationId,
+			var commit = new CommitLogRecord(Writer.NextRecordPosition, prepare.CorrelationId,
 				prepare.LogPosition, DateTime.UtcNow, int.MaxValue,
 				commitRecordVersion: LogRecordVersion.LogRecordV0);
 			Writer.Write(commit, out pos);

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_hard_deleting_stream_with_log_version_0.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_hard_deleting_stream_with_log_version_0.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 
 		private void WriteV0HardDelete(string eventStreamId) {
 			long pos;
-			var logPosition = WriterCheckpoint.ReadNonFlushed();
+			var logPosition = Writer.LogPosition;
 			var prepare = new PrepareLogRecord(logPosition, Guid.NewGuid(), Guid.NewGuid(), logPosition, 0,
 				eventStreamId,
 				int.MaxValue - 1, DateTime.UtcNow,
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 				prepareRecordVersion: LogRecordVersion.LogRecordV0);
 			Writer.Write(prepare, out pos);
 
-			var commit = new CommitLogRecord(WriterCheckpoint.ReadNonFlushed(), prepare.CorrelationId,
+			var commit = new CommitLogRecord(Writer.LogPosition, prepare.CorrelationId,
 				prepare.LogPosition, DateTime.UtcNow, int.MaxValue,
 				commitRecordVersion: LogRecordVersion.LogRecordV0);
 			Writer.Write(commit, out pos);

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_delete_prepare_but_no_commit_read_index_should.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_delete_prepare_but_no_commit_read_index_should.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 			var eventTypeId = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
 			_event0 = WriteSingleEvent("ES", 0, "bla1");
 			Assert.True(_logFormat.StreamNameIndex.GetOrReserve("ES", out var esStreamId, out _, out _));
-			var prepare = LogRecord.DeleteTombstone(_recordFactory, Writer.LogPosition, Guid.NewGuid(), Guid.NewGuid(),
+			var prepare = LogRecord.DeleteTombstone(_recordFactory, Writer.NextRecordPosition, Guid.NewGuid(), Guid.NewGuid(),
 				esStreamId, eventTypeId, 1);
 			long pos;
 			Assert.IsTrue(Writer.Write(prepare, out pos));

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_delete_prepare_but_no_commit_read_index_should.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_delete_prepare_but_no_commit_read_index_should.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 			var eventTypeId = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
 			_event0 = WriteSingleEvent("ES", 0, "bla1");
 			Assert.True(_logFormat.StreamNameIndex.GetOrReserve("ES", out var esStreamId, out _, out _));
-			var prepare = LogRecord.DeleteTombstone(_recordFactory, WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(),
+			var prepare = LogRecord.DeleteTombstone(_recordFactory, Writer.LogPosition, Guid.NewGuid(), Guid.NewGuid(),
 				esStreamId, eventTypeId, 1);
 			long pos;
 			Assert.IsTrue(Writer.Write(prepare, out pos));

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.LogPosition;
+			long pos = _writer.NextRecordPosition;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
@@ -67,6 +67,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);
+			_writer.Commit();
 			_writer.Flush();
 			return epoch;
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.LogPosition;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
@@ -62,7 +62,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.LogPosition;
+			long pos = _writer.NextRecordPosition;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
 				SystemRecordSerialization.Json, epoch.AsSerialized());

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
@@ -62,7 +62,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.LogPosition;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
 				SystemRecordSerialization.Json, epoch.AsSerialized());

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
@@ -67,6 +67,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
 				SystemRecordSerialization.Json, epoch.AsSerialized());
 			_writer.Write(rec, out _);
+			_writer.Commit();
 			_writer.Flush();
 			return epoch;
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
@@ -66,6 +66,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
 				SystemRecordSerialization.Json, epoch.AsSerialized());
 			_writer.Write(rec, out _);
+			_writer.Commit();
 			_writer.Flush();
 			return epoch;
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
@@ -61,7 +61,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.LogPosition;
+			long pos = _writer.NextRecordPosition;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
 				SystemRecordSerialization.Json, epoch.AsSerialized());

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
@@ -61,7 +61,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.LogPosition;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
 				SystemRecordSerialization.Json, epoch.AsSerialized());

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.Services.Storage.EpochManager {
 		private const int CachedEpochCount = 10;
 
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.LogPosition;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
@@ -27,6 +27,7 @@ namespace EventStore.Core.Tests.Services.Storage.EpochManager {
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);
+			_writer.Commit();
 			_writer.Flush();
 			return epoch;
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.Services.Storage.EpochManager {
 		private const int CachedEpochCount = 10;
 
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.LogPosition;
+			long pos = _writer.NextRecordPosition;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -477,7 +477,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		}
 
 		protected TFPos GetBackwardReadPos() {
-			var pos = new TFPos(WriterCheckpoint.ReadNonFlushed(), WriterCheckpoint.ReadNonFlushed());
+			var pos = new TFPos(WriterCheckpoint.Read(), WriterCheckpoint.Read());
 			return pos;
 		}
 

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -176,7 +176,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		protected abstract void WriteTestScenario();
 
 		protected void GetOrReserve(string eventStreamName, out TStreamId eventStreamId, out long newPos) {
-			newPos = Writer.LogPosition;
+			newPos = Writer.NextRecordPosition;
 			_streamNameIndex.GetOrReserve(_logFormat.RecordFactory, eventStreamName, newPos, out eventStreamId, out var streamRecord);
 			if (streamRecord != null) {
 				Writer.Write(streamRecord, out newPos);
@@ -184,7 +184,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		}
 		
 		protected void GetOrReserveEventType(string eventType, out TStreamId eventTypeId, out long newPos) {
-			newPos = Writer.LogPosition;
+			newPos = Writer.NextRecordPosition;
 			_eventTypeIndex.GetOrReserveEventType(_logFormat.RecordFactory, eventType, newPos, out eventTypeId, out var eventTypeRecord);
 			if (eventTypeRecord != null) {
 				Writer.Write(eventTypeRecord, out newPos);
@@ -231,7 +231,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			}
 
 			
-			var commit = LogRecord.Commit(Writer.LogPosition, prepare.CorrelationId, prepare.LogPosition,
+			var commit = LogRecord.Commit(Writer.NextRecordPosition, prepare.CorrelationId, prepare.LogPosition,
 				eventNumber);
 			if (!retryOnFail) {
 				Assert.IsTrue(Writer.Write(commit, out pos));
@@ -267,7 +267,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				PrepareFlags.IsJson);
 			Assert.IsTrue(Writer.Write(prepare, out pos));
 
-			var commit = LogRecord.Commit(Writer.LogPosition, prepare.CorrelationId, prepare.LogPosition,
+			var commit = LogRecord.Commit(Writer.NextRecordPosition, prepare.CorrelationId, prepare.LogPosition,
 				eventNumber);
 			Assert.IsTrue(Writer.Write(commit, out pos));
 			Assert.AreEqual(eventStreamId, prepare.EventStreamId);
@@ -284,7 +284,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			var prepare = LogRecord.Prepare(_recordFactory, pos,
 				Guid.NewGuid(),
 				Guid.NewGuid(),
-				Writer.LogPosition,
+				Writer.NextRecordPosition,
 				0,
 				eventStreamId,
 				expectedVersion,
@@ -366,7 +366,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 
 		protected IPrepareLogRecord<TStreamId> WriteTransactionEnd(Guid correlationId, long transactionId, TStreamId eventStreamId) {
 			LogFormatHelper<TLogFormat, TStreamId>.CheckIfExplicitTransactionsSupported();
-			var prepare = LogRecord.TransactionEnd(_recordFactory, Writer.LogPosition,
+			var prepare = LogRecord.TransactionEnd(_recordFactory, Writer.NextRecordPosition,
 				correlationId,
 				Guid.NewGuid(),
 				transactionId,
@@ -401,7 +401,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 
 		protected CommitLogRecord WriteCommit(long preparePos, string eventStreamName, long eventNumber) {
 			LogFormatHelper<TLogFormat, TStreamId>.CheckIfExplicitTransactionsSupported();
-			var commit = LogRecord.Commit(Writer.LogPosition, Guid.NewGuid(), preparePos, eventNumber);
+			var commit = LogRecord.Commit(Writer.NextRecordPosition, Guid.NewGuid(), preparePos, eventNumber);
 			long pos;
 			Assert.IsTrue(Writer.Write(commit, out pos));
 			return commit;
@@ -415,7 +415,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 
 		protected long WriteCommit(Guid correlationId, long transactionId, TStreamId eventStreamId, long eventNumber) {
 			LogFormatHelper<TLogFormat, TStreamId>.CheckIfExplicitTransactionsSupported();
-			var commit = LogRecord.Commit(Writer.LogPosition, correlationId, transactionId, eventNumber);
+			var commit = LogRecord.Commit(Writer.NextRecordPosition, correlationId, transactionId, eventNumber);
 			long pos;
 			Assert.IsTrue(Writer.Write(commit, out pos));
 			return commit.LogPosition;
@@ -427,7 +427,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			var prepare = LogRecord.DeleteTombstone(_recordFactory, pos,
 				Guid.NewGuid(), Guid.NewGuid(), eventStreamId, streamDeletedEventTypeId, EventNumber.DeletedStream - 1);
 			Assert.IsTrue(Writer.Write(prepare, out pos));
-			var commit = LogRecord.Commit(Writer.LogPosition,
+			var commit = LogRecord.Commit(Writer.NextRecordPosition,
 				prepare.CorrelationId,
 				prepare.LogPosition,
 				EventNumber.DeletedStream);
@@ -450,7 +450,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		protected CommitLogRecord WriteDeleteCommit(IPrepareLogRecord prepare) {
 			LogFormatHelper<TLogFormat, TStreamId>.CheckIfExplicitTransactionsSupported();
 			long pos;
-			var commit = LogRecord.Commit(Writer.LogPosition,
+			var commit = LogRecord.Commit(Writer.NextRecordPosition,
 				prepare.CorrelationId,
 				prepare.LogPosition,
 				EventNumber.DeletedStream);

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -100,7 +100,6 @@ namespace EventStore.Core.Tests.Services.Storage {
 			Writer.Open();
 			WriteTestScenario();
 			Writer.Close();
-			Writer = null;
 
 			WriterCheckpoint.Flush();
 			ChaserCheckpoint.Write(WriterCheckpoint.Read());

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -176,7 +176,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		protected abstract void WriteTestScenario();
 
 		protected void GetOrReserve(string eventStreamName, out TStreamId eventStreamId, out long newPos) {
-			newPos = WriterCheckpoint.ReadNonFlushed();
+			newPos = Writer.LogPosition;
 			_streamNameIndex.GetOrReserve(_logFormat.RecordFactory, eventStreamName, newPos, out eventStreamId, out var streamRecord);
 			if (streamRecord != null) {
 				Writer.Write(streamRecord, out newPos);
@@ -184,7 +184,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		}
 		
 		protected void GetOrReserveEventType(string eventType, out TStreamId eventTypeId, out long newPos) {
-			newPos = WriterCheckpoint.ReadNonFlushed();
+			newPos = Writer.LogPosition;
 			_eventTypeIndex.GetOrReserveEventType(_logFormat.RecordFactory, eventType, newPos, out eventTypeId, out var eventTypeRecord);
 			if (eventTypeRecord != null) {
 				Writer.Write(eventTypeRecord, out newPos);
@@ -231,7 +231,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			}
 
 			
-			var commit = LogRecord.Commit(WriterCheckpoint.ReadNonFlushed(), prepare.CorrelationId, prepare.LogPosition,
+			var commit = LogRecord.Commit(Writer.LogPosition, prepare.CorrelationId, prepare.LogPosition,
 				eventNumber);
 			if (!retryOnFail) {
 				Assert.IsTrue(Writer.Write(commit, out pos));
@@ -267,7 +267,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				PrepareFlags.IsJson);
 			Assert.IsTrue(Writer.Write(prepare, out pos));
 
-			var commit = LogRecord.Commit(WriterCheckpoint.ReadNonFlushed(), prepare.CorrelationId, prepare.LogPosition,
+			var commit = LogRecord.Commit(Writer.LogPosition, prepare.CorrelationId, prepare.LogPosition,
 				eventNumber);
 			Assert.IsTrue(Writer.Write(commit, out pos));
 			Assert.AreEqual(eventStreamId, prepare.EventStreamId);
@@ -284,7 +284,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			var prepare = LogRecord.Prepare(_recordFactory, pos,
 				Guid.NewGuid(),
 				Guid.NewGuid(),
-				WriterCheckpoint.ReadNonFlushed(),
+				Writer.LogPosition,
 				0,
 				eventStreamId,
 				expectedVersion,
@@ -366,7 +366,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 
 		protected IPrepareLogRecord<TStreamId> WriteTransactionEnd(Guid correlationId, long transactionId, TStreamId eventStreamId) {
 			LogFormatHelper<TLogFormat, TStreamId>.CheckIfExplicitTransactionsSupported();
-			var prepare = LogRecord.TransactionEnd(_recordFactory, WriterCheckpoint.ReadNonFlushed(),
+			var prepare = LogRecord.TransactionEnd(_recordFactory, Writer.LogPosition,
 				correlationId,
 				Guid.NewGuid(),
 				transactionId,
@@ -401,7 +401,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 
 		protected CommitLogRecord WriteCommit(long preparePos, string eventStreamName, long eventNumber) {
 			LogFormatHelper<TLogFormat, TStreamId>.CheckIfExplicitTransactionsSupported();
-			var commit = LogRecord.Commit(WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), preparePos, eventNumber);
+			var commit = LogRecord.Commit(Writer.LogPosition, Guid.NewGuid(), preparePos, eventNumber);
 			long pos;
 			Assert.IsTrue(Writer.Write(commit, out pos));
 			return commit;
@@ -415,7 +415,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 
 		protected long WriteCommit(Guid correlationId, long transactionId, TStreamId eventStreamId, long eventNumber) {
 			LogFormatHelper<TLogFormat, TStreamId>.CheckIfExplicitTransactionsSupported();
-			var commit = LogRecord.Commit(WriterCheckpoint.ReadNonFlushed(), correlationId, transactionId, eventNumber);
+			var commit = LogRecord.Commit(Writer.LogPosition, correlationId, transactionId, eventNumber);
 			long pos;
 			Assert.IsTrue(Writer.Write(commit, out pos));
 			return commit.LogPosition;
@@ -427,7 +427,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			var prepare = LogRecord.DeleteTombstone(_recordFactory, pos,
 				Guid.NewGuid(), Guid.NewGuid(), eventStreamId, streamDeletedEventTypeId, EventNumber.DeletedStream - 1);
 			Assert.IsTrue(Writer.Write(prepare, out pos));
-			var commit = LogRecord.Commit(WriterCheckpoint.ReadNonFlushed(),
+			var commit = LogRecord.Commit(Writer.LogPosition,
 				prepare.CorrelationId,
 				prepare.LogPosition,
 				EventNumber.DeletedStream);
@@ -450,7 +450,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 		protected CommitLogRecord WriteDeleteCommit(IPrepareLogRecord prepare) {
 			LogFormatHelper<TLogFormat, TStreamId>.CheckIfExplicitTransactionsSupported();
 			long pos;
-			var commit = LogRecord.Commit(WriterCheckpoint.ReadNonFlushed(),
+			var commit = LogRecord.Commit(Writer.LogPosition,
 				prepare.CorrelationId,
 				prepare.LogPosition,
 				EventNumber.DeletedStream);

--- a/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ReadIndexTestScenario.cs
@@ -99,6 +99,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 			Writer = new TFChunkWriter(Db);
 			Writer.Open();
 			WriteTestScenario();
+			Writer.Commit();
 			Writer.Close();
 
 			WriterCheckpoint.Flush();

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
@@ -16,11 +16,11 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 
 			GetOrReserve("s1", out var s1StreamId, out _);
 			GetOrReserveEventType("event-type", out var eventTypeId, out _);
-			var transPos = WriterCheckpoint.ReadNonFlushed();
+			var transPos = Writer.LogPosition;
 
 			for (int i = 0; i < 10; ++i) {
 				long tmp;
-				var r = LogRecord.Prepare(_recordFactory, WriterCheckpoint.ReadNonFlushed(),
+				var r = LogRecord.Prepare(_recordFactory, Writer.LogPosition,
 					Guid.NewGuid(),
 					Guid.NewGuid(),
 					transPos,

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
@@ -16,11 +16,11 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 
 			GetOrReserve("s1", out var s1StreamId, out _);
 			GetOrReserveEventType("event-type", out var eventTypeId, out _);
-			var transPos = Writer.LogPosition;
+			var transPos = Writer.NextRecordPosition;
 
 			for (int i = 0; i < 10; ++i) {
 				long tmp;
-				var r = LogRecord.Prepare(_recordFactory, Writer.LogPosition,
+				var r = LogRecord.Prepare(_recordFactory, Writer.NextRecordPosition,
 					Guid.NewGuid(),
 					Guid.NewGuid(),
 					transPos,

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
@@ -19,24 +19,24 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 
 		protected override void WriteTestScenario() {
 			// Stream that will be kept
-			_event1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.LogPosition,
+			_event1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.NextRecordPosition,
 				0);
-			_event2 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.LogPosition,
+			_event2 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.NextRecordPosition,
 				1);
 
 			// Stream that will be deleted
-			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, Writer.LogPosition,
+			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, Writer.NextRecordPosition,
 				0);
-			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, Writer.LogPosition,
+			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, Writer.NextRecordPosition,
 				1);
 			_deleted = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId,
-				Writer.LogPosition, int.MaxValue - 1,
+				Writer.NextRecordPosition, int.MaxValue - 1,
 				PrepareFlags.StreamDelete | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd);
 
 			// Stream that will be kept
-			_event3 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.LogPosition,
+			_event3 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.NextRecordPosition,
 				2);
-			_event4 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.LogPosition,
+			_event4 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.NextRecordPosition,
 				3);
 
 			Writer.CompleteChunk();

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
@@ -19,24 +19,24 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 
 		protected override void WriteTestScenario() {
 			// Stream that will be kept
-			_event1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			_event1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.LogPosition,
 				0);
-			_event2 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			_event2 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.LogPosition,
 				1);
 
 			// Stream that will be deleted
-			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, Writer.LogPosition,
 				0);
-			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, Writer.LogPosition,
 				1);
 			_deleted = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId,
-				WriterCheckpoint.ReadNonFlushed(), int.MaxValue - 1,
+				Writer.LogPosition, int.MaxValue - 1,
 				PrepareFlags.StreamDelete | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd);
 
 			// Stream that will be kept
-			_event3 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			_event3 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.LogPosition,
 				2);
-			_event4 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			_event4 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.LogPosition,
 				3);
 
 			Writer.CompleteChunk();

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
@@ -22,37 +22,37 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		private long _t2CommitPos, _t1CommitPos, _postCommitPos;
 
 		protected override void WriteTestScenario() {
-			var t1 = WriteTransactionBeginV0(Guid.NewGuid(), Writer.LogPosition, _streamIdOne,
+			var t1 = WriteTransactionBeginV0(Guid.NewGuid(), Writer.NextRecordPosition, _streamIdOne,
 				ExpectedVersion.NoStream);
-			var t2 = WriteTransactionBeginV0(Guid.NewGuid(), Writer.LogPosition, _streamIdTwo,
+			var t2 = WriteTransactionBeginV0(Guid.NewGuid(), Writer.NextRecordPosition, _streamIdTwo,
 				ExpectedVersion.NoStream);
 
-			_p1 = WriteTransactionEventV0(t1.CorrelationId, Writer.LogPosition, t1.LogPosition, 0,
+			_p1 = WriteTransactionEventV0(t1.CorrelationId, Writer.NextRecordPosition, t1.LogPosition, 0,
 				t1.EventStreamId, 0, "es1", PrepareFlags.Data);
-			_p2 = WriteTransactionEventV0(t2.CorrelationId, Writer.LogPosition, t2.LogPosition, 0,
+			_p2 = WriteTransactionEventV0(t2.CorrelationId, Writer.NextRecordPosition, t2.LogPosition, 0,
 				t2.EventStreamId, 0, "abc1", PrepareFlags.Data);
-			_p3 = WriteTransactionEventV0(t1.CorrelationId, Writer.LogPosition, t1.LogPosition, 1,
+			_p3 = WriteTransactionEventV0(t1.CorrelationId, Writer.NextRecordPosition, t1.LogPosition, 1,
 				t1.EventStreamId, 1, "es1", PrepareFlags.Data);
-			_p4 = WriteTransactionEventV0(t2.CorrelationId, Writer.LogPosition, t2.LogPosition, 1,
+			_p4 = WriteTransactionEventV0(t2.CorrelationId, Writer.NextRecordPosition, t2.LogPosition, 1,
 				t2.EventStreamId, 1, "abc1", PrepareFlags.Data);
-			_p5 = WriteTransactionEventV0(t1.CorrelationId, Writer.LogPosition, t1.LogPosition, 2,
+			_p5 = WriteTransactionEventV0(t1.CorrelationId, Writer.NextRecordPosition, t1.LogPosition, 2,
 				t1.EventStreamId, 2, "es1", PrepareFlags.Data);
 
-			WriteTransactionEndV0(t2.CorrelationId, Writer.LogPosition, t2.TransactionPosition,
+			WriteTransactionEndV0(t2.CorrelationId, Writer.NextRecordPosition, t2.TransactionPosition,
 				t2.EventStreamId);
-			WriteTransactionEndV0(t1.CorrelationId, Writer.LogPosition, t1.TransactionPosition,
+			WriteTransactionEndV0(t1.CorrelationId, Writer.NextRecordPosition, t1.TransactionPosition,
 				t1.EventStreamId);
 
-			_t2CommitPos = WriteCommitV0(t2.CorrelationId, Writer.LogPosition, t2.TransactionPosition,
+			_t2CommitPos = WriteCommitV0(t2.CorrelationId, Writer.NextRecordPosition, t2.TransactionPosition,
 				t2.EventStreamId, 0, out _postCommitPos);
-			_t1CommitPos = WriteCommitV0(t1.CorrelationId, Writer.LogPosition, t1.TransactionPosition,
+			_t1CommitPos = WriteCommitV0(t1.CorrelationId, Writer.NextRecordPosition, t1.TransactionPosition,
 				t1.EventStreamId, 0, out _postCommitPos);
 
 			Writer.CompleteChunk();
 
 			// Need to have a second chunk as otherwise the checkpoints will be off
 			_random1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), "random-stream",
-				Writer.LogPosition, 0);
+				Writer.NextRecordPosition, 0);
 
 			Scavenge(completeLast: false, mergeChunks: true);
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
@@ -22,37 +22,37 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		private long _t2CommitPos, _t1CommitPos, _postCommitPos;
 
 		protected override void WriteTestScenario() {
-			var t1 = WriteTransactionBeginV0(Guid.NewGuid(), WriterCheckpoint.ReadNonFlushed(), _streamIdOne,
+			var t1 = WriteTransactionBeginV0(Guid.NewGuid(), Writer.LogPosition, _streamIdOne,
 				ExpectedVersion.NoStream);
-			var t2 = WriteTransactionBeginV0(Guid.NewGuid(), WriterCheckpoint.ReadNonFlushed(), _streamIdTwo,
+			var t2 = WriteTransactionBeginV0(Guid.NewGuid(), Writer.LogPosition, _streamIdTwo,
 				ExpectedVersion.NoStream);
 
-			_p1 = WriteTransactionEventV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.LogPosition, 0,
+			_p1 = WriteTransactionEventV0(t1.CorrelationId, Writer.LogPosition, t1.LogPosition, 0,
 				t1.EventStreamId, 0, "es1", PrepareFlags.Data);
-			_p2 = WriteTransactionEventV0(t2.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t2.LogPosition, 0,
+			_p2 = WriteTransactionEventV0(t2.CorrelationId, Writer.LogPosition, t2.LogPosition, 0,
 				t2.EventStreamId, 0, "abc1", PrepareFlags.Data);
-			_p3 = WriteTransactionEventV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.LogPosition, 1,
+			_p3 = WriteTransactionEventV0(t1.CorrelationId, Writer.LogPosition, t1.LogPosition, 1,
 				t1.EventStreamId, 1, "es1", PrepareFlags.Data);
-			_p4 = WriteTransactionEventV0(t2.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t2.LogPosition, 1,
+			_p4 = WriteTransactionEventV0(t2.CorrelationId, Writer.LogPosition, t2.LogPosition, 1,
 				t2.EventStreamId, 1, "abc1", PrepareFlags.Data);
-			_p5 = WriteTransactionEventV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.LogPosition, 2,
+			_p5 = WriteTransactionEventV0(t1.CorrelationId, Writer.LogPosition, t1.LogPosition, 2,
 				t1.EventStreamId, 2, "es1", PrepareFlags.Data);
 
-			WriteTransactionEndV0(t2.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t2.TransactionPosition,
+			WriteTransactionEndV0(t2.CorrelationId, Writer.LogPosition, t2.TransactionPosition,
 				t2.EventStreamId);
-			WriteTransactionEndV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.TransactionPosition,
+			WriteTransactionEndV0(t1.CorrelationId, Writer.LogPosition, t1.TransactionPosition,
 				t1.EventStreamId);
 
-			_t2CommitPos = WriteCommitV0(t2.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t2.TransactionPosition,
+			_t2CommitPos = WriteCommitV0(t2.CorrelationId, Writer.LogPosition, t2.TransactionPosition,
 				t2.EventStreamId, 0, out _postCommitPos);
-			_t1CommitPos = WriteCommitV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.TransactionPosition,
+			_t1CommitPos = WriteCommitV0(t1.CorrelationId, Writer.LogPosition, t1.TransactionPosition,
 				t1.EventStreamId, 0, out _postCommitPos);
 
 			Writer.CompleteChunk();
 
 			// Need to have a second chunk as otherwise the checkpoints will be off
 			_random1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), "random-stream",
-				WriterCheckpoint.ReadNonFlushed(), 0);
+				Writer.LogPosition, 0);
 
 			Scavenge(completeLast: false, mergeChunks: true);
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
@@ -130,11 +130,33 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		}
 
 		[Test]
-		public void when_in_first_extraneous_files_throws_corrupt_database_exception() {
+		public void one_sequential_extraneous_file_does_not_throw_corrupt_database_exception() {
 			var config = TFChunkHelper.CreateDbConfig(PathName, 9000);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000000"));
+				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
+			}
+		}
+
+		[Test]
+		public void one_sequential_extraneous_file_with_non_zero_version_throws_corrupt_database_exception() {
+			var config = TFChunkHelper.CreateDbConfig(PathName, 9000);
+			using (var db = new TFChunkDb(config)) {
+				DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
+				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"));
+				Assert.That(() => db.Open(verifyHash: false),
+					Throws.Exception.InstanceOf<CorruptDatabaseException>()
+						.With.InnerException.InstanceOf<ExtraneousFileFoundException>());
+			}
+		}
+
+		[Test]
+		public void one_non_sequential_extraneous_file_throws_corrupt_database_exception() {
+			var config = TFChunkHelper.CreateDbConfig(PathName, 9000);
+			using (var db = new TFChunkDb(config)) {
+				DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
+				DbUtil.CreateSingleChunk(config, 2, GetFilePathFor("chunk-000002.000000"));
 				Assert.That(() => db.Open(verifyHash: false),
 					Throws.Exception.InstanceOf<CorruptDatabaseException>()
 						.With.InnerException.InstanceOf<ExtraneousFileFoundException>());
@@ -147,11 +169,12 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateOngoingChunk(config, 1, GetFilePathFor("chunk-000001.000000"));
-				DbUtil.CreateSingleChunk(config, 2, GetFilePathFor("chunk-000002.000000"));
+				DbUtil.CreateSingleChunk(config, 2, GetFilePathFor("chunk-000002.000000")); // extraneous file, but valid case
+				DbUtil.CreateSingleChunk(config, 3, GetFilePathFor("chunk-000003.000000")); // extraneous file
 				Assert.That(() => db.Open(verifyHash: false),
 					Throws.Exception.InstanceOf<CorruptDatabaseException>()
 						.With.InnerException.InstanceOf<ExtraneousFileFoundException>()
-						.With.InnerException.Message.Contains("chunk-000002.000000"));
+						.With.InnerException.Message.Contains("chunk-000003.000000"));
 			}
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_chasing_a_chunked_transaction_log.cs
@@ -147,6 +147,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			writer.Open();
 			long pos;
 			Assert.IsTrue(writer.Write(recordToWrite, out pos));
+			writer.Commit();
 			writer.Close();
 
 			writerchk.Write(recordToWrite.GetSizeWithLengthPrefixAndSuffix());
@@ -194,6 +195,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			writer.Open();
 			long pos;
 			Assert.IsTrue(writer.Write(recordToWrite, out pos));
+			writer.Commit();
 			writer.Close();
 
 			writerchk.Write(recordToWrite.GetSizeWithLengthPrefixAndSuffix());

--- a/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
@@ -72,7 +72,9 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var writer = new TFChunkWriter(_db);
 			Assert.IsTrue(writer.Write(CreateRecord(), out _));
-			_db.Config.ChaserCheckpoint.Write(_db.Config.WriterCheckpoint.ReadNonFlushed());
+
+			_db.Config.WriterCheckpoint.Write(writer.LogPosition); // move the writer checkpoint, but don't flush it yet
+			_db.Config.ChaserCheckpoint.Write(1);
 
 			_db.Close();
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
@@ -72,9 +72,9 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var writer = new TFChunkWriter(_db);
 			Assert.IsTrue(writer.Write(CreateRecord(), out _));
+			writer.Commit();
 
-			_db.Config.WriterCheckpoint.Write(writer.LogPosition); // move the writer checkpoint, but don't flush it yet
-			_db.Config.ChaserCheckpoint.Write(1);
+			_db.Config.ChaserCheckpoint.Write(1); // any non-zero value just to test if the checkpoint is flushed
 
 			_db.Close();
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_reading_an_empty_chunked_transaction_log.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_reading_an_empty_chunked_transaction_log.cs
@@ -45,7 +45,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 			var rec = LogRecord.SingleWrite(recordFactory, 0, Guid.NewGuid(), Guid.NewGuid(), streamId, -1, eventTypeId, new byte[] {7}, null);
 			long tmp;
 			Assert.IsTrue(writer.Write(rec, out tmp));
-			writer.Flush();
+			writer.Commit();
 			writer.Close();
 
 			var res = reader.TryReadNext();

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_a_new_chunked_transaction_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_a_new_chunked_transaction_file.cs
@@ -43,6 +43,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				metadata: new byte[] {7, 17});
 			long tmp;
 			tf.Write(record, out tmp);
+			tf.Commit();
 			tf.Close();
 			db.Dispose();
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum.cs
@@ -50,6 +50,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				metadata: new byte[] {7, 17});
 			long tmp;
 			tf.Write(record, out tmp);
+			tf.Commit();
 			tf.Close();
 			db.Dispose();
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum_and_data_bigger_than_buffer.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_checksum_and_data_bigger_than_buffer.cs
@@ -58,6 +58,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			long pos;
 			Assert.IsTrue(writer.Write(record, out pos));
+			writer.Commit();
 			writer.Close();
 			db.Dispose();
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_not_enough_space_in_chunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_an_existing_chunked_transaction_file_with_not_enough_space_in_chunk.cs
@@ -85,6 +85,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				data: new byte[] {1, 2, 3, 4, 5},
 				metadata: new byte[2000]);
 			Assert.IsTrue(tf.Write(record3, out pos));
+			tf.Commit();
 			tf.Close();
 			db.Dispose();
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_commit_record_to_file.cs
@@ -32,6 +32,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				firstEventNumber: 10);
 			long newPos;
 			_writer.Write(_record, out newPos);
+			_writer.Commit();
 			_writer.Flush();
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_prepare_record_to_file.cs
@@ -48,6 +48,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 				metadata: new byte[] {7, 17});
 			long newPos;
 			_writer.Write(_record, out newPos);
+			_writer.Commit();
 			_writer.Flush();
 		}
 

--- a/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
@@ -142,8 +142,11 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 	}
 	
 	class FakeWriter: ITransactionFileWriter {
+		public long LogPosition { get; }
+		public long CommittedLogPosition { get; }
+		public long FlushedLogPosition { get; }
+
 		public FakeWriter() {
-			Checkpoint = new InMemoryCheckpoint();
 			WrittenRecords = new List<ILogRecord>();
 		}
 		
@@ -158,13 +161,12 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 			return true;
 		}
 
+		public void Commit() {}
+
 		public void Flush() {
 			IsFlushed = true;
 		}
 		public void Close() {}
-
-		public ICheckpoint Checkpoint { get; }
-		
 		public void Dispose() {}
 	}
 	

--- a/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
@@ -142,9 +142,9 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 	}
 	
 	class FakeWriter: ITransactionFileWriter {
-		public long LogPosition { get; }
-		public long CommittedLogPosition { get; }
-		public long FlushedLogPosition { get; }
+		public long NextRecordPosition { get; }
+		public long CommittedPosition { get; }
+		public long FlushedPosition { get; }
 
 		public FakeWriter() {
 			WrittenRecords = new List<ILogRecord>();

--- a/src/EventStore.Core/LogV3/PartitionManager.cs
+++ b/src/EventStore.Core/LogV3/PartitionManager.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.LogV3 {
 			// below code only takes into account offline truncation
 			if (!RootTypeId.HasValue) {
 				RootTypeId = Guid.NewGuid();
-				long pos = _writer.Checkpoint.ReadNonFlushed();
+				long pos = _writer.LogPosition;
 				var rootPartitionType = _recordFactory.CreatePartitionTypeRecord(
 					timeStamp: DateTime.UtcNow,
 					logPosition: pos,
@@ -57,7 +57,7 @@ namespace EventStore.Core.LogV3 {
 
 			if (!RootId.HasValue) {
 				RootId = Guid.NewGuid();
-				long pos = _writer.Checkpoint.ReadNonFlushed();
+				long pos = _writer.LogPosition;
 				var rootPartition = _recordFactory.CreatePartitionRecord(
 					timeStamp: DateTime.UtcNow,
 					logPosition: pos, 

--- a/src/EventStore.Core/LogV3/PartitionManager.cs
+++ b/src/EventStore.Core/LogV3/PartitionManager.cs
@@ -50,6 +50,7 @@ namespace EventStore.Core.LogV3 {
 				if (!_writer.Write(rootPartitionType, out pos))
 					throw new Exception($"Failed to write root partition type!");
 
+				_writer.Commit();
 				_writer.Flush();
 				
 				_log.Debug("Root partition type created, id: {id}", RootTypeId);
@@ -71,6 +72,7 @@ namespace EventStore.Core.LogV3 {
 				if (!_writer.Write(rootPartition, out pos))
 					throw new Exception($"Failed to write root partition!");
 
+				_writer.Commit();
 				_writer.Flush();
 
 				_recordFactory.SetRootPartitionId(RootId.Value);

--- a/src/EventStore.Core/LogV3/PartitionManager.cs
+++ b/src/EventStore.Core/LogV3/PartitionManager.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.LogV3 {
 			// below code only takes into account offline truncation
 			if (!RootTypeId.HasValue) {
 				RootTypeId = Guid.NewGuid();
-				long pos = _writer.LogPosition;
+				long pos = _writer.NextRecordPosition;
 				var rootPartitionType = _recordFactory.CreatePartitionTypeRecord(
 					timeStamp: DateTime.UtcNow,
 					logPosition: pos,
@@ -58,7 +58,7 @@ namespace EventStore.Core.LogV3 {
 
 			if (!RootId.HasValue) {
 				RootId = Guid.NewGuid();
-				long pos = _writer.LogPosition;
+				long pos = _writer.NextRecordPosition;
 				var rootPartition = _recordFactory.CreatePartitionRecord(
 					timeStamp: DateTime.UtcNow,
 					logPosition: pos, 

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -219,7 +219,7 @@ namespace EventStore.Core.Services {
 			Bus.Publish(new ReplicationMessage.AckLogPosition(
 				subscriptionId: _subscriptionId,
 				replicationLogPosition: _ackedSubscriptionPos,
-				writerLogPosition: Writer.CommittedLogPosition));
+				writerLogPosition: Writer.CommittedPosition));
 		}
 
 		public void Handle(ReplicationMessage.RawChunkBulk message) {
@@ -270,7 +270,7 @@ namespace EventStore.Core.Services {
 				Bus.Publish(new ReplicationMessage.AckLogPosition(
 					subscriptionId: _subscriptionId,
 					replicationLogPosition: _ackedSubscriptionPos,
-					writerLogPosition: Writer.CommittedLogPosition));
+					writerLogPosition: Writer.CommittedPosition));
 			}
 		}
 
@@ -336,7 +336,7 @@ namespace EventStore.Core.Services {
 					subscriptionId: _subscriptionId,
 					replicationLogPosition: _ackedSubscriptionPos,
 					// we leave it up to the Flush call above whether to truly flush or not
-					writerLogPosition: Writer.CommittedLogPosition));
+					writerLogPosition: Writer.CommittedPosition));
 			}
 		}
 

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -216,7 +216,7 @@ namespace EventStore.Core.Services {
 			Bus.Publish(new ReplicationMessage.AckLogPosition(
 				subscriptionId: _subscriptionId,
 				replicationLogPosition: _ackedSubscriptionPos,
-				writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
+				writerLogPosition: Writer.LogPosition));
 		}
 
 		public void Handle(ReplicationMessage.RawChunkBulk message) {
@@ -267,7 +267,7 @@ namespace EventStore.Core.Services {
 				Bus.Publish(new ReplicationMessage.AckLogPosition(
 					subscriptionId: _subscriptionId,
 					replicationLogPosition: _ackedSubscriptionPos,
-					writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
+					writerLogPosition: Writer.LogPosition));
 			}
 		}
 
@@ -326,7 +326,7 @@ namespace EventStore.Core.Services {
 					subscriptionId: _subscriptionId,
 					replicationLogPosition: _ackedSubscriptionPos,
 					// we leave it up to the Flush call above whether to truly flush or not
-					writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
+					writerLogPosition: Writer.LogPosition));
 			}
 		}
 

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -312,6 +312,9 @@ namespace EventStore.Core.Services {
 
 					_subscriptionPos = chunk.ChunkHeader.ChunkEndPosition;
 					_framer.Reset();
+				} else {
+					// we do not want to commit at chunk boundaries since it's not necessarily a transaction boundary
+					Commit();
 				}
 			} catch (Exception exc) {
 				Log.Error(exc, "Exception in writer.");

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -216,7 +216,7 @@ namespace EventStore.Core.Services {
 			Bus.Publish(new ReplicationMessage.AckLogPosition(
 				subscriptionId: _subscriptionId,
 				replicationLogPosition: _ackedSubscriptionPos,
-				writerLogPosition: Writer.LogPosition));
+				writerLogPosition: Writer.CommittedLogPosition));
 		}
 
 		public void Handle(ReplicationMessage.RawChunkBulk message) {
@@ -267,7 +267,7 @@ namespace EventStore.Core.Services {
 				Bus.Publish(new ReplicationMessage.AckLogPosition(
 					subscriptionId: _subscriptionId,
 					replicationLogPosition: _ackedSubscriptionPos,
-					writerLogPosition: Writer.LogPosition));
+					writerLogPosition: Writer.CommittedLogPosition));
 			}
 		}
 
@@ -329,7 +329,7 @@ namespace EventStore.Core.Services {
 					subscriptionId: _subscriptionId,
 					replicationLogPosition: _ackedSubscriptionPos,
 					// we leave it up to the Flush call above whether to truly flush or not
-					writerLogPosition: Writer.LogPosition));
+					writerLogPosition: Writer.CommittedLogPosition));
 			}
 		}
 

--- a/src/EventStore.Core/Services/Replication/TransactionTracker.cs
+++ b/src/EventStore.Core/Services/Replication/TransactionTracker.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.TransactionLog.LogRecords;
+
+namespace EventStore.Core.Services.Replication;
+
+public record TrackerRecord;
+public record TrackerLogRecord : TrackerRecord {
+	public ILogRecord LogRecord { get; init; }
+}
+
+public record CompleteChunkRecord : TrackerRecord {
+	public int ChunkStartNumber { get; init; } = -1;
+	public int ChunkEndNumber { get; init; } = -1;
+}
+
+public class TransactionTracker {
+	private readonly List<TrackerRecord> _records = new();
+	public IEnumerable<TrackerRecord> Records => _records;
+	public bool IsChunkCompletionPending { get; private set; }
+
+	public void Track(ILogRecord record, out bool canCommit) {
+		_records.Add(new TrackerLogRecord {
+			LogRecord = record
+		});
+
+		if (record is IPrepareLogRecord prepare
+		    && prepare.Flags.HasFlag(PrepareFlags.IsCommitted)
+		    && !prepare.Flags.HasFlag(PrepareFlags.TransactionEnd)) {
+			canCommit = false;
+			return;
+		}
+
+		// at the moment, all other log record types are atomic and can immediately be written to the log
+		canCommit = true;
+	}
+
+	public bool CanCompleteChunk(int chunkStartNumber, int chunkEndNumber) {
+		if (_records.Count == 0)
+			return true;
+
+		_records.Add(new CompleteChunkRecord {
+			ChunkStartNumber = chunkStartNumber,
+			ChunkEndNumber = chunkEndNumber
+		});
+
+		IsChunkCompletionPending = true;
+
+		return false;
+	}
+
+	public void Clear() {
+		_records.Clear();
+		IsChunkCompletionPending = false;
+	}
+}

--- a/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -114,7 +114,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 					if (epochPos < 0) {
 						// we probably have lost/uninitialized epoch checkpoint scan back to find the most recent epoch in the log
 						Log.Information("No epoch checkpoint. Scanning log backwards for most recent epoch...");
-						reader.Reposition(_writer.FlushedLogPosition);
+						reader.Reposition(_writer.FlushedPosition);
 
 						SeqReadResult result;
 						while ((result = reader.TryReadPrev()).Success) {
@@ -296,7 +296,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 
 		private EpochRecord WriteEpochRecordWithRetry(int epochNumber, Guid epochId, long lastEpochPosition,
 			Guid instanceId) {
-			long pos = _writer.LogPosition;
+			long pos = _writer.NextRecordPosition;
 			var epoch = new EpochRecord(pos, epochNumber, epochId, lastEpochPosition, DateTime.UtcNow, instanceId);
 			var rec = _recordFactory.CreateEpoch(epoch);
 
@@ -335,7 +335,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 			if (!TryGetExpectedVersionForEpochInformation(epoch, out var expectedVersion))
 				expectedVersion = ExpectedVersion.NoStream;
 
-			var originalLogPosition = _writer.LogPosition;
+			var originalLogPosition = _writer.NextRecordPosition;
 
 			var epochInformation = LogRecord.Prepare(
 					factory: _recordFactory,

--- a/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -312,6 +312,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 			}
 			_partitionManager.Initialize();
 			WriteEpochInformationWithRetry(epoch);
+			_writer.Commit();
 			_writer.Flush();
 			_bus.Publish(new ReplicationTrackingMessage.WriterCheckpointFlushed());
 			_bus.Publish(new SystemMessage.EpochWritten(epoch));

--- a/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -114,7 +114,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 					if (epochPos < 0) {
 						// we probably have lost/uninitialized epoch checkpoint scan back to find the most recent epoch in the log
 						Log.Information("No epoch checkpoint. Scanning log backwards for most recent epoch...");
-						reader.Reposition(_writer.Checkpoint.Read());
+						reader.Reposition(_writer.FlushedLogPosition);
 
 						SeqReadResult result;
 						while ((result = reader.TryReadPrev()).Success) {
@@ -296,7 +296,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 
 		private EpochRecord WriteEpochRecordWithRetry(int epochNumber, Guid epochId, long lastEpochPosition,
 			Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.LogPosition;
 			var epoch = new EpochRecord(pos, epochNumber, epochId, lastEpochPosition, DateTime.UtcNow, instanceId);
 			var rec = _recordFactory.CreateEpoch(epoch);
 
@@ -334,7 +334,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 			if (!TryGetExpectedVersionForEpochInformation(epoch, out var expectedVersion))
 				expectedVersion = ExpectedVersion.NoStream;
 
-			var originalLogPosition = _writer.Checkpoint.ReadNonFlushed();
+			var originalLogPosition = _writer.LogPosition;
 
 			var epochInformation = LogRecord.Prepare(
 					factory: _recordFactory,

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -335,6 +335,8 @@ namespace EventStore.Core.Services.Storage {
 					SoftUndeleteStream(streamId, commitCheck.CurrentVersion + 1);
 				if (softUndeleteMetastream)
 					SoftUndeleteMetastream(streamId);
+
+				Commit();
 			} catch (Exception exc) {
 				Log.Error(exc, "Exception in writer.");
 				throw;
@@ -469,6 +471,8 @@ namespace EventStore.Core.Services.Storage {
 							data, null));
 					_indexWriter.PreCommit(new[] { res.Prepare });
 				}
+
+				Commit();
 			} catch (Exception exc) {
 				Log.Error(exc, "Exception in writer.");
 				throw;
@@ -493,6 +497,8 @@ namespace EventStore.Core.Services.Storage {
 				// we update cache to avoid non-cached look-up on next TransactionWrite
 				_indexWriter.UpdateTransactionInfo(res.WrittenPos, res.WrittenPos,
 					new TransactionInfo<TStreamId>(-1, streamId));
+
+				Commit();
 			} catch (Exception exc) {
 				Log.Error(exc, "Exception in writer.");
 				throw;
@@ -536,6 +542,8 @@ namespace EventStore.Core.Services.Storage {
 						transactionInfo.EventStreamId);
 					_indexWriter.UpdateTransactionInfo(message.TransactionId, lastLogPosition, info);
 				}
+
+				Commit();
 			} catch (Exception exc) {
 				Log.Error(exc, "Exception in writer.");
 				throw;
@@ -560,6 +568,8 @@ namespace EventStore.Core.Services.Storage {
 					message.TransactionId,
 					transactionInfo.EventStreamId);
 				WritePrepareWithRetry(record);
+
+				Commit();
 			} catch (Exception exc) {
 				Log.Error(exc, "Exception in writer.");
 				throw;
@@ -610,6 +620,8 @@ namespace EventStore.Core.Services.Storage {
 					SoftUndeleteStream(commitCheck.EventStreamId, commitCheck.CurrentVersion + 1);
 				if (softUndeleteMetastream)
 					SoftUndeleteMetastream(commitCheck.EventStreamId);
+
+				Commit();
 			} catch (Exception exc) {
 				Log.Error(exc, "Exception in writer.");
 				throw;
@@ -707,6 +719,10 @@ namespace EventStore.Core.Services.Storage {
 			}
 
 			return commit;
+		}
+
+		protected void Commit() {
+			Writer.Commit();
 		}
 
 		protected bool Flush(bool force = false) {

--- a/src/EventStore.Core/Services/Storage/StorageWriterService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageWriterService.cs
@@ -236,7 +236,12 @@ namespace EventStore.Core.Services.Storage {
 				_vnodeState != VNodeState.PreReadOnlyReplica)
 				throw new Exception(string.Format("{0} appeared in {1} state.", message.GetType().Name, _vnodeState));
 
-			if (Writer.FlushedLogPosition != Writer.LogPosition) {
+			if (Writer.CommittedLogPosition != Writer.LogPosition)
+				throw new Exception("Invariant failure: " +
+				                    $"writer's log position ({Writer.LogPosition}) does not match " +
+				                    $"writer's committed position ({Writer.CommittedLogPosition})");
+
+			if (Writer.FlushedLogPosition != Writer.CommittedLogPosition) {
 				Writer.Flush();
 				Bus.Publish(new ReplicationTrackingMessage.WriterCheckpointFlushed());
 			}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkDb.cs
@@ -237,13 +237,19 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			return chunkFooter;
 		}
 
-		private static void EnsureNoExcessiveChunks(TFChunkEnumerator chunkEnumerator, int lastChunkNum) {
+		private void EnsureNoExcessiveChunks(TFChunkEnumerator chunkEnumerator, int lastChunkNum) {
 			var extraneousFiles = new List<string>();
 
 			foreach (var chunkInfo in chunkEnumerator.EnumerateChunks(lastChunkNum)) {
 				switch (chunkInfo) {
-					case LatestVersion(var fileName, var start, _):
-						if (start > lastChunkNum)
+					case LatestVersion(var fileName, var start, var end):
+						// there can be at most one excessive chunk at startup:
+						// a new chunk was created but the writer checkpoint was not yet committed and flushed
+						if (start == lastChunkNum + 1 &&
+						    start == end &&
+						    Config.FileNamingStrategy.GetVersionFor(Path.GetFileName(fileName)) == 0)
+							RemoveFile("Removing excessive chunk: {chunk}", fileName);
+						else if (start > lastChunkNum)
 							extraneousFiles.Add(fileName);
 						break;
 					case OldVersion(var fileName, var start):

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -7,9 +7,8 @@ using Serilog.Events;
 
 namespace EventStore.Core.TransactionLog.Chunks {
 	public class TFChunkWriter : ITransactionFileWriter {
-		public ICheckpoint Checkpoint {
-			get { return _writerCheckpoint; }
-		}
+		public long LogPosition => _writerPosition;
+		public long FlushedLogPosition => _writerCheckpoint.Read();
 
 		public TFChunk.TFChunk CurrentChunk {
 			get { return _currentChunk; }

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -8,6 +8,7 @@ using Serilog.Events;
 namespace EventStore.Core.TransactionLog.Chunks {
 	public class TFChunkWriter : ITransactionFileWriter {
 		public long LogPosition => _writerPosition;
+		public long CommittedLogPosition => _writerCheckpoint.ReadNonFlushed();
 		public long FlushedLogPosition => _writerCheckpoint.Read();
 
 		public TFChunk.TFChunk CurrentChunk {
@@ -53,6 +54,10 @@ namespace EventStore.Core.TransactionLog.Chunks {
 				CompleteChunk(); // complete updates checkpoint internally
 			newPos = _writerPosition;
 			return result.Success;
+		}
+
+		public void Commit() {
+			_writerCheckpoint.Write(_writerPosition);
 		}
 
 		public void CompleteChunk() {
@@ -121,7 +126,6 @@ namespace EventStore.Core.TransactionLog.Chunks {
 			if (_currentChunk == null) // the last chunk allocation failed
 				return;
 			_currentChunk.Flush();
-			_writerCheckpoint.Write(_writerPosition);
 			_writerCheckpoint.Flush();
 		}
 	}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -7,9 +7,9 @@ using Serilog.Events;
 
 namespace EventStore.Core.TransactionLog.Chunks {
 	public class TFChunkWriter : ITransactionFileWriter {
-		public long LogPosition => _writerPosition;
-		public long CommittedLogPosition => _writerCheckpoint.ReadNonFlushed();
-		public long FlushedLogPosition => _writerCheckpoint.Read();
+		public long NextRecordPosition => _writerPosition;
+		public long CommittedPosition => _writerCheckpoint.ReadNonFlushed();
+		public long FlushedPosition => _writerCheckpoint.Read();
 
 		public TFChunk.TFChunk CurrentChunk {
 			get { return _currentChunk; }

--- a/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
@@ -6,10 +6,12 @@ namespace EventStore.Core.TransactionLog {
 	public interface ITransactionFileWriter : IDisposable {
 		void Open();
 		bool Write(ILogRecord record, out long newPos);
+		void Commit();
 		void Flush();
 		void Close();
 
 		long LogPosition { get; }
+		long CommittedLogPosition { get; }
 		long FlushedLogPosition { get; }
 	}
 }

--- a/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
@@ -10,8 +10,8 @@ namespace EventStore.Core.TransactionLog {
 		void Flush();
 		void Close();
 
-		long LogPosition { get; }
-		long CommittedLogPosition { get; }
-		long FlushedLogPosition { get; }
+		long NextRecordPosition { get; }
+		long CommittedPosition { get; }
+		long FlushedPosition { get; }
 	}
 }

--- a/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
@@ -9,6 +9,7 @@ namespace EventStore.Core.TransactionLog {
 		void Flush();
 		void Close();
 
-		ICheckpoint Checkpoint { get; }
+		long LogPosition { get; }
+		long FlushedLogPosition { get; }
 	}
 }


### PR DESCRIPTION
Fixed: Prevent torn implicit transactions

- Move writer checkpoint across transaction boundaries, not across each log record
- Do not flush writer checkpoint when completing a chunk