### PR TITLE
Upgrade to .NET 7 (DB-460)

### DIFF
--- a/.github/workflows/build-container-jammy.yml
+++ b/.github/workflows/build-container-jammy.yml
@@ -1,4 +1,4 @@
-name: Build Focal Container
+name: Build Jammy Container
 
 on:
   pull_request:
@@ -21,5 +21,5 @@ jobs:
   build-container:
     uses: ./.github/workflows/build-container-reusable.yml
     with:
-      container-runtime: focal
+      container-runtime: jammy
 

--- a/.github/workflows/build-container-reusable.yml
+++ b/.github/workflows/build-container-reusable.yml
@@ -18,10 +18,10 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - name: Install net6.0
+    - name: Install net7.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
     - name: Set up Docker Buildx
@@ -44,7 +44,7 @@ jobs:
         key: "${{ inputs.container-runtime }}"
         map: |
           {
-            "focal": {
+            "jammy": {
               "runtime": "linux-x64"
             },
             "bullseye-slim": {
@@ -102,7 +102,7 @@ jobs:
         docker tag eventstore ghcr.io/eventstore/eventstore:${{ env.VERSION }}
         docker push ghcr.io/eventstore/eventstore:${{ env.VERSION }}
     - name: Push GitHub Container Registry (CI)
-      if: always() && github.event_name == 'push' && inputs.container-runtime == 'focal' && github.ref == 'refs/heads/master'
+      if: always() && github.event_name == 'push' && inputs.container-runtime == 'jammy' && github.ref == 'refs/heads/master'
       shell: bash
       run: |
         docker tag eventstore ghcr.io/eventstore/eventstore:ci

--- a/.github/workflows/build-reusable.yml
+++ b/.github/workflows/build-reusable.yml
@@ -28,10 +28,10 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.x
-    - name: Install net6.0
+    - name: Install net7.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Clear Nuget Cache
       shell: powershell
       if: inputs.os == 'windows-2019'

--- a/.github/workflows/common.yml
+++ b/.github/workflows/common.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Install net6.0
+    - name: Install net7.0
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Scan for Vulnerabilities
       run: |
         cd src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # "build" image
-ARG CONTAINER_RUNTIME=focal
-FROM mcr.microsoft.com/dotnet/sdk:6.0-focal AS build
+ARG CONTAINER_RUNTIME=jammy
+FROM mcr.microsoft.com/dotnet/sdk:7.0-jammy AS build
 ARG RUNTIME=linux-x64
 
 WORKDIR /build/ci
@@ -31,7 +31,7 @@ RUN find /build/src -maxdepth 1 -type d -name "*.Tests" -print0 | xargs -I{} -0 
     'dotnet publish --runtime=${RUNTIME} --no-self-contained --configuration Release --output /build/published-tests/`basename $1` $1' - '{}'
 
 # "test" image
-FROM mcr.microsoft.com/dotnet/sdk:6.0-${CONTAINER_RUNTIME} as test
+FROM mcr.microsoft.com/dotnet/sdk:7.0-${CONTAINER_RUNTIME} as test
 WORKDIR /build
 COPY --from=build ./build/published-tests ./published-tests
 COPY --from=build ./build/ci ./ci
@@ -53,10 +53,10 @@ FROM build as publish
 ARG RUNTIME=linux-x64
 
 RUN dotnet publish --configuration=Release --runtime=${RUNTIME} --self-contained \
-     --framework=net6.0 --output /publish EventStore.ClusterNode
+     --framework=net7.0 --output /publish EventStore.ClusterNode
 
 # "runtime" image
-FROM mcr.microsoft.com/dotnet/runtime-deps:6.0-${CONTAINER_RUNTIME} AS runtime
+FROM mcr.microsoft.com/dotnet/runtime-deps:7.0-${CONTAINER_RUNTIME} AS runtime
 ARG RUNTIME=linux-x64
 ARG UID=1000
 ARG GID=1000

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The build scripts: `build.sh` and `build.ps1` are also available for Linux and W
 To start a single node, you can then run:
 
 ```
-dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net6.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
+dotnet ./src/EventStore.ClusterNode/bin/x64/Release/net7.0/EventStore.ClusterNode.dll --dev --db ./tmp/data --index ./tmp/index --log ./tmp/log
 ```
 
 ### Running the tests
@@ -160,9 +160,9 @@ Currently, we support the following configurations:
 - `CONTAINER_RUNTIME=bullseye-slim`
 - `RUNTIME=linux-x64`
 
-2. Focal:
+2. Jammy:
 
-- `CONTAINER_RUNTIME=focal`
+- `CONTAINER_RUNTIME=Jammy`
 - `RUNTIME=linux-x64`
 
 3. Alpine:
@@ -194,4 +194,4 @@ docker run --rm myeventstore --insecure --what-if
 
 ![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-bullseye-slim.yml/badge.svg)
 
-![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-focal.yml/badge.svg)
+![Build](https://github.com/EventStore/EventStore/actions/workflows/build-container-jammy.yml/badge.svg)

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ COPYRIGHT="Copyright 2021 Event Store Ltd. All rights reserved."
 
 CONFIGURATION="Release"
 BUILD_UI="no"
-NET_FRAMEWORK="net6.0"
+NET_FRAMEWORK="net7.0"
 
 function usage() {    
 cat <<EOF

--- a/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
+++ b/src/EventStore.BufferManagement.Tests/EventStore.BufferManagement.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<DebugSymbols>true</DebugSymbols>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
+++ b/src/EventStore.BufferManagement/EventStore.BufferManagement.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.ClusterNode.Web/EventStore.ClusterNode.Web.csproj
+++ b/src/EventStore.ClusterNode.Web/EventStore.ClusterNode.Web.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<OutputType>Exe</OutputType>
 		<ApplicationIcon>app2.ico</ApplicationIcon>

--- a/src/EventStore.Common.Tests/Configuration/ConfigurationRootExtensionsTest.cs
+++ b/src/EventStore.Common.Tests/Configuration/ConfigurationRootExtensionsTest.cs
@@ -10,7 +10,7 @@ public class ConfigurationRootExtensionsTest {
 	
 	[Fact]
 	public void successful_comma_separated_value() {
-		var config = new Dictionary<string, string> {
+		var config = new Dictionary<string, string?> {
 			{ GOSSIP_SEED, "nodeb.eventstore.test:2113,nodec.eventstore.test:3113" }
 		};
 		IConfigurationRoot configuration = MemoryConfigurationBuilderExtensions
@@ -24,7 +24,7 @@ public class ConfigurationRootExtensionsTest {
 
 	[Fact]
 	public void invalid_delimiter() {
-		var config = new Dictionary<string, string> {
+		var config = new Dictionary<string, string?> {
 			{ GOSSIP_SEED, "nodeb.eventstore.test:2113;nodec.eventstore.test:3113" }
 		};
 		IConfigurationRoot configuration = MemoryConfigurationBuilderExtensions
@@ -38,7 +38,7 @@ public class ConfigurationRootExtensionsTest {
 	
 	[Fact]
 	public void mixed_invalid_delimiter() {
-		var config = new Dictionary<string, string> {
+		var config = new Dictionary<string, string?> {
 			{ GOSSIP_SEED, "nodea.eventstore.test:2113,nodeb.eventstore.test:2113;nodec.eventstore.test:3113" }
 		};
 

--- a/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
+++ b/src/EventStore.Common.Tests/EventStore.Common.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/EventStore.Common.Utils/EventStore.Common.Utils.csproj
+++ b/src/EventStore.Common.Utils/EventStore.Common.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 	<ItemGroup>

--- a/src/EventStore.Common/Configuration/ConfigurationBuilderExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace EventStore.Common.Configuration {
 			var root = builder.Build(); // need to build twice as on disk config is configurable
 			
 			var yamlSource = new YamlSource {
-				Path = root.GetValue<string>(configFileKey),
+				Path = root.GetString(configFileKey),
 				Optional = !root.IsUserSpecified(configFileKey),
 				ReloadOnChange = true
 			};

--- a/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
+++ b/src/EventStore.Common/Configuration/ConfigurationRootExtensions.cs
@@ -78,5 +78,9 @@ namespace EventStore.Common.Configuration {
 				
 			return builder.ToString().PadRight(optionColumnWidth, ' ') + description;
 		}
+
+		public static string GetString(this IConfigurationRoot configurationRoot, string key) {
+			return configurationRoot.GetValue<string>(key) ?? string.Empty;
+		}
 	}
 }

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Core.Tests/ClientAPI/connect.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/connect.cs
@@ -13,10 +13,10 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[TestFixture(typeof(LogFormat.V3), typeof(uint), TcpType.Normal)]
 	[TestFixture(typeof(LogFormat.V2), typeof(string), TcpType.Ssl)]
 	[TestFixture(typeof(LogFormat.V3), typeof(uint), TcpType.Ssl)]
-	public class connect<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
+	public class Connect<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
 		private readonly TcpType _tcpType;
 
-		public connect(TcpType tcpType) {
+		public Connect(TcpType tcpType) {
 			_tcpType = tcpType;
 		}
 

--- a/src/EventStore.Core.Tests/ClientAPI/transaction.cs
+++ b/src/EventStore.Core.Tests/ClientAPI/transaction.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Tests.ClientAPI {
 	[Category("ClientAPI"), Category("LongRunning")]
 	[TestFixture(typeof(LogFormat.V2), typeof(string))]
 	[TestFixture(typeof(LogFormat.V3), typeof(uint), Ignore = "Explicit transactions are not supported yet by Log V3")]
-	public class transaction<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
+	public class Transaction<TLogFormat, TStreamId> : SpecificationWithDirectoryPerTestFixture {
 		private MiniNode<TLogFormat, TStreamId> _node;
 
 		[OneTimeSetUp]

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>
@@ -27,7 +27,6 @@
 
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\EventStore.ClusterNode\EventStore.ClusterNode.csproj" />
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		<ProjectReference Include="..\EventStore.PluginHosting\EventStore.PluginHosting.csproj" />

--- a/src/EventStore.Core.Tests/FakePlugin/FakePlugin.csproj
+++ b/src/EventStore.Core.Tests/FakePlugin/FakePlugin.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/EventStore.Core.Tests/Http/Streams/filtered.cs
+++ b/src/EventStore.Core.Tests/Http/Streams/filtered.cs
@@ -9,7 +9,7 @@ using HttpStatusCode = System.Net.HttpStatusCode;
 using EventStore.Transport.Http;
 
 namespace EventStore.Core.Tests.Http.Streams {
-	public class filtered {
+	public class Filtered {
 		public abstract class SpecificationWithLongFeed<TLogFormat, TStreamId> : with_admin_user<TLogFormat, TStreamId> {
 			protected int NumberOfEvents;
 

--- a/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/Authentication/rfc_2898_password_hash_algorithm.cs
@@ -55,5 +55,23 @@ namespace EventStore.Core.Tests.Services.Transport.Http.Authentication {
 				Assert.That(_hash1 != _hash2);
 			}
 		}
+		
+		[TestFixture]
+		public class when_upgrading_the_hashes {
+			private Rfc2898PasswordHashAlgorithm _algorithm;
+			private readonly string _password = "Pa55w0rd!";
+			private readonly string _hash = "HKoq6xw3Oird4KqU4RyoY9aFFRc=";
+			private readonly string _salt = "+6eoSEkays/BOpzGMLE6Uw==";
+
+			[SetUp]
+			public void SetUp() {
+				_algorithm = new Rfc2898PasswordHashAlgorithm();
+			}
+
+			[Test]
+			public void old_hashes_should_successfully_verify() {
+				Assert.True(_algorithm.Verify(_password, _hash, _salt));
+			}
+		}
 	}
 }

--- a/src/EventStore.Core.Tests/options.cs
+++ b/src/EventStore.Core.Tests/options.cs
@@ -16,7 +16,7 @@ using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
 
 namespace EventStore.Core.Tests {
 	[TestFixture]
-	public class options {
+	public class Options {
 		[TestCaseSource(typeof(ParseCaseData), nameof(ParseCaseData.TestCases))]
 		public object are_parsed_correctly_when_well_formed(string option, string[] args) {
 			var sut = new TestOptions(args);

--- a/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.Core.XUnit.Tests/Metrics/ProcessMetricsTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/ProcessMetricsTests.cs
@@ -103,7 +103,7 @@ public class ProcessMetricsTests : IDisposable {
 	[Fact]
 	public void can_collect_proc_cpu() {
 		Assert.Collection(
-			_intListener.RetrieveMeasurements("eventstore-proc-cpu"),
+			_doubleListener.RetrieveMeasurements("eventstore-proc-cpu"),
 			m => {
 				Assert.True(m.Value >= 0);
 				Assert.Empty(m.Tags);
@@ -228,7 +228,7 @@ public class ProcessMetricsTests : IDisposable {
 		Assert.Collection(
 			_longListener.RetrieveMeasurements("eventstore-gc-generation-size-bytes"),
 			m => {
-				Assert.True(m.Value > 0);
+				Assert.True(m.Value >= 0);
 				Assert.Collection(
 					m.Tags,
 					tag => {

--- a/src/EventStore.Core.XUnit.Tests/PluginLoaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/PluginLoaderTests.cs
@@ -88,7 +88,7 @@ public class PluginLoaderTests : IAsyncLifetime {
 		using var process = new Process {
 			StartInfo = new ProcessStartInfo {
 				FileName = "dotnet",
-				Arguments = $"publish --configuration {BuildConfiguration} --framework=net6.0 --output {outputFolder.FullName}",
+				Arguments = $"publish --configuration {BuildConfiguration} --framework=net7.0 --output {outputFolder.FullName}",
 				WorkingDirectory = PluginSourceDirectory,
 				UseShellExecute = false,
 				RedirectStandardError = true,

--- a/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.Framework.cs
@@ -51,7 +51,7 @@ namespace EventStore.Core {
 				from option in section.GetProperties()
 				let deprecationWarning = option.GetCustomAttribute<DeprecatedAttribute>()?.Message
 				where deprecationWarning is not null
-				let value = ConfigurationRoot.GetValue<string?>(option.Name)
+				let value = ConfigurationRoot?.GetValue<string?>(option.Name)
 				where defaultValues.TryGetValue(option.Name, out var defaultValue)
 				      && !string.Equals(value, defaultValue?.ToString(), StringComparison.OrdinalIgnoreCase)
 				      select deprecationWarning;

--- a/src/EventStore.Core/ClusterVNodeOptions.cs
+++ b/src/EventStore.Core/ClusterVNodeOptions.cs
@@ -101,8 +101,8 @@ namespace EventStore.Core {
 			public string DefaultOpsPassword { get; init; } = "changeit";
  
 			internal static DefaultUserOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				DefaultAdminPassword = configurationRoot.GetValue<string>(nameof(DefaultAdminPassword)),
-				DefaultOpsPassword = configurationRoot.GetValue<string>(nameof(DefaultOpsPassword))
+				DefaultAdminPassword = configurationRoot.GetString(nameof(DefaultAdminPassword)),
+				DefaultOpsPassword = configurationRoot.GetString(nameof(DefaultOpsPassword))
 			};
 		}
 		
@@ -178,7 +178,7 @@ namespace EventStore.Core {
 			public bool TelemetryOptout { get; init; } = false;
 
 			internal static ApplicationOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				Config = configurationRoot.GetValue<string>(nameof(Config)),
+				Config = configurationRoot.GetString(nameof(Config)),
 				Help = configurationRoot.GetValue<bool>(nameof(Help)),
 				Version = configurationRoot.GetValue<bool>(nameof(Version)),
 				EnableHistograms = configurationRoot.GetValue<bool>(nameof(EnableHistograms)),
@@ -227,8 +227,8 @@ namespace EventStore.Core {
 			public bool DisableLogFile { get; init; } = false;
 
 			public static LoggingOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				Log = configurationRoot.GetValue<string>(nameof(Log)),
-				LogConfig = configurationRoot.GetValue<string>(nameof(LogConfig)),
+				Log = configurationRoot.GetString(nameof(Log)),
+				LogConfig = configurationRoot.GetString(nameof(LogConfig)),
 				LogLevel = configurationRoot.GetValue<LogLevel>(nameof(LogLevel)),
 				LogConsoleFormat = configurationRoot.GetValue<LogConsoleFormat>(nameof(LogConsoleFormat)),
 				LogFileSize = configurationRoot.GetValue<int>(nameof(LogFileSize)),
@@ -257,9 +257,9 @@ namespace EventStore.Core {
 			public bool DisableFirstLevelHttpAuthorization { get; init; } = false;
 
 			internal static AuthOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				AuthorizationType = configurationRoot.GetValue<string>(nameof(AuthorizationType)),
+				AuthorizationType = configurationRoot.GetString(nameof(AuthorizationType)),
 				AuthenticationConfig = configurationRoot.GetValue<string>(nameof(AuthenticationConfig)),
-				AuthenticationType = configurationRoot.GetValue<string>(nameof(AuthenticationType)),
+				AuthenticationType = configurationRoot.GetString(nameof(AuthenticationType)),
 				AuthorizationConfig = configurationRoot.GetValue<string>(nameof(AuthorizationConfig)),
 				DisableFirstLevelHttpAuthorization =
 					configurationRoot.GetValue<bool>(nameof(DisableFirstLevelHttpAuthorization))
@@ -304,8 +304,7 @@ namespace EventStore.Core {
 
 			internal static CertificateOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
 				TrustedRootCertificatesPath = configurationRoot.GetValue<string>(nameof(TrustedRootCertificatesPath)),
-				CertificateReservedNodeCommonName =
-					configurationRoot.GetValue<string>(nameof(CertificateReservedNodeCommonName))
+				CertificateReservedNodeCommonName = configurationRoot.GetString(nameof(CertificateReservedNodeCommonName))
 			};
 		}
 
@@ -336,18 +335,14 @@ namespace EventStore.Core {
 			public string TrustedRootCertificateThumbprint { get; init; } = string.Empty;
 
 			internal static CertificateStoreOptions FromConfiguration(IConfigurationRoot configurationRoot) => new() {
-				CertificateStoreLocation = configurationRoot.GetValue<string>(nameof(CertificateStoreLocation)),
-				CertificateStoreName = configurationRoot.GetValue<string>(nameof(CertificateStoreName)),
-				CertificateSubjectName = configurationRoot.GetValue<string>(nameof(CertificateSubjectName)),
-				CertificateThumbprint = configurationRoot.GetValue<string>(nameof(CertificateThumbprint)),
-				TrustedRootCertificateStoreLocation =
-					configurationRoot.GetValue<string>(nameof(TrustedRootCertificateStoreLocation)),
-				TrustedRootCertificateStoreName =
-					configurationRoot.GetValue<string>(nameof(TrustedRootCertificateStoreName)),
-				TrustedRootCertificateThumbprint =
-					configurationRoot.GetValue<string>(nameof(TrustedRootCertificateThumbprint)),
-				TrustedRootCertificateSubjectName =
-					configurationRoot.GetValue<string>(nameof(TrustedRootCertificateSubjectName))
+				CertificateStoreLocation = configurationRoot.GetString(nameof(CertificateStoreLocation)),
+				CertificateStoreName = configurationRoot.GetString(nameof(CertificateStoreName)),
+				CertificateSubjectName = configurationRoot.GetString(nameof(CertificateSubjectName)),
+				CertificateThumbprint = configurationRoot.GetString(nameof(CertificateThumbprint)),
+				TrustedRootCertificateStoreLocation = configurationRoot.GetString(nameof(TrustedRootCertificateStoreLocation)),
+				TrustedRootCertificateStoreName = configurationRoot.GetString(nameof(TrustedRootCertificateStoreName)),
+				TrustedRootCertificateThumbprint = configurationRoot.GetString(nameof(TrustedRootCertificateThumbprint)),
+				TrustedRootCertificateSubjectName = configurationRoot.GetString(nameof(TrustedRootCertificateSubjectName))
 			};
 		}
 
@@ -405,7 +400,7 @@ namespace EventStore.Core {
 				DiscoverViaDns = configurationRoot.GetValue<bool>(nameof(DiscoverViaDns)),
 				ClusterSize = configurationRoot.GetValue<int>(nameof(ClusterSize)),
 				NodePriority = configurationRoot.GetValue<int>(nameof(NodePriority)),
-				ClusterDns = configurationRoot.GetValue<string>(nameof(ClusterDns)),
+				ClusterDns = configurationRoot.GetString(nameof(ClusterDns)),
 				ClusterGossipPort = configurationRoot.GetValue<int>(nameof(ClusterGossipPort)),
 				GossipIntervalMs = configurationRoot.GetValue<int>(nameof(GossipIntervalMs)),
 				GossipAllowedDifferenceMs = configurationRoot.GetValue<int>(nameof(GossipAllowedDifferenceMs)),
@@ -587,7 +582,7 @@ namespace EventStore.Core {
 				MinFlushDelayMs = configurationRoot.GetValue<double>(nameof(MinFlushDelayMs)),
 				DisableScavengeMerging = configurationRoot.GetValue<bool>(nameof(DisableScavengeMerging)),
 				MemDb = configurationRoot.GetValue<bool>(nameof(MemDb)),
-				Db = configurationRoot.GetValue<string>(nameof(Db)),
+				Db = configurationRoot.GetString(nameof(Db)),
 				ScavengeHistoryMaxAge = configurationRoot.GetValue<int>(nameof(ScavengeHistoryMaxAge)),
 				CachedChunks = configurationRoot.GetValue<int>(nameof(CachedChunks)),
 				ChunksCacheSize = configurationRoot.GetValue<long>(nameof(ChunksCacheSize)),

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.Core/Metrics/ProcessMetrics.cs
+++ b/src/EventStore.Core/Metrics/ProcessMetrics.cs
@@ -41,7 +41,7 @@ public class ProcessMetrics {
 			.Assembly
 			.GetType("System.Diagnostics.Tracing.RuntimeEventSourceHelper")!
 			.GetMethod("GetCpuUsage", BindingFlags.Static | BindingFlags.NonPublic)!
-			.CreateDelegate<Func<int>>();
+			.CreateDelegate<Func<double>>();
 
 		var getExceptionCount = typeof(Exception)
 			.GetMethod("GetExceptionCount", BindingFlags.Static | BindingFlags.NonPublic)!

--- a/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Authentication/Rfc2898PasswordHashAlgorithm.cs
@@ -5,19 +5,23 @@ namespace EventStore.Core.Services.Transport.Http.Authentication {
 	public class Rfc2898PasswordHashAlgorithm : PasswordHashAlgorithm {
 		private const int HashSize = 20;
 		private const int SaltSize = 16;
-
+		private const int Iterations = 1000;
+		
 		public override void Hash(string password, out string hash, out string salt) {
-			var salt_ = new byte[SaltSize];
-			RandomNumberGenerator.Fill(salt_);
-			var hash_ = new Rfc2898DeriveBytes(password, salt_).GetBytes(HashSize);
-			hash = System.Convert.ToBase64String(hash_);
-			salt = System.Convert.ToBase64String(salt_);
+			var saltData = new byte[SaltSize];
+			RandomNumberGenerator.Fill(saltData);
+			
+			using var rfcBytes = new Rfc2898DeriveBytes(password, saltData, Iterations, HashAlgorithmName.SHA1);
+			var hashData = rfcBytes.GetBytes(HashSize);
+			hash = System.Convert.ToBase64String(hashData);
+			salt = System.Convert.ToBase64String(saltData);
 		}
 
 		public override bool Verify(string password, string hash, string salt) {
-			var salt_ = System.Convert.FromBase64String(salt);
+			var saltData = System.Convert.FromBase64String(salt);
 
-			var newHash = System.Convert.ToBase64String(new Rfc2898DeriveBytes(password, salt_).GetBytes(HashSize));
+			using var rfcBytes = new Rfc2898DeriveBytes(password, saltData, Iterations, HashAlgorithmName.SHA1);
+			var newHash = System.Convert.ToBase64String(rfcBytes.GetBytes(HashSize));
 
 			return hash == newHash;
 		}

--- a/src/EventStore.LogCommon/EventStore.LogCommon.csproj
+++ b/src/EventStore.LogCommon/EventStore.LogCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.LogV3.Tests/EventStore.LogV3.Tests.csproj
+++ b/src/EventStore.LogV3.Tests/EventStore.LogV3.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.LogV3/EventStore.LogV3.csproj
+++ b/src/EventStore.LogV3/EventStore.LogV3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.MicroBenchmarks/EventStore.MicroBenchmarks.csproj
+++ b/src/EventStore.MicroBenchmarks/EventStore.MicroBenchmarks.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
 

--- a/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
+++ b/src/EventStore.NETCore.Compatibility/EventStore.NETCore.Compatibility.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>

--- a/src/EventStore.Native/EventStore.Native.csproj
+++ b/src/EventStore.Native/EventStore.Native.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.PluginHosting/EventStore.PluginHosting.csproj
+++ b/src/EventStore.PluginHosting/EventStore.PluginHosting.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Projections.Core.Javascript.Tests/EventStore.Projections.Core.Javascript.Tests.csproj
+++ b/src/EventStore.Projections.Core.Javascript.Tests/EventStore.Projections.Core.Javascript.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 
 		<IsPackable>false</IsPackable>
 

--- a/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
+++ b/src/EventStore.Projections.Core.Tests/EventStore.Projections.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_persistent_projection.cs
@@ -13,7 +13,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 		[Ignore("Persistent projections are admin only")]
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
 		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		public class Authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 			private ClaimsPrincipal _testUserPrincipal;
 
@@ -70,7 +70,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
 		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class anonymous<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		public class Anonymous<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 
 			private string _projectionBody = @"fromAll().when({$any:function(s,e){return s;}});";

--- a/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
+++ b/src/EventStore.Projections.Core.Tests/Services/projections_manager/runas/when_posting_a_transient_projection.cs
@@ -12,7 +12,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 	namespace when_posting_a_transient_projection {
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
 		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		public class Authenticated<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 			private ClaimsPrincipal _testUserPrincipal;
 
@@ -69,7 +69,7 @@ namespace EventStore.Projections.Core.Tests.Services.projections_manager.runas {
 
 		[TestFixture(typeof(LogFormat.V2), typeof(string))]
 		[TestFixture(typeof(LogFormat.V3), typeof(uint))]
-		public class anonymous<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
+		public class Anonymous<TLogFormat, TStreamId> : TestFixtureWithProjectionCoreAndManagementServices<TLogFormat, TStreamId> {
 			private string _projectionName;
 
 			private string _projectionBody = @"fromAll().when({$any:function(s,e){return s;}});";

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
+++ b/src/EventStore.SourceGenerators.Tests/EventStore.SourceGenerators.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<Platforms>x64;ARM64</Platforms>

--- a/src/EventStore.TestClient/EventStore.TestClient.csproj
+++ b/src/EventStore.TestClient/EventStore.TestClient.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<OutputType>Exe</OutputType>
 		<GenerateSupportedRuntime>false</GenerateSupportedRuntime>

--- a/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
+++ b/src/EventStore.Transport.Http/EventStore.Transport.Http.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>

--- a/src/EventStore.Transport.Tcp/EventStore.Transport.Tcp.csproj
+++ b/src/EventStore.Transport.Tcp/EventStore.Transport.Tcp.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>


### PR DESCRIPTION
Changed: Upgrade to .NET 7.

- [x] Possible breaking change, CPU usage changed from int to double have to check how dashboards are handling it. System metrics already use floating point so makes sense to use double instead of an integer.

The same configuration of Prometheus & Grafana could handle the switch from integer to double, so the change should have minimal impact.
![image](https://github.com/EventStore/EventStore/assets/7116354/b3c25e00-eeaf-4c10-9858-3eb21417d47c)
