### PR TITLE
Fix: Point to Pypi for Python client and organize client listing and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,22 @@ EventStoreDB supports two protocols: gRPC and TCP(legacy).
 
 EventStoreDB supported gRPC clients
 
-- Go: [EventStore/EventStore-Client-Go](https://github.com/EventStore/EventStore-Client-Go)
-- .NET: [EventStore/EventStore-Client-Dotnet](https://github.com/EventStore/EventStore-Client-Dotnet)
-- Java: [(EventStore/EventStoreDB-Client-Java](https://github.com/EventStore/EventStoreDB-Client-Java)
+- Python: [pyeventsourcing/esdbclient](https://pypi.org/project/esdbclient/)
 - Node.js (javascript/typescript): [EventStore/EventStore-Client-NodeJS](https://github.com/EventStore/EventStore-Client-NodeJS)
+- Java: [(EventStore/EventStoreDB-Client-Java](https://github.com/EventStore/EventStoreDB-Client-Java)
+- .NET: [EventStore/EventStore-Client-Dotnet](https://github.com/EventStore/EventStore-Client-Dotnet)
+- Go: [EventStore/EventStore-Client-Go](https://github.com/EventStore/EventStore-Client-Go)
 - Rust: [EventStore/EventStoreDB-Client-Rust](https://github.com/EventStore/EventStoreDB-Client-Rust)
 - Read more in the [gRPC clients documentation](https://developers.eventstore.com/clients/grpc)
 
 Community supported gRPC clients
 
 - Elixir: [NFIBrokerage/spear](https://github.com/NFIBrokerage/spear)
-- Python: (coming soon)
 - Ruby: [yousty/event_store_client](https://github.com/yousty/event_store_client)
 
 Read more in the [documentation](https://developers.eventstore.com/server/v22.10/#protocols-clients-and-sdks).
 
-Legacy TCP Clients
+Legacy TCP Clients (support ends with 23.10 LTS)
 
 - .Net: [EventStoreDB-Client-Dotnet-Legacy](https://github.com/EventStore/EventStoreDB-Client-Dotnet-Legacy)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,11 +43,12 @@ We recommend using gRPC since it is the primary protocol for EventStoreDB moving
 
 #### EventStoreDB supported clients
 
-- [.NET (EventStore/EventStore-Client-Dotnet)](https://github.com/EventStore/EventStore-Client-Dotnet)
-- [Java (EventStore/EventStoreDB-Client-Java)](https://github.com/EventStore/EventStoreDB-Client-Java)
-- [Node.js (EventStore/EventStore-Client-NodeJS)](https://github.com/EventStore/EventStore-Client-NodeJS)
-- [Go (EventStore/EventStore-Client-Go)](https://github.com/EventStore/EventStore-Client-Go)
-- [Rust (EventStore/EventStoreDB-Client-Rust)](https://github.com/EventStore/EventStoreDB-Client-Rust)
+- Python: [pyeventsourcing/esdbclient](https://pypi.org/project/esdbclient/)
+- Node.js (javascript/typescript): [EventStore/EventStore-Client-NodeJS](https://github.com/EventStore/EventStore-Client-NodeJS)
+- Java: [(EventStore/EventStoreDB-Client-Java](https://github.com/EventStore/EventStoreDB-Client-Java)
+- .NET: [EventStore/EventStore-Client-Dotnet](https://github.com/EventStore/EventStore-Client-Dotnet)
+- Go: [EventStore/EventStore-Client-Go](https://github.com/EventStore/EventStore-Client-Go)
+- Rust: [EventStore/EventStoreDB-Client-Rust](https://github.com/EventStore/EventStoreDB-Client-Rust)
 
 Read more in the [gRPC clients documentation](@clients/grpc/README.md).
 
@@ -56,7 +57,7 @@ Read more in the [gRPC clients documentation](@clients/grpc/README.md).
 - [Ruby (yousty/event_store_client)](https://github.com/yousty/event_store_client)
 - [Elixir (NFIBrokerage/spear)](https://github.com/NFIBrokerage/spear)
 
-### TCP protocol
+### Legacy TCP protocol (support ends with 23.10 LTS)
 
 EventStoreDB offers a low-level protocol in the form of an asynchronous TCP protocol that exchanges protobuf objects. At present this protocol has adapters for .NET and the JVM.
 
@@ -99,7 +100,4 @@ As the AtomPub protocol doesn't get any changes, you can use the v5 [HTTP API do
 #### Community developed clients
 
 - [PHP (prooph/event-store-http-client)](https://github.com/prooph/event-store-http-client/)
-- [Python (madedotcom/atomicpuppy)](https://github.com/madedotcom/atomicpuppy)
-- [Ruby (arkency/http_eventstore)](https://github.com/arkency/http_eventstore)
-- [Go (jetbasrawi/go.geteventstore)](https://github.com/jetbasrawi/go.geteventstore)
 - [Ruby (yousty/event_store_client)](https://github.com/yousty/event_store_client)


### PR DESCRIPTION
Point to Pypi for Python client and organize client listing and clean up community supported clients and other bits.