### PR TITLE
Updating TCP deprecation notes and supported clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <a href="https://www.eventstore.com/"><img src="https://lh3.googleusercontent.com/G6tLxSbJvFodjR_FHrsXs5WOIls0VfuXkWgv60vbRB0WSuJoe-m1cADCsroUHQgJUQMcwp_HNKCLfiTWuCfVwlT607G8niENuGfq5DsnEmWUx_4Szx3GAWI6X1GKRA5iwv_loW0T75cWCAZsRZm3DL4" height=50% width=50% alt="EventStoreDB" /></a>
 
 EventStoreDB is an operational database built to store events, powered by the state-transition data model, for developers building true data-driven applications for next-generation use cases.
+
 - [What is EventStoreDB ](#what-is-eventstoredb)
 - [What is EventStore Cloud ](#what-is-event-store-cloud)
 - [Licensing](#licensing)
@@ -50,10 +51,11 @@ See the online documentation: [Getting started with Event Store Cloud](https://d
 
 ## Client libraries
 
-This getting started guide shows you how to get started with EventStoreDB by setting up an instance or cluster and configuring it.
+This guide shows you how to get started with EventStoreDB by setting up an instance or cluster and configuring it.
 EventStoreDB supports two protocols: gRPC and TCP(legacy).
 
-EventStoreDB supported clients
+EventStoreDB supported gRPC clients
+
 - Go: [EventStore/EventStore-Client-Go](https://github.com/EventStore/EventStore-Client-Go)
 - .NET: [EventStore/EventStore-Client-Dotnet](https://github.com/EventStore/EventStore-Client-Dotnet)
 - Java: [(EventStore/EventStoreDB-Client-Java](https://github.com/EventStore/EventStoreDB-Client-Java)
@@ -61,21 +63,21 @@ EventStoreDB supported clients
 - Rust: [EventStore/EventStoreDB-Client-Rust](https://github.com/EventStore/EventStoreDB-Client-Rust)
 - Read more in the [gRPC clients documentation](https://developers.eventstore.com/clients/grpc)
 
-Legacy TCP Clients
-- .Net: [EventStoreDB-Client-Dotnet-Legacy](https://github.com/EventStore/EventStoreDB-Client-Dotnet-Legacy)
-- JVM: [EventStore.JVM](https://github.com/EventStore/EventStore.JVM)
-- Haskell: [EventStoreDB-Client-Haskell](https://github.com/EventStore/EventStoreDB-Client-Haskell)
+Community supported gRPC clients
 
-Community developed clients
 - Elixir: [NFIBrokerage/spear](https://github.com/NFIBrokerage/spear)
 - Python: (coming soon)
 - Ruby: [yousty/event_store_client](https://github.com/yousty/event_store_client)
 
 Read more in the [documentation](https://developers.eventstore.com/server/v22.10/#protocols-clients-and-sdks).
 
+Legacy TCP Clients
+
+- .Net: [EventStoreDB-Client-Dotnet-Legacy](https://github.com/EventStore/EventStoreDB-Client-Dotnet-Legacy)
+
 ## Deployment
 
-- Event Store Cloud - [steps to get started in cloud](https://developers.eventstore.com/cloud/).
+- Event Store Cloud - [steps to get started in Cloud](https://developers.eventstore.com/cloud/).
 - Self-managed - [steps to host EventStoreDB yourself](https://developers.eventstore.com/server/v22.10/#getting-started).
 
 ## Communities
@@ -100,6 +102,7 @@ If you want to switch to a particular release, you can check out the release bra
 EventStoreDB is written in a mixture of C# and JavaScript. It can run on Windows, Linux and macOS (using Docker) using the .NET Core runtime.
 
 **Prerequisites**
+
 - [.NET Core SDK 6.0](https://dotnet.microsoft.com/download/dotnet/6.0)
 
 Once you've installed the prerequisites for your system, you can launch a `Release` build of EventStore as follows:
@@ -150,16 +153,22 @@ $env:DOCKER_BUILDKIT=0; docker build --tag myeventstore . `
 --build-arg RUNTIME=linux-x64
 ```
 
-Currently we support following configurations:
+Currently, we support the following configurations:
+
 1. Bullseye slim:
-  - `CONTAINER_RUNTIME=bullseye-slim`
-  - `RUNTIME=linux-x64`
+
+- `CONTAINER_RUNTIME=bullseye-slim`
+- `RUNTIME=linux-x64`
+
 2. Focal:
-  - `CONTAINER_RUNTIME=focal`
-  - `RUNTIME=linux-x64`
+
+- `CONTAINER_RUNTIME=focal`
+- `RUNTIME=linux-x64`
+
 3. Alpine:
-  - `CONTAINER_RUNTIME=alpine`
-  - `RUNTIME=alpine-x64`
+
+- `CONTAINER_RUNTIME=alpine`
+- `RUNTIME=alpine-x64`
 
 You can verify the built image by running:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -72,6 +72,8 @@ Find out more about configuring the TCP protocol on the [TCP configuration](netw
 
 #### Community supported clients
 
+Community supported clients are developed and maintained by community members, not Event Store staff. Feel free to open issues and PRs, when possible, in the client's GitHub repository. **The following clients which use TCP protocol, will not be compatible with Event Store server versions after 23.10.**
+
 - [Node.js (x-cubed/event-store-client)](https://github.com/x-cubed/event-store-client)
 - [Node.js (nicdex/node-eventstore-client)](https://github.com/nicdex/node-eventstore-client)
 - [Elixir (exponentially/extreme)](https://github.com/exponentially/extreme)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,14 +4,14 @@ Welcome to the EventStoreDB 22.10 documentation.
 
 EventStoreDB is a database designed for [Event Sourcing](https://eventstore.com/blog/what-is-event-sourcing/). This documentation introduces key concepts of EventStoreDB and explains its installation, configuration and operational concerns.
 
-EventStoreDB is available as both a Open-Source and an Enterprise versions:
+EventStoreDB is available in both an Open-Source and an Enterprise version:
 
-- EventStoreDB OSS is the [open-source](https://github.com/EventStore/EventStore) and free to use edition of EventStoreDB.
-- EventStoreDB Enterprise is available for customers with EventStoreDB [paid support subscription](https://eventstore.com/support/). EventStoreDB Enterprise adds enterprise-focused features such as LDAP integration, correlation event sequence visualisation and management CLI.
+- EventStoreDB OSS is the [open-source](https://github.com/EventStore/EventStore) and free-to-use edition of EventStoreDB.
+- EventStoreDB Enterprise is available for customers with an EventStoreDB [paid support subscription](https://eventstore.com/support/). EventStoreDB Enterprise adds enterprise-focused features such as LDAP integration, correlation event sequence visualisation, and management CLI.
 
 ## Getting started
 
-Get started by learning more about principles of EventStoreDB, Event Sourcing, database installation guidelines and choosing the [client SDK](#protocols-clients-and-sdks).
+Get started by learning more about the principles of EventStoreDB, Event Sourcing, database installation guidelines and choosing a [client SDK](#protocols-clients-and-sdks).
 
 ## Support
 
@@ -25,11 +25,11 @@ Customers with the paid [support plan](https://eventstore.com/support/) can open
 
 ### Issues
 
-Since EventStoreDB is the open-source product, we track most of the issues openly in the EventStoreDB [repository on GitHub](https://github.com/EventStore/EventStore). Before opening an issue, please ensure that a similar issue hasn't been opened already. Also, try searching closed issues that might contain a solution or workaround for your problem.
+Since EventStoreDB is an open-source product, we track most of the issues openly in the EventStoreDB [repository on GitHub](https://github.com/EventStore/EventStore). Before opening an issue, please ensure that a similar issue hasn't been opened already. Also, try searching closed issues that might contain a solution or workaround for your problem.
 
-When opening an issue, follow our guidelines for bug reports and feature requests. By doing so, you would greatly help us to solve your concerns in the most efficient way.
+When opening an issue, follow our [guidelines](../CONTRIBUTING.md) for bug reports and feature requests. By doing so, you would greatly help us to solve your concerns most efficiently.
 
-## Protocols, clients and SDKs
+## Protocols, clients, and SDKs
 
 This getting started guide shows you how to get started with EventStoreDB by setting up an instance or cluster and configuring it.
 
@@ -60,8 +60,8 @@ Read more in the [gRPC clients documentation](@clients/grpc/README.md).
 
 EventStoreDB offers a low-level protocol in the form of an asynchronous TCP protocol that exchanges protobuf objects. At present this protocol has adapters for .NET and the JVM.
 
-::: warning
-We plan to phase out the TCP protocol in later versions. Please consider migrating your applications that use the TCP protocol and refactor them to use gRPC instead.
+::: warning Deprecation Note
+TCP protocol will be available only through version 23.10. Please plan to refactor your applications that use the TCP protocol to use gRPC instead.
 :::
 
 Find out more about configuring the TCP protocol on the [TCP configuration](networking.md#tcp-configuration) page.
@@ -69,10 +69,8 @@ Find out more about configuring the TCP protocol on the [TCP configuration](netw
 #### EventStoreDB supported clients
 
 - [.NET Framework and .NET Core](http://www.nuget.org/packages/EventStore.Client)
-- [JVM Client (EventStore/EventStore.JVM)](https://github.com/EventStore/EventStore.JVM)
-- [Haskell (EventStore/EventStoreDB-Client-Haskell)](https://github.com/EventStore/EventStoreDB-Client-Haskell)
 
-#### Community developed clients
+#### Community supported clients
 
 - [Node.js (x-cubed/event-store-client)](https://github.com/x-cubed/event-store-client)
 - [Node.js (nicdex/node-eventstore-client)](https://gitork.org/nicdex/node-eventstore-client)
@@ -81,6 +79,8 @@ Find out more about configuring the TCP protocol on the [TCP configuration](netw
 - [Maven plugin (fuinorg/event-store-maven-plugin)](https://github.com/fuinorg/event-store-maven-plugin)
 - [Go (jdextraze/go-gesclient)](https://github.com/jdextraze/go-gesclient)
 - [PHP (prooph/event-store-client)](https://github.com/prooph/event-store-client/)
+- [JVM Client (EventStore/EventStore.JVM)](https://github.com/EventStore/EventStore.JVM)
+- [Haskell (EventStore/EventStoreDB-Client-Haskell)](https://github.com/EventStore/EventStoreDB-Client-Haskell)
 
 ### HTTP
 
@@ -88,15 +88,11 @@ EventStoreDB also offers an HTTP-based interface, based specifically on the [Ato
 
 Find out more about configuring the HTTP protocol on the [HTTP configuration](networking.md#http-configuration) page.
 
-::: warning "Deprecation note"
-The current AtomPub-based HTTP application API is disabled by default since v20 of EventStoreDB. You can enable it by adding an [option](networking.md#atompub) to the server configuration.
+::: warning Deprecation Note
+The current AtomPub-based HTTP application API is disabled by default since v20 of EventStoreDB. You can enable it by adding an [option](networking.md#atompub) to the server configuration. Although we plan to remove AtomPub support from future server versions, the server management HTTP API will still be available.
 :::
 
 As the AtomPub protocol doesn't get any changes, you can use the v5 [HTTP API documentation](@clients/httpapi/README.md) for it.
-
-::: note
-Although we plan to remove AtomPub support from the future server versions, the server management HTTP API will still be available.
-:::
 
 #### Community developed clients
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,7 +61,7 @@ Read more in the [gRPC clients documentation](@clients/grpc/README.md).
 EventStoreDB offers a low-level protocol in the form of an asynchronous TCP protocol that exchanges protobuf objects. At present this protocol has adapters for .NET and the JVM.
 
 ::: warning Deprecation Note
-TCP protocol will be available only through version 23.10. Please plan to refactor your applications that use the TCP protocol to use gRPC instead.
+TCP protocol will be available only through version 23.10. Please plan to migrate your applications that use the TCP client SDK to use the gRPC SDK instead.
 :::
 
 Find out more about configuring the TCP protocol on the [TCP configuration](networking.md#tcp-configuration) page.
@@ -73,10 +73,10 @@ Find out more about configuring the TCP protocol on the [TCP configuration](netw
 #### Community supported clients
 
 - [Node.js (x-cubed/event-store-client)](https://github.com/x-cubed/event-store-client)
-- [Node.js (nicdex/node-eventstore-client)](https://gitork.org/nicdex/node-eventstore-client)
+- [Node.js (nicdex/node-eventstore-client)](https://github.com/nicdex/node-eventstore-client)
 - [Elixir (exponentially/extreme)](https://github.com/exponentially/extreme)
 - [Java 8 (msemys/esjc)](https://github.com/msemys/esjc)
-- [Maven plugin (fuinorg/event-store-maven-plugin)](https://github.com/fuinorg/event-store-maven-plugin)
+- [Maven plugin (fuinorg/event-store-maven-plugin)](https://github.com/fuinorg/event-store-maven-plugin) (archived)
 - [Go (jdextraze/go-gesclient)](https://github.com/jdextraze/go-gesclient)
 - [PHP (prooph/event-store-client)](https://github.com/prooph/event-store-client/)
 - [JVM Client (EventStore/EventStore.JVM)](https://github.com/EventStore/EventStore.JVM)
@@ -89,7 +89,7 @@ EventStoreDB also offers an HTTP-based interface, based specifically on the [Ato
 Find out more about configuring the HTTP protocol on the [HTTP configuration](networking.md#http-configuration) page.
 
 ::: warning Deprecation Note
-The current AtomPub-based HTTP application API is disabled by default since v20 of EventStoreDB. You can enable it by adding an [option](networking.md#atompub) to the server configuration. Although we plan to remove AtomPub support from future server versions, the server management HTTP API will still be available.
+The current AtomPub-based HTTP application API is disabled by default since v20 of EventStoreDB. You can enable it by adding an [option](networking.md#atompub) to the server configuration. Although we plan to remove AtomPub support from future server versions, the server management HTTP API will remain available.
 :::
 
 As the AtomPub protocol doesn't get any changes, you can use the v5 [HTTP API documentation](@clients/httpapi/README.md) for it.


### PR DESCRIPTION
This PR addresses [Linear issue DEV-111](https://linear.app/eventstore/issue/DEV-111/can-we-remove-eventstorejvm-from-supported-clients-in-our-docs).

Clarifying which TCP clients are supported and announcing the complete deprecation of TCP, which will potentially illicit response from customers, which will build a case for continuing TCP support as a plugin.