### PR TITLE
Add an override option for anonymous gossip

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -75,11 +75,11 @@ For this to work, you can use the `DefaultOpsPassword` option:
 Due to security reasons the DefaultAdminPassword and DefaultOpsPassword options can only be set through environment variables. The user will receive the error message if they try to pass the options using command line or config file.
 :::
 
-### Allow anonymous access to some endpoints and streams
+### Anonymous access to streams
 
 Historically, anonymous users with network access have been allowed to read/write streams that do not have access control lists.
 
-This is now disabled by default but can be enabled with this setting.
+This is now disabled by default but can be enabled by setting `AllowAnonymousStreamAccess` to `true`.
 
 | Format               | Syntax                                     |
 |:---------------------|:-------------------------------------------|
@@ -89,11 +89,13 @@ This is now disabled by default but can be enabled with this setting.
 
 **Default**: `false`
 
-Similarly to streams above, anonymous access has historically been available to the `/stats` and `/gossip` endpoints, and the `HTTP OPTIONS` method.
+### Anonymous access to endpoints
 
-This is now disabled by default but can be enabled with this setting.
+Similarly to streams above, anonymous access has historically been available to some http endpoints.
 
-Anonymous access is still always granted to `/ping`, `/info`, the static content of the UI, and http redirects.
+Anonymous access to `/gossip`, `/stats` and the `HTTP OPTIONS` method can now be configured with the following two options. By default `/gossip` is still accessible anonymously but the others are not. Some clients currently rely on anonymous access to `/gossip`. This will likely change in the future.
+
+The `AllowAnonymousEndpointAccess` option controls anonymous access to these endpoints. Setting `OverrideAnonymousEndpointAccessForGossip` to `true` allows anonymous access to `/gossip` specifically, overriding the other option.
 
 | Format               | Syntax                                       |
 |:---------------------|:---------------------------------------------|
@@ -102,6 +104,18 @@ Anonymous access is still always granted to `/ping`, `/info`, the static content
 | Environment variable | `EVENTSTORE_ALLOW_ANONYMOUS_ENDPOINT_ACCESS` |
 
 **Default**: `false`
+
+| Format               | Syntax                                                     |
+|:---------------------|:-----------------------------------------------------------|
+| Command line         | `--override-anonymous-endpoint-access-for-gossip`          |
+| YAML                 | `OverrideAnonymousEndpointAccessForGossip`                 |
+| Environment variable | `EVENTSTORE_OVERRIDE_ANONYMOUS_ENDPOINT_ACCESS_FOR_GOSSIP` |
+
+**Default**: `true`
+
+::: tip
+Anonymous access is still always granted to `/ping`, `/info`, the static content of the UI, and http redirects.
+:::
 
 ### Certificates configuration
 

--- a/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
+++ b/src/EventStore.ClusterNode/ClusterVNodeHostedService.cs
@@ -124,7 +124,8 @@ namespace EventStore.ClusterNode {
 						"internal", new AuthorizationProviderFactory(components =>
 							new LegacyAuthorizationProviderFactory(components.MainQueue,
 								_options.Application.AllowAnonymousEndpointAccess,
-								_options.Application.AllowAnonymousStreamAccess))
+								_options.Application.AllowAnonymousStreamAccess,
+								_options.Application.OverrideAnonymousEndpointAccessForGossip))
 					}
 				};
 

--- a/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
+++ b/src/EventStore.Core.Tests/ClientOperations/specification_with_bare_vnode.cs
@@ -25,7 +25,9 @@ namespace EventStore.Core.Tests.ClientOperations {
 				new AuthenticationProviderFactory(
 					c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
-					options.Application.AllowAnonymousEndpointAccess, options.Application.AllowAnonymousStreamAccess)),
+					options.Application.AllowAnonymousEndpointAccess,
+					options.Application.AllowAnonymousStreamAccess,
+					options.Application.OverrideAnonymousEndpointAccessForGossip)),
 				certificateProvider: new OptionsCertificateProvider());
 			_node.StartAsync(true).Wait();
 		}

--- a/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
+++ b/src/EventStore.Core.Tests/Common/ClusterNodeOptionsTests/ClusterVNodeOptionsScenarios.cs
@@ -37,7 +37,8 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 					new InternalAuthenticationProviderFactory(c, _options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
 					_options.Application.AllowAnonymousEndpointAccess,
-					_options.Application.AllowAnonymousStreamAccess)),
+					_options.Application.AllowAnonymousStreamAccess,
+					_options.Application.OverrideAnonymousEndpointAccessForGossip)),
 				certificateProvider: new OptionsCertificateProvider());
 			_node.Start();
 		}
@@ -73,7 +74,8 @@ namespace EventStore.Core.Tests.Common.ClusterNodeOptionsTests {
 					new InternalAuthenticationProviderFactory(_, _options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
 					_options.Application.AllowAnonymousEndpointAccess,
-					_options.Application.AllowAnonymousStreamAccess)),
+					_options.Application.AllowAnonymousStreamAccess,
+					_options.Application.OverrideAnonymousEndpointAccessForGossip)),
 				certificateProvider: new OptionsCertificateProvider());
 			_node.Start();
 		}

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -178,7 +178,8 @@ namespace EventStore.Core.Tests.Helpers {
 				new AuthorizationProviderFactory(components =>
 					new LegacyAuthorizationProviderFactory(components.MainQueue,
 						options.Application.AllowAnonymousEndpointAccess,
-						options.Application.AllowAnonymousStreamAccess)),
+						options.Application.AllowAnonymousStreamAccess,
+						options.Application.OverrideAnonymousEndpointAccessForGossip)),
 				Array.Empty<IPersistentSubscriptionConsumerStrategyFactory>(),
 				new OptionsCertificateProvider(),
 				telemetryConfiguration: null,

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -166,7 +166,9 @@ namespace EventStore.Core.Tests.Helpers {
 				new AuthenticationProviderFactory(
 					c => new InternalAuthenticationProviderFactory(c, options.DefaultUser)),
 				new AuthorizationProviderFactory(c => new LegacyAuthorizationProviderFactory(c.MainQueue,
-					options.Application.AllowAnonymousEndpointAccess, options.Application.AllowAnonymousStreamAccess)),
+					options.Application.AllowAnonymousEndpointAccess,
+					options.Application.AllowAnonymousStreamAccess,
+					options.Application.OverrideAnonymousEndpointAccessForGossip)),
 				telemetryConfiguration: null,
 				expiryStrategy: expiryStrategy,
 				certificateProvider: new OptionsCertificateProvider());

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -170,6 +170,10 @@ namespace EventStore.Core {
 			[Description("Allow anonymous access to streams.")]
 			public bool AllowAnonymousStreamAccess { get; init; } = false;
 
+			[Description("Overrides anonymous access for the gossip enpdoint. If set to true, the gossip endpoint will accept anonymous access. " +
+			             $"Otherwise anonymous access wil be dis/allowed based on the value of the '{nameof(AllowAnonymousEndpointAccess)}' option")]
+			public bool OverrideAnonymousEndpointAccessForGossip { get; init; } = true;
+
 			internal static ApplicationOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				Config = configurationRoot.GetValue<string>(nameof(Config)),
 				Help = configurationRoot.GetValue<bool>(nameof(Help)),
@@ -187,7 +191,8 @@ namespace EventStore.Core {
 				SkipIndexScanOnReads = configurationRoot.GetValue<bool>(nameof(SkipIndexScanOnReads)),
 				Insecure = configurationRoot.GetValue<bool>(nameof(Insecure)),
 				AllowAnonymousEndpointAccess = configurationRoot.GetValue<bool>(key:nameof(AllowAnonymousEndpointAccess)),
-				AllowAnonymousStreamAccess = configurationRoot.GetValue<bool>(key:nameof(AllowAnonymousStreamAccess))
+				AllowAnonymousStreamAccess = configurationRoot.GetValue<bool>(key:nameof(AllowAnonymousStreamAccess)),
+				OverrideAnonymousEndpointAccessForGossip = configurationRoot.GetValue<bool>(key:nameof(OverrideAnonymousEndpointAccessForGossip))
 			};
 		}
 


### PR DESCRIPTION
Added: New 'OverrideAnonymousGossipAccess' option which will override the 'AllowAnonymousEndpiontAccess' setting for the gossip endpoint when set to true.

This is set to true by default, but we intend on changing the default after we are sure that the clients can support it.