### PR TITLE
Support bloom filters for 400gb+ ptables (DB-195)

### DIFF
--- a/src/EventStore.Core.Tests/Index/IndexV1/when_creating_large_bloom_filter.cs
+++ b/src/EventStore.Core.Tests/Index/IndexV1/when_creating_large_bloom_filter.cs
@@ -1,0 +1,25 @@
+using EventStore.Core.DataStructures.ProbabilisticFilter;
+using EventStore.Core.Index;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Index.IndexV1 {
+	public class when_creating_large_bloom_filter : SpecificationWithDirectory {
+		[Ignore("Quick but requires 4gb disk")]
+		[Test]
+		public void ptable_exceeding_maximum_filter_size_succeeds() {
+			var file = GetTempFilePath();
+
+			// create
+			var filter = PTable.ConstructBloomFilter(
+				useBloomFilter: true,
+				filename: file,
+				indexEntryCount: 16_384_000_000);
+			filter.Dispose();
+
+			// and reopen
+			filter = new PersistentBloomFilter(FileStreamPersistence.FromFile(
+				PTable.GenBloomFilterFilename(file)));
+			filter.Dispose();
+		}
+	}
+}

--- a/src/EventStore.Core/DataStructures/ProbabilisticFilter/BloomFilterAccessor.cs
+++ b/src/EventStore.Core/DataStructures/ProbabilisticFilter/BloomFilterAccessor.cs
@@ -40,6 +40,7 @@ namespace EventStore.Core.DataStructures.ProbabilisticFilter {
 			if (logicalFilterSize < MinSizeKB * 1000 || logicalFilterSize > MaxSizeKB * 1000) {
 				throw new ArgumentOutOfRangeException(
 					nameof(logicalFilterSize),
+					logicalFilterSize,
 					$"size should be between {MinSizeKB:N0} KB and {MaxSizeKB:N0} KB inclusive");
 			}
 

--- a/src/EventStore.Core/DataStructures/ProbabilisticFilter/FileStreamPersistence.cs
+++ b/src/EventStore.Core/DataStructures/ProbabilisticFilter/FileStreamPersistence.cs
@@ -122,11 +122,13 @@ namespace EventStore.Core.DataStructures.ProbabilisticFilter {
 					$"The expected file size ({DataAccessor.FileSize:N0}) does not match " +
 					$"the actual file size ({bulkFileStream.Length:N0}) of file {_path}");
 
+			// linux only reads 2147479552 at a time (4095 bytes less than intmax)
+			var blockSize = int.MaxValue / 2;
 			var bytesToRead = DataAccessor.FileSize;
 			var bytesRead = 0L;
 			while (bytesToRead > 0) {
-				var bytesToReadInBlock = bytesToRead > int.MaxValue
-					? int.MaxValue
+				var bytesToReadInBlock = bytesToRead > blockSize
+					? blockSize
 					: (int)bytesToRead;
 				
 				// consider reading in buffer size blocks. or using random access in net6

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -71,7 +71,10 @@ namespace EventStore.Core.Index {
 			// We could count them to be precise, but a reasonable estimate will be faster.
 			const int averageEventsPerStreamPerFile = 4;
 			long size = entryCount / averageEventsPerStreamPerFile;
-			size = Math.Max(size, 10_000);
+			size = Math.Clamp(
+				value: size,
+				min: BloomFilterAccessor.MinSizeKB * 1000,
+				max: BloomFilterAccessor.MaxSizeKB * 1000);
 			return size;
 		}
 

--- a/src/EventStore.Core/Index/PTableConstruction.cs
+++ b/src/EventStore.Core/Index/PTableConstruction.cs
@@ -25,7 +25,7 @@ namespace EventStore.Core.Index {
 
 		private const int MidpointsOverflowSafetyNet = 20;
 
-		private static PersistentBloomFilter ConstructBloomFilter(
+		public static PersistentBloomFilter ConstructBloomFilter(
 			bool useBloomFilter,
 			string filename,
 			long indexEntryCount) {


### PR DESCRIPTION
Fixed: Support bloom filters for 400gb+ index files

Before this fix, large ptables (>400gb (16 billion events)) tried to create a bloomfilter that is larger than the maximum allowed size (4gb) causing the server to exit. Now we clamp it to the maximum allowed size.

Also, bloom filters above int32.max bytes (~2gb) were not openable on linux because we were reading in batches of int32.max bytes but linux reads 4095 bytes less than that. This was causing large bloom filters to be unused by the server.