### PR TITLE
Send checkpoints on correct interval after catching-up (DB-348)

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -106,17 +107,19 @@ namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
 			_batchAppender.Call(requests);
 
 		internal static IEnumerable<BatchAppendReq.Types.ProposedMessage> CreateEvents(int count) =>
-			Enumerable.Range(0, count)
-				.Select(_ => new BatchAppendReq.Types.ProposedMessage {
-					Data = ByteString.Empty,
-					Id = Uuid.NewUuid().ToDto(),
-					CustomMetadata = ByteString.Empty,
-					Metadata = {
-						{GrpcMetadata.ContentType, GrpcMetadata.ContentTypes.ApplicationOctetStream},
-						{GrpcMetadata.Type, "-"}
-					}
-				});
+			Enumerable.Range(0, count).Select(_ => CreateEvent());
 
+		internal static BatchAppendReq.Types.ProposedMessage CreateEvent(string type="-") =>
+			new BatchAppendReq.Types.ProposedMessage {
+				Data = ByteString.Empty,
+				Id = Uuid.NewUuid().ToDto(),
+				CustomMetadata = ByteString.Empty,
+				Metadata = {
+					{GrpcMetadata.ContentType, GrpcMetadata.ContentTypes.ApplicationOctetStream},
+					{GrpcMetadata.Type, type}
+				}
+			};
+		
 		private class BatchAppender : IAsyncDisposable {
 			private readonly Lazy<AsyncDuplexStreamingCall<BatchAppendReq, BatchAppendResp>> _batchAppendLazy;
 			private AsyncDuplexStreamingCall<BatchAppendReq, BatchAppendResp> BatchAppend => _batchAppendLazy.Value;

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/SubscribeToAllFilteredTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/SubscribeToAllFilteredTests.cs
@@ -1,12 +1,17 @@
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using EventStore.Client;
 using EventStore.Client.Streams;
 using EventStore.Core.Services.Transport.Grpc;
 using Google.Protobuf;
 using Grpc.Core;
 using NUnit.Framework;
 using Position = EventStore.Core.Services.Transport.Grpc.Position;
+using GrpcMetadata = EventStore.Core.Services.Transport.Grpc.Constants.Metadata;
 using LogV3StreamId = System.UInt32;
 
 namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
@@ -270,6 +275,193 @@ namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
 			[Test]
 			public void checkpoint_is_before_last_written_event() {
 				Assert.True(_positions[0] < _position);
+			}
+		}
+		
+		[TestFixture(typeof(LogFormat.V2), typeof(string), 8, 6)]
+		[TestFixture(typeof(LogFormat.V2), typeof(string), 32, 6)]
+		[TestFixture(typeof(LogFormat.V2), typeof(string), 36, 6)]
+		public class when_subscribing_to_all_with_a_filter_and_transitioning_to_live<TLogFormat, TStreamId>
+			: GrpcSpecification<TLogFormat, TStreamId> {
+
+			private const string StreamA = nameof(StreamA);
+			private const string MarkerStream = nameof(MarkerStream);
+			private const string FinishEventType = nameof(FinishEventType);
+			private const int CheckpointIntervalMultiplier = 2;
+			private const int CheckpointInterval = CheckpointIntervalMultiplier * 32; 
+
+			private int _expectedEventCount;
+			private AllStreamPosition _markerPosition;
+			private readonly int _numberOfEventsToCatchUp;
+			private readonly int _expectedCheckpoints;
+			private readonly List<int> _checkpointPositions = new (); 
+			private readonly Dictionary<ReadResp.ContentOneofCase, int> _contentCaseCounts = new ();
+
+			public when_subscribing_to_all_with_a_filter_and_transitioning_to_live(int catchupCount, int expectedCheckpoints)
+				: base (new LotsOfExpiriesStrategy()) {
+				
+				_expectedCheckpoints = expectedCheckpoints;
+				_numberOfEventsToCatchUp = catchupCount;
+
+				foreach (var c in Enum.GetValues<ReadResp.ContentOneofCase>()) {
+					_contentCaseCounts.Add(c, 0);
+				}
+			}
+
+			protected override async Task Given() {
+				// marker stream, start subscription after this
+				var result = await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						Any = new(),
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(MarkerStream) }
+					},
+					IsFinal = true,
+					ProposedMessages = { CreateEvents(1) },
+					CorrelationId = Uuid.NewUuid().ToDto()
+				});
+
+				_markerPosition = result.Success.Position;
+				
+				// initial events used for catching-up the subscription
+				await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						Any = new(),
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamA) }
+					},
+					IsFinal = true,
+					ProposedMessages = { ExpectEvents(CreateEvents(_numberOfEventsToCatchUp)) },
+					CorrelationId = Uuid.NewUuid().ToDto()
+				});
+			}
+
+			protected override async Task When() {
+				var caughtUp = new TaskCompletionSource();
+				var cancelSubscription = new TaskCompletionSource();
+				var _ = Task.Run(async () => {
+					// subscribe
+					using var call = StreamsClient.Read(new ReadReq {
+						Options = new ReadReq.Types.Options {
+							Subscription = new(),
+							All = new() { Position = new ReadReq.Types.Options.Types.Position() {
+								CommitPosition = _markerPosition.CommitPosition,
+								PreparePosition = _markerPosition.PreparePosition
+							}},
+							Filter = new() {
+								Count = new Empty(),
+								CheckpointIntervalMultiplier = CheckpointIntervalMultiplier,
+								EventType = new ReadReq.Types.Options.Types.FilterOptions.Types.Expression() {
+									Regex = "^[^$].*" // exclude system events
+								},
+							},
+							UuidOption = new() { Structured = new() },
+							ReadDirection = ReadReq.Types.Options.Types.ReadDirection.Forwards
+						}
+					}, GetCallOptions(AdminCredentials));
+					
+					// consume
+					var cts = new CancellationTokenSource();
+					var sw = Stopwatch.StartNew();
+					var maxResponseTimeMs = TimeSpan.Zero.TotalMilliseconds;
+					try {
+						await foreach (var response in call.ResponseStream.ReadAllAsync(cts.Token)) {
+							maxResponseTimeMs = Math.Max(maxResponseTimeMs, sw.Elapsed.TotalMilliseconds);
+
+							_contentCaseCounts[response.ContentCase]++;
+
+							switch (response.ContentCase) {
+								case ReadResp.ContentOneofCase.Checkpoint:
+									_checkpointPositions.Add(_contentCaseCounts[ReadResp.ContentOneofCase.Event]);
+									break;
+								case ReadResp.ContentOneofCase.CaughtUp:
+									caughtUp.TrySetResult();
+									break;
+								case ReadResp.ContentOneofCase.Event: {
+									if (response.Event.Event.Metadata[GrpcMetadata.Type] == FinishEventType) {
+										// allow some time for final events, like checkpoints, to arrive
+										cts.CancelAfter(TimeSpan.FromMilliseconds(maxResponseTimeMs * 10));
+									}
+									break;
+								}
+							}
+
+							sw.Restart();
+						}
+					} catch (RpcException ex) when(ex.StatusCode == StatusCode.Cancelled) {
+						// expected
+					}
+					
+					cancelSubscription.TrySetResult();
+				});
+
+				// wait for initial events to be caught-up and subscription transitions to live
+				await caughtUp.Task;
+				
+				for (int i = 0; i < 18; i++) {
+					await AppendToStreamBatch(new BatchAppendReq {
+						Options = new() {
+							Any = new(),
+							StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamA) }
+						},
+						IsFinal = true,
+						ProposedMessages = { ExpectEvents(CreateEvents(20)) },
+						CorrelationId = Uuid.NewUuid().ToDto()
+					});
+
+					await Task.Delay(10);
+				}
+
+				await AppendToStreamBatch(new BatchAppendReq {
+					Options = new() {
+						Any = new(),
+						StreamIdentifier = new() { StreamName = ByteString.CopyFromUtf8(StreamA) }
+					},
+					IsFinal = true,
+					ProposedMessages = {
+						ExpectEvents(CreateEvents(15)),
+						ExpectEvents(CreateEvent(FinishEventType))
+					},
+					CorrelationId = Uuid.NewUuid().ToDto()
+				});
+				
+				await cancelSubscription.Task;
+			}
+
+			private IEnumerable<BatchAppendReq.Types.ProposedMessage> ExpectEvents(
+				IEnumerable<BatchAppendReq.Types.ProposedMessage> events) => ExpectEvents(events.ToArray());
+
+			private IEnumerable<BatchAppendReq.Types.ProposedMessage> ExpectEvents(params BatchAppendReq.Types.ProposedMessage[] events) {
+				_expectedEventCount += events.Length;
+				return events;
+			}
+			
+			[Test]
+			public void receives_the_correct_number_of_confirmations() {
+				Assert.AreEqual(1, _contentCaseCounts[ReadResp.ContentOneofCase.Confirmation]);
+			}
+			
+			[Test]
+			public void receives_the_correct_number_of_events() {
+				Assert.AreEqual(_expectedEventCount, _contentCaseCounts[ReadResp.ContentOneofCase.Event]);
+			}
+			
+			[Test]
+			public void receives_the_correct_number_of_checkpoints() {
+				Assert.AreEqual(_expectedCheckpoints, _contentCaseCounts[ReadResp.ContentOneofCase.Checkpoint]);
+			}
+			
+			[Test]
+			public void receives_the_checkpoints_on_correct_interval() {
+				_checkpointPositions.ForEach(p => Assert.Zero( p % CheckpointInterval, $"checkpoint at: {p}"));
+			}
+			
+			[Test]
+			public void receives_the_subscription_was_caught_up() {
+				Assert.AreEqual(1, _contentCaseCounts[ReadResp.ContentOneofCase.CaughtUp]);
+			}
+			
+			[Test]
+			public void does_not_receive_the_subscription_fell_behind() {
+				Assert.Zero(_contentCaseCounts[ReadResp.ContentOneofCase.FellBehind]);
 			}
 		}
 	}

--- a/src/EventStore.Core/Messages/ClientMessage.cs
+++ b/src/EventStore.Core/Messages/ClientMessage.cs
@@ -1613,10 +1613,11 @@ namespace EventStore.Core.Messages {
 			public readonly bool ResolveLinkTos;
 			public readonly IEventFilter EventFilter;
 			public readonly int CheckpointInterval;
+			public readonly int CheckpointIntervalCurrent;
 
 			public FilteredSubscribeToStream(Guid internalCorrId, Guid correlationId, IEnvelope envelope,
 				Guid connectionId, string eventStreamId, bool resolveLinkTos, ClaimsPrincipal user,
-				IEventFilter eventFilter, int checkpointInterval, DateTime? expires = null)
+				IEventFilter eventFilter, int checkpointInterval, int checkpointIntervalCurrent, DateTime? expires = null)
 				: base(internalCorrId, correlationId, envelope, user, expires) {
 				Ensure.NotEmptyGuid(connectionId, "connectionId");
 				ConnectionId = connectionId;
@@ -1624,6 +1625,7 @@ namespace EventStore.Core.Messages {
 				ResolveLinkTos = resolveLinkTos;
 				EventFilter = eventFilter;
 				CheckpointInterval = checkpointInterval;
+				CheckpointIntervalCurrent = checkpointIntervalCurrent;
 			}
 		}
 

--- a/src/EventStore.Core/Services/SubscriptionsService.cs
+++ b/src/EventStore.Core/Services/SubscriptionsService.cs
@@ -131,7 +131,7 @@ namespace EventStore.Core.Services {
 			var lastCommitPos = _readIndex.LastIndexedPosition;
 			SubscribeToStream(msg.CorrelationId, msg.Envelope, msg.ConnectionId, msg.EventStreamId,
 				msg.ResolveLinkTos, lastCommitPos, lastEventNumber, msg.EventFilter,
-				msg.CheckpointInterval);
+				msg.CheckpointInterval, msg.CheckpointIntervalCurrent);
 			var subscribedMessage =
 				new ClientMessage.SubscriptionConfirmation(msg.CorrelationId, lastCommitPos, lastEventNumber);
 			msg.Envelope.ReplyWith(subscribedMessage);
@@ -144,7 +144,7 @@ namespace EventStore.Core.Services {
 
 		private void SubscribeToStream(Guid correlationId, IEnvelope envelope, Guid connectionId,
 			string eventStreamId, bool resolveLinkTos, long lastIndexedPosition, long? lastEventNumber,
-			IEventFilter eventFilter, int? checkpointInterval = null) {
+			IEventFilter eventFilter, int? checkpointInterval = null, int checkpointIntervalCurrent = 0) {
 			List<Subscription> subscribers;
 			if (!_subscriptionTopics.TryGetValue(eventStreamId, out subscribers)) {
 				subscribers = new List<Subscription>();
@@ -160,7 +160,8 @@ namespace EventStore.Core.Services {
 				lastIndexedPosition,
 				lastEventNumber ?? -1,
 				eventFilter,
-				checkpointInterval);
+				checkpointInterval,
+				checkpointIntervalCurrent);
 			subscribers.Add(subscription);
 			_subscriptionsById[correlationId] = subscription;
 		}
@@ -377,7 +378,8 @@ namespace EventStore.Core.Services {
 				long lastIndexedPosition,
 				long lastEventNumber,
 				IEventFilter eventFilter,
-				int? checkpointInterval) {
+				int? checkpointInterval,
+				int checkpointIntervalCurrent) {
 				CorrelationId = correlationId;
 				Envelope = envelope;
 				ConnectionId = connectionId;
@@ -389,6 +391,7 @@ namespace EventStore.Core.Services {
 
 				EventFilter = eventFilter;
 				CheckpointInterval = checkpointInterval;
+				CheckpointIntervalCurrent = checkpointInterval == null ? 0 : checkpointIntervalCurrent;
 			}
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -258,7 +258,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				_bus.Publish(new ClientMessage.FilteredSubscribeToStream(Guid.NewGuid(), _subscriptionId,
 					new ContinuationEnvelope(OnSubscriptionMessage, _semaphore, _cancellationToken), _subscriptionId,
-					string.Empty, _resolveLinks, _user, _eventFilter, (int)_checkpointInterval));
+					string.Empty, _resolveLinks, _user, _eventFilter, (int)_checkpointInterval, (int)_checkpointIntervalCounter));
 
 				Task.Factory.StartNew(PumpLiveMessages, _cancellationToken);
 

--- a/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
+++ b/src/EventStore.Core/Services/Transport/Tcp/ClientTcpDispatcher.cs
@@ -304,7 +304,7 @@ namespace EventStore.Core.Services.Transport.Tcp {
 
 			return new ClientMessage.FilteredSubscribeToStream(Guid.NewGuid(), package.CorrelationId, envelope,
 				connection.ConnectionId, dto.EventStreamId, dto.ResolveLinkTos, user, eventFilter,
-				dto.CheckpointInterval);
+				dto.CheckpointInterval, checkpointIntervalCurrent: 0);
 		}
 
 		private ClientMessage.UnsubscribeFromStream UnwrapUnsubscribeFromStream(TcpPackage package, IEnvelope envelope,


### PR DESCRIPTION
Fixed: Checkpoints of filtered $all subscription not always send on correct interval.