### PR TITLE
[DB-605] gRPC $all subscriptions: when subscribing at an invalid position

### DIFF
--- a/src/EventStore.Core/Data/ReadAllResult.cs
+++ b/src/EventStore.Core/Data/ReadAllResult.cs
@@ -5,5 +5,6 @@ namespace EventStore.Core.Data {
 		Error = 2,
 		AccessDenied = 3,
 		Expired = 4,
+		InvalidPosition = 5
 	}
 }

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscription.cs
@@ -145,7 +145,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 						(checkpoint, sequenceNumber) = await GoLive(checkpoint, sequenceNumber, ct);
 					}
 				} catch (Exception ex) {
-					if (ex is not OperationCanceledException)
+					if (ex is not (OperationCanceledException or ReadResponseException.InvalidPosition))
 						Log.Error(ex, "Subscription {subscriptionId} to $all experienced an error.", _subscriptionId);
 					_channel.Writer.TryComplete(ex);
 				} finally {
@@ -257,6 +257,8 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 								return;
 							case ReadAllResult.AccessDenied:
 								throw new ReadResponseException.AccessDenied();
+							case ReadAllResult.InvalidPosition:
+								throw new ReadResponseException.InvalidPosition();
 							default:
 								throw ReadResponseException.UnknownError.Create(completed.Result);
 						}

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -141,7 +141,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 					try {
 						CatchUpFromCheckpoint(Position.FromInt64(commitPosition, preparePosition));
 					} catch (InvalidReadException ex) {
-						Fail(new ReadResponseException.InvalidPositionException());
+						Fail(new ReadResponseException.InvalidPosition());
 						Log.Error(ex, "Error starting catch-up subscription {subscriptionId} to $all:{eventFilter}@{position}",
 							_subscriptionId, _eventFilter, startPosition);
 					}

--- a/src/EventStore.Core/Services/Transport/Enumerators/ReadResponseException.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/ReadResponseException.cs
@@ -14,7 +14,7 @@ public abstract class ReadResponseException : Exception {
 
 	public class AccessDenied : ReadResponseException { }
 
-	public class InvalidPositionException : ReadResponseException { }
+	public class InvalidPosition : ReadResponseException { }
 
 	public class Timeout : ReadResponseException {
 		public readonly string ErrorMessage;

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -298,7 +298,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					throw RpcExceptions.AccessDenied();
 				case ReadResponseException.Timeout timeout:
 					throw RpcExceptions.Timeout(timeout.ErrorMessage);
-				case ReadResponseException.InvalidPositionException:
+				case ReadResponseException.InvalidPosition:
 					throw RpcExceptions.InvalidPositionException();
 				case ReadResponseException.UnknownMessage unknownMessage:
 					throw RpcExceptions.UnknownMessage(unknownMessage.UnknownMessageType, unknownMessage.ExpectedMessageType);

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -249,6 +249,7 @@ namespace EventStore.Core.Services.Transport.Http {
 					case ReadAllResult.NotModified:
 						return NotModified();
 					case ReadAllResult.Error:
+					case ReadAllResult.InvalidPosition:
 						return InternalServerError(msg.Error);
 					case ReadAllResult.AccessDenied:
 						return Unauthorized();
@@ -307,6 +308,7 @@ namespace EventStore.Core.Services.Transport.Http {
 					case ReadAllResult.NotModified:
 						return NotModified();
 					case ReadAllResult.Error:
+					case ReadAllResult.InvalidPosition:
 						return InternalServerError(msg.Error);
 					case ReadAllResult.AccessDenied:
 						return Unauthorized();


### PR DESCRIPTION
Fixed: $all subscription enumerator returns `InvalidPosition` when subscribing at an invalid position

This is a follow-up PR to https://github.com/EventStore/EventStore/pull/4117. Tests were missing for the case where a user subscribes at an invalid position.

As @timothycoleman found out, when https://github.com/EventStore/EventStore/pull/4057 got rid of the `ReadIndex`, a small regression was introduced: the code still handles the exception `InvalidReadException` but this exception is no longer being thrown. This results in the `InvalidPosition` exception not being sent to the client when subscribing at an invalid position.

This PR fixes this with the following changes:
- Throw `InvalidReadException` in some additional cases in `TFChunkReadSide`
- Add a new `ReadAllResult` enum value: `InvalidPosition` and use/handle it where necessary
- Add a test `subscribe to $all at an invalid position` (note that the test doesn't cover all the different ways of obtaining an `invalid position` error)

Note: Similar changes must be applied to filtered $all in another PR.