### PR TITLE
DB-33: Add a check to verify if something is blocking the data transfer between nodes

### DIFF
--- a/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/TcpConnectionManager.cs
@@ -209,6 +209,13 @@ namespace EventStore.Core.Services.Transport.Tcp {
 				"Connection '{connectionName}{clientConnectionName}' [{remoteEndPoint}, {connectionId:B}] closed: {e}.",
 				ConnectionName, ClientConnectionName.IsEmptyString() ? string.Empty : ":" + ClientConnectionName,
 				connection.RemoteEndPoint, ConnectionId, socketError);
+
+			if (_serviceType == TcpServiceType.Internal && _connection.TotalBytesSent == 0) {
+				Log.Warning(
+					"Unable to connect to Remote EndPoint : {remoteEndPoint}. Connection is potentially blocked. Total bytes sent: {TotalBytesSent}, Total bytes received: {TotalBytesReceived}",
+					RemoteEndPoint, _connection.TotalBytesSent, _connection.TotalBytesReceived);
+			}
+			
 			if (_connectionClosed != null)
 				_connectionClosed(this, socketError);
 		}


### PR DESCRIPTION
Fixed: Improved log message for connectivity problem between nodes

Fixes #3766 

Currently we are logging the message as connection lost even the node cannot reach to another node due to some reasons. For example, a firewall configuration blocks the necessary port. The goal of this PR is to log a warning to differentiate whether the connection is lost or the connection is blocked for some reasons.