### PR TITLE
Projection should be faulted if the last event in the checkpoint stream is not a checkpoint event

### DIFF
--- a/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointWriter.cs
+++ b/src/EventStore.Projections.Core/Services/Processing/CoreProjectionCheckpointWriter.cs
@@ -75,9 +75,9 @@ namespace EventStore.Projections.Core.Services.Processing {
 
 				switch (operationResult) {
 					case OperationResult.WrongExpectedVersion:
-						_envelope.ReplyWith(
-							new CoreProjectionCheckpointWriterMessage.RestartRequested(
-								"Checkpoint stream has been written to from the outside"));
+						_envelope.ReplyWith(new CoreProjectionProcessingMessage.Failed(Guid.Empty,
+							$"Checkpoint stream `{eventStreamId}` has been written to from the outside"
+						));
 						break;
 					case OperationResult.PrepareTimeout:
 					case OperationResult.ForwardTimeout:


### PR DESCRIPTION
Fixed: #2187 

The goal of this PR is to fault the projection in the UI and the stop the restart loop when the last event in the checkpoint stream is not a checkpoint event.