### PR TITLE
Fix build. Two recent PRs did not textually conflict but still caused a compile error

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
+++ b/src/EventStore.Core.XUnit.Tests/Scavenge/Infrastructure/Scenario.cs
@@ -711,7 +711,8 @@ namespace EventStore.Core.XUnit.Tests.Scavenge {
 					writethrough: false,
 					initialReaderCount: 1,
 					maxReaderCount: 1,
-					reduceFileCachePressure: false);
+					reduceFileCachePressure: false,
+					new TFChunkTracker.NoOp());
 
 				newChunk.CompleteScavenge(null);
 


### PR DESCRIPTION
Fixed: Compile error caused by conflicting PRs