### PR TITLE
Loading new certs on calling the admin/reloadconfig endpoint

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -134,7 +134,7 @@ namespace EventStore.ClusterNode {
 					Log.Information("Running in dev mode using certificate '{cert}'", certs[0]);
 					certificateProvider = new DevCertificateProvider(certs[0]);
 				} else {
-					certificateProvider = new OptionsCertificateProvider(options);
+					certificateProvider = new OptionsCertificateProvider();
 				}
 
 				var deprecationWarnings = options.GetDeprecationWarnings();

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Tests.ClientOperations {
 					c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
 					options.Application.AllowAnonymousEndpointAccess, options.Application.AllowAnonymousStreamAccess)),
-				certificateProvider: new OptionsCertificateProvider(options));
+				certificateProvider: new OptionsCertificateProvider());
 			_node.StartAsync(true).Wait();
 		}
 		public void Publish(Message message) {

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
@@ -29,7 +29,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
 					_options.Application.AllowAnonymousEndpointAccess,
 					_options.Application.AllowAnonymousStreamAccess)),
-				certificateProvider: new OptionsCertificateProvider(_options));
+				certificateProvider: new OptionsCertificateProvider());
 			_node.Start();
 		}
 
@@ -64,7 +64,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
 					_options.Application.AllowAnonymousEndpointAccess,
 					_options.Application.AllowAnonymousStreamAccess)),
-				certificateProvider: new OptionsCertificateProvider(_options));
+				certificateProvider: new OptionsCertificateProvider());
 			_node.Start();
 		}
 

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_cluster_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_cluster_node_and_custom_settings.cs
@@ -49,7 +49,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
 			}.RunInMemory();
 			try {
 				_ = new ClusterVNode<TStreamId>(_options, LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory,
-					certificateProvider: new OptionsCertificateProvider(_options));
+					certificateProvider: new OptionsCertificateProvider());
 			} catch (Exception e) {
 				_caughtException = e;
 			}

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_secure_tcp.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_secure_tcp.cs
@@ -110,7 +110,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
 				.WithExternalSecureTcpOn(externalSecTcp);
 			try {
 				_ = new ClusterVNode<TStreamId>(_options, LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory,
-					certificateProvider: new OptionsCertificateProvider(_options));
+					certificateProvider: new OptionsCertificateProvider());
 			} catch (Exception ex) {
 				_caughtException = ex;
 			}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -179,7 +179,7 @@ namespace EventStore.Core.Tests.Helpers {
 						options.Application.AllowAnonymousEndpointAccess,
 						options.Application.AllowAnonymousStreamAccess)),
 				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>(),
-				new OptionsCertificateProvider(options),
+				new OptionsCertificateProvider(),
 				telemetryConfiguration: null,
 				expiryStrategy,
 				Guid.NewGuid(), debugIndex);

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -167,7 +167,7 @@ namespace EventStore.Core.Tests.Helpers {
 					options.Application.AllowAnonymousEndpointAccess, options.Application.AllowAnonymousStreamAccess)),
 				telemetryConfiguration: null,
 				expiryStrategy: expiryStrategy,
-				certificateProvider: new OptionsCertificateProvider(options));
+				certificateProvider: new OptionsCertificateProvider());
 			Db = Node.Db;
 
 			Node.HttpService.SetupController(new TestController(Node.MainQueue));

--- a/src/EventStore.Core/Certificates/CertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/CertificateProvider.cs
@@ -5,8 +5,7 @@ namespace EventStore.Core.Certificates {
 		public X509Certificate2 Certificate;
 		public X509Certificate2Collection IntermediateCerts;
 		public X509Certificate2Collection TrustedRootCerts;
-
-		public abstract LoadCertificateResult LoadCertificates();
+		public abstract LoadCertificateResult LoadCertificates(ClusterVNodeOptions options);
 	}
 
 	public enum LoadCertificateResult {

--- a/src/EventStore.Core/Certificates/DevCertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/DevCertificateProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Security.Cryptography.X509Certificates;
 
 namespace EventStore.Core.Certificates {
@@ -6,8 +7,7 @@ namespace EventStore.Core.Certificates {
 			Certificate = certificate;
 			TrustedRootCerts = new X509Certificate2Collection(certificate);
 		}
-
-		public override LoadCertificateResult LoadCertificates() {
+		public override LoadCertificateResult LoadCertificates(ClusterVNodeOptions options) {
 			return LoadCertificateResult.Skipped;
 		}
 	}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -193,7 +193,6 @@ namespace EventStore.Core {
 		private readonly CertificateDelegates.ClientCertificateValidator _externalClientCertificateValidator;
 		private readonly CertificateDelegates.ServerCertificateValidator _externalServerCertificateValidator;
 		private readonly CertificateProvider _certificateProvider;
-
 		private readonly ClusterVNodeStartup<TStreamId> _startup;
 		private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
 
@@ -1816,8 +1815,8 @@ namespace EventStore.Core {
 				Log.Information("Skipping reload of certificates since TLS is disabled.");
 				return;
 			}
-
-			if (_certificateProvider?.LoadCertificates() == LoadCertificateResult.VerificationFailed){
+			
+			if (_certificateProvider?.LoadCertificates(options) == LoadCertificateResult.VerificationFailed){
 				throw new InvalidConfigurationException("Aborting certificate loading due to verification errors.");
 			}
 		}

--- a/src/EventStore.Core/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/ClusterVNodeOptionsValidator.cs
@@ -121,4 +121,3 @@ public static class ClusterVNodeOptionsValidator {
 		return true;
 	}
 }
-


### PR DESCRIPTION
Fixed : Calling the admin/reloadconfig endpoint only reloaded/updated the LogLevel and the certificates were not updated on reloading the config. 

Fixes : https://linear.app/eventstore/issue/DB-166/new-certs-are-not-loaded-on-calling-the-adminreloadconfig-endpoint

As of now, as per the codebase, we only allow reloading of certificates or LogLevel to be readjusted on reloading the config file by calling the admin/reloadconfig endpoint.