### PR TITLE
Bump System.Security.Cryptography.Xml for CVE-2023-29331 (DB-179)

### DIFF
--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -1,11 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
+		<!-- CVE-2023-29331 -->
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
Fixed: Bump transitive reference of System.Security.Cryptography.Pkcs from 7.0.2.

for https://github.com/advisories/GHSA-555c-2p6r-68mm