### PR TITLE
Prevent unreplicated data from being visible before truncation (DB-418)

### DIFF
--- a/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
+++ b/src/EventStore.Core.Tests/Services/Replication/LeaderReplication/when_replica_subscribes_with_epochs.cs
@@ -32,12 +32,13 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_from_start() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.Zero(subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.AreEqual(1, messages.Length);
+
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.Zero(subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
 		}
 	}
 
@@ -65,12 +66,15 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_from_last_epoch_position() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(_lastEpoch.EpochPosition, subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.IsTrue(messages.Length >= 2);
+
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.AreEqual(_lastEpoch.EpochPosition, subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
+
+			Assert.IsInstanceOf<ReplicationTrackingMessage.ReplicatedTo>(messages[1]);
 		}
 	}
 
@@ -99,12 +103,15 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_from_requested_position() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(_subscribedPosition, subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.IsTrue(messages.Length >= 2);
+
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.AreEqual(_subscribedPosition, subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
+
+			Assert.IsInstanceOf<ReplicationTrackingMessage.ReplicatedTo>(messages[1]);
 		}
 	}
 
@@ -140,12 +147,13 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_replica_subscribed_message_for_epoch_after_common_epoch() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(_replicaEpochs[2].EpochPosition, subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.AreEqual(1, messages.Length);
+
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.AreEqual(_replicaEpochs[2].EpochPosition, subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
 		}
 	}
 
@@ -175,13 +183,15 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_replica_subscribed_message_for_epoch_after_common_epoch() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.IsTrue(messages.Length >= 2);
 
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(_replicaEpochs[0].EpochPosition, subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.AreEqual(_replicaEpochs[0].EpochPosition, subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
+
+			Assert.IsInstanceOf<ReplicationTrackingMessage.ReplicatedTo>(messages[1]);
 		}
 	}
 
@@ -212,12 +222,13 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_replica_subscribed_message_for_leaders_writer_checkpoint() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(Writer.Position, subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.AreEqual(1, messages.Length);
+
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.AreEqual(Writer.Position, subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
 		}
 	}
 
@@ -250,12 +261,13 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_replica_subscribed_message_for_leaders_epoch_after_common_epoch() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(EpochManager.GetLastEpoch().EpochPosition, subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.AreEqual(1, messages.Length);
+
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.AreEqual(EpochManager.GetLastEpoch().EpochPosition, subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
 		}
 	}
 
@@ -289,12 +301,15 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_common_epoch() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(_replicaEpochs[0].EpochPosition, subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.IsTrue(messages.Length >= 2);
+
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.AreEqual(_replicaEpochs[0].EpochPosition, subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
+
+			Assert.IsInstanceOf<ReplicationTrackingMessage.ReplicatedTo>(messages[1]);
 		}
 	}
 
@@ -336,12 +351,13 @@ namespace EventStore.Core.Tests.Services.Replication.LeaderReplication {
 
 		[Test]
 		public void subscription_is_sent_a_replica_subscribed_message_to_epoch_position_after_common_epoch() {
-			var subscribed = GetTcpSendsFor(_replicaManager).Select(x => x.Message)
-				.OfType<ReplicationMessage.ReplicaSubscribed>().ToArray();
-			Assert.AreEqual(1, subscribed.Length);
-			Assert.AreEqual(EpochManager.GetLastEpochs(5).First(x => x.EpochNumber == 4).EpochPosition, subscribed[0].SubscriptionPosition);
-			Assert.AreEqual(_replicaId, subscribed[0].SubscriptionId);
-			Assert.AreEqual(LeaderId, subscribed[0].LeaderId);
+			var messages = GetTcpSendsFor(_replicaManager).Select(x => x.Message).ToArray();
+			Assert.AreEqual(1, messages.Length);
+
+			var subscribed = (ReplicationMessage.ReplicaSubscribed)messages[0];
+			Assert.AreEqual(EpochManager.GetLastEpochs(5).First(x => x.EpochNumber == 4).EpochPosition, subscribed.SubscriptionPosition);
+			Assert.AreEqual(_replicaId, subscribed.SubscriptionId);
+			Assert.AreEqual(LeaderId, subscribed.LeaderId);
 		}
 	}
 }


### PR DESCRIPTION
Fixed: An way for unreplicated data to appear in a subscription or reads before being truncated

Before this change it was possible for a follower that needs truncating to expose the unreplicated data before truncating it:

0. follower has extra data from last time it was leader that will need to be truncated.
1. follower sends a request to subscribe to leader, but doesn't hear back quickly.
2. follower sends another request to subscribe to leader.
3. leader responds to both subscribe requests by sending the ReplicaSubscribed and LeaderReplicatedTo.
4. follower receives the first ReplicaSubscribed BUT discards it because it does not have the current subscription id. (if it had the current id we would have detected that truncation is required and stopped the replication tracking service)
5. follower receives the first LeaderReplicatedTo message and incorrectly updates its replication checkpoint to match. - this can result in unreplicated data being read or sent in subscriptions.
6. follower receives the second ReplicaSubscribed message (with the current subscription id) and stops the replication tracking service but it is too late.
7. follower receives the second LeaderReplicatedTo message.

The fix causes the leader to recognise that the follower will go offline for truncation and not sent it any more messages (i.e. not the initial LeaderReplicatedTo message and no subsequent ones either).

Even if we implement online truncation later, the node can still resubscribe after it has done the truncation.

This involves no changes to the replication protocol.