### PR TITLE
Configure `CertificateReservedNodeCommonName` to be the node's CN by default

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/client_certificate_authentication_provider.cs
@@ -6,7 +6,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using EventStore.Core.Services.Transport.Http.Authentication;
 using EventStore.Core.Services.UserManagement;
-using EventStore.Core.Util;
 using Microsoft.AspNetCore.Http;
 using NUnit.Framework;
 
@@ -15,7 +14,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 		protected ClientCertificateAuthenticationProvider _provider;
 
 		protected void SetUpProvider() {
-			_provider = new ClientCertificateAuthenticationProvider(Opts.CertificateReservedNodeCommonNameDefault);
+			_provider = new ClientCertificateAuthenticationProvider(() => "eventstoredb-node");
 		}
 	}
 

--- a/src/EventStore.Core/Certificates/CertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/CertificateProvider.cs
@@ -6,6 +6,7 @@ namespace EventStore.Core.Certificates {
 		public X509Certificate2Collection IntermediateCerts;
 		public X509Certificate2Collection TrustedRootCerts;
 		public abstract LoadCertificateResult LoadCertificates(ClusterVNodeOptions options);
+		public abstract string GetReservedNodeCommonName();
 	}
 
 	public enum LoadCertificateResult {

--- a/src/EventStore.Core/Certificates/DevCertificateProvider.cs
+++ b/src/EventStore.Core/Certificates/DevCertificateProvider.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Security.Cryptography.X509Certificates;
+using EventStore.Common.Utils;
 
 namespace EventStore.Core.Certificates {
 	public class DevCertificateProvider : CertificateProvider {
@@ -9,6 +9,10 @@ namespace EventStore.Core.Certificates {
 		}
 		public override LoadCertificateResult LoadCertificates(ClusterVNodeOptions options) {
 			return LoadCertificateResult.Skipped;
+		}
+
+		public override string GetReservedNodeCommonName() {
+			return Certificate.GetCommonName();
 		}
 	}
 }

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1000,7 +1000,7 @@ namespace EventStore.Core {
 			if (!options.Application.Insecure) {
 				//transport-level authentication providers
 				httpAuthenticationProviders.Add(
-					new ClientCertificateAuthenticationProvider(options.Certificate.CertificateReservedNodeCommonName));
+					new ClientCertificateAuthenticationProvider(() => _certificateProvider.GetReservedNodeCommonName()));
 
 				if (options.Interface.EnableTrustedAuth)
 					httpAuthenticationProviders.Add(new TrustedHttpAuthenticationProvider());

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -295,7 +295,7 @@ namespace EventStore.Core {
 			public string? TrustedRootCertificatesPath { get; init; } =
 				Locations.DefaultTrustedRootCertificateDirectory;
 
-			[Description("The pattern the CN (Common Name) of a connecting EventStoreDB node must match to be authenticated. A wildcard FQDN can be specified if using wildcard certificates or if the CN is not the same on all nodes.")]
+			[Description("The pattern the CN (Common Name) of a connecting EventStoreDB node must match to be authenticated. A wildcard FQDN can be specified if using wildcard certificates or if the CN is not the same on all nodes. Leave empty to automatically use the CN of this node's certificate.")]
 			public string CertificateReservedNodeCommonName { get; init; } = "eventstoredb-node";
 
 			internal static CertificateOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/ClientCertificateAuthenticationProvider.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using EventStore.Common.Utils;
 using EventStore.Core.Services.UserManagement;
+using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http;
 using Serilog;
 
@@ -16,10 +18,62 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 		}
 
 		public bool Authenticate(HttpContext context, out HttpAuthenticationRequest request) {
-			request = null;
-			var clientCertificate = context.Connection.ClientCertificate;
-			if (clientCertificate is null) return false;
+			return AuthenticateCached(context, out request);
+		}
 
+		private bool AuthenticateCached(HttpContext context, out HttpAuthenticationRequest request) {
+			// we cache the authentication result as the same TLS connection may be used for multiple HTTP requests.
+			// performance aside, the cache also ensures that authentication requests that were successful in the past
+			// will succeed in the future for the same TLS connection even if certificates are rotated.
+
+			request = null;
+
+			// if the connection doesn't have a client certificate, take a shortcut
+			var clientCertificate = context.Connection.ClientCertificate;
+			if (clientCertificate is null)
+				return false;
+
+			bool authenticated;
+
+			var connectionItems = context.Features.Get<IConnectionItemsFeature>()?.Items;
+			const string connectionItemsKey = "ClientCertificateAuthenticationStatus";
+			if (TryGetDictionaryValue(connectionItems, connectionItemsKey, out var wasAuthenticated)) {
+				authenticated = (bool) wasAuthenticated;
+			} else {
+				authenticated = AuthenticateUncached(context, clientCertificate);
+				TrySetDictionaryValue(connectionItems, connectionItemsKey, authenticated);
+			}
+
+			if (!authenticated)
+				return false;
+
+			request = new HttpAuthenticationRequest(context, "system", "");
+			request.Authenticated(SystemAccounts.System);
+
+			return true;
+		}
+
+		private static bool TryGetDictionaryValue(IDictionary<object, object> dictionary, string key, out object value) {
+			if (dictionary == null) {
+				value = null;
+				return false;
+			}
+
+			lock (dictionary) {
+				return dictionary.TryGetValue(key, out value);
+			}
+		}
+
+		private static bool TrySetDictionaryValue(IDictionary<object, object> dictionary, string key, object value) {
+			if (dictionary == null)
+				return false;
+
+			lock (dictionary) {
+				return dictionary.TryAdd(key, value);
+			}
+		}
+
+		private bool AuthenticateUncached(HttpContext context, X509Certificate2 clientCertificate) {
 			var reservedNodeCN = _getCertificateReservedNodeCommonName();
 			bool hasReservedNodeCN;
 			try {
@@ -49,8 +103,6 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 				return false;
 			}
 			
-			request = new HttpAuthenticationRequest(context, "system", "");
-			request.Authenticated(SystemAccounts.System);
 			return true;
 		}
 	}


### PR DESCRIPTION
Changed: Configure `CertificateReservedNodeCommonName` to be the node's CN by default
Changed: Make `CertificateReservedNodeCommonName` dynamically reloadable
Fixed: Cache client certificate authentication results for better performance/to make sure already established TLS connections continue to work properly.

This PR makes the following main change:
- read the CN from the node's certificate and use it as the `CertificateReservedNodeCommonName` (as proposed by @alexeyzimarev). The rationale is that in most cases, the CN is exactly the same on all nodes so this makes the user experience better by not having to specify an additional configuration option. In cases where the CN doesn't match on all nodes, a wildcard FQDN can be manually specified (https://github.com/EventStore/EventStore/pull/3960)

Additionally, the following changes are included:
- `CertificateReservedNodeCommonName` is now dynamically reloadable when reloading certificates. This means that new certificates don't necessarily need to match with the CN of the previous set of certificates. In production, it is reasonable to assume that cases will exist where certificates are rotated after a long period of time (e.g a few years) and within this time there may have been PKI changes within an organization enforcing new constraints on certificates. So this change also makes the user experience better as no restart is required.
- To make the above change possible, an additional optimization is required. Prior to this PR, all HTTP requests were re-authenticated by the client certificate authentication provider even if they belonged to the same TLS connection (for e.g due to HTTP/2 multiplexing). The authentication result is now cached for better performance / to make sure that already established TLS connections continue to work properly.