### PR TITLE
Do not autosize when EventStoreDB runs in containerized environment

### DIFF
--- a/src/EventStore.Common/Utils/ContainerizedEnvironment.cs
+++ b/src/EventStore.Common/Utils/ContainerizedEnvironment.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace EventStore.Common.Utils;
+
+public static class ContainerizedEnvironment {
+
+	public const int ReaderThreadCount = 4;
+	public const int WorkerThreadCount = 5;
+	public const int StreamInfoCacheCapacity = 100000;
+
+	private static readonly string _dotnetContainerEnv;
+
+	static ContainerizedEnvironment() {
+		_dotnetContainerEnv = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER");
+	}
+
+	public static bool IsRunningInContainer() {
+		return !string.IsNullOrEmpty(_dotnetContainerEnv);
+	}
+}

--- a/src/EventStore.Core.Tests/Settings/ReaderThreadCountCalculatorTests.cs
+++ b/src/EventStore.Core.Tests/Settings/ReaderThreadCountCalculatorTests.cs
@@ -5,24 +5,30 @@ namespace EventStore.Core.Tests.Settings {
 	[TestFixture]
 	public class ReaderThreadCountCalculatorTests {
 		[TestCase]
-		public void configured_takes_precedence() => Test(configuredCount: 1, processorCount: 4, expected: 1);
+		public void configured_takes_precedence() => Test(configuredCount: 1, processorCount: 4, isRunningInContainer: false, expected: 1);
 
 		[TestCase]
-		public void enforces_minimum() => Test(configuredCount: 0, processorCount: 1, expected: 4);
+		public void enforces_minimum() => Test(configuredCount: 0, processorCount: 1, isRunningInContainer: false, expected: 4);
 
 		[TestCase]
-		public void enforces_maximum() => Test(configuredCount: 0, processorCount: 20, expected: 16);
+		public void enforces_maximum() => Test(configuredCount: 0, processorCount: 20, isRunningInContainer: false, expected: 16);
 
 		[TestCase]
-		public void at_3_cores() => Test(configuredCount: 0, processorCount: 3, expected: 6);
+		public void at_3_cores() => Test(configuredCount: 0, processorCount: 3, isRunningInContainer: false, expected: 6);
 
 		[TestCase]
-		public void at_4_cores() => Test(configuredCount: 0, processorCount: 4, expected: 8);
+		public void at_4_cores() => Test(configuredCount: 0, processorCount: 4, isRunningInContainer: false, expected: 8);
 
 		[TestCase]
-		public void at_6_cores() => Test(configuredCount: 0, processorCount: 6, expected: 12);
+		public void at_6_cores() => Test(configuredCount: 0, processorCount: 6, isRunningInContainer: false, expected: 12);
 
-		public static void Test(int configuredCount, int processorCount, int expected) =>
-			Assert.AreEqual(expected, ThreadCountCalculator.CalculateReaderThreadCount(configuredCount, processorCount));
+		[TestCase]
+		public void running_in_docker_container_at_6_cores() => Test(configuredCount: 0, processorCount: 6, isRunningInContainer: true, expected: 4);
+
+		[TestCase]
+		public void running_in_docker_container_configured_takes_precedence() => Test(configuredCount: 1, processorCount: 4, isRunningInContainer: true, expected: 1);
+
+		public static void Test(int configuredCount, int processorCount, bool isRunningInContainer, int expected) =>
+			Assert.AreEqual(expected, ThreadCountCalculator.CalculateReaderThreadCount(configuredCount, processorCount, isRunningInContainer));
 	}
 }

--- a/src/EventStore.Core.Tests/Settings/WorkerThreadCountCalculatorTests.cs
+++ b/src/EventStore.Core.Tests/Settings/WorkerThreadCountCalculatorTests.cs
@@ -5,22 +5,28 @@ namespace EventStore.Core.Tests.Settings {
 	[TestFixture]
 	public class WorkerThreadCountCalculatorTests {
 		[TestCase]
-		public void configured_takes_precedence() => Test(configuredCount: 1, readerCount: 10, expected: 1);
+		public void configured_takes_precedence() => Test(configuredCount: 1, readerCount: 10, isRunningInContainer: false, expected: 1);
 
 		[TestCase]
-		public void enforces_minimum() => Test(configuredCount: 0, readerCount: 1, expected: 5);
+		public void enforces_minimum() => Test(configuredCount: 0, readerCount: 1, isRunningInContainer: false, expected: 5);
 
 		[TestCase]
-		public void enforces_maximum() => Test(configuredCount: 0, readerCount: 1000, expected: 10);
+		public void enforces_maximum() => Test(configuredCount: 0, readerCount: 1000, isRunningInContainer: false, expected: 10);
 
 		[TestCase]
-		public void at_4_reader_threads() => Test(configuredCount: 0, 4, expected: 5);
+		public void at_4_reader_threads() => Test(configuredCount: 0, readerCount: 4, isRunningInContainer: false, expected: 5);
 
 		[TestCase]
-		public void at_increased_reader_threads() => Test(configuredCount: 0, 8, expected: 10);
+		public void at_increased_reader_threads() => Test(configuredCount: 0, readerCount: 8, isRunningInContainer: false, expected: 10);
 
-		public static void Test(int configuredCount, int readerCount, int expected) =>
-			Assert.AreEqual(expected, ThreadCountCalculator.CalculateWorkerThreadCount(configuredCount, readerCount));
+		[TestCase]
+		public void running_in_docker_container_configured_takes_precedence() => Test(configuredCount: 1, readerCount: 4, isRunningInContainer: true, expected: 1);
+
+		[TestCase]
+		public void running_in_docker_container_at_4_reader_threads() => Test(configuredCount: 0, readerCount: 4, isRunningInContainer: true, expected: 5);
+
+		public static void Test(int configuredCount, int readerCount, bool isRunningInContainer, int expected) =>
+			Assert.AreEqual(expected, ThreadCountCalculator.CalculateWorkerThreadCount(configuredCount, readerCount, isRunningInContainer));
 
 	}
 }

--- a/src/EventStore.Core/Settings/ThreadCountCalculator.cs
+++ b/src/EventStore.Core/Settings/ThreadCountCalculator.cs
@@ -1,24 +1,68 @@
 using System;
+using EventStore.Common.Utils;
+using Serilog;
 
 namespace EventStore.Core.Settings {
 
 	public static class ThreadCountCalculator {
 		private const int ReaderThreadCountFloor = 4;
 
-		public static int CalculateReaderThreadCount(int configuredCount, int processorCount) {
-			if (configuredCount > 0)
+		public static int CalculateReaderThreadCount(int configuredCount, int processorCount,
+			bool isRunningInContainer) {
+			if (configuredCount > 0) {
+				Log.Information(
+					"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
+					"Calculated based on processor count of {processorCount:N0} and configured value of {configuredCount:N0}",
+					configuredCount,
+					processorCount, configuredCount);
 				return configuredCount;
+			}
+
+			if (isRunningInContainer) {
+				Log.Information(
+					"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
+					"Calculated based on containerized environment and configured value of {configuredCount:N0}",
+					ContainerizedEnvironment.ReaderThreadCount,
+					configuredCount);
+				return ContainerizedEnvironment.ReaderThreadCount;
+			}
 
 			var readerCount = Math.Clamp(processorCount * 2, ReaderThreadCountFloor, 16);
-
+			Log.Information(
+				"ReaderThreadsCount set to {readerThreadsCount:N0}. " +
+				"Calculated based on processor count of {processorCount:N0} and configured value of {configuredCount:N0}",
+				readerCount,
+				processorCount, configuredCount);
 			return readerCount;
 		}
 
-		public static int CalculateWorkerThreadCount(int configuredCount, int readerCount) {
-			if (configuredCount > 0)
+		public static int CalculateWorkerThreadCount(int configuredCount, int readerCount, bool isRunningInContainer) {
+			if (configuredCount > 0) {
+				Log.Information(
+					"WorkerThreads set to {workerThreadsCount:N0}. " +
+					"Calculated based on a reader thread count of {readerThreadsCount:N0} and a configured value of {configuredCount:N0}",
+					configuredCount,
+					readerCount, configuredCount);
 				return configuredCount;
+			}
 
-			return readerCount > ReaderThreadCountFloor ? 10 : 5;
+
+			if (isRunningInContainer) {
+				Log.Information(
+					"WorkerThreads set to {workerThreadsCount:N0}. " +
+					"Calculated based on containerized environment and a configured value of {configuredCount:N0}",
+					ContainerizedEnvironment.WorkerThreadCount,
+					configuredCount);
+				return ContainerizedEnvironment.WorkerThreadCount;
+			}
+
+			var workerThreadsCount = readerCount > ReaderThreadCountFloor ? 10 : 5;
+			Log.Information(
+				"WorkerThreads set to {workerThreadsCount:N0}. " +
+				"Calculated based on a reader thread count of {readerThreadsCount:N0} and a configured value of {configuredCount:N0}",
+				workerThreadsCount,
+				readerCount, configuredCount);
+			return workerThreadsCount;
 		}
 	}
 }

--- a/src/EventStore.Core/Telemetry/ContainerInfo.cs
+++ b/src/EventStore.Core/Telemetry/ContainerInfo.cs
@@ -11,7 +11,7 @@ public class ContainerInfo {
 
 	private static ContainerInfo Collect() {
 		var info = new ContainerInfo {
-			 IsContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") != null,
+			IsContainer = ContainerizedEnvironment.IsRunningInContainer()
 		};
 
 		if (OS.OsFlavor != OsFlavor.Linux || !File.Exists("/proc/self/cgroup"))


### PR DESCRIPTION
Changed: Do not autosize thread count and streaminfocache size in containerized environments

Fixes: https://linear.app/eventstore/issue/DB-408/do-not-autosize-when-containerised