### PR TITLE
Add section headings to projections HTTP API docs

### DIFF
--- a/docs/http-api/projections.md
+++ b/docs/http-api/projections.md
@@ -157,15 +157,33 @@ The server then returns the state for the partition:
 |:---------------------------------------------------|:-----------------------------|:----------|
 | `/projections/any`                                 | Returns all known projections.             | GET       |
 | `/projections/all-non-transient`                   | Returns all known non ad-hoc projections.  | GET       |
-| `/projections/transient`                           | Returns all known ad-hoc projections.      | GET       |
-| `/projections/onetime`                             | Returns all known one-time projections.    | GET       |
-| `/projections/continuous`                          | Returns all known continuous projections.  | GET       |
 
-### Create an Ad-Hoc Projection
+
+### Manage Continuous Projections
+
+Continuous projections will continue to run until they are disabled or until they encounter an unrecoverable error. These are the most typical projections.
 
 | URI                                                | Description                  | HTTP verb |
 |:---------------------------------------------------|:-----------------------------|:----------|
-| `/projections/transient?name={name}&type={type}&enabled={enabled}` | Create an ad-hoc projection (or query). This type of projection runs until completion and automatically deleted afterwards. | POST      |
+| `/projections/continuous`                          | Returns all known continuous projections.  | GET       |
+| `/projections/continuous?name={name}&type={type}&enabled={enabled}&emit={emit}&trackemittedstreams={trackemittedstreams}` | Create a continuous projection. | POST      |
+
+#### Parameters
+
+* `name`: Name of the projection
+* `type`: JS or Native. (JavaScript or native. At this time, EventStoreDB only supports JavaScript)
+* `enabled`: Enable the projection (true/false)
+* `emit`: Allow the projection to append to streams (true/false)
+* `trackemittedstreams`: Write the name of the streams the projection is managing to a separate stream. $projections-{projection-name}-emittedstreams (true/false)
+
+### Manage Transient Projections
+
+Transient projections are sometimes called ad-hoc projections or queries. This type of projection will run until completion and automatically delete itself afterwards.
+
+| URI                                                | Description                  | HTTP verb |
+|:---------------------------------------------------|:-----------------------------|:----------|
+| `/projections/transient`                                           | Returns all known ad-hoc projections.      | GET       |
+| `/projections/transient?name={name}&type={type}&enabled={enabled}` | Create an ad-hoc projection (or query).    | POST      |
 
 #### Parameters
 
@@ -173,11 +191,14 @@ The server then returns the state for the partition:
 * `type`: JS or Native. (JavaScript or native. At this time, EventStoreDB only supports JavaScript)
 * `enabled`: Enable the projection (true/false)
 
-### Create OneTime Projection
+### Manage OneTime Projections
+
+OneTime projections run until completion and then stop. These are useful for periodically generating state or reports when you don't need the projection to be always running.
 
 | URI                                                | Description                  | HTTP verb |
 |:---------------------------------------------------|:-----------------------------|:----------|
-| `/projections/onetime?name={name}&type={type}&enabled={enabled}&checkpoints={checkpoints}&emit={emit}&trackemittedstreams={trackemittedstreams}` | Create a one-time projection. This type of projection runs until completion and then stops. | POST      |
+| `/projections/onetime`                             | Returns all known one-time projections.    | GET       |
+| `/projections/onetime?name={name}&type={type}&enabled={enabled}&checkpoints={checkpoints}&emit={emit}&trackemittedstreams={trackemittedstreams}` | Create a one-time projection. | POST      |
 
 #### Parameters
 
@@ -188,137 +209,32 @@ The server then returns the state for the partition:
 * `emit`: Enable the ability for the projection to append to streams (true/false)
 * `trackemittedstreams`: Write the name of the streams the projection is managing to a separate stream. $projections-{projection-name}-emittedstreams (true/false)
 
-### Create a Continuous Projection
+### Manage a Projection
 
 | URI                                                | Description                  | HTTP verb |
 |:---------------------------------------------------|:-----------------------------|:----------|
-| `/projections/continuous?name={name}&type={type}&enabled={enabled}&emit={emit}&trackemittedstreams={trackemittedstreams}` | Create a continuous projection. This type of projection will, if enabled will continuously run unless disabled or an unrecoverable error is encountered. | POST      |
-
-#### Parameters
-
-* `name`: Name of the projection
-* `type`: JS or Native. (JavaScript or native. At this time, EventStoreDB only supports JavaScript)
-* `enabled`: Enable the projection (true/false)
-* `emit`: Allow the projection to append to streams (true/false)
-* `trackemittedstreams`: Write the name of the streams the projection is managing to a separate stream. $projections-{projection-name}-emittedstreams (true/false)
-
-### Get a Projection's Query and Config
-
-| URI                                                | Description                  | HTTP verb |
-|:---------------------------------------------------|:-----------------------------|:----------|
-| `/projection/{name}/query?config={config}` | Returns the definition query and if config is set to true, will return the configuration. | GET
+| `/projection/{name}`                               | Returns information for a projection.          | GET       |
+| `/projection/{name}/query?config={config}`         | Returns the definition query and if config is set to true, will return the configuration. | GET
+| `/projection/{name}/query?type={type}&emit={emit}` | Update a projection's query.                   | PUT       |
+| `/projection/{name}?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}&deleteEmittedStreams={deleteEmittedStreams}` | Delete a projection, optionally delete the streams that were created as part of the projection. | DELETE    |
+| `/projection/{name}/statistics`                    | Returns detailed information for a projection. | GET       |
+| `/projection/{name}/state?partition={partition}`   | Query for the state of a projection.           | GET       |
+| `/projection/{name}/result?partition={partition}`  | Query for the result of a projection.          | GET       |
+| `/projection/{name}/command/enable?enableRunAs={enableRunAs}`  | Enable a projection.               | POST      |
+| `/projection/{name}/command/disable?enableRunAs={enableRunAs}` | Disable a projection.              | POST      |
+| `/projection/{name}/command/reset?enableRunAs={enableRunAs}` | Reset a projection. (This will re-emit events, streams that are written to from the projection will also be soft deleted). | POST      |
+| `/projection/{name}/command/abort?enableRunAs={enableRunAs}` | Abort a projection.                  | POST      |
 
 #### Parameters
 
 * `name`: Name of the projection
 * `config`: Return the definition of the projection (true/false)
-
-### Update a Projection's Query
-
-| URI                                                | Description                  | HTTP verb |
-|:---------------------------------------------------|:-----------------------------|:----------|
-| `/projection/{name}/query?type={type}&emit={emit}` | Update a projection's query. | PUT       |
-
-#### Parameters
-
-* `name`: Name of the projection
 * `type`: JS or Native. (JavaScript or native. At this time, EventStoreDB only supports JavaScript)
 * `emit`: Allow the projection to write to streams (true/false)
 * `trackemittedstreams`: Write the name of the streams the projection is managing to a separate stream. $projections-{projection-name}-emittedstreams (true/false)
-
-### Get a Projection's Information
-
-| URI                             | Description                                    | HTTP verb |
-|:--------------------------------|:-----------------------------------------------|:----------|
-| `/projection/{name}`            | Returns information for a projection.          | GET       |
-
-#### Parameters
-
-* `name`: Name of the projection
-
-### Delete a Projection
-
-| URI                             | Description                                    | HTTP verb |
-|:--------------------------------|:-----------------------------------------------|:----------|
-| `/projection/{name}?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}&deleteEmittedStreams={deleteEmittedStreams}` | Delete a projection, optionally delete the streams that were created as part of the projection. | DELETE    |
-
-#### Parameters
-
 * `name`: Name of the projection
 * `deleteStateStream`: Delete the state stream (true/false)
 * `deleteCheckpointStream`: Delete the checkpoint stream (true/false)
 * `deleteEmittedStreams`: Delete the emitted streams stream (true/false)
-
-### Get a Projection's Statistics
-
-| URI                             | Description                                    | HTTP verb |
-|:--------------------------------|:-----------------------------------------------|:----------|
-| `/projection/{name}/statistics` | Returns detailed information for a projection. | GET       |
-
-#### Parameters
-
-* name: Name of the projection
-
-### Get a Projection's State
-
-| URI                                              | Description                          | HTTP verb |
-|:-------------------------------------------------|:-------------------------------------|:----------|
-| `/projection/{name}/state?partition={partition}` | Query for the state of a projection. | GET       |
-
-#### Parameters
-
-* `name`: Name of the projection
-* `partition`: The partition
-
-### Get a Projection's Result
-| URI                                               | Description                           | HTTP verb |
-|:--------------------------------------------------|:--------------------------------------|:----------|
-| `/projection/{name}/result?partition={partition}` | Query for the result of a projection. | GET       |
-
-#### Parameters
-
-* `name`: Name of the projection
-* `partition`: The partition
-
-### Disable a Projection
-
-| URI                                                            | Description           | HTTP verb |
-|:---------------------------------------------------------------|:----------------------|:----------|
-| `/projection/{name}/command/disable?enableRunAs={enableRunAs}` | Disable a projection. | POST      |
-
-#### Parameters
-
-* `name`: Name of the projection
+* `partition`: The name of the partition
 * `enableRunAs`: Enables the projection to run as the user who issued the request.
-
-### Enable a Projection
-| URI                                                           | Description          | HTTP verb |
-|:--------------------------------------------------------------|:---------------------|:----------|
-| `/projection/{name}/command/enable?enableRunAs={enableRunAs}` | Enable a projection. | POST      |
-
-#### Parameters
-
-* `name`: Name of the projection
-* `enableRunAs`: Enables the projection to run as the user who issued the request.
-
-### Reset a Projection
-
-| URI                                                           | Description          | HTTP verb |
-|:--------------------------------------------------------------|:---------------------|:----------|
-| `/projection/{name}/command/reset?enableRunAs={enableRunAs}` | Reset a projection. (This will re-emit events, streams that are written to from the projection will also be soft deleted). | POST      |
-
-#### Parameters
-
-* `name`: Name of the projection
-* `enableRunAs`: Enables the projection to run as the user who issued the request.
-
-### Abort a Projection
-
-| URI                                                          | Description         | HTTP verb |
-|:-------------------------------------------------------------|:--------------------|:----------|
-| `/projection/{name}/command/abort?enableRunAs={enableRunAs}` | Abort a projection. | POST      |
-
-#### Parameters
-
-* `name`: Name of the projection
-* `enableRunAs`: Enables the projection to run as the user who issued th 

--- a/docs/http-api/projections.md
+++ b/docs/http-api/projections.md
@@ -151,14 +151,21 @@ The server then returns the state for the partition:
 
 ## Projections API
 
-| URI                                                                | Description                                                                                                      | HTTP verb |
-|:-------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------|:----------|
-| `/projections/any`                                                 | Returns all known projections.                                                                                   | GET       |
-| `/projections/all-non-transient`                                   | Returns all known non ad-hoc projections.                                                                        | GET       |
-| `/projections/transient`                                           | Returns all known ad-hoc projections.                                                                            | GET       |
-| `/projections/onetime`                                             | Returns all known one-time projections.                                                                          | GET       |
-| `/projections/continuous`                                          | Returns all known continuous projections.                                                                        | GET       |
-| `/projections/transient?name={name}&type={type}&enabled={enabled}` | Create an ad-hoc projection. This type of projection runs until completion and automatically deleted afterwards. | POST      |
+### List Projections
+
+| URI                                                | Description                  | HTTP verb |
+|:---------------------------------------------------|:-----------------------------|:----------|
+| `/projections/any`                                 | Returns all known projections.             | GET       |
+| `/projections/all-non-transient`                   | Returns all known non ad-hoc projections.  | GET       |
+| `/projections/transient`                           | Returns all known ad-hoc projections.      | GET       |
+| `/projections/onetime`                             | Returns all known one-time projections.    | GET       |
+| `/projections/continuous`                          | Returns all known continuous projections.  | GET       |
+
+### Create an Ad-Hoc Projection
+
+| URI                                                | Description                  | HTTP verb |
+|:---------------------------------------------------|:-----------------------------|:----------|
+| `/projections/transient?name={name}&type={type}&enabled={enabled}` | Create an ad-hoc projection (or query). This type of projection runs until completion and automatically deleted afterwards. | POST      |
 
 #### Parameters
 
@@ -166,8 +173,10 @@ The server then returns the state for the partition:
 * `type`: JS or Native. (JavaScript or native. At this time, EventStoreDB only supports JavaScript)
 * `enabled`: Enable the projection (true/false)
 
-| URI                                                                                                                                              | Description                                                                                 | HTTP verb |
-|:-------------------------------------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------|:----------|
+### Create OneTime Projection
+
+| URI                                                | Description                  | HTTP verb |
+|:---------------------------------------------------|:-----------------------------|:----------|
 | `/projections/onetime?name={name}&type={type}&enabled={enabled}&checkpoints={checkpoints}&emit={emit}&trackemittedstreams={trackemittedstreams}` | Create a one-time projection. This type of projection runs until completion and then stops. | POST      |
 
 #### Parameters
@@ -179,8 +188,10 @@ The server then returns the state for the partition:
 * `emit`: Enable the ability for the projection to append to streams (true/false)
 * `trackemittedstreams`: Write the name of the streams the projection is managing to a separate stream. $projections-{projection-name}-emittedstreams (true/false)
 
-| URI                                                                                                                       | Description                                                                                                                                              | HTTP verb |
-|:--------------------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------|:----------|
+### Create a Continuous Projection
+
+| URI                                                | Description                  | HTTP verb |
+|:---------------------------------------------------|:-----------------------------|:----------|
 | `/projections/continuous?name={name}&type={type}&enabled={enabled}&emit={emit}&trackemittedstreams={trackemittedstreams}` | Create a continuous projection. This type of projection will, if enabled will continuously run unless disabled or an unrecoverable error is encountered. | POST      |
 
 #### Parameters
@@ -191,12 +202,18 @@ The server then returns the state for the partition:
 * `emit`: Allow the projection to append to streams (true/false)
 * `trackemittedstreams`: Write the name of the streams the projection is managing to a separate stream. $projections-{projection-name}-emittedstreams (true/false)
 
-`/projection/{name}/query?config={config}` | Returns the definition query and if config is set to true, will return the configuration. | GET
+### Get a Projection's Query and Config
+
+| URI                                                | Description                  | HTTP verb |
+|:---------------------------------------------------|:-----------------------------|:----------|
+| `/projection/{name}/query?config={config}` | Returns the definition query and if config is set to true, will return the configuration. | GET
 
 #### Parameters
 
 * `name`: Name of the projection
 * `config`: Return the definition of the projection (true/false)
+
+### Update a Projection's Query
 
 | URI                                                | Description                  | HTTP verb |
 |:---------------------------------------------------|:-----------------------------|:----------|
@@ -209,9 +226,20 @@ The server then returns the state for the partition:
 * `emit`: Allow the projection to write to streams (true/false)
 * `trackemittedstreams`: Write the name of the streams the projection is managing to a separate stream. $projections-{projection-name}-emittedstreams (true/false)
 
-| URI                                                                                                                                                    | Description                                                                                     | HTTP verb |
-|:-------------------------------------------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------------------------------|:----------|
-| `/projection/{name}`                                                                                                                                   | Returns information for a projection.                                                           | GET       |
+### Get a Projection's Information
+
+| URI                             | Description                                    | HTTP verb |
+|:--------------------------------|:-----------------------------------------------|:----------|
+| `/projection/{name}`            | Returns information for a projection.          | GET       |
+
+#### Parameters
+
+* `name`: Name of the projection
+
+### Delete a Projection
+
+| URI                             | Description                                    | HTTP verb |
+|:--------------------------------|:-----------------------------------------------|:----------|
 | `/projection/{name}?deleteStateStream={deleteStateStream}&deleteCheckpointStream={deleteCheckpointStream}&deleteEmittedStreams={deleteEmittedStreams}` | Delete a projection, optionally delete the streams that were created as part of the projection. | DELETE    |
 
 #### Parameters
@@ -221,6 +249,8 @@ The server then returns the state for the partition:
 * `deleteCheckpointStream`: Delete the checkpoint stream (true/false)
 * `deleteEmittedStreams`: Delete the emitted streams stream (true/false)
 
+### Get a Projection's Statistics
+
 | URI                             | Description                                    | HTTP verb |
 |:--------------------------------|:-----------------------------------------------|:----------|
 | `/projection/{name}/statistics` | Returns detailed information for a projection. | GET       |
@@ -228,6 +258,8 @@ The server then returns the state for the partition:
 #### Parameters
 
 * name: Name of the projection
+
+### Get a Projection's State
 
 | URI                                              | Description                          | HTTP verb |
 |:-------------------------------------------------|:-------------------------------------|:----------|
@@ -238,6 +270,7 @@ The server then returns the state for the partition:
 * `name`: Name of the projection
 * `partition`: The partition
 
+### Get a Projection's Result
 | URI                                               | Description                           | HTTP verb |
 |:--------------------------------------------------|:--------------------------------------|:----------|
 | `/projection/{name}/result?partition={partition}` | Query for the result of a projection. | GET       |
@@ -246,6 +279,8 @@ The server then returns the state for the partition:
 
 * `name`: Name of the projection
 * `partition`: The partition
+
+### Disable a Projection
 
 | URI                                                            | Description           | HTTP verb |
 |:---------------------------------------------------------------|:----------------------|:----------|
@@ -256,6 +291,7 @@ The server then returns the state for the partition:
 * `name`: Name of the projection
 * `enableRunAs`: Enables the projection to run as the user who issued the request.
 
+### Enable a Projection
 | URI                                                           | Description          | HTTP verb |
 |:--------------------------------------------------------------|:---------------------|:----------|
 | `/projection/{name}/command/enable?enableRunAs={enableRunAs}` | Enable a projection. | POST      |
@@ -265,14 +301,18 @@ The server then returns the state for the partition:
 * `name`: Name of the projection
 * `enableRunAs`: Enables the projection to run as the user who issued the request.
 
-| URI                                                          | Description                                                                                                                | HTTP verb |
-|:-------------------------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------|:----------|
+### Reset a Projection
+
+| URI                                                           | Description          | HTTP verb |
+|:--------------------------------------------------------------|:---------------------|:----------|
 | `/projection/{name}/command/reset?enableRunAs={enableRunAs}` | Reset a projection. (This will re-emit events, streams that are written to from the projection will also be soft deleted). | POST      |
 
 #### Parameters
 
 * `name`: Name of the projection
 * `enableRunAs`: Enables the projection to run as the user who issued the request.
+
+### Abort a Projection
 
 | URI                                                          | Description         | HTTP verb |
 |:-------------------------------------------------------------|:--------------------|:----------|


### PR DESCRIPTION
The HTTP API docs were missing headings for each operation, which makes it difficult to find what you're looking for