### PR TITLE
Fix stream (hard) deletion when gRPC subscription is live [regression] [DB-573]

### DIFF
--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.StreamSubscription.cs
@@ -104,7 +104,6 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 
 					if (@event.OriginalEvent.EventType == SystemEventTypes.StreamDeleted) {
 						Fail(new ReadResponseException.StreamDeleted(_streamName));
-						return false;
 					}
 
 					var streamRevision = StreamRevision.FromInt64(@event.OriginalEventNumber);


### PR DESCRIPTION
Fixed: Stream (hard) deletion when gRPC subscription is live [regression]

A stream deleted exception was not being thrown on the gRPC client side when a gRPC stream subscription was live and the stream was hard deleted. That's because the exception was set only on the channel and nothing reads from the channel again after returning false in MoveNextAsync().

This is a regression introduced by: 0923c5632e3341adfe603d8d6a6b2e4bc04d3b69. The `return false` wasn't previously present. The regression isn't present in any release (we would have caught it during QA as the .NET client tests fail)