### PR TITLE
Simplify TFChunk by removing unused paths (DB-321)

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1212,6 +1212,9 @@ namespace EventStore.Core {
 					if (logFormat is not LogFormatAbstractor<string> logFormatV2)
 						throw new NotSupportedException("Scavenge is not yet supported on Log V3");
 
+					if (options.Database.MemDb)
+						throw new NotSupportedException("Scavenge is not supported on in-memory databases");
+
 					var cancellationCheckPeriod = 1024;
 
 					var longHasher = new CompositeHasher<TStreamId>(logFormat.LowHasher, logFormat.HighHasher);


### PR DESCRIPTION
Changed: Removed unused code paths

Alignv2File was never called

ResizeMemStream was only called when scavenging an in-memory chunk, which isn't supported on new or old scavenges Added an error log to make this slightly more obvious