### PR TITLE
Removes handlerType from UpdateQuery when we modify projection using the gRPC client (DB-53)

### DIFF
--- a/src/EventStore.Projections.Core.Tests/Integration/system_projections/when_changing_categorization_projection_configurations.cs
+++ b/src/EventStore.Projections.Core.Tests/Integration/system_projections/when_changing_categorization_projection_configurations.cs
@@ -22,11 +22,11 @@ namespace EventStore.Projections.Core.Tests.Integration.system_projections {
 			yield return
 				new ProjectionManagementMessage.Command.UpdateQuery(
 					Envelope, ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection,
-					ProjectionManagementMessage.RunAs.System, handlerType: null, query: query, emitEnabled: null);
+					ProjectionManagementMessage.RunAs.System, query: query, emitEnabled: null);
 			yield return
 				new ProjectionManagementMessage.Command.UpdateQuery(
 					Envelope, ProjectionNamesBuilder.StandardProjections.EventByCategoryStandardProjection,
-					ProjectionManagementMessage.RunAs.System, handlerType: null, query: query, emitEnabled: null);
+					ProjectionManagementMessage.RunAs.System, query: query, emitEnabled: null);
 			yield return
 				new ProjectionManagementMessage.Command.Enable(
 					Envelope, ProjectionNamesBuilder.StandardProjections.StreamByCategoryStandardProjection,

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_failed_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/query/a_failed_projection.cs
@@ -39,7 +39,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.query {
 				yield return
 					(new ProjectionManagementMessage.Command.UpdateQuery(
 						new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.Anonymous,
-						"native:" + typeof(FakeProjection).AssemblyQualifiedName, @"", null));
+						@"", null));
 			}
 
 			[Test]

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_faulted_projection_query_text_invalid_defintion.cs
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			_newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
 			yield return
 				(new ProjectionManagementMessage.Command.UpdateQuery(
-					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System, "JS",
+					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System,
 					_newProjectionSource, emitEnabled: null));
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_emit_enabled_option.cs
@@ -36,7 +36,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			// when
 			yield return
 				(new ProjectionManagementMessage.Command.UpdateQuery(
-					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System, "JS",
+					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System,
 					_source, emitEnabled: false));
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_a_persistent_projection_query_text.cs
@@ -37,7 +37,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			_newProjectionSource = @"fromAll().when({a:function(){return {};}});log(2);";
 			yield return
 				(new ProjectionManagementMessage.Command.UpdateQuery(
-					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System, "JS",
+					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.System,
 					_newProjectionSource, emitEnabled: null));
 		}
 

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/when_updating_an_onetime_projection_query_text.cs
@@ -77,7 +77,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager {
 			_newProjectionSource = @"fromAll(); on_any(function(){});log(2);";
 			yield return
 				(new ProjectionManagementMessage.Command.UpdateQuery(
-					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.Anonymous, "JS",
+					new PublishEnvelope(_bus), _projectionName, ProjectionManagementMessage.RunAs.Anonymous,
 					_newProjectionSource, emitEnabled: null));
 		}
 	}

--- a/src/EventStore.Projections.Core.Tests/Services/projections_system/updating_projections/updating_projection_sources.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_system/updating_projections/updating_projection_sources.cs
@@ -42,7 +42,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_system.updating
 						Envelope, _projectionName, ProjectionManagementMessage.RunAs.System);
 				yield return
 					new ProjectionManagementMessage.Command.UpdateQuery(
-						Envelope, _projectionName, ProjectionManagementMessage.RunAs.System, "js",
+						Envelope, _projectionName, ProjectionManagementMessage.RunAs.System,
 						GivenUpdatedSource(), _emitEnabled);
 				yield return CreateWriteEvent("stream2", "type3", "{\"Data\": 6}");
 				yield return CreateWriteEvent("stream3", "type4", "{\"Data\": 7}");

--- a/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
+++ b/src/EventStore.Projections.Core/Messages/ProjectionManagementMessage.cs
@@ -232,15 +232,13 @@ namespace EventStore.Projections.Core.Messages {
 			[DerivedMessage(ProjectionMessage.Management)]
 			public partial class UpdateQuery : ControlMessage {
 				private readonly string _name;
-				private readonly string _handlerType;
 				private readonly string _query;
 				private readonly bool? _emitEnabled;
 
 				public UpdateQuery(
-					IEnvelope envelope, string name, RunAs runAs, string handlerType, string query, bool? emitEnabled)
+					IEnvelope envelope, string name, RunAs runAs, string query, bool? emitEnabled)
 					: base(envelope, runAs) {
 					_name = name;
-					_handlerType = handlerType;
 					_query = query;
 					_emitEnabled = emitEnabled;
 				}
@@ -251,10 +249,6 @@ namespace EventStore.Projections.Core.Messages {
 
 				public string Name {
 					get { return _name; }
-				}
-
-				public string HandlerType {
-					get { return _handlerType; }
 				}
 
 				public bool? EmitEnabled {

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Update.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Update.cs
@@ -20,7 +20,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				.ConfigureAwait(false)) {
 				throw RpcExceptions.AccessDenied();
 			}
-			const string handlerType = "JS";
+
 			var name = options.Name;
 			var query = options.Query;
 			bool? emitEnabled = (options.EmitOptionCase, options.EmitEnabled) switch {
@@ -33,7 +33,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 
 			var envelope = new CallbackEnvelope(OnMessage);
 			_queue.Publish(
-				new ProjectionManagementMessage.Command.UpdateQuery(envelope, name, runAs, handlerType, query,
+				new ProjectionManagementMessage.Command.UpdateQuery(envelope, name, runAs, query,
 					emitEnabled));
 
 			await updatedSource.Task.ConfigureAwait(false);

--- a/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
+++ b/src/EventStore.Projections.Core/Services/Http/ProjectionsController.cs
@@ -189,9 +189,9 @@ namespace EventStore.Projections.Core.Services.Http {
 			http.ReadTextRequestAsync(
 				(o, s) =>
 					Publish(
-						new ProjectionManagementMessage.Command.UpdateQuery(
-							envelope, match.BoundVariables["name"], GetRunAs(http, match), match.BoundVariables["type"],
-							s, emitEnabled: emitEnabled)), Console.WriteLine);
+				new ProjectionManagementMessage.Command.UpdateQuery(
+					envelope, match.BoundVariables["name"], GetRunAs(http, match),
+					s, emitEnabled: emitEnabled)), Console.WriteLine);
 		}
 
 		private void OnProjectionConfigGet(HttpEntityManager http, UriTemplateMatch match) {

--- a/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ManagedProjection.cs
@@ -993,7 +993,6 @@ namespace EventStore.Projections.Core.Services.Management {
 		}
 
 		private void UpdateQuery(ProjectionManagementMessage.Command.UpdateQuery message) {
-			PersistedProjectionState.HandlerType = message.HandlerType ?? HandlerType;
 			PersistedProjectionState.Query = message.Query;
 			PersistedProjectionState.EmitEnabled = message.EmitEnabled ?? PersistedProjectionState.EmitEnabled;
 			_pendingWritePersistedState = true;

--- a/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
+++ b/src/EventStore.Projections.Core/Services/Management/ProjectionManager.cs
@@ -366,11 +366,11 @@ namespace EventStore.Projections.Core.Services.Management {
 			if (!_projectionsStarted)
 				return;
 			_logger.Information(
-				"Updating '{projection}' projection source to '{source}' (Requested type is: '{type}')",
+				"Updating '{projection}' projection source to '{source}`",
 				message.Name,
-				message.Query,
-				message.HandlerType);
+				message.Query);
 			var projection = GetProjection(message.Name);
+
 			if (projection == null)
 				message.Envelope.ReplyWith(new ProjectionManagementMessage.NotFound());
 			else {


### PR DESCRIPTION
Fixed: Do not change the handlerType of a projection when it is updated

Fixes #3751

Currently the system projections results in faulted when update using gRPC client. The goal of this PR is to remove the handlerType from the update projection so the query can use the existing handler type.