### PR TITLE
Use reloaded options when reloading certificates

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -130,7 +130,7 @@ namespace EventStore.ClusterNode {
 					Log.Information("Running in dev mode using certificate '{cert}'", certs[0]);
 					certificateProvider = new DevCertificateProvider(certs[0]);
 				} else {
-					certificateProvider = new OptionsCertificateProvider(options);
+					certificateProvider = new OptionsCertificateProvider();
 				}
 
 				var deprecationWarnings = options.GetDeprecationWarnings();

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -23,7 +23,7 @@ namespace EventStore.Core.Tests.ClientOperations {
 			_node = new ClusterVNode<TStreamId>(options, logFormatFactory,
 				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
-				certificateProvider: new OptionsCertificateProvider(options));
+				certificateProvider: new OptionsCertificateProvider());
 			_node.StartAsync(true).Wait();
 		}
 		public void Publish(Message message) {

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
@@ -26,7 +26,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 			_node = new ClusterVNode<TStreamId>(_options, _logFormatFactory,
 				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
-				certificateProvider: new OptionsCertificateProvider(_options));
+				certificateProvider: new OptionsCertificateProvider());
 			_node.Start();
 		}
 
@@ -58,7 +58,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 			_node = new ClusterVNode<TStreamId>(_options, _logFormatFactory,
 				new AuthenticationProviderFactory(_ => new InternalAuthenticationProviderFactory(_)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
-				certificateProvider: new OptionsCertificateProvider(_options));
+				certificateProvider: new OptionsCertificateProvider());
 			_node.Start();
 		}
 

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_cluster_node_and_custom_settings.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_cluster_node_and_custom_settings.cs
@@ -42,7 +42,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
 			}.RunInMemory();
 			try {
 				_ = new ClusterVNode<TStreamId>(_options, LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory,
-					certificateProvider: new OptionsCertificateProvider(_options));
+					certificateProvider: new OptionsCertificateProvider());
 			} catch (Exception e) {
 				_caughtException = e;
 			}

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_secure_tcp.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/when_building/with_secure_tcp.cs
@@ -110,7 +110,7 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests.when_building {
 				.WithExternalSecureTcpOn(externalSecTcp);
 			try {
 				_ = new ClusterVNode<TStreamId>(_options, LogFormatHelper<TLogFormat, TStreamId>.LogFormatFactory,
-					certificateProvider: new OptionsCertificateProvider(_options));
+					certificateProvider: new OptionsCertificateProvider());
 			} catch (Exception ex) {
 				_caughtException = ex;
 			}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -178,7 +178,7 @@ namespace EventStore.Core.Tests.Helpers {
 				new AuthorizationProviderFactory(components =>
 					new LegacyAuthorizationProviderFactory(components.MainQueue)),
 				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>(),
-				new OptionsCertificateProvider(options),
+				new OptionsCertificateProvider(),
 				expiryStrategy,
 				Guid.NewGuid(), debugIndex);
 			Node.HttpService.SetupController(new TestController(Node.MainQueue));

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -164,7 +164,7 @@ namespace EventStore.Core.Tests.Helpers {
 				new AuthenticationProviderFactory(c => new InternalAuthenticationProviderFactory(c)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue)),
 				expiryStrategy: expiryStrategy,
-				certificateProvider: new OptionsCertificateProvider(options));
+				certificateProvider: new OptionsCertificateProvider());
 			Db = Node.Db;
 
 			Node.HttpService.SetupController(new TestController(Node.MainQueue));

--- a/src/EventStore.Core/Certificates/CertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/CertificateProvider.cs
@@ -6,7 +6,7 @@ namespace EventStore.Core.Certificates {
 		public X509Certificate2Collection IntermediateCerts;
 		public X509Certificate2Collection TrustedRootCerts;
 
-		public abstract LoadCertificateResult LoadCertificates();
+		public abstract LoadCertificateResult LoadCertificates(ClusterVNodeOptions options);
 	}
 
 	public enum LoadCertificateResult {

--- a/src/EventStore.Core/Certificates/DevCertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/DevCertificateProvider.cs
@@ -7,7 +7,7 @@ namespace EventStore.Core.Certificates {
 			TrustedRootCerts = new X509Certificate2Collection(certificate);
 		}
 
-		public override LoadCertificateResult LoadCertificates() {
+		public override LoadCertificateResult LoadCertificates(ClusterVNodeOptions options) {
 			return LoadCertificateResult.Skipped;
 		}
 	}

--- a/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
@@ -5,19 +5,13 @@ using Serilog;
 namespace EventStore.Core.Certificates {
 	public class OptionsCertificateProvider: CertificateProvider {
 		private static readonly ILogger Log = Serilog.Log.ForContext<ClusterVNode>();
-		private ClusterVNodeOptions _options;
-
-		public OptionsCertificateProvider(ClusterVNodeOptions options) {
-			_options = options;
-		}
-
-		public override LoadCertificateResult LoadCertificates() {
-			if (_options.Application.Insecure) {
+		public override LoadCertificateResult LoadCertificates(ClusterVNodeOptions options) {
+			if (options.Application.Insecure) {
 				Log.Information("Skipping reload of certificates since TLS is disabled.");
 				return LoadCertificateResult.Skipped;
 			}
 
-			var (certificate, intermediates) = _options.LoadNodeCertificate();
+			var (certificate, intermediates) = options.LoadNodeCertificate();
 
 			var previousThumbprint = Certificate?.Thumbprint;
 			var newThumbprint = certificate.Thumbprint;
@@ -30,7 +24,7 @@ namespace EventStore.Core.Certificates {
 				}
 			}
 
-			var trustedRootCerts = _options.LoadTrustedRootCertificates();
+			var trustedRootCerts = options.LoadTrustedRootCertificates();
 
 			foreach (var trustedRootCert in trustedRootCerts) {
 				Log.Information("Loading trusted root certificate. Subject: {subject}, Thumbprint: {thumbprint}", trustedRootCert.SubjectName.Name, trustedRootCert.Thumbprint);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1826,7 +1826,7 @@ namespace EventStore.Core {
 				return;
 			}
 
-			if (_certificateProvider?.LoadCertificates() == LoadCertificateResult.VerificationFailed){
+			if (_certificateProvider?.LoadCertificates(options) == LoadCertificateResult.VerificationFailed){
 				throw new InvalidConfigurationException("Aborting certificate loading due to verification errors.");
 			}
 		}


### PR DESCRIPTION
Fixed : Calling the admin/reloadconfig endpoint only reloaded/updated the LogLevel and the certificates were not updated on reloading the config. This was broken by the Dev Certificate changes in v22.10. This PR has the changes backported to v22.10.

Fixes : https://linear.app/eventstore/issue/DB-166/new-certs-are-not-loaded-on-calling-the-adminreloadconfig-endpoint