### PR TITLE
[DB-287] Improve the error message when subscribing from an invalid position

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
@@ -10,6 +10,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using Serilog;
 
 namespace EventStore.Core.Services.Transport.Grpc {
@@ -131,10 +132,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							_readIndex.ReadAllEventsForward(new TFPos(commitPosition, preparePosition), 1);
 						CatchUp(Position.FromInt64(indexResult.NextPos.CommitPosition,
 							indexResult.NextPos.PreparePosition));
-					} catch (Exception ex) {
+					} catch (InvalidReadException ex) {
+						Fail(RpcExceptions.InvalidPositionException());
 						Log.Error(ex, "Error starting catch-up subscription {subscriptionId} to $all@{position}",
 							_subscriptionId, startPosition);
-						throw;
 					}
 				}
 			}

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -10,6 +10,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services.Storage.ReaderIndex;
+using EventStore.Core.TransactionLog.Chunks.TFChunk;
 using Serilog;
 using IReadIndex = EventStore.Core.Services.Storage.ReaderIndex.IReadIndex;
 
@@ -154,10 +155,10 @@ namespace EventStore.Core.Services.Transport.Grpc {
 							_readIndex.ReadAllEventsForward(new TFPos(commitPosition, preparePosition), 1);
 						CatchUp(Position.FromInt64(indexResult.NextPos.CommitPosition,
 							indexResult.NextPos.PreparePosition));
-					} catch (Exception ex) {
+					} catch (InvalidReadException ex) {
+						Fail(RpcExceptions.InvalidPositionException());
 						Log.Error(ex, "Error starting catch-up subscription {subscriptionId} to $all:{eventFilter}@{position}",
 							_subscriptionId, _eventFilter, startPosition);
-						throw;
 					}
 				}
 			}

--- a/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Runtime.CompilerServices;
 using EventStore.Common.Utils;
+using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using Grpc.Core;
@@ -232,5 +233,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 		public static RpcException InvalidCombination<T>(T combination) where T : ITuple
 			=> new(new Status(StatusCode.InvalidArgument, $"The combination of {combination} is invalid."));
+		
+		public static RpcException InvalidPositionException() =>
+			new(new Status(StatusCode.InvalidArgument, $"Trying to read from an invalid position."));
 	}
 }


### PR DESCRIPTION
Fixed : https://github.com/EventStore/EventStore/issues/3195

Fixes : Improves the error message on the client side when a catch subscription is created from an invalid position. When the above mentioned exception was thrown, the error message on the client side was unclear stating "An exception was thrown by the handler", without specifying the actual error message, thus making it difficult to diagnose what the actual issue was. This PR improves the error message when the above issue is encountered.