### PR TITLE
Add documentation for FIPS 140-2 compliance (DB-186)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -750,3 +750,20 @@ Use the following option to enable this feature:
 | YAML                 | `EnableTrustedAuth`              |
 | Environment variable | `EVENTSTORE_ENABLE_TRUSTED_AUTH` |
 
+## FIPS 140-2
+
+EventStoreDB runs on FIPS 140-2 enabled operating systems, this feature requires a commercial licence.
+
+The Federal Information Processing Standards (FIPS) of the United States are a set of publicly announced standards that the National Institute of Standards and Technology (NIST) has developed for use in computer systems of non-military United States government agencies and contractors.
+
+The 140 series of FIPS (FIPS 140) are U.S. government computer security standards that specify requirements for cryptography modules.
+
+To run EventStoreDB on FIPS 140-2 enabled operating systems, the following is required:
+
+1. The FIPS plugin must be installed. It is available on our commercial downloads page.
+2. The node's certificates & keys must be FIPS 140-2 compliant
+    - Our certificate generation tool, [es-gencert-cli](https://github.com/EventStore/es-gencert-cli/releases), generates FIPS 140-2 compliant certificates & keys as from version 1.2.0 (only the linux build).
+    - If you want to manually generate your certificates or keys with openssl, you must use openssl 3 or later.
+    - If you want to use PKCS #12 bundles (.p12/.pfx extension), you must use a FIPS 140-2 compliant encryption algorithm (e.g AES-256) & hash algorithm (e.g SHA-256) to encrypt the bundle's contents.
+
+Note that EventStoreDB will also likely run properly on FIPS 140-3 compliant systems with the above steps but this cannot reliably be confirmed at the moment as FIPS 140-3 certification is still ongoing for several operating systems.


### PR DESCRIPTION
Added: Documentation for FIPS 140-2 compliance

Note: This PR needs to wait for the next release of es-gencert-cli with this change in: https://github.com/EventStore/es-gencert-cli/pull/20. (It's been assumed that the next version will be 1.2.0)