### PR TITLE
Reduce gRPC log level on the server

### DIFF
--- a/src/EventStore.ClusterNode/logconfig.json
+++ b/src/EventStore.ClusterNode/logconfig.json
@@ -4,7 +4,7 @@
 			"Default": "Debug",
 			"System": "Warning",
 			"Microsoft": "Warning",
-			"Grpc": "Fatal"
+			"Grpc": "Warning"
 		}
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.BatchAppend.cs
@@ -36,8 +36,17 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				requestStream, responseStream,
 				context.GetHttpContext().User, _maxAppendSize, _writeTimeout,
 				GetRequiresLeader(context.RequestHeaders));
-			
-			await worker.Work(context.CancellationToken);
+			try {
+				await worker.Work(context.CancellationToken);
+			} catch (IOException) {
+				// ignored
+			} catch (TaskCanceledException) {
+				//ignored
+			} catch (InvalidOperationException) {
+				//ignored
+			} catch (OperationCanceledException) {
+				//ignored
+			}
 		}
 
 		private class BatchAppendWorker {
@@ -79,13 +88,13 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
 
 #if DEBUG
-		var sendTask = 		
-#endif				
+		var sendTask =
+#endif
 				Send(_channel.Reader, cancellationToken)
 					.ContinueWith(HandleCompletion, CancellationToken.None);
 #if DEBUG
-		var receiveTask = 		
-#endif				
+		var receiveTask =
+#endif
 				Receive(_channel.Writer, _user, _requiresLeader, cancellationToken)
 					.ContinueWith(HandleCompletion, CancellationToken.None);
 

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading;
@@ -76,6 +77,14 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					}
 				} catch (ReadResponseException ex) {
 					ConvertReadResponseException(ex);
+				} catch (IOException) {
+					// ignored
+				} catch (TaskCanceledException) {
+					//ignored
+				} catch (InvalidOperationException) {
+					//ignored
+				} catch (OperationCanceledException) {
+					//ignored
 				}
 			} catch (Exception ex) {
 				duration.SetException(ex);


### PR DESCRIPTION
Fixed : Decrease grpc log level on the server. https://linear.app/eventstore/issue/DB-568/decrease-grpc-log-level-on-the-server

Before this fix/change, when the log level for gRPC was set to Warning (like the others), there were lots of erroneous logs generated in the server logs for client operations that were cancelled before they were completed (For example killing a test client performing gRPC reads and write flood on a cluster node).