### PR TITLE
[DB-393] gRPC stream subscriptions with smooth transitions between live and catchup

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.StreamSubscription.Tests.cs
@@ -18,14 +18,14 @@ public partial class EnumeratorTests {
 	private static EnumeratorWrapper CreateStreamSubscription<TStreamId>(
 		IPublisher publisher,
 		string streamName,
-		StreamRevision? startRevision = null,
+		StreamRevision? checkpoint = null,
 		ClaimsPrincipal user = null) {
 
 		return new EnumeratorWrapper(new Enumerator.StreamSubscription<TStreamId>(
 			bus: publisher,
 			expiryStrategy: new DefaultExpiryStrategy(),
 			streamName: streamName,
-			startRevision: startRevision,
+			checkpoint: checkpoint,
 			resolveLinks: false,
 			user: user ?? SystemAccounts.System,
 			requiresLeader: false,

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.Tests.cs
@@ -12,6 +12,7 @@ public partial class EnumeratorTests {
 	public record Event(Guid Id, long EventNumber) : SubscriptionResponse { }
 	public record SubscriptionConfirmation() : SubscriptionResponse { }
 	public record CaughtUp : SubscriptionResponse { }
+	public record FellBehind : SubscriptionResponse { }
 
 	public class EnumeratorWrapper : IAsyncDisposable {
 		private readonly IAsyncEnumerator<ReadResponse> _enumerator;
@@ -33,6 +34,7 @@ public partial class EnumeratorTests {
 				ReadResponse.EventReceived eventReceived => new Event(eventReceived.Event.Event.EventId, eventReceived.Event.OriginalEventNumber),
 				ReadResponse.SubscriptionConfirmed => new SubscriptionConfirmation(),
 				ReadResponse.SubscriptionCaughtUp => new CaughtUp(),
+				ReadResponse.SubscriptionFellBehind => new FellBehind(),
 				_ => throw new ArgumentOutOfRangeException(nameof(resp), resp, null),
 			};
 		}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1127,7 +1127,7 @@ namespace EventStore.Core {
 			_mainBus.Subscribe(subscrQueue.WidenFrom<StorageMessage.EventCommitted, Message>());
 			_mainBus.Subscribe(subscrQueue.WidenFrom<StorageMessage.InMemoryEventCommitted, Message>());
 
-			var subscription = new SubscriptionsService<TStreamId>(_mainQueue, subscrQueue, _authorizationProvider, readIndex);
+			var subscription = new SubscriptionsService<TStreamId>(_mainQueue, subscrQueue, _authorizationProvider, readIndex, inMemReader);
 			subscrBus.Subscribe<SystemMessage.SystemStart>(subscription);
 			subscrBus.Subscribe<SystemMessage.BecomeShuttingDown>(subscription);
 			subscrBus.Subscribe<TcpMessage.ConnectionClosed>(subscription);

--- a/src/EventStore.Core/Messaging/AsyncTaskEnvelope.cs
+++ b/src/EventStore.Core/Messaging/AsyncTaskEnvelope.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EventStore.Core.Messaging;
+
+// WARNING: ReplyWith only _calls_ onMessage.
+// - it does not await it because ReplyWith is not asynchronous
+// - it does not synchronously wait for it because onMessage might be scheduled on our local
+//      task queue and we'd have to wait until another thread comes and steals it
+// - instead we just call it and return.
+// - the synchronous portion of onMessage must be quick as it is called on the replyer's thread
+// - the asynchronous portion of onMessage must be aware that the call to ReplyWith has completed and
+//      therefore a single thread calling ReplyWith might call it again before onMessage has completed.
+public class AsyncTaskEnvelope : IEnvelope {
+	private readonly Func<Message, CancellationToken, Task> _onMessage;
+	private readonly CancellationToken _cancellationToken;
+
+	public AsyncTaskEnvelope(Func<Message, CancellationToken, Task> onMessage, CancellationToken cancellationToken) {
+		_onMessage = onMessage;
+		_cancellationToken = cancellationToken;
+	}
+
+	public void ReplyWith<T>(T message) where T : Message {
+		try {
+			_onMessage(message, _cancellationToken);
+		} catch (OperationCanceledException) {
+			// depending on the implementation of _onMessage, the OperationCancelled exception might be caught here or
+			// it might end up on the Task according to whether it is thrown synchronously or not. this isn't a problem
+			// as we're ignoring the exception in both cases.
+		}
+	}
+}

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.cs
@@ -14,6 +14,13 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 				SingleWriter = true
 			};
 
+		private static readonly BoundedChannelOptions LiveChannelOptions =
+			new(MaxLiveEventBufferCount) {
+				FullMode = BoundedChannelFullMode.DropOldest,
+				SingleReader = true,
+				SingleWriter = true
+			};
+
 		private static bool TryHandleNotHandled(ClientMessage.NotHandled notHandled, out ReadResponseException exception) {
 			exception = null;
 			switch (notHandled.Reason) {

--- a/src/EventStore.Core/Services/Transport/Enumerators/ReadResponse.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/ReadResponse.cs
@@ -14,6 +14,8 @@ public abstract class ReadResponse {
 
 	public class SubscriptionCaughtUp: ReadResponse { }
 
+	public class SubscriptionFellBehind: ReadResponse { }
+
 	public class CheckpointReceived: ReadResponse {
 		public readonly ulong CommitPosition;
 		public readonly ulong PreparePosition;


### PR DESCRIPTION
Added: gRPC stream subscriptions with smooth transitions between live and catchup. Subscriptions no longer drop with "consumer too slow" reason.

Fixes: https://github.com/EventStore/EventStore/issues/4089

This PR restores the ability of gRPC stream subscriptions to smoothly switch between live and catch-up. It also stops using the ContinuationEnvelope which internally uses a semaphore which could block critical threads like the subscription service thread.

Thanks to @timothycoleman for contributing many of the main ideas in this PR!

The main changes in this PR are:
- As before we use a bounded channel to store live events but the `FullMode` has been changed to `DropOldest`. When the live buffer becomes full and we want to add a new event, the oldest event is dropped to create space for the new event. We thus keep a "window" of the last 32 live events. Thus, the subscription service now never blocks when writing events to the live channel.
- To detect gaps in the live channel due to dropped events, we use a sequence number when adding items to the live channel. When we're live and a gap is detected, we switch back to catch-up.
- Many of the methods like `Catchup`, `GoLive`  now return Tasks, which allows us to put the core logic of the subscription in a loop (`MainLoop`) and there's no longer the need to do any "manual" synchronization between the catch-up and live threads.
- The live subscription also runs permanently now as this makes the algorithm simpler and more efficient:
  - we can switch to live directly when the subscription starts if the checkpoint matches the last live event number
  - if the subscription is switching back and forth between live/catch-up, we don't need to unsubscribe/re-subscribe internally each time

## Fast producer / Slow consumer
Note that the main channel that the subscription reads from (`_channel`) is still a bounded channel with `FullMode` = `Wait`

### Live
If we're live and events are written to the live channel/database at a rate that's faster than they're being read by the client, then the live channel will eventually become full and events will be dropped. Dropped events will be detected (with sequence numbers) and we will switch to catch-up mode.

In parallel, it's also possible that the output channel (`_channel`) will become full. Since `_channel` uses `FullMode` = `Wait`, then the live task will wait and write events as space is made on _channel.

### Catch-up
If we're in catch-up mode and the rate at which events are read from the disk is higher than the rate they're being read by the client, then the output channel (`_channel`) will eventually become full when writing events in the `ReadPage` callback. Just like when we're live, the task will wait till space is made on _channel.

## Performance
Some basic tests done on my machine:

### Catch-up
| Branch  | Catch-up time for 1M events (events / sec) |
|---------|--------------------------------------------|
| This PR | ~76000                                      |
| master  | ~76000                                      |

### Live
| Branch  | Live event rate without switching to catch-up/consumer too slow (events / sec)               |
|---------|----------------------------------------------------------------------------------------------|
| This PR | > 1000
| master  | 465 (gets consumer too slow after this point)