### PR TITLE
Add the 5 seconds shutdown timeout for HostOptions to match with the ESDB shutdown timeout

### DIFF
--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -190,6 +190,8 @@ namespace EventStore.ClusterNode {
 							.ConfigureServices(services => services.Configure<KestrelServerOptions>(
 								EventStoreKestrelConfiguration.GetConfiguration()))
 							.ConfigureServices(services => services.Configure<MetricsConfiguration>(metricsConfiguration))
+							.ConfigureServices(services => services.Configure<HostOptions>(
+							 	opts => opts.ShutdownTimeout = TimeSpan.FromSeconds(5)))
 							.ConfigureWebHostDefaults(builder => builder
 								.UseKestrel(server => {
 									server.Limits.Http2.KeepAlivePingDelay =


### PR DESCRIPTION
Changed: Explicitly set the shutdown timeout to 5s, which was default in previous dotnet versions. Behaviour unchanged since previous release

Fixes https://linear.app/eventstore/issue/DB-588/investigate-esdb-not-shutting-down-quickly-with-slow-subscriptions

Currently the default shutdown timeout for HostOptions is 30 seconds. The goal of this PR is to set the timeout to 5 seconds.