### PR TITLE
Add support for reading from $all with gRPC to `testclient`

### DIFF
--- a/src/EventStore.TestClient/Client.cs
+++ b/src/EventStore.TestClient/Client.cs
@@ -77,6 +77,7 @@ namespace EventStore.TestClient {
 			_commands.Register(new SubscriptionStressTestProcessor());
 
 			// gRPC
+			_commands.Register(new GrpcCommands.ReadAllProcessor());
 			_commands.Register(new GrpcCommands.WriteFloodProcessor());
 
 			// TCP Client API

--- a/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadAllProcessor.cs
@@ -84,20 +84,7 @@ namespace EventStore.TestClient.Commands {
 						return;
 					}
 
-					var sb = new StringBuilder();
-					for (int i = 0; i < dto.Events.Count; ++i) {
-						var evnt = dto.Events[i].Event;
-						sb.AppendFormat(
-							"\n{0}:\tStreamId: {1},\n\tEventNumber: {2},\n\tData:\n{3},\n\tEventType: {4}\n",
-							total,
-							evnt.EventStreamId,
-							evnt.EventNumber,
-							Helper.UTF8NoBom.GetString(evnt.Data.ToByteArray()),
-							evnt.EventType);
-						total += 1;
-					}
-
-					context.Log.Information("Next {count} events read:\n{events}", dto.Events.Count, sb.ToString());
+					total += dto.Events.Count;
 
 					var readDto = new ReadAllEvents(dto.NextCommitPosition, dto.NextPreparePosition,
 						10, resolveLinkTos, requireLeader);

--- a/src/EventStore.TestClient/Commands/ReadFloodProcessor.cs
+++ b/src/EventStore.TestClient/Commands/ReadFloodProcessor.cs
@@ -97,7 +97,6 @@ namespace EventStore.TestClient.Commands {
 						}
 
 						if (localAll == requestsCnt) {
-							context.Success();
 							doneEvent.Set();
 						}
 					},
@@ -126,6 +125,8 @@ namespace EventStore.TestClient.Commands {
 							Thread.Sleep(1);
 						}
 					}
+					context.Log.Information("Reader #{clientNum} done", clientNum);
+					
 				}) {IsBackground = true});
 			}
 

--- a/src/EventStore.TestClient/Commands/RunTestScenarios/MassProjectionsScenario.cs
+++ b/src/EventStore.TestClient/Commands/RunTestScenarios/MassProjectionsScenario.cs
@@ -105,17 +105,7 @@ namespace EventStore.TestClient.Commands.RunTestScenarios {
 			if (!success)
 				throw new ApplicationException("Last bank projection failed");
 		}
-
-		private class ProjectionTask {
-			public string Name;
-			public Task Task;
-
-			public ProjectionTask(string name, Task task) {
-				Name = name;
-				Task = task;
-			}
-		}
-
+		
 		private void StartOrStopProjection(IEnumerable<string> projections, bool enable) {
 			var manager = GetProjectionsManager();
 			const int retriesNumber = 5;

--- a/src/EventStore.TestClient/Commands/RunTestScenariosProcessor.cs
+++ b/src/EventStore.TestClient/Commands/RunTestScenariosProcessor.cs
@@ -4,7 +4,6 @@ using System.Net;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading;
-using EventStore.ClientAPI.Exceptions;
 using EventStore.Core.Services.Transport.Tcp;
 using EventStore.TestClient.Commands.RunTestScenarios;
 using EventStore.Transport.Tcp;
@@ -16,7 +15,7 @@ namespace EventStore.TestClient.Commands {
 		private const string AllScenariosFlag = "ALL";
 
 		public string Keyword {
-			get { return string.Format("RT"); }
+			get { return "RT"; }
 		}
 
 		public string Usage {

--- a/src/EventStore.TestClient/Commands/WriteFloodWaitingProcessor.cs
+++ b/src/EventStore.TestClient/Commands/WriteFloodWaitingProcessor.cs
@@ -73,7 +73,6 @@ namespace EventStore.TestClient.Commands {
 						}
 
 						if (Interlocked.Increment(ref all) == requestsCnt) {
-							context.Success();
 							doneEvent.Set();
 						}
 

--- a/src/EventStore.TestClient/CommandsProcessor.cs
+++ b/src/EventStore.TestClient/CommandsProcessor.cs
@@ -55,8 +55,11 @@ namespace EventStore.TestClient {
 						exitC = context.ExitCode;
 					} else {
 						exitC = 1;
-						_log.Information("Usage of {command}:{newLine}{usage}", commandName, Environment.NewLine,
-							commandProcessor.Usage);
+						_log.Information("Usage of {command}:", commandName);
+						
+						foreach (var s in commandProcessor.Usage.Split("\n")) {
+							_log.Information("    {usage}", s);
+						}
 					}
 
 					executedEvent.Set();

--- a/src/EventStore.TestClient/GrpcCommands/ReadAllProcessor.cs
+++ b/src/EventStore.TestClient/GrpcCommands/ReadAllProcessor.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using EventStore.Client;
+using Serilog;
+
+namespace EventStore.TestClient.GrpcCommands {
+	internal class ReadAllProcessor : ICmdProcessor {
+		public string Usage {
+			get { return "RDALLGRPC [[F|B] [clients] [<commit pos> <prepare pos>]]"; }
+		}
+
+		public string Keyword {
+			get { return "RDALLGRPC"; }
+		}
+
+		public bool Execute(CommandProcessorContext context, string[] args) {
+			Direction direction = Direction.Forwards;
+			Position position = Position.Start;
+			bool forward = true;
+			bool posOverriden = false;
+			int clientCount = 1;
+
+			if (args.Length > 0) {
+				if (args.Length > 4)
+					return false;
+
+				if (args[0].ToUpper() == "F")
+					forward = true;
+				else if (args[0].ToUpper() == "B")
+					forward = false;
+				else
+					return false;
+
+				if (args.Length > 1) {
+					clientCount = MetricPrefixValue.ParseInt(args[1]);
+				}
+
+				if (args.Length == 4) {
+					posOverriden = true;
+					if (!ulong.TryParse(args[2], out var commitPos) || !ulong.TryParse(args[3], out var preparePos))
+						return false;
+
+					position = new Position(commitPos, preparePos);
+				}
+			}
+
+			if (!posOverriden) {
+				position = forward ? Position.Start : Position.End;
+			}
+
+			context.IsAsync();
+
+			if (context._grpcTestClient.AreCredentialsMissing) {
+				context.Fail(reason: "Credentials are needed in order to read from the $all stream, specify a connection string with credentials!");
+				return true;
+			}
+			
+			var task = ReadAll(context, clientCount, direction, position);
+			task.Wait();
+
+			return true;
+		}
+		
+		private async Task ReadAll(CommandProcessorContext context, int clientCount, Direction direction, Position position) {
+
+			var cts = new CancellationTokenSource();
+
+			ProgressMonitor monitor = new ProgressMonitor(context.Log);
+
+			var clientTasks = new List<Task>();
+			for (int i = 0; i < clientCount; i++) {
+				if (i > 0) {
+					await Task.Delay(TimeSpan.FromSeconds(30));
+				}
+				
+				EventStoreClient client = context._grpcTestClient.CreateGrpcClient();
+				clientTasks.Add(ReadAllTask(client));
+			}
+			
+			await Task.WhenAll(clientTasks);
+			
+			monitor.Stop();
+			context.Log.Information("=== Reading ALL {readDirection} completed in {elapsed}. Total read: {total}",
+				direction, monitor.Duration, monitor.Total);
+			context.Success();
+			
+			async Task ReadAllTask(EventStoreClient c) {
+				var r = c.ReadAllAsync(direction, position, cancellationToken: cts.Token);
+				await foreach (var _ in r.Messages.WithCancellation(cts.Token)) {
+					monitor.Increment();
+				}
+			}
+		}
+		
+		class ProgressMonitor {
+			private ulong _i;
+			private readonly ILogger _log;
+			private readonly Stopwatch _duration;
+			private readonly Stopwatch _interval;
+
+			public ProgressMonitor (ILogger log) {
+				_log = log;
+				_duration = Stopwatch.StartNew();
+				_interval = Stopwatch.StartNew();
+			}
+
+			public TimeSpan Duration => _duration.Elapsed;
+			public ulong Total => _i;
+			
+			public void Increment() {
+				var result = Interlocked.Increment(ref _i);
+
+				if (result % 1000 == 0) {
+					Console.Write(".");
+				}
+				
+				if (result % 100_000 == 0) {
+					_log.Information(
+						"\nDONE TOTAL {reads} READ IN {elapsed} ({rate:0.0}/s)",
+						_i, _interval.Elapsed, 1000.0 * (_i / _duration.Elapsed.TotalMilliseconds));
+					_interval.Restart();
+				}
+			}
+
+			public void Stop() {
+				_duration.Stop();
+				_interval.Stop();
+			}
+		}
+	}
+}

--- a/src/EventStore.TestClient/GrpcTestClient.cs
+++ b/src/EventStore.TestClient/GrpcTestClient.cs
@@ -1,4 +1,5 @@
-﻿using EventStore.Client;
+﻿using System;
+using EventStore.Client;
 using Connection = EventStore.Transport.Tcp.TcpTypedConnection<byte[]>;
 using ILogger = Serilog.ILogger;
 
@@ -25,12 +26,22 @@ namespace EventStore.TestClient {
 		/// </summary>
 		/// <returns></returns>
 		public EventStoreClient CreateGrpcClient() {
-			var connectionString = string.IsNullOrWhiteSpace(_options.ConnectionString)
-				? $"esdb://{_options.Host}:{_options.HttpPort}?tls={_options.UseTls}&tlsVerifyCert={_options.TlsValidateServer}"
-				: _options.ConnectionString;
-			_log.Debug("Creating gRPC client with connection string '{connectionString}'.", connectionString);
-			var settings = EventStoreClientSettings.Create(connectionString);
-			return new EventStoreClient(settings);
+			_log.Debug("Creating gRPC client with connection string '{connectionString}'.", ConnectionString);
+			return new EventStoreClient(Settings);
 		}
+
+		/// <summary>
+		/// True in case username and/or password are not specified.
+		/// </summary>
+		public bool AreCredentialsMissing =>
+			string.IsNullOrWhiteSpace(Settings.DefaultCredentials?.Username) ||
+			string.IsNullOrWhiteSpace(Settings.DefaultCredentials?.Password);
+
+		private EventStoreClientSettings Settings => EventStoreClientSettings.Create(ConnectionString);
+		
+		private string ConnectionString => string.IsNullOrWhiteSpace(_options.ConnectionString)
+			? $"esdb://{_options.Host}:{_options.HttpPort}?tls={_options.UseTls}&tlsVerifyCert={_options.TlsValidateServer}"
+			: _options.ConnectionString;
+		
 	}
 }

--- a/src/EventStore.TestClient/TcpTestClient.cs
+++ b/src/EventStore.TestClient/TcpTestClient.cs
@@ -110,7 +110,7 @@ namespace EventStore.TestClient {
 					() => null,
 					onConnectionEstablished,
 					onConnectionFailed,
-					verbose: !_interactiveMode);
+					verbose: false);
 			} else {
 				connection = _connector.ConnectTo(
 					Guid.NewGuid(),
@@ -118,7 +118,7 @@ namespace EventStore.TestClient {
 					TcpConnectionManager.ConnectionTimeout,
 					onConnectionEstablished,
 					onConnectionFailed,
-					verbose: !_interactiveMode);
+					verbose: false);
 			}
 
 			typedConnection = new Connection(connection, new RawMessageFormatter(_bufferManager),


### PR DESCRIPTION
Fixed: Only call `context.Success()` once to prevent early exit of command.
Added: Read $all command `RDALLGRPC`.
Removed: Some logging to prevent flooding of console/logs.