### PR TITLE
Fix documentation link syntax

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -375,7 +375,7 @@ For a given _NAME_, the current status can be determined by taking the max of al
 - Cleaning
 - Idle
 
-Read more about node roles [here](cluster.html#node-roles)
+`Node` can be one of the [node roles](cluster.md#node-roles).
 
 Example Configuration:
 ```


### PR DESCRIPTION
Fixed: trivial documentation adjustment

yarn complains about the .html link when i run it locally (though it does still seem to work)