### PR TITLE
Set TrustedRootCertificatePath to sensible default on Linux

### DIFF
--- a/src/EventStore.Common/Utils/Locations.cs
+++ b/src/EventStore.Common/Utils/Locations.cs
@@ -17,6 +17,7 @@ namespace EventStore.Common.Utils {
 		public static readonly string DefaultLogDirectory;
 		public static readonly string DefaultTestClientLogDirectory;
 		public static readonly string FallbackDefaultDataDirectory;
+		public static readonly string DefaultTrustedRootCertificateDirectory;
 
 		static Locations() {
 			ApplicationDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ??
@@ -31,6 +32,7 @@ namespace EventStore.Common.Utils {
 					DefaultConfigurationDirectory = "/etc/eventstore";
 					DefaultDataDirectory = "/var/lib/eventstore";
 					DefaultLogDirectory = "/var/log/eventstore";
+					DefaultTrustedRootCertificateDirectory = "/etc/ssl/certs";
 					DefaultTestClientLogDirectory = Path.Combine(ApplicationDirectory, "testclientlog");
 					if (!Directory.Exists(PluginsDirectory))
 						PluginsDirectory = Path.Combine(DefaultContentDirectory, "plugins");

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -274,7 +274,8 @@ namespace EventStore.Core {
 		public record CertificateOptions {
 			[Description("The path to a directory which contains trusted X.509 (.pem, .crt, .cer, .der) " +
 			             "root certificate files.")]
-			public string? TrustedRootCertificatesPath { get; init; }
+			public string? TrustedRootCertificatesPath { get; init; } =
+				Locations.DefaultTrustedRootCertificateDirectory;
 
 			[Description("The reserved common name to authenticate EventStoreDB nodes/servers from certificates")]
 			public string CertificateReservedNodeCommonName { get; init; } = "eventstoredb-node";


### PR DESCRIPTION
Added: default location for trusted root certs

fixes #3790
