### PR TITLE
Decode Base64 usernames/passwords as UTF-8 strings (DB-421)

### DIFF
--- a/src/EventStore.Core.Tests/ClientAPI/UserManagement/creating_a_user.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/UserManagement/creating_a_user.cs
@@ -57,5 +57,18 @@ namespace EventStore.Core.Tests.ClientAPI.UserManagement {
 			Assert.AreEqual("foo", d.Groups[0]);
 			Assert.AreEqual("bar", d.Groups[1]);
 		}
+
+		[Test]
+		public async System.Threading.Tasks.Task creating_a_user_with_unicode_chars_can_be_readAsync() {
+			UserDetails d = null;
+			await _manager.CreateUserAsync("码ou£ro码", "ourofull", new[] { "foo", "bar" }, "ou码码ro",
+				new UserCredentials("admin", "changeit"));
+			d = await _manager.GetUserAsync("码ou£ro码", new UserCredentials("admin", "changeit"));
+
+			Assert.AreEqual("码ou£ro码", d.LoginName);
+			Assert.AreEqual("ourofull", d.FullName);
+			Assert.AreEqual("foo", d.Groups[0]);
+			Assert.AreEqual("bar", d.Groups[1]);
+		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/BasicHttpAuthenticationProvider.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/BasicHttpAuthenticationProvider.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 		private static bool TryDecodeCredential(string value, out string username, out string password) {
 			username = password = default;
 
-			var parts = Encoding.ASCII.GetString(System.Convert.FromBase64String(value)).Split(':', 2);
+			var parts = Encoding.UTF8.GetString(System.Convert.FromBase64String(value)).Split(':', 2);
 			if (parts.Length < 2) {
 				return false;
 			}


### PR DESCRIPTION
Fixed: Allow users to login with usernames/passwords having unicode characters

Corresponding UI PR: https://github.com/EventStore/EventStore.UI/pull/364

The password change tests have been marked as `Explicit` and must be run manually as password changes take a long time to be processed just after startup (since the password change notification reader's stream does not initially exist and it waits for 10 seconds before the next retry)
