### PR TITLE
DB-107: Add busy/idle metric for queues

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -101,9 +101,17 @@
 		"DiskWrittenOps": true
 	},
 
+	"Queues": {
+		"Busy": true,
+		"Length": true,
+		// this is the most expensive metric, creating a histogram for each
+		// queue grouping and message type grouping as defined in the config below
+		"Processing": true
+	},
+
 	// this specifies what name to track each queue under, according to regular expressions to
 	// match the queue names against
-	"Queues": [
+	"QueueLabels": [
 		{
 			"Regex": "MainQueue",
 			"Label": "Main"

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -131,6 +131,12 @@ namespace EventStore.Common.Configuration {
 			DiskWrittenOps,
 		}
 
+		public enum QueueTracker {
+			Busy = 1,
+			Length,
+			Processing,
+		}
+
 		public class LabelMappingCase {
 			public string Regex { get; set; }
 			public string Label { get; set; }
@@ -163,7 +169,9 @@ namespace EventStore.Common.Configuration {
 		// must be 0, 1, 5, 10 or a multiple of 15
 		public int ExpectedScrapeIntervalSeconds { get; set; }
 
-		public LabelMappingCase[] Queues { get; set; } = Array.Empty<LabelMappingCase>();
+		public Dictionary<QueueTracker, bool> Queues { get; set; } = new();
+
+		public LabelMappingCase[] QueueLabels { get; set; } = Array.Empty<LabelMappingCase>();
 
 		public LabelMappingCase[] MessageTypes { get; set; } = Array.Empty<LabelMappingCase>();
 	}

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/AverageMetricTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/AverageMetricTests.cs
@@ -1,0 +1,39 @@
+﻿using System.Diagnostics.Metrics;
+using EventStore.Core.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public class AverageMetricTests {
+	[Fact]
+	public void calculates_average() {
+		using var meter = new Meter($"{typeof(QueueProcessingTrackerTests)}");
+		using var listener = new TestMeterListener<double>(meter);
+		var sut = new AverageMetric(meter, "the-metric", "seconds", label => new("queue", label));
+		sut.Register("readers", () => 1);
+		sut.Register("readers", () => 2);
+		sut.Register("writer", () => 3);
+		listener.Observe();
+
+		Assert.Collection(
+			listener.RetrieveMeasurements("the-metric-seconds"),
+			m => {
+				Assert.Equal(1.5, m.Value);
+				Assert.Collection(
+					m.Tags,
+					t => {
+						Assert.Equal("queue", t.Key);
+						Assert.Equal("readers", t.Value);
+					});
+			},
+			m => {
+				Assert.Equal(3, m.Value);
+				Assert.Collection(
+					m.Tags,
+					t => {
+						Assert.Equal("queue", t.Key);
+						Assert.Equal("writer", t.Value);
+					});
+			});
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/QueueBusyTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/QueueBusyTrackerTests.cs
@@ -1,0 +1,33 @@
+﻿using System.Diagnostics.Metrics;
+using System.Threading.Tasks;
+using EventStore.Core.Telemetry;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public class QueueBusyTrackerTests {
+	[Fact]
+	public async Task records() {
+		using var meter = new Meter($"{typeof(QueueProcessingTrackerTests)}");
+		using var listener = new TestMeterListener<double>(meter);
+		var metric = new AverageMetric(meter, "the-metric", "seconds", label => new("queue", label));
+		var sut = new QueueBusyTracker(metric, "the-queue");
+
+		sut.EnterBusy();
+		await Task.Delay(1);
+		sut.EnterIdle();
+		listener.Observe();
+
+		Assert.Collection(
+			listener.RetrieveMeasurements("the-metric-seconds"),
+			m => {
+				Assert.True(m.Value > 0.0001);
+				Assert.Collection(
+					m.Tags,
+					t => {
+						Assert.Equal("queue", t.Key);
+						Assert.Equal("the-queue", t.Value);
+					});
+			});
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/QueueTrackersTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/QueueTrackersTests.cs
@@ -80,13 +80,19 @@ namespace EventStore.Core.XUnit.Tests.Telemetry {
 		}
 
 		QueueTrackers GenSut(params Conf.LabelMappingCase[] map) =>
-			new(map, x => {
-				var tracker = new FakeTracker { Name = x };
-				return new QueueTracker(x, tracker, tracker);
-			});
+			new(map,
+				x => new FakeTracker { Name = x },
+				x => new FakeTracker { Name = x },
+				x => new FakeTracker { Name = x });
 
-		class FakeTracker : IDurationMaxTracker, IQueueProcessingTracker {
+		class FakeTracker : IDurationMaxTracker, IQueueProcessingTracker, IQueueBusyTracker {
 			public string Name { get; init; }
+
+			public void EnterBusy() {
+			}
+
+			public void EnterIdle() {
+			}
 
 			public Instant RecordNow(Instant start) => start;
 

--- a/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerMRES.cs
@@ -103,6 +103,7 @@ namespace EventStore.Core.Bus {
 							_starving = true;
 
 							_queueStats.EnterIdle();
+							_tracker.EnterIdle();
 							_msgAddEvent.Wait(100);
 							_msgAddEvent.Reset();
 
@@ -111,6 +112,7 @@ namespace EventStore.Core.Bus {
 							var start = _tracker.RecordMessageDequeued(item.EnqueuedAt);
 							msg = item.Message;
 							_queueStats.EnterBusy();
+							_tracker.EnterBusy();
 #if DEBUG
 							_queueStats.Dequeued(msg);
 #endif

--- a/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
+++ b/src/EventStore.Core/Bus/QueuedHandlerThreadPool.cs
@@ -105,6 +105,7 @@ namespace EventStore.Core.Bus {
 				while (proceed) {
 					_stopped.Reset();
 					_queueStats.EnterBusy();
+					_tracker.EnterBusy();
 
 					Message msg;
 					while (!_stop && _queue.TryDequeue(out var item)) {
@@ -152,6 +153,7 @@ namespace EventStore.Core.Bus {
 					}
 
 					_queueStats.EnterIdle();
+					_tracker.EnterIdle();
 					Interlocked.CompareExchange(ref _isRunning, 0, 1);
 					if (_stop) {
 						TryStopQueueStats();

--- a/src/EventStore.Core/Telemetry/AverageMetric.cs
+++ b/src/EventStore.Core/Telemetry/AverageMetric.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Tag = System.Collections.Generic.KeyValuePair<string, object>;
+
+namespace EventStore.Core.Telemetry {
+	// When observed, this calculates the average for each group
+	public class AverageMetric {
+		private readonly object _lock = new();
+		private readonly Func<string, Tag> _genTag;
+		private readonly Dictionary<string, (List<Func<double>>, Tag[])> _subMetricGroups = new();
+
+		public AverageMetric(Meter meter, string name, string unit, Func<string, Tag> genTag) {
+			_genTag = genTag;
+			meter.CreateObservableCounter(name, Observe, unit);
+		}
+
+		public void Register(string group, Func<double> subMetric) {
+			lock (_lock) {
+				if (_subMetricGroups.TryGetValue(group, out var pair)) {
+					pair.Item1.Add(subMetric);
+				} else {
+					var tags = new[] { _genTag(group) };
+					_subMetricGroups[group] = (new() { subMetric }, tags);
+				}
+			}
+		}
+
+		private IEnumerable<Measurement<double>> Observe() {
+			lock (_lock) {
+				foreach (var (groupFuncs, groupTags) in _subMetricGroups.Values) {
+					var total = 0d;
+					foreach (var observe in groupFuncs) {
+						total += observe();
+					}
+					var average = total / groupFuncs.Count;
+					yield return new(average, groupTags);
+				}
+			}
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/QueueBusyTracker.cs
+++ b/src/EventStore.Core/Telemetry/QueueBusyTracker.cs
@@ -1,0 +1,28 @@
+﻿using System.Diagnostics;
+
+namespace EventStore.Core.Telemetry;
+
+public interface IQueueBusyTracker {
+	void EnterBusy();
+	void EnterIdle();
+}
+
+public class QueueBusyTracker : IQueueBusyTracker {
+	private readonly Stopwatch _stopwatch = new();
+
+	public QueueBusyTracker(AverageMetric metric, string label) {
+		metric.Register(label, () => _stopwatch.Elapsed.TotalSeconds);
+	}
+
+	public void EnterBusy() => _stopwatch.Start();
+
+	public void EnterIdle() => _stopwatch.Stop();
+
+	public class NoOp : IQueueBusyTracker {
+		public void EnterBusy() {
+		}
+
+		public void EnterIdle() {
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/QueueTrackers.cs
+++ b/src/EventStore.Core/Telemetry/QueueTrackers.cs
@@ -6,28 +6,58 @@ using Conf = EventStore.Common.Configuration.TelemetryConfiguration;
 
 namespace EventStore.Core.Telemetry;
 
+// Some of the trackers are shared between all the queues that have the same label
+// We cache those in _sharedTrackers.
+// Other trackers each queue has its own instance.
 public class QueueTrackers {
 	private static readonly ILogger Log = Serilog.Log.ForContext<QueueTrackers>();
 
-	private readonly Dictionary<string, QueueTracker> _trackers = new();
-	private readonly QueueTracker _noOp = QueueTracker.NoOp;
+	private readonly Dictionary<string, SharedTrackers> _sharedTrackers = new();
+
+	private readonly PrivateTrackers _noOpPrivate = new(
+		new QueueBusyTracker.NoOp());
+
+	private readonly SharedTrackers _noOpShared = new(
+		"NoOp",
+		new DurationMaxTracker.NoOp(),
+		new QueueProcessingTracker.NoOp());
+
 	private readonly Conf.LabelMappingCase[] _cases;
-	private readonly Func<string, QueueTracker> _trackerFactory;
+	private readonly Func<string, IQueueBusyTracker> _busyTrackerFactory;
+	private readonly Func<string, IDurationMaxTracker> _durationTrackerFactory;
+	private readonly Func<string, IQueueProcessingTracker> _processingTrackerFactory;
 
 	public QueueTrackers() {
 		_cases = Array.Empty<Conf.LabelMappingCase>();
-		_trackerFactory = _ => _noOp;
+		_busyTrackerFactory = _ => _noOpPrivate.QueueBusyTracker;
+		_durationTrackerFactory = _ => _noOpShared.QueueingDurationTracker;
+		_processingTrackerFactory = _ => _noOpShared.QueueProcessingTracker;
 	}
 
 	public QueueTrackers(
 		Conf.LabelMappingCase[] cases,
-		Func<string, QueueTracker> trackerFactory) {
+		Func<string, IQueueBusyTracker> busyTrackerFactory,
+		Func<string, IDurationMaxTracker> durationTrackerFactory,
+		Func<string, IQueueProcessingTracker> processingTrackerFactory) {
 
 		_cases = cases;
-		_trackerFactory = trackerFactory;
+		_busyTrackerFactory = busyTrackerFactory;
+		_durationTrackerFactory = durationTrackerFactory;
+		_processingTrackerFactory = processingTrackerFactory;
 	}
 
 	public QueueTracker GetTrackerForQueue(string queueName) {
+		var sharedTrackers = GetSharedTrackerForQueue(queueName);
+		var privateTrackers = GetPrivateTrackerForLabel(sharedTrackers.Label);
+
+		return new QueueTracker(
+			sharedTrackers.Label,
+			privateTrackers.QueueBusyTracker,
+			sharedTrackers.QueueingDurationTracker,
+			sharedTrackers.QueueProcessingTracker);
+	}
+
+	private SharedTrackers GetSharedTrackerForQueue(string queueName) {
 		foreach (var @case in _cases) {
 			var pattern = $"^{@case.Regex}$";
 			var match = Regex.Match(input: queueName, pattern: pattern);
@@ -38,26 +68,44 @@ public class QueueTrackers {
 					replacement: @case.Label);
 
 				if (string.IsNullOrWhiteSpace(label))
-					return _noOp;
+					return _noOpShared;
 
 				Log.Information(
 					"Telemetry matched queue {queueName} with pattern {pattern}. Label: {label}",
 					queueName, @case.Regex, label);
 
-				return GetTrackerByName(label);
+				return GetSharedTrackerForLabel(label);
 			}
 		}
 
 		Log.Information("Telemetry did not match queue {queueName}. Metrics will not be collected", queueName);
-		return _noOp;
+		return _noOpShared;
 	}
 
-	private QueueTracker GetTrackerByName(string trackerName) {
-		if (!_trackers.TryGetValue(trackerName, out var tracker)) {
-			tracker = _trackerFactory(trackerName);
-			_trackers[trackerName] = tracker;
+	private SharedTrackers GetSharedTrackerForLabel(string label) {
+		if (!_sharedTrackers.TryGetValue(label, out var tracker)) {
+			tracker = new(
+				label,
+				_durationTrackerFactory(label),
+				_processingTrackerFactory(label));
+			_sharedTrackers[label] = tracker;
 		}
 
 		return tracker;
 	}
+
+	private PrivateTrackers GetPrivateTrackerForLabel(string label) {
+		return new(_busyTrackerFactory(label));
+	}
+
+	// each queue gets its own instance of the busytracker because it deals with the aggregation
+	// on observation rather than on measurement. two queues trying to start/stop the same stopwatch
+	// wouldn't make sense.
+	private record PrivateTrackers(
+		IQueueBusyTracker QueueBusyTracker);
+
+	private record SharedTrackers(
+		string Label,
+		IDurationMaxTracker QueueingDurationTracker,
+		IQueueProcessingTracker QueueProcessingTracker);
 }


### PR DESCRIPTION
Added: metric for queue busy/idle

![image](https://github.com/EventStore/EventStore/assets/2587665/6e2c3d0a-acf9-4fc5-a9fa-ea98d89df15e)

(dont panic about the screenshot, i was flooding the server with trivial requests for streams that dont exist)

- we time, using a stopwatch, how long each queue has been busy for
- when observed, we take the average busy time per queue group (whether groups are defined by the configuration)
- promql can then see how much the average time has changed since the begining of the period and calculate the percentage

note that we couldn't take the max instead of the average: say we were measuring two queues in the group
and on scape 1 queue1 had been active for 10s, and queue2 had been active for 0s. The scrape would return 10s. then on scrape 2, 5 seconds later, queue1 had been active for 10s still, but queue2 had been active for 5s. Well the max busyness for the group ought to be 100% but the scrape will return 10s which is the same as before making it seem like no work was done.

Taking the average avoids this problem and is equally (or more) valid to meaure because 100% means that all the queues are fully busy.

`irate(eventstore_queue_busy_seconds{instance="$Instance"}[$__rate_interval])`