### PR TITLE
Add a warning for node certificate expiring within 30 days (DB-138)

### DIFF
--- a/src/EventStore.Core.Tests/Certificates/CertificateExpiryMonitorTests.cs
+++ b/src/EventStore.Core.Tests/Certificates/CertificateExpiryMonitorTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using NUnit.Framework;
+using EventStore.Core.Certificates;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Fakes;
+
+namespace EventStore.Core.Tests.Certificates {
+
+	public class CertificateExpiryMonitorTests : with_certificates {
+		private FakePublisher _publisher;
+		private FakeLogger _logger;
+
+		private static X509Certificate2 GenCertificate(TimeSpan timeUntilExpiry) {
+			using var rsa = RSA.Create();
+			var certificate = new CertificateRequest(GenerateSubject(), rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
+				.CreateSelfSigned(
+					notBefore: DateTime.Now,
+					notAfter: DateTime.Now + timeUntilExpiry);
+			return certificate;
+		}
+
+		[SetUp]
+		public void SetUp() {
+			_publisher = new();
+			_logger = new();
+		}
+
+		[Test]
+		public void on_start() {
+			// given
+			var certificate = GenCertificate(TimeSpan.FromDays(60));
+			var sut = new CertificateExpiryMonitor(_publisher, () => certificate, _logger);
+
+			// when
+			sut.Handle(new SystemMessage.SystemStart());
+
+			// then
+			Assert.IsInstanceOf<MonitoringMessage.CheckCertificateExpiry>(_publisher.Messages.Single());
+			Assert.IsEmpty(_logger.LogMessages);
+		}
+
+		[Test]
+		public void certificate_is_going_to_expire_within_30_days() {
+			// given
+			var certificate = GenCertificate(TimeSpan.FromDays(29));
+			var sut = new CertificateExpiryMonitor(_publisher, () => certificate, _logger);
+
+			// when
+			sut.Handle(new MonitoringMessage.CheckCertificateExpiry());
+
+			// then
+			var schedule = (TimerMessage.Schedule)_publisher.Messages.Single();
+			Assert.AreEqual(TimeSpan.FromHours(24), schedule.TriggerAfter);
+			Assert.IsInstanceOf<MonitoringMessage.CheckCertificateExpiry>(schedule.ReplyMessage);
+
+			var logMessage = _logger.LogMessages.Single();
+			Assert.AreEqual(
+				"Certificates are going to expire in 29.0 days",
+				logMessage.RenderMessage());
+		}
+
+		[Test]
+		public void certificate_is_not_going_to_expire_within_30_days() {
+			// given
+			var certificate = GenCertificate(TimeSpan.FromDays(31));
+			var sut = new CertificateExpiryMonitor(_publisher, () => certificate, _logger);
+
+			// when
+			sut.Handle(new MonitoringMessage.CheckCertificateExpiry());
+
+			// then
+			var schedule = (TimerMessage.Schedule)_publisher.Messages.Single();
+			Assert.AreEqual(TimeSpan.FromHours(24), schedule.TriggerAfter);
+			Assert.IsInstanceOf<MonitoringMessage.CheckCertificateExpiry>(schedule.ReplyMessage);
+
+			Assert.IsEmpty(_logger.LogMessages);
+		}
+	}
+}

--- a/src/EventStore.Core.Tests/Certificates/with_certificates.cs
+++ b/src/EventStore.Core.Tests/Certificates/with_certificates.cs
@@ -51,7 +51,7 @@ namespace EventStore.Core.Tests.Certificates {
 			return utf8Encoding.GetBytes(s);
 		}
 
-		private static string GenerateSubject() {
+		protected static string GenerateSubject() {
 			var charset = GetCharset();
 			string s = "";
 			for (var j = 0; j < 10; j++) {

--- a/src/EventStore.Core.Tests/Fakes/FakeLogger.cs
+++ b/src/EventStore.Core.Tests/Fakes/FakeLogger.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Serilog;
+using Serilog.Events;
+
+namespace EventStore.Core.Tests.Fakes;
+
+public class FakeLogger : ILogger {
+	public List<LogEvent> LogMessages { get; } = new();
+
+	public void Write(LogEvent logEvent) {
+		LogMessages.Add(logEvent);
+	}
+}

--- a/src/EventStore.Core/Certificates/CertificateExpiryMonitor.cs
+++ b/src/EventStore.Core/Certificates/CertificateExpiryMonitor.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Common.Utils;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using Serilog;
+
+namespace EventStore.Core.Certificates;
+
+public class CertificateExpiryMonitor :
+	IHandle<SystemMessage.SystemStart>,
+	IHandle<MonitoringMessage.CheckCertificateExpiry> {
+
+	private static readonly TimeSpan _warningThreshold = TimeSpan.FromDays(30);
+	private static readonly TimeSpan _interval = TimeSpan.FromDays(1);
+
+	private readonly Func<X509Certificate2> _getCertificate;
+	private readonly IPublisher _publisher;
+	private readonly TimerMessage.Schedule _nodeCertificateExpirySchedule;
+	private readonly ILogger _logger;
+
+	public CertificateExpiryMonitor(
+		IPublisher publisher,
+		Func<X509Certificate2> getCertificate,
+		ILogger logger) {
+
+		Ensure.NotNull(publisher, nameof(publisher));
+		Ensure.NotNull(getCertificate, nameof(getCertificate));
+		Ensure.NotNull(logger, nameof(logger));
+
+		_publisher = publisher;
+		_getCertificate = getCertificate;
+		_logger = logger;
+		_nodeCertificateExpirySchedule = TimerMessage.Schedule.Create(
+			_interval,
+			new PublishEnvelope(publisher),
+			new MonitoringMessage.CheckCertificateExpiry());
+	}
+
+	public void Handle(SystemMessage.SystemStart message) {
+		_publisher.Publish(new MonitoringMessage.CheckCertificateExpiry());
+	}
+
+	public void Handle(MonitoringMessage.CheckCertificateExpiry message) {
+		var certificate = _getCertificate();
+
+		if (certificate != null) {
+			var certExpiryDate = certificate.NotAfter;
+			var timeUntilExpiry = certExpiryDate - DateTime.Now;
+
+			if (timeUntilExpiry <= _warningThreshold) {
+				_logger.Warning(
+					"Certificates are going to expire in {daysUntilExpiry:N1} days",
+					timeUntilExpiry.TotalDays);
+			}
+		}
+
+		_publisher.Publish(_nodeCertificateExpirySchedule);
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -193,7 +193,7 @@ namespace EventStore.Core {
 		private readonly CertificateDelegates.ClientCertificateValidator _externalClientCertificateValidator;
 		private readonly CertificateDelegates.ServerCertificateValidator _externalServerCertificateValidator;
 		private readonly CertificateProvider _certificateProvider;
-
+		
 		private readonly ClusterVNodeStartup<TStreamId> _startup;
 		private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
 
@@ -1536,6 +1536,9 @@ namespace EventStore.Core {
 				options.Cluster.DiscoverViaDns ? options.Cluster.ClusterDns : null);
 			_mainBus.Subscribe<SystemMessage.SystemReady>(_startup);
 			_mainBus.Subscribe<SystemMessage.BecomeShuttingDown>(_startup);
+			var certificateExpiryMonitor = new CertificateExpiryMonitor(_mainQueue, _certificateSelector, Log);
+			_mainBus.Subscribe<SystemMessage.SystemStart>(certificateExpiryMonitor);
+			_mainBus.Subscribe<MonitoringMessage.CheckCertificateExpiry>(certificateExpiryMonitor);
 
 			dynamicCacheManager.Start();
 		}

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -208,5 +208,9 @@ namespace EventStore.Core.Messages {
 		[DerivedMessage(CoreMessage.Misc)]
 		public partial class DynamicCacheManagerTick : Message {
 		}
+		
+		[DerivedMessage(CoreMessage.Misc)]
+		public partial class CheckCertificateExpiry : Message {
+		}
 	}
 }


### PR DESCRIPTION
Fixed: Log a warning when certificates are close to expiry.

Fixes https://linear.app/eventstore/issue/DB-138/log-a-warning-when-certificates-are-close-to-expiry

The goal of this PR is to add a warning daily if the node certificate is going to expire within 30 days. 