### PR TITLE
Log error message for commonName mismatch when nodes gossip with each other.

### DIFF
--- a/src/EventStore.Common/Utils/CertificateExtensions.cs
+++ b/src/EventStore.Common/Utils/CertificateExtensions.cs
@@ -74,7 +74,7 @@ namespace EventStore.Common.Utils {
 			return cn != null && MatchesName(cn, CertificateNameType.DnsName, name);
 		}
 
-		private static string GetCommonName(X509Certificate2 certificate) => certificate.GetNameInfo(X509NameType.SimpleName, false);
+		public static string GetCommonName(this X509Certificate2 certificate) => certificate.GetNameInfo(X509NameType.SimpleName, false);
 
 		private static bool HasNonAsciiChars(string s) => s.Any(t => t > 127);
 

--- a/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
@@ -19,6 +19,16 @@ namespace EventStore.Core.Certificates {
 
 			var (certificate, intermediates) = _options.LoadNodeCertificate();
 
+			var certificateCN = certificate.GetCommonName();
+			var reservedNodeCN = _options.Certificate.CertificateReservedNodeCommonName;
+
+			if (certificateCN != reservedNodeCN) {
+				Log.Error(
+					"Certificate CN: {certificateCN} does not match with the CertificateReservedNodeCommonName configuration setting: {reservedNodeCN}",
+					certificateCN, reservedNodeCN);
+				return LoadCertificateResult.VerificationFailed;
+			}
+			
 			var previousThumbprint = Certificate?.Thumbprint;
 			var newThumbprint = certificate.Thumbprint;
 			Log.Information("Loading the node's certificate. Subject: {subject}, Previous thumbprint: {previousThumbprint}, New thumbprint: {newThumbprint}",


### PR DESCRIPTION
Fixed: #3791 

This PR logs an error message for common name mismatch when nodes trying to communicate with each other.