### PR TITLE
Improve clarity of logging

### DIFF
--- a/src/EventStore.Core/DataStructures/ProbabilisticFilter/FileStreamPersistence.cs
+++ b/src/EventStore.Core/DataStructures/ProbabilisticFilter/FileStreamPersistence.cs
@@ -223,7 +223,7 @@ namespace EventStore.Core.DataStructures.ProbabilisticFilter {
 			var flushedMegaBytes = (float)flushedBytes / 1000 / 1000;
 			var activeFlushRateMBperS = flushedMegaBytes / activelyFlushing.Elapsed.TotalSeconds;
 
-			Log.Information(
+			Log.Verbose(
 				"Flushed {pages:N0} pages out of {totalPages:N0}. {bytes:N0} bytes. " +
 				"Delay {delay} ms per batch. Total delay {totalDelay:N0} ms. " +
 				"Actively flushing: {activeFlushTime} {activeFlushRate:N2} MB/s. ",

--- a/src/EventStore.Core/LogAbstraction/Common/StreamExistenceFilter.cs
+++ b/src/EventStore.Core/LogAbstraction/Common/StreamExistenceFilter.cs
@@ -126,16 +126,16 @@ namespace EventStore.Core.LogAbstraction.Common {
 		public void Verify(double corruptionThreshold) => _persistentBloomFilter.Verify(corruptionThreshold);
 
 		private async Task TakeCheckpointAsync() {
+			var checkpoint = Interlocked.Read(ref _lastNonFlushedCheckpoint);
 			try {
-				var checkpoint = Interlocked.Read(ref _lastNonFlushedCheckpoint);
 				var prevCheckpoint = _checkpoint.Read();
 				var diff = checkpoint - prevCheckpoint;
 
 				var startTime = DateTime.UtcNow;
-				Log.Debug("{filterName} is flushing at {checkpoint:N0}. Diff {diff:N0} ...", _filterName, checkpoint, diff);
+				Log.Verbose("{filterName} is flushing at {checkpoint:N0}. Diff {diff:N0} ...", _filterName, checkpoint, diff);
 				_persistentBloomFilter.Flush();
 				var endTime = DateTime.UtcNow;
-				Log.Debug("{filterName} has flushed at {checkpoint:N0}. Diff {diff:N0}. Took {flushLength}",
+				Log.Verbose("{filterName} has flushed at {checkpoint:N0}. Diff {diff:N0}. Took {flushLength}",
 					       _filterName, checkpoint, diff, endTime - startTime);
 
 				// safety precaution against anything in the stack lying about the data
@@ -144,11 +144,11 @@ namespace EventStore.Core.LogAbstraction.Common {
 
 				_checkpoint.Write(checkpoint);
 				_checkpoint.Flush();
-				Log.Debug("{filterName} took checkpoint at position: {position:N0}.",
+				Log.Verbose("{filterName} took checkpoint at position: {position:N0}.",
 					_filterName,
 					_checkpoint.Read());
 			} catch (Exception ex) {
-				Log.Error(ex, "{filterName} could not take checkpoint at position: {position:N0}", _filterName, _checkpoint.Read());
+				Log.Error(ex, "{filterName} could not take checkpoint at position: {position:N0}", _filterName, checkpoint);
 			}
 		}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscription.cs
@@ -126,10 +126,16 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					CatchUp(Position.Start);
 				} else {
 					var (commitPosition, preparePosition) = startPosition.Value.ToInt64();
-					var indexResult =
-						_readIndex.ReadAllEventsForward(new TFPos(commitPosition, preparePosition), 1);
-					CatchUp(Position.FromInt64(indexResult.NextPos.CommitPosition,
-						indexResult.NextPos.PreparePosition));
+					try {
+						var indexResult =
+							_readIndex.ReadAllEventsForward(new TFPos(commitPosition, preparePosition), 1);
+						CatchUp(Position.FromInt64(indexResult.NextPos.CommitPosition,
+							indexResult.NextPos.PreparePosition));
+					} catch (Exception ex) {
+						Log.Error(ex, "Error starting catch-up subscription {subscriptionId} to $all@{position}",
+							_subscriptionId, startPosition);
+						throw;
+					}
 				}
 			}
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Enumerators.AllSubscriptionFiltered.cs
@@ -149,10 +149,16 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					CatchUp(Position.Start);
 				} else {
 					var (commitPosition, preparePosition) = startPosition.Value.ToInt64();
-					var indexResult =
-						_readIndex.ReadAllEventsForward(new TFPos(commitPosition, preparePosition), 1);
-					CatchUp(Position.FromInt64(indexResult.NextPos.CommitPosition,
-						indexResult.NextPos.PreparePosition));
+					try {
+						var indexResult =
+							_readIndex.ReadAllEventsForward(new TFPos(commitPosition, preparePosition), 1);
+						CatchUp(Position.FromInt64(indexResult.NextPos.CommitPosition,
+							indexResult.NextPos.PreparePosition));
+					} catch (Exception ex) {
+						Log.Error(ex, "Error starting catch-up subscription {subscriptionId} to $all:{eventFilter}@{position}",
+							_subscriptionId, _eventFilter, startPosition);
+						throw;
+					}
 				}
 			}
 

--- a/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
+++ b/src/EventStore.Transport.Tcp/TcpConnectionSsl.cs
@@ -287,21 +287,21 @@ namespace EventStore.Transport.Tcp {
 
 		private void DisplaySslStreamInfo(SslStream stream) {
 			Log.Information("[S{remoteEndPoint}, L{localEndPoint}]", RemoteEndPoint, LocalEndPoint);
-			Log.Information("Cipher: {cipherAlgorithm}", stream.CipherAlgorithm);
+			Log.Verbose("Cipher: {cipherAlgorithm}", stream.CipherAlgorithm);
 			try {
-				Log.Information("Cipher strength: {cipherStrength}", stream.CipherStrength);
+				Log.Verbose("Cipher strength: {cipherStrength}", stream.CipherStrength);
 			} catch (NotImplementedException) {
 			}
 
-			Log.Information("Hash: {hashAlgorithm}", stream.HashAlgorithm);
+			Log.Verbose("Hash: {hashAlgorithm}", stream.HashAlgorithm);
 			try {
-				Log.Information("Hash strength: {hashStrength}", stream.HashStrength);
+				Log.Verbose("Hash strength: {hashStrength}", stream.HashStrength);
 			} catch (NotImplementedException) {
 			}
 
-			Log.Information("Key exchange: {keyExchangeAlgorithm}", stream.KeyExchangeAlgorithm);
+			Log.Verbose("Key exchange: {keyExchangeAlgorithm}", stream.KeyExchangeAlgorithm);
 			try {
-				Log.Information("Key exchange strength: {keyExchangeStrength}", stream.KeyExchangeStrength);
+				Log.Verbose("Key exchange strength: {keyExchangeStrength}", stream.KeyExchangeStrength);
 			} catch (NotImplementedException) {
 			}
 


### PR DESCRIPTION
Changed: Log levels

- StreamExistenceFilter flushing now verbose. This has been stable since moving to file streams
- Some properties of new TLS connections now verbose.
- Log an error when a read fails when starting a grpc $all subscription. This is the same thing that the StorageReaderWorker does but we are bypassing it in this case If an invalid checkpoint is used we will now get the familiar "Log record at actual pos 123 has too large length" message