### PR TITLE
Raise the AssemblySelectLimit (DB-349)

### DIFF
--- a/ci/ci.runsettings
+++ b/ci/ci.runsettings
@@ -3,6 +3,7 @@
 	<NUnit>
 		<DefaultTestNamePattern>{C}.{m}</DefaultTestNamePattern>
 		<DefaultTimeout>20000</DefaultTimeout>
+		<AssemblySelectLimit>2147483647</AssemblySelectLimit>
 	</NUnit>
 	<RunConfiguration>
 		<TestCaseFilter>FullyQualifiedName!~EventStore.Core.Tests.LogFormat+V3</TestCaseFilter>


### PR DESCRIPTION
Changed: CI Unit test settings

the nunit vs adapter ignores the test filter if there are more test cases than this, which is causing tests to run even though they are filtered out and do not appear in the test passed/failed counts

https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#assemblyselectlimit