### PR TITLE
Set the default value of `CertificateReservedNodeCommonName` to empty string [DB-370]

### DIFF
--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -300,7 +300,7 @@ namespace EventStore.Core {
 				Locations.DefaultTrustedRootCertificateDirectory;
 
 			[Description("The pattern the CN (Common Name) of a connecting EventStoreDB node must match to be authenticated. A wildcard FQDN can be specified if using wildcard certificates or if the CN is not the same on all nodes. Leave empty to automatically use the CN of this node's certificate.")]
-			public string CertificateReservedNodeCommonName { get; init; } = "eventstoredb-node";
+			public string CertificateReservedNodeCommonName { get; init; } = string.Empty;
 
 			internal static CertificateOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				TrustedRootCertificatesPath = configurationRoot.GetValue<string>(nameof(TrustedRootCertificatesPath)),

--- a/src/EventStore.Core/Util/Opts.cs
+++ b/src/EventStore.Core/Util/Opts.cs
@@ -17,8 +17,6 @@ namespace EventStore.Core.Util {
 
 		public const int ProjectionsQueryExpiryDefault = 5;
 
-		public const string CertificateReservedNodeCommonNameDefault = "eventstoredb-node";
-
 		public const byte IndexBitnessVersionDefault = Index.PTableVersions.IndexV4;
 
 		public static readonly string AuthenticationTypeDefault = "internal";


### PR DESCRIPTION
Changed: Set the default value of `CertificateReservedNodeCommonName` to empty string

This was a mistake that slipped through when rebasing: https://github.com/EventStore/EventStore/pull/3966