### PR TITLE
Update log level to Warning if allowUnknownOptions sets to true

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -82,7 +82,7 @@ namespace EventStore.ClusterNode {
 				Log.Information(options.DumpOptions());
 
 				var level = options.Application.AllowUnknownOptions
-					? LogEventLevel.Information
+					? LogEventLevel.Warning
 					: LogEventLevel.Fatal;
 
 				foreach (var (option, suggestion) in options.Unknown.Options) {


### PR DESCRIPTION
Fixed: Update log level to Warning if allowUnknownOptions sets to true

Fixes https://linear.app/eventstore/issue/DB-60/unknown-options-log-level-when-allowunknownoptions-is-enabled

The goal of this PR is to update the log level from INF to WRN when allowUnknownOptions sets to true. This will help to detect the cases where user accidentally entered the incorrect option. 