### PR TITLE
Periodically log esdb version on each node

### DIFF
--- a/src/EventStore.Core.Tests/Services/PeriodicLogs/PeriodicallyLoggingServiceTests.cs
+++ b/src/EventStore.Core.Tests/Services/PeriodicLogs/PeriodicallyLoggingServiceTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using EventStore.Core.Messages;
+using EventStore.Core.Services.PeriodicLogs;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Tests.Fakes;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.PeriodicLogs; 
+
+public class PeriodicallyLoggingServiceTests {
+
+	private FakePublisher _publisher;
+	private FakeLogger _logger;
+	private string _esVersion;
+
+	[SetUp]
+	public void SetUp() {
+		_publisher = new();
+		_logger = new FakeLogger();
+		_esVersion = "0.0.0.0";
+	}
+	
+	[Test]
+	public void on_start() {
+		// given
+		var sut = new PeriodicallyLoggingService(_publisher, _esVersion, _logger);
+		
+		// when
+		sut.Handle(new SystemMessage.SystemStart());
+		
+		// then
+		Assert.IsInstanceOf<MonitoringMessage.CheckEsVersion>(_publisher.Messages.Single());
+		Assert.IsEmpty(_logger.LogMessages);
+	}
+
+	[Test]
+	public void log_es_version_periodically() {
+		// given
+		var sut = new PeriodicallyLoggingService(_publisher, _esVersion, _logger);
+		
+		// when
+		sut.Handle(new MonitoringMessage.CheckEsVersion());
+		
+		// then
+		var schedule = (TimerMessage.Schedule)_publisher.Messages.Single();
+		Assert.AreEqual(TimeSpan.FromHours(12), schedule.TriggerAfter);
+		Assert.IsInstanceOf<MonitoringMessage.CheckEsVersion>(schedule.ReplyMessage);
+
+		var logMessage = _logger.LogMessages.Single();
+		Assert.AreEqual($"Current version of Event Store is : \"0.0.0.0\" ", logMessage.RenderMessage());
+	} 
+
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -52,6 +52,7 @@ using EventStore.Core.Authorization;
 using EventStore.Core.Caching;
 using EventStore.Core.Certificates;
 using EventStore.Core.Cluster;
+using EventStore.Core.Services.PeriodicLogs;
 using EventStore.Core.Synchronization;
 using EventStore.Core.TransactionLog.Checkpoint;
 using EventStore.Core.TransactionLog.FileNamingStrategy;
@@ -193,7 +194,7 @@ namespace EventStore.Core {
 		private readonly CertificateDelegates.ClientCertificateValidator _externalClientCertificateValidator;
 		private readonly CertificateDelegates.ServerCertificateValidator _externalServerCertificateValidator;
 		private readonly CertificateProvider _certificateProvider;
-		
+
 		private readonly ClusterVNodeStartup<TStreamId> _startup;
 		private readonly EventStoreClusterClientCache _eventStoreClusterClientCache;
 
@@ -1539,6 +1540,9 @@ namespace EventStore.Core {
 			var certificateExpiryMonitor = new CertificateExpiryMonitor(_mainQueue, _certificateSelector, Log);
 			_mainBus.Subscribe<SystemMessage.SystemStart>(certificateExpiryMonitor);
 			_mainBus.Subscribe<MonitoringMessage.CheckCertificateExpiry>(certificateExpiryMonitor);
+			var periodicLogging = new PeriodicallyLoggingService(_mainQueue, VersionInfo.Version, Log);
+			_mainBus.Subscribe<SystemMessage.SystemStart>(periodicLogging);
+			_mainBus.Subscribe<MonitoringMessage.CheckEsVersion>(periodicLogging);
 
 			dynamicCacheManager.Start();
 		}

--- a/src/EventStore.Core/Messages/MonitoringMessage.cs
+++ b/src/EventStore.Core/Messages/MonitoringMessage.cs
@@ -212,5 +212,9 @@ namespace EventStore.Core.Messages {
 		[DerivedMessage(CoreMessage.Misc)]
 		public partial class CheckCertificateExpiry : Message {
 		}
+
+		[DerivedMessage(CoreMessage.Misc)]
+		public partial class CheckEsVersion : Message {
+		}
 	}
 }

--- a/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
+++ b/src/EventStore.Core/Services/Gossip/GossipServiceBase.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
-using EventStore.Common.Log;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Cluster;
@@ -32,7 +31,6 @@ namespace EventStore.Core.Services.Gossip {
 		public static readonly TimeSpan GossipStartupInterval = TimeSpan.FromMilliseconds(100);
 		private readonly TimeSpan DeadMemberRemovalPeriod;
 		private static readonly ILogger Log = Serilog.Log.ForContext<GossipServiceBase>();
-		private static readonly ThrottledLog<GossipServiceBase> ThrottledLog = new(TimeSpan.FromHours(12));
 
 		protected readonly MemberInfo _memberInfo;
 		protected VNodeState CurrentRole = VNodeState.Initializing;
@@ -142,7 +140,6 @@ namespace EventStore.Core.Services.Gossip {
 			var gossipRound = Math.Min(int.MaxValue - 1, node == null ? message.GossipRound : message.GossipRound + 1);
 			_bus.Publish(
 				TimerMessage.Schedule.Create(interval, _publishEnvelope, new GossipMessage.Gossip(gossipRound)));
-			ThrottledLog.Information($"Current version of Event Store is : {_memberInfo.ESVersion}");
 		}
 
 		private MemberInfo GetNodeToGossipTo(MemberInfo[] members) {


### PR DESCRIPTION
Added: Periodically log esdb version on each node

Fixes https://linear.app/eventstore/issue/DB-177/periodically-log-the-eventstore-version-on-single-node
