### PR TITLE
Stop using deprecated way of setting workflow output (DB-84)

### DIFF
--- a/.github/workflows/release-client.yml
+++ b/.github/workflows/release-client.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF:25}
+        run: echo "version=${GITHUB_REF:25}" >> $GITHUB_OUTPUT
       - name: Perform Release 
         run: |
           curl -X POST https://api.github.com/repos/EventStore/TrainStation/dispatches \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF:15}
+        run: echo "version=${GITHUB_REF:15}" >> $GITHUB_OUTPUT
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Changed: Use `$GITHUB_OUTPUT` for workflow output.
Changed: Use latest `actions/checkout@v3`.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/