### PR TITLE
Ignore unknown options when dumping them

### DIFF
--- a/src/EventStore.Common.Tests/Configuration/OptionsDumperTest.cs
+++ b/src/EventStore.Common.Tests/Configuration/OptionsDumperTest.cs
@@ -124,6 +124,13 @@ public class OptionsDumperTest {
 	}
 
 	[Fact]
+	public void ignores_unknown_option() {
+		var options = new TestOptions(new Dictionary<string, string>(), new[] { "--unknown-option=something" });
+		var printable = OptionsDumper.GetOptionSourceInfo(options.ConfigurationRoot);
+		Assert.False(printable.TryGetValue("UnknownOption", out _));
+	}
+
+	[Fact]
 	public void option_set_by_multiple_sources_shows_the_source_with_precedence() {
 		var expected = "foo";
 		var options = new TestOptions(new Dictionary<string, string> {

--- a/src/EventStore.Common/Configuration/OptionsDumper.cs
+++ b/src/EventStore.Common/Configuration/OptionsDumper.cs
@@ -125,8 +125,9 @@ namespace EventStore.Common.Configuration {
 				var source = provider.GetType();
 				foreach (var key in provider.GetChildKeys(Enumerable.Empty<string>(), default)) {
 					if (provider.TryGet(key, out var value)) {
-						var opt = result[key];
-						result[key] = opt.WithValue(value, source);
+						if(result.TryGetValue(key, out var opt)) {
+							result[key] = opt.WithValue(value, source);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixed: Ignore unknown options when dumping startup configuration

Otherwise EventStore shuts down without printing the closest matching option to the mistyped one