### PR TITLE
Fix 500 HTTP error when performing CRUD operations to $all stream (DB-51)

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -281,11 +281,21 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void Handle(ClientMessage.CreatePersistentSubscriptionToStream message) {
-			if (string.IsNullOrEmpty(message.EventStreamId) || message.EventStreamId == SystemStreams.AllStream) {
+			if (string.IsNullOrEmpty(message.EventStreamId)) {
 				message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
 					message.CorrelationId,
-					ClientMessage.CreatePersistentSubscriptionToStreamCompleted.CreatePersistentSubscriptionToStreamResult.Fail,
+					ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+						.CreatePersistentSubscriptionToStreamResult.Fail,
 					"Bad stream name."));
+				return;
+			}
+
+			if (message.EventStreamId == SystemStreams.AllStream) {
+				message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
+					message.CorrelationId,
+					ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+						.CreatePersistentSubscriptionToStreamResult.Fail,
+					"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
 				return;
 			}
 
@@ -340,7 +350,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			} catch (Exception ex) {
 				message.Envelope.ReplyWith(new ClientMessage.CreatePersistentSubscriptionToStreamCompleted(
 					message.CorrelationId,
-					ClientMessage.CreatePersistentSubscriptionToStreamCompleted.CreatePersistentSubscriptionToStreamResult.Fail,
+					ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+						.CreatePersistentSubscriptionToStreamResult.Fail,
 					ex.Message));
 			}
 		}
@@ -499,11 +510,21 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		}
 
 		public void Handle(ClientMessage.UpdatePersistentSubscriptionToStream message) {
-			if (string.IsNullOrEmpty(message.EventStreamId) || message.EventStreamId == SystemStreams.AllStream) {
+			if (string.IsNullOrEmpty(message.EventStreamId)) {
 				message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
 					message.CorrelationId,
-					ClientMessage.UpdatePersistentSubscriptionToStreamCompleted.UpdatePersistentSubscriptionToStreamResult.Fail,
+					ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+						.UpdatePersistentSubscriptionToStreamResult.Fail,
 					"Bad stream name."));
+				return;
+			}
+
+			if (message.EventStreamId == SystemStreams.AllStream) {
+				message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
+					message.CorrelationId,
+					ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+						.UpdatePersistentSubscriptionToStreamResult.Fail,
+					"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
 				return;
 			}
 
@@ -558,7 +579,8 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			} catch (Exception ex) {
 				message.Envelope.ReplyWith(new ClientMessage.UpdatePersistentSubscriptionToStreamCompleted(
 					message.CorrelationId,
-					ClientMessage.UpdatePersistentSubscriptionToStreamCompleted.UpdatePersistentSubscriptionToStreamResult.Fail,
+					ClientMessage.UpdatePersistentSubscriptionToStreamCompleted
+						.UpdatePersistentSubscriptionToStreamResult.Fail,
 					ex.Message));
 			}
 		}
@@ -704,11 +726,21 @@ namespace EventStore.Core.Services.PersistentSubscription {
 
 
 		public void Handle(ClientMessage.DeletePersistentSubscriptionToStream message) {
-			if (string.IsNullOrEmpty(message.EventStreamId) || message.EventStreamId == SystemStreams.AllStream) {
+			if (string.IsNullOrEmpty(message.EventStreamId)) {
 				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
 					message.CorrelationId,
-					ClientMessage.DeletePersistentSubscriptionToStreamCompleted.DeletePersistentSubscriptionToStreamResult.Fail,
+					ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+						.DeletePersistentSubscriptionToStreamResult.Fail,
 					"Bad stream name."));
+				return;
+			}
+
+			if (message.EventStreamId == SystemStreams.AllStream) {
+				message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
+					message.CorrelationId,
+					ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+						.DeletePersistentSubscriptionToStreamResult.Fail,
+					"Persistent subscriptions to $all are only supported over gRPC through gRPC clients"));
 				return;
 			}
 
@@ -724,19 +756,22 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				(error) => {
 					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
 						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToStreamCompleted.DeletePersistentSubscriptionToStreamResult.Fail,
+						ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+							.DeletePersistentSubscriptionToStreamResult.Fail,
 						error));
 				},
 				(error) => {
 					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
 						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToStreamCompleted.DeletePersistentSubscriptionToStreamResult.DoesNotExist,
+						ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+							.DeletePersistentSubscriptionToStreamResult.DoesNotExist,
 						error));
 				},
 				(error) => {
 					message.Envelope.ReplyWith(new ClientMessage.DeletePersistentSubscriptionToStreamCompleted(
 						message.CorrelationId,
-						ClientMessage.DeletePersistentSubscriptionToStreamCompleted.DeletePersistentSubscriptionToStreamResult.AccessDenied,
+						ClientMessage.DeletePersistentSubscriptionToStreamCompleted
+							.DeletePersistentSubscriptionToStreamResult.AccessDenied,
 						error));
 				},
 				message.User?.Identity?.Name
@@ -1004,11 +1039,19 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		public void Handle(ClientMessage.ReadNextNPersistentMessages message) {
 			if (!_started) return;
 
-			if (string.IsNullOrEmpty(message.EventStreamId) || message.EventStreamId == SystemStreams.AllStream) {
+			if (string.IsNullOrEmpty(message.EventStreamId)) {
 				message.Envelope.ReplyWith(new ClientMessage.ReadNextNPersistentMessagesCompleted(
 					message.CorrelationId,
 					ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Fail,
 					"Bad stream name.", null));
+				return;
+			}
+
+			if (message.EventStreamId == SystemStreams.AllStream) {
+				message.Envelope.ReplyWith(new ClientMessage.ReadNextNPersistentMessagesCompleted(
+					message.CorrelationId,
+					ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult.Fail,
+					"Persistent subscriptions to $all are only supported over gRPC through gRPC clients", null));
 				return;
 			}
 

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/PersistentSubscriptionController.cs
@@ -456,17 +456,24 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 					var m = message as ClientMessage.CreatePersistentSubscriptionToStreamCompleted;
 					if (m == null) throw new Exception("unexpected message " + message);
 					switch (m.Result) {
-						case ClientMessage.CreatePersistentSubscriptionToStreamCompleted.CreatePersistentSubscriptionToStreamResult
+						case ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+							.CreatePersistentSubscriptionToStreamResult
 							.Success:
 							code = HttpStatusCode.Created;
 							break;
-						case ClientMessage.CreatePersistentSubscriptionToStreamCompleted.CreatePersistentSubscriptionToStreamResult
+						case ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+							.CreatePersistentSubscriptionToStreamResult
 							.AlreadyExists:
 							code = HttpStatusCode.Conflict;
 							break;
-						case ClientMessage.CreatePersistentSubscriptionToStreamCompleted.CreatePersistentSubscriptionToStreamResult
+						case ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+							.CreatePersistentSubscriptionToStreamResult
 							.AccessDenied:
 							code = HttpStatusCode.Unauthorized;
+							break;
+						case ClientMessage.CreatePersistentSubscriptionToStreamCompleted
+							.CreatePersistentSubscriptionToStreamResult.Fail:
+							code = HttpStatusCode.BadRequest;
 							break;
 						default:
 							code = HttpStatusCode.InternalServerError;
@@ -533,6 +540,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 						case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted.UpdatePersistentSubscriptionToStreamResult
 							.AccessDenied:
 							code = HttpStatusCode.Unauthorized;
+							break;
+						case ClientMessage.UpdatePersistentSubscriptionToStreamCompleted.UpdatePersistentSubscriptionToStreamResult
+							.Fail:
+							code = HttpStatusCode.BadRequest;
 							break;
 						default:
 							code = HttpStatusCode.InternalServerError;
@@ -672,6 +683,10 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 						case ClientMessage.DeletePersistentSubscriptionToStreamCompleted.DeletePersistentSubscriptionToStreamResult
 							.AccessDenied:
 							code = HttpStatusCode.Unauthorized;
+							break;
+						case ClientMessage.DeletePersistentSubscriptionToStreamCompleted.DeletePersistentSubscriptionToStreamResult
+							.Fail:
+							code = HttpStatusCode.BadRequest;
 							break;
 						default:
 							code = HttpStatusCode.InternalServerError;
@@ -829,6 +844,11 @@ namespace EventStore.Core.Services.Transport.Http.Controllers {
 							ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult
 								.AccessDenied:
 							code = HttpStatusCode.Unauthorized;
+							break;
+						case
+							ClientMessage.ReadNextNPersistentMessagesCompleted.ReadNextNPersistentMessagesResult
+								.Fail:
+							code = HttpStatusCode.BadRequest;
 							break;
 						default:
 							code = HttpStatusCode.InternalServerError;

--- a/src/EventStore.Core/Services/Transport/Http/Format.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Format.cs
@@ -135,9 +135,10 @@ namespace EventStore.Core.Services.Transport.Http {
 			string streamId, string groupName, int count, EmbedLevel embed) {
 			var msg = message as ClientMessage.ReadNextNPersistentMessagesCompleted;
 			if (msg == null || msg.Result != ClientMessage.ReadNextNPersistentMessagesCompleted
-				    .ReadNextNPersistentMessagesResult.Success)
-				return String.Empty;
-
+				    .ReadNextNPersistentMessagesResult.Success) {
+				return msg != null ? entity.ResponseCodec.To(msg.Reason) : string.Empty;
+			}
+			
 			return entity.ResponseCodec.To(Convert.ToNextNPersistentMessagesFeed(msg, entity.ResponseUrl, streamId,
 				groupName, count, embed));
 		}


### PR DESCRIPTION
Fixed: add an error message when user performs an CRUD operation to $all stream using HTTP API

Fixes #3665 

Currently the user is receiving an HTTP 500 error when performs a CRUD operation to $all stream. The goal of this PR is to add an error message to inform the user that the operation can only be performed using gRPC client.