### PR TITLE
Collect metrics from dynamic cache manager

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -59,6 +59,8 @@
 		"Chunk": false
 	},
 
+	"CacheResources": true,
+
 	"Kestrel": {
 		"ConnectionCount": true
 	},

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -159,6 +159,8 @@ namespace EventStore.Common.Configuration {
 		public Dictionary<EventTracker, bool> Events { get; set; } = new();
 
 		public Dictionary<Cache, bool> CacheHitsMisses { get; set; } = new();
+		
+		public bool CacheResources { get; set; } = false;
 
 		// must be 0, 1, 5, 10 or a multiple of 15
 		public int ExpectedScrapeIntervalSeconds { get; set; }

--- a/src/EventStore.Core.Tests/Caching/DynamicCacheManagerTests.cs
+++ b/src/EventStore.Core.Tests/Caching/DynamicCacheManagerTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using EventStore.Core.Caching;
 using EventStore.Core.Messages;
 using EventStore.Core.Services.TimerService;
+using EventStore.Core.Telemetry;
 using EventStore.Core.Tests.Fakes;
 using EventStore.Core.Tests.Services.Replication;
 using NUnit.Framework;
@@ -37,7 +38,8 @@ namespace EventStore.Core.Tests.Caching {
 				monitoringInterval,
 				minResizeInterval,
 				minResizeThreshold,
-				rootCacheResizer);
+				rootCacheResizer,
+				new CacheResourcesTracker.NoOp());
 			sut.Start();
 
 			_fakePublisher.Messages.Clear();
@@ -80,13 +82,15 @@ namespace EventStore.Core.Tests.Caching {
 				() => 0,
 				mem => Interlocked.Exchange(ref cache1Mem, mem),
 				() => 1, // included in total free mem
-				() => { }));
+				() => { },
+				name: "cache1"));
 
 			var cache2 = new DynamicCacheResizer(ResizerUnit.Bytes, 2, 100_000, 40, new AdHocDynamicCache(
 				() => 0,
 				mem => Interlocked.Exchange(ref cache2Mem, mem),
 				() => 1, // included in total free mem
-				() => { }));
+				() => { },
+				name: "cache2"));
 
 			var freeSystemMemReq = 0;
 			var freeSystemMem = new[] { 100, 11 + (aboveKeepFreeMem ? 1 : 0)}; // included in total free mem
@@ -127,10 +131,10 @@ namespace EventStore.Core.Tests.Caching {
 			long cache1Mem = -1, cache2Mem = -1;
 			var cache1 = new DynamicCacheResizer(ResizerUnit.Bytes, 1, 100_000, 60, new AdHocDynamicCache(
 				() => 0,
-				mem => Interlocked.Exchange(ref cache1Mem, mem)));
+				mem => Interlocked.Exchange(ref cache1Mem, mem), name: "cache1"));
 			var cache2 = new DynamicCacheResizer(ResizerUnit.Bytes, 2, 100_000, 40, new AdHocDynamicCache(
 				() => 0,
-				mem => Interlocked.Exchange(ref cache2Mem, mem)));
+				mem => Interlocked.Exchange(ref cache2Mem, mem), name: "cache2"));
 
 			var request = 0;
 			var freeMem = new[] { 100, 90 };
@@ -168,11 +172,11 @@ namespace EventStore.Core.Tests.Caching {
 			long cache1Mem = -1, cache2Mem = -1;
 			var cache1 = new DynamicCacheResizer(ResizerUnit.Bytes, 1, 100_000, 60, new AdHocDynamicCache(
 				() => 0,
-				mem => Interlocked.Exchange(ref cache1Mem, mem)));
+				mem => Interlocked.Exchange(ref cache1Mem, mem), name: "cache1"));
 
 			var cache2 = new DynamicCacheResizer(ResizerUnit.Bytes, 2, 100_000, 40, new AdHocDynamicCache(
 				() => 0,
-				mem => Interlocked.Exchange(ref cache2Mem, mem)));
+				mem => Interlocked.Exchange(ref cache2Mem, mem), name: "cache2"));
 
 			var freeSystemMemReq = 0;
 			var freeSystemMem = new[] { 100, 19 };

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/CacheResourcesTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/CacheResourcesTrackerTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using EventStore.Core.Telemetry;
+using EventStore.Core.Tests;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public sealed class CacheResourcesTrackerTests : IDisposable {
+	private readonly Disposables _disposables = new();
+
+	public void Dispose() {
+		_disposables?.Dispose();
+	}
+
+	private (CacheResourcesTracker, TestMeterListener<long>) GenSut(
+		[CallerMemberName] string callerName = "") {
+
+		var meter = new Meter($"{typeof(CacheResourcesTrackerTests)}-{callerName}").DisposeWith(_disposables);
+		var listener = new TestMeterListener<long>(meter).DisposeWith(_disposables);
+		var metrics = new CacheResourcesMetrics(meter, "the-metric");
+		var sut =  new CacheResourcesTracker(metrics);
+		return (sut, listener);
+	}
+
+	[Fact]
+	public void observes_all_caches() {
+		var (sut, listener) = GenSut();
+
+		sut.Register("cacheA", Caching.ResizerUnit.Entries, () => new("", "",
+			capacity: 1,
+			size: 2,
+			count: 3,
+			numChildren: 0));
+
+		sut.Register("cacheB", Caching.ResizerUnit.Bytes, () => new("", "",
+			capacity: 4,
+			size: 5,
+			count: 6,
+			numChildren: 0));
+
+		listener.Observe();
+		AssertMeasurements(listener, "the-metric-entries",
+			AssertMeasurement("cacheA", "capacity", 1),
+			AssertMeasurement("cacheA", "size", 2),
+			AssertMeasurement("cacheA", "count", 3),
+			AssertMeasurement("cacheB", "count", 6));
+
+		AssertMeasurements(listener, "the-metric-bytes",
+			AssertMeasurement("cacheB", "capacity", 4),
+			AssertMeasurement("cacheB", "size", 5));
+	}
+
+	static Action<TestMeterListener<long>.TestMeasurement> AssertMeasurement(
+		string cacheKey,
+		string kind,
+		long expectedValue) =>
+
+		actualMeasurement => {
+			Assert.Equal(expectedValue, actualMeasurement.Value);
+			Assert.Collection(
+				actualMeasurement.Tags.ToArray(),
+				tag => {
+					Assert.Equal("cache", tag.Key);
+					Assert.Equal(cacheKey, tag.Value);
+				},
+				tag => {
+					Assert.Equal("kind", tag.Key);
+					Assert.Equal(kind, tag.Value);
+				});
+		};
+
+	static void AssertMeasurements(
+		TestMeterListener<long> listener,
+		string metric,
+		params Action<TestMeterListener<long>.TestMeasurement>[] actions) {
+
+		Assert.Collection(listener.RetrieveMeasurements(metric), actions);
+	}
+}

--- a/src/EventStore.Core/Caching/CacheStats.cs
+++ b/src/EventStore.Core/Caching/CacheStats.cs
@@ -5,14 +5,16 @@ namespace EventStore.Core.Caching {
 		public long Capacity { get; }
 		public long Size { get; }
 		public long Count { get; }
+		public int NumChildren { get; }
 		public double UtilizationPercent => Capacity != 0 ? 100.0 * Size / Capacity : 0;
 
-		public CacheStats(string key, string name, long capacity, long size, long count) {
+		public CacheStats(string key, string name, long capacity, long size, long count, int numChildren) {
 			Key = key;
 			Name = name;
 			Capacity = capacity;
 			Size = size;
 			Count = count;
+			NumChildren = numChildren;
 		}
 	}
 }

--- a/src/EventStore.Core/Caching/CompositeCacheResizer.cs
+++ b/src/EventStore.Core/Caching/CompositeCacheResizer.cs
@@ -31,19 +31,21 @@ namespace EventStore.Core.Caching {
 			var key = BuildStatsKey(parentKey);
 			var size = 0L;
 			var count = 0L;
+			var numChildren = 0;
 
 			foreach (var child in _children) {
 				foreach (var childStats in child.GetStats(key)) {
 					if (GetParentKey(childStats.Key) == key) {
 						size += childStats.Size;
 						count += childStats.Count;
+						numChildren++;
 					}
 
 					yield return childStats;
 				}
 			}
 
-			yield return new CacheStats(key, Name, Cache.Capacity, size, count);
+			yield return new CacheStats(key, Name, Cache.Capacity, size, count, numChildren);
 		}
 
 		private static ResizerUnit GetUniqueUnit(ICacheResizer[] children) {

--- a/src/EventStore.Core/Caching/DynamicCacheResizer.cs
+++ b/src/EventStore.Core/Caching/DynamicCacheResizer.cs
@@ -47,7 +47,7 @@ namespace EventStore.Core.Caching {
 		}
 
 		public IEnumerable<CacheStats> GetStats(string parentKey) {
-			yield return new CacheStats(BuildStatsKey(parentKey), Name, Cache.Capacity, Size, Count);
+			yield return new CacheStats(BuildStatsKey(parentKey), Name, Cache.Capacity, Size, Count, numChildren: 0);
 		}
 	}
 }

--- a/src/EventStore.Core/Caching/StaticCacheResizer.cs
+++ b/src/EventStore.Core/Caching/StaticCacheResizer.cs
@@ -28,7 +28,7 @@ namespace EventStore.Core.Caching {
 		}
 
 		public IEnumerable<CacheStats> GetStats(string parentKey) {
-			yield return new CacheStats(BuildStatsKey(parentKey), Name, Cache.Capacity, Size, Count);
+			yield return new CacheStats(BuildStatsKey(parentKey), Name, Cache.Capacity, Size, Count, numChildren: 0);
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -622,7 +622,8 @@ namespace EventStore.Core {
 				monitoringInterval: TimeSpan.FromSeconds(15),
 				minResizeInterval: TimeSpan.FromMinutes(10),
 				minResizeThreshold: 200L * 1024 * 1024, // 200 MiB
-				rootCacheResizer: new CompositeCacheResizer("cache", 100, streamInfoCacheResizer));
+				rootCacheResizer: new CompositeCacheResizer("cache", 100, streamInfoCacheResizer),
+				cacheResourcesTracker: trackers.CacheResourcesTracker);
 
 			_mainBus.Subscribe<MonitoringMessage.DynamicCacheManagerTick>(dynamicCacheManager);
 			monitoringRequestBus.Subscribe<MonitoringMessage.InternalStatsRequest>(dynamicCacheManager);

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -31,6 +31,7 @@ public class Trackers {
 	public IMaxTracker<long> WriterFlushSizeTracker { get; set; } = new MaxTracker<long>.NoOp();
 	public IDurationMaxTracker WriterFlushDurationTracker { get; set; } = new DurationMaxTracker.NoOp();
 	public ICacheHitsMissesTracker CacheHitsMissesTracker { get; set; } = new CacheHitsMissesTracker.NoOp();
+	public ICacheResourcesTracker CacheResourcesTracker { get; set; } = new CacheResourcesTracker.NoOp();
 }
 
 public class GrpcTrackers {
@@ -98,6 +99,12 @@ public static class MetricsBootstrapper {
 				{ Conf.Cache.Chunk, "chunk" },
 			});
 			trackers.CacheHitsMissesTracker = new CacheHitsMissesTracker(metric);
+		}
+
+		// dynamic cache resources
+		if (conf.CacheResources) {
+			var metrics = new CacheResourcesMetrics(coreMeter, "eventstore-cache-resources");
+			trackers.CacheResourcesTracker = new CacheResourcesTracker(metrics);
 		}
 
 		// events

--- a/src/EventStore.Core/Telemetry/CacheResourcesMetrics.cs
+++ b/src/EventStore.Core/Telemetry/CacheResourcesMetrics.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using EventStore.Core.Caching;
+
+namespace EventStore.Core.Telemetry;
+
+public class CacheResourcesMetrics {
+	private readonly ObservableUpDownMetric<long> _bytesMetric;
+	private readonly ObservableUpDownMetric<long> _entriesMetric;
+
+	public CacheResourcesMetrics(Meter meter, string name) {
+		_bytesMetric = new ObservableUpDownMetric<long>(meter, name, "bytes");
+		_entriesMetric = new ObservableUpDownMetric<long>(meter, name, "entries");
+	}
+
+	public void Register(string cache, ResizerUnit unit, Func<CacheStats> getStats) {
+		var sizeAndCapacityMetric = unit == ResizerUnit.Entries
+			? _entriesMetric
+			: _bytesMetric;
+
+		Register(sizeAndCapacityMetric, cache, "capacity", () => getStats().Capacity);
+		Register(sizeAndCapacityMetric, cache, "size", () => getStats().Size);
+		Register(_entriesMetric, cache, "count", () => getStats().Count);
+	}
+
+	private static void Register(
+		ObservableUpDownMetric<long> metric,
+		string cache,
+		string metricName,
+		Func<long> measurementProvider) {
+
+		var tags = new KeyValuePair<string, object>[] {
+			new("cache", cache),
+			new("kind", metricName)
+		};
+		metric.Register(() => new(measurementProvider(), tags));
+	}
+}

--- a/src/EventStore.Core/Telemetry/CacheResourcesTracker.cs
+++ b/src/EventStore.Core/Telemetry/CacheResourcesTracker.cs
@@ -1,0 +1,25 @@
+using System;
+using EventStore.Core.Caching;
+
+namespace EventStore.Core.Telemetry;
+
+public interface ICacheResourcesTracker {
+	public void Register(string cacheKey, ResizerUnit unit, Func<CacheStats> getStats);
+}
+
+public class CacheResourcesTracker : ICacheResourcesTracker {
+	private readonly CacheResourcesMetrics _metrics;
+
+	public CacheResourcesTracker(CacheResourcesMetrics metrics) {
+		_metrics = metrics;
+	}
+
+	public void Register(string cache, ResizerUnit unit, Func<CacheStats> getStats) {
+		_metrics.Register(cache, unit, getStats);
+	}
+
+	public class NoOp : ICacheResourcesTracker {
+		public void Register(string cacheKey, ResizerUnit unit, Func<CacheStats> getStats) {
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/ObservableUpDownMetric.cs
+++ b/src/EventStore.Core/Telemetry/ObservableUpDownMetric.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+
+namespace EventStore.Core.Telemetry;
+
+public class ObservableUpDownMetric<T> where T : struct {
+	private readonly List<Func<Measurement<T>>> _measurementProviders = new();
+	private readonly object _lock = new();
+
+	public ObservableUpDownMetric(Meter meter, string name, string unit = null) {
+		meter.CreateObservableUpDownCounter(name, Observe, unit);
+	}
+
+	public void Register(Func<Measurement<T>> measurementProvider) {
+		if (measurementProvider is null) {
+			throw new ArgumentException("Measurement provider couldn't be null");
+		}
+
+		lock (_lock) {
+			_measurementProviders.Add(measurementProvider);
+		}
+	}
+
+	private IEnumerable<Measurement<T>> Observe() {
+		lock (_lock) {
+			foreach (var measurementProvider in _measurementProviders) {
+				yield return measurementProvider();
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added : collect count, size and capacity metrics from DynamicCacheManager

![image](https://github.com/EventStore/EventStore/assets/2587665/a0c01d69-a2c2-46d9-bc5f-f5efa8ae9477)
