### PR TITLE
Remove reliance on UseNet5CompatFileStream

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,7 +30,4 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 	</ItemGroup>
-	<ItemGroup>
-		<RuntimeHostConfigurationOption Include="System.IO.UseNet5CompatFileStream" Value="true" />
-	</ItemGroup>
 </Project>

--- a/src/EventStore.Core.Tests/TransactionLog/when_creating_tfchunk_from_empty_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_creating_tfchunk_from_empty_file.cs
@@ -22,8 +22,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 		}
 
 		[Test]
-		public void the_chunk_is_not_cached() {
-			Assert.IsFalse(_chunk.IsCached);
+		public void the_chunk_is_cached() {
+			Assert.IsTrue(_chunk.IsCached);
 		}
 
 		[Test]

--- a/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_destroying_a_tfchunk_that_is_locked.cs
@@ -13,6 +13,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 		public override void SetUp() {
 			base.SetUp();
 			_chunk = TFChunkHelper.CreateNewChunk(Filename, 1000);
+			_chunk.Complete();
+			_chunk.UnCacheFromMemory();
 			_reader = _chunk.AcquireReader();
 			_chunk.MarkForDeletion();
 		}

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_multiple_records_to_a_tfchunk.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_multiple_records_to_a_tfchunk.cs
@@ -50,8 +50,8 @@ namespace EventStore.Core.Tests.TransactionLog {
 		}
 
 		[Test]
-		public void the_chunk_is_not_cached() {
-			Assert.IsFalse(_chunk.IsCached);
+		public void the_chunk_is_cached() {
+			Assert.IsTrue(_chunk.IsCached);
 		}
 
 		[Test]

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -289,8 +289,6 @@ namespace EventStore.Core {
 			NodeInfo = new VNodeInfo(instanceId.Value, debugIndex, intTcp, intSecIp, extTcp, extSecIp,
 				httpEndPoint, options.Cluster.ReadOnlyReplica);
 
-			EnsureNet5CompatFileStream();
-
 			var dbConfig = CreateDbConfig(
 				out var statsHelper,
 				out var readerThreadsCount,
@@ -1827,19 +1825,6 @@ namespace EventStore.Core {
 			if (_certificateProvider?.LoadCertificates(options) == LoadCertificateResult.VerificationFailed){
 				throw new InvalidConfigurationException("Aborting certificate loading due to verification errors.");
 			}
-		}
-
-		private static void EnsureNet5CompatFileStream() {
-			var assembly = System.Reflection.Assembly.GetAssembly(typeof(FileStream));
-			var type = assembly?.GetType("System.IO.Strategies.FileStreamHelpers");
-			var prop = type?.GetProperty("UseNet5CompatStrategy",
-				System.Reflection.BindingFlags.NonPublic |
-				System.Reflection.BindingFlags.Static);
-			var value = prop?.GetValue(null);
-			if (value is not bool useNet5)
-				throw new Exception("Could not establish whether UseNet5CompatFileStream is set.");
-			if (!useNet5)
-				throw new Exception("UseNet5CompatFileStream is disabled but must be enabled.");
 		}
 
 		public override string ToString() =>

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkReader.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunkBulkReader.cs
@@ -17,12 +17,14 @@ namespace EventStore.Core.TransactionLog.Chunks {
 		private readonly TFChunk.TFChunk _chunk;
 		private readonly Stream _stream;
 		private bool _disposed;
+		public bool IsMemory { get; init; }
 
-		internal TFChunkBulkReader(TFChunk.TFChunk chunk, Stream streamToUse) {
+		internal TFChunkBulkReader(TFChunk.TFChunk chunk, Stream streamToUse, bool isMemory) {
 			Ensure.NotNull(chunk, "chunk");
 			Ensure.NotNull(streamToUse, "stream");
 			_chunk = chunk;
 			_stream = streamToUse;
+			IsMemory = isMemory;
 		}
 
 		~TFChunkBulkReader() {


### PR DESCRIPTION
Changed: Always read the active chunk from memory instead of from the FileStream.

We used Net5CompatFileStream until now because in net6+ if one filestream writes to a file, another filestream that is reading from the same file cannot necessarily tell that anything has changed.

This change makes it so that FileStreams are not instantiated for reading until the chunk is readonly. Instead, the active chunk is always cached, and reads are served from the memstream.