### PR TITLE
update eventType to $PersistentConfig  while creating persistent subscription

### DIFF
--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1212,7 +1212,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		private void SaveConfiguration(Action continueWith) {
 			Log.Debug("Saving persistent subscription configuration");
 			var data = _config.GetSerializedForm();
-			var ev = new Event(Guid.NewGuid(), "PersistentConfig1", true, data, new byte[0]);
+			var ev = new Event(Guid.NewGuid(), "$PersistentConfig", true, data, new byte[0]);
 			var metadata = new StreamMetadata(maxCount: 2);
 			Lazy<StreamMetadata> streamMetadata = new Lazy<StreamMetadata>(() => metadata);
 			Event[] events = new Event[] {ev};


### PR DESCRIPTION
Fixed: PersistentConfig1 system event does not begin with $

Fixes #3395 

Currently the system event generated during creating persistent subscription process does not contains $ sign. The goal of this PR is just update the eventType from PersistentConfig1 to $PersistentConfig