### PR TITLE
Add support for multiple media types specified in one Accept header (DB-457)

### DIFF
--- a/src/EventStore.Core.Tests/Http/ArgumentPassing/matching.cs
+++ b/src/EventStore.Core.Tests/Http/ArgumentPassing/matching.cs
@@ -36,6 +36,16 @@ namespace EventStore.Core.Tests.Http.ArgumentPassing {
 				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
 				HelperExtensions.AssertJson(new { a = _ra, b = _rb }, _response);
 			}
+
+			[Test]
+			[TestCase("*/*")]
+			[TestCase("application/json")]
+			[TestCase("application/json,*/*;q=0.1")]
+			public async Task can_specify_multple_accepts(string accept) {
+				_response = await GetJson<JObject>("/test-encoding/1", accept: accept);
+				Assert.AreEqual(HttpStatusCode.OK, _lastResponse.StatusCode);
+				HelperExtensions.AssertJson(new { a = "1" }, _response);
+			}
 		}
 
 		[Category("LongRunning")]

--- a/src/EventStore.Core/Services/Transport/Http/Controllers/MetricsController.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Controllers/MetricsController.cs
@@ -9,6 +9,7 @@ using EventStore.Transport.Http.Codecs;
 namespace EventStore.Core.Services.Transport.Http.Controllers {
 	public class MetricsController : CommunicationController {
 		private static readonly ICodec[] SupportedCodecs = new ICodec[] {
+			Codec.CreateCustom(Codec.Text, "text/plain", Helper.UTF8NoBom, false, false),
 			Codec.CreateCustom(Codec.Text, "application/openmetrics-text", Helper.UTF8NoBom, false, false),
 		};
 

--- a/src/EventStore.Transport.Http/EntityManagement/CoreHttpRequestAdapter.cs
+++ b/src/EventStore.Transport.Http/EntityManagement/CoreHttpRequestAdapter.cs
@@ -14,7 +14,7 @@ namespace EventStore.Transport.Http.EntityManagement {
 			_inner = inner;
 		}
 
-		public string[] AcceptTypes => _inner.Headers["accept"];
+		public string[] AcceptTypes => _inner.Headers.GetCommaSeparatedValues("accept");
 
 		public long ContentLength64 => _inner.ContentLength ?? 0;
 


### PR DESCRIPTION
Added: Support for multiple media types specified in one Accept header.

Previously if you issued a GET to any of the non-grpc http endpoints with `Accept = "text/plain;version=0.0.4;q=1,*/*;q=0.1"` or more simply `"text/plain,*/*"` then you would get a `406 Not Acceptable` because the media types from the single header were not being parsed into multiple comma separated types.

We have also changed the metrics controller to support `text/plain` since that is the content type of the response it generates.

Unit test limitation: Unfortunately we can't figure out how to get the HTTP client to send a request that causes the problem, so the included test passes even before the fix. Everything we tried seemed to result in a request that the server handled fine, perhaps it is automatically splitting the string into multiple headers when we set it.

Fixes #4009 