### PR TITLE
Make Process CPU a UpDownCounter rather than Counter

### DIFF
--- a/src/EventStore.Core/Telemetry/ProcessMetrics.cs
+++ b/src/EventStore.Core/Telemetry/ProcessMetrics.cs
@@ -81,11 +81,11 @@ public class ProcessMetrics {
 			_ = new GcSuspensionMetric(maxGcPauseDurationTracker);
 		}
 
-		CreateObservableCounter(ProcessTracker.Cpu, getProcCpuUsage);
 		CreateObservableCounter(ProcessTracker.LockContentionCount, () => Monitor.LockContentionCount);
 		CreateObservableCounter(ProcessTracker.ExceptionCount, () => (int)getExceptionCount());
 		CreateObservableCounter(ProcessTracker.TotalAllocatedBytes, () => GC.GetTotalAllocatedBytes(), "bytes");
 
+		CreateObservableUpDownCounter(ProcessTracker.Cpu, getProcCpuUsage);
 		CreateObservableUpDownCounter(ProcessTracker.ThreadCount, () => ThreadPool.ThreadCount);
 		CreateObservableUpDownCounter(ProcessTracker.ThreadPoolPendingWorkItemCount, () => ThreadPool.PendingWorkItemCount);
 		CreateObservableUpDownCounter(ProcessTracker.TimeInGc, getPercentTimeInGc);


### PR DESCRIPTION
Fixed: Make Process CPU a UpDownCounter rather than Counter

Because it is a % that goes up and down