### PR TITLE
Remove ConfigureAwait(false) calls and analyzer (DB-549)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -178,30 +178,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-## ConfigureAwaitChecker
-
-MIT License
-
-Copyright (c) 2017 Jiri Cincura
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 ## Google protobuf
 
 Copyright 2008 Google Inc.  All rights reserved.

--- a/src/EventStore.Common.Utils/EventStore.Common.Utils.csproj
+++ b/src/EventStore.Common.Utils/EventStore.Common.Utils.csproj
@@ -4,10 +4,4 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Platforms>x64;ARM64</Platforms>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
 </Project>

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -9,10 +9,6 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="GitInfo" Version="3.3.3">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -233,8 +233,7 @@ namespace EventStore.Core.Tests.Helpers {
 			}
 
 			await _host.StartAsync().WithTimeout();
-			await Node.StartAsync(true).WithTimeout(TimeSpan.FromSeconds(60))
-				.ConfigureAwait(false); //starts the node
+			await Node.StartAsync(true).WithTimeout(TimeSpan.FromSeconds(60)); //starts the node
 
 			await Started.WithTimeout();
 			
@@ -250,7 +249,7 @@ namespace EventStore.Core.Tests.Helpers {
 			_kestrelTestServer.Dispose();
 			HttpMessageHandler.Dispose();
 			HttpClient.Dispose();
-			await Node.StopAsync(TimeSpan.FromSeconds(20)).ConfigureAwait(false);
+			await Node.StopAsync(TimeSpan.FromSeconds(20));
 
 			if (!keepDb)
 				TryDeleteDirectory(DbPath);

--- a/src/EventStore.Core.Tests/Http/HealthChecks/when_performing_a_live_check.cs
+++ b/src/EventStore.Core.Tests/Http/HealthChecks/when_performing_a_live_check.cs
@@ -48,8 +48,7 @@ namespace EventStore.Core.Tests.Http.HealthChecks {
 		[TestCaseSource(nameof(MethodAllowedTestCases))]
 		public async Task after_start_returns_success(HttpMethod method) {
 			await _node.Start()
-				.WithTimeout()
-				.ConfigureAwait(false);
+				.WithTimeout();
 			_nodeStarted = true;
 			using var response = await _node.HttpClient.SendAsync(new HttpRequestMessage(method, "/health/live") {
 				Version = new Version(2, 0)
@@ -62,12 +61,10 @@ namespace EventStore.Core.Tests.Http.HealthChecks {
 		[TestCaseSource(nameof(MethodAllowedTestCases))]
 		public async Task after_shutdown_returns_error(HttpMethod method) {
 			await _node.Start()
-				.WithTimeout()
-				.ConfigureAwait(false);
+				.WithTimeout();
 			_nodeStarted = true;
 			await _node.Node.StopAsync()
-				.WithTimeout()
-				.ConfigureAwait(false);
+				.WithTimeout();
 
 			using var response = await _node.HttpClient.SendAsync(new HttpRequestMessage(method, "/health/live"));
 
@@ -77,8 +74,7 @@ namespace EventStore.Core.Tests.Http.HealthChecks {
 		[TestCaseSource(nameof(MethodNotAllowedTestCases))]
 		public async Task using_methods_other_than_get_or_head_returns_method_not_allowed(HttpMethod method) {
 			await _node.Start()
-				.WithTimeout()
-				.ConfigureAwait(false);
+				.WithTimeout();
 			_nodeStarted = true;
 			using var response = await _node.HttpClient.SendAsync(new HttpRequestMessage(method, "/health/live"));
 

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/EnumeratorsTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/EnumeratorsTests.cs
@@ -437,7 +437,7 @@ public class EnumeratorsTests {
 		public ValueTask DisposeAsync() => _enumerator.DisposeAsync();
 
 		public async Task<SubscriptionResponse> GetNext() {
-			if (!await _enumerator.MoveNextAsync().ConfigureAwait(false)) {
+			if (!await _enumerator.MoveNextAsync()) {
 				throw new Exception("No more items in enumerator");
 			}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/GetInfoTests.cs
@@ -57,7 +57,7 @@ namespace EventStore.Core.Tests.Services.Transport.Grpc.PersistentSubscriptionTe
 					}
 				});
 
-				await call.ResponseStream.MoveNext().ConfigureAwait(false);
+				await call.ResponseStream.MoveNext();
 				
 				Assert.IsTrue(call.ResponseStream.Current.ContentCase == ReadResp.ContentOneofCase.SubscriptionConfirmation);
 

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/ReplayParkedTests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/PersistentSubscriptionTests/ReplayParkedTests.cs
@@ -279,8 +279,8 @@ namespace EventStore.Core.Tests.Services.Transport.Grpc.PersistentSubscriptionTe
 						Structured = new Empty()
 					}
 				}
-			}).ConfigureAwait(false);
-			if (!await call.ResponseStream.MoveNext().ConfigureAwait(false) ||
+			});
+			if (!await call.ResponseStream.MoveNext() ||
 				call.ResponseStream.Current.ContentCase != ReadResp.ContentOneofCase.SubscriptionConfirmation) {
 				throw new InvalidOperationException();
 			}

--- a/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Grpc/StreamsTests/GrpcSpecification.cs
@@ -134,7 +134,7 @@ namespace EventStore.Core.Tests.Services.Transport.Grpc.StreamsTests {
 
 			public void Start() =>
 				Task.Run(async () => {
-					while (await BatchAppend.ResponseStream.MoveNext().ConfigureAwait(false)) {
+					while (await BatchAppend.ResponseStream.MoveNext()) {
 						var response = BatchAppend.ResponseStream.Current;
 						var correlationId = Uuid.FromDto(response.CorrelationId);
 

--- a/src/EventStore.Core/Authorization/AndAssertion.cs
+++ b/src/EventStore.Core/Authorization/AndAssertion.cs
@@ -41,7 +41,7 @@ namespace EventStore.Core.Authorization {
 		private async ValueTask<bool> EvaluateAsync(ValueTask<bool> pending, ReadOnlyMemory<IAssertion> remaining,
 			ClaimsPrincipal cp, Operation operation, PolicyInformation policy, EvaluationContext result) {
 			bool evaluated;
-			while ((evaluated = await pending.ConfigureAwait(false)) && !remaining.IsEmpty) {
+			while ((evaluated = await pending) && !remaining.IsEmpty) {
 				pending = remaining.Span[0].Evaluate(cp, operation, policy, result);
 				remaining = remaining.Slice(1);
 			}

--- a/src/EventStore.Core/Authorization/LegacyStreamPermissionAssertion.cs
+++ b/src/EventStore.Core/Authorization/LegacyStreamPermissionAssertion.cs
@@ -34,8 +34,8 @@ namespace EventStore.Core.Authorization {
 
 		private async ValueTask<bool> CheckStreamAccessAsync(ValueTask<string> pending, ClaimsPrincipal cp,
 			Operation operation, PolicyInformation policy, EvaluationContext result) {
-			var streamId = await pending.ConfigureAwait(false);
-			return await CheckStreamAccess(cp, operation, policy, result, streamId).ConfigureAwait(false);
+			var streamId = await pending;
+			return await CheckStreamAccess(cp, operation, policy, result, streamId);
 		}
 
 		private ValueTask<bool> CheckStreamAccess(ClaimsPrincipal cp, Operation operation, PolicyInformation policy,
@@ -100,18 +100,17 @@ namespace EventStore.Core.Authorization {
 		private async ValueTask<bool> IsSystemOrAdminAsync(ValueTask<bool> isSystem, ClaimsPrincipal cp,
 			Operation operation,
 			PolicyInformation policy, EvaluationContext context) {
-			if (await isSystem.ConfigureAwait(false)) return true;
+			if (await isSystem) return true;
 
-			return await WellKnownAssertions.Admin.Evaluate(cp, operation, policy, context).ConfigureAwait(false);
+			return await WellKnownAssertions.Admin.Evaluate(cp, operation, policy, context);
 		}
 
 		private async ValueTask<bool> CheckAsync(ValueTask<bool> preChecks, ClaimsPrincipal cp, string action,
 			string streamId, PolicyInformation policy, EvaluationContext context) {
-			var isSystemOrAdmin = await preChecks.ConfigureAwait(false);
+			var isSystemOrAdmin = await preChecks;
 			if (isSystemOrAdmin)
 				return true;
-			var acl = await StorageMessage.EffectiveAcl.LoadAsync(_publisher, streamId, context.CancellationToken)
-				.ConfigureAwait(false);
+			var acl = await StorageMessage.EffectiveAcl.LoadAsync(_publisher, streamId, context.CancellationToken);
 			var roles = RolesFor(action, acl);
 			if (roles.Any(x => x == SystemRoles.All)) {
 				context.Add(new AssertionMatch(policy,

--- a/src/EventStore.Core/Authorization/OrAssertion.cs
+++ b/src/EventStore.Core/Authorization/OrAssertion.cs
@@ -34,7 +34,7 @@ namespace EventStore.Core.Authorization {
 		private async ValueTask<bool> EvaluateAsync(ValueTask<bool> pending, ReadOnlyMemory<IAssertion> remaining,
 			ClaimsPrincipal cp, Operation operation, PolicyInformation policy, EvaluationContext result) {
 			bool evaluated;
-			while (!(evaluated = await pending.ConfigureAwait(false)) && !remaining.IsEmpty) {
+			while (!(evaluated = await pending) && !remaining.IsEmpty) {
 				pending = remaining.Span[0].Evaluate(cp, operation, policy, result);
 				remaining = remaining.Slice(1);
 			}

--- a/src/EventStore.Core/Authorization/PolicyAuthorizationProvider.cs
+++ b/src/EventStore.Core/Authorization/PolicyAuthorizationProvider.cs
@@ -37,7 +37,7 @@ namespace EventStore.Core.Authorization {
 		private async ValueTask<bool> CheckAccessAsync(TimeSpan startedAt, ClaimsPrincipal cp,
 			ValueTask<EvaluationResult> evaluationTask) {
 			try {
-				return LogAndCheck(startedAt, cp, await evaluationTask.ConfigureAwait(false));
+				return LogAndCheck(startedAt, cp, await evaluationTask);
 			} catch (Exception ex) when (ex is not OperationCanceledException) {
 				_logger.Error(ex, "Error performing permission check for {identity}",
 					cp.FindFirst(ClaimTypes.Name)?.Value ?? "unknown");

--- a/src/EventStore.Core/Authorization/PolicyEvaluator.cs
+++ b/src/EventStore.Core/Authorization/PolicyEvaluator.cs
@@ -45,7 +45,7 @@ namespace EventStore.Core.Authorization {
 			CancellationToken ct) {
 			do {
 				if (ct.IsCancellationRequested) break;
-				await pending.ConfigureAwait(false);
+				await pending;
 				if (ct.IsCancellationRequested) break;
 				if (assertions.IsEmpty) break;
 				pending = assertions.Span[0].Evaluate(cp, operation, _policyInfo, evaluationContext);

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.Elections.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.Elections.cs
@@ -101,7 +101,7 @@ namespace EventStore.Core.Cluster {
 				ServerHttp = new GossipEndPoint(serverHttpEndPoint.GetHost(), (uint)serverHttpEndPoint.GetPort()),
 				AttemptedView = attemptedView
 			};
-			await _electionsClient.ViewChangeAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+			await _electionsClient.ViewChangeAsync(request, deadline: deadline.ToUniversalTime());
 		}
 
 		private async Task SendViewChangeProofAsync(Guid serverId, EndPoint serverHttpEndPoint, int installedView,
@@ -111,7 +111,7 @@ namespace EventStore.Core.Cluster {
 				ServerHttp = new GossipEndPoint(serverHttpEndPoint.GetHost(), (uint)serverHttpEndPoint.GetPort()),
 				InstalledView = installedView
 			};
-			await _electionsClient.ViewChangeProofAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+			await _electionsClient.ViewChangeProofAsync(request, deadline: deadline.ToUniversalTime());
 		}
 
 		private async Task SendPrepareAsync(Guid serverId, EndPoint serverHttpEndPoint, int view, DateTime deadline) {
@@ -120,7 +120,7 @@ namespace EventStore.Core.Cluster {
 				ServerHttp = new GossipEndPoint(serverHttpEndPoint.GetHost(), (uint)serverHttpEndPoint.GetPort()),
 				View = view
 			};
-			await _electionsClient.PrepareAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+			await _electionsClient.PrepareAsync(request, deadline: deadline.ToUniversalTime());
 		}
 
 		private async Task SendPrepareOkAsync(int view, Guid serverId, EndPoint serverHttpEndPoint, int epochNumber,
@@ -140,7 +140,7 @@ namespace EventStore.Core.Cluster {
 				NodePriority = nodePriority,
 				ClusterInfo = ClusterInfo.ToGrpcClusterInfo(clusterInfo)
 			};
-			await _electionsClient.PrepareOkAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+			await _electionsClient.PrepareOkAsync(request, deadline: deadline.ToUniversalTime());
 		}
 
 		private async Task SendProposalAsync(Guid serverId, EndPoint serverHttpEndPoint, Guid leaderId,
@@ -162,7 +162,7 @@ namespace EventStore.Core.Cluster {
 				ChaserCheckpoint = chaserCheckpoint,
 				NodePriority = nodePriority
 			};
-			await _electionsClient.ProposalAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+			await _electionsClient.ProposalAsync(request, deadline: deadline.ToUniversalTime());
 		}
 
 		private async Task SendAcceptAsync(Guid serverId, EndPoint serverHttpEndPoint, Guid leaderId,
@@ -174,7 +174,7 @@ namespace EventStore.Core.Cluster {
 				LeaderHttp = new GossipEndPoint(leaderHttp.GetHost(), (uint)leaderHttp.GetPort()),
 				View = view
 			};
-			await _electionsClient.AcceptAsync(request).ConfigureAwait(false);
+			await _electionsClient.AcceptAsync(request);
 			_electionsClient.Accept(request, deadline: deadline.ToUniversalTime());
 		}
 
@@ -183,7 +183,7 @@ namespace EventStore.Core.Cluster {
 				LeaderId = Uuid.FromGuid(leaderId).ToDto(),
 				LeaderHttp = new GossipEndPoint(leaderHttp.GetHost(), (uint)leaderHttp.GetPort()),
 			};
-			await _electionsClient.LeaderIsResigningAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+			await _electionsClient.LeaderIsResigningAsync(request, deadline: deadline.ToUniversalTime());
 		}
 
 		private async Task SendLeaderIsResigningOkAsync(Guid leaderId, EndPoint leaderHttp,
@@ -194,7 +194,7 @@ namespace EventStore.Core.Cluster {
 				ServerId = Uuid.FromGuid(serverId).ToDto(),
 				ServerHttp = new GossipEndPoint(serverHttpEndPoint.GetHost(), (uint)serverHttpEndPoint.GetPort()),
 			};
-			await _electionsClient.LeaderIsResigningOkAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+			await _electionsClient.LeaderIsResigningOkAsync(request, deadline: deadline.ToUniversalTime());
 		}
 	}
 }

--- a/src/EventStore.Core/Cluster/EventStoreClusterClient.Gossip.cs
+++ b/src/EventStore.Core/Cluster/EventStoreClusterClient.Gossip.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Cluster {
 				async response => {
 					try {
 						_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(_ => { }),
-							await response.ConfigureAwait(false), destinationEndpoint));
+							await response, destinationEndpoint));
 					} catch (Exception ex) {
 						_bus.Publish(new GossipMessage.GossipSendFailed(ex.Message, destinationEndpoint));
 					}
@@ -29,7 +29,7 @@ namespace EventStore.Core.Cluster {
 		public void GetGossip(EndPoint destinationEndpoint, DateTime deadline) {
 			GetGossipAsync(deadline).ContinueWith(async response => {
 				try {
-					_bus.Publish(new GossipMessage.GetGossipReceived(await response.ConfigureAwait(false),
+					_bus.Publish(new GossipMessage.GetGossipReceived(await response,
 						destinationEndpoint));
 				} catch (Exception ex) {
 					_bus.Publish(new GossipMessage.GetGossipFailed(ex.Message, destinationEndpoint));
@@ -46,7 +46,7 @@ namespace EventStore.Core.Cluster {
 					Info = ClusterInfo.ToGrpcClusterInfo(clusterInfo),
 					Server = new GossipEndPoint(server.GetHost(), (uint)server.GetPort())
 				};
-				var clusterInfoDto = await _gossipClient.UpdateAsync(request, deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+				var clusterInfoDto = await _gossipClient.UpdateAsync(request, deadline: deadline.ToUniversalTime());
 				return ClusterInfo.FromGrpcClusterInfo(clusterInfoDto, _clusterDns);
 			}
 			catch (Exception ex) {
@@ -58,7 +58,7 @@ namespace EventStore.Core.Cluster {
 		private async Task<ClusterInfo> GetGossipAsync(DateTime deadline) {
 			using var duration = _gossipGetTracker.Start();
 			try {
-				var clusterInfoDto = await _gossipClient.ReadAsync(new Empty(), deadline: deadline.ToUniversalTime()).ConfigureAwait(false);
+				var clusterInfoDto = await _gossipClient.ReadAsync(new Empty(), deadline: deadline.ToUniversalTime());
 				return ClusterInfo.FromGrpcClusterInfo(clusterInfoDto, _clusterDns);
 			} catch (Exception ex) {
 				duration.SetException(ex);

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1689,10 +1689,10 @@ namespace EventStore.Core {
 
 			var cts = new CancellationTokenSource();
 
-			await using var _ = cts.Token.Register(() => _shutdownSource.TrySetCanceled(cancellationToken)).ConfigureAwait(false);
+			await using var _ = cts.Token.Register(() => _shutdownSource.TrySetCanceled(cancellationToken));
 
 			cts.CancelAfter(timeout.Value);
-			await _shutdownSource.Task.ConfigureAwait(false);
+			await _shutdownSource.Task;
 			_switchChunksLock?.Dispose();
 		}
 
@@ -1764,7 +1764,7 @@ namespace EventStore.Core {
 
 			Start();
 
-			return await tcs.Task.ConfigureAwait(false);
+			return await tcs.Task;
 		}
 
 		public static ValueTuple<bool, string> ValidateServerCertificate(X509Certificate certificate,

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -10,10 +10,6 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="EventStore.Plugins" Version="23.10.1" />
 		<PackageReference Include="Google.Protobuf" Version="3.25.0" />
 		<PackageReference Include="Grpc.AspNetCore" Version="2.59.0" />

--- a/src/EventStore.Core/LogAbstraction/Common/Debouncer.cs
+++ b/src/EventStore.Core/LogAbstraction/Common/Debouncer.cs
@@ -29,10 +29,10 @@ namespace EventStore.Core.LogAbstraction.Common {
 
 		async Task RunAsync() {
 			while (true) {
-				await Task.Delay(_interval, _token).ConfigureAwait(false);
+				await Task.Delay(_interval, _token);
 				if (_mres.IsSet) {
 					_mres.Reset();
-					await _func(_token).ConfigureAwait(false);
+					await _func(_token);
 				}
 			}
 		}

--- a/src/EventStore.Core/LogAbstraction/Common/StreamExistenceFilter.cs
+++ b/src/EventStore.Core/LogAbstraction/Common/StreamExistenceFilter.cs
@@ -118,7 +118,7 @@ namespace EventStore.Core.LogAbstraction.Common {
 			_checkpointer = new Debouncer(
 				checkpointInterval,
 				async _ => {
-					await TakeCheckpointAsync().ConfigureAwait(false);
+					await TakeCheckpointAsync();
 				},
 				_cancellationTokenSource.Token);
 		}
@@ -140,7 +140,7 @@ namespace EventStore.Core.LogAbstraction.Common {
 
 				// safety precaution against anything in the stack lying about the data
 				// truly being on disk.
-				await Task.Delay(_checkpointDelay).ConfigureAwait(false);
+				await Task.Delay(_checkpointDelay);
 
 				_checkpoint.Write(checkpoint);
 				_checkpoint.Flush();

--- a/src/EventStore.Core/LogV3/FASTER/FASTERNameIndexPersistence.cs
+++ b/src/EventStore.Core/LogV3/FASTER/FASTERNameIndexPersistence.cs
@@ -120,7 +120,7 @@ namespace EventStore.Core.LogV3.FASTER {
 				checkpointInterval,
 				async token => {
 					try {
-						var success = await CheckpointLogAsync().ConfigureAwait(false);
+						var success = await CheckpointLogAsync();
 						if (!success)
 							throw new Exception($"not successful");
 
@@ -445,7 +445,7 @@ namespace EventStore.Core.LogV3.FASTER {
 		public async Task<bool> CheckpointLogAsync() {
 			LogStats();
 			Log.Debug("{indexName} is checkpointing", _indexName);
-			var (success, _) = await _store.TakeHybridLogCheckpointAsync(CheckpointType.FoldOver).ConfigureAwait(false);
+			var (success, _) = await _store.TakeHybridLogCheckpointAsync(CheckpointType.FoldOver);
 			return success;
 		}
 

--- a/src/EventStore.Core/Services/AuthorizationGateway.cs
+++ b/src/EventStore.Core/Services/AuthorizationGateway.cs
@@ -358,7 +358,7 @@ namespace EventStore.Core.Services {
 
 		async void AuthorizeAsync<TRequest>(ValueTask<bool> accessCheck, IEnvelope replyTo, IPublisher destination, TRequest request,
 			Func<TRequest, Message> createAccessDenied) where TRequest : Message {
-			if (await accessCheck.ConfigureAwait(false)) {
+			if (await accessCheck) {
 				destination.Publish(request);
 			} else {
 				replyTo.ReplyWith(createAccessDenied(request));

--- a/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStreamReader.cs
+++ b/src/EventStore.Core/Services/PersistentSubscription/PersistentSubscriptionStreamReader.cs
@@ -50,7 +50,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				_ioDispatcher.ReadForward(
 					eventSource.EventStreamId, startPosition.StreamEventNumber, Math.Min(countToLoad, actualBatchSize),
 					resolveLinkTos, SystemAccounts.System, new ResponseHandler(onEventsFound, onEventsSkipped, onError, skipFirstEvent).FetchCompleted,
-					async () => await HandleTimeout(eventSource.EventStreamId).ConfigureAwait(false),
+					async () => await HandleTimeout(eventSource.EventStreamId),
 					Guid.NewGuid());
 			} else if (eventSource.FromAll) {
 				if (eventSource.EventFilter is null) {
@@ -64,7 +64,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 						SystemAccounts.System,
 						null,
 						new ResponseHandler(onEventsFound, onEventsSkipped, onError, skipFirstEvent).FetchAllCompleted,
-						async () => await HandleTimeout(SystemStreams.AllStream).ConfigureAwait(false),
+						async () => await HandleTimeout(SystemStreams.AllStream),
 						Guid.NewGuid());
 				} else {
 					var maxSearchWindow = Math.Max(actualBatchSize, maxWindowSize);
@@ -80,7 +80,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 						SystemAccounts.System,
 						null,
 						new ResponseHandler(onEventsFound, onEventsSkipped, onError, skipFirstEvent).FetchAllFilteredCompleted,
-						async () => await HandleTimeout($"{SystemStreams.AllStream} with filter {eventSource.EventFilter}").ConfigureAwait(false),
+						async () => await HandleTimeout($"{SystemStreams.AllStream} with filter {eventSource.EventFilter}"),
 						Guid.NewGuid());
 				}
 			} else {
@@ -92,7 +92,7 @@ namespace EventStore.Core.Services.PersistentSubscription {
 				Log.Warning(
 					"Timed out reading from stream: {stream}. Retrying in {retryInterval} seconds.",
 					streamName, backOff);
-				await Task.Delay(TimeSpan.FromSeconds(backOff)).ConfigureAwait(false);
+				await Task.Delay(TimeSpan.FromSeconds(backOff));
 				BeginReadEventsInternal(eventSource, startPosition, countToLoad, batchSize, maxWindowSize, resolveLinkTos,
 					skipFirstEvent, onEventsFound, onEventsSkipped, onError, retryCount + 1);
 			}

--- a/src/EventStore.Core/Services/Storage/StorageScavenger.cs
+++ b/src/EventStore.Core/Services/Storage/StorageScavenger.cs
@@ -123,7 +123,7 @@ namespace EventStore.Core.Services.Storage {
 		private async void HandleCleanupWhenFinished(Task newScavengeTask, IScavenger newScavenge, ILogger logger) {
 			// Clean up the reference to the TfChunkScavenger once it's finished.
 			try {
-				await newScavengeTask.ConfigureAwait(false);
+				await newScavengeTask;
 			} catch (Exception ex) {
 				logger.Error(ex, "SCAVENGING: Unexpected error when scavenging");
 			} finally {

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
@@ -87,11 +87,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			public async ValueTask<bool> MoveNextAsync() {
 				ReadLoop:
 
-				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken)) {
 					return false;
 				}
 
-				var readResponse = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+				var readResponse = await _channel.Reader.ReadAsync(_cancellationToken);
 
 				if (readResponse is ReadResponse.EventReceived eventReceived) {
 					var eventPos = eventReceived.Event.OriginalPosition!.Value;
@@ -156,7 +156,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 
 					switch (completed.Result) {
 						case ReadAllResult.Success:
-							await ConfirmSubscription().ConfigureAwait(false);
+							await ConfirmSubscription();
 
 							foreach (var @event in completed.Events) {
 								var position = Position.FromInt64(
@@ -167,7 +167,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									"Catch-up subscription {subscriptionId} to $all received event {position}.",
 									_subscriptionId, position);
 
-								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct).ConfigureAwait(false);
+								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct);
 							}
 
 							var nextPosition = Position.FromInt64(completed.NextPos.CommitPosition,
@@ -213,12 +213,12 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 				Task.Factory.StartNew(PumpLiveMessages, _cancellationToken);
 
 				async Task PumpLiveMessages() {
-					await caughtUpSource.Task.ConfigureAwait(false);
+					await caughtUpSource.Task;
 
-					await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(), _cancellationToken).ConfigureAwait(false);
+					await _channel.Writer.WriteAsync(new ReadResponse.SubscriptionCaughtUp(), _cancellationToken);
 
-					await foreach (var @event in liveEvents.Reader.ReadAllAsync(_cancellationToken).ConfigureAwait(false)) {
-						await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), _cancellationToken).ConfigureAwait(false);
+					await foreach (var @event in liveEvents.Reader.ReadAllAsync(_cancellationToken)) {
+						await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), _cancellationToken);
 					}
 				}
 
@@ -231,7 +231,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 
 					switch (message) {
 						case ClientMessage.SubscriptionConfirmation confirmed:
-							await ConfirmSubscription().ConfigureAwait(false);
+							await ConfirmSubscription();
 
 							var caughtUp = new TFPos(confirmed.LastIndexedPosition,
 								confirmed.LastIndexedPosition);

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwards.cs
@@ -59,11 +59,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken)) {
 					return false;
 				}
 
-				_current = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+				_current = await _channel.Reader.ReadAsync(_cancellationToken);
 
 				return true;
 			}
@@ -102,7 +102,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									return;
 								}
 
-								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct).ConfigureAwait(false);
+								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct);
 								nextPosition = @event.OriginalPosition ?? TFPos.Invalid;
 								readCount++;
 							}

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllBackwardsFiltered.cs
@@ -80,11 +80,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken)) {
 					return false;
 				}
 
-				_current = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+				_current = await _channel.Reader.ReadAsync(_cancellationToken);
 
 				return true;
 			}
@@ -120,7 +120,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									_channel.Writer.TryComplete();
 									return;
 								}
-								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct).ConfigureAwait(false);
+								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct);
 								readCount++;
 							}
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwards.cs
@@ -58,11 +58,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken)) {
 					return false;
 				}
 
-				_current = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+				_current = await _channel.Reader.ReadAsync(_cancellationToken);
 
 				return true;
 			}
@@ -99,7 +99,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									return;
 								}
 
-								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct).ConfigureAwait(false);
+								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct);
 								readCount++;
 							}
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadAllForwardsFiltered.cs
@@ -80,11 +80,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken)) {
 					return false;
 				}
 
-				_current = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+				_current = await _channel.Reader.ReadAsync(_cancellationToken);
 
 				return true;
 			}
@@ -123,7 +123,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									return;
 								}
 
-								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct).ConfigureAwait(false);
+								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct);
 								readCount++;
 							}
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamBackwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamBackwards.cs
@@ -60,11 +60,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken)) {
 					return false;
 				}
 
-				_current = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+				_current = await _channel.Reader.ReadAsync(_cancellationToken);
 
 				return true;
 			}
@@ -97,7 +97,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 								if (readCount >= _maxCount) {
 									break;
 								}
-								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct).ConfigureAwait(false);
+								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct);
 								readCount++;
 							}
 
@@ -110,14 +110,13 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 								await _channel.Writer
 									.WriteAsync(
 										new ReadResponse.LastStreamPositionReceived(
-											StreamRevision.FromInt64(completed.LastEventNumber)), ct)
-									.ConfigureAwait(false);
+											StreamRevision.FromInt64(completed.LastEventNumber)), ct);
 							}
 
 							_channel.Writer.TryComplete();
 							return;
 						case ReadStreamResult.NoStream:
-							await _channel.Writer.WriteAsync(new ReadResponse.StreamNotFound(_streamName), ct).ConfigureAwait(false);
+							await _channel.Writer.WriteAsync(new ReadResponse.StreamNotFound(_streamName), ct);
 							_channel.Writer.TryComplete();
 							return;
 						case ReadStreamResult.StreamDeleted:

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamForwards.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.ReadStreamForwards.cs
@@ -60,11 +60,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 			}
 
 			public async ValueTask<bool> MoveNextAsync() {
-				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken).ConfigureAwait(false)) {
+				if (!await _channel.Reader.WaitToReadAsync(_cancellationToken)) {
 					return false;
 				}
 
-				_current = await _channel.Reader.ReadAsync(_cancellationToken).ConfigureAwait(false);
+				_current = await _channel.Reader.ReadAsync(_cancellationToken);
 
 				return true;
 			}
@@ -98,8 +98,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									var firstStreamPosition = StreamRevision.FromInt64(completed.NextEventNumber);
 									if (startRevision != firstStreamPosition) {
 										await _channel.Writer
-											.WriteAsync(new ReadResponse.FirstStreamPositionReceived(firstStreamPosition), ct)
-											.ConfigureAwait(false);
+											.WriteAsync(new ReadResponse.FirstStreamPositionReceived(firstStreamPosition), ct);
 									}
 								}
 							}
@@ -108,7 +107,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 								if (readCount >= _maxCount) {
 									break;
 								}
-								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct).ConfigureAwait(false);
+								await _channel.Writer.WriteAsync(new ReadResponse.EventReceived(@event), ct);
 								readCount++;
 							}
 
@@ -121,16 +120,14 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 								await _channel.Writer
 									.WriteAsync(
 										new ReadResponse.LastStreamPositionReceived(
-											StreamRevision.FromInt64(completed.LastEventNumber)), ct)
-									.ConfigureAwait(false);
+											StreamRevision.FromInt64(completed.LastEventNumber)), ct);
 							}
 
 							_channel.Writer.TryComplete();
 							return;
 
 						case ReadStreamResult.NoStream:
-							await _channel.Writer.WriteAsync(new ReadResponse.StreamNotFound(_streamName), ct)
-								.ConfigureAwait(false);
+							await _channel.Writer.WriteAsync(new ReadResponse.StreamNotFound(_streamName), ct);
 							_channel.Writer.TryComplete();
 							return;
 						case ReadStreamResult.StreamDeleted:

--- a/src/EventStore.Core/Services/Transport/Grpc/AsyncStreamExtensions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/AsyncStreamExtensions.cs
@@ -33,8 +33,8 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			Func<T, ValueTask> asyncAction,
 			CancellationToken token)
 			where T : class {
-			while (await streamReader.MoveNext(token).ConfigureAwait(false)) {
-				await asyncAction(streamReader.Current).ConfigureAwait(false);
+			while (await streamReader.MoveNext(token)) {
+				await asyncAction(streamReader.Current);
 			}
 		}
 	}

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Elections.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Elections.cs
@@ -34,7 +34,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 		
 		public override async Task<Empty> ViewChange(ViewChangeRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ViewChangeOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ViewChangeOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_bus.Publish(new ElectionMessage.ViewChange(
@@ -46,7 +46,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 		
 		public override async Task<Empty> ViewChangeProof(ViewChangeProofRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ViewChangeProofOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ViewChangeProofOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_bus.Publish(new ElectionMessage.ViewChangeProof(
@@ -58,7 +58,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 		
 		public override async Task<Empty> Prepare(PrepareRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, PrepareOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, PrepareOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_bus.Publish(new ElectionMessage.Prepare(
@@ -70,7 +70,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 	
 		public override async Task<Empty> PrepareOk(PrepareOkRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, PrepareOkOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, PrepareOkOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_bus.Publish(new ElectionMessage.PrepareOk(
@@ -91,7 +91,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 				
 		public override async Task<Empty> Proposal(ProposalRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ProposalOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ProposalOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_bus.Publish(new ElectionMessage.Proposal(
@@ -113,7 +113,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 
 		public override async Task<Empty> Accept(AcceptRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, AcceptOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, AcceptOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_bus.Publish(new ElectionMessage.Accept(
@@ -129,7 +129,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 
 		public override async Task<Empty> LeaderIsResigning(LeaderIsResigningRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, MasterIsResigningOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, MasterIsResigningOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_bus.Publish(new ElectionMessage.LeaderIsResigning(
@@ -141,7 +141,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 		
 		public override async Task<Empty> LeaderIsResigningOk(LeaderIsResigningOkRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, MasterIsResigningOkOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, MasterIsResigningOkOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_bus.Publish(new ElectionMessage.LeaderIsResigningOk(

--- a/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Cluster.Gossip.cs
@@ -34,7 +34,7 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 
 		public override async Task<ClusterInfo> Update(GossipRequest request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var clusterInfo = EventStore.Core.Cluster.ClusterInfo.FromGrpcClusterInfo(request.Info, _clusterDns);
@@ -42,18 +42,18 @@ namespace EventStore.Core.Services.Transport.Grpc.Cluster {
 			var duration = _updateTracker.Start();
 			_bus.Publish(new GossipMessage.GossipReceived(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration)),
 				clusterInfo, new DnsEndPoint(request.Server.Address, (int)request.Server.Port).WithClusterDns(_clusterDns)));
-			return await tcs.Task.ConfigureAwait(false);
+			return await tcs.Task;
 		}
 
 		public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var tcs = new TaskCompletionSource<ClusterInfo>();
 			var duration = _readTracker.Start();
 			_bus.Publish(new GossipMessage.ReadGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration))));
-			return await tcs.Task.ConfigureAwait(false);
+			return await tcs.Task;
 		}
 
 		private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs, Duration duration) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Gossip.Read.cs
@@ -16,13 +16,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		private static readonly Operation ReadOperation = new Operation(Plugins.Authorization.Operations.Node.Gossip.ClientRead);
 		public override async Task<ClusterInfo> Read(Empty request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ReadOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var tcs = new TaskCompletionSource<ClusterInfo>();
 			var duration = _tracker.Start();
 			_bus.Publish(new GossipMessage.ClientGossip(new CallbackEnvelope(msg => GossipResponse(msg, tcs, duration))));;
-			return await tcs.Task.ConfigureAwait(false);
+			return await tcs.Task;
 		}
 
 		private void GossipResponse(Message msg, TaskCompletionSource<ClusterInfo> tcs, Duration duration) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Monitoring.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Monitoring.cs
@@ -44,7 +44,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_publisher.Publish(
 						new MonitoringMessage.GetFreshStats(envelope, x => x, request.UseMetadata, false));
 
-					await Task.Delay(delay, context.CancellationToken).ConfigureAwait(false);
+					await Task.Delay(delay, context.CancellationToken);
 				}
 			}
 		}

--- a/src/EventStore.Core/Services/Transport/Grpc/Operations.Admin.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Operations.Admin.cs
@@ -27,8 +27,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 		public override async Task<Empty> Shutdown(Empty request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ShutdownOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ShutdownOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -40,15 +39,14 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var mergeResultSource = new TaskCompletionSource<string>();
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, MergeIndexesOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, MergeIndexesOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
 			var correlationId = Guid.NewGuid();
 			_publisher.Publish(new ClientMessage.MergeIndexes(new CallbackEnvelope(OnMessage), correlationId, user));
 
-			await mergeResultSource.Task.ConfigureAwait(false);
+			await mergeResultSource.Task;
 			return EmptyResult;
 
 			void OnMessage(Message message) {
@@ -64,8 +62,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 		public override async Task<Empty> ResignNode(Empty request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ResignOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ResignOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -76,8 +73,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		public override async Task<Empty> SetNodePriority(SetNodePriorityReq request, ServerCallContext context) {
 			var user = context.GetHttpContext().User;
 			if (!await _authorizationProvider
-				.CheckAccessAsync(user, SetNodePriorityOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+				.CheckAccessAsync(user, SetNodePriorityOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -91,14 +87,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			var user = context.GetHttpContext().User;
 			if (!await _authorizationProvider.CheckAccessAsync(user, RestartPersistentSubscriptionsOperation,
-					context.CancellationToken)
-				.ConfigureAwait(false)) {
+					context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
 			_publisher.Publish(new SubscriptionMessage.PersistentSubscriptionsRestart(envelope));
 
-			await restart.Task.ConfigureAwait(false);
+			await restart.Task;
 			return new Empty();
 
 			void OnMessage(Message message) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Operations.Scavenge.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Operations.Scavenge.cs
@@ -14,13 +14,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var scavengeResultSource = new TaskCompletionSource<(string, ScavengeResp.Types.ScavengeResult)>();
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, StartOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, StartOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_publisher.Publish(new ClientMessage.ScavengeDatabase(new CallbackEnvelope(OnMessage), Guid.NewGuid(), user,
 				request.Options.StartFromChunk, request.Options.ThreadCount, null, null, false));
 
-			var (scavengeId, scavengeResult) = await scavengeResultSource.Task.ConfigureAwait(false);
+			var (scavengeId, scavengeResult) = await scavengeResultSource.Task;
 
 			return new ScavengeResp {
 				ScavengeId = scavengeId,
@@ -34,13 +34,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var scavengeResultSource = new TaskCompletionSource<(string, ScavengeResp.Types.ScavengeResult)>();
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, StopOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, StopOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			_publisher.Publish(new ClientMessage.StopDatabaseScavenge(new CallbackEnvelope(OnMessage), Guid.NewGuid(), user,
 				request.Options.ScavengeId));
 
-			var (scavengeId, scavengeResult) = await scavengeResultSource.Task.ConfigureAwait(false);
+			var (scavengeId, scavengeResult) = await scavengeResultSource.Task;
 
 			return new ScavengeResp {
 				ScavengeId = scavengeId,

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Create.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Create.cs
@@ -27,7 +27,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var user = context.GetHttpContext().User;
 			
 			if (!await _authorizationProvider.CheckAccessAsync(user,
-				CreateOperation, context.CancellationToken).ConfigureAwait(false)) {
+				CreateOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -170,7 +170,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_ => throw RpcExceptions.InvalidArgument(filter.FilterCase)
 				};
 
-			return await createPersistentSubscriptionSource.Task.ConfigureAwait(false);
+			return await createPersistentSubscriptionSource.Task;
 
 			void HandleCreatePersistentSubscriptionCompleted(Message message) {
 				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Delete.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var user = context.GetHttpContext().User;
 
 			if (!await _authorizationProvider.CheckAccessAsync(user,
-				DeleteOperation, context.CancellationToken).ConfigureAwait(false)) {
+				DeleteOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -53,7 +53,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw new InvalidOperationException();
 			}
 
-			return await createPersistentSubscriptionSource.Task.ConfigureAwait(false);
+			return await createPersistentSubscriptionSource.Task;
 
 			void HandleDeletePersistentSubscriptionCompleted(Message message) {
 				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Info.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Info.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var user = context.GetHttpContext().User;
 
 			if (!await _authorizationProvider.CheckAccessAsync(user,
-				GetInfoOperation, context.CancellationToken).ConfigureAwait(false)) {
+				GetInfoOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -31,7 +31,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				new CallbackEnvelope(HandleGetPersistentSubscriptionStatsCompleted),
 				streamId,
 				request.Options.GroupName));
-			return await getPersistentSubscriptionInfoSource.Task.ConfigureAwait(false);
+			return await getPersistentSubscriptionInfoSource.Task;
 
 			void HandleGetPersistentSubscriptionStatsCompleted(Message message) {
 				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {
@@ -80,7 +80,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var user = context.GetHttpContext().User;
 
 			if (!await _authorizationProvider.CheckAccessAsync(user,
-				GetInfoOperation, context.CancellationToken).ConfigureAwait(false)) {
+				GetInfoOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -106,7 +106,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw new InvalidOperationException();
 			}
 
-			return await listPersistentSubscriptionsSource.Task.ConfigureAwait(false);
+			return await listPersistentSubscriptionsSource.Task;
 
 			void HandleListSubscriptionsCompleted(Message message) {
 				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.ReplayParked.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.ReplayParked.cs
@@ -16,7 +16,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var user = context.GetHttpContext().User;
 
 			if (!await _authorizationProvider.CheckAccessAsync(user,
-				ReplayParkedOperation, context.CancellationToken).ConfigureAwait(false)) {
+				ReplayParkedOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -40,7 +40,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				request.Options.GroupName,
 				stopAt,
 				user));
-			return await replayParkedMessagesSource.Task.ConfigureAwait(false);
+			return await replayParkedMessagesSource.Task;
 
 			void HandleReplayParkedMessagesCompleted(Message message) {
 				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.RestartSubsystem.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.RestartSubsystem.cs
@@ -16,13 +16,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var user = context.GetHttpContext().User;
 
 			if (!await _authorizationProvider.CheckAccessAsync(user,
-				RestartOperation, context.CancellationToken).ConfigureAwait(false)) {
+				RestartOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
 			_publisher.Publish(new SubscriptionMessage.PersistentSubscriptionsRestart(
 				new CallbackEnvelope(HandleRestartSubsystemCompleted)));
-			return await restartSubsystemSource.Task.ConfigureAwait(false);
+			return await restartSubsystemSource.Task;
 
 			void HandleRestartSubsystemCompleted(Message message) {
 				if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Update.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/PersistentSubscriptions.Update.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			var user = context.GetHttpContext().User;
 			if (!await _authorizationProvider.CheckAccessAsync(user,
-				UpdateOperation, context.CancellationToken).ConfigureAwait(false)) {
+				UpdateOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -130,7 +130,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw new InvalidOperationException();
 			}
 
-			return await updatePersistentSubscriptionSource.Task.ConfigureAwait(false);
+			return await updatePersistentSubscriptionSource.Task;
 
 			void HandleUpdatePersistentSubscriptionCompleted(Message message) {
 				if (message is ClientMessage.NotHandled notHandled && RpcExceptions.TryHandleNotHandled(notHandled, out var ex)) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Redaction.SwitchChunks.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Redaction.SwitchChunks.cs
@@ -17,15 +17,15 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			ServerCallContext context) {
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, SwitchChunkOperation, context.CancellationToken).ConfigureAwait(false))
+			if (!await _authorizationProvider.CheckAccessAsync(user, SwitchChunkOperation, context.CancellationToken))
 				throw RpcExceptions.AccessDenied();
 
 			var acquisitionId = Guid.Empty;
 			try {
-				acquisitionId = await AcquireChunksLock(context).ConfigureAwait(false);
-				await SwitchChunks(requestStream, responseStream, acquisitionId).ConfigureAwait(false);
+				acquisitionId = await AcquireChunksLock(context);
+				await SwitchChunks(requestStream, responseStream, acquisitionId);
 			} finally {
-				await ReleaseChunksLock(acquisitionId).ConfigureAwait(false);
+				await ReleaseChunksLock(acquisitionId);
 			}
 		}
 
@@ -33,13 +33,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var tcsEnvelope = new TcsEnvelope<RedactionMessage.AcquireChunksLockCompleted>();
 			_bus.Publish(new RedactionMessage.AcquireChunksLock(tcsEnvelope));
 
-			var completionMsg = await tcsEnvelope.Task.ConfigureAwait(false);
+			var completionMsg = await tcsEnvelope.Task;
 			if (completionMsg.Result != AcquireChunksLockResult.Success)
 				throw RpcExceptions.RedactionLockFailed();
 
 			// we've managed to acquire the lock. we need to write the headers here since the client's waiting for them.
 			// (they're written automatically when throwing an RpcException e.g. when acquiring the lock failed above)
-			await context.WriteResponseHeadersAsync(new Metadata()).ConfigureAwait(false);
+			await context.WriteResponseHeadersAsync(new Metadata());
 
 			return completionMsg.AcquisitionId;
 		}
@@ -49,16 +49,16 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			IServerStreamWriter<SwitchChunkResp> responseStream,
 			Guid acquisitionId) {
 
-			await foreach(var request in requestStream.ReadAllAsync().ConfigureAwait(false)) {
+			await foreach(var request in requestStream.ReadAllAsync()) {
 				var tcsEnvelope = new TcsEnvelope<RedactionMessage.SwitchChunkCompleted>();
 				_bus.Publish(new RedactionMessage.SwitchChunk(tcsEnvelope, acquisitionId, request.TargetChunkFile, request.NewChunkFile));
 
-				var completionMsg = await tcsEnvelope.Task.ConfigureAwait(false);
+				var completionMsg = await tcsEnvelope.Task;
 				var result = completionMsg.Result;
 				if (result != SwitchChunkResult.Success)
 					throw RpcExceptions.RedactionSwitchChunkFailed(result.GetErrorMessage());
 
-				await responseStream.WriteAsync(new SwitchChunkResp()).ConfigureAwait(false);
+				await responseStream.WriteAsync(new SwitchChunkResp());
 			}
 		}
 
@@ -69,7 +69,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var tcsEnvelope = new TcsEnvelope<RedactionMessage.ReleaseChunksLockCompleted>();
 			_bus.Publish(new RedactionMessage.ReleaseChunksLock(tcsEnvelope, acquisitionId));
 
-			var completionMsg = await tcsEnvelope.Task.ConfigureAwait(false);
+			var completionMsg = await tcsEnvelope.Task;
 			var result = completionMsg.Result;
 			if (result != ReleaseChunksLockResult.Success)
 				throw RpcExceptions.RedactionSwitchChunkFailed(result.GetErrorMessage());

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Append.cs
@@ -17,7 +17,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			using var duration = _appendTracker.Start();
 			try {
-				if (!await requestStream.MoveNext().ConfigureAwait(false))
+				if (!await requestStream.MoveNext())
 					throw new InvalidOperationException();
 
 				if (requestStream.Current.ContentCase != AppendReq.ContentOneofCase.Options)
@@ -42,7 +42,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				var user = context.GetHttpContext().User;
 				var op = WriteOperation.WithParameter(
 					Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
-				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
+				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken)) {
 					throw RpcExceptions.AccessDenied();
 				}
 
@@ -51,7 +51,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				var events = new List<Event>();
 
 				var size = 0;
-				while (await requestStream.MoveNext().ConfigureAwait(false)) {
+				while (await requestStream.MoveNext()) {
 					if (requestStream.Current.ContentCase != AppendReq.ContentOneofCase.ProposedMessage)
 						throw new InvalidOperationException();
 
@@ -96,7 +96,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					user,
 					cancellationToken: context.CancellationToken));
 
-				return await appendResponseSource.Task.ConfigureAwait(false);
+				return await appendResponseSource.Task;
 
 				void HandleWriteEventsCompleted(Message message) {
 					if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Delete.cs
@@ -30,13 +30,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 				var user = context.GetHttpContext().User;
 				var op = DeleteOperation.WithParameter(Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
-				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
+				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken)) {
 					throw RpcExceptions.AccessDenied();
 				}
 				var requiresLeader = GetRequiresLeader(context.RequestHeaders);
 
 				var position = await DeleteInternal(streamName, expectedVersion, user, false, requiresLeader,
-					context.CancellationToken).ConfigureAwait(false);
+					context.CancellationToken);
 
 				return position.HasValue
 					? new DeleteResp {
@@ -76,12 +76,12 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			
 				var user = context.GetHttpContext().User;
 				var op = DeleteOperation.WithParameter(Plugins.Authorization.Operations.Streams.Parameters.StreamId(streamName));
-				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
+				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken)) {
 					throw RpcExceptions.AccessDenied();
 				}
 
 				var position = await DeleteInternal(streamName, expectedVersion, user, true, requiresLeader,
-					context.CancellationToken).ConfigureAwait(false);
+					context.CancellationToken);
 
 				return position.HasValue
 					? new TombstoneResp {
@@ -117,7 +117,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				user,
 				cancellationToken: cancellationToken));
 
-			return await deleteResponseSource.Task.ConfigureAwait(false);
+			return await deleteResponseSource.Task;
 
 			void HandleStreamDeletedCompleted(Message message) {
 				if (message is ClientMessage.NotHandled notHandled &&

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -47,7 +47,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					_ => throw RpcExceptions.InvalidArgument(streamOptionsCase)
 				};
 
-				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken).ConfigureAwait(false)) {
+				if (!await _provider.CheckAccessAsync(user, op, context.CancellationToken)) {
 					throw RpcExceptions.AccessDenied();
 				}
 
@@ -64,13 +64,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 						context.Deadline,
 						context.CancellationToken);
 
-					async void DisposeEnumerator() => await enumerator.DisposeAsync().ConfigureAwait(false);
+					async void DisposeEnumerator() => await enumerator.DisposeAsync();
 
-					await using (enumerator.ConfigureAwait(false)) {
-						await using (context.CancellationToken.Register(DisposeEnumerator).ConfigureAwait(false)) {
-							while (await enumerator.MoveNextAsync().ConfigureAwait(false)) {
+					await using (enumerator) {
+						await using (context.CancellationToken.Register(DisposeEnumerator)) {
+							while (await enumerator.MoveNextAsync()) {
 								var readResponse = ConvertReadResponse(enumerator.Current, options.UuidOption);
-								await responseStream.WriteAsync(readResponse).ConfigureAwait(false);
+								await responseStream.WriteAsync(readResponse);
 							}
 						}
 					}

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.ChangePassword.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.ChangePassword.cs
@@ -19,7 +19,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					changePasswordOperation.WithParameter(
 						Plugins.Authorization.Operations.Users.Parameters.User(user.Identity.Name));
 			}
-			if (!await _authorizationProvider.CheckAccessAsync(user, changePasswordOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, changePasswordOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var changePasswordSource = new TaskCompletionSource<bool>();
@@ -30,7 +30,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				options.CurrentPassword,
 				options.NewPassword));
 
-			await changePasswordSource.Task.ConfigureAwait(false);
+			await changePasswordSource.Task;
 
 			return new ChangePasswordResp();
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Create.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Create.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, CreateOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, CreateOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var createSource = new TaskCompletionSource<bool>();
@@ -24,7 +24,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				options.Groups.ToArray(),
 				options.Password));
 
-			await createSource.Task.ConfigureAwait(false);
+			await createSource.Task;
 
 			return new CreateResp();
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Delete.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Delete.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, DeleteOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, DeleteOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var deleteSource = new TaskCompletionSource<bool>();
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			_publisher.Publish(new UserManagementMessage.Delete(envelope, user, options.LoginName));
 
-			await deleteSource.Task.ConfigureAwait(false);
+			await deleteSource.Task;
 
 			return new DeleteResp();
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Details.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Details.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					readOperation.WithParameter(
 						Plugins.Authorization.Operations.Users.Parameters.User(user.Identity.Name));
 			}
-			if (!await _authorizationProvider.CheckAccessAsync(user, readOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, readOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var detailsSource = new TaskCompletionSource<UserManagementMessage.UserData[]>();
@@ -31,7 +31,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				? (Message)new UserManagementMessage.GetAll(envelope, user)
 				: new UserManagementMessage.Get(envelope, user, options.LoginName));
 
-			var details = await detailsSource.Task.ConfigureAwait(false);
+			var details = await detailsSource.Task;
 
 			foreach (var detail in details) {
 				await responseStream.WriteAsync(new DetailsResp {
@@ -45,7 +45,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 								{TicksSinceEpoch = detail.DateLastUpdated.Value.UtcDateTime.ToTicksSinceEpoch()}
 							: null
 					}
-				}).ConfigureAwait(false);
+				});
 			}
 
 			void OnMessage(Message message) {

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Disable.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Disable.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, DisableOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, DisableOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var disableSource = new TaskCompletionSource<bool>();
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			_publisher.Publish(new UserManagementMessage.Disable(envelope, user, options.LoginName));
 
-			await disableSource.Task.ConfigureAwait(false);
+			await disableSource.Task;
 
 			return new DisableResp();
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Enable.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Enable.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, EnableOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, EnableOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var enableSource = new TaskCompletionSource<bool>();
@@ -21,7 +21,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 
 			_publisher.Publish(new UserManagementMessage.Enable(envelope, user, options.LoginName));
 
-			await enableSource.Task.ConfigureAwait(false);
+			await enableSource.Task;
 
 			return new EnableResp();
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.ResetPassword.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.ResetPassword.cs
@@ -13,7 +13,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ResetOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ResetOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var resetPasswordSource = new TaskCompletionSource<bool>();
@@ -23,7 +23,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			_publisher.Publish(
 				new UserManagementMessage.ResetPassword(envelope, user, options.LoginName, options.NewPassword));
 
-			await resetPasswordSource.Task.ConfigureAwait(false);
+			await resetPasswordSource.Task;
 
 			return new ResetPasswordResp();
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Users.Update.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Users.Update.cs
@@ -14,7 +14,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken).ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var updateSource = new TaskCompletionSource<bool>();
@@ -24,7 +24,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 			_publisher.Publish(new UserManagementMessage.Update(envelope, user, options.LoginName, options.FullName,
 				options.Groups.ToArray()));
 
-			await updateSource.Task.ConfigureAwait(false);
+			await updateSource.Task;
 
 			return new UpdateResp();
 

--- a/src/EventStore.Core/Services/Transport/Http/AuthorizationMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/AuthorizationMiddleware.cs
@@ -15,8 +15,8 @@ namespace EventStore.Core.Services.Transport.Http
 		}
 		public async Task InvokeAsync(HttpContext context, RequestDelegate next) {
 			if (InternalHttpHelper.TryGetInternalContext(context, out var manager, out var match, out _)) {
-				if (await _authorization.CheckAccessAsync(manager.User, match.ControllerAction.Operation(match.TemplateMatch), context.RequestAborted).ConfigureAwait(false)) {
-					await next(context).ConfigureAwait(false);
+				if (await _authorization.CheckAccessAsync(manager.User, match.ControllerAction.Operation(match.TemplateMatch), context.RequestAborted)) {
+					await next(context);
 					return;
 				}
 

--- a/src/EventStore.Core/Services/Transport/Http/ClearTextHttpMultiplexingMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/ClearTextHttpMultiplexingMiddleware.cs
@@ -20,7 +20,7 @@ namespace EventStore.Core.Services.Transport.Http
 
 	    private static async Task<bool> HasHttp2Preface(PipeReader input) {
 		    while (true) {
-			    var result = await input.ReadAsync().ConfigureAwait(false);
+			    var result = await input.ReadAsync();
 			    try {
 				    int pos = 0;
 				    foreach (var x in result.Buffer) {
@@ -51,9 +51,9 @@ namespace EventStore.Core.Services.Transport.Http
         }
 
         public async Task OnConnectAsync(ConnectionContext context) {
-	        var hasHttp2Preface = await HasHttp2Preface(context.Transport.Input).ConfigureAwait(false);
+	        var hasHttp2Preface = await HasHttp2Preface(context.Transport.Input);
 	        SetProtocols(_next.Target, hasHttp2Preface ? HttpProtocols.Http2 : HttpProtocols.Http1);
-	        await _next(context).ConfigureAwait(false);
+	        await _next(context);
         }
     }
 }

--- a/src/EventStore.Core/Services/Transport/Http/UnixSocketConnectionMiddleware.cs
+++ b/src/EventStore.Core/Services/Transport/Http/UnixSocketConnectionMiddleware.cs
@@ -12,6 +12,6 @@ public class UnixSocketConnectionMiddleware {
 
 	public async Task OnConnectAsync(ConnectionContext context) {
 		context.Items.Add(UnixSocketConnectionKey, true);
-		await _next(context).ConfigureAwait(false);
+		await _next(context);
 	}
 }

--- a/src/EventStore.Core/Telemetry/TelemetryService.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryService.cs
@@ -53,7 +53,7 @@ public sealed class TelemetryService : IDisposable,
 		_nodeId = nodeId;
 		Task.Run(async () => {
 			try {
-				await ProcessAsync(publisher, sink).ConfigureAwait(false);
+				await ProcessAsync(publisher, sink);
 			} catch (Exception ex) when (ex is not OperationCanceledException) {
 				_log.Error(ex, "Telemetry loop stopped");
 			}
@@ -82,7 +82,7 @@ public sealed class TelemetryService : IDisposable,
 		publisher.Publish(scheduleInitialCollect);
 
 		var data = new JsonObject();
-		await foreach (var message in channel.Reader.ReadAllAsync(_cts.Token).ConfigureAwait(false)) {
+		await foreach (var message in channel.Reader.ReadAllAsync(_cts.Token)) {
 			switch (message) {
 				case TelemetryMessage.Collect:
 					Handle(usageRequest);
@@ -95,7 +95,7 @@ public sealed class TelemetryService : IDisposable,
 					break;
 
 				case TelemetryMessage.Flush:
-					await sink.Flush(data, _cts.Token).ConfigureAwait(false);
+					await sink.Flush(data, _cts.Token);
 					data.Clear();
 					publisher.Publish(scheduleCollect);
 					break;

--- a/src/EventStore.Core/Telemetry/TelemetrySink.cs
+++ b/src/EventStore.Core/Telemetry/TelemetrySink.cs
@@ -38,7 +38,7 @@ public class TelemetrySink : ITelemetrySink {
 		} else {
 			_log.Information("Sending telemetry data to {url} (visit for more information): " + Environment.NewLine + json, ApiHost);
 			try {
-				await _httpClient.PostAsync(ApiHost, JsonContent.Create(data), token).ConfigureAwait(false);
+				await _httpClient.PostAsync(ApiHost, JsonContent.Create(data), token);
 			} catch (Exception ex) when (ex is not TaskCanceledException) {
 				_log.Error("Error when sending telemetry payload: {exception}", ex);
 			}

--- a/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ScavengePointSource.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/DbAccess/ScavengePointSource.cs
@@ -51,7 +51,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 			ResolvedEvent[] events;
 			using (cancellationToken.Register(() => readTcs.TrySetCanceled())) {
-				events = await readTcs.Task.ConfigureAwait(false);
+				events = await readTcs.Task;
 			}
 
 			if (events.Length == 0) {
@@ -113,19 +113,18 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 			);
 
 			using (cancellationToken.Register(() => writeTcs.TrySetCanceled())) {
-				await writeTcs.Task.ConfigureAwait(false);
+				await writeTcs.Task;
 			}
 
 			_logger.Information("SCAVENGING: Added new scavenge point.");
 
 			// initial chance to replicate (handy if we are follower)
-			await Task.Delay(500, cancellationToken).ConfigureAwait(false);
+			await Task.Delay(500, cancellationToken);
 
 			const int MaxAttempts = 30;
 			var attempt = 0;
 			while (true) {
-				var scavengePoint = await GetLatestScavengePointOrDefaultAsync(cancellationToken)
-					.ConfigureAwait(false);
+				var scavengePoint = await GetLatestScavengePointOrDefaultAsync(cancellationToken);
 
 				// success
 				if (scavengePoint.EventNumber == expectedVersion + 1)
@@ -144,7 +143,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					"Found {actual} but expected {expected}. Retrying {attempt}/{maxAttempts}...",
 					scavengePoint.EventNumber, expectedVersion + 1, attempt, MaxAttempts);
 
-				await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
+				await Task.Delay(1000, cancellationToken);
 			}
 		}
 	}

--- a/src/EventStore.Core/TransactionLog/Scavenging/Scavenger.cs
+++ b/src/EventStore.Core/TransactionLog/Scavenging/Scavenger.cs
@@ -86,7 +86,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 				_scavengerLogger.ScavengeStarted();
 
-				await RunInternal(_scavengerLogger, stopwatch, cancellationToken).ConfigureAwait(false);
+				await RunInternal(_scavengerLogger, stopwatch, cancellationToken);
 
 				_logger.Debug(
 					"SCAVENGING: Scavenge Completed. Total time taken: {elapsed}. Total space saved: {spaceSaved}.",
@@ -150,7 +150,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					prevScavengePoint: null,
 					scavengerLogger,
 					stopwatch,
-					cancellationToken).ConfigureAwait(false);
+					cancellationToken);
 
 			} else if (checkpoint is ScavengeCheckpoint.Done done) {
 				// start of a subsequent scavenge.
@@ -159,7 +159,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 					prevScavengePoint: done.ScavengePoint,
 					scavengerLogger,
 					stopwatch,
-					cancellationToken).ConfigureAwait(false);
+					cancellationToken);
 
 			} else {
 				// the other cases are continuing an incomplete scavenge
@@ -236,8 +236,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 
 			ScavengePoint nextScavengePoint;
 			var latestScavengePoint = await _scavengePointSource
-				.GetLatestScavengePointOrDefaultAsync(cancellationToken)
-				.ConfigureAwait(false);
+				.GetLatestScavengePointOrDefaultAsync(cancellationToken);
 			if (latestScavengePoint == null) {
 				if (_syncOnly) {
 					_logger.Debug("SCAVENGING: No existing scavenge point to sync with, nothing to do.");
@@ -249,8 +248,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 						.AddScavengePointAsync(
 							ExpectedVersion.NoStream,
 							threshold: _thresholdForNewScavenge,
-							cancellationToken)
-						.ConfigureAwait(false);
+							cancellationToken);
 				}
 			} else {
 				// got the latest scavenge point
@@ -276,8 +274,7 @@ namespace EventStore.Core.TransactionLog.Scavenging {
 							.AddScavengePointAsync(
 								expectedVersion,
 								threshold: _thresholdForNewScavenge,
-								cancellationToken)
-							.ConfigureAwait(false);
+								cancellationToken);
 					}
 				}
 			}

--- a/src/EventStore.Projections.Core.Tests/ClientAPI/with_standard_projections_running.cs
+++ b/src/EventStore.Projections.Core.Tests/ClientAPI/with_standard_projections_running.cs
@@ -21,7 +21,7 @@ namespace EventStore.Projections.Core.Tests.ClientAPI {
 
 			[Test, Category("Network")]
 			public async Task deleted_stream_events_are_indexed() {
-				await Task.Delay(500).ConfigureAwait(false); //give the projection time to catchup...
+				await Task.Delay(500); //give the projection time to catchup...
 				var slice = await _conn.ReadStreamEventsForwardAsync("$ce-cat", 0, 10, true, _admin);
 				Assert.AreEqual(SliceReadStatus.Success, slice.Status);
 

--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -26,10 +26,6 @@
 		</Content>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="5.0.0.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="Grpc.Tools" Version="2.59.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Create.cs
@@ -17,8 +17,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, CreateOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, CreateOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			const string handlerType = "JS";
@@ -58,7 +57,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			_queue.Publish(new ProjectionManagementMessage.Command.Post(envelope, projectionMode, name, runAs,
 				handlerType, options.Query, true, checkpointsEnabled, emitEnabled, trackEmittedStreams, true));
 
-			await createdSource.Task.ConfigureAwait(false);
+			await createdSource.Task;
 
 			return new CreateResp();
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Delete.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Delete.cs
@@ -14,8 +14,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, DeleteOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, DeleteOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var name = options.Name;
@@ -29,7 +28,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			_queue.Publish(new ProjectionManagementMessage.Command.Delete(envelope, name, runAs,
 				deleteCheckpointStream, deleteStateStream, deleteEmittedStreams));
 
-			await deletedSource.Task.ConfigureAwait(false);
+			await deletedSource.Task;
 
 			return new DeleteResp();
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Disable.cs
@@ -15,8 +15,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, DisableOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, DisableOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var name = options.Name;
@@ -28,7 +27,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				? new ProjectionManagementMessage.Command.Disable(envelope, name, runAs)
 				: (Message)new ProjectionManagementMessage.Command.Abort(envelope, name, runAs));
 
-			await disableSource.Task.ConfigureAwait(false);
+			await disableSource.Task;
 
 			return new DisableResp();
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Enable.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Enable.cs
@@ -15,8 +15,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, EnableOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, EnableOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var name = options.Name;
@@ -26,7 +25,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 
 			_queue.Publish(new ProjectionManagementMessage.Command.Enable(envelope, name, runAs));
 
-			await enableSource.Task.ConfigureAwait(false);
+			await enableSource.Task;
 
 			return new EnableResp();
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Reset.cs
@@ -15,8 +15,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ResetOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ResetOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var name = options.Name;
@@ -26,7 +25,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 
 			_queue.Publish(new ProjectionManagementMessage.Command.Reset(envelope, name, runAs));
 
-			await resetSource.Task.ConfigureAwait(false);
+			await resetSource.Task;
 
 			return new ResetResp();
 

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.RestartSubsystem.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.RestartSubsystem.cs
@@ -15,14 +15,13 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			var envelope = new CallbackEnvelope(OnMessage);
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, RestartOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, RestartOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
 			_queue.Publish(new ProjectionSubsystemMessage.RestartSubsystem(envelope));
 
-			await restart.Task.ConfigureAwait(false);
+			await restart.Task;
 			return new Empty();
 
 			void OnMessage(Message message) {

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Result.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Result.cs
@@ -15,8 +15,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 		public override async Task<ResultResp> Result(ResultReq request, ServerCallContext context) {
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, ResultOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, ResultOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -31,7 +30,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			_queue.Publish(new ProjectionManagementMessage.Command.GetResult(envelope, name, partition));
 
 			return new ResultResp {
-				Result = await resultSource.Task.ConfigureAwait(false)
+				Result = await resultSource.Task
 			};
 
 			void OnMessage(Message message) {
@@ -55,8 +54,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 		public override async Task<StateResp> State(StateReq request, ServerCallContext context) {
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, StateOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, StateOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 			var resultSource = new TaskCompletionSource<Value>();
@@ -71,7 +69,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			_queue.Publish(new ProjectionManagementMessage.Command.GetState(envelope, name, partition));
 
 			return new StateResp {
-				State = await resultSource.Task.ConfigureAwait(false)
+				State = await resultSource.Task
 			};
 
 			void OnMessage(Message message) {

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Statistics.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Statistics.cs
@@ -14,8 +14,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 		public override async Task Statistics(StatisticsReq request, IServerStreamWriter<StatisticsResp> responseStream,
 			ServerCallContext context) {
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, StatisticsOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, StatisticsOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -34,7 +33,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 
 			_queue.Publish(new ProjectionManagementMessage.Command.GetStatistics(envelope, mode, name, true));
 
-			foreach (var stats in Array.ConvertAll(await statsSource.Task.ConfigureAwait(false), s => new StatisticsResp.Types.Details {
+			foreach (var stats in Array.ConvertAll(await statsSource.Task, s => new StatisticsResp.Types.Details {
 				BufferedEvents = s.BufferedEvents,
 				CheckpointStatus = s.CheckpointStatus,
 				CoreProcessingTime = s.CoreProcessingTime,
@@ -55,7 +54,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				WritePendingEventsBeforeCheckpoint = s.WritePendingEventsBeforeCheckpoint,
 				WritesInProgress = s.WritesInProgress
 			})) {
-				await responseStream.WriteAsync(new StatisticsResp { Details = stats }).ConfigureAwait(false);
+				await responseStream.WriteAsync(new StatisticsResp { Details = stats });
 			}
 
 			void OnMessage(Message message) {

--- a/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Update.cs
+++ b/src/EventStore.Projections.Core/Services/Grpc/ProjectionManagement.Update.cs
@@ -16,8 +16,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 			var options = request.Options;
 
 			var user = context.GetHttpContext().User;
-			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken)
-				.ConfigureAwait(false)) {
+			if (!await _authorizationProvider.CheckAccessAsync(user, UpdateOperation, context.CancellationToken)) {
 				throw RpcExceptions.AccessDenied();
 			}
 
@@ -36,7 +35,7 @@ namespace EventStore.Projections.Core.Services.Grpc {
 				new ProjectionManagementMessage.Command.UpdateQuery(envelope, name, runAs, query,
 					emitEnabled));
 
-			await updatedSource.Task.ConfigureAwait(false);
+			await updatedSource.Task;
 
 			return new UpdateResp();
 

--- a/src/EventStore.TestClient/ClientApiTcpCommands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/ClientApiTcpCommands/WriteFloodProcessor.cs
@@ -158,7 +158,7 @@ namespace EventStore.TestClient.ClientApiTcpCommands {
 							}
 						}));
 					if (pending.Count == capacity) {
-						await Task.WhenAny(pending).ConfigureAwait(false);
+						await Task.WhenAny(pending);
 
 						while (pending.Count > 0 && Task.WhenAny(pending).IsCompleted) {
 							pending.RemoveAll(x => x.IsCompleted);

--- a/src/EventStore.TestClient/GrpcCommands/WriteFloodProcessor.cs
+++ b/src/EventStore.TestClient/GrpcCommands/WriteFloodProcessor.cs
@@ -139,7 +139,7 @@ namespace EventStore.TestClient.GrpcCommands {
 					}));
 					
 					if (pending.Count >= capacity) {
-						await Task.WhenAny(pending).ConfigureAwait(false);
+						await Task.WhenAny(pending);
 						
 						while (pending.Count > 0 && Task.WhenAny(pending).IsCompleted) {
 							pending


### PR DESCRIPTION
Removed: Unncessary code

I think these were originally added because there were some places in the code (mostly in the client and embedded client) where they there necessary. These days the client lives in another repository and there is no embedded client. There aren't any synchronization contexts to forget in the server code and none of the async paths are hot enough that we need the cycles saved by not checking for a sync context, so we can remove the ugly calls.