### PR TITLE
Cleanup unused software licenses (DB-231)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -89,62 +89,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-## Google V8
-
-*(Note: Event Store takes a source dependency on Google V8 and the other
-projects necessary to build it, including GN and ICU.)*
-
-This license applies to all parts of V8 that are not externally
-maintained libraries.  The externally maintained libraries used by V8
-are:
-  - PCRE test suite, located in
-    test/mjsunit/third_party/regexp-pcre/regexp-pcre.js.  This is based on the
-    test suite from PCRE-7.3, which is copyrighted by the University
-    of Cambridge and Google, Inc.  The copyright notice and license
-    are embedded in regexp-pcre.js.
-  - Layout tests, located in test/mjsunit/third_party/object-keys.  These are
-    based on layout tests from webkit.org which are copyrighted by
-    Apple Computer, Inc. and released under a 3-clause BSD license.
-  - Strongtalk assembler, the basis of the files assembler-arm-inl.h,
-    assembler-arm.cc, assembler-arm.h, assembler-ia32-inl.h,
-    assembler-ia32.cc, assembler-ia32.h, assembler-x64-inl.h,
-    assembler-x64.cc, assembler-x64.h, assembler-mips-inl.h,
-    assembler-mips.cc, assembler-mips.h, assembler.cc and assembler.h.
-    This code is copyrighted by Sun Microsystems Inc. and released
-    under a 3-clause BSD license.
-  - Valgrind client API header, located at third_party/valgrind/valgrind.h
-    This is release under the BSD license.
-  - antlr4 parser generator Cpp library located in third_party/antlr4
-    This is release under the BSD license.
-These libraries have their own licenses; we recommend you read them,
-as their terms may differ from the terms below.
-Further license information can be found in LICENSE files located in
-sub-directories.
-Copyright 2014, the V8 project authors. All rights reserved.
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 ## YamlDotNet
 
 Copyright (c) 2008, 2009, 2010, 2011, 2012, 2013, 2014 Antoine Aubry and contributors
@@ -165,51 +109,6 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-## libc++
-*(Note: libc++ is statically linked in Linux builds of the EventStore Projections library (js1) )*
-
-University of Illinois/NCSA
-Open Source License
-
-Copyright (c) 2009-2017 by the contributors listed in CREDITS.TXT
-
-All rights reserved.
-
-Developed by:
-
-    LLVM Team
-
-    University of Illinois at Urbana-Champaign
-
-    http://llvm.org
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal with
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimers.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimers in the
-      documentation and/or other materials provided with the distribution.
-
-    * Neither the names of the LLVM Team, University of Illinois at
-      Urbana-Champaign, nor the names of its contributors may be used to
-      endorse or promote products derived from this Software without specific
-      prior written permission.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
 SOFTWARE.
 
 ## HdrHistogram


### PR DESCRIPTION
Removed: Software licenses we no longer depend on.