### PR TITLE
Fix replication service heartbeat interval init.

### DIFF
--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1469,7 +1469,7 @@ namespace EventStore.Core {
 					!disableInternalTcpTls, _internalServerCertificateValidator,
 					_certificateSelector,
 					TimeSpan.FromMilliseconds(options.Interface.ReplicationHeartbeatTimeout),
-					TimeSpan.FromMilliseconds(options.Interface.NodeHeartbeatInterval),
+					TimeSpan.FromMilliseconds(options.Interface.ReplicationHeartbeatInterval),
 					TimeSpan.FromMilliseconds(options.Database.WriteTimeoutMs));
 				_mainBus.Subscribe<SystemMessage.StateChangeMessage>(replicaService);
 				_mainBus.Subscribe<ReplicationMessage.ReconnectToLeader>(replicaService);


### PR DESCRIPTION
Fixed: Initialize replication service heartbeat interval with `ReplicationHeartbeatInterval` instead of `NodeHeartbeatInterval `.