### PR TITLE
[DOC-7] Fix links from security/configuration to installation doc

### DIFF
--- a/docs/security/configuration.md
+++ b/docs/security/configuration.md
@@ -2,7 +2,7 @@
 
 On this page you find all the configuration options related to in-flight security of EventStoreDB.
 
-The protocol security configuration depends a lot on the deployment topology and platform. We have created an interactive [configuration tool](../installation/README.md), which also has instructions on how to generate and install the certificates and configure EventStoreDB nodes to use them. 
+The protocol security configuration depends a lot on the deployment topology and platform. We have created an interactive [configuration tool](../installation.md), which also has instructions on how to generate and install the certificates and configure EventStoreDB nodes to use them.
 
 Below you can find more details about each of the available security options.
 
@@ -13,11 +13,11 @@ Unlike previous versions, EventStoreDB v20+ is secure by default. It means that 
 We realise that many users want to try out the latest version with their existing applications, and also run a previous version of EventStoreDB without any security in their internal networks.
 
 For this to work, you can use the `Insecure` option:
- 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--insecure` |
-| YAML                 | `Insecure` |
+
+| Format               | Syntax                |
+| :------------------- | :-------------------- |
+| Command line         | `--insecure`          |
+| YAML                 | `Insecure`            |
 | Environment variable | `EVENTSTORE_INSECURE` |
 
 **Default**: `false`
@@ -32,18 +32,17 @@ In this section, you can find settings related to protocol security (HTTPS and T
 
 ### Certificate common name
 
-SSL certificates can be created with a common name (CN), which is an arbitrary string. Usually is contains the DNS name for which the certificate is issued. When cluster nodes connect to each other, they need to ensure that they indeed talk to another node and not something that pretends to be a node. Therefore, EventStoreDB expects the connecting party to have a certificate with a pre-defined CN `eventstoredb-node`. 
+SSL certificates can be created with a common name (CN), which is an arbitrary string. Usually is contains the DNS name for which the certificate is issued. When cluster nodes connect to each other, they need to ensure that they indeed talk to another node and not something that pretends to be a node. Therefore, EventStoreDB expects the connecting party to have a certificate with a pre-defined CN `eventstoredb-node`.
 
 When using the Event Store [certificate generator](#certificate-generation-cli), the CN is properly set by default. However, you might want to change the CN and in this case, you'd also need to tell EventStoreDB what value it should expect instead of the default one, using the setting below:
- 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--certificate-reserved-node-common-name` |
-| YAML                 | `CertificateReservedNodeCommonName` |
+
+| Format               | Syntax                                             |
+| :------------------- | :------------------------------------------------- |
+| Command line         | `--certificate-reserved-node-common-name`          |
+| YAML                 | `CertificateReservedNodeCommonName`                |
 | Environment variable | `EVENTSTORE_CERTIFICATE_RESERVED_NODE_COMMON_NAME` |
 
 **Default**: `eventstoredb-node`
-
 
 ::: warning
 Server certificates **must** have the internal and external IP addresses or DNS names as subject alternative names.
@@ -55,10 +54,10 @@ When getting an incoming connection, the server needs to ensure if the certifica
 
 EventStoreDB will not use the default trusted root certificates store location of the platform. So, even if you use a certificate signed by a publicly trusted CA, you'd need to explicitly tell the node to use the OS default root certificate store. For certificates signed by a private CA, you just provide the path to the CA certificate file (but not the filename).
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--trusted-root-certificates-paths` |
-| YAML                 | `TrustedRootCertificatesPath` |
+| Format               | Syntax                                      |
+| :------------------- | :------------------------------------------ |
+| Command line         | `--trusted-root-certificates-paths`         |
+| YAML                 | `TrustedRootCertificatesPath`               |
 | Environment variable | `EVENTSTORE_TRUSTED_ROOT_CERTIFICATES_PATH` |
 
 **Default**: n/a
@@ -67,66 +66,68 @@ EventStoreDB will not use the default trusted root certificates store location o
 
 The `CertificateFile` setting needs to point to the certificate file, which will be used by the cluster node.
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--certificate-file` |
-| YAML                 | `CertificateFile` |
+| Format               | Syntax                        |
+| :------------------- | :---------------------------- |
+| Command line         | `--certificate-file`          |
+| YAML                 | `CertificateFile`             |
 | Environment variable | `EVENTSTORE_CERTIFICATE_FILE` |
 
 If the certificate file is protected by password, you'd need to set the `CertificatePassword` value accordingly, so the server can load the certificate.
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--certificate-password` |
-| YAML                 | `CertificatePassword` |
+| Format               | Syntax                            |
+| :------------------- | :-------------------------------- |
+| Command line         | `--certificate-password`          |
+| YAML                 | `CertificatePassword`             |
 | Environment variable | `EVENTSTORE_CERTIFICATE_PASSWORD` |
 
 If the certificate file doesn't contain the certificate private key, you need to tell the node where to find the key file using the `CertificatePrivateKeyFile` setting.
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--certificate-private-key-file` |
-| YAML                 | `CertificatePrivateKeyFile` |
+| Format               | Syntax                                    |
+| :------------------- | :---------------------------------------- |
+| Command line         | `--certificate-private-key-file`          |
+| YAML                 | `CertificatePrivateKeyFile`               |
 | Environment variable | `EVENTSTORE_CERTIFICATE_PRIVATE_KEY_FILE` |
 
 ::: warning RSA private key
 EventStoreDB expects the private key to be in RSA format. Check the first line of the key file and ensure that it looks like this:
+
 ```
 -----BEGIN RSA PRIVATE KEY-----
 ```
+
 If you have non-RSA private key, you can use `openssl` to convert it:
+
 ```bash
 openssl rsa -in privkey.pem -out privkeyrsa.pem
 ```
+
 :::
 
 ### Certificate store (Windows)
 
 The certificate store location is the location of the Windows certificate store, for example `CurrentUser`.
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--certificate-store-location` |
-| YAML                 | `CertificateStoreLocation` |
+| Format               | Syntax                                  |
+| :------------------- | :-------------------------------------- |
+| Command line         | `--certificate-store-location`          |
+| YAML                 | `CertificateStoreLocation`              |
 | Environment variable | `EVENTSTORE_CERTIFICATE_STORE_LOCATION` |
 
 The certificate store name is the name of the Windows certificate store, for example `My`.
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--certificate-store-name` |
-| YAML                 | `CertificateStoreName` |
+| Format               | Syntax                              |
+| :------------------- | :---------------------------------- |
+| Command line         | `--certificate-store-name`          |
+| YAML                 | `CertificateStoreName`              |
 | Environment variable | `EVENTSTORE_CERTIFICATE_STORE_NAME` |
 
 You need to add the certificate thumbprint setting on Windows so the server can ensure that it's using the correct certificate found in the certificates store.
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--certificate-thumbprint` |
-| YAML                 | `CertificateThumbprint` |
+| Format               | Syntax                              |
+| :------------------- | :---------------------------------- |
+| Command line         | `--certificate-thumbprint`          |
+| YAML                 | `CertificateThumbprint`             |
 | Environment variable | `EVENTSTORE_CERTIFICATE_THUMBPRINT` |
-
-
 
 ### Intermediate CA certificates
 
@@ -135,7 +136,9 @@ Intermediate certificates are supported by loading them from a [PEM](https://www
 Additionally, in order to improve performance, the server will also try to bypass intermediate certificate downloads, when they are available on the system in the appropriate locations:
 
 #### Steps on Linux:
+
 The following script assumes EventStoreDB is running under the `eventstore` account.
+
 ```
 sudo su eventstore --shell /bin/bash
 dotnet tool install --global dotnet-certificate-tool
@@ -143,20 +146,22 @@ dotnet tool install --global dotnet-certificate-tool
 ```
 
 #### Steps on Windows:
+
 To import the intermediate certificate in the Certificate store, run the following PowerShell under the same account as EventStoreDB is running:
+
 ```PowerShell
 Import-Certificate -FilePath .\path\to\intermediate.crt -CertStoreLocation Cert:\CurrentUser\CA
 ```
 
 To import the intermediate certificate in the `Local Computer` store, run the following as `Administrator`:
+
 ```PowerShell
 Import-Certificate -FilePath .\ca.crt -CertStoreLocation Cert:\LocalMachine\CA
 ```
 
-
 ## Certificate Generation CLI
 
-Event Store provides the interactive Certificate Generation CLI, which creates certificates signed by a private, auto-generated CA for EventStoreDB. You can use the [configuration wizard](../installation/README.md), that will provide you exact CLI commands that you need to run to generates certificates matching your configuration. 
+Event Store provides the interactive Certificate Generation CLI, which creates certificates signed by a private, auto-generated CA for EventStoreDB. You can use the [configuration wizard](../installation.md#configuration-wizard), that will provide you exact CLI commands that you need to run to generates certificates matching your configuration.
 
 ### Getting Started
 
@@ -181,18 +186,21 @@ If you are running EventStoreDB on Linux, remember that all certificate files sh
 Usually, you'd need to change rights for each certificate file to prevent the "permissions are too open" error.
 
 You can do it by running the following command:
+
 ```bash
 chmod 600 [file]
 ```
+
 :::
 
 #### Generating the CA certificate
 
-As the first step CA certificate needs to be generated. It'll need to be trusted for each of the nodes and client environment. 
+As the first step CA certificate needs to be generated. It'll need to be trusted for each of the nodes and client environment.
 
 By default, the tool will create the `ca` directory in the `certs` directory you created. Two keys will be generated:
+
 - `ca.crt` - public file that need to be used also for the nodes and client configuration,
-- `ca.key` - private key file that should be used only in the nodes configuration (**Do not copy it to client environment**). 
+- `ca.key` - private key file that should be used only in the nodes configuration (**Do not copy it to client environment**).
 
 CA certificate will be generated with pre-defined CN `eventstoredb-node`.
 
@@ -204,10 +212,10 @@ To generate CA certificate run:
 
 You can customise generated cert by providing following params:
 
-| Param | Description |
-| :------------------- | :----- |
+| Param   | Description                                                       |
+| :------ | :---------------------------------------------------------------- |
 | `-days` | The validity period of the certificate in days (default: 5 years) |
-| `-out` | The output directory (default: ./ca) |
+| `-out`  | The output directory (default: ./ca)                              |
 
 Example:
 
@@ -220,8 +228,9 @@ Example:
 You need to generate certificates signed by the CA for each node. They should be installed only on the specific node machine.
 
 By default, the tool will create the `ca` directory in the `certs` directory you created. Two keys will be generated:
+
 - `node.crt` - the public file that needs to be also used for the nodes and client configuration,
-- `node.key` - the private key file that should be used only in the node's configuration (**Do not copy it to client environment**). 
+- `node.key` - the private key file that should be used only in the node's configuration (**Do not copy it to client environment**).
 
 To generate node certificate run command:
 
@@ -231,21 +240,22 @@ To generate node certificate run command:
 
 You can customise generated cert by providing following params:
 
-| Param | Description |
-| :-- | :-- |
-| `-ca-certificate` | The path to the CA certificate file (default: `./ca/ca.crt`) |
-| `-ca-key` | The path to the CA key file (default: `./ca/ca.key`) |
-| `-days` | The output directory (default: `./nodeX` where X is an auto-generated number) |
-| `-out` | The output directory (default: `./ca`) |
-| `-ip-addresses` | Comma-separated list of IP addresses of the node |
-| `-dns-names` | Comma-separated list of DNS names of the node |
+| Param             | Description                                                                   |
+| :---------------- | :---------------------------------------------------------------------------- |
+| `-ca-certificate` | The path to the CA certificate file (default: `./ca/ca.crt`)                  |
+| `-ca-key`         | The path to the CA key file (default: `./ca/ca.key`)                          |
+| `-days`           | The output directory (default: `./nodeX` where X is an auto-generated number) |
+| `-out`            | The output directory (default: `./ca`)                                        |
+| `-ip-addresses`   | Comma-separated list of IP addresses of the node                              |
+| `-dns-names`      | Comma-separated list of DNS names of the node                                 |
 
 ::: warning
 While generating the certificate, you need to remember to pass internal end external:
-- IP addresses to `-ip-addresses`: e.g. `127.0.0.1,172.20.240.1` and/or 
+
+- IP addresses to `-ip-addresses`: e.g. `127.0.0.1,172.20.240.1` and/or
 - DNS names to `-dns-names`: e.g. `localhost,node1.eventstore`
-that will match the URLs that you will be accessing EventStoreDB nodes.
-:::
+  that will match the URLs that you will be accessing EventStoreDB nodes.
+  :::
 
 Sample:
 
@@ -285,7 +295,7 @@ services:
       - ./certs:/certs
 ```
 
-See more in the [complete sample of docker-compose secured cluster configuration.](../installation/docker.md#use-docker-compose)
+See more in the [complete sample of docker-compose secured cluster configuration.](../installation.md#use-docker-compose)
 
 ## Certificate installation on a client environment
 
@@ -293,14 +303,18 @@ To connect to EventStoreDB, you need to install the auto-generated CA certificat
 
 #### Linux (Ubuntu, Debian)
 
-1. Copy auto-generated CA file to dir `/usr/local/share/ca-certificates/`, e.g. using command: 
-  ```bash
-  sudo cp ca.crt /usr/local/share/ca-certificates/event_store_ca.crt
-  ```
-2. Update the CA store: 
-  ```bash
-  sudo update-ca-certificates
-  ```
+1. Copy auto-generated CA file to dir `/usr/local/share/ca-certificates/`, e.g. using command:
+
+```bash
+sudo cp ca.crt /usr/local/share/ca-certificates/event_store_ca.crt
+```
+
+2. Update the CA store:
+
+```bash
+sudo update-ca-certificates
+```
+
 #### Windows
 
 1. You can manually import it to the local CA cert store through `Certificates Local Machine Management Console`. To do that select **Run** from the **Start** menu, and then enter `certmgr.msc`. Then import certificate to `Trusted Root Certification`.
@@ -309,13 +323,14 @@ To connect to EventStoreDB, you need to install the auto-generated CA certificat
 ```powershell
 Import-Certificate -FilePath ".\certs\ca\ca.crt" -CertStoreLocation Cert:\CurrentUser\Root
 ```
+
 #### MacOS
 
 1. In the Keychain Access app on your Mac, select either the login or System keychain. Drag the certificate file onto the Keychain Access app. If you're asked to provide a name and password, type the name and password for an administrator user on this computer.
 2. You can also run the bash script:
 
 ```bash
-sudo security add-certificates -k /Library/Keychains/System.keychain ca.crt 
+sudo security add-certificates -k /Library/Keychains/System.keychain ca.crt
 ```
 
 ## TCP protocol security
@@ -324,19 +339,18 @@ Although TCP is disabled by default for external connections (clients), cluster 
 
 You can, however, disable TLS for both internal and external TCP.
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--disable-internal-tcp-tls` |
-| YAML                 | `DisableInternalTcpTls` |
+| Format               | Syntax                                |
+| :------------------- | :------------------------------------ |
+| Command line         | `--disable-internal-tcp-tls`          |
+| YAML                 | `DisableInternalTcpTls`               |
 | Environment variable | `EVENTSTORE_DISABLE_INTERNAL_TCP_TLS` |
 
 **Default**: `false`
 
-| Format               | Syntax |
-| :------------------- | :----- |
-| Command line         | `--disable-external-tcp-tls` |
-| YAML                 | `DisableExternalTcpTls` |
+| Format               | Syntax                                |
+| :------------------- | :------------------------------------ |
+| Command line         | `--disable-external-tcp-tls`          |
+| YAML                 | `DisableExternalTcpTls`               |
 | Environment variable | `EVENTSTORE_DISABLE_EXTERNAL_TCP_TLS` |
 
 **Default**: `false`
-

--- a/docs/security/configuration.md
+++ b/docs/security/configuration.md
@@ -10,7 +10,7 @@ Below you can find more details about each of the available security options.
 
 Unlike previous versions, EventStoreDB v20+ is secure by default. It means that you have to supply valid certificates and configuration for the database node to work.
 
-We realise that many users want to try out the latest version with their existing applications, and also run a previous version of EventStoreDB without any security in their internal networks.
+We realize that many users want to try out the latest version with their existing applications, and also run a previous version of EventStoreDB without any security in their internal networks.
 
 For this to work, you can use the `Insecure` option:
 
@@ -32,7 +32,7 @@ In this section, you can find settings related to protocol security (HTTPS and T
 
 ### Certificate common name
 
-SSL certificates can be created with a common name (CN), which is an arbitrary string. Usually is contains the DNS name for which the certificate is issued. When cluster nodes connect to each other, they need to ensure that they indeed talk to another node and not something that pretends to be a node. Therefore, EventStoreDB expects the connecting party to have a certificate with a pre-defined CN `eventstoredb-node`.
+SSL certificates can be created with a common name (CN), which is an arbitrary string. Usually it contains the DNS name for which the certificate is issued. When cluster nodes connect to each other, they need to ensure that they indeed talk to another node and not something that pretends to be a node. Therefore, EventStoreDB expects the connecting party to have a certificate with a pre-defined CN `eventstoredb-node`.
 
 When using the Event Store [certificate generator](#certificate-generation-cli), the CN is properly set by default. However, you might want to change the CN and in this case, you'd also need to tell EventStoreDB what value it should expect instead of the default one, using the setting below:
 
@@ -195,12 +195,12 @@ chmod 600 [file]
 
 #### Generating the CA certificate
 
-As the first step CA certificate needs to be generated. It'll need to be trusted for each of the nodes and client environment.
+As the first step, a CA certificate needs to be generated. It'll need to be trusted for each of the nodes and client environment.
 
 By default, the tool will create the `ca` directory in the `certs` directory you created. Two keys will be generated:
 
 - `ca.crt` - public file that need to be used also for the nodes and client configuration,
-- `ca.key` - private key file that should be used only in the nodes configuration (**Do not copy it to client environment**).
+- `ca.key` - private key file that should be used only in the nodes configuration (**Do not copy it to client environments**).
 
 CA certificate will be generated with pre-defined CN `eventstoredb-node`.
 
@@ -210,7 +210,7 @@ To generate CA certificate run:
 ./es-gencert-cli create-ca
 ```
 
-You can customise generated cert by providing following params:
+You can customize the generated cert by providing the following parameters:
 
 | Param   | Description                                                       |
 | :------ | :---------------------------------------------------------------- |
@@ -230,7 +230,7 @@ You need to generate certificates signed by the CA for each node. They should be
 By default, the tool will create the `ca` directory in the `certs` directory you created. Two keys will be generated:
 
 - `node.crt` - the public file that needs to be also used for the nodes and client configuration,
-- `node.key` - the private key file that should be used only in the node's configuration (**Do not copy it to client environment**).
+- `node.key` - the private key file that should be used only in the node's configuration (**Do not copy it to client environments**).
 
 To generate node certificate run command:
 
@@ -238,7 +238,7 @@ To generate node certificate run command:
 ./es-gencert-cli -help create_node
 ```
 
-You can customise generated cert by providing following params:
+You can customize the generated cert by providing the following parameters:
 
 | Param             | Description                                                                   |
 | :---------------- | :---------------------------------------------------------------------------- |
@@ -303,7 +303,7 @@ To connect to EventStoreDB, you need to install the auto-generated CA certificat
 
 #### Linux (Ubuntu, Debian)
 
-1. Copy auto-generated CA file to dir `/usr/local/share/ca-certificates/`, e.g. using command:
+1. Copy the auto-generated CA file to `/usr/local/share/ca-certificates/`, e.g. using command:
 
 ```bash
 sudo cp ca.crt /usr/local/share/ca-certificates/event_store_ca.crt
@@ -317,7 +317,7 @@ sudo update-ca-certificates
 
 #### Windows
 
-1. You can manually import it to the local CA cert store through `Certificates Local Machine Management Console`. To do that select **Run** from the **Start** menu, and then enter `certmgr.msc`. Then import certificate to `Trusted Root Certification`.
+1. You can manually import it to the local CA cert store through `Certificates Local Machine Management Console`. To do that select **Run** from the **Start** menu, and then enter `certmgr.msc`. Then import the certificate to `Trusted Root Certification`.
 2. You can also run the PowerShell script instead:
 
 ```powershell


### PR DESCRIPTION
The installation doc is not in an `installation/` directory in this version. Fixing links to follow the correct path.