### PR TITLE
Add support for clusters with nodes that have certificates with different CNs

### DIFF
--- a/src/EventStore.Common/Utils/CertificateExtensions.cs
+++ b/src/EventStore.Common/Utils/CertificateExtensions.cs
@@ -111,7 +111,7 @@ namespace EventStore.Common.Utils {
 			label == "*" || IsValidDnsNameLabel(label);
 
 		private static bool MatchesName(string certName, string certNameType, string name) {
-			const char Wildcard = '*';
+			const string Wildcard = "*";
 			const char Delimiter = '.';
 
 			if (string.IsNullOrEmpty(certName) ||
@@ -152,7 +152,11 @@ namespace EventStore.Common.Utils {
 			if (certNameLabels.First() != Wildcard.ToString())
 				return certNameLabels.EqualsOrdinalIgnoreCase(dnsNameLabels);
 
-			// first label is wildcard, compare the other labels
+			// first label is wildcard, a wildcard FQDN should have at least 3 labels
+			if (certNameLabels.Length <= 2)
+				return false;
+
+			// compare the other labels of the wildcard FQDN
 			return certNameLabels.Skip(1).EqualsOrdinalIgnoreCase(dnsNameLabels.Skip(1));
 		}
 	}

--- a/src/EventStore.Core.Tests/Certificates/name_matching.cs
+++ b/src/EventStore.Core.Tests/Certificates/name_matching.cs
@@ -114,6 +114,21 @@ namespace EventStore.Core.Tests.Certificates {
 		}
 
 		[Test]
+		public void dns_name_does_not_match_wildcard_cn_with_less_than_three_domain_labels() {
+			var sut = GenSut("CN=*", Array.Empty<(string name, string type)>());
+			Assert.False(sut.MatchesName("tld"));
+
+			sut = GenSut("CN=*.com", Array.Empty<(string name, string type)>());
+			Assert.False(sut.MatchesName("example.com"));
+		}
+
+		[Test]
+		public void dns_name_matches_wildcard_cn_with_four_domain_labels() {
+			var sut = GenSut("CN=*.test.example.com", Array.Empty<(string name, string type)>());
+			Assert.True(sut.MatchesName("abc.test.example.com"));
+		}
+
+		[Test]
 		public void dns_name_matches_wildcard_dns_san() {
 			var sut = GenSut("CN=test", new [] {
 				("*.example.com", CertificateNameType.DnsName)

--- a/src/EventStore.Core.Tests/Certificates/name_matching.cs
+++ b/src/EventStore.Core.Tests/Certificates/name_matching.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Certificates {
 	public class name_matching {
-		private X509Certificate GenSut(string subjectName, (string name, string type)[] sans)  {
+		private X509Certificate2 GenSut(string subjectName, (string name, string type)[] sans)  {
 			using (RSA rsa = RSA.Create())
 			{
 				var certReq = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);

--- a/src/EventStore.Core.Tests/Certificates/subject_alternative_names.cs
+++ b/src/EventStore.Core.Tests/Certificates/subject_alternative_names.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 
 namespace EventStore.Core.Tests.Certificates {
 	public class subject_alternative_names {
-		private X509Certificate GenSut((string name, string type)[] sans)  {
+		private X509Certificate2 GenSut((string name, string type)[] sans)  {
 			using (RSA rsa = RSA.Create())
 			{
 				var certReq = new CertificateRequest("CN=hello", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);

--- a/src/EventStore.Core.XUnit.Tests/Certificates/client_name_matching.cs
+++ b/src/EventStore.Core.XUnit.Tests/Certificates/client_name_matching.cs
@@ -7,7 +7,7 @@ using Xunit;
 namespace EventStore.Core.XUnit.Tests.Certificates;
 
 public class client_name_matching {
-	private static X509Certificate GenSut(string subjectName) {
+	private static X509Certificate2 GenSut(string subjectName) {
 		using (RSA rsa = RSA.Create()) {
 			var certReq = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
 			return certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddMonths(-1), DateTimeOffset.UtcNow.AddMonths(1));

--- a/src/EventStore.Core.XUnit.Tests/Certificates/client_name_matching.cs
+++ b/src/EventStore.Core.XUnit.Tests/Certificates/client_name_matching.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using EventStore.Common.Utils;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Certificates;
+
+public class client_name_matching {
+	private static X509Certificate GenSut(string subjectName) {
+		using (RSA rsa = RSA.Create()) {
+			var certReq = new CertificateRequest(subjectName, rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+			return certReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddMonths(-1), DateTimeOffset.UtcNow.AddMonths(1));
+		}
+	}
+
+	[Theory]
+	[InlineData("CN=10.123.45.6", "10.123.45.6", "client_cn_matches_ip_address")]
+	[InlineData("CN=abc.test.com", "abc.test.com", "client_cn_matches_dns_name")]
+	[InlineData("CN=abc.test.com", "abC.tEst.cOm", "client_cn_matches_dns_name_case_insensitive")]
+	[InlineData("CN=eventstoredb-node", "eventstoredb-node", "client_cn_matches_non_fqdn_dns_name")]
+	[InlineData("CN=eventstoredb-node", "EventstoreDB-Node", "client_cn_matches_non_fqdn_dns_name_case_insensitive")]
+	[InlineData("CN=abc.test.com", "*.test.com", "client_cn_matches_wildcard_dns_name")]
+	[InlineData("CN=abc.test.com", "*.tEst.cOm", "client_cn_matches_wildcard_dns_name_case_insensitive")]
+	[InlineData("CN=*.test.com", "*.test.com", "client_wildcard_cn_matches_wildcard_dns_name")]
+	[InlineData("CN=*.test.com", "*.teSt.cOm", "client_wildcard_cn_matches_wildcard_dns_name_case_insensitive")]
+	public void does_match(string clientCN, string pattern, string testCase) {
+		var sut = GenSut(clientCN);
+		Assert.True(sut.ClientCertificateMatchesName(pattern), testCase);
+	}
+
+
+	[Theory]
+	[InlineData("CN=abc.test.com", "*.com", "client_cn_does_not_match_wildcard_on_main_domain_name")]
+	[InlineData("CN=abc.test.com", "cde.test.com", "client_cn_does_not_match_different_host_name")]
+	[InlineData("CN=abc.test.com", "abc.test1.com", "client_cn_does_not_match_different_domain_name")]
+	[InlineData("CN=abc.def.test.com", "abc.ghi.test.com", "client_cn_does_not_match_different_subdomain_name")]
+	[InlineData("CN=*.test.com", "*.test1.com", "client_wildcard_cn_does_not_match_different_wildcard_dns_name")]
+	[InlineData("CN=*.test.com", "abc.test.com", "client_wildcard_cn_does_not_match_non_wildcard_dns_name")]
+	[InlineData("CN=*.test.com", "abc.d.test.com", "client_wildcard_cn_does_not_match_non_wildcard_subdomain_name")]
+	[InlineData("CN=*.*.test.com", "*.*.test.com", "client_invalid_wildcard_cn_does_not_match_invalid_wildcard_dns_name")]
+	[InlineData("CN=*", "*", "client_single_star_cn_does_not_match_single_star_dns_name")]
+	public void does_not_match(string clientCN, string pattern, string testCase) {
+		var sut = GenSut(clientCN);
+		Assert.False(sut.ClientCertificateMatchesName(pattern), testCase);
+	}
+}

--- a/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/OptionsCertificateProvider.cs
@@ -12,11 +12,10 @@ namespace EventStore.Core.Certificates {
 			}
 
 			var (certificate, intermediates) = options.LoadNodeCertificate();
-
-			var certificateCN = certificate.GetCommonName();
 			var reservedNodeCN = options.Certificate.CertificateReservedNodeCommonName;
 
-			if (certificateCN != reservedNodeCN) {
+			if (!certificate.ClientCertificateMatchesName(reservedNodeCN)) {
+				var certificateCN = certificate.GetCommonName();
 				Log.Error(
 					"Certificate CN: {certificateCN} does not match with the CertificateReservedNodeCommonName configuration setting: {reservedNodeCN}",
 					certificateCN, reservedNodeCN);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1741,15 +1741,17 @@ namespace EventStore.Core {
 		public static ValueTuple<bool, string> ValidateServerCertificate(X509Certificate certificate,
 			X509Chain chain, SslPolicyErrors sslPolicyErrors, Func<X509Certificate2Collection> intermediateCertsSelector,
 			Func<X509Certificate2Collection> trustedRootCertsSelector, string[] otherNames) {
-			return ValidateCertificate(certificate, chain, sslPolicyErrors, intermediateCertsSelector, trustedRootCertsSelector, "server", otherNames);
+			using var _ = certificate.ConvertToCertificate2(out var certificate2);
+			return ValidateCertificate(certificate2, chain, sslPolicyErrors, intermediateCertsSelector, trustedRootCertsSelector, "server", otherNames);
 		}
 
 		public static ValueTuple<bool, string> ValidateClientCertificate(X509Certificate certificate,
 			X509Chain chain, SslPolicyErrors sslPolicyErrors, Func<X509Certificate2Collection> intermediateCertsSelector, Func<X509Certificate2Collection> trustedRootCertsSelector) {
-			return ValidateCertificate(certificate, chain, sslPolicyErrors, intermediateCertsSelector, trustedRootCertsSelector, "client", null);
+			using var _ = certificate.ConvertToCertificate2(out var certificate2);
+			return ValidateCertificate(certificate2, chain, sslPolicyErrors, intermediateCertsSelector, trustedRootCertsSelector, "client", null);
 		}
 
-		private static ValueTuple<bool, string> ValidateCertificate(X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors,
+		private static ValueTuple<bool, string> ValidateCertificate(X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors,
 			Func<X509Certificate2Collection> intermediateCertsSelector, Func<X509Certificate2Collection> trustedRootCertsSelector,
 			string certificateOrigin, string[] otherNames) {
 			if (certificate == null)

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -295,7 +295,7 @@ namespace EventStore.Core {
 			public string? TrustedRootCertificatesPath { get; init; } =
 				Locations.DefaultTrustedRootCertificateDirectory;
 
-			[Description("The reserved common name to authenticate EventStoreDB nodes/servers from certificates")]
+			[Description("The pattern the CN (Common Name) of a connecting EventStoreDB node must match to be authenticated. A wildcard FQDN can be specified if using wildcard certificates or if the CN is not the same on all nodes.")]
 			public string CertificateReservedNodeCommonName { get; init; } = "eventstoredb-node";
 
 			internal static CertificateOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
@@ -21,10 +21,8 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 			if (clientCertificate is null) return false;
 
 			bool hasReservedNodeCN;
-			string clientCertificateCN;
 			try {
-				clientCertificateCN = clientCertificate.GetCommonName();
-				hasReservedNodeCN = clientCertificateCN == _certificateReservedNodeCommonName;
+				hasReservedNodeCN = clientCertificate.ClientCertificateMatchesName(_certificateReservedNodeCommonName);
 			} catch (CryptographicException) {
 				return false;
 			} catch (NullReferenceException) {
@@ -32,6 +30,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 			}
 
 			if (!hasReservedNodeCN) {
+				var clientCertificateCN = clientCertificate.GetCommonName();
 				var ip = context.Connection.RemoteIpAddress?.ToString() ?? "<unknown>";
 				Log.Error(
 					"Connection from node: {ip} was denied because its CN: {clientCertificateCN} does not match with the reserved node CN: {reservedNodeCN}",


### PR DESCRIPTION
Added: Support clusters with nodes that have certificates with different CNs
Fixed: Certificate was disposed during the call if it was not an X509Certificate2 object
Fixed: Wildcard certificate names should have at least 3 domain labels