### PR TITLE
[DB-606] gRPC filtered $all subscriptions: when subscribing at an invalid position

### DIFF
--- a/src/EventStore.Core/Data/FilteredReadAllResult.cs
+++ b/src/EventStore.Core/Data/FilteredReadAllResult.cs
@@ -7,5 +7,6 @@ namespace EventStore.Core.Data
         Error = 2,
         AccessDenied = 3,
         Expired = 4,
+        InvalidPosition = 5,
     }
 }

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -138,13 +138,7 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 					CatchUp(Position.Start);
 				} else {
 					var (commitPosition, preparePosition) = startPosition.Value.ToInt64();
-					try {
-						CatchUpFromCheckpoint(Position.FromInt64(commitPosition, preparePosition));
-					} catch (InvalidReadException ex) {
-						Fail(new ReadResponseException.InvalidPosition());
-						Log.Error(ex, "Error starting catch-up subscription {subscriptionId} to $all:{eventFilter}@{position}",
-							_subscriptionId, _eventFilter, startPosition);
-					}
+					CatchUpFromCheckpoint(Position.FromInt64(commitPosition, preparePosition));
 				}
 			}
 

--- a/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
+++ b/src/EventStore.Core/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.cs
@@ -189,6 +189,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 						case FilteredReadAllResult.AccessDenied:
 							Fail(new ReadResponseException.AccessDenied());
 							return Task.CompletedTask;
+
+						case FilteredReadAllResult.InvalidPosition:
+							Fail(new ReadResponseException.InvalidPosition());
+							return Task.CompletedTask;
+
 						default:
 							Fail(ReadResponseException.UnknownError.Create(completed.Result));
 							return Task.CompletedTask;
@@ -273,6 +278,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 						case FilteredReadAllResult.AccessDenied:
 							Fail(new ReadResponseException.AccessDenied());
 							return;
+
+						case FilteredReadAllResult.InvalidPosition:
+							Fail(new ReadResponseException.InvalidPosition());
+							return;
+
 						default:
 							Fail(ReadResponseException.UnknownError.Create(completed.Result));
 							return;
@@ -415,6 +425,11 @@ namespace EventStore.Core.Services.Transport.Enumerators {
 									case FilteredReadAllResult.AccessDenied:
 										Fail(new ReadResponseException.AccessDenied());
 										return;
+
+									case FilteredReadAllResult.InvalidPosition:
+										Fail(new ReadResponseException.InvalidPosition());
+										return;
+
 									default:
 										Fail(ReadResponseException.UnknownError.Create(completed.Result));
 										return;

--- a/src/EventStore.Core/Services/Transport/Http/Configure.cs
+++ b/src/EventStore.Core/Services/Transport/Http/Configure.cs
@@ -279,6 +279,7 @@ namespace EventStore.Core.Services.Transport.Http {
 					case FilteredReadAllResult.NotModified:
 						return NotModified();
 					case FilteredReadAllResult.Error:
+					case FilteredReadAllResult.InvalidPosition:
 						return InternalServerError(msg.Error);
 					case FilteredReadAllResult.AccessDenied:
 						return Unauthorized();
@@ -338,6 +339,7 @@ namespace EventStore.Core.Services.Transport.Http {
 					case FilteredReadAllResult.NotModified:
 						return NotModified();
 					case FilteredReadAllResult.Error:
+					case FilteredReadAllResult.InvalidPosition:
 						return InternalServerError(msg.Error);
 					case FilteredReadAllResult.AccessDenied:
 						return Unauthorized();


### PR DESCRIPTION
Fixed: filtered $all subscription enumerator returns InvalidPosition when subscribing at an invalid position

Similar to https://github.com/EventStore/EventStore/pull/4128 but for filtered $all subscriptions.
Tests have been added in the next PR: https://github.com/EventStore/EventStore/pull/4132