### PR TITLE
Fixed persistent subscription dropped message for TCP client

### DIFF
--- a/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
+++ b/src/EventStore.Core.Tests/Services/PersistentSubscription/PinnedConsumerStrategyTests.cs
@@ -281,7 +281,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			Assert.AreEqual(3, client1Envelope.Replies.Count);
 			Assert.AreEqual(0, client2Envelope.Replies.Count);
 
-			sub.RemoveClientByConnectionId(conn1Id);
+			Assert.IsTrue(sub.RemoveClientByConnectionId(conn1Id));
 
 			// Used to throw a null reference exception.
 			Assert.That(() => sub.RemoveClientByConnectionId(conn2Id), Throws.Nothing);
@@ -314,7 +314,7 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 			Assert.AreEqual(1, client1Envelope.Replies.Count);
 			Assert.AreEqual(1, client2Envelope.Replies.Count);
 
-			sub.RemoveClientByConnectionId(client2Id);
+			Assert.IsTrue(sub.RemoveClientByConnectionId(client2Id));
 
 			// Message 2 should be retried on client 1 as it wasn't acked.
 			Assert.AreEqual(2, client1Envelope.Replies.Count);
@@ -348,11 +348,11 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(24));
 
-			sub.RemoveClientByConnectionId(client2Id);
+			Assert.IsTrue(sub.RemoveClientByConnectionId(client2Id));
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(14));
 
-			sub.RemoveClientByConnectionId(client1Id);
+			Assert.IsTrue(sub.RemoveClientByConnectionId(client1Id));
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(0));
 		}
@@ -393,11 +393,11 @@ namespace EventStore.Core.Tests.Services.PersistentSubscription {
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(22));
 
-			sub.RemoveClientByConnectionId(client2Id);
+			Assert.IsTrue(sub.RemoveClientByConnectionId(client2Id));
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(12));
 
-			sub.RemoveClientByConnectionId(client1Id);
+			Assert.IsTrue(sub.RemoveClientByConnectionId(client1Id));
 
 			Assert.That(consumerStrategy.AvailableCapacity, Is.EqualTo(0));
 		}

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -847,12 +847,13 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void Handle(TcpMessage.ConnectionClosed message) {
-			//TODO CC make a map for this
-			Log.Debug("Persistent subscription lost connection from {remoteEndPoint}",
-				message.Connection.RemoteEndPoint);
-			if (_subscriptionsById == null) return; //havn't built yet.
+			if (_subscriptionsById == null) return; //haven't built yet.
+
 			foreach (var subscription in _subscriptionsById.Values) {
-				subscription.RemoveClientByConnectionId(message.Connection.ConnectionId);
+				if (subscription.RemoveClientByConnectionId(message.Connection.ConnectionId))
+					Log.Debug("Persistent subscription {subscription} lost connection from {remoteEndPoint}",
+						subscription.SubscriptionId,
+						message.Connection.RemoteEndPoint);
 			}
 		}
 


### PR DESCRIPTION
Fixed: #https://github.com/EventStore/home/issues/65

The goal of this PR is to verify whether the dropped TCP connection has any persistent subscription before logging the persistent subscription dropped message in the server logs.