### PR TITLE
Respond correctly when batch appending idempotent write to deleted stream (DB-535)

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/BatchAppendResp.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/BatchAppendResp.cs
@@ -15,7 +15,7 @@ namespace EventStore.Client.Streams {
 							CommitPosition = (ulong)commitPosition,
 							PreparePosition = (ulong)preparePosition
 						},
-						_ => null,
+						_ => new Google.Protobuf.WellKnownTypes.Empty()
 					},
 					currentRevisionOptionCase_ = currentVersion switch {
 						>= 0 => CurrentRevisionOptionOneofCase.CurrentRevision,


### PR DESCRIPTION
Fixed: 'Unknown' error reported to client after successful idempotent write to deleted stream.

Before this fix the null value here resulted in a NRE when sending the proto message.

The server did correctly identify that the write was idempotent and not append any more events. The IndexWriter then returns -1 as the position of the existing event because it is deleted, and this was not being correctly represented in the batch append proto message.

#4058