### PR TITLE
[DB-590] Live subscriptions: Re-authorize $all subscriptions when $$$all changes (Enumerators: 2/4)

### DIFF
--- a/src/EventStore.Core/Services/SubscriptionsService.cs
+++ b/src/EventStore.Core/Services/SubscriptionsService.cs
@@ -387,6 +387,9 @@ namespace EventStore.Core.Services {
 
 			eventStreamId = SystemStreams.OriginalStreamOf(eventStreamId);
 
+			if (eventStreamId == SystemStreams.AllStream)
+				eventStreamId = string.Empty;
+
 			if (!_subscriptionTopics.TryGetValue(eventStreamId, out var subscriptions))
 				return;
 


### PR DESCRIPTION
Changed: Re-authorize subscriptions to `$all` when its stream metadata (`$$$all`) changes

This is a follow-up PR to: https://github.com/EventStore/EventStore/pull/4104
Changes to the $$$all stream are now also detected.

A test has been added for this case in the next PR: https://github.com/EventStore/EventStore/pull/4119
(`subscribe to $all from start then revoke access with stream acl`)