### PR TITLE
DB-91: Provide a little context when logging the telemetry config

### DIFF
--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -290,6 +290,6 @@ public static class MetricsBootstrapper {
 			Formatting.Indented,
 			jsonSerializerSettings);
 
-		Log.Information(confJson);
+		Log.Information("Telemetry Configuration: " + confJson);
 	}
 }


### PR DESCRIPTION
Added: context when logging the telemetry config