### PR TITLE
Call home from the database.

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/EnvelopePublisher.cs
+++ b/src/EventStore.Core.XUnit.Tests/EnvelopePublisher.cs
@@ -1,0 +1,16 @@
+﻿using EventStore.Core.Bus;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.XUnit.Tests;
+
+class EnvelopePublisher : IPublisher {
+	private readonly IEnvelope _envelope;
+
+	public EnvelopePublisher(IEnvelope envelope) {
+		_envelope = envelope;
+	}
+
+	public void Publish(Message message) {
+		_envelope.ReplyWith(message);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Telemetry/TelemetryServiceTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Text.Json.Nodes;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.Telemetry;
+using EventStore.Core.Tests.TransactionLog;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Telemetry;
+
+public sealed class TelemetryServiceTests : IAsyncLifetime {
+	private readonly TelemetryService _sut;
+	private readonly InMemoryTelemetrySink _sink;
+	private readonly ChannelReader<Message> _channelReader;
+	private readonly TFChunkDb _db;
+	private readonly DirectoryFixture<TelemetryServiceTests> _fixture = new();
+
+	public TelemetryServiceTests() {
+		var config = TFChunkHelper.CreateSizedDbConfig(_fixture.Directory, 0, chunkSize: 4096);
+		_db = new TFChunkDb(config);
+		_db.Open(false);
+		var channel = Channel.CreateUnbounded<Message>();
+		_channelReader = channel.Reader;
+		_sink = new InMemoryTelemetrySink();
+		_sut =  new TelemetryService(
+			_db.Manager,
+			new ClusterVNodeOptions(),
+			new EnvelopePublisher(new ChannelEnvelope(channel)),
+			_sink,
+			new InMemoryCheckpoint(0),
+			Guid.NewGuid());
+	}
+
+	public Task InitializeAsync() => _fixture.InitializeAsync();
+
+	public async Task DisposeAsync() {
+		_sut.Dispose();
+		_db.Close();
+		await _fixture.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task can_collect_and_flush_telemetry() {
+		// receive schedule of collect trigger it
+		var schedule = Assert.IsType<TimerMessage.Schedule>(await _channelReader.ReadAsync());
+		Assert.IsType<TelemetryMessage.Collect>(schedule.ReplyMessage);
+		schedule.Reply();
+
+		// receive the gossip request the telemetry service sends.
+		Assert.IsType<GossipMessage.ReadGossip>(await _channelReader.ReadAsync());
+
+		// receive usage request and send response
+		var request = Assert.IsType<TelemetryMessage.Request>(await _channelReader.ReadAsync());
+		request.Envelope.ReplyWith(new TelemetryMessage.Response(
+			"foo",
+			new JsonObject {
+				["bar"] = 42,
+			}));
+
+		// receive schedule of flush and trigger it
+		schedule = Assert.IsType<TimerMessage.Schedule>(await _channelReader.ReadAsync());
+		Assert.IsType<TelemetryMessage.Flush>(schedule.ReplyMessage);
+		schedule.Reply();
+
+		// receive schedule of collect indicating flush is complete
+		schedule = Assert.IsType<TimerMessage.Schedule>(await _channelReader.ReadAsync());
+		Assert.IsType<TelemetryMessage.Collect>(schedule.ReplyMessage);
+
+		// check sink has received the data
+		Assert.NotNull(_sink.Data);
+		Assert.NotNull(_sink.Data["foo"]);
+		Assert.Equal(new JsonObject { ["bar"] = 42 }.ToString(), _sink.Data["foo"].ToString());
+	}
+}

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -174,6 +174,9 @@ namespace EventStore.Core {
 			             $"Otherwise anonymous access wil be dis/allowed based on the value of the '{nameof(AllowAnonymousEndpointAccess)}' option")]
 			public bool OverrideAnonymousEndpointAccessForGossip { get; init; } = true;
 
+			[Description("Disable telemetry data collection."), EnvironmentOnly("You can only opt-out of telemetry using Environment Variables")]
+			public bool TelemetryOptout { get; init; } = false;
+
 			internal static ApplicationOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				Config = configurationRoot.GetValue<string>(nameof(Config)),
 				Help = configurationRoot.GetValue<bool>(nameof(Help)),
@@ -192,7 +195,8 @@ namespace EventStore.Core {
 				Insecure = configurationRoot.GetValue<bool>(nameof(Insecure)),
 				AllowAnonymousEndpointAccess = configurationRoot.GetValue<bool>(key:nameof(AllowAnonymousEndpointAccess)),
 				AllowAnonymousStreamAccess = configurationRoot.GetValue<bool>(key:nameof(AllowAnonymousStreamAccess)),
-				OverrideAnonymousEndpointAccessForGossip = configurationRoot.GetValue<bool>(key:nameof(OverrideAnonymousEndpointAccessForGossip))
+				OverrideAnonymousEndpointAccessForGossip = configurationRoot.GetValue<bool>(key:nameof(OverrideAnonymousEndpointAccessForGossip)),
+				TelemetryOptout = configurationRoot.GetValue<bool>(key:nameof(TelemetryOptout))
 			};
 		}
 

--- a/src/EventStore.Core/ClusterVNodeOptionsValidator.cs
+++ b/src/EventStore.Core/ClusterVNodeOptionsValidator.cs
@@ -102,7 +102,7 @@ public static class ClusterVNodeOptionsValidator {
 
 		var environmentOnlyOptions = options.CheckForEnvironmentOnlyOptions();
 		if (environmentOnlyOptions != null) {
-			Log.Error($"PLAIN TEXT PASSWORD {Environment.NewLine}{environmentOnlyOptions}");
+			Log.Error($"Invalid Option {environmentOnlyOptions}");
 			return false;
 		}
 

--- a/src/EventStore.Core/Messaging/CoreMessage.cs
+++ b/src/EventStore.Core/Messaging/CoreMessage.cs
@@ -21,6 +21,7 @@
 		Subscription,
 		System,
 		Tcp,
+		Telemetry,
 		Timer,
 		UserManagement
 	}

--- a/src/EventStore.Core/Messaging/IEnvelope.cs
+++ b/src/EventStore.Core/Messaging/IEnvelope.cs
@@ -1,5 +1,8 @@
 namespace EventStore.Core.Messaging {
-	public interface IEnvelope {
-		void ReplyWith<T>(T message) where T : Message;
+	public interface IEnvelope<in T> {
+		void ReplyWith<U>(U message) where U : T;
+	}
+
+	public interface IEnvelope : IEnvelope<Message> {
 	}
 }

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Nodes;
 using EventStore.Common.Utils;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
@@ -11,6 +12,7 @@ using EventStore.Core.Services.PersistentSubscription.ConsumerStrategy;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;
+using EventStore.Core.Telemetry;
 using ILogger = Serilog.ILogger;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;
 
@@ -42,6 +44,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 		IHandle<ClientMessage.UpdatePersistentSubscriptionToAll>,
 		IHandle<ClientMessage.DeletePersistentSubscriptionToAll>,
 		IHandle<ClientMessage.ReadNextNPersistentMessages>,
+		IHandle<TelemetryMessage.Request>,
 		IHandle<MonitoringMessage.GetAllPersistentSubscriptionStats>,
 		IHandle<MonitoringMessage.GetPersistentSubscriptionStats>,
 		IHandle<MonitoringMessage.GetStreamPersistentSubscriptionStats> {
@@ -1237,6 +1240,12 @@ namespace EventStore.Core.Services.PersistentSubscription {
 			}
 		}
 
+		public void Handle(TelemetryMessage.Request message) {
+			message.Envelope.ReplyWith(new TelemetryMessage.Response("persistentSubscriptions", new JsonObject {
+				["count"] = _subscriptionsById?.Count ?? 0
+			}));
+		}
+		
 		public void Handle(MonitoringMessage.GetPersistentSubscriptionStats message) {
 			if (!_started) {
 				message.Envelope.ReplyWith(new MonitoringMessage.GetPersistentSubscriptionStatsCompleted(

--- a/src/EventStore.Core/Telemetry/ContainerInfo.cs
+++ b/src/EventStore.Core/Telemetry/ContainerInfo.cs
@@ -1,0 +1,29 @@
+using System;
+using System.IO;
+using EventStore.Common.Utils;
+
+namespace EventStore.Core.Telemetry; 
+
+public class ContainerInfo {
+	public static ContainerInfo Instance { get; } = Collect();
+	public bool IsContainer { get; init; }
+	public bool IsKubernetes { get; private set; }
+
+	private static ContainerInfo Collect() {
+		var info = new ContainerInfo {
+			 IsContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") != null,
+		};
+
+		if (OS.OsFlavor != OsFlavor.Linux || !File.Exists("/proc/self/cgroup"))
+			return info;
+
+		try {
+			string cgroup = File.ReadAllText("/proc/self/cgroup");
+			info.IsKubernetes = cgroup.Contains("kubepods");
+		} catch (Exception) {
+			// ignored
+		}
+
+		return info;
+	}
+}

--- a/src/EventStore.Core/Telemetry/EnvironmentTelemetry.cs
+++ b/src/EventStore.Core/Telemetry/EnvironmentTelemetry.cs
@@ -1,0 +1,17 @@
+using System.Runtime.InteropServices;
+
+namespace EventStore.Core.Telemetry;
+
+public class EnvironmentTelemetry {
+	public string Arch { get; init; }
+	public ContainerInfo Container { get; init; }
+	public MachineInfo Machine { get; init; }
+
+	public static EnvironmentTelemetry Collect(ClusterVNodeOptions options) {
+		return new EnvironmentTelemetry {
+			Arch = RuntimeInformation.ProcessArchitecture.ToString(),
+			Container = ContainerInfo.Instance,
+			Machine = MachineInfo.Collect(options),
+		};
+	}
+}

--- a/src/EventStore.Core/Telemetry/ITelemetrySink.cs
+++ b/src/EventStore.Core/Telemetry/ITelemetrySink.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Telemetry; 
+
+public interface ITelemetrySink {
+	Task Flush(JsonObject data, CancellationToken token);
+}

--- a/src/EventStore.Core/Telemetry/InMemoryTelemetrySink.cs
+++ b/src/EventStore.Core/Telemetry/InMemoryTelemetrySink.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Telemetry; 
+
+public class InMemoryTelemetrySink : ITelemetrySink {
+	public JsonObject Data { get; private set; }
+	
+	public Task Flush(JsonObject data, CancellationToken token) {
+		Data = (JsonObject)JsonNode.Parse(data.ToJsonString());
+		return Task.CompletedTask;
+	}
+}

--- a/src/EventStore.Core/Telemetry/MachineInfo.cs
+++ b/src/EventStore.Core/Telemetry/MachineInfo.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Diagnostics;
+using EventStore.Common.Utils;
+using EventStore.Core.Services.Monitoring.Stats;
+using EventStore.Native.Monitoring;
+
+namespace EventStore.Core.Telemetry; 
+
+public class MachineInfo {
+	public int ProcessorCount { get; set; }
+	public long TotalMemory { get; set; }
+	public long TotalDiskSpace { get; set; }
+
+	public static MachineInfo Collect(ClusterVNodeOptions options) {
+		var diskInfo = EsDriveInfo.FromDirectory(options.Database.Db, Serilog.Log.Logger);
+		return new MachineInfo {
+			ProcessorCount = Environment.ProcessorCount,
+			TotalMemory = GetTotalMemory(),
+			TotalDiskSpace = diskInfo?.TotalBytes ?? 0,
+		};
+	}
+
+	private static long GetTotalMemory() {
+		if (OS.IsUnix) {
+			var stats = new HostStat.HostStat();
+			return (long) stats.GetTotalMemory();
+		}
+
+		if (OS.OsFlavor == OsFlavor.Windows) {
+			return (long)WinNativeMemoryStatus.GetTotalMemory();
+		}
+
+		return -1;
+	}
+}

--- a/src/EventStore.Core/Telemetry/TelemetryMessage.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryMessage.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Nodes;
+using EventStore.Common.Utils;
+using EventStore.Core.Messaging;
+
+namespace EventStore.Core.Telemetry;
+
+[DerivedMessage]
+public abstract partial class TelemetryMessage : Message {
+	[DerivedMessage(CoreMessage.Telemetry)]
+	public partial class Request : TelemetryMessage {
+		public readonly IEnvelope<Response> Envelope;
+
+		public Request(IEnvelope<Response> envelope) {
+			Ensure.NotNull(envelope, "envelope");
+
+			Envelope = envelope;
+		}
+	}
+
+	[DerivedMessage(CoreMessage.Telemetry)]
+	public partial class Response : TelemetryMessage {
+		public readonly string Key;
+		public readonly JsonNode Value;
+
+		public Response(string key, JsonNode value) {
+			Ensure.NotNullOrEmpty(key, "key");
+			Ensure.NotNull(value, "value");
+
+			Key = key;
+			Value = value;
+		}
+	}
+
+	[DerivedMessage(CoreMessage.Telemetry)]
+	public partial class Collect : TelemetryMessage { }
+
+	[DerivedMessage(CoreMessage.Telemetry)]
+	public partial class Flush : TelemetryMessage { }
+}

--- a/src/EventStore.Core/Telemetry/TelemetryService.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryService.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using EventStore.Common.Utils;
+using EventStore.Core.Bus;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services.TimerService;
+using EventStore.Core.TransactionLog.Checkpoint;
+using EventStore.Core.TransactionLog.Chunks;
+using EventStore.Core.TransactionLog.LogRecords;
+using Serilog;
+
+namespace EventStore.Core.Telemetry;
+
+public sealed class TelemetryService : IDisposable,
+	IHandle<SystemMessage.StateChangeMessage>,
+	IHandle<ElectionMessage.ElectionsDone> {
+
+	private static readonly ILogger _log = Log.ForContext<TelemetryService>();
+	private static readonly TimeSpan _initialInterval = TimeSpan.FromHours(1);
+	private static readonly TimeSpan _interval = TimeSpan.FromHours(24);
+	private static readonly TimeSpan _flushDelay = TimeSpan.FromSeconds(10);
+
+	private readonly ClusterVNodeOptions _nodeOptions;
+	private readonly CancellationTokenSource _cts = new();
+	private readonly IPublisher _publisher;
+	private readonly IReadOnlyCheckpoint _writerCheckpoint;
+	private readonly DateTime _startTime = DateTime.UtcNow;
+	private readonly Guid _nodeId;
+	private readonly TFChunkManager _manager;
+
+	private VNodeState _nodeState;
+	private int _epochNumber;
+	private Guid _leaderId = Guid.Empty;
+	private Guid _firstEpochId = Guid.Empty;
+
+	public TelemetryService(
+		TFChunkManager manager,
+		ClusterVNodeOptions nodeOptions,
+		IPublisher publisher,
+		ITelemetrySink sink,
+		IReadOnlyCheckpoint writerCheckpoint,
+		Guid nodeId) {
+
+		_manager = manager;
+		_nodeOptions = nodeOptions;
+		_publisher = publisher;
+		_writerCheckpoint = writerCheckpoint;
+		_nodeId = nodeId;
+		Task.Run(async () => {
+			try {
+				await ProcessAsync(publisher, sink).ConfigureAwait(false);
+			} catch (Exception ex) when (ex is not OperationCanceledException) {
+				_log.Error(ex, "Telemetry loop stopped");
+			}
+		});
+	}
+
+	public void Dispose() {
+		_cts.Cancel();
+		_cts.Dispose();
+	}
+
+	// we send messages on the publisher, and receive responses directly to the channel
+	// using the channel reduces chatter on the main queue.
+	private async Task ProcessAsync(IPublisher publisher, ITelemetrySink sink) {
+		var channel = Channel.CreateBounded<Message>(new BoundedChannelOptions(500) {
+			SingleReader = true,
+			FullMode = BoundedChannelFullMode.DropOldest,
+		});
+
+		var envelope = new ChannelEnvelope(channel);
+		var scheduleInitialCollect = TimerMessage.Schedule.Create(_initialInterval, envelope, new TelemetryMessage.Collect());
+		var scheduleCollect = TimerMessage.Schedule.Create(_interval - _flushDelay, envelope, new TelemetryMessage.Collect());
+		var scheduleFlush = TimerMessage.Schedule.Create(_flushDelay, envelope, new TelemetryMessage.Flush());
+		var usageRequest = new TelemetryMessage.Request(envelope);
+
+		publisher.Publish(scheduleInitialCollect);
+
+		var data = new JsonObject();
+		await foreach (var message in channel.Reader.ReadAllAsync(_cts.Token).ConfigureAwait(false)) {
+			switch (message) {
+				case TelemetryMessage.Collect:
+					Handle(usageRequest);
+					publisher.Publish(usageRequest);
+					publisher.Publish(scheduleFlush);
+					break;
+
+				case TelemetryMessage.Response response:
+					data[response.Key] = response.Value;
+					break;
+
+				case TelemetryMessage.Flush:
+					await sink.Flush(data, _cts.Token).ConfigureAwait(false);
+					data.Clear();
+					publisher.Publish(scheduleCollect);
+					break;
+			}
+		}
+	}
+
+	public void Handle(SystemMessage.StateChangeMessage message) {
+		_nodeState = message.State;
+	}
+
+	public void Handle(ElectionMessage.ElectionsDone message) {
+		_epochNumber = message.ProposalNumber;
+		_leaderId = message.Leader.InstanceId;
+	}
+
+	private void Handle(TelemetryMessage.Request message) {
+		if (_firstEpochId == Guid.Empty)
+			ReadFirstEpoch();
+
+		message.Envelope.ReplyWith(new TelemetryMessage.Response(
+			"version", JsonValue.Create(VersionInfo.Version)));
+
+		message.Envelope.ReplyWith(new TelemetryMessage.Response(
+			"tag", JsonValue.Create(VersionInfo.Tag)));
+
+		message.Envelope.ReplyWith(new TelemetryMessage.Response(
+			"uptime", JsonValue.Create(DateTime.UtcNow - _startTime)));
+
+		message.Envelope.ReplyWith(new TelemetryMessage.Response(
+			"cluster", new JsonObject {
+				["leaderId"] = JsonValue.Create(_leaderId),
+				["nodeId"] = JsonValue.Create(_nodeId),
+				["nodeState"] = _nodeState.ToString(),
+			}));
+
+		message.Envelope.ReplyWith(new TelemetryMessage.Response(
+			"configuration", new JsonObject {
+				["clusterSize"] = _nodeOptions.Cluster.ClusterSize,
+				["enableAtomPubOverHttp"] = _nodeOptions.Interface.EnableAtomPubOverHttp,
+				["enableExternalTcp"] = _nodeOptions.Interface.EnableExternalTcp,
+				["insecure"] = _nodeOptions.Application.Insecure,
+				["runProjections"] = _nodeOptions.Projections.RunProjections.ToString(),
+			}));
+
+		message.Envelope.ReplyWith(new TelemetryMessage.Response(
+			"database", new JsonObject {
+				["epochNumber"] = _epochNumber,
+				["firstEpochId"] = _firstEpochId,
+				["activeChunkNumber"] = _writerCheckpoint.Read() / _nodeOptions.Database.ChunkSize,
+			}));
+
+		var env = EnvironmentTelemetry.Collect(_nodeOptions);
+		message.Envelope.ReplyWith(new TelemetryMessage.Response(
+			"environment", new JsonObject {
+				["coreCount"] = env.Machine.ProcessorCount,
+				["isContainer"] = env.Container.IsContainer,
+				["isKubernetes"] = env.Container.IsKubernetes,
+				["processorArchitecture"] = env.Arch,
+				["totalDiskSpace"] = env.Machine.TotalDiskSpace,
+				["totalMemory"] = env.Machine.TotalMemory,
+			}));
+
+		_publisher.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(resp => OnGossipReceived(message.Envelope, resp))));
+	}
+
+	private static void OnGossipReceived(IEnvelope<TelemetryMessage.Response> envelope, Message message) {
+		if (message is not GossipMessage.SendGossip gossip)
+			return;
+
+		var seeds = new JsonObject();
+
+		foreach (var member in gossip.ClusterInfo.Members) {
+			seeds.Add(new (member.InstanceId.ToString(), member.State.ToString()));
+		}
+
+		envelope.ReplyWith(new TelemetryMessage.Response("gossip", seeds));
+	}
+
+	private void ReadFirstEpoch() {
+		try {
+			var chunk = _manager.GetChunkFor(0);
+			var result = chunk.TryReadAt(0, false);
+
+			if (!result.Success)
+				return;
+
+			var epoch = ((SystemLogRecord)result.LogRecord).GetEpochRecord();
+			_firstEpochId = epoch.EpochId;
+		} catch {
+			// noop
+		}
+	}
+}

--- a/src/EventStore.Core/Telemetry/TelemetrySink.cs
+++ b/src/EventStore.Core/Telemetry/TelemetrySink.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+
+namespace EventStore.Core.Telemetry; 
+
+public class TelemetrySink : ITelemetrySink {
+	private static readonly ILogger _log = Log.ForContext<TelemetrySink>();
+	private const string ApiHost = "https://eventstore.com/telemetry";
+	private readonly bool _optout;
+	private readonly HttpClient _httpClient;
+	private readonly JsonSerializerOptions _serializerOptions = new() {
+		WriteIndented = true,
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+	};
+
+	public TelemetrySink(bool optout) {
+		_optout = optout;
+
+		LogTelemetryMessage();
+
+		if (!optout) {
+			_httpClient = new HttpClient();
+		}
+	}
+
+	public async Task Flush(JsonObject data, CancellationToken token) {
+		var json = JsonSerializer.Serialize(data, _serializerOptions);
+
+		if (_optout) {
+			_log.Information("Telemetry not sent; opted out: " + Environment.NewLine + json);
+		} else {
+			_log.Information("Sending telemetry data to {url} (visit for more information): " + Environment.NewLine + json, ApiHost);
+			try {
+				await _httpClient.PostAsync(ApiHost, JsonContent.Create(data), token).ConfigureAwait(false);
+			} catch (Exception ex) when (ex is not TaskCanceledException) {
+				_log.Error("Error when sending telemetry payload: {exception}", ex);
+			}
+		}
+	}
+
+	private void LogTelemetryMessage() {
+		var sb = new StringBuilder();
+
+		sb.AppendLine("");
+		sb.AppendLine("Telemetry");
+		sb.AppendLine("---------");
+		sb.Append("EventStoreDB collects usage data in order to improve your experience. ");
+		sb.AppendLine("The data is anonymous and collected by EventStore Ltd.");
+
+		sb.Append(_optout ? "You have opted" : "You can opt");
+		sb.AppendLine(" out of sending telemetry by setting the EVENTSTORE_TELEMETRY_OPTOUT environment variable to true.");
+
+		sb.AppendLine("For more information visit https://eventstore.com/telemetry");
+		_log.Information(sb.ToString());
+	}
+}

--- a/src/EventStore.Projections.Core/ProjectionManagerNode.cs
+++ b/src/EventStore.Projections.Core/ProjectionManagerNode.cs
@@ -8,6 +8,7 @@ using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.AwakeReaderService;
 using EventStore.Core.Services.TimerService;
+using EventStore.Core.Telemetry;
 using EventStore.Projections.Core.Messages;
 using EventStore.Projections.Core.Messaging;
 using EventStore.Projections.Core.Services.Http;
@@ -101,6 +102,7 @@ namespace EventStore.Projections.Core {
 			mainBus.Subscribe<ClientMessage.DeleteStreamCompleted>(projectionManager);
 			mainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(projectionManager);
 			mainBus.Subscribe<ClientMessage.ReadStreamEventsForwardCompleted>(projectionManager);
+			mainBus.Subscribe<TelemetryMessage.Request>(projectionManager);
 
 			mainBus.Subscribe(ioDispatcher.Awaker);
 			mainBus.Subscribe<ClientMessage.ReadStreamEventsBackwardCompleted>(ioDispatcher.BackwardReader);
@@ -148,6 +150,8 @@ namespace EventStore.Projections.Core {
 			standardComponents.MainBus.Subscribe(
 				Forwarder.Create<ProjectionCoreServiceMessage.SubComponentStopped>(projectionsStandardComponents
 					.LeaderInputQueue));
+			standardComponents.MainBus.Subscribe(
+				Forwarder.Create<TelemetryMessage.Request>(projectionsStandardComponents.LeaderInputQueue));
 			projectionsStandardComponents.LeaderMainBus.Subscribe(new UnwrapEnvelopeHandler());
 		}
 	}


### PR DESCRIPTION
Added: Call home database telemetry.

- First payload is sent after the server is up for 1h.
- Payloads are sent once per 24h after that.
- Notice and optout message is logged on startup:
```
Telemetry
---------
EventStoreDB collects usage data in order to improve your experience. The data is anonymous and collected by EventStore Ltd.
You can opt out of sending telemetry by setting the EVENTSTORE_TELEMETRY_OPTOUT environment variable to true.
For more information visit https://eventstore.com/telemetry
```

- Payload contents:
```json
{
  "version": "23.6.1.0",
  "tag": "oss-v23.6.0-91-g2091bb932",
  "uptime": "00:00:30.2391235",
  "cluster": {
    "leaderId": "b4950b0e-abf1-4036-961e-878812cf9b0c",
    "nodeId": "b4950b0e-abf1-4036-961e-878812cf9b0c",
    "nodeState": "Leader"
  },
  "configuration": {
    "clusterSize": 3,
    "enableAtomPubOverHttp": true,
    "enableExternalTcp": true,
    "insecure": false,
    "runProjections": "All"
  },
  "database": {
    "epochNumber": 26,
    "firstEpochId": "783e96d6-a595-4127-8d7c-03a084b21ec6",
    "activeChunkNumber": 0
  },
  "environment": {
    "coreCount": 24,
    "isContainer": false,
    "isKubernetes": false,
    "processorArchitecture": "X64",
    "totalDiskSpace": 1000186310656,
    "totalMemory": 68631052288
  },
  "gossip": {
    "b8be0b16-ddc1-4eb5-a869-9fd189b5dcf5": "ReadOnlyReplica",
    "a9d7ef4d-c63a-494c-af8e-ddfd2862aa3a": "Follower",
    "8c3dd2b6-a5bb-4b44-a4fd-07d90f2c7e16": "Follower",
    "b4950b0e-abf1-4036-961e-878812cf9b0c": "Leader"
  },
  "projections": {
    "customProjectionCount": 1,
    "standardProjectionCount": 4,
    "customProjectionRunningCount": 1,
    "standardProjectionRunningCount": 0,
    "totalCount": 5,
    "totalRunningCount": 1,
  },
  "persistentSubscriptions": {
    "count": 0
  }
}
```