### PR TITLE
[release/oss-v21.10] Fix reported version with annotated tag

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -63,7 +63,7 @@ namespace EventStore.ClusterNode {
 				}
 
 				Log.Information("\n{description,-25} {version} ({branch}/{hashtag}, {timestamp})", "ES VERSION:",
-					VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp);
+					VersionInfo.Version, VersionInfo.Tag, VersionInfo.Hashtag, VersionInfo.Timestamp);
 				Log.Information("{description,-25} {osArchitecture} ", "OS ARCHITECTURE:",
 					RuntimeInformation.OSArchitecture);
 				Log.Information("{description,-25} {osFlavor} ({osVersion})", "OS:", OS.OsFlavor,

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -13,7 +13,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="GitInfo" Version="2.0.26">
+		<PackageReference Include="GitInfo" Version="3.3.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>

--- a/src/EventStore.Common/Utils/VersionInfo.cs
+++ b/src/EventStore.Common/Utils/VersionInfo.cs
@@ -5,10 +5,10 @@ namespace EventStore.Common.Utils {
 		public static string Version => typeof(VersionInfo).Assembly
 			.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? "0.0.0.0";
 
-		public static string Branch => ThisAssembly.Git.Branch;
+		public static string Tag => ThisAssembly.Git.Tag;
 		public static string Hashtag => ThisAssembly.Git.Commit;
-		public static readonly string Timestamp = "Unknown";
+		public static readonly string Timestamp = ThisAssembly.Git.CommitDate;
 
-		public static string Text => $"EventStoreDB version {Version} ({Branch}/{Hashtag}, {Timestamp})";
+		public static string Text => $"EventStoreDB version {Version} ({Tag}/{Hashtag}, {Timestamp})";
 	}
 }

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -163,7 +163,7 @@ namespace EventStore.Core.Tests.Helpers {
 			Log.Information(
 				"\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"
 				+ "{11,-25} {12}\n" + "{13,-25} {14}\n" + "{15,-25} {16}\n" + "{17,-25} {18}\n\n",
-				"ES VERSION:", VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp,
+				"ES VERSION:", VersionInfo.Version, VersionInfo.Tag, VersionInfo.Hashtag, VersionInfo.Timestamp,
 				"OS:", OS.OsFlavor, Environment.OSVersion, "RUNTIME:", OS.GetRuntimeVersion(),
 				Marshal.SizeOf(typeof(IntPtr)) * 8, "GC:",
 				GC.MaxGeneration == 0

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -141,7 +141,7 @@ namespace EventStore.Core.Tests.Helpers {
 					 + "{13,-25} {14}\n"
 					 + "{15,-25} {16}\n"
 					 + "{17,-25} {18}\n\n",
-				"ES VERSION:", VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp,
+				"ES VERSION:", VersionInfo.Version, VersionInfo.Tag, VersionInfo.Hashtag, VersionInfo.Timestamp,
 				"OS:", OS.OsFlavor, Environment.OSVersion,
 				"RUNTIME:", OS.GetRuntimeVersion(), Marshal.SizeOf(typeof(IntPtr)) * 8,
 				"GC:",

--- a/src/EventStore.Core.Tests/TestsInitFixture.cs
+++ b/src/EventStore.Core.Tests/TestsInitFixture.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests {
 					 + "{5,-25} {6} ({7})\n"
 					 + "{8,-25} {9} ({10}-bit)\n"
 					 + "{11,-25} {12}\n\n",
-				"ES VERSION:", VersionInfo.Version, VersionInfo.Branch, VersionInfo.Hashtag, VersionInfo.Timestamp,
+				"ES VERSION:", VersionInfo.Version, VersionInfo.Tag, VersionInfo.Hashtag, VersionInfo.Timestamp,
 				"OS:", OS.OsFlavor, Environment.OSVersion,
 				"RUNTIME:", OS.GetRuntimeVersion(), Marshal.SizeOf(typeof(IntPtr)) * 8,
 				"GC:",


### PR DESCRIPTION
Fixed: Report same version info when using different kind of release tags (annotated or lightweight).

Cherry picked from https://github.com/EventStore/EventStore/pull/3950