### PR TITLE
[DB-590] Live subscriptions: Re-authorize when a stream's metadata changes

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1121,18 +1121,20 @@ namespace EventStore.Core {
 			_mainBus.Subscribe(subscrQueue.WidenFrom<ClientMessage.SubscribeToStream, Message>());
 			_mainBus.Subscribe(subscrQueue.WidenFrom<ClientMessage.FilteredSubscribeToStream, Message>());
 			_mainBus.Subscribe(subscrQueue.WidenFrom<ClientMessage.UnsubscribeFromStream, Message>());
+			_mainBus.Subscribe(subscrQueue.WidenFrom<SubscriptionMessage.DropSubscription, Message>());
 			_mainBus.Subscribe(subscrQueue.WidenFrom<SubscriptionMessage.PollStream, Message>());
 			_mainBus.Subscribe(subscrQueue.WidenFrom<SubscriptionMessage.CheckPollTimeout, Message>());
 			_mainBus.Subscribe(subscrQueue.WidenFrom<StorageMessage.EventCommitted, Message>());
 			_mainBus.Subscribe(subscrQueue.WidenFrom<StorageMessage.InMemoryEventCommitted, Message>());
 
-			var subscription = new SubscriptionsService<TStreamId>(_mainQueue, subscrQueue, readIndex);
+			var subscription = new SubscriptionsService<TStreamId>(_mainQueue, subscrQueue, _authorizationProvider, readIndex);
 			subscrBus.Subscribe<SystemMessage.SystemStart>(subscription);
 			subscrBus.Subscribe<SystemMessage.BecomeShuttingDown>(subscription);
 			subscrBus.Subscribe<TcpMessage.ConnectionClosed>(subscription);
 			subscrBus.Subscribe<ClientMessage.SubscribeToStream>(subscription);
 			subscrBus.Subscribe<ClientMessage.FilteredSubscribeToStream>(subscription);
 			subscrBus.Subscribe<ClientMessage.UnsubscribeFromStream>(subscription);
+			subscrBus.Subscribe<SubscriptionMessage.DropSubscription>(subscription);
 			subscrBus.Subscribe<SubscriptionMessage.PollStream>(subscription);
 			subscrBus.Subscribe<SubscriptionMessage.CheckPollTimeout>(subscription);
 			subscrBus.Subscribe<StorageMessage.EventCommitted>(subscription);

--- a/src/EventStore.Core/Messages/SubscriptionMessage.cs
+++ b/src/EventStore.Core/Messages/SubscriptionMessage.cs
@@ -1,5 +1,6 @@
 using System;
 using EventStore.Core.Messaging;
+using EventStore.Core.Services;
 
 namespace EventStore.Core.Messages {
 	public static partial class SubscriptionMessage {
@@ -24,6 +25,17 @@ namespace EventStore.Core.Messages {
 
 		[DerivedMessage(CoreMessage.Subscription)]
 		public partial class CheckPollTimeout : Message {
+		}
+
+		[DerivedMessage(CoreMessage.Subscription)]
+		public partial class DropSubscription : Message {
+			public readonly Guid SubscriptionId;
+			public readonly SubscriptionDropReason DropReason;
+
+			public DropSubscription(Guid subscriptionId, SubscriptionDropReason dropReason) {
+				SubscriptionId = subscriptionId;
+				DropReason = dropReason;
+			}
 		}
 
 		[DerivedMessage(CoreMessage.Subscription)]


### PR DESCRIPTION
Changed: Re-authorize stream access in live subscriptions when stream metadata changes

Note that:
i)  some live events can still go through before the AccessDenied message is sent to the subscription.
ii) user group changes are not taken into consideration. this is OK as with claims-based authorization, existing access is maintained until the claims expire.

Note: .NET client tests pass against this branch.