### PR TITLE
PRO-105: Added out of support to the EventStore.JVM client in the docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ Find out more about configuring the TCP protocol on the [TCP configuration](netw
 #### EventStoreDB supported clients
 
 - [.NET Framework and .NET Core](http://www.nuget.org/packages/EventStore.Client)
-- [JVM Client (EventStore/EventStore.JVM)](https://github.com/EventStore/EventStore.JVM)
+- [JVM Client (EventStore/EventStore.JVM)](https://github.com/EventStore/EventStore.JVM) (Out Of Support)
 - [Haskell (EventStore/EventStoreDB-Client-Haskell)](https://github.com/EventStore/EventStoreDB-Client-Haskell)
 
 #### Community developed clients


### PR DESCRIPTION
Added "Out Of Support" to the docs to mention that the https://github.com/EventStore/EventStore.JVM is not supported anymore.