### PR TITLE
Make StreamExistenceFilter 10k by default in tests

### DIFF
--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -67,7 +67,7 @@ namespace EventStore.Core.Tests.Helpers {
 			int hashCollisionReadLimit = Util.Opts.HashCollisionReadLimitDefault,
 			byte indexBitnessVersion = Util.Opts.IndexBitnessVersionDefault,
 			string dbPath = "", bool isReadOnlyReplica = false,
-			long streamExistenceFilterSize = Util.Opts.StreamExistenceFilterSizeDefault,
+			long streamExistenceFilterSize = 10_000,
 			int streamExistenceFilterCheckpointIntervalMs = 30_000,
 			int streamExistenceFilterCheckpointDelayMs = 5_000,
 			IExpiryStrategy expiryStrategy = null) {


### PR DESCRIPTION
Changed: reduced memory usage in tests

There are some tests that are constructing the MiniNode without setting a smaller value. But it would be very very unusual for a test to need more than 10k