### PR TITLE
[DB-614] Make gossip available as a mem stream: $mem-gossip

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/GossipListenerServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/GossipListenerServiceTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using EventStore.Core.Cluster;
+using EventStore.Core.Messages;
+using EventStore.Core.Messaging;
+using EventStore.Core.Services;
+using EventStore.Core.Services.Storage.InMemory;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Services.Storage.InMemory;
+
+public class GossipListenerServiceTests {
+	private readonly GossipListenerService _sut;
+	private readonly ChannelReader<Message> _channelReader;
+	private readonly Guid _nodeId = Guid.NewGuid();
+
+	private readonly JsonSerializerOptions _options = new() {
+		Converters = {
+			new JsonStringEnumConverter(),
+		},
+	};
+
+	public GossipListenerServiceTests() {
+		var channel = Channel.CreateUnbounded<Message>();
+		_channelReader = channel.Reader;
+		_sut = new GossipListenerService(
+			nodeId: _nodeId,
+			publisher: new EnvelopePublisher(new ChannelEnvelope(channel)),
+			new InMemoryLog());
+	}
+
+	[Fact]
+	public async Task notify_state_change() {
+		static int random() => Random.Shared.Next(65000);
+
+		var member = MemberInfo.ForVNode(
+				instanceId: Guid.NewGuid(),
+				timeStamp: DateTime.Now,
+				state: Data.VNodeState.DiscoverLeader,
+				isAlive: true,
+				internalTcpEndPoint: default,
+				internalSecureTcpEndPoint: new DnsEndPoint("myhost", random()),
+				externalTcpEndPoint: default,
+				externalSecureTcpEndPoint: new DnsEndPoint("myhost", random()),
+				httpEndPoint: new DnsEndPoint("myhost", random()),
+				advertiseHostToClientAs: "advertiseHostToClientAs",
+				advertiseHttpPortToClientAs: random(),
+				advertiseTcpPortToClientAs: random(),
+				lastCommitPosition: random(),
+				writerCheckpoint: random(),
+				chaserCheckpoint: random(),
+				epochPosition: random(),
+				epochNumber: random(),
+				epochId: Guid.NewGuid(),
+				nodePriority: random(),
+				isReadOnlyReplica: true);
+
+		// when
+		_sut.Handle(new GossipMessage.GossipUpdated(new ClusterInfo(member)));
+
+		// then
+		var @event = Assert.IsType<StorageMessage.InMemoryEventCommitted>(await _channelReader.ReadAsync());
+
+		Assert.Equal(SystemStreams.GossipStream, @event.Event.EventStreamId);
+		Assert.Equal(GossipListenerService.EventType, @event.Event.EventType);
+		Assert.Equal(0, @event.Event.EventNumber);
+
+		var expectedBytes = JsonSerializer.SerializeToUtf8Bytes(
+			new {
+				NodeId = _nodeId,
+				Members = new[] { new ClientClusterInfo.ClientMemberInfo(member) },
+			},
+			_options);
+
+		var actualBytes = @event.Event.Data;
+
+		Assert.Equal(
+			Encoding.UTF8.GetString(expectedBytes),
+			Encoding.UTF8.GetString(actualBytes.Span));
+
+		Assert.Equal(expectedBytes, actualBytes);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/InMemoryStreamReaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/InMemoryStreamReaderTests.cs
@@ -6,10 +6,10 @@ using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
-using EventStore.Core.Services.Storage;
+using EventStore.Core.Services.Storage.InMemory;
 using Xunit;
 
-namespace EventStore.Core.XUnit.Tests.Services.Storage;
+namespace EventStore.Core.XUnit.Tests.Services.Storage.InMemory;
 
 public class InMemoryStreamReaderTests {
 	private readonly InMemoryStreamReader _sut;
@@ -17,7 +17,9 @@ public class InMemoryStreamReaderTests {
 
 	public InMemoryStreamReaderTests() {
 		var channel = Channel.CreateUnbounded<Message>();
-		_listener = new NodeStateListenerService(new EnvelopePublisher(new ChannelEnvelope(channel)));
+		_listener = new NodeStateListenerService(
+			new EnvelopePublisher(new ChannelEnvelope(channel)),
+			new InMemoryLog());
 		_sut = new InMemoryStreamReader(new Dictionary<string, IInMemoryStreamReader> {
 			[SystemStreams.NodeStateStream] = _listener,
 		});
@@ -145,7 +147,7 @@ public class InMemoryStreamReaderTests {
 			// - not find event 49 (like we do for regular maxCount reads, even if old events have been scavenged)
 			//   and not reach the end of the stream (nextEventNumber <= 49 so that we can read it in subsequent pages)
 			// current implementation finds the event.
-			for (int i = 0; i < 50; i++)
+			for (var i = 0; i < 50; i++)
 				_listener.Handle(new SystemMessage.BecomeLeader(Guid.NewGuid()));
 			var correlation = Guid.NewGuid();
 

--- a/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/NodeStateListenerServiceTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Services/Storage/InMemory/NodeStateListenerServiceTests.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Services;
+using EventStore.Core.Services.Storage.InMemory;
 using Xunit;
 
-namespace EventStore.Core.XUnit.Tests.Services.VNode;
+namespace EventStore.Core.XUnit.Tests.Services.Storage.InMemory;
 
 public class NodeStateListenerServiceTests {
 	private readonly NodeStateListenerService _sut;
@@ -18,7 +18,9 @@ public class NodeStateListenerServiceTests {
 	public NodeStateListenerServiceTests() {
 		var channel = Channel.CreateUnbounded<Message>();
 		_channelReader = channel.Reader;
-		_sut = new NodeStateListenerService(new EnvelopePublisher(new ChannelEnvelope(channel)));
+		_sut = new NodeStateListenerService(
+			new EnvelopePublisher(new ChannelEnvelope(channel)),
+			new InMemoryLog());
 	}
 
 	[Fact]
@@ -30,7 +32,7 @@ public class NodeStateListenerServiceTests {
 		Assert.Equal(NodeStateListenerService.EventType, @event.Event.EventType);
 		Assert.Equal(0, @event.Event.EventNumber);
 		Assert.Equal(JsonSerializer.SerializeToUtf8Bytes(new {
-			state = VNodeState.Leader.ToString(),
+			State = VNodeState.Leader.ToString(),
 		}), @event.Event.Data.ToArray());
 	}
 }

--- a/src/EventStore.Core/Services/Storage/InMemory/GossipListenerService.cs
+++ b/src/EventStore.Core/Services/Storage/InMemory/GossipListenerService.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+
+namespace EventStore.Core.Services.Storage.InMemory;
+
+public class GossipListenerService :
+	IInMemoryStreamReader,
+	IHandle<GossipMessage.GossipUpdated> {
+
+	private readonly SingleEventInMemoryStream _stream;
+	private readonly Guid _nodeId;
+	public const string EventType = "$GossipUpdated";
+
+	private readonly JsonSerializerOptions _options = new() {
+		Converters = {
+			new JsonStringEnumConverter(),
+		},
+	};
+
+	public GossipListenerService(Guid nodeId, IPublisher publisher, InMemoryLog memLog) {
+		_stream = new(publisher, memLog, SystemStreams.GossipStream);
+		_nodeId = nodeId;
+	}
+
+	public void Handle(GossipMessage.GossipUpdated message) {
+		// SystemStreams.GossipStream is a system stream so only readable by admins
+		// we use ClientMemberInfo because plugins will consume this stream and
+		// it is less likely to change than the internal gossip.
+		var payload = new {
+			NodeId = _nodeId,
+			Members = message.ClusterInfo.Members.Select(static x =>
+				new Cluster.ClientClusterInfo.ClientMemberInfo(x)),
+		};
+
+		var data = JsonSerializer.SerializeToUtf8Bytes(payload, _options);
+		_stream.Write(EventType, data);
+	}
+
+	public ClientMessage.ReadStreamEventsForwardCompleted ReadForwards(
+		ClientMessage.ReadStreamEventsForward msg) => _stream.ReadForwards(msg);
+
+	public ClientMessage.ReadStreamEventsBackwardCompleted ReadBackwards(
+		ClientMessage.ReadStreamEventsBackward msg) => _stream.ReadBackwards(msg);
+}

--- a/src/EventStore.Core/Services/Storage/InMemory/IInMemoryStreamReader.cs
+++ b/src/EventStore.Core/Services/Storage/InMemory/IInMemoryStreamReader.cs
@@ -1,6 +1,6 @@
 using EventStore.Core.Messages;
 
-namespace EventStore.Core.Services.Storage;
+namespace EventStore.Core.Services.Storage.InMemory;
 
 public interface IInMemoryStreamReader {
 	ClientMessage.ReadStreamEventsForwardCompleted ReadForwards(ClientMessage.ReadStreamEventsForward msg);

--- a/src/EventStore.Core/Services/Storage/InMemory/InMemoryLog.cs
+++ b/src/EventStore.Core/Services/Storage/InMemory/InMemoryLog.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading;
+
+namespace EventStore.Core.Services.Storage.InMemory;
+
+// does not support $all style reads, but tracks the LastCommitPosition so that
+// the long poll mechanism works in the SubscriptionsService.
+// note that the SubscriptionsService currently only supports one physical log
+// and one inmemory log so we can't have separate inmemory logs per inmemory stream.
+public class InMemoryLog {
+	long _lastCommitPosition = 0L;
+
+	public long GetLastCommitPosition() => Interlocked.Read(ref _lastCommitPosition);
+	public long GetNextCommitPosition() => Interlocked.Increment(ref _lastCommitPosition);
+}

--- a/src/EventStore.Core/Services/Storage/InMemory/InMemoryStreamReader.cs
+++ b/src/EventStore.Core/Services/Storage/InMemory/InMemoryStreamReader.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 
-namespace EventStore.Core.Services.Storage;
+namespace EventStore.Core.Services.Storage.InMemory;
 
 public class InMemoryStreamReader : IInMemoryStreamReader {
 	private readonly Dictionary<string, IInMemoryStreamReader> _readers;

--- a/src/EventStore.Core/Services/Storage/InMemory/NodeStateListenerService.cs
+++ b/src/EventStore.Core/Services/Storage/InMemory/NodeStateListenerService.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+
+namespace EventStore.Core.Services.Storage.InMemory;
+
+// threading: we expect to handle one StateChangeMessage at a time, but Reads can happen concurrently
+// with those handlings and with other reads.
+public class NodeStateListenerService :
+	IInMemoryStreamReader,
+	IHandle<SystemMessage.StateChangeMessage> {
+
+	private readonly SingleEventInMemoryStream _stream;
+
+	public const string EventType = "$NodeStateChanged";
+
+	private readonly JsonSerializerOptions _options = new() {
+		Converters = {
+			new JsonStringEnumConverter(),
+		},
+	};
+
+	public NodeStateListenerService(IPublisher publisher, InMemoryLog memLog) {
+		_stream = new(publisher, memLog, SystemStreams.NodeStateStream);
+	}
+
+	public void Handle(SystemMessage.StateChangeMessage message) {
+		var payload = new { message.State };
+		var data = JsonSerializer.SerializeToUtf8Bytes(payload, _options);
+		_stream.Write(EventType, data);
+	}
+
+	public ClientMessage.ReadStreamEventsForwardCompleted ReadForwards(
+		ClientMessage.ReadStreamEventsForward msg) => _stream.ReadForwards(msg);
+
+	public ClientMessage.ReadStreamEventsBackwardCompleted ReadBackwards(
+		ClientMessage.ReadStreamEventsBackward msg) => _stream.ReadBackwards(msg);
+}

--- a/src/EventStore.Core/Services/Storage/InMemory/SingleEventInMemoryStream.cs
+++ b/src/EventStore.Core/Services/Storage/InMemory/SingleEventInMemoryStream.cs
@@ -1,54 +1,53 @@
-using System;
-using System.Text.Json;
+﻿using System;
 using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
-using EventStore.Core.Services.Storage;
 using EventStore.Core.TransactionLog.LogRecords;
 
-namespace EventStore.Core.Services;
+namespace EventStore.Core.Services.Storage.InMemory;
 
-// threading: we expect to handle one StateChangeMessage at a time, but Reads can happen concurrently
-// with those handlings and with other reads.
-public class NodeStateListenerService :
-	IInMemoryStreamReader,
-	IHandle<SystemMessage.StateChangeMessage> {
+// threading: we expect to handle one Write at a time, but Reads can happen concurrently
+// with the write and with other reads.
+public class SingleEventInMemoryStream : IInMemoryStreamReader {
 	private readonly IPublisher _publisher;
-	public const string EventType = "$NodeStateChanged";
+	private readonly InMemoryLog _memLog;
+	private readonly string _streamName;
 	private const PrepareFlags Flags = PrepareFlags.Data | PrepareFlags.IsCommitted | PrepareFlags.IsJson;
 	private long _eventNumber;
 	private EventRecord _lastEvent;
 
-	public NodeStateListenerService(IPublisher publisher) {
+	public SingleEventInMemoryStream(IPublisher publisher, InMemoryLog memLog, string streamName) {
 		_publisher = publisher;
 		_eventNumber = 0;
+		_memLog = memLog;
+		_streamName = streamName;
 	}
 
-	public ClientMessage.ReadStreamEventsForwardCompleted ReadForwards(ClientMessage.ReadStreamEventsForward msg) {
+	public ClientMessage.ReadStreamEventsForwardCompleted ReadForwards(
+		ClientMessage.ReadStreamEventsForward msg) {
+
 		ReadStreamResult result;
 		ResolvedEvent[] events;
-		long nextEventNumber, lastEventNumber, tfLastCommitPosition;
+		long nextEventNumber, lastEventNumber;
 
 		var lastEvent = _lastEvent;
 		if (lastEvent == null) {
 			// no stream
 			result = ReadStreamResult.NoStream;
-			events = Array.Empty<ResolvedEvent>();
+			events = [];
 			nextEventNumber = -1;
 			lastEventNumber = ExpectedVersion.NoStream;
-			tfLastCommitPosition = -1;
 		} else {
 			result = ReadStreamResult.Success;
 			nextEventNumber = lastEvent.EventNumber + 1;
 			lastEventNumber = lastEvent.EventNumber;
-			tfLastCommitPosition = lastEvent.EventNumber;
 
 			if (msg.FromEventNumber > lastEvent.EventNumber) {
 				// from too high. empty read
-				events = Array.Empty<ResolvedEvent>();
+				events = [];
 			} else {
 				// read containing the event
-				events = new[] { ResolvedEvent.ForUnresolvedEvent(lastEvent) };
+				events = [ResolvedEvent.ForUnresolvedEvent(lastEvent)];
 			}
 		}
 
@@ -65,36 +64,36 @@ public class NodeStateListenerService :
 			nextEventNumber: nextEventNumber,
 			lastEventNumber: lastEventNumber,
 			isEndOfStream: true,
-			tfLastCommitPosition: tfLastCommitPosition);
+			tfLastCommitPosition: _memLog.GetLastCommitPosition());
 	}
 
-	public ClientMessage.ReadStreamEventsBackwardCompleted ReadBackwards(ClientMessage.ReadStreamEventsBackward msg) {
+	public ClientMessage.ReadStreamEventsBackwardCompleted ReadBackwards(
+		ClientMessage.ReadStreamEventsBackward msg) {
+
 		ReadStreamResult result;
 		ResolvedEvent[] events;
-		long adjustedFromEventNumber, lastEventNumber, tfLastCommitPosition;
+		long adjustedFromEventNumber, lastEventNumber;
 
 		var lastEvent = _lastEvent;
 		if (lastEvent == null) {
 			// no stream
 			adjustedFromEventNumber = msg.FromEventNumber;
 			result = ReadStreamResult.NoStream;
-			events = Array.Empty<ResolvedEvent>();
+			events = [];
 			lastEventNumber = ExpectedVersion.NoStream;
-			tfLastCommitPosition = -1L;
 		} else {
 			result = ReadStreamResult.Success;
 			lastEventNumber = lastEvent.EventNumber;
-			tfLastCommitPosition = lastEvent.EventNumber;
 
 			var readFromEnd = msg.FromEventNumber < 0;
 			adjustedFromEventNumber = readFromEnd ? lastEvent.EventNumber : msg.FromEventNumber;
 
 			if (adjustedFromEventNumber < lastEvent.EventNumber) {
 				// from too low. empty read
-				events = Array.Empty<ResolvedEvent>();
+				events = [];
 			} else {
 				// read containing the event
-				events = new[] { ResolvedEvent.ForUnresolvedEvent(lastEvent) };
+				events = [ResolvedEvent.ForUnresolvedEvent(lastEvent)];
 			}
 		}
 
@@ -111,29 +110,28 @@ public class NodeStateListenerService :
 			nextEventNumber: -1,
 			lastEventNumber: lastEventNumber,
 			isEndOfStream: true,
-			tfLastCommitPosition: tfLastCommitPosition);
+			tfLastCommitPosition: _memLog.GetLastCommitPosition());
 	}
 
-	public void Handle(SystemMessage.StateChangeMessage message) {
-		var payload = new { state = message.State.ToString() };
-		var data = JsonSerializer.SerializeToUtf8Bytes(payload);
+	public void Write(string eventType, ReadOnlyMemory<byte> data) {
+		var commitPosition = _memLog.GetNextCommitPosition();
 		var prepare = new PrepareLogRecord(
-			logPosition: _eventNumber,
-			correlationId: message.CorrelationId,
+			logPosition: commitPosition,
+			correlationId: Guid.NewGuid(),
 			eventId: Guid.NewGuid(),
-			transactionPosition: _eventNumber,
+			transactionPosition: commitPosition,
 			transactionOffset: 0,
-			eventStreamId: SystemStreams.NodeStateStream,
+			eventStreamId: _streamName,
 			eventStreamIdSize: null,
 			expectedVersion: _eventNumber - 1,
 			timeStamp: DateTime.Now,
 			flags: Flags,
-			eventType: EventType,
+			eventType: eventType,
 			eventTypeSize: null,
 			data: data,
 			metadata: Array.Empty<byte>());
-		_lastEvent = new EventRecord(_eventNumber, prepare, SystemStreams.NodeStateStream, EventType);
-		_publisher.Publish(new StorageMessage.InMemoryEventCommitted(_eventNumber, _lastEvent));
+		_lastEvent = new EventRecord(_eventNumber, prepare, _streamName, eventType);
+		_publisher.Publish(new StorageMessage.InMemoryEventCommitted(commitPosition, _lastEvent));
 		_eventNumber++;
 	}
 }

--- a/src/EventStore.Core/Services/Storage/StorageReaderService.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderService.cs
@@ -6,6 +6,7 @@ using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
 using EventStore.Core.Metrics;
+using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.Checkpoint;
 using ILogger = Serilog.ILogger;

--- a/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
+++ b/src/EventStore.Core/Services/Storage/StorageReaderWorker.cs
@@ -7,6 +7,7 @@ using EventStore.Core.Data;
 using EventStore.Core.Exceptions;
 using EventStore.Core.LogAbstraction;
 using EventStore.Core.Messages;
+using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.TransactionLog.Checkpoint;
 using ReadStreamResult = EventStore.Core.Data.ReadStreamResult;

--- a/src/EventStore.Core/Services/SubscriptionsService.cs
+++ b/src/EventStore.Core/Services/SubscriptionsService.cs
@@ -9,7 +9,7 @@ using EventStore.Core.Bus;
 using EventStore.Core.Data;
 using EventStore.Core.Messages;
 using EventStore.Core.Messaging;
-using EventStore.Core.Services.Storage;
+using EventStore.Core.Services.Storage.InMemory;
 using EventStore.Core.Services.Storage.ReaderIndex;
 using EventStore.Core.Services.TimerService;
 using EventStore.Core.Services.UserManagement;

--- a/src/EventStore.Core/Services/SystemNames.cs
+++ b/src/EventStore.Core/Services/SystemNames.cs
@@ -27,7 +27,10 @@ namespace EventStore.Core.Services {
 		public const string ScavengesStream = "$scavenges";
 		public const string EpochInformationStream = "$epoch-information";
 		public const string ScavengePointsStream = "$scavengePoints";
+
+		// mem streams
 		public const string NodeStateStream = "$mem-node-state";
+		public const string GossipStream = "$mem-gossip";
 
 		public static bool IsSystemStream(string streamId) {
 			return streamId.Length != 0 && streamId[0] == '$';


### PR DESCRIPTION
Added: $mem-gossip memory stream

Works very similarly to the $mem-node-state stream. Factored out a helper class.

Plugins will then be able to subscribe to the gossip like other streams without needing a special API