### PR TITLE
Make minor adjustments to metrics (DB-203)

### DIFF
--- a/src/EventStore.ClusterNode/telemetryconfig.json
+++ b/src/EventStore.ClusterNode/telemetryconfig.json
@@ -34,7 +34,7 @@
 
 	"IncomingGrpcCalls": {
 		"Current": true,
-		"Total" :  true,
+		"Total": true,
 		"Failed": true,
 		"Unimplemented": true,
 		"DeadlineExceeded": true
@@ -42,7 +42,7 @@
 
 	"Gossip": {
 		"PullFromPeer": false,
-		"PushToPeer":  true,
+		"PushToPeer": true,
 		"ProcessingPushFromPeer": true,
 		"ProcessingRequestFromPeer": false,
 		"ProcessingRequestFromGrpcClient": false,
@@ -80,8 +80,8 @@
 		"UpTime": true,
 		"Cpu": true,
 		"MemWorkingSet": true,
-		"MemPagedBytes": true,
-		"MemVirtualBytes": true,
+		"MemPagedBytes": false,
+		"MemVirtualBytes": false,
 		"ThreadCount": true,
 		"ThreadPoolPendingWorkItemCount": true,
 		"LockContentionCount": true,

--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -200,7 +200,9 @@ namespace EventStore.Core {
 							.SetResourceBuilder(ResourceBuilder.CreateDefault().AddService("eventstore"))
 							.AddMeter(_telemetryConfiguration.Meters)
 							.AddView(i => {
-								if (i.Name.StartsWith("eventstore-latency") && i.Unit == "seconds")
+								if (i.Name.StartsWith("eventstore-") &&
+									i.Name.EndsWith("-latency") &&
+									i.Unit == "seconds")
 									return new ExplicitBucketHistogramConfiguration {
 										Boundaries = new double[] {
 											0.001, //    1 ms

--- a/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
+++ b/src/EventStore.Core/Services/Storage/ReaderIndex/IndexCommitter.cs
@@ -442,9 +442,9 @@ namespace EventStore.Core.Services.Storage.ReaderIndex {
 							new EventRecord(indexEntries[i].Version, prepares[i], streamName, eventType),
 							isTfEof && i == n - 1));
 				}
-			}
 
-			_tracker.OnIndexed(prepares);
+				_tracker.OnIndexed(prepares);
+			}
 
 			return eventNumber;
 		}


### PR DESCRIPTION
Added: polishing new metrics

- Don't count rebuilding the index as indexing events, it was meant really to count the events as they become available to read so counting on rebuild would be double counting
- Rename metrics that were originally too general to be more specific
- Disable MemVirtualBytes by default (Process.VirtualMemorySize64 doesn't show bytes allocated in the virtual address space)
- Disable MemPagedBytes by default (Process.PagedMemorySize64 shows pagable bytes not bytes actually paged)
- Separate grpc CURRENT incoming calls into its own metric because it isn't comparable with the other dimensions of the current calls metric