### PR TITLE
Add GC max Execution Engine Suspension duration.

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -89,6 +89,7 @@
 		"Gen2Size": true,
 		"LohSize": true,
 		"TimeInGc": true,
+		"GcPauseDuration": true,
 		"HeapSize": true,
 		"HeapFragmentation": true,
 		"TotalAllocatedBytes": true,

--- a/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
+++ b/src/EventStore.Common/Configuration/TelemetryConfiguration.cs
@@ -126,6 +126,7 @@ namespace EventStore.Common.Configuration {
 			DiskReadOps,
 			DiskWrittenBytes,
 			DiskWrittenOps,
+			GcPauseDuration,
 		}
 
 		public class LabelMappingCase {

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/ProcessMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/ProcessMetricsTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Metrics;
+using System.Threading;
 using EventStore.Common.Configuration;
 using EventStore.Core.Telemetry;
 using Xunit;
+using Xunit.Sdk;
 
 namespace EventStore.Core.XUnit.Tests.Telemetry;
 
@@ -25,7 +27,7 @@ public class ProcessMetricsTests : IDisposable {
 			config[value] = true;
 		}
 
-		_sut = new ProcessMetrics(meter, TimeSpan.FromSeconds(42), config);
+		_sut = new ProcessMetrics(meter, TimeSpan.FromSeconds(42), scrapingPeriodInSeconds: 15, config);
 		_sut.CreateObservableMetrics(new() {
 			{ TelemetryConfiguration.ProcessTracker.UpTime, "eventstore-proc-up-time" },
 			{ TelemetryConfiguration.ProcessTracker.Cpu, "eventstore-proc-cpu" },
@@ -36,6 +38,7 @@ public class ProcessMetricsTests : IDisposable {
 			{ TelemetryConfiguration.ProcessTracker.HeapSize, "eventstore-gc-heap-size" },
 			{ TelemetryConfiguration.ProcessTracker.HeapFragmentation, "eventstore-gc-heap-fragmentation" },
 			{ TelemetryConfiguration.ProcessTracker.TotalAllocatedBytes, "eventstore-gc-total-allocated" },
+			{ TelemetryConfiguration.ProcessTracker.GcPauseDuration, "eventstore-gc-pause-duration" },
 		});
 
 		_sut.CreateMemoryMetric("eventstore-proc-mem", new() {
@@ -64,6 +67,9 @@ public class ProcessMetricsTests : IDisposable {
 			{ TelemetryConfiguration.ProcessTracker.DiskReadBytes, "read" },
 			{ TelemetryConfiguration.ProcessTracker.DiskWrittenBytes, "written" },
 		});
+
+		// To trigger the GC pause detection metric.
+		GC.Collect();
 
 		_intListener.Observe();
 		_doubleListener.Observe();
@@ -283,5 +289,31 @@ public class ProcessMetricsTests : IDisposable {
 						Assert.Equal("written", tag.Value);
 					});
 			});
+	}
+
+	[Fact]
+	public void can_detect_gc_pauses() {
+		for (var count = 0; count < 50; ++count) {
+			try {
+				Assert.Collection(
+					_doubleListener.RetrieveMeasurements("eventstore-gc-pause-duration-seconds"),
+					m => {
+						Assert.Collection(
+							m.Tags,
+							tag => {
+								Assert.Equal("range", tag.Key);
+								Assert.Equal("16-20 seconds", tag.Value);
+							});
+
+						Assert.True(m.Value > 0);
+					});
+
+				return;
+			} catch (CollectionException) {
+			}
+
+			Thread.Sleep(10);
+			_doubleListener.Observe();
+		}
 	}
 }

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -235,7 +235,7 @@ public static class MetricsBootstrapper {
 		});
 
 		// process
-		var processMetrics = new ProcessMetrics(coreMeter, timeout, conf.Process);
+		var processMetrics = new ProcessMetrics(coreMeter, timeout, conf.ExpectedScrapeIntervalSeconds, conf.Process);
 		processMetrics.CreateObservableMetrics(new() {
 			{ Conf.ProcessTracker.UpTime, "eventstore-proc-up-time" },
 			{ Conf.ProcessTracker.Cpu, "eventstore-proc-cpu" },
@@ -246,6 +246,7 @@ public static class MetricsBootstrapper {
 			{ Conf.ProcessTracker.HeapSize, "eventstore-gc-heap-size" },
 			{ Conf.ProcessTracker.HeapFragmentation, "eventstore-gc-heap-fragmentation" },
 			{ Conf.ProcessTracker.TotalAllocatedBytes, "eventstore-gc-total-allocated" },
+			{ Conf.ProcessTracker.GcPauseDuration, "eventstore-gc-pause-duration-max" },
 		});
 
 		processMetrics.CreateMemoryMetric("eventstore-proc-mem", new() {

--- a/src/EventStore.Core/Telemetry/DurationMaxTracker.cs
+++ b/src/EventStore.Core/Telemetry/DurationMaxTracker.cs
@@ -55,6 +55,10 @@ public class DurationMaxTracker : IDurationMaxTracker {
 		return now;
 	}
 
+	public void RecordNow(TimeSpan duration) {
+		_recentMax.Record(_clock.Now, duration.TotalSeconds);
+	}
+
 	public Measurement<double> Observe() {
 		var value = _recentMax.Observe(_clock.Now);
 		return new(value, _maxTags.AsSpan());

--- a/src/EventStore.Core/Telemetry/GCSuspensionMetric.cs
+++ b/src/EventStore.Core/Telemetry/GCSuspensionMetric.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Diagnostics.Tracing;
+
+namespace EventStore.Core.Telemetry;
+
+public class GcSuspensionMetric : EventListener {
+	private const int GcKeyword = 0x0000001;
+	private const int GCSuspendEEBegin = 9;
+	private const int GCRestartEEEnd = 3;
+	private const uint SuspendForGc = 0x1;
+	private const uint SuspendForGcPrep = 0x6;
+	private readonly DurationMaxTracker _tracker;
+	private DateTime? _started;
+
+	public GcSuspensionMetric(DurationMaxTracker tracker) {
+		_tracker = tracker;
+	}
+
+	protected override void OnEventSourceCreated(EventSource eventSource) {
+		if (eventSource.Name.Equals("Microsoft-Windows-DotNETRuntime")) {
+			EnableEvents(eventSource, EventLevel.Informational, (EventKeywords)GcKeyword);
+		}
+	}
+
+	protected override void OnEventWritten(EventWrittenEventArgs eventData) {
+		if (_tracker == null)
+			return;
+
+		switch (eventData.EventId) {
+			case GCSuspendEEBegin: {
+				var idx = eventData.PayloadNames!.IndexOf("Reason");
+				var value = (uint)eventData.Payload![idx]!;
+
+				// We only track suspensions that are meant for garbage collection.
+				// See https://learn.microsoft.com/en-us/dotnet/fundamentals/diagnostics/runtime-garbage-collection-events
+				if (value is SuspendForGc or SuspendForGcPrep)
+					_started = eventData.TimeStamp;
+
+				break;
+			}
+
+			case GCRestartEEEnd: {
+				// Means that the suspension end event comes from a suspension that was not due to garbage collection.
+				if (!_started.HasValue)
+					return;
+
+				_tracker.RecordNow(eventData.TimeStamp.Subtract(_started.Value));
+				_started = null;
+				break;
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added: Add CG max Execution Engine Suspension duration.

```
# TYPE eventstore_gc_max_pause_duration_max_seconds gauge
# UNIT eventstore_gc_max_pause_duration_max_seconds seconds
eventstore_gc_max_pause_duration_max_seconds{range="16-20 seconds"} 0.000253622 1684188262384
```

![image](https://github.com/EventStore/EventStore/assets/2587665/065e3f68-c222-473f-8fd4-4ef5cc42e961)

The execution engine is suspended for the duration of any blocking GC (gen0, gen1, and blocking gen2 collections). For a background gen2 collection the execution engine is suspended twice at points during the collection but not for the duration of the collection.

The idea here is to be able to determine if execution engine pauses due to GC are the cause of any 'slow queue' messages
