### PR TITLE
Restore OpenAPI specification for HTTP API (DB-197)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ WORKDIR /build/ci
 
 COPY ./ci ./
 
+WORKDIR /build/docs
+
+COPY ./docs ./
+
 WORKDIR /build/src
 
 COPY ./src/EventStore.sln ./src/*/*.csproj ./src/Directory.Build.* ./

--- a/build.ps1
+++ b/build.ps1
@@ -159,7 +159,7 @@ Function Start-Build{
     if($RunTests -eq "yes"){
         (Get-ChildItem -Attributes Directory src | % FullName) -Match '.Tests' | `
         ForEach-Object {
-          dotnet test -v normal -c $Configuration --no-build --logger trx --results-directory testResults $_ -- RunConfiguration.TargetPlatform=x64
+          dotnet test -v normal -c $Configuration /p:Platform=x64 --no-build --logger trx --results-directory testResults $_
           if (-Not $?) { throw "Exit code is $?" }
         }
     }

--- a/docs/http-api/swagger.yaml
+++ b/docs/http-api/swagger.yaml
@@ -1,0 +1,2695 @@
+swagger: "2.0"
+info:
+  description: The HTTP API for EventStoreDB
+  version: 23.6.0
+  title: HTTP API
+  contact:
+    url: https://www.eventstore.com/contact
+  license:
+    name: BSD 3-Clause
+    url: https://github.com/EventStore/EventStore/blob/master/LICENSE.md
+host: eventstore.com
+securityDefinitions:
+  basicAuth:
+    type: basic
+schemes:
+  - https
+paths:
+  "/admin/node/priority/{nodePriority}":
+    post:
+      description: Issues a command to change the priority of a node.
+      summary: Change node priority
+      tags:
+        - Admin
+      operationId: Change node priority
+      parameters:
+        - name: nodePriority
+          in: path
+          description: The new priority
+          required: true
+          type: integer
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /admin/node/resign:
+    post:
+      description: Issues a command to resign a node.
+      summary: Resign node
+      tags:
+        - Admin
+      operationId: Resign node
+      parameters: []
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /admin/reloadconfig:
+    post:
+      description: Reload the configuration of a node.
+      summary: Reload configuration
+      tags:
+        - Admin
+      operationId: Reload configuration
+      parameters: []
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /admin/shutdown:
+    post:
+      description: Issues a shut down command to a node.
+      summary: Shutdown a node
+      tags:
+        - Admin
+      operationId: Shutdown a node
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        "200":
+          description: OK
+      security:
+        - basicAuth: []
+  /admin/scavenge:
+    post:
+      description: >-
+        Scavenge reclaims disk space by rewriting database chunks, minus the
+        events to delete, and then deleting the old chunks.
+      summary: Scavenge a node
+      tags:
+        - Admin
+      operationId: Scavenge a node
+      produces:
+        - application/json
+      parameters:
+        - name: threads
+          in: query
+          description: The number of threads to run the scavenge operation on (max 4).
+          type: integer
+          required: false
+          default: 1
+        - name: threshold
+          in: query
+          description: The threshold to use during the scavenge.
+          type: integer
+          required: false
+          default: 0
+        - name: throttlePercent
+          in: query
+          description: When set to 100 the scavenge will run at full speed. When set to 50 the scavenge will take twice as long by pausing at regular intervals. This allows it to be run with less impact on the server.
+          type: integer
+          required: false
+          default: 100
+        - name: syncOnly
+          in: query
+          description: When true, prevents a new scavenge point from being written.
+          type: boolean
+          required: false
+          default: false
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  "/admin/scavenge/{scavengeId}":
+    delete:
+      description: Stop a running scavenge operation.
+      summary: Stop a scavenge operation
+      tags:
+        - Admin
+      operationId: Stop a scavenge
+      produces:
+        - application/json
+      parameters:
+        - name: scavengeId
+          in: path
+          description: The scavenge ID.
+          required: true
+          type: integer
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    get:
+      description: Returns a link to the current scavenge.
+      summary: Get current scavenge
+      tags:
+        - Scavenge
+      operationId: Get current scavenge
+      parameters:
+        - name: scavengeId
+          in: path
+          description: Alias for current scavenge ID.
+          required: true
+          type: string
+          enum:
+            - current
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: "#/definitions/ScavengeCurrentItem"
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /admin/mergeindexes:
+    delete:
+      description: Manually merge indexes after a scavenge operation.
+      summary: Merge indexes
+      tags:
+        - Admin
+      operationId: Merge Indexes
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /info:
+    get:
+      description: Returns information about node.
+      summary: Get info for node
+      tags:
+        - Info
+      operationId: Get info for node
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /info/options:
+    get:
+      description: Returns configuration details about node.
+      summary: Get configuration for node
+      tags:
+        - Info
+      operationId: Get configuration for node
+      produces:
+        - application/json
+      parameters: []
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /metrics:
+    get:
+      description: Returns the metrics of a node in OpenMetrics/Prometheus format.
+      summary: Node metrics
+      tags:
+        - Stats
+      operationId: Node metrics
+      parameters: []
+      produces:
+        - text/plain
+      responses:
+        "200":
+          description: OK
+  /ping:
+    get:
+      description: Send a ping to the server.
+      summary: Server ping
+      tags:
+        - Admin
+      operationId: Server ping
+      parameters: []
+      responses:
+        "200":
+          description: OK
+  "/streams/{stream}":
+    get:
+      summary: Reads a stream
+      tags:
+        - Streams
+      description: Read a stream, receiving a standard AtomFeed document as a response.
+      operationId: Read a stream
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream ID
+          required: true
+          type: string
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "304":
+          description: Not modified
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+      security:
+        - basicAuth: []
+    post:
+      summary: Append to a stream
+      tags:
+        - Streams
+      description: Append to a stream.
+      operationId: Append to a stream
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The name of the stream.
+          required: true
+          type: string
+        - in: body
+          name: stream data
+          description: Stream events to create.
+          required: true
+          schema:
+            $ref: "#/definitions/streamData"
+        - $ref: "#/parameters/ES-ExpectedVersion"
+        - $ref: "#/parameters/ES-EventType"
+        - $ref: "#/parameters/ES-EventId"
+        - $ref: "#/parameters/ES-RequiresLeader"
+      responses:
+        "201":
+          description: New stream created
+        "307":
+          description: Temporary Redirect
+        "400":
+          description: Write request body invalid
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+        "413":
+          description: Request entity too large
+      security:
+        - basicAuth: []
+    delete:
+      summary: Deletes a stream
+      tags:
+        - Streams
+      description: Delete specified stream.
+      operationId: Delete a stream
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - name: stream
+          in: path
+          description: The stream ID to delete.
+          required: true
+          type: string
+      responses:
+        "204":
+          description: Stream deleted
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+      security:
+        - basicAuth: []
+  "/streams/{stream}/incoming/{guid}":
+    post:
+      tags:
+        - Streams
+      summary: An alternative URL to post events to
+      description: >-
+        A URL generated by EventStoreDB if you don't supply an ID when creating a
+        stream. You then use this URL to post events to.
+      operationId: Alternative stream URL
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The name of the stream.
+          required: true
+          type: string
+        - name: guid
+          in: path
+          description: Autogenerated UUID.
+          required: true
+          type: string
+      responses:
+        "201":
+          description: New event created
+        "307":
+          description: Temporary Redirect
+        "400":
+          description: Write request body invalid
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+        "413":
+          description: Request entity too large
+      security:
+        - basicAuth: []
+  "/streams/{stream}/{event}":
+    get:
+      tags:
+        - Streams
+      summary: Read a stream event
+      description: Reads a single event from a stream.
+      operationId: Read stream event
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream ID.
+          required: true
+          type: string
+        - name: event
+          in: path
+          description: The event ID.
+          required: true
+          type: string
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+      security:
+        - basicAuth: []
+  "/streams/{stream}/{event}/{count}":
+    get:
+      tags:
+        - Streams
+      summary: Paginate backwards through stream events
+      description: Paginate backwards though stream events by a specified amount.
+      operationId: "Get {n} events"
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream ID.
+          required: true
+          type: string
+        - name: event
+          in: path
+          description: The event ID.
+          required: true
+          type: string
+        - name: count
+          in: path
+          description: How many events to skip backwards from in the request.
+          required: true
+          type: integer
+          format: int64
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "304":
+          description: Not modified
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+      security:
+        - basicAuth: []
+  "/streams/{stream}/{event}/backward/{count}":
+    get:
+      tags:
+        - Streams
+      summary: Paginate backwards through stream events
+      description: Paginate backwards though stream events by a specified amount.
+      operationId: Page back through events
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream ID.
+          required: true
+          type: string
+        - name: event
+          in: path
+          description: The event ID.
+          required: true
+          type: string
+        - name: count
+          in: path
+          description: How many events to skip backwards from in the request.
+          required: true
+          type: integer
+          format: int64
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "304":
+          description: Not modified
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+      security:
+        - basicAuth: []
+  "/streams/{stream}/{event}/forward/{count}":
+    get:
+      tags:
+        - Streams
+      summary: Paginate forwards through stream events
+      description: Paginate forwards though stream events by a specified amount.
+      operationId: Page forward through events
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream ID.
+          required: true
+          type: string
+        - name: event
+          in: path
+          description: The event ID.
+          required: true
+          type: string
+        - name: count
+          in: path
+          description: How many events to skip forwards in the request.
+          required: true
+          type: integer
+          format: int64
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "304":
+          description: Not modified
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+      security:
+        - basicAuth: []
+  "/streams/{stream}/metadata":
+    get:
+      tags:
+        - Streams
+      summary: Reads the metadata of a stream
+      description: >-
+        Returns metadata of a stream, typically information associated with an
+        event that is not part of the event.
+      operationId: Read stream metadata
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream ID.
+          required: true
+          type: string
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "304":
+          description: Not modified
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+      security:
+        - basicAuth: []
+    post:
+      tags:
+        - Streams
+      summary: Update stream metadata
+      description: Update the metadata of a stream.
+      operationId: Update stream metadata
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: stream
+          in: path
+          description: The name of the stream.
+          required: true
+          type: string
+        - in: body
+          name: streamMetadataItem
+          description: Metadata object.
+          required: false
+          schema:
+            $ref: "#/definitions/StreamMetadataItem"
+      responses:
+        "201":
+          description: New stream created
+        "307":
+          description: Temporary Redirect
+        "400":
+          description: Write request body invalid
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+        "413":
+          description: Request entity too large
+      security:
+        - basicAuth: []
+  /streams/$all:
+    get:
+      tags:
+        - Streams
+      summary: Returns all events from all streams
+      description: Returns all events from all streams, you must provide user details.
+      operationId: Get all events
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "304":
+          description: Not modified
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "410":
+          description: Gone
+      security:
+        - basicAuth: []
+  /subscriptions:
+    get:
+      tags:
+        - Subscriptions
+      summary: Get information for all subscriptions
+      description: Returns all subscriptions from all streams.
+      operationId: Get all subscriptions
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters: []
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}":
+    get:
+      tags:
+        - Subscriptions
+      summary: Returns information about the subscriptions for a stream
+      description: Returns information about the subscriptions for a stream.
+      operationId: Get subscription stream information
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream name.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}/{subscription}/info":
+    get:
+      tags:
+        - Subscriptions
+      summary: Reads stream information via a persistent subscription
+      description: Reads stream information via a persistent subscription.
+      operationId: Get subscription information
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}/{subscription}":
+    get:
+      tags:
+        - Subscriptions
+      summary: Read a stream
+      description: Read a specified stream by a persistent subscription.
+      operationId: Get a stream
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    post:
+      tags:
+        - Subscriptions
+      summary: Update a persistant subscription
+      description: >-
+        You can edit the settings of an existing subscription while it is
+        running. This will drop the current subscribers and will reset the
+        subscription internally.
+      operationId: Update subscription
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - in: body
+          name: subscriptionItem
+          description: Subscription to create.
+          required: false
+          schema:
+            $ref: "#/definitions/SubscriptionItem"
+      responses:
+        "200":
+          description: Subscription updated
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    put:
+      tags:
+        - Subscriptions
+      summary: Create a persistent subscription
+      description: >-
+        Before interacting with a subscription group, you need to create one.
+        You will receive an error if you attempt to create a subscription group
+        more than once. This requires [admin permissions](/v5/server/access-control-lists).
+      operationId: Create subscription
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - in: body
+          name: subscriptionItem
+          description: Subscription to create.
+          required: false
+          schema:
+            $ref: "#/definitions/SubscriptionItem"
+      responses:
+        "201":
+          description: Subscription created
+        "209":
+          description: Conflict
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    delete:
+      tags:
+        - Subscriptions
+      summary: Deletes a subscription
+      description: Deletes a subscription.
+      operationId: Delete subscription
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}/{subscription}/{count}":
+    get:
+      tags:
+        - Subscriptions
+      summary: >-
+        Reads a stream via a persistent subscription and return a specific
+        number of events
+      description: >-
+        Reads a stream via a persistent subscription and return a specific
+        number of events.
+      operationId: "Get {n} subscription events"
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - name: count
+          in: path
+          description: How many events to return for the request.
+          required: true
+          type: integer
+          format: int64
+        - name: embed
+          in: query
+          required: false
+          type: string
+          enum:
+            - None
+            - Content
+            - Rich
+            - Body
+            - PrettyBody
+            - TryHarder
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}/{subscription}/ack/{messageid}":
+    post:
+      tags:
+        - Subscriptions
+      summary: Acknowledge a single message
+      description: >-
+        Clients must acknowledge (or not acknowledge) messages in the competing
+        consumer model. If the client fails to respond in the given timeout
+        period, the message will be retried. You should use the `rel` links in
+        the feed for acknowledgements not bookmark URIs as they are subject to
+        change in future versions.
+      operationId: Acknowledge a single message
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - name: messageid
+          in: path
+          description: The id of the message that needs to be acked.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: Message was acked
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}/{subscription}/ack":
+    post:
+      tags:
+        - Subscriptions
+      summary: Acknowledge multiple messages
+      description: >-
+        Clients must acknowledge (or not acknowledge) messages in the competing
+        consumer model. If the client fails to respond in the given timeout
+        period, the message will be retried. You should use the `rel` links in
+        the feed for acknowledgements not bookmark URIs as they are subject to
+        change in future versions.
+      operationId: Acknowledge multiple messages
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - name: ids
+          in: query
+          description: The ids of the messages that need to be acked separated by commas.
+          required: false
+          type: string
+      responses:
+        "200":
+          description: Messages were acked
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}/{subscription}/nack/{messageid}":
+    post:
+      tags:
+        - Subscriptions
+      summary: Negative acknowledge a single message
+      description: >-
+        Clients must acknowledge (or not acknowledge) messages in the competing
+        consumer model. If the client fails to respond in the given timeout
+        period, the message will be retried. You should use the `rel` links in
+        the feed for acknowledgements not bookmark URIs as they are subject to
+        change in future versions.
+      operationId: Don't acknowledge a single message
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - name: messageid
+          in: path
+          description: The id of the message that needs to be nacked.
+          required: true
+          type: string
+        - name: action
+          in: query
+          description: >-
+            <ul><li>**Park** - Don't retry the message, park it until a request
+            is sent to reply the parked messages<li>**Retry** - Retry the
+            message<li>**Skip** - Discard the message<li>**Stop** - Stop the
+            subscription</ul>
+          required: false
+          type: string
+          enum:
+            - Park
+            - Retry
+            - Skip
+            - Stop
+      responses:
+        "200":
+          description: Message was nacked
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}/{subscription}/nack":
+    post:
+      tags:
+        - Subscriptions
+      summary: Negative acknowledge multiple messages
+      description: >-
+        Clients must acknowledge (or not acknowledge) messages in the competing
+        consumer model. If the client fails to respond in the given timeout
+        period, the message will be retried. You should use the `rel` links in
+        the feed for acknowledgements not bookmark URIs as they are subject to
+        change in future versions.
+      operationId: Don't acknowledge multiple messages
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - name: ids
+          in: query
+          description: The ids of the messages that need to be nacked separated by commas.
+          required: false
+          type: string
+        - name: action
+          in: query
+          description: >-
+            <ul><li>**Park** - Don't retry the message, park it until a request
+            is sent to reply the parked messages<li>**Retry** - Retry the
+            message<li>**Skip** - Discard the message<li>**Stop** - Stop the
+            subscription</ul>
+          required: false
+          type: string
+          enum:
+            - Park
+            - Retry
+            - Skip
+            - Stop
+      responses:
+        "200":
+          description: Messages were nacked
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/subscriptions/{stream}/{subscription}/replayParked":
+    post:
+      tags:
+        - Subscriptions
+      summary: Replay any previously parked messages in a stream
+      description: >-
+        Replay any previously parked messages in a stream that were parked by a
+        negative acknowledgement action.
+      operationId: Replay previously parked messages
+      produces:
+        - application/vnd.eventstore.competingatom+json
+        - application/vnd.eventstore.competingatom+xml
+      parameters:
+        - name: stream
+          in: path
+          description: The stream the persistent subscription is on.
+          required: true
+          type: string
+        - name: subscription
+          in: path
+          description: The name of the subscription group.
+          required: true
+          type: string
+        - name: stopAt
+          in: query
+          description: The stream event number to stop at.
+          required: false
+          type: long
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  /subscriptions/restart:
+    post:
+      description: Restart the subscription subsystem on a node.
+      summary: Restart subscriptions
+      tags:
+        - Subscriptions
+      operationId: Restart subscriptions
+      parameters: []
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /users:
+    get:
+      tags:
+        - Users
+      summary: Get all users
+      description: Returns all users defined in EventStoreDB.
+      operationId: Get all users
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+    post:
+      tags:
+        - Users
+      summary: Create a User
+      description: Create a new user.
+      operationId: Create a user
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - in: body
+          name: userItem
+          description: User to create.
+          required: false
+          schema:
+            $ref: "#/definitions/UserItem"
+      responses:
+        "201":
+          description: New user created
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  "/users/{login}":
+    get:
+      tags:
+        - Users
+      summary: Get user
+      description: >-
+        Returns the user currently authenticated with the API, or the user
+        specified.
+      operationId: Get a user
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: login
+          in: path
+          description: The user passed to the API call.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    put:
+      tags:
+        - Users
+      summary: Update specified user
+      description: Update the FullName or Groups of the specified user.
+      operationId: Update a user
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: login
+          in: path
+          description: The user's name.
+          required: true
+          type: string
+        - in: body
+          name: userUpdateItem
+          description: User to update.
+          required: false
+          schema:
+            $ref: "#/definitions/UserUpdateItem"
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    delete:
+      tags:
+        - Users
+      summary: Deletes a user
+      description: Delete specified user.
+      operationId: Delete a user
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - name: login
+          in: path
+          description: The user's name.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: User deleted
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  "/users/{login}/command/enable":
+    put:
+      tags:
+        - Users
+      summary: Enable the specified user
+      description: Enable the acount of the specified user.
+      operationId: Enable a user
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: login
+          in: path
+          description: The user's name.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/users/{login}/command/disable":
+    put:
+      tags:
+        - Users
+      summary: Disable the specified user
+      description: Disable the acount of the specified user.
+      operationId: Disable a user
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: login
+          in: path
+          description: The user's name.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/users/{login}/command/reset-password":
+    post:
+      tags:
+        - Users
+      summary: Reset user password
+      description: Reset the password of the specified user.
+      operationId: Reset password
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: login
+          in: path
+          description: The user's name.
+          required: true
+          type: string
+        - in: body
+          name: newPassword
+          description: The new password for the user.
+          required: true
+          schema:
+            $ref: "#/definitions/PasswordResetItem"
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "400":
+          description: Bad request
+      security:
+        - basicAuth: []
+  "/users/{login}/command/change-password":
+    post:
+      tags:
+        - Users
+      summary: Change user password
+      description: Change the password of the specified user.
+      operationId: Change password
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: login
+          in: path
+          description: The user's name.
+          required: true
+          type: string
+        - in: body
+          name: newPassword
+          description: The new password for the user.
+          required: true
+          schema:
+            $ref: "#/definitions/PasswordChangeItem"
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "400":
+          description: Bad request
+      security:
+        - basicAuth: []
+  /projections/any:
+    get:
+      tags:
+        - Projections
+      summary: Get all projections
+      description: Returns all projections defined in EventStoreDB.
+      operationId: Get all projections
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  /projections/all-non-transient:
+    get:
+      tags:
+        - Projections
+      summary: Get all non-transient projections
+      description: Returns all known projections except ad-hoc projections.
+      operationId: Get all non-transient projections
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  /projections/onetime:
+    get:
+      tags:
+        - Projections
+      summary: Get all queries
+      description: Returns all queries defined in EventStoreDB.
+      operationId: Get all queries
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    post:
+      tags:
+        - Projections
+      summary: Create a onetime projection
+      description: Create a new onetime projection.
+      operationId: Create a onetime projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: query
+          description: Name of the projection.
+          required: false
+          type: string
+        - name: type
+          in: query
+          description: The projection type.
+          required: false
+          type: string
+          enum:
+            - JS
+        - name: enabled
+          in: query
+          description: Is the projection enabled.
+          required: false
+          type: boolean
+        - name: checkpoints
+          in: query
+          description: Are checkpoints enabled.
+          required: false
+          type: boolean
+        - name: emit
+          in: query
+          description: Is emit enabled.
+          required: false
+          type: boolean
+        - name: trackemittedstreams
+          in: query
+          description: >-
+            Should your projection create a separate stream and write any
+            streams it emits to that stream.
+          required: false
+          type: boolean
+      responses:
+        "201":
+          description: New projection created
+        "209":
+          description: Conflict
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /projections/continuous:
+    get:
+      tags:
+        - Projections
+      summary: Get all continious projections
+      description: Returns all continually running projections defined in EventStoreDB.
+      operationId: Get all continious projections
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    post:
+      tags:
+        - Projections
+      summary: Create a continious projection
+      description: Create a new continious projection.
+      operationId: Create a continious projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: query
+          description: Name of the projection.
+          required: false
+          type: string
+        - name: enabled
+          in: query
+          description: Is the projection enabled.
+          required: false
+          type: boolean
+        - name: checkpoints
+          in: query
+          description: Are checkpoints enabled.
+          required: false
+          type: boolean
+        - name: emit
+          in: query
+          description: Is emit enabled.
+          required: false
+          type: boolean
+        - name: type
+          in: query
+          description: The projection type.
+          required: false
+          type: string
+          enum:
+            - JS
+        - name: trackemittedstreams
+          in: query
+          description: >-
+            Should your projection create a separate stream and write any
+            streams it emits to that stream.
+          required: false
+          type: boolean
+      responses:
+        "201":
+          description: New projection created
+        "209":
+          description: Conflict
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /projections/restart:
+    post:
+      description: Restart the projections subsystem on a node.
+      summary: Restart projections
+      tags:
+        - Projections
+      operationId: Restart projections
+      parameters: []
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  /projections/transient:
+    get:
+      tags:
+        - Projections
+      summary: Get all transient projections
+      description: Returns all transient projections defined in EventStoreDB.
+      operationId: Get all transient projections
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    post:
+      tags:
+        - Projections
+      summary: Create a transient projection
+      description: Create a new transient projection.
+      operationId: Create a transient projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: query
+          description: Name of the projection.
+          required: false
+          type: string
+        - name: type
+          in: query
+          description: The projection type.
+          required: false
+          type: string
+          enum:
+            - JS
+        - name: enabled
+          in: query
+          description: Is the projection enabled.
+          required: false
+          type: boolean
+      responses:
+        "201":
+          description: New projection created
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+      security:
+        - basicAuth: []
+  "/projection/{name}/query":
+    get:
+      tags:
+        - Projections
+      summary: Get projection definition
+      description: Returns definition of the specified projection.
+      operationId: Get projection definition
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+        - name: config
+          in: query
+          required: false
+          type: boolean
+          description: Wether to return the projection definition config.
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    put:
+      tags:
+        - Projections
+      summary: Update projection definition
+      description: Update the specified projection definition.
+      operationId: Update projection definition
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+        - name: type
+          in: query
+          description: The projection type.
+          required: false
+          type: string
+          enum:
+            - JS
+        - name: emit
+          in: query
+          description: Is emit enabled.
+          required: false
+          type: boolean
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}/state":
+    get:
+      tags:
+        - Projections
+      summary: Get the projection state
+      description: Return the current state of the specified projection.
+      operationId: Get the projection state
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+        - name: partition
+          in: query
+          required: false
+          type: string
+          description: The partition name in state.
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}/result":
+    get:
+      tags:
+        - Projections
+      summary: Get result of projection
+      description: Get the final result of a projection.
+      operationId: Get result of projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+        - name: partition
+          in: query
+          required: false
+          type: string
+          description: The partition name in state.
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}/statistics":
+    get:
+      tags:
+        - Projections
+      summary: Get projection statistics
+      description: >-
+        Returns the statistics for a projection, such as how many events, the
+        status etc.
+      operationId: Get projection statistics
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}/command/disable":
+    post:
+      tags:
+        - Projections
+      summary: Disable projection
+      description: Disable the specified projection.
+      operationId: Disable projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+        - name: enableRunAs
+          in: query
+          description: Run as the user issuing the command.
+          required: false
+          type: boolean
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}/command/enable":
+    post:
+      tags:
+        - Projections
+      summary: Enable projection
+      description: Enable the specified projection.
+      operationId: Enable projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+        - name: enableRunAs
+          in: query
+          description: Run as the user issuing the command.
+          required: false
+          type: boolean
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}/command/reset":
+    post:
+      tags:
+        - Projections
+      summary: Reset projection
+      description: Reset the specified projection.
+      operationId: Reset projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+        - name: enableRunAs
+          in: query
+          description: Run as the user issuing the command.
+          required: false
+          type: boolean
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}/command/abort":
+    post:
+      tags:
+        - Projections
+      summary: Abort projection
+      description: Abort the specified projection.
+      operationId: Abort projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+        - name: enableRunAs
+          in: query
+          description: Run as the user issuing the command.
+          required: false
+          type: boolean
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}/config":
+    get:
+      tags:
+        - Projections
+      summary: Get the config of a projection
+      description: Returns the performance configuration of the specified projection.
+      operationId: Get projection config
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    put:
+      tags:
+        - Projections
+      summary: Update the config of a projection
+      description: Update the performance configuration of the specified projection.
+      operationId: Update projection config
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  "/projection/{name}":
+    get:
+      tags:
+        - Projections
+      summary: Get a projection
+      description: Returns a specific projection.
+      operationId: Get a projection
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: name
+          in: path
+          description: The name of the projection.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+    delete:
+      tags:
+        - Projections
+      summary: Deletes a projection
+      description: Deletes a projection.
+      operationId: Delete a projection
+      produces:
+        - application/xml
+        - application/json
+      parameters:
+        - name: name
+          in: path
+          description: The projection to delete.
+          required: true
+          type: string
+        - name: deleteStateStream
+          in: query
+          description: Whether the state stream should also be deleted.
+          required: false
+          type: boolean
+        - name: deleteCheckpointStream
+          in: query
+          description: Whether the checkpoint stream should also be deleted.
+          required: false
+          type: boolean
+        - name: deleteEmittedStreams
+          in: query
+          description: Whether the emitted streams should also be deleted. Note that this only has an effect if 'track emitted streams' was enabled on the projection.
+          required: false
+          type: boolean
+      responses:
+        "204":
+          description: Projection deleted
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+      security:
+        - basicAuth: []
+  /stats:
+    get:
+      tags:
+        - Stats
+      summary: Get all stats
+      description: Returns all stats enabled for EventStoreDB.
+      operationId: Get all stats
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        "200":
+          description: A list of stats
+          schema:
+            $ref: "#/definitions/Stats"
+        "404":
+          description: Not found
+  "/stats/{statPath}":
+    get:
+      tags:
+        - Stats
+      summary: Get stats sub path
+      description: Returns the sub path of the EventStoreDB statistics available.
+      operationId: Get specified stat
+      produces:
+        - application/json
+        - application/xml
+      parameters:
+        - name: statPath
+          in: path
+          description: The stats sub path.
+          required: true
+          type: string
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not found
+  /gossip:
+    get:
+      tags:
+        - Gossip
+      summary: Return Gossip details for cluster
+      description: Return Gossip details for nodes in cluster.
+      operationId: Return Gossip details
+      produces:
+        - application/json
+        - application/xml
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not found
+parameters:
+  ES-ExpectedVersion:
+    name: ES-ExpectedVersion
+    in: header
+    required: false
+    type: integer
+    description: Expected stream version.
+  ES-ResolveLinkTo:
+    name: ES-ResolveLinkTo
+    in: header
+    required: false
+    type: boolean
+    description: Wether to resolve `linkTos` in a stream.
+  ES-RequiresLeader:
+    name: ES-RequiresLeader
+    in: header
+    required: false
+    type: boolean
+    description: Wether to run on a leader node.
+  ES-TrustedAuth:
+    name: ES-TrustedAuth
+    in: header
+    required: false
+    type: string
+    description: Allows a trusted intermediary to handle authentication.
+  ES-LongPoll:
+    name: ES-LongPoll
+    in: header
+    required: false
+    type: integer
+    description: Long poll operation on a stream read.
+  ES-HardDelete:
+    name: ES-HardDelete
+    in: header
+    required: false
+    type: boolean
+    description: Hard delete the stream when deleting.
+  ES-EventType:
+    name: ES-EventType
+    in: header
+    required: false
+    type: string
+    description: The event type associated to a posted body.
+  ES-EventId:
+    name: ES-EventId
+    in: header
+    required: false
+    type: integer
+    description: Event ID associated to a posted body.
+definitions:
+  UserItem:
+    type: object
+    properties:
+      LoginName:
+        type: string
+        description: The new users login name.
+      FullName:
+        type: string
+        description: The full name for the new user.
+      Groups:
+        type: array
+        items:
+          type: string
+        description: The groups the new user is a member of.
+      Password:
+        type: string
+        description: The password for the new user.
+    example:
+      LoginName: admin
+      FullName: EventStore Admin
+      Groups:
+        - Admin
+        - DataScience
+      Password: aVerySecurePassword
+  UserUpdateItem:
+    type: object
+    properties:
+      FullName:
+        type: string
+        description: The full name of the new user.
+      Groups:
+        type: array
+        items:
+          type: string
+        description: The groups the new user should become a member of.
+    example:
+      FullName: EventStore Admin
+      Groups:
+        - Admin
+        - DataScience
+  PasswordResetItem:
+    type: object
+    properties:
+      NewPassword:
+        type: string
+        description: The new password for the user.
+    example:
+      NewPassword: aNewSecurePassword
+  PasswordChangeItem:
+    type: object
+    properties:
+      CurrentPassword:
+        type: string
+        description: The current password for the user.
+      NewPassword:
+        type: string
+        description: The new password for the user.
+    example:
+      CurrentPassword: anOldSecurePassword
+      NewPassword: aNewSecurePassword
+  ScavengeCurrentItem:
+    type: object
+    properties:
+      ScavengeId:
+        type: string
+        description: The identifier of the current scavenge.
+      ScavengeLink:
+        type: string
+        description: Link to current scavenge.
+  streamData:
+    type: object
+    required:
+      - body
+    properties:
+      body:
+        type: object
+        description: Event data.
+  StreamMetadataItem:
+    type: object
+    properties:
+      eventId:
+        type: string
+        description: Alphanumeric ID.
+      eventType:
+        type: string
+        description: The type of event.
+      data:
+        $ref: "#/definitions/StreamMetadataItem_data"
+  SubscriptionItem:
+    type: object
+    properties:
+      ResolveLinkTos:
+        type: boolean
+        description: Whether to resolve link events.
+      startFrom:
+        type: integer
+        format: int64
+        description: Which event position in the stream the subscription should start from.
+      extraStatistics:
+        type: boolean
+        description: Whether to track latency statistics on this subscription.
+      checkPointAfterMilliseconds:
+        type: integer
+        format: int64
+        description: The amount of time to try to checkpoint after.
+      liveBufferSize:
+        type: integer
+        format: int64
+        description: >-
+          The size of the buffer (in-memory) listening to live messages as they
+          happen before paging occurs.
+      readBatchSize:
+        type: integer
+        format: int64
+        description: The number of events to read per batch when reading the history.
+      bufferSize:
+        type: integer
+        format: int64
+        description: The number of events to cache when paging through history.
+      maxCheckPointCount:
+        type: integer
+        format: int64
+        description: >-
+          The maximum number of messages not checkpointed before forcing a
+          checkpoint.
+      maxRetryCount:
+        type: integer
+        format: int64
+        description: >-
+          The maximum number of retries (due to timeout) before a message is
+          considered to be parked.
+      maxSubscriberCount:
+        type: integer
+        format: int64
+        description: The maximum number of TCP subscribers allowed.
+      messageTimeoutMilliseconds:
+        type: integer
+        format: int64
+        description: >-
+          The amount of time after which to consider a message as timedout and
+          retried.
+      minCheckPointCount:
+        type: integer
+        format: int64
+        description: The minimum number of messages to write to a checkpoint.
+      namedConsumerStrategy:
+        type: string
+        description: The strategy to use for distributing events to client consumers.
+        enum:
+          - RoundRobin
+          - DispatchToSingle
+          - Pinned
+    example:
+      minCheckPointCount: 2
+      startFrom: 0
+      ResolveLinkTos: true
+      readBatchSize: 5
+      namedConsumerStrategy: RoundRobin
+      extraStatistics: true
+      maxRetryCount: 7
+      liveBufferSize: 1
+      messageTimeoutMilliseconds: 3
+      maxCheckPointCount: 2
+      maxSubscriberCount: 9
+      checkPointAfterMilliseconds: 6
+      bufferSize: 5
+  StreamMetadataItem_data:
+    properties:
+      maxAge:
+        type: integer
+        description: The maximum age of events in the stream
+      maxCount:
+        type: integer
+        description: The maximum count of events in the stream
+      truncateBefore:
+        type: integer
+        description: Events prior to this event are truncated and removed
+      cacheControl:
+        type: string
+        description: Period of time to make feed head cacheable
+      acl:
+        type: object
+        description: Access control list for this stream
+        properties:
+          r:
+            description: Read roles
+            type: string
+          w:
+            description: Write roles
+            type: string
+          d:
+            description: Delete roles
+            type: string
+          mr:
+            description: Metadata read roles
+            type: string
+          mw:
+            description: Metadata write roles
+            type: string
+  Stats:
+    properties:
+      proc:
+        type: object
+        description: Stats on the currently active process.
+        properties:
+          startTime:
+            type: string
+            description: Time the associated process started.
+          id:
+            type: integer
+            description: Id of the associated process.
+          mem:
+            type: integer
+            description: Virtual memory used by the associated process.
+          cpu:
+            type: number
+            description: CPU usage of the process.
+          cpuScaled:
+            type: number
+            description: CPU usage of the process scaled by logical processor count.
+          threadsCount:
+            type: integer
+            description: Number of threads used by process.
+          contentionsRate:
+            type: number
+            description: >-
+              The rate at which threads in the process attempt to acquire a
+              managed lock unsuccessfully.
+          thrownExceptionsRate:
+            type: number
+            description: Number of exceptions thrown per second.
+          gc:
+            type: object
+            description: Stats on garbage collection.
+            properties:
+              allocationSpeed:
+                type: number
+                description: Memory allocation speed.
+              gen0ItemsCount:
+                type: number
+                description: Number of generation 0 garbage collections.
+              gen0Size:
+                type: number
+                description: Generation 0 heap size.
+              gen1ItemsCount:
+                type: number
+                description: Number of generation 1 garbage collections.
+              gen1Size:
+                type: number
+                description: Generation 1 heap size.
+              gen2ItemsCount:
+                type: number
+                description: Number of generation 2 garbage collections.
+              gen2Size:
+                type: number
+                description: Generation 2 heap size.
+              largeHeapSize:
+                type: number
+                description: Large object heap size.
+              timeInGc:
+                type: number
+                description: Percentage of time in garbage collection.
+              totalBytesInHeaps:
+                type: number
+                description: Total bytes in all heaps.
+          diskIo:
+            type: object
+            description: Disk input and output stats.
+            properties:
+              readBytes:
+                type: number
+                description: The number of bytes read by EventStoreDB since server start.
+              writtenBytes:
+                type: number
+                description: The number of bytes written by EventStoreDB since server start.
+              readOps:
+                type: number
+                description: The number of read operations by EventStoreDB since server start.
+              writeOps:
+                type: number
+                description: The number of write operations by EventStoreDB since server start.
+          tcp:
+            type: object
+            description: TCP connection stats.
+            properties:
+              connections:
+                type: integer
+                description: Number of TCP connections to EventStoreDB.
+              receivingSpeed:
+                type: string
+                description: Receiving speed in bytes per second.
+              sendingSpeed:
+                type: number
+                description: Sending speed in bytes per second.
+              inSend:
+                type: number
+                description: >-
+                  Number of bytes sent to connections but not yet acknowledged
+                  by the receiving party.
+              measureTime:
+                type: number
+                description: Time elapsed since last stats read.
+              pendingReceived:
+                type: number
+                description: Number of bytes waiting to be received by connections.
+              pendingSend:
+                type: number
+                description: Number of bytes waiting to be sent to connections.
+              receivedBytesSinceLastRun:
+                type: number
+                description: Total bytes received by TCP connections since last run.
+              receivedBytesTotal:
+                type: number
+                description: Total bytes received by TCP connections.
+              sentBytesSinceLastRun:
+                type: number
+                description: Total bytes sent to TCP connections since last run.
+              sentBytesTotal:
+                type: number
+                description: Total bytes sent from TCP connections.
+      sys:
+        type: object
+        description: System usage stats.
+        properties:
+          cpu:
+            type: number
+            description: Total CPU usage in percentage.
+          freeMem:
+            type: number
+            description: Free memory in bytes.
+          drive:
+            type: object
+            description: Drive usage stats.
+            properties:
+              driveName:
+                type: object
+                description: Drive path.
+                properties:
+                  availableBytes:
+                    type: number
+                    description: Remaining bytes of space available to EventStoreDB.
+                  totalBytes:
+                    type: number
+                    description: Total bytes of space available to EventStoreDB.
+                  usage:
+                    type: number
+                    description: Percentage usage of space used by EventStoreDB.
+                  usedBytes:
+                    type: number
+                    description: Total bytes of space used by EventStoreDB.
+      es:
+        type: object
+        description: ""
+        properties:
+          checksum:
+            type: number
+            description: ""
+          checksumNonFlushed:
+            type: number
+            description: ""
+          queue:
+            type: object
+            description: Multiple queue instance stats
+            properties:
+              queueName:
+                type: string
+                description: Queue name.
+              groupName:
+                type: string
+                description: Group queue is a member of.
+              avgItemsPerSecond:
+                type: integer
+                description: The average number of items processed per second by the queue.
+              avgProcessingTime:
+                type: number
+                description: Average number of items processed per second.
+              currentIdleTime:
+                type: string
+                description: Time elapsed since queue went idle.
+              currentItemProcessingTime:
+                type: string
+                description: Time elapsed processing the current item.
+              idleTimePercent:
+                type: number
+                description: Percentage of time queue spent idle.
+              length:
+                type: integer
+                description: Number of items in the queue.
+              lengthCurrentTryPeak:
+                type: number
+                description: The highest number of items in the queue within the past 100ms.
+              lengthLifetimePeak:
+                type: number
+                description: The highest number of items in the queue.
+              totalItemsProcessed:
+                type: number
+                description: The total number of items processed by the queue.
+              inProgressMessage:
+                type: string
+                description: Current message type queue is processing.
+              lastProcessedMessage:
+                type: string
+                description: Last message type processed.
+          writer:
+            type: object
+            description: Storage writing stats.
+            properties:
+              lastFlushSize:
+                type: number
+                description: Last flush size.
+              lastFlushDelayMs:
+                type: number
+                description: Last flush delay in ms.
+              meanFlushSize:
+                type: number
+                description: Average flush size.
+              meanFlushDelayMs:
+                type: number
+                description: Average flush delay in ms.
+              maxFlushSize:
+                type: number
+                description: Max flush size.
+              maxFlushDelayMs:
+                type: number
+                description: Max flush delay in ms.
+              queuedFlushMessages:
+                type: integer
+                description: Queued flush messages.
+          readIndex:
+            type: object
+            description: ""
+            properties:
+              cachedRecord:
+                type: number
+                description: Number of cached record reads.
+              notCachedRecord:
+                type: number
+                description: Number of uncached record reads.
+              cachedStreamInfo:
+                type: number
+                description: ""
+              notCachedStreamInfo:
+                type: number
+                description: ""
+              cachedTransInfo:
+                type: number
+                description: ""
+              notCachedTransInfo:
+                type: number
+                description: ""
+              hashCollisions:
+                type: number
+                description: ""
+tags:
+  - name: Streams
+    description: Endpoints for Stream operations.
+  - name: Subscriptions
+    description: Endpoints for Subscription operations.
+  - name: Projections
+    description: Endpoints for Projection operations.
+  - name: Admin
+    description: Endpoints for Admin operations.
+  - name: Info
+    description: Endpoints for Info operations.
+  - name: Users
+    description: Endpoints for User operations.
+  - name: Stats
+    description: Endpoints for Statistics operations.
+    externalDocs:
+      url: "http://docs.my-api.com/pet-operations.htm"

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.16" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.5" />
 		<PackageReference Include="NUnit" Version="3.13.3" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="CompareNETObjects" Version="4.78.0" />
@@ -61,11 +62,13 @@
 		<None Include="Resources\es-tile.png">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</None>
+		<None Include="..\..\docs\http-api\swagger.yaml">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 	<ItemGroup>
 		<None Remove="FakePlugin\**" />
 		<Compile Remove="FakePlugin\**" />
 		<Content Include="FakePlugin\**" CopyToOutputDirectory="Always" />
 	</ItemGroup>
-
 </Project>

--- a/src/EventStore.Core.Tests/Services/Transport/Http/open_api_document.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/open_api_document.cs
@@ -1,0 +1,64 @@
+﻿using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using EventStore.Core.Services.Transport.Http;
+using EventStore.Core.Tests.Helpers;
+using EventStore.Core.Tests.Integration;
+using NUnit.Framework;
+
+namespace EventStore.Core.Tests.Services.Transport.Http;
+
+[TestFixture(typeof(LogFormat.V2), typeof(string))]
+public class open_api_document<TLogFormat, TStreamId> : specification_with_a_single_node<TLogFormat, TStreamId> {
+	
+	[Test]
+	public async Task should_document_the_actions_of_all_controllers() {
+		var skipActionPaths = new [] {
+			"/admin/login",
+			"/users/$current",
+			"/histogram/{name}",
+			// handled by: /stats/{statPath}
+			"/stats/replication",
+			"/stats/tcp",
+			// handled by: /admin/scavenge/{scavengeId}
+			"/admin/scavenge/current",
+			// redirected
+			"/users/",
+			"/streams/$all/",
+			"/streams/%24all/",
+			"/streams/{stream}/",
+			"/streams/{stream}/metadata/", 
+		};
+	
+		var httpActions = _node.Node.HttpService.Actions
+			.Where(a => !skipActionPaths.Contains(a.UriTemplate))
+			.Where(a => !a.UriTemplate.StartsWith("/test"))
+			// exclude AtomPub controller actions
+			.Where(a => !a.UriTemplate.Contains("embed={embed}"))
+			.ToArray();
+		
+		var absoluteSwaggerPath = HelperExtensions.GetFilePathFromAssembly("swagger.yaml");
+		
+		var openApiReader = new Microsoft.OpenApi.Readers.OpenApiTextReaderReader();
+		var openApiDoc = File.OpenText(absoluteSwaggerPath);
+		var result = await openApiReader.ReadAsync(openApiDoc);
+
+		Assert.IsEmpty(result.OpenApiDiagnostic.Errors, "OpenAPI document has errors!");
+		Assert.IsEmpty(result.OpenApiDiagnostic.Warnings, "OpenAPI document has warnings!");
+		
+		var missingPaths = httpActions
+			.Select(ActionUriPath)
+			.Except(result.OpenApiDocument.Paths.Keys);
+			
+		Assert.IsEmpty(missingPaths, "OpenAPI document has extra or missing paths!");
+		
+		string ActionUriPath(ControllerAction a) {
+			var path = a.UriTemplate;
+			if (a.UriTemplate.Contains("?")) {
+				var parts = path.Split("?");
+				path = parts.First();
+			}
+			return path.Replace("{*", "{");
+		}
+	}
+}

--- a/src/EventStore.sln
+++ b/src/EventStore.sln
@@ -32,7 +32,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A19631BB-65CF-4726-8732-4EFD977E9B32}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
-		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
 		default.runsettings = default.runsettings
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets


### PR DESCRIPTION
Added: Restored OpenAPI specification for HTTP API.

Restored from [release/oss-v5/docs/http-api/swagger.yaml](https://github.com/EventStore/EventStore/blob/release/oss-v5/docs/http-api/swagger.yaml)