### PR TITLE
[release/oss-v21.10] Security fixes (DB-233)

### DIFF
--- a/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
+++ b/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
@@ -15,5 +15,7 @@
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+		<!-- CVE-2019-0820 -->
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -10,15 +10,15 @@
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
 		<PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
 		<PackageReference Include="Grpc.Core" Version="2.39.1" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
 		<PackageReference Include="Microsoft.AspNetCore.TestHost" Version="5.0.6" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
 		<PackageReference Include="CompareNETObjects" Version="4.65.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.15.8" />
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.52.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.Elections.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.Elections.cs
@@ -101,7 +101,7 @@ namespace EventStore.Core.Cluster {
 				ServerHttp = new GossipEndPoint(serverHttpEndPoint.GetHost(), (uint)serverHttpEndPoint.GetPort()),
 				AttemptedView = attemptedView
 			};
-			await _electionsClient.ViewChangeAsync(request, deadline: deadline.ToUniversalTime());
+			await _electionsClient.ViewChangeAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 		}
 
 		private async Task SendViewChangeProofAsync(Guid serverId, EndPoint serverHttpEndPoint, int installedView,
@@ -111,7 +111,7 @@ namespace EventStore.Core.Cluster {
 				ServerHttp = new GossipEndPoint(serverHttpEndPoint.GetHost(), (uint)serverHttpEndPoint.GetPort()),
 				InstalledView = installedView
 			};
-			await _electionsClient.ViewChangeProofAsync(request, deadline: deadline.ToUniversalTime());
+			await _electionsClient.ViewChangeProofAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 		}
 
 		private async Task SendPrepareAsync(Guid serverId, EndPoint serverHttpEndPoint, int view, DateTime deadline) {
@@ -120,7 +120,7 @@ namespace EventStore.Core.Cluster {
 				ServerHttp = new GossipEndPoint(serverHttpEndPoint.GetHost(), (uint)serverHttpEndPoint.GetPort()),
 				View = view
 			};
-			await _electionsClient.PrepareAsync(request, deadline: deadline.ToUniversalTime());
+			await _electionsClient.PrepareAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 		}
 
 		private async Task SendPrepareOkAsync(int view, Guid serverId, EndPoint serverHttpEndPoint, int epochNumber,
@@ -140,7 +140,7 @@ namespace EventStore.Core.Cluster {
 				NodePriority = nodePriority,
 				ClusterInfo = ClusterInfo.ToGrpcClusterInfo(clusterInfo)
 			};
-			await _electionsClient.PrepareOkAsync(request, deadline: deadline.ToUniversalTime());
+			await _electionsClient.PrepareOkAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 		}
 
 		private async Task SendProposalAsync(Guid serverId, EndPoint serverHttpEndPoint, Guid leaderId,
@@ -162,7 +162,7 @@ namespace EventStore.Core.Cluster {
 				ChaserCheckpoint = chaserCheckpoint,
 				NodePriority = nodePriority
 			};
-			await _electionsClient.ProposalAsync(request, deadline: deadline.ToUniversalTime());
+			await _electionsClient.ProposalAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 		}
 
 		private async Task SendAcceptAsync(Guid serverId, EndPoint serverHttpEndPoint, Guid leaderId,
@@ -174,7 +174,7 @@ namespace EventStore.Core.Cluster {
 				LeaderHttp = new GossipEndPoint(leaderHttp.GetHost(), (uint)leaderHttp.GetPort()),
 				View = view
 			};
-			await _electionsClient.AcceptAsync(request);
+			await _electionsClient.AcceptAsync(request).ConfigureAwait(false);
 			_electionsClient.Accept(request, deadline: deadline.ToUniversalTime());
 		}
 
@@ -183,7 +183,7 @@ namespace EventStore.Core.Cluster {
 				LeaderId = Uuid.FromGuid(leaderId).ToDto(),
 				LeaderHttp = new GossipEndPoint(leaderHttp.GetHost(), (uint)leaderHttp.GetPort()),
 			};
-			await _electionsClient.LeaderIsResigningAsync(request, deadline: deadline.ToUniversalTime());
+			await _electionsClient.LeaderIsResigningAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 		}
 
 		private async Task SendLeaderIsResigningOkAsync(Guid leaderId, EndPoint leaderHttp,
@@ -194,7 +194,7 @@ namespace EventStore.Core.Cluster {
 				ServerId = Uuid.FromGuid(serverId).ToDto(),
 				ServerHttp = new GossipEndPoint(serverHttpEndPoint.GetHost(), (uint)serverHttpEndPoint.GetPort()),
 			};
-			await _electionsClient.LeaderIsResigningOkAsync(request, deadline: deadline.ToUniversalTime());
+			await _electionsClient.LeaderIsResigningOkAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.Gossip.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.Gossip.cs
@@ -43,12 +43,12 @@ namespace EventStore.Core.Cluster {
 				Info = ClusterInfo.ToGrpcClusterInfo(clusterInfo),
 				Server = new GossipEndPoint(server.GetHost(), (uint)server.GetPort())
 			};
-			var clusterInfoDto = await _gossipClient.UpdateAsync(request, deadline: deadline.ToUniversalTime());
+			var clusterInfoDto = await _gossipClient.UpdateAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 			return ClusterInfo.FromGrpcClusterInfo(clusterInfoDto, _clusterDns);
 		}
 
 		private async Task<ClusterInfo> GetGossipAsync(DateTime deadline) {
-			var clusterInfoDto = await _gossipClient.ReadAsync(new Empty(), deadline: deadline.ToUniversalTime());
+			var clusterInfoDto = await _gossipClient.ReadAsync(new Empty(), deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
 			return ClusterInfo.FromGrpcClusterInfo(clusterInfoDto, _clusterDns);
 		}
 	}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -15,15 +15,16 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="EventStore.Plugins" Version="21.2.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.15.8" />
-		<PackageReference Include="Grpc.AspNetCore" Version="2.39.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
+		<PackageReference Include="Grpc.AspNetCore" Version="2.52.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.52.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
 		<PackageReference Include="Microsoft.FASTER.Core" Version="1.9.5" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
+		<PackageReference Include="System.Drawing.Common" Version="4.7.2" />
 		<PackageReference Include="System.IO.Pipelines" Version="4.7.2" />
 		<PackageReference Include="System.Linq.Async" Version="5.0.0" />
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
@@ -31,7 +32,7 @@
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.0.3" />
 		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 		<PackageReference Include="HostStat.NET" Version="1.0.2" />
-		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="5.0.1" />
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.BufferManagement\EventStore.BufferManagement.csproj" />

--- a/src/EventStore.LogV3.Tests/EventStore.LogV3.Tests.csproj
+++ b/src/EventStore.LogV3.Tests/EventStore.LogV3.Tests.csproj
@@ -8,8 +8,10 @@
 	<ItemGroup>
 		<PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
 		<PackageReference Include="ObjectLayoutInspector" Version="0.1.2" />
 		<PackageReference Include="System.Linq.Async" Version="5.0.0" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="xunit" Version="2.4.1" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/EventStore.LogV3/EventStore.LogV3.csproj
+++ b/src/EventStore.LogV3/EventStore.LogV3.csproj
@@ -7,11 +7,12 @@
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Google.Protobuf" Version="3.15.8" />
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.52.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.LogCommon\EventStore.LogCommon.csproj" />

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -5,6 +5,9 @@
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
 	<ItemGroup>
+			<!-- CVE-2023-29331 -->
+		<PackageReference Include="System.Security.Cryptography.Pkcs" Version="7.0.2" />
+		<PackageReference Include="System.Security.Cryptography.Xml" Version="7.0.1" />
 		<PackageReference Include="System.ServiceModel.Http" Version="4.7.0" />
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -30,7 +30,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Grpc.Tools" Version="2.52.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -14,9 +14,9 @@
 		<PackageReference Include="EventStore.Client" Version="21.2.0" />
 		<PackageReference Include="EventStore.Client.Grpc.Streams" Version="21.2.0" />
 		<PackageReference Include="EventStore.Plugins" Version="21.2.0" />
-		<PackageReference Include="Google.Protobuf" Version="3.15.8" />
-		<PackageReference Include="Grpc.Net.Client" Version="2.39.0" />
-		<PackageReference Include="Grpc.Tools" Version="2.39.1">
+		<PackageReference Include="Google.Protobuf" Version="3.22.0" />
+		<PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
+		<PackageReference Include="Grpc.Tools" Version="2.52.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
Fixed: Bump gRPC packages for [CVE-2023-32731](https://github.com/advisories/GHSA-cfgp-2977-2fmm)
Fixed: Bump System.Text.RegularExpressions for [CVE-2019-0820](https://github.com/advisories/GHSA-cmhx-cq75-c4mj)
Fixed: Bump System.Drawing.Common [CVE-2021-24112](https://github.com/advisories/GHSA-rxg9-xrhp-64gj)
Fixed: Bump System.Security.Cryptography.* [CVE-2022-34716](https://github.com/advisories/GHSA-2m65-m22p-9wjw)