### PR TITLE
Upgrade Jint to version 3.0.0-beta-2059

### DIFF
--- a/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
+++ b/src/EventStore.Projections.Core/EventStore.Projections.Core.csproj
@@ -33,7 +33,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Jint" Version="3.0.0-beta-2055" />
+		<PackageReference Include="Jint" Version="3.0.0-beta-2059" />
 		<ProjectReference Include="..\EventStore.Common\EventStore.Common.csproj" />
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		<ProjectReference Include="..\EventStore.Transport.Http\EventStore.Transport.Http.csproj" />


### PR DESCRIPTION
Changed: Upgrade Jint to version 3.0.0-beta-2059

With [latest release](https://github.com/sebastienros/jint/releases/tag/v3.0.0-beta-2059) we made some API changes for consistency and clearer type names. This requires some code changes in consuming code and here I'm offering them to you, free of charge.