### PR TITLE
Tidy/standardize http pipeline (DB-551)

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Http/PortableServer.cs
@@ -129,7 +129,7 @@ namespace EventStore.Core.Tests.Services.Transport.Http {
 				.AddRouting()
 				.BuildServiceProvider();
 
-			public void Configure(IApplicationBuilder app) => app.UseLegacyHttp(_dispatcher ,_httpService);
+			public void Configure(IApplicationBuilder app) => app.UseEndpoints(ep => ep.MapLegacyHttp(_dispatcher, _httpService));
 		}
 	}
 }

--- a/src/EventStore.Core/EventStoreLegacyHttpMiddleware.cs
+++ b/src/EventStore.Core/EventStoreLegacyHttpMiddleware.cs
@@ -6,11 +6,12 @@ using EventStore.Plugins.Authorization;
 using EventStore.Transport.Http;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
 
 namespace EventStore.Core {
 	public static class EventStoreLegacyHttpMiddleware {
-		public static IApplicationBuilder UseLegacyHttp(
-			this IApplicationBuilder app, RequestDelegate dispatcher,
+		public static IEndpointRouteBuilder MapLegacyHttp(
+			this IEndpointRouteBuilder app, RequestDelegate dispatcher,
 			params IHttpService[] httpServices) {
 			if (app == null) throw new ArgumentNullException(nameof(app));
 			if (httpServices == null) throw new ArgumentNullException(nameof(httpServices));
@@ -19,23 +20,29 @@ namespace EventStore.Core {
 				.SelectMany(x => x.Actions.Select(action =>
 					(ConvertToRoute(action.UriTemplate), action.HttpMethod, action.Operation)))
 				.ToArray();
-			return actions
+
+			var actionsToRegister = actions
 				.Concat(actions
 					.Select(_ => _.Item1)
 					.Select(route => (route, HttpMethod.Options, new Func<UriTemplateMatch, Operation>(_ => new Operation(Operations.Node.Options)))))
-				.Distinct(RouteAndMethodComparer.Instance)
-				.Aggregate(app.UseRouting(), RegisterRoute);
-			IApplicationBuilder RegisterRoute(
-				IApplicationBuilder builder,
+				.Distinct(RouteAndMethodComparer.Instance);
+
+			foreach (var action in actionsToRegister) {
+				RegisterRoute(app, action);
+			}
+
+			return app;
+
+			void RegisterRoute(
+				IEndpointRouteBuilder builder,
 				(string route, string method, Func<UriTemplateMatch, Operation> operation) action) => builder
-				.UseEndpoints(routeBuilder => routeBuilder
 					.MapMethods(
 						action.route,
 						action.method == HttpMethod.Get
 							? new[] {HttpMethod.Get, HttpMethod.Head}
 							: new[] {action.method},
 						dispatcher)
-					.WithMetadata(action.operation));
+					.WithMetadata(action.operation);
 
 			static string ConvertToRoute(string uriTemplate) {
 				var route = uriTemplate.Split('?').First();


### PR DESCRIPTION
Changed: Simplified HTTP pipeline

UseEndpoints registers endpoints. UseRouting selects an endpoint from those registered to that builder (app) instance.
The _first_ call to UseEndpoints is when the selected endpoint is executed.

For us this meant that the selected endpoint was executed on the UseEndPoints call on old line 142 (and not later as it might appear at first glance)

This is what necessitated the OPTIONS check on old line 137 _above_ the first UseEndPoints call (otherwise the gRPC code handles the OPTIONS request in UseEndPoints, and returns 404 if it is for a non gRPC endpoint)

Note that the non gRPC endpoints are registered in a _different_ builder because UseWhen (e.g. old line 143) gives you a different builder which needs its own calls to UseRounting and UseEndpoints. Therefore the original call to UseRouting on old line 136 does not know about the non grpc endpoints.

The idea in this PR is to make the main pipeline easier to understand by having only one call to UseEndpoints. It is then clear when the endpoint is executed and the gRPC code no longer intercepts OPTIONS requests that were intended for different endpoints.
