### PR TITLE
Update log level to Verbose for NACK logs for persistent subscriptions

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscription.cs
@@ -455,7 +455,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			string reason) {
 			lock (_lock) {
 				foreach (var id in processedEventIds) {
-					Log.Information("Message NAK'ed id {id} action to take {action} reason '{reason}'", id, action,
+					Log.Verbose("Message NAK'ed id {id} action to take {action} reason '{reason}'", id, action,
 						reason ?? "");
 					HandleNackedMessage(action, id, reason);
 				}


### PR DESCRIPTION
Fixed: Lower the log level of NACK logs for persistent subscriptions

Fixes https://linear.app/eventstore/issue/DB-140/remove-or-lower-the-log-level-of-nack-logs-for-persistent

Currently we are logging the NACK messages for persistent subscriptions at DEBUG level. The goal of this PR is lower the log level to VERBOSE to make server logs more clean. The user can modify the LogLevel in the config file as per their requirements. 