### PR TITLE
Remove the verify tag step for triggering a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,29 +13,6 @@ jobs:
         id: get_version
         run: echo "version=${GITHUB_REF:15}" >> $GITHUB_OUTPUT
 
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Verify new release tag
-        shell: pwsh
-        run: |
-          #
-          # Verify the tag to make sure minver can find it.
-          #
-          $tag="oss-v${{ steps.get_version.outputs.version }}"
-          # only check the first tag of every maintained release
-          if ($tag -like "oss-v*.*.0") {
-            Write-Output "Checking tag: $($tag)"
-            $branchesWithTag = $(git branch --all --contains $tag) -join " "
-            if (-not ($branchesWithTag -match "master")) {
-              Write-Error "Tag $($tag) should be created with a commit from master and not from a release branch!"
-            }
-          } else {
-            Write-Output "Skip checking tag: $($tag)"
-          }
-
       - name: Perform Release 
         run: |
           curl -X POST https://api.github.com/repos/EventStore/TrainStation/dispatches \


### PR DESCRIPTION
We sometimes need to re-tag a version on the release branch rather than on master, and master has already diverged.