### PR TITLE
Added support for multiple private key file format

### DIFF
--- a/src/EventStore.Core.Tests/Certificates/X509Certificate2Extensions.cs
+++ b/src/EventStore.Core.Tests/Certificates/X509Certificate2Extensions.cs
@@ -1,9 +1,19 @@
+using System;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 
 namespace EventStore.Core.Tests.Certificates {
 	public static class X509Certificate2Extensions {
 		public static string PemPrivateKey(this X509Certificate2 certificate) {
-			return certificate.GetRSAPrivateKey()!.ExportRSAPrivateKey().PEM("PRIVATE KEY");
+			return certificate.GetRSAPrivateKey()!.ExportRSAPrivateKey().PEM("RSA PRIVATE KEY");
+		}
+		
+		public static string PemPkcs8PrivateKey(this X509Certificate2 certificate) {
+			return certificate.GetRSAPrivateKey()!.ExportPkcs8PrivateKey().PEM("PRIVATE KEY");
+		}
+		
+		public static string EncryptedPemPkcs8PrivateKey(this X509Certificate2 certificate, string password) {
+			return certificate.GetRSAPrivateKey()!.ExportEncryptedPkcs8PrivateKey(password.AsSpan(), new PbeParameters(PbeEncryptionAlgorithm.Aes128Cbc, HashAlgorithmName.SHA1, 1)).PEM("ENCRYPTED PRIVATE KEY");
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -270,9 +270,14 @@ namespace EventStore.Core {
 			[Description("The password to the certificate if a PKCS #12 (.p12/.pfx) certificate file is provided."),
 			 Sensitive]
 			public string? CertificatePassword { get; init; }
+			
+			[Description("The password to the certificate private key file if an encrypted PKCS #8 private key file is provided."),
+			 Sensitive]
+			public string? CertificatePrivateKeyPassword { get; init; }
 
 			public static CertificateFileOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				CertificatePassword = configurationRoot.GetValue<string>(nameof(CertificatePassword)),
+				CertificatePrivateKeyPassword = configurationRoot.GetValue<string>(nameof(CertificatePrivateKeyPassword)),
 				CertificatePrivateKeyFile = configurationRoot.GetValue<string>(nameof(CertificatePrivateKeyFile)),
 				CertificateFile = configurationRoot.GetValue<string>(nameof(CertificateFile))
 			};

--- a/src/EventStore.Core/ClusterVNodeOptionsExtensions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptionsExtensions.cs
@@ -237,7 +237,7 @@ namespace EventStore.Core {
 
 			if (options.CertificateFile.CertificateFile.IsNotEmptyString()) {
 				Log.Information("Loading the node's certificate(s) from file: {path}", options.CertificateFile.CertificateFile);
-				return CertificateUtils.LoadFromFile(options.CertificateFile.CertificateFile, options.CertificateFile.CertificatePrivateKeyFile, options.CertificateFile.CertificatePassword);
+				return CertificateUtils.LoadFromFile(options.CertificateFile.CertificateFile, options.CertificateFile.CertificatePrivateKeyFile, options.CertificateFile.CertificatePassword, options.CertificateFile.CertificatePrivateKeyPassword);
 			}
 
 			throw new InvalidConfigurationException(


### PR DESCRIPTION
Added : Based on header of the private key file, ES will now accept encrypted and unencrypted PKCS8 private key files