### PR TITLE
Log error message when the SSL handshakes fail [DB-32]

### DIFF
--- a/src/EventStore.Core.Tests/Certificates/chain_building.cs
+++ b/src/EventStore.Core.Tests/Certificates/chain_building.cs
@@ -8,7 +8,7 @@ namespace EventStore.Core.Tests.Certificates {
 			var chainStatus = CertificateUtils.BuildChain(
 				_leaf,
 				new X509Certificate2Collection(),
-				new X509Certificate2Collection(_root));
+				new X509Certificate2Collection(_root), out _);
 			Assert.True(chainStatus == X509ChainStatusFlags.NoError);
 		}
 	}
@@ -19,7 +19,7 @@ namespace EventStore.Core.Tests.Certificates {
 			var chainStatus = CertificateUtils.BuildChain(
 				_leaf,
 				new X509Certificate2Collection(_intermediate),
-				new X509Certificate2Collection(_root));
+				new X509Certificate2Collection(_root), out _);
 			Assert.True(chainStatus == X509ChainStatusFlags.NoError);
 		}
 	}
@@ -32,7 +32,7 @@ namespace EventStore.Core.Tests.Certificates {
 			var chainStatus = CertificateUtils.BuildChain(
 				_leaf,
 				new X509Certificate2Collection(_intermediate),
-				new X509Certificate2Collection(_root));
+				new X509Certificate2Collection(_root), out _);
 			Assert.True(chainStatus == X509ChainStatusFlags.NotTimeValid);
 		}
 	}
@@ -44,7 +44,7 @@ namespace EventStore.Core.Tests.Certificates {
 			var chainStatus = CertificateUtils.BuildChain(
 				_leaf,
 				new X509Certificate2Collection(_intermediate),
-				new X509Certificate2Collection(_root));
+				new X509Certificate2Collection(_root), out _);
 			Assert.True(chainStatus == X509ChainStatusFlags.NotTimeValid);
 		}
 	}
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.Certificates {
 			var chainStatus = CertificateUtils.BuildChain(
 				_leaf,
 				new X509Certificate2Collection(_intermediate),
-				new X509Certificate2Collection(_root));
+				new X509Certificate2Collection(_root), out _);
 			Assert.True(chainStatus == X509ChainStatusFlags.NotTimeValid);
 		}
 	}
@@ -68,7 +68,7 @@ namespace EventStore.Core.Tests.Certificates {
 			var chainStatus = CertificateUtils.BuildChain(
 				_leaf,
 				new X509Certificate2Collection(),
-				new X509Certificate2Collection(_root));
+				new X509Certificate2Collection(_root), out _);
 			Assert.True(chainStatus == X509ChainStatusFlags.PartialChain);
 		}
 	}
@@ -79,7 +79,7 @@ namespace EventStore.Core.Tests.Certificates {
 			var chainStatus = CertificateUtils.BuildChain(
 				_leaf,
 				new X509Certificate2Collection(_intermediate),
-				new X509Certificate2Collection());
+				new X509Certificate2Collection(), out _);
 			Assert.True(chainStatus == X509ChainStatusFlags.PartialChain);
 		}
 	}
@@ -90,7 +90,7 @@ namespace EventStore.Core.Tests.Certificates {
 			var chainStatus = CertificateUtils.BuildChain(
 				_leaf,
 				new X509Certificate2Collection(new []{_intermediate, _root}),
-				new X509Certificate2Collection());
+				new X509Certificate2Collection(), out _);
 			Assert.True(chainStatus == X509ChainStatusFlags.UntrustedRoot);
 		}
 	}

--- a/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
@@ -90,16 +90,21 @@ namespace EventStore.Core.Certificates {
 
 			if (error) return false;
 
-			var chainStatus = CertificateUtils.BuildChain(nodeCertificate, intermediates, trustedRoots);
+			var chainStatus = CertificateUtils.BuildChain(nodeCertificate, intermediates, trustedRoots, out var chainStatusInformation );
 
 			if (chainStatus != X509ChainStatusFlags.NoError) {
-				Log.Error("Failed to build the certificate chain with the node's own certificate up to the root with error: {chainStatus}. " +
-				             "If you have intermediate certificates, please bundle them with the node's certificate (in PEM or PKCS #12 format).", chainStatus);
+				Log.Error(
+					"Failed to build the certificate chain with the node's own certificate up to the root. " +
+					"If you have intermediate certificates, please bundle them with the node's certificate (in PEM or PKCS #12 format). Errors:-");
+				foreach (var status in chainStatusInformation) {
+					Log.Error(status);
+				}
+
 				error = true;
 			}
 
 			if (!error && intermediates != null) {
-				chainStatus = CertificateUtils.BuildChain(nodeCertificate, null, trustedRoots);
+				chainStatus = CertificateUtils.BuildChain(nodeCertificate, null, trustedRoots, out chainStatusInformation);
 
 				// Adding the intermediate certificates to the store is required so that
 				// i)  the full certificate chain (excluding the root) is sent from client to server (on both Windows/Linux)

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1752,7 +1752,7 @@ namespace EventStore.Core {
 				}
 			}
 
-			var chainStatus = CertificateUtils.BuildChain(certificate, intermediates, trustedRootCertsSelector());
+			var chainStatus = CertificateUtils.BuildChain(certificate, intermediates, trustedRootCertsSelector(), out var chainStatusInformation);
 			if (chainStatus == X509ChainStatusFlags.NoError)
 				sslPolicyErrors &= ~SslPolicyErrors.RemoteCertificateChainErrors; //clear the RemoteCertificateChainErrors flag
 			else
@@ -1765,6 +1765,9 @@ namespace EventStore.Core {
 			}
 
 			if (sslPolicyErrors != SslPolicyErrors.None) {
+				foreach (var status in chainStatusInformation) {
+					Log.Error(status);
+				}
 				return (false, $"The certificate ({certificate.Subject}) provided by the {certificateOrigin} failed validation with the following error(s): {sslPolicyErrors.ToString()} ({chainStatus})");
 			}
 


### PR DESCRIPTION
Fixed: Log more readable error message in the server logs when the SSL handshakes fail.

Fixes #3765 

The goal of this PR to add more readable error messages rather than dumping the error status when the SSL handshakes fail.