### PR TITLE
Remove the options dump from server logs incase the config is incorrect

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -96,8 +96,7 @@ namespace EventStore.ClusterNode {
 				if (options.Unknown.Options.Any() && !options.Application.AllowUnknownOptions) {
 					Log.Fatal(
 						$"Found unknown options. To continue anyway, set {nameof(ClusterVNodeOptions.ApplicationOptions.AllowUnknownOptions)} to true.");
-					Log.Information($"Options:{Environment.NewLine}{ClusterVNodeOptions.HelpText}");
-
+					Log.Information("Use the --help option in the command line to see the full list of EventStoreDB configuration options.");
 					return 1;
 				}
 


### PR DESCRIPTION
Fixed: Remove options dump from server logs incase the config is incorrect

Fixes https://linear.app/eventstore/issue/DB-59/dont-dump-all-the-options-when-the-config-is-wrong

Currently we dump the full list of EventStoreDB options in the server logs if the config contains an incorrect option. The goal of this PR is remove the options dump and notify the user to use the --help option to get a list of all available configuration options.