### PR TITLE
Fixed errors while deleting projections without substreams (DB-22)

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Services/core_projection/when_writing_projection_persisted_state_races_with_stream_deletion.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/core_projection/when_writing_projection_persisted_state_races_with_stream_deletion.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EventStore.Core.Messaging;
+using EventStore.Core.Tests;
+using EventStore.Projections.Core.Messages;
+using EventStore.Projections.Core.Services;
+using EventStore.Projections.Core.Tests.Services.projections_manager;
+using NUnit.Framework;
+
+namespace EventStore.Projections.Core.Tests.Services.core_projection {
+	/**
+	 * tests whether race condition exists or not; currently deleting a projection involves following operations
+	 * 1. Deleting projection "sub-streams" (checkpoint, emitted, etc. streams)
+	 * 2. Writing new projection persisted state to $projection-<projection_name> stream
+	 *
+	 * steps 1 and 2 are independent and gives rise to race condition :
+	 * * if step 2 completes after step 1, multiple ProjectionManagement.Internal.Deleted events will be published
+	 * * in addition, if step 2 completes shortly after step 1, WrongExpectedVersion will be encountered
+	 */
+	
+	public static class when_writing_projection_persisted_state_races_with_stream_deletion {
+		[TestFixture(typeof(LogFormat.V2), typeof(string))]
+		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
+		public class when_projection_persisted_state_write_races_with_projections_substream_deletion<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+			private const string _projectionName = "my-projection";
+
+			protected override void Given() {
+				base.Given();
+				NoOtherStreams();
+				AllWritesSucceed();
+			}
+
+			protected override IEnumerable<WhenStep> When() {
+				yield return (new ProjectionSubsystemMessage.StartComponents(Guid.NewGuid()));
+				yield return
+					(new ProjectionManagementMessage.Command.Post(
+						new PublishEnvelope(_bus), ProjectionMode.Continuous, _projectionName,
+						ProjectionManagementMessage.RunAs.System, "native:" + typeof(FakeProjection).AssemblyQualifiedName,
+						@"", enabled: true, checkpointsEnabled: true,
+						emitEnabled: false, trackEmittedStreams: false));
+				yield return
+					new ProjectionManagementMessage.Command.Disable(new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System);
+				yield return new ProjectionManagementMessage.Command.Delete(new NoopEnvelope(), _projectionName, ProjectionManagementMessage.RunAs.System, 
+					true, false, false);
+			}
+
+			[Test]
+			public void should_publish_single_projection_deleted_event() {
+				Assert.AreEqual(
+					1, _consumer.HandledMessages.OfType<ProjectionManagementMessage.Internal.Deleted>().Count()); }
+		}
+	}
+}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -515,8 +515,7 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		private void DeleteIfConditionsAreMet() {
-			Interlocked.Decrement(ref PersistedProjectionState.NumberOfPrequisitesMetForDeletion);
-			if (PersistedProjectionState.NumberOfPrequisitesMetForDeletion <= 0) {
+			if (Interlocked.Decrement(ref PersistedProjectionState.NumberOfPrequisitesMetForDeletion) <= 0) {
 				Deleted = true;
 				Deleting = false;
 				Reply();
@@ -723,6 +722,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			if (Mode == ProjectionMode.Transient) {
 				//TODO: move to common completion procedure
 				_lastWrittenVersion = PersistedProjectionState.Version ?? -1;
+				_pendingWritePersistedState = false;
 				StartOrLoadStopped();
 				return;
 			}
@@ -781,6 +781,14 @@ namespace EventStore.Projections.Core.Services.Management {
 
 		private void DeleteStreamCompleted(ClientMessage.DeleteStreamCompleted message, string streamId,
 			Action completed) {
+			// this piece of code works because, DeleteStream request is always made with ExpectedVersion.Any
+			// this is a workaround to maintain contract and compatibility with TCP/GRPC/Web clients who expect WrongExpectedVersion in response to deleting non-existing streams
+			if (message.Result == OperationResult.WrongExpectedVersion) {
+				// stream was never created
+				_logger.Information("PROJECTIONS: Projection Stream '{stream}' was not deleted since it does not exist", streamId);
+				completed();
+				return;
+			}
 			if (message.Result == OperationResult.Success || message.Result == OperationResult.StreamDeleted) {
 				_logger.Information("PROJECTIONS: Projection Stream '{stream}' deleted", streamId);
 				completed();
@@ -1022,7 +1030,7 @@ namespace EventStore.Projections.Core.Services.Management {
 			if (_lastReplyEnvelope != null)
 				_lastReplyEnvelope.ReplyWith(new ProjectionManagementMessage.Updated(_name));
 			_lastReplyEnvelope = null;
-			if (Deleted) {
+			if (Deleted && !_pendingWritePersistedState) {
 				DisposeCoreProjection();
 				_output.Publish(new ProjectionManagementMessage.Internal.Deleted(_name, Id));
 			}

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -781,8 +781,9 @@ namespace EventStore.Projections.Core.Services.Management {
 
 		private void DeleteStreamCompleted(ClientMessage.DeleteStreamCompleted message, string streamId,
 			Action completed) {
-			// this piece of code works because, DeleteStream request is always made with ExpectedVersion.Any
-			// this is a workaround to maintain contract and compatibility with TCP/GRPC/Web clients who expect WrongExpectedVersion in response to deleting non-existing streams
+			// currently, WrongExpectedVersion is returned when deleting non-existing streams, even when specifying ExpectedVersion.Any.
+			// it is not too intuitive but changing the response would break the contract and compatibility with TCP/gRPC/web clients or require adding a new error code to all clients.
+			// note: we don't need to check if CurrentVersion == -1 here to make sure it's a non-existing stream since the deletion is done with ExpectedVersion.Any
 			if (message.Result == OperationResult.WrongExpectedVersion) {
 				// stream was never created
 				_logger.Information("PROJECTIONS: Projection Stream '{stream}' was not deleted since it does not exist", streamId);

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsDeleter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsDeleter.cs
@@ -74,7 +74,12 @@ namespace EventStore.Projections.Core.Services.Processing {
 				if (onReadCompleted.Events.Length == 0) {
 					_ioDispatcher.DeleteStream(_emittedStreamsCheckpointStreamId, ExpectedVersion.Any, false,
 						SystemAccounts.System, x => {
-							if (x.Result == OperationResult.Success || x.Result == OperationResult.StreamDeleted) {
+							// this piece of code works because, DeleteStream request is always made with ExpectedVersion.Any
+							// this is a workaround to maintain contract and compatibility with TCP/GRPC/Web clients who expect WrongExpectedVersion in response to deleting non-existing streams
+							if (x.Result == OperationResult.WrongExpectedVersion) {
+								// stream was never created
+								Log.Information("PROJECTIONS: Projection Stream '{stream}' was not deleted since it does not exist", _emittedStreamsCheckpointStreamId);
+							} else if (x.Result == OperationResult.Success || x.Result == OperationResult.StreamDeleted) {
 								Log.Information("PROJECTIONS: Projection Stream '{stream}' deleted",
 									_emittedStreamsCheckpointStreamId);
 							} else {
@@ -84,8 +89,13 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 							_ioDispatcher.DeleteStream(_emittedStreamsId, ExpectedVersion.Any, false,
 								SystemAccounts.System, y => {
-									if (y.Result == OperationResult.Success ||
-									    y.Result == OperationResult.StreamDeleted) {
+									// this piece of code works because, DeleteStream request is always made with ExpectedVersion.Any
+									// this is a workaround to maintain contract and compatibility with TCP/GRPC/Web clients who expect WrongExpectedVersion in response to deleting non-existing streams
+									if (x.Result == OperationResult.WrongExpectedVersion) {
+										// stream was never created
+										Log.Information("PROJECTIONS: Projection Stream '{stream}' was not deleted since it does not exist", _emittedStreamsId);
+									} else if (y.Result == OperationResult.Success ||
+									           y.Result == OperationResult.StreamDeleted) {
 										Log.Information("PROJECTIONS: Projection Stream '{stream}' deleted",
 											_emittedStreamsId);
 									} else {

--- a/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsDeleter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/EmittedStreamsDeleter.cs
@@ -74,8 +74,9 @@ namespace EventStore.Projections.Core.Services.Processing {
 				if (onReadCompleted.Events.Length == 0) {
 					_ioDispatcher.DeleteStream(_emittedStreamsCheckpointStreamId, ExpectedVersion.Any, false,
 						SystemAccounts.System, x => {
-							// this piece of code works because, DeleteStream request is always made with ExpectedVersion.Any
-							// this is a workaround to maintain contract and compatibility with TCP/GRPC/Web clients who expect WrongExpectedVersion in response to deleting non-existing streams
+							// currently, WrongExpectedVersion is returned when deleting non-existing streams, even when specifying ExpectedVersion.Any.
+							// it is not too intuitive but changing the response would break the contract and compatibility with TCP/gRPC/web clients or require adding a new error code to all clients.
+							// note: we don't need to check if CurrentVersion == -1 here to make sure it's a non-existing stream since the deletion is done with ExpectedVersion.Any
 							if (x.Result == OperationResult.WrongExpectedVersion) {
 								// stream was never created
 								Log.Information("PROJECTIONS: Projection Stream '{stream}' was not deleted since it does not exist", _emittedStreamsCheckpointStreamId);
@@ -89,8 +90,9 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 							_ioDispatcher.DeleteStream(_emittedStreamsId, ExpectedVersion.Any, false,
 								SystemAccounts.System, y => {
-									// this piece of code works because, DeleteStream request is always made with ExpectedVersion.Any
-									// this is a workaround to maintain contract and compatibility with TCP/GRPC/Web clients who expect WrongExpectedVersion in response to deleting non-existing streams
+									// currently, WrongExpectedVersion is returned when deleting non-existing streams, even when specifying ExpectedVersion.Any.
+									// it is not too intuitive but changing the response would break the contract and compatibility with TCP/gRPC/web clients or require adding a new error code to all clients.
+									// note: we don't need to check if CurrentVersion == -1 here to make sure it's a non-existing stream since the deletion is done with ExpectedVersion.Any
 									if (x.Result == OperationResult.WrongExpectedVersion) {
 										// stream was never created
 										Log.Information("PROJECTIONS: Projection Stream '{stream}' was not deleted since it does not exist", _emittedStreamsId);


### PR DESCRIPTION
Fixed: race condition in ManagedProjection code when deleting a projection
Fixed: projection code used to throw error if projection substreams (e.g. emitted streams, checkpoint streams etc.) did not exist, when deleting projection