### PR TITLE
[DB-550] Don't use ReadIndex when subscribing

### DIFF
--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -179,7 +179,7 @@ namespace EventStore.Core {
 						.AddSingleton<AuthorizationMiddleware>()
 						.AddSingleton(new KestrelToInternalBridgeMiddleware(_httpService.UriRouter, _httpService.LogHttpRequests, _httpService.AdvertiseAsHost, _httpService.AdvertiseAsPort))
 						.AddSingleton(_readIndex)
-						.AddSingleton(new Streams<TStreamId>(_mainQueue, _readIndex, _maxAppendSize,
+						.AddSingleton(new Streams<TStreamId>(_mainQueue, _maxAppendSize,
 							_writeTimeout, _expiryStrategy,
 							_trackers.GrpcTrackers,
 							_authorizationProvider))

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.cs
@@ -24,7 +24,6 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			private readonly IEventFilter _eventFilter;
 			private readonly ClaimsPrincipal _user;
 			private readonly bool _requiresLeader;
-			private readonly IReadIndex _readIndex;
 			private readonly DateTime _deadline;
 			private readonly uint _maxSearchWindow;
 			private readonly CancellationToken _cancellationToken;
@@ -42,7 +41,6 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 				IEventFilter eventFilter,
 				ClaimsPrincipal user,
 				bool requiresLeader,
-				IReadIndex readIndex,
 				uint? maxSearchWindow,
 				DateTime deadline,
 				CancellationToken cancellationToken) {
@@ -54,17 +52,12 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 					throw new ArgumentNullException(nameof(eventFilter));
 				}
 
-				if (readIndex == null) {
-					throw new ArgumentNullException(nameof(readIndex));
-				}
-
 				_bus = bus;
 				_maxCount = maxCount;
 				_resolveLinks = resolveLinks;
 				_eventFilter = eventFilter;
 				_user = user;
 				_requiresLeader = requiresLeader;
-				_readIndex = readIndex;
 				_maxSearchWindow = maxSearchWindow ?? ReadBatchSize;
 				_deadline = deadline;
 				_cancellationToken = cancellationToken;

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.cs
@@ -24,7 +24,6 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			private readonly IEventFilter _eventFilter;
 			private readonly ClaimsPrincipal _user;
 			private readonly bool _requiresLeader;
-			private readonly IReadIndex _readIndex;
 			private readonly DateTime _deadline;
 			private readonly uint _maxSearchWindow;
 			private readonly CancellationToken _cancellationToken;
@@ -42,7 +41,6 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 				IEventFilter eventFilter,
 				ClaimsPrincipal user,
 				bool requiresLeader,
-				IReadIndex readIndex,
 				uint? maxSearchWindow,
 				DateTime deadline,
 				CancellationToken cancellationToken) {
@@ -54,17 +52,12 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 					throw new ArgumentNullException(nameof(eventFilter));
 				}
 
-				if (readIndex == null) {
-					throw new ArgumentNullException(nameof(readIndex));
-				}
-
 				_bus = bus;
 				_maxCount = maxCount;
 				_resolveLinks = resolveLinks;
 				_eventFilter = eventFilter;
 				_user = user;
 				_requiresLeader = requiresLeader;
-				_readIndex = readIndex;
 				_maxSearchWindow = maxSearchWindow ?? ReadBatchSize;
 				_deadline = deadline;
 				_cancellationToken = cancellationToken;

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -146,7 +146,6 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						ConvertToEventFilter(true, request.Options.Filter),
 						user,
 						requiresLeader,
-						_readIndex,
 						request.Options.Filter.WindowCase switch {
 							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
 							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
@@ -178,7 +177,6 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						ConvertToEventFilter(true, request.Options.Filter),
 						user,
 						requiresLeader,
-						_readIndex,
 						request.Options.Filter.WindowCase switch {
 							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
 							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter
@@ -209,7 +207,6 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						request.Options.ResolveLinks,
 						user,
 						requiresLeader,
-						_readIndex,
 						cancellationToken),
 				(StreamOptionOneofCase.All,
 					CountOptionOneofCase.Subscription,
@@ -222,7 +219,6 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						ConvertToEventFilter(true, request.Options.Filter),
 						user,
 						requiresLeader,
-						_readIndex,
 						request.Options.Filter.WindowCase switch {
 							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Count => null,
 							ReadReq.Types.Options.Types.FilterOptions.WindowOneofCase.Max => request.Options.Filter

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.cs
@@ -8,7 +8,6 @@ using EventStore.Plugins.Authorization;
 namespace EventStore.Core.Services.Transport.Grpc {
 	internal partial class Streams<TStreamId> : EventStore.Client.Streams.Streams.StreamsBase {
 		private readonly IPublisher _publisher;
-		private readonly IReadIndex<TStreamId> _readIndex;
 		private readonly int _maxAppendSize;
 		private readonly TimeSpan _writeTimeout;
 		private readonly IExpiryStrategy _expiryStrategy;
@@ -22,14 +21,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		private static readonly Operation WriteOperation = new Operation(Plugins.Authorization.Operations.Streams.Write);
 		private static readonly Operation DeleteOperation = new Operation(Plugins.Authorization.Operations.Streams.Delete);
 
-		public Streams(IPublisher publisher, IReadIndex<TStreamId> readIndex, int maxAppendSize, TimeSpan writeTimeout,
+		public Streams(IPublisher publisher, int maxAppendSize, TimeSpan writeTimeout,
 			IExpiryStrategy expiryStrategy,
 			GrpcTrackers trackers,
 			IAuthorizationProvider provider) {
 	
 			if (publisher == null) throw new ArgumentNullException(nameof(publisher));
 			_publisher = publisher;
-			_readIndex = readIndex;
 			_maxAppendSize = maxAppendSize;
 			_writeTimeout = writeTimeout;
 			_expiryStrategy = expiryStrategy;


### PR DESCRIPTION
Changed: Don't require ReadIndex in the enumerators when subscribing from $all

Instead, read from the provided position and skip the first event.