### PR TITLE
Remove outdated instructions from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We also host native packages for Linux on [Package Cloud](https://packagecloud.i
 
 ## Building EventStoreDB
 
-EventStoreDB is written in a mixture of C#, C++ and JavaScript. It can run on Windows, Linux and macOS (using Docker) using the .NET Core runtime. However, the projections library (which uses the V8 javascript engine) contains platform specific code and it must be built for the platform on which you intend to run it.
+EventStoreDB is written in a mixture of C# and JavaScript. It can run on Windows, Linux and macOS (using Docker) using the .NET Core runtime.
 
 ### Windows / Linux
 **Prerequisites**
@@ -50,10 +50,8 @@ The build scripts: `build.sh` and `build.ps1` are also available for Linux and W
 
 To start a single node, you can then run:
 ```
-dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net6.0/EventStore.ClusterNode.dll --insecure --db ./tmp/data --index ./tmp/index --log ./tmp/log -runprojections all --startstandardprojections --EnableAtomPubOverHttp
+dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net6.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
 ```
-
-_Note: The build system has changed after version `5.0.5`, therefore the above instructions will not work for older releases._
 
 ### Running the tests
 You can launch the tests as follows:
@@ -124,24 +122,13 @@ TCP clients:
 
 Note: the TCP protocol is being phased out.
 
-## Building the EventStoreDB web UI
-The [web UI repository](https://github.com/EventStore/EventStore.UI) is a git submodule of the current repository located under `src/EventStore.UI`.
-
-The web UI is prebuilt and the files are located in [src/EventStore.ClusterNode.Web/clusternode-web](src/EventStore.ClusterNode.Web/clusternode-web). However, if you still want to build the latest web UI, there is a parameter in the `build.sh` (`[<build_ui=yes|no>]`) and `build.ps1` (`-BuildUI`) scripts to allow you to do so.
-
-## Building the Projections Library
-The list of precompiled projections libraries can be found in `src/libs/x64`. If you still want to build the projections library please follow the links below.
-- [Windows](scripts/build-js1/build-js1-win/build-js1-win-instructions.md)
-- [Linux](scripts/build-js1/build-js1-linux/README.md)
-- [macOS](scripts/build-js1/build-js1-mac/build-js1-mac.sh)
-
 ## Contributing
 
 Development is done on the `master` branch.
 We attempt to do our best to ensure that the history remains clean and to do so, we generally ask contributors to squash their commits into a set or single logical commit.
 
-If you want to switch to a particular release, you can check out the tag for this particular version. For example:  
-`git checkout oss-v6.0.0-preview1`
+If you want to switch to a particular release, you can check out the release branch for that particular release. For example:  
+`git checkout release/oss-v22.10`
 
 Read more in the [contribution guidelines](./CONTRIBUTING.md).
 


### PR DESCRIPTION
- Remove instructions to build UI (these can still be found in the EventStore.UI repo)
- Remove instructions for building projections, as v8 is no longer used
- Update release branch for contributing guidelines