### PR TITLE
Update help output

### DIFF
--- a/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
@@ -126,16 +126,11 @@ namespace EventStore.Core {
 
 			string GetOption(PropertyInfo property) {
 				var builder = new StringBuilder();
-				if (Runtime.IsWindows) {
-					builder.Append('-').Append(property.Name);
-				} else {
-					builder.AppendJoin(string.Empty, GnuOption(property.Name));
-				}
+				builder.AppendJoin(string.Empty, GnuOption(property.Name));
 
 				var defaultValue = DefaultValue(property);
-
 				if (defaultValue != string.Empty) {
-					builder.Append('=').Append(defaultValue);
+					builder.Append(" (Default:").Append(defaultValue).Append(')');
 				}
 
 				return builder.ToString();

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -164,10 +164,10 @@ namespace EventStore.Core {
 			[Description("Disable Authentication, Authorization and TLS on all TCP/HTTP interfaces.")]
 			public bool Insecure { get; init; } = false;
 
-			[Description("Allow anonymous access to API end points")]
+			[Description("Allow anonymous access to HTTP API endpoints.")]
 			public bool AllowAnonymousEndpointAccess { get; init; } = true;
 
-			[Description("Allow anonymous access to streams")]
+			[Description("Allow anonymous access to streams.")]
 			public bool AllowAnonymousStreamAccess { get; init; } = true;
 
 			internal static ApplicationOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {


### PR DESCRIPTION
Changed: Update help output so that it matches the documentation

Fixes https://github.com/EventStore/EventStore/issues/3903

- Remove '=' from the default options, as there are cases where using `=` does not work on Windows
- Only print options with '--' as there are cases where '-' does not work on Windows