### PR TITLE
Add grpc incoming call metrics (DB-19)

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -32,6 +32,14 @@
 		"StreamTombstone": ""
 	},
 
+	"IncomingGrpcCalls": {
+		"Current": true,
+		"Total" :  true,
+		"Failed": true,
+		"Unimplemented": true,
+		"DeadlineExceeded": true
+	},
+
 	"GossipTrackers": [
 //		"PullFromPeer",
 		"PushToPeer",

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -49,6 +49,14 @@ namespace EventStore.Common.Configuration {
 			Writer,
 		}
 
+		public enum IncomingGrpcCall {
+			Current = 1,
+			Total,
+			Failed,
+			Unimplemented,
+			DeadlineExceeded,
+		}
+
 		public enum GrpcMethod {
 			StreamRead = 1,
 			StreamAppend,
@@ -81,6 +89,8 @@ namespace EventStore.Common.Configuration {
 		public StatusTracker[] StatusTrackers { get; set; } = Array.Empty<StatusTracker>();
 
 		public Checkpoint[] Checkpoints { get; set; } = Array.Empty<Checkpoint>();
+
+		public Dictionary<IncomingGrpcCall, bool> IncomingGrpcCalls { get; set; } = new();
 
 		public Dictionary<GrpcMethod, string> GrpcMethods { get; set; } = new();
 

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/IncomingGrpcCallsMetricTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/IncomingGrpcCallsMetricTests.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using EventStore.Core.Telemetry;
+using Xunit;
+using Conf = EventStore.Common.Configuration.TelemetryConfiguration;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public class IncomingGrpcCallsMetricTests {
+	[EventSource(Name = nameof(IncomingGrpcCallsMetricTests))]
+	private class TestEventSource : EventSource {
+		[Event(1)] public void CallStart() => WriteEvent(1);
+		[Event(2)] public void CallStop() => WriteEvent(2);
+		[Event(3)] public void CallFailed() => WriteEvent(3);
+		[Event(4)] public void CallDeadlineExceeded() => WriteEvent(4);
+		[Event(5)] public void CallUnimplemented() => WriteEvent(5);
+	}
+
+	[Fact]
+	public void can_collect() {
+		using var testSource = new TestEventSource();
+		using var meter = new Meter($"{typeof(IncomingGrpcCallsMetricTests)}");
+		using var listener = new TestMeterListener<long>(meter);
+		using var sut = new IncomingGrpcCallsMetric(meter, "grpc-calls", new[] {
+			Conf.IncomingGrpcCall.Current,
+			Conf.IncomingGrpcCall.Total,
+			Conf.IncomingGrpcCall.Failed,
+			Conf.IncomingGrpcCall.Unimplemented,
+			Conf.IncomingGrpcCall.DeadlineExceeded
+		});
+
+		sut.EnableEvents(testSource, EventLevel.Verbose);
+		AssertMeasurements(listener,
+			AssertMeasurement("current", 0),
+			AssertMeasurement("total", 0),
+			AssertMeasurement("failed", 0),
+			AssertMeasurement("unimplemented", 0),
+			AssertMeasurement("deadline-exceeded", 0));
+
+		testSource.CallStart();
+		AssertMeasurements(listener,
+			AssertMeasurement("current", 1),
+			AssertMeasurement("total", 1),
+			AssertMeasurement("failed", 0),
+			AssertMeasurement("unimplemented", 0),
+			AssertMeasurement("deadline-exceeded", 0));
+
+		testSource.CallFailed();
+		AssertMeasurements(listener,
+			AssertMeasurement("current", 1),
+			AssertMeasurement("total", 1),
+			AssertMeasurement("failed", 1),
+			AssertMeasurement("unimplemented", 0),
+			AssertMeasurement("deadline-exceeded", 0));
+
+		testSource.CallUnimplemented();
+		AssertMeasurements(listener,
+			AssertMeasurement("current", 1),
+			AssertMeasurement("total", 1),
+			AssertMeasurement("failed", 1),
+			AssertMeasurement("unimplemented", 1),
+			AssertMeasurement("deadline-exceeded", 0));
+
+		testSource.CallDeadlineExceeded();
+		AssertMeasurements(listener,
+			AssertMeasurement("current", 1),
+			AssertMeasurement("total", 1),
+			AssertMeasurement("failed", 1),
+			AssertMeasurement("unimplemented", 1),
+			AssertMeasurement("deadline-exceeded", 1));
+
+		testSource.CallStop();
+		AssertMeasurements(listener,
+			AssertMeasurement("current", 0),
+			AssertMeasurement("total", 1),
+			AssertMeasurement("failed", 1),
+			AssertMeasurement("unimplemented", 1),
+			AssertMeasurement("deadline-exceeded", 1));
+	}
+
+	[Fact]
+	public void can_collect_filtered() {
+		using var testSource = new TestEventSource();
+		using var meter = new Meter($"{typeof(IncomingGrpcCallsMetricTests)}");
+		using var listener = new TestMeterListener<long>(meter);
+		using var sut = new IncomingGrpcCallsMetric(meter, "grpc-calls", new[] {
+			Conf.IncomingGrpcCall.Total,
+			Conf.IncomingGrpcCall.DeadlineExceeded
+		});
+
+		sut.EnableEvents(testSource, EventLevel.Verbose);
+		AssertMeasurements(listener,
+			AssertMeasurement("total", 0),
+			AssertMeasurement("deadline-exceeded", 0));
+
+		testSource.CallStart();
+		AssertMeasurements(listener,
+			AssertMeasurement("total", 1),
+			AssertMeasurement("deadline-exceeded", 0));
+
+		testSource.CallFailed();
+		AssertMeasurements(listener,
+			AssertMeasurement("total", 1),
+			AssertMeasurement("deadline-exceeded", 0));
+
+		testSource.CallUnimplemented();
+		AssertMeasurements(listener,
+			AssertMeasurement("total", 1),
+			AssertMeasurement("deadline-exceeded", 0));
+
+		testSource.CallDeadlineExceeded();
+		AssertMeasurements(listener,
+			AssertMeasurement("total", 1),
+			AssertMeasurement("deadline-exceeded", 1));
+
+		testSource.CallStop();
+		AssertMeasurements(listener,
+			AssertMeasurement("total", 1),
+			AssertMeasurement("deadline-exceeded", 1));
+	}
+
+	static Action<TestMeterListener<long>.TestMeasurement> AssertMeasurement(
+		string expectedKind,
+		long expectedValue) =>
+
+		actualMeasurement => {
+			Assert.Equal(expectedValue, actualMeasurement.Value);
+			Assert.Collection(
+				actualMeasurement.Tags.ToArray(),
+				tag => {
+					Assert.Equal("kind", tag.Key);
+					Assert.Equal(expectedKind, tag.Value);
+				});
+		};
+
+	static void AssertMeasurements(
+		TestMeterListener<long> listener,
+		params Action<TestMeterListener<long>.TestMeasurement>[] actions) {
+
+		listener.Observe();
+		Assert.Collection(listener.RetrieveMeasurements("grpc-calls"), actions);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Checkpoint/CheckpointMetricTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Checkpoint/CheckpointMetricTests.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.XUnit.Tests.TransactionLog.Checkpoint {
 	public class CheckpointMetricTests {
 		[Fact]
 		public void can_collect() {
-			var meter = new Meter($"{typeof(CheckpointMetricTests)}");
+			using var meter = new Meter($"{typeof(CheckpointMetricTests)}");
 			using var listener = new TestMeterListener<long>(meter);
 			var metric = new CheckpointMetric(
 				meter,

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -74,6 +74,12 @@ public static class MetricsBootstrapper {
 		var byteMetric = coreMeter.CreateCounter<long>("eventstore-io", unit: "bytes");
 		var eventMetric = coreMeter.CreateCounter<long>("eventstore-io", unit: "events");
 
+		// incoming grpc calls
+		var enabledCalls = conf.IncomingGrpcCalls.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToArray();
+		if (enabledCalls.Length > 0) {
+			_ = new IncomingGrpcCallsMetric(coreMeter, "eventstore-incoming-grpc-calls", enabledCalls);
+		}
+
 		// events
 		if (conf.Events.TryGetValue(Conf.EventTracker.Read, out var readEnabled) && readEnabled) {
 			var readTag = new KeyValuePair<string, object>("activity", "read");

--- a/src/EventStore.Core/Telemetry/IncomingGrpcCallsMetric.cs
+++ b/src/EventStore.Core/Telemetry/IncomingGrpcCallsMetric.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Diagnostics.Tracing;
+using System.Linq;
+using System.Threading;
+using static EventStore.Common.Configuration.TelemetryConfiguration;
+
+namespace EventStore.Core.Telemetry;
+
+// using observable counters rather than regular to reduce the cost of incrementing
+// (although, its probably not important at the rate calls are created)
+// works in a similar way to the PollingCounters here
+// https://github.com/grpc/grpc-dotnet/blob/master/src/Grpc.AspNetCore.Server/Internal/GrpcEventSource.cs
+public class IncomingGrpcCallsMetric : EventListener {
+	private long _callsCurrent;
+	private long _callsTotal;
+	private long _callsFailed;
+	private long _callsUnimplemented;
+	private long _callsDeadlineExceeded;
+
+	public IncomingGrpcCallsMetric(Meter meter, string name, IncomingGrpcCall[] filter) {
+		var funcs = new List<Func<Measurement<long>>>();
+
+		if (filter.Contains(IncomingGrpcCall.Current)) {
+			var tags = GenTags("current");
+			funcs.Add(() => new(Volatile.Read(ref _callsCurrent), tags.AsSpan()));
+		}
+
+		if (filter.Contains(IncomingGrpcCall.Total)) {
+			var tags = GenTags("total");
+			funcs.Add(() => new(Volatile.Read(ref _callsTotal), tags.AsSpan()));
+		}
+
+		if (filter.Contains(IncomingGrpcCall.Failed)) {
+			var tags = GenTags("failed");
+			funcs.Add(() => new(Volatile.Read(ref _callsFailed), tags.AsSpan()));
+		}
+
+		if (filter.Contains(IncomingGrpcCall.Unimplemented)) {
+			var tags = GenTags("unimplemented");
+			funcs.Add(() => new(Volatile.Read(ref _callsUnimplemented), tags.AsSpan()));
+		}
+
+		if (filter.Contains(IncomingGrpcCall.DeadlineExceeded)) {
+			var tags = GenTags("deadline-exceeded");
+			funcs.Add(() => new(Volatile.Read(ref _callsDeadlineExceeded), tags.AsSpan()));
+		}
+
+		meter.CreateObservableUpDownCounter(name, GenObserveCalls(funcs.ToArray()));
+	}
+
+	private static KeyValuePair<string, object>[] GenTags(string kind) =>
+		new KeyValuePair<string, object>[] { new("kind", kind) };
+
+	private static Func<IEnumerable<Measurement<long>>> GenObserveCalls(
+		Func<Measurement<long>>[] funcs) {
+
+		var measurements = new Measurement<long>[funcs.Length];
+
+		return () => {
+			for (var i = 0; i < measurements.Length; i++) {
+				measurements[i] = funcs[i]();
+			}
+			return measurements;
+		};
+	}
+
+	protected override void OnEventSourceCreated(EventSource eventSource) {
+		if (eventSource.Name != "Grpc.AspNetCore.Server")
+			return;
+
+		EnableEvents(eventSource, EventLevel.Verbose);
+	}
+
+	protected override void OnEventWritten(EventWrittenEventArgs eventData) {
+		switch (eventData.EventName) {
+			case "CallStart":
+				Interlocked.Increment(ref _callsTotal);
+				Interlocked.Increment(ref _callsCurrent);
+				break;
+
+			case "CallStop":
+				Interlocked.Decrement(ref _callsCurrent);
+				break;
+
+			case "CallFailed":
+				Interlocked.Increment(ref _callsFailed);
+				break;
+
+			case "CallDeadlineExceeded":
+				Interlocked.Increment(ref _callsDeadlineExceeded);
+				break;
+
+			case "CallUnimplemented":
+				Interlocked.Increment(ref _callsUnimplemented);
+				break;
+		}
+	}
+}


### PR DESCRIPTION
Added: metrics for current/total/failed grpc calls

- Current calls
- Total calls
- Failed calls
- Unimplemented calls
- Deadline exceeded calls