### PR TITLE
Torn transactions (1/3): Prevent at chunk boundaries on the leader node (DB-64)

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -118,7 +118,7 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 			Guid eventId = default(Guid),
 			string eventType = "some-type") {
 
-			long pos = WriterCheckpoint.ReadNonFlushed();
+			long pos = Writer.Position;
 			_logFormatFactory.StreamNameIndex.GetOrReserve(
 				_logFormatFactory.RecordFactory,
 				eventStreamName,

--- a/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkTests.cs
+++ b/src/EventStore.Core.Tests/Services/RedactionService/SwitchChunkTests.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Services.RedactionService {
 			WriteSingleEvent(StreamId, 7, new string('7', 50), retryOnFail: true);
 			WriteSingleEvent(StreamId, 8, new string('8', 50), retryOnFail: true);
 
-			var writerPos = Db.Config.WriterCheckpoint.Read();
+			var writerPos = Writer.Position;
 			var chunk = Path.GetFileName(Db.Manager.GetChunkFor(writerPos).FileName);
 			var chunkNum = Db.Config.FileNamingStrategy.GetIndexFor(chunk);
 			Assert.AreEqual(2, chunkNum);

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -200,7 +200,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(4), out _);
 			EpochManager.WriteNewEpoch(1);
 
-			var subscribePosition = Db.Config.WriterCheckpoint.ReadNonFlushed() + 1000;
+			var subscribePosition = Writer.Position + 1000;
 			_replicaEpochs = new List<Epoch> {
 				new Epoch(subscribePosition, 2, Guid.NewGuid()),
 			};
@@ -215,7 +215,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
 				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
 			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(Db.Config.WriterCheckpoint.ReadNonFlushed(), subscribed[0].SubscriptionPosition);
+			Assert.AreEqual(Writer.Position, subscribed[0].SubscriptionPosition);
 			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
 			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
 		}
@@ -237,7 +237,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 			Writer.Write(CreateLogRecord(4), out _);
 			EpochManager.WriteNewEpoch(4);
 
-			var subscribePosition = Db.Config.WriterCheckpoint.ReadNonFlushed() + 1000;
+			var subscribePosition = Writer.Position + 1000;
 			_replicaEpochs = new List<Epoch> {
 				new Epoch(subscribePosition, 2, Guid.NewGuid()),
 			};

--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/with_replication_service_and_epoch_manager.cs
@@ -101,7 +101,7 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 		public IPrepareLogRecord<TStreamId> CreateLogRecord(long eventNumber, string data = "*************") {
 			var tStreamId = LogFormatHelper<TLogFormat, TStreamId>.StreamId;
 			var eventType = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
-			return LogRecord.Prepare(_logFormat.RecordFactory, Db.Config.WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(), 0, 0,
+			return LogRecord.Prepare(_logFormat.RecordFactory, Writer.Position, Guid.NewGuid(), Guid.NewGuid(), 0, 0,
 				tStreamId, eventNumber, PrepareFlags.None, eventType, Encoding.UTF8.GetBytes(data),
 				null, DateTime.UtcNow);
 		}

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_a_single_write_before_the_transaction_is_present.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_a_single_write_before_the_transaction_is_present.cs
@@ -13,9 +13,9 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 				Rec.TransSt(1, "transaction_stream_id"),
 				Rec.Prepare(1, "transaction_stream_id"),
 				Rec.TransEnd(1, "transaction_stream_id"),
-				Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
-				Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
-				Rec.Prepare(4, "single_write_stream_id_4", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted));
+				Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
+				Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
+				Rec.Prepare(4, "single_write_stream_id_4", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted));
 
 			var firstRead = ReadIndex.ReadAllEventsForward(new Data.TFPos(0, 0), 10);
 
@@ -30,9 +30,9 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 				Rec.TransSt(1, "transaction_stream_id"),
 				Rec.Prepare(1, "transaction_stream_id"),
 				Rec.TransEnd(1, "transaction_stream_id"),
-				Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
-				Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
-				Rec.Prepare(4, "single_write_stream_id_4", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+				Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
+				Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
+				Rec.Prepare(4, "single_write_stream_id_4", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
 				Rec.Commit(1, "transaction_stream_id"));
 
 			var transactionRead = ReadIndex.ReadAllEventsForward(firstRead.NextPos, 10);

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_a_single_write_is_after_transaction_end_but_before_commit_is_present.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_a_single_write_is_after_transaction_end_but_before_commit_is_present.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			CreateDb(Rec.TransSt(0, "transaction_stream_id"),
 				Rec.Prepare(0, "transaction_stream_id"),
 				Rec.TransEnd(0, "transaction_stream_id"),
-				Rec.Prepare(1, "single_write_stream_id", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted));
+				Rec.Prepare(1, "single_write_stream_id", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted));
 
 			var firstRead = ReadIndex.ReadAllEventsForward(new Data.TFPos(0, 0), 10);
 
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			CreateDb(Rec.TransSt(0, "transaction_stream_id"),
 				Rec.Prepare(0, "transaction_stream_id"),
 				Rec.TransEnd(0, "transaction_stream_id"),
-				Rec.Prepare(1, "single_write_stream_id", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+				Rec.Prepare(1, "single_write_stream_id", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
 				Rec.Commit(0, "transaction_stream_id"));
 
 			var transactionRead = ReadIndex.ReadAllEventsForward(firstRead.NextPos, 10);

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_multiple_single_writes_are_after_transaction_end_but_before_commit_is_present.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_multiple_single_writes_are_after_transaction_end_but_before_commit_is_present.cs
@@ -18,9 +18,9 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			CreateDb(Rec.TransSt(0, "transaction_stream_id"),
 				Rec.Prepare(0, "transaction_stream_id"),
 				Rec.TransEnd(0, "transaction_stream_id"),
-				Rec.Prepare(1, "single_write_stream_id_1", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
-				Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
-				Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted));
+				Rec.Prepare(1, "single_write_stream_id_1", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
+				Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
+				Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted));
 
 			var firstRead = ReadIndex.ReadAllEventsForward(new Data.TFPos(0, 0), 10);
 
@@ -33,9 +33,9 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 			CreateDb(Rec.TransSt(0, "transaction_stream_id"),
 				Rec.Prepare(0, "transaction_stream_id"),
 				Rec.TransEnd(0, "transaction_stream_id"),
-				Rec.Prepare(1, "single_write_stream_id_1", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
-				Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
-				Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.Data | PrepareFlags.IsCommitted),
+				Rec.Prepare(1, "single_write_stream_id_1", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
+				Rec.Prepare(2, "single_write_stream_id_2", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
+				Rec.Prepare(3, "single_write_stream_id_3", prepareFlags: PrepareFlags.SingleWrite | PrepareFlags.IsCommitted),
 				Rec.Commit(0, "transaction_stream_id"));
 
 			var transactionRead = ReadIndex.ReadAllEventsForward(firstRead.NextPos, 10);

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_disallowed_streams.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_disallowed_streams.cs
@@ -31,7 +31,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 				retryOnFail: true); //allowed
 
 			_forwardReadPos = new TFPos(firstEvent.LogPosition, firstEvent.LogPosition);
-			_backwardReadPos = new TFPos(WriterCheckpoint.ReadNonFlushed(), WriterCheckpoint.ReadNonFlushed());
+			_backwardReadPos = new TFPos(Writer.Position, Writer.Position);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/AllReader/when_reading_all_with_filtering.cs
@@ -24,7 +24,7 @@ namespace EventStore.Core.Tests.Services.Storage.AllReader {
 				retryOnFail: true);
 
 			_forwardReadPos = new TFPos(firstEvent.LogPosition, firstEvent.LogPosition);
-			_backwardReadPos = new TFPos(WriterCheckpoint.ReadNonFlushed(), WriterCheckpoint.ReadNonFlushed());
+			_backwardReadPos = new TFPos(Writer.Position, Writer.Position);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/Services/Storage/ChunkBoundary/when_writing_implicit_transaction_at_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ChunkBoundary/when_writing_implicit_transaction_at_chunk_boundary.cs
@@ -1,0 +1,34 @@
+using System;
+using EventStore.Core.Data;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.ChunkBoundary;
+
+// Note: this test does not verify the behaviour of the StorageWriterService.
+// It only verifies if TFChunkWriter works properly.
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+public class when_writing_implicit_transaction_at_chunk_boundary<TLogFormat, TStreamId> : ReadIndexTestScenario<TLogFormat, TStreamId> {
+	private long _writerChk;
+
+	protected override void WriteTestScenario() {
+		WriteEvents("ES", 5, new[] {
+			new Event(Guid.NewGuid(), "type", false, new string('.', 4000), null), // chunk 0
+			new Event(Guid.NewGuid(), "type", false, new string('.', 4000), null),
+			new Event(Guid.NewGuid(), "type", false, new string('.', 4000), null), // chunk 1
+			new Event(Guid.NewGuid(), "type", false, new string('.', 4000), null)
+		});
+
+		// verify that the writer is in the correct chunk
+		var chunk = WriterCheckpoint.ReadNonFlushed() / Db.Config.ChunkSize;
+		Assert.AreEqual(1, chunk);
+
+		_writerChk = WriterCheckpoint.Read();
+	}
+
+	[Test]
+	public void writer_checkpoint_is_not_flushed() {
+		Assert.AreEqual(0, _writerChk);
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/ChunkBoundary/when_writing_single_events_at_chunk_boundary.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/ChunkBoundary/when_writing_single_events_at_chunk_boundary.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Storage.ChunkBoundary;
+
+// Note: this test does not verify the behaviour of the StorageWriterService.
+// It only verifies if TFChunkWriter works properly.
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+public class when_writing_single_events_at_chunk_boundary<TLogFormat, TStreamId> : ReadIndexTestScenario<TLogFormat, TStreamId> {
+	private long _writerChk;
+
+	protected override void WriteTestScenario() {
+		WriteSingleEvent("ES", 0, new string('.', 4000));
+		WriteSingleEvent("ES", 1, new string('.', 4000));
+		WriteSingleEvent("ES", 2, new string('.', 4000), retryOnFail: true); // chunk 1
+
+		// verify that the writer is in the correct chunk
+		var chunk = WriterCheckpoint.ReadNonFlushed() / Db.Config.ChunkSize;
+		Assert.AreEqual(1, chunk);
+
+		_writerChk = WriterCheckpoint.Read();
+	}
+
+	[Test]
+	public void writer_checkpoint_is_not_flushed() {
+		Assert.AreEqual(0, _writerChk);
+	}
+}

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_hard_deleting_stream_with_log_version_0.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_hard_deleting_stream_with_log_version_0.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 
 		private void WriteV0HardDelete(string eventStreamId) {
 			long pos;
-			var logPosition = WriterCheckpoint.ReadNonFlushed();
+			var logPosition = Writer.Position;
 			var prepare = new PrepareLogRecord(logPosition, Guid.NewGuid(), Guid.NewGuid(), logPosition, 0,
 				eventStreamId,
 				int.MaxValue - 1, DateTime.UtcNow,
@@ -30,7 +30,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 				prepareRecordVersion: LogRecordVersion.LogRecordV0);
 			Writer.Write(prepare, out pos);
 
-			var commit = new CommitLogRecord(WriterCheckpoint.ReadNonFlushed(), prepare.CorrelationId,
+			var commit = new CommitLogRecord(pos, prepare.CorrelationId,
 				prepare.LogPosition, DateTime.UtcNow, int.MaxValue,
 				commitRecordVersion: LogRecordVersion.LogRecordV0);
 			Writer.Write(commit, out pos);

--- a/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_delete_prepare_but_no_commit_read_index_should.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/DeletingStream/when_writing_delete_prepare_but_no_commit_read_index_should.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Tests.Services.Storage.DeletingStream {
 			var eventTypeId = LogFormatHelper<TLogFormat, TStreamId>.EventTypeId;
 			_event0 = WriteSingleEvent("ES", 0, "bla1");
 			Assert.True(_logFormat.StreamNameIndex.GetOrReserve("ES", out var esStreamId, out _, out _));
-			var prepare = LogRecord.DeleteTombstone(_recordFactory, WriterCheckpoint.ReadNonFlushed(), Guid.NewGuid(), Guid.NewGuid(),
+			var prepare = LogRecord.DeleteTombstone(_recordFactory, Writer.Position, Guid.NewGuid(), Guid.NewGuid(),
 				esStreamId, eventTypeId, 1);
 			long pos;
 			Assert.IsTrue(Writer.Write(prepare, out pos));

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_TFLog_with_existing_epochs.cs
@@ -63,7 +63,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.Position;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_having_an_epoch_manager_and_empty_tf_log.cs
@@ -62,7 +62,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.Position;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
 				SystemRecordSerialization.Json, epoch.AsSerialized());

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_starting_having_TFLog_with_existing_epochs.cs
@@ -61,7 +61,7 @@ namespace EventStore.Core.Tests.Services.Storage {
 				.GetValue(_epochManager);
 		}
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.Position;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = new SystemLogRecord(epoch.EpochPosition, epoch.TimeStamp, SystemRecordType.Epoch,
 				SystemRecordSerialization.Json, epoch.AsSerialized());

--- a/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/EpochManager/when_truncating_the_epoch_checkpoint.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.Services.Storage.EpochManager {
 		private const int CachedEpochCount = 10;
 
 		private EpochRecord WriteEpoch(int epochNumber, long lastPos, Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.Position;
 			var epoch = new EpochRecord(pos, epochNumber, Guid.NewGuid(), lastPos, DateTime.UtcNow, instanceId);
 			var rec = _logFormat.RecordFactory.CreateEpoch(epoch);
 			_writer.Write(rec, out _);

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_having_commit_spanning_multiple_chunks.cs
@@ -16,11 +16,10 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 
 			GetOrReserve("s1", out var s1StreamId, out _);
 			GetOrReserveEventType("event-type", out var eventTypeId, out _);
-			var transPos = WriterCheckpoint.ReadNonFlushed();
+			var transPos = Writer.Position;
 
 			for (int i = 0; i < 10; ++i) {
-				long tmp;
-				var r = LogRecord.Prepare(_recordFactory, WriterCheckpoint.ReadNonFlushed(),
+				var r = LogRecord.Prepare(_recordFactory, Writer.Position,
 					Guid.NewGuid(),
 					Guid.NewGuid(),
 					transPos,
@@ -31,7 +30,7 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 					eventTypeId,
 					new byte[3],
 					new byte[3]);
-				Assert.IsTrue(Writer.Write(r, out tmp));
+				Assert.IsTrue(Writer.Write(r, out _));
 				Writer.CompleteChunk();
 
 				_scavenged.Add(r);

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_and_deleted_records.cs
@@ -19,24 +19,24 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 
 		protected override void WriteTestScenario() {
 			// Stream that will be kept
-			_event1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			_event1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.Position,
 				0);
-			_event2 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			_event2 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.Position,
 				1);
 
 			// Stream that will be deleted
-			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, Writer.Position,
 				0);
-			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId, Writer.Position,
 				1);
 			_deleted = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _deletedEventStreamId,
-				WriterCheckpoint.ReadNonFlushed(), int.MaxValue - 1,
+				Writer.Position, int.MaxValue - 1,
 				PrepareFlags.StreamDelete | PrepareFlags.TransactionBegin | PrepareFlags.TransactionEnd);
 
 			// Stream that will be kept
-			_event3 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			_event3 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.Position,
 				2);
-			_event4 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, WriterCheckpoint.ReadNonFlushed(),
+			_event4 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), _eventStreamId, Writer.Position,
 				3);
 
 			Writer.CompleteChunk();

--- a/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
+++ b/src/EventStore.Core.Tests/Services/Storage/Scavenge/when_scavenging_tfchunk_with_version0_log_records_using_transactions.cs
@@ -22,37 +22,37 @@ namespace EventStore.Core.Tests.Services.Storage.Scavenge {
 		private long _t2CommitPos, _t1CommitPos, _postCommitPos;
 
 		protected override void WriteTestScenario() {
-			var t1 = WriteTransactionBeginV0(Guid.NewGuid(), WriterCheckpoint.ReadNonFlushed(), _streamIdOne,
+			var t1 = WriteTransactionBeginV0(Guid.NewGuid(), Writer.Position, _streamIdOne,
 				ExpectedVersion.NoStream);
-			var t2 = WriteTransactionBeginV0(Guid.NewGuid(), WriterCheckpoint.ReadNonFlushed(), _streamIdTwo,
+			var t2 = WriteTransactionBeginV0(Guid.NewGuid(), Writer.Position, _streamIdTwo,
 				ExpectedVersion.NoStream);
 
-			_p1 = WriteTransactionEventV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.LogPosition, 0,
+			_p1 = WriteTransactionEventV0(t1.CorrelationId, Writer.Position, t1.LogPosition, 0,
 				t1.EventStreamId, 0, "es1", PrepareFlags.Data);
-			_p2 = WriteTransactionEventV0(t2.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t2.LogPosition, 0,
+			_p2 = WriteTransactionEventV0(t2.CorrelationId, Writer.Position, t2.LogPosition, 0,
 				t2.EventStreamId, 0, "abc1", PrepareFlags.Data);
-			_p3 = WriteTransactionEventV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.LogPosition, 1,
+			_p3 = WriteTransactionEventV0(t1.CorrelationId, Writer.Position, t1.LogPosition, 1,
 				t1.EventStreamId, 1, "es1", PrepareFlags.Data);
-			_p4 = WriteTransactionEventV0(t2.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t2.LogPosition, 1,
+			_p4 = WriteTransactionEventV0(t2.CorrelationId, Writer.Position, t2.LogPosition, 1,
 				t2.EventStreamId, 1, "abc1", PrepareFlags.Data);
-			_p5 = WriteTransactionEventV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.LogPosition, 2,
+			_p5 = WriteTransactionEventV0(t1.CorrelationId, Writer.Position, t1.LogPosition, 2,
 				t1.EventStreamId, 2, "es1", PrepareFlags.Data);
 
-			WriteTransactionEndV0(t2.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t2.TransactionPosition,
+			WriteTransactionEndV0(t2.CorrelationId, Writer.Position, t2.TransactionPosition,
 				t2.EventStreamId);
-			WriteTransactionEndV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.TransactionPosition,
+			WriteTransactionEndV0(t1.CorrelationId, Writer.Position, t1.TransactionPosition,
 				t1.EventStreamId);
 
-			_t2CommitPos = WriteCommitV0(t2.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t2.TransactionPosition,
+			_t2CommitPos = WriteCommitV0(t2.CorrelationId, Writer.Position, t2.TransactionPosition,
 				t2.EventStreamId, 0, out _postCommitPos);
-			_t1CommitPos = WriteCommitV0(t1.CorrelationId, WriterCheckpoint.ReadNonFlushed(), t1.TransactionPosition,
+			_t1CommitPos = WriteCommitV0(t1.CorrelationId, Writer.Position, t1.TransactionPosition,
 				t1.EventStreamId, 0, out _postCommitPos);
 
 			Writer.CompleteChunk();
 
 			// Need to have a second chunk as otherwise the checkpoints will be off
 			_random1 = WriteSingleEventWithLogVersion0(Guid.NewGuid(), "random-stream",
-				WriterCheckpoint.ReadNonFlushed(), 0);
+				Writer.Position, 0);
 
 			Scavenge(completeLast: false, mergeChunks: true);
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Scavenging/Helpers/ScavengeLifeCycleScenario.cs
@@ -33,7 +33,7 @@ namespace EventStore.Core.Tests.TransactionLog.Scavenging.Helpers {
 				.Chunk().CompleteLastChunk()
 				.Chunk().CompleteLastChunk()
 				.Chunk()
-				.CreateDb();
+				.CreateDb(commit: true);
 
 			_dbResult.Db.Config.WriterCheckpoint.Flush();
 			_dbResult.Db.Config.ChaserCheckpoint.Write(_dbResult.Db.Config.WriterCheckpoint.Read());

--- a/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Validation/when_validating_tfchunk_db.cs
@@ -130,11 +130,33 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 		}
 
 		[Test]
-		public void when_in_first_extraneous_files_throws_corrupt_database_exception() {
+		public void one_sequential_extraneous_file_does_not_throw_corrupt_database_exception() {
 			var config = TFChunkHelper.CreateDbConfig(PathName, 9000);
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000000"));
+				Assert.DoesNotThrow(() => db.Open(verifyHash: false));
+			}
+		}
+
+		[Test]
+		public void one_sequential_extraneous_file_with_non_zero_version_throws_corrupt_database_exception() {
+			var config = TFChunkHelper.CreateDbConfig(PathName, 9000);
+			using (var db = new TFChunkDb(config)) {
+				DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
+				DbUtil.CreateSingleChunk(config, 1, GetFilePathFor("chunk-000001.000001"));
+				Assert.That(() => db.Open(verifyHash: false),
+					Throws.Exception.InstanceOf<CorruptDatabaseException>()
+						.With.InnerException.InstanceOf<ExtraneousFileFoundException>());
+			}
+		}
+
+		[Test]
+		public void one_non_sequential_extraneous_file_throws_corrupt_database_exception() {
+			var config = TFChunkHelper.CreateDbConfig(PathName, 9000);
+			using (var db = new TFChunkDb(config)) {
+				DbUtil.CreateOngoingChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
+				DbUtil.CreateSingleChunk(config, 2, GetFilePathFor("chunk-000002.000000"));
 				Assert.That(() => db.Open(verifyHash: false),
 					Throws.Exception.InstanceOf<CorruptDatabaseException>()
 						.With.InnerException.InstanceOf<ExtraneousFileFoundException>());
@@ -147,11 +169,12 @@ namespace EventStore.Core.Tests.TransactionLog.Validation {
 			using (var db = new TFChunkDb(config)) {
 				DbUtil.CreateSingleChunk(config, 0, GetFilePathFor("chunk-000000.000000"));
 				DbUtil.CreateOngoingChunk(config, 1, GetFilePathFor("chunk-000001.000000"));
-				DbUtil.CreateSingleChunk(config, 2, GetFilePathFor("chunk-000002.000000"));
+				DbUtil.CreateSingleChunk(config, 2, GetFilePathFor("chunk-000002.000000")); // extraneous file, but valid case
+				DbUtil.CreateSingleChunk(config, 3, GetFilePathFor("chunk-000003.000000")); // extraneous file
 				Assert.That(() => db.Open(verifyHash: false),
 					Throws.Exception.InstanceOf<CorruptDatabaseException>()
 						.With.InnerException.InstanceOf<ExtraneousFileFoundException>()
-						.With.InnerException.Message.Contains("chunk-000002.000000"));
+						.With.InnerException.Message.Contains("chunk-000003.000000"));
 			}
 		}
 

--- a/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_closing_the_database.cs
@@ -72,7 +72,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 			var writer = new TFChunkWriter(_db);
 			Assert.IsTrue(writer.Write(CreateRecord(), out _));
-			_db.Config.ChaserCheckpoint.Write(_db.Config.WriterCheckpoint.ReadNonFlushed());
+
+			_db.Config.ChaserCheckpoint.Write(1); // any non-zero value just to test if the checkpoint is flushed
 
 			_db.Close();
 

--- a/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
@@ -142,8 +142,10 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 	}
 	
 	class FakeWriter: ITransactionFileWriter {
+		public long Position { get; }
+		public long FlushedPosition { get; }
+
 		public FakeWriter() {
-			Checkpoint = new InMemoryCheckpoint();
 			WrittenRecords = new List<ILogRecord>();
 		}
 		
@@ -163,8 +165,6 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 		}
 		public void Close() {}
 
-		public ICheckpoint Checkpoint { get; }
-		
 		public void Dispose() {}
 	}
 	

--- a/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogV3/PartitionManagerTests.cs
@@ -160,9 +160,18 @@ namespace EventStore.Core.XUnit.Tests.LogV3 {
 			return true;
 		}
 
+		public void OpenTransaction() => throw new NotImplementedException();
+
+		public bool WriteToTransaction(ILogRecord record, out long newPos) => throw new NotImplementedException();
+
+		public void CommitTransaction() => throw new NotImplementedException();
+
+		public bool HasOpenTransaction() => throw new NotImplementedException();
+
 		public void Flush() {
 			IsFlushed = true;
 		}
+
 		public void Close() {}
 
 		public void Dispose() {}

--- a/src/EventStore.Core/LogV3/PartitionManager.cs
+++ b/src/EventStore.Core/LogV3/PartitionManager.cs
@@ -39,7 +39,7 @@ namespace EventStore.Core.LogV3 {
 			// below code only takes into account offline truncation
 			if (!RootTypeId.HasValue) {
 				RootTypeId = Guid.NewGuid();
-				long pos = _writer.Checkpoint.ReadNonFlushed();
+				long pos = _writer.Position;
 				var rootPartitionType = _recordFactory.CreatePartitionTypeRecord(
 					timeStamp: DateTime.UtcNow,
 					logPosition: pos,
@@ -57,7 +57,7 @@ namespace EventStore.Core.LogV3 {
 
 			if (!RootId.HasValue) {
 				RootId = Guid.NewGuid();
-				long pos = _writer.Checkpoint.ReadNonFlushed();
+				long pos = _writer.Position;
 				var rootPartition = _recordFactory.CreatePartitionRecord(
 					timeStamp: DateTime.UtcNow,
 					logPosition: pos, 

--- a/src/EventStore.Core/Services/ClusterStorageWriterService.cs
+++ b/src/EventStore.Core/Services/ClusterStorageWriterService.cs
@@ -219,7 +219,7 @@ namespace EventStore.Core.Services {
 			Bus.Publish(new ReplicationMessage.AckLogPosition(
 				subscriptionId: _subscriptionId,
 				replicationLogPosition: _ackedSubscriptionPos,
-				writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
+				writerLogPosition: Writer.Position));
 		}
 
 		public void Handle(ReplicationMessage.RawChunkBulk message) {
@@ -270,7 +270,7 @@ namespace EventStore.Core.Services {
 				Bus.Publish(new ReplicationMessage.AckLogPosition(
 					subscriptionId: _subscriptionId,
 					replicationLogPosition: _ackedSubscriptionPos,
-					writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
+					writerLogPosition: Writer.Position));
 			}
 		}
 
@@ -329,7 +329,7 @@ namespace EventStore.Core.Services {
 					subscriptionId: _subscriptionId,
 					replicationLogPosition: _ackedSubscriptionPos,
 					// we leave it up to the Flush call above whether to truly flush or not
-					writerLogPosition: Writer.Checkpoint.ReadNonFlushed()));
+					writerLogPosition: Writer.Position));
 			}
 		}
 

--- a/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
+++ b/src/EventStore.Core/Services/Storage/EpochManager/EpochManager.cs
@@ -114,7 +114,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 					if (epochPos < 0) {
 						// we probably have lost/uninitialized epoch checkpoint scan back to find the most recent epoch in the log
 						Log.Information("No epoch checkpoint. Scanning log backwards for most recent epoch...");
-						reader.Reposition(_writer.Checkpoint.Read());
+						reader.Reposition(_writer.FlushedPosition);
 
 						SeqReadResult result;
 						while ((result = reader.TryReadPrev()).Success) {
@@ -296,7 +296,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 
 		private EpochRecord WriteEpochRecordWithRetry(int epochNumber, Guid epochId, long lastEpochPosition,
 			Guid instanceId) {
-			long pos = _writer.Checkpoint.ReadNonFlushed();
+			long pos = _writer.Position;
 			var epoch = new EpochRecord(pos, epochNumber, epochId, lastEpochPosition, DateTime.UtcNow, instanceId);
 			var rec = _recordFactory.CreateEpoch(epoch);
 
@@ -334,7 +334,7 @@ namespace EventStore.Core.Services.Storage.EpochManager {
 			if (!TryGetExpectedVersionForEpochInformation(epoch, out var expectedVersion))
 				expectedVersion = ExpectedVersion.NoStream;
 
-			var originalLogPosition = _writer.Checkpoint.ReadNonFlushed();
+			var originalLogPosition = _writer.Position;
 
 			var epochInformation = LogRecord.Prepare(
 					factory: _recordFactory,

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkWriter.cs
@@ -7,9 +7,8 @@ using Serilog.Events;
 
 namespace EventStore.Core.TransactionLog.Chunks {
 	public class TFChunkWriter : ITransactionFileWriter {
-		public ICheckpoint Checkpoint {
-			get { return _writerCheckpoint; }
-		}
+		public long Position => _writerCheckpoint.ReadNonFlushed();
+		public long FlushedPosition => _writerCheckpoint.Read();
 
 		public TFChunk.TFChunk CurrentChunk {
 			get { return _currentChunk; }

--- a/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
@@ -1,5 +1,4 @@
 using System;
-using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.LogRecords;
 
 namespace EventStore.Core.TransactionLog {
@@ -9,6 +8,7 @@ namespace EventStore.Core.TransactionLog {
 		void Flush();
 		void Close();
 
-		ICheckpoint Checkpoint { get; }
+		long Position { get; }
+		long FlushedPosition { get; }
 	}
 }

--- a/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
+++ b/src/EventStore.Core/TransactionLog/ITransactionFileWriter.cs
@@ -5,6 +5,10 @@ namespace EventStore.Core.TransactionLog {
 	public interface ITransactionFileWriter : IDisposable {
 		void Open();
 		bool Write(ILogRecord record, out long newPos);
+		void OpenTransaction();
+		bool WriteToTransaction(ILogRecord record, out long newPos);
+		void CommitTransaction();
+		bool HasOpenTransaction();
 		void Flush();
 		void Close();
 


### PR DESCRIPTION
Fixed: Prevent risk of implicit transactions being partially written when crossing a chunk boundary on the leader node

Parts 2 & 3 are planned to be as follows:
2. Prevent torn transactions when replicating
3. Handle existing torn transactions during index rebuild at startup
