### PR TITLE
Make checkpoints always cached (DB-223)

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/ExpectedVersion64Bit/MiniNodeWithExistingRecords.cs
@@ -64,8 +64,8 @@ namespace EventStore.Core.Tests.ClientAPI.ExpectedVersion64Bit {
 			var writerCheckFilename = Path.Combine(dbPath, Checkpoint.Writer + ".chk");
 			var chaserCheckFilename = Path.Combine(dbPath, Checkpoint.Chaser + ".chk");
 
-			WriterCheckpoint = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
-			ChaserCheckpoint = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
+			WriterCheckpoint = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer);
+			ChaserCheckpoint = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser);
 
 			Db = new TFChunkDb(TFChunkHelper.CreateDbConfig(dbPath, WriterCheckpoint, ChaserCheckpoint, TFConsts.ChunkSize));
 			Db.Open();

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_a_file_checksum_to_a_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_a_file_checksum_to_a_file.cs
@@ -43,23 +43,19 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public async Task the_new_value_is_not_accessible_if_not_flushed_even_with_delay() {
 			var checkSum = new FileCheckpoint(Filename);
-			var readChecksum = new FileCheckpoint(Filename);
 			checkSum.Write(1011);
 			await Task.Delay(200);
-			Assert.AreEqual(0, readChecksum.Read());
+			Assert.AreEqual(0, checkSum.Read());
 			checkSum.Close(flush: true);
-			readChecksum.Close(flush: true);
 		}
 
 		[Test]
 		public void the_new_value_is_accessible_after_flush() {
 			var checkSum = new FileCheckpoint(Filename);
-			var readChecksum = new FileCheckpoint(Filename);
 			checkSum.Write(1011);
 			checkSum.Flush();
-			Assert.AreEqual(1011, readChecksum.Read());
+			Assert.AreEqual(1011, checkSum.Read());
 			checkSum.Close(flush: true);
-			readChecksum.Close(flush: true);
 		}
 	}
 }

--- a/src/EventStore.Core.Tests/TransactionLog/when_writing_a_memorymappedpoint_to_a_file.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/when_writing_a_memorymappedpoint_to_a_file.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Core.TransactionLog.Checkpoint;
 using NUnit.Framework;
@@ -22,7 +21,7 @@ namespace EventStore.Core.Tests.TransactionLog {
 
 		[Test]
 		public void name_is_set() {
-			var checksum = new MemoryMappedFileCheckpoint(Filename, "test", false);
+			var checksum = new MemoryMappedFileCheckpoint(Filename, "test");
 			Assert.AreEqual("test", checksum.Name);
 			checksum.Close(flush: true);
 		}
@@ -51,23 +50,19 @@ namespace EventStore.Core.Tests.TransactionLog {
 		[Test]
 		public async Task the_new_value_is_not_accessible_if_not_flushed_even_with_delay() {
 			var checkSum = new MemoryMappedFileCheckpoint(Filename);
-			var readChecksum = new MemoryMappedFileCheckpoint(Filename);
 			checkSum.Write(1011);
 			await Task.Delay(200);
-			Assert.AreEqual(0, readChecksum.Read());
+			Assert.AreEqual(0, checkSum.Read());
 			checkSum.Close(flush: true);
-			readChecksum.Close(flush: true);
 		}
 
 		[Test]
 		public async Task the_new_value_is_accessible_after_flush() {
 			var checkSum = new MemoryMappedFileCheckpoint(Filename);
-			var readChecksum = new MemoryMappedFileCheckpoint(Filename);
 			checkSum.Write(1011);
 			checkSum.Flush();
-			Assert.AreEqual(1011, readChecksum.Read());
+			Assert.AreEqual(1011, checkSum.Read());
 			checkSum.Close(flush: true);
-			readChecksum.Close(flush: true);
 			await Task.Delay(100);
 		}
 	}

--- a/src/EventStore.Core.XUnit.Tests/LogAbstraction/Common/StreamExistenceFilterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/LogAbstraction/Common/StreamExistenceFilterTests.cs
@@ -29,7 +29,7 @@ namespace EventStore.Core.XUnit.Tests.LogAbstraction.Common {
 
 			checkpointInterval ??= TimeSpan.FromMilliseconds(10);
 			var checkpointPath = Path.Combine(_fixture.Directory, $"{name}.chk");
-			var checkpoint = new FileCheckpoint(checkpointPath, name, cached: true, initValue: -1);
+			var checkpoint = new FileCheckpoint(checkpointPath, name, initValue: -1);
 			var filter = new StreamExistenceFilter(
 				directory: _fixture.Directory,
 				checkpoint: checkpoint,

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -359,30 +359,28 @@ namespace EventStore.Core {
 
 					if (OS.IsUnix) {
 						Log.Debug("Using File Checkpoints");
-						writerChk = new FileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
-						chaserChk = new FileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
-						epochChk = new FileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true,
+						writerChk = new FileCheckpoint(writerCheckFilename, Checkpoint.Writer);
+						chaserChk = new FileCheckpoint(chaserCheckFilename, Checkpoint.Chaser);
+						epochChk = new FileCheckpoint(epochCheckFilename, Checkpoint.Epoch,
 							initValue: -1);
 						proposalChk = new FileCheckpoint(proposalCheckFilename, Checkpoint.Proposal,
-							cached: true,
 							initValue: -1);
 						truncateChk = new FileCheckpoint(truncateCheckFilename, Checkpoint.Truncate,
-							cached: true, initValue: -1);
+							initValue: -1);
 						streamExistenceFilterChk = new FileCheckpoint(streamExistenceFilterCheckFilename, Checkpoint.StreamExistenceFilter,
-							cached: true, initValue: -1);
+							initValue: -1);
 					} else {
 						Log.Debug("Using Memory Mapped File Checkpoints");
-						writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer, cached: true);
-						chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser, cached: true);
-						epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch, cached: true,
+						writerChk = new MemoryMappedFileCheckpoint(writerCheckFilename, Checkpoint.Writer);
+						chaserChk = new MemoryMappedFileCheckpoint(chaserCheckFilename, Checkpoint.Chaser);
+						epochChk = new MemoryMappedFileCheckpoint(epochCheckFilename, Checkpoint.Epoch,
 							initValue: -1);
 						proposalChk = new MemoryMappedFileCheckpoint(proposalCheckFilename, Checkpoint.Proposal,
-							cached: true,
 							initValue: -1);
 						truncateChk = new MemoryMappedFileCheckpoint(truncateCheckFilename, Checkpoint.Truncate,
-							cached: true, initValue: -1);
+							initValue: -1);
 						streamExistenceFilterChk = new MemoryMappedFileCheckpoint(streamExistenceFilterCheckFilename, Checkpoint.StreamExistenceFilter,
-							cached: true, initValue: -1);
+							initValue: -1);
 					}
 				}
 

--- a/src/EventStore.Core/TransactionLog/Checkpoint/InMemoryCheckpoint.cs
+++ b/src/EventStore.Core/TransactionLog/Checkpoint/InMemoryCheckpoint.cs
@@ -47,7 +47,7 @@ namespace EventStore.Core.TransactionLog.Checkpoint {
 
 		public event Action<long> Flushed;
 
-		protected virtual void OnFlushed(long obj) {
+		private void OnFlushed(long obj) {
 			var onFlushed = Flushed;
 			if (onFlushed != null)
 				onFlushed.Invoke(obj);


### PR DESCRIPTION
Removed: Unused code around checkpoints

Previously, checkpoints did happen to always be cached in the production code, but they had the capability to not be.

When cached, Reads and Writes are always through an Interlocked call which provides a full memory barrier, but when not cached the Read calls read through to the underlying storage (FileStream or MemoryMappedFile respectively), without a memory barrier.

The memory barrier can be important. For example when the chunk WriterWorkItem writes to the active chunk and it is cached, the writes are to some unmanaged memory, and then it moves the writer checkpoint. A thread reading the writer checkpoint (e.g. chaser, replication, etc) can then be sure that its reads from the unmanaged memory (via a chunk ReaderWorkItem) will be correct up to the checkpoint value that was read. This is because the barrier on write ensures that the data is written before the checkpoint is updated and the barrier on read ensures that the checkpoint is read before the data is read.

(Related to DB-162 because the other changes in that ticket result in us always caching the active chunk)