### PR TITLE
Read common name from node certificate

### DIFF
--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_single_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_single_node_and_custom_settings.cs
@@ -193,7 +193,8 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
 			_configurationRoot = new ConfigurationBuilder()
 				.Add(new DefaultSource(new Dictionary<string, object> {
 					[nameof(ClusterVNodeOptions.DefaultUser.DefaultAdminPassword)] = SystemUsers.DefaultAdminPassword,
-					[nameof(ClusterVNodeOptions.DefaultUser.DefaultOpsPassword)] = SystemUsers.DefaultOpsPassword
+					[nameof(ClusterVNodeOptions.DefaultUser.DefaultOpsPassword)] = SystemUsers.DefaultOpsPassword,
+					[nameof(ClusterVNodeOptions.Certificate.CertificateReservedNodeCommonName)] = "es"
 				}))
 				.Add(new CommandLineSource(args))
 				.Build();
@@ -214,7 +215,8 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
 			_configurationRoot = new ConfigurationBuilder()
 				.Add(new DefaultSource(new Dictionary<string, object> {
 					[nameof(ClusterVNodeOptions.DefaultUser.DefaultAdminPassword)] = SystemUsers.DefaultAdminPassword,
-					[nameof(ClusterVNodeOptions.DefaultUser.DefaultOpsPassword)] = SystemUsers.DefaultOpsPassword
+					[nameof(ClusterVNodeOptions.DefaultUser.DefaultOpsPassword)] = SystemUsers.DefaultOpsPassword,
+					[nameof(ClusterVNodeOptions.Certificate.CertificateReservedNodeCommonName)] = "es"
 				}))
 				.Add(new CommandLineSource(args))
 				.Add(new EnvironmentVariablesSource(environmentVariables))

--- a/src/EventStore.Core/Certificates/CertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/CertificateProvider.cs
@@ -5,6 +5,8 @@ namespace EventStore.Core.Certificates {
 		public X509Certificate2 Certificate;
 		public X509Certificate2Collection IntermediateCerts;
 		public X509Certificate2Collection TrustedRootCerts;
+		public string CertificateCN = null;
+		
 		public abstract LoadCertificateResult LoadCertificates(ClusterVNodeOptions options);
 	}
 

--- a/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
@@ -14,14 +14,16 @@ namespace EventStore.Core.Certificates {
 			var (certificate, intermediates) = options.LoadNodeCertificate();
 
 			var certificateCN = certificate.GetCommonName();
-			var reservedNodeCN = options.Certificate.CertificateReservedNodeCommonName;
-
-			if (certificateCN != reservedNodeCN) {
+			var optionsCertificateCN = options.Certificate.CertificateReservedNodeCommonName;
+			
+			if (optionsCertificateCN is not null && certificateCN != optionsCertificateCN) {
 				Log.Error(
 					"Certificate CN: {certificateCN} does not match with the CertificateReservedNodeCommonName configuration setting: {reservedNodeCN}",
-					certificateCN, reservedNodeCN);
+					certificateCN, optionsCertificateCN);
 				return LoadCertificateResult.VerificationFailed;
 			}
+
+			CertificateCN = certificateCN;
 			
 			var previousThumbprint = Certificate?.Thumbprint;
 			var newThumbprint = certificate.Thumbprint;

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -996,7 +996,7 @@ namespace EventStore.Core {
 			if (!options.Application.Insecure) {
 				//transport-level authentication providers
 				httpAuthenticationProviders.Add(
-					new ClientCertificateAuthenticationProvider(options.Certificate.CertificateReservedNodeCommonName));
+					new ClientCertificateAuthenticationProvider(_certificateProvider.CertificateCN));
 
 				if (options.Interface.EnableTrustedAuth)
 					httpAuthenticationProviders.Add(new TrustedHttpAuthenticationProvider());

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -291,7 +291,7 @@ namespace EventStore.Core {
 				Locations.DefaultTrustedRootCertificateDirectory;
 
 			[Description("The reserved common name to authenticate EventStoreDB nodes/servers from certificates")]
-			public string CertificateReservedNodeCommonName { get; init; } = "eventstoredb-node";
+			public string? CertificateReservedNodeCommonName { get; set; }
 
 			internal static CertificateOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				TrustedRootCertificatesPath = configurationRoot.GetValue<string>(nameof(TrustedRootCertificatesPath)),

--- a/src/EventStore.Core/ClusterVNodeOptionsExtensions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptionsExtensions.cs
@@ -91,6 +91,18 @@ namespace EventStore.Core {
 			};
 
 		/// <summary>
+		/// Sets/Unsets dev mode
+		/// </summary>
+		/// <param name="options">The <see cref="ClusterVNodeOptions"/></param>
+		/// <param name="dev">true/false flag denoting whether dev mode or not</param>
+		/// <param name="removeDevCerts">true/false flag denoting whether to remove dev certificates or not</param>
+		/// <returns>A <see cref="ClusterVNodeOptions"/> with the options set</returns>
+		public static ClusterVNodeOptions WithDevMode(this ClusterVNodeOptions options, bool dev, bool removeDevCerts = false) =>
+			options with {
+				DevMode = new ClusterVNodeOptions.DevModeOptions { Dev = dev, RemoveDevCerts = removeDevCerts }
+			};
+
+		/// <summary>
 		/// Sets the external tcp endpoint to the specified value
 		/// </summary>
 		/// <param name="options">The <see cref="ClusterVNodeOptions"/></param>


### PR DESCRIPTION
Added : If common name is not specified in config (in secure mode), read from node certificate