### PR TITLE
Bump System.Security.Cryptography.Pkcs for CVE-2023-29331 (DB-179)

### DIFF
--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -31,7 +31,7 @@
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.5" />
 		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 		<PackageReference Include="HostStat.NET" Version="1.0.2" />
-		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.1" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.10" />
 		<!-- CVE-2022-35737 -->
 		<PackageReference Include="SQLitePCLRaw.core" Version="2.1.2" />

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -5,6 +5,8 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup>
+		<!-- CVE-2023-29331 -->
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.3" />
 		<PackageReference Include="System.Security.Cryptography.Xml" Version="6.0.1" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.10.0" />
 	</ItemGroup>


### PR DESCRIPTION
Fixed: Bump reference of System.Security.Cryptography.Pkcs for CVE-2023-29331