### PR TITLE
Fix missing EVENTSTORE prefixes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -325,11 +325,11 @@ significantly improves write and read performance to cached streams on larger da
 
 By default, the cache dynamically resizes according to the amount of free memory. The minimum that it can be set to is 100,000 entries.
 
-| Format               | Syntax                         |
-|:---------------------|:-------------------------------|
-| Command line         | `--stream-info-cache-capacity` |
-| YAML                 | `StreamInfoCacheCapacity`      |
-| Environment variable | `STREAM_INFO_CACHE_CAPACITY`   | 
+| Format               | Syntax                                  |
+|:---------------------|:----------------------------------------|
+| Command line         | `--stream-info-cache-capacity`          |
+| YAML                 | `StreamInfoCacheCapacity`               |
+| Environment variable | `EVENTSTORE_STREAM_INFO_CACHE_CAPACITY` |
 
 The option is set to 0 by default, which enables dynamic resizing. The default on previous versions of
 EventStoreDb was 100,000 entries.
@@ -342,11 +342,11 @@ allows more concurrent reads to be processed.
 The reader threads count will be set at startup to twice the number of available processors, with a minimum of
 4 and a maximum of 16 threads.
 
-| Format               | Syntax                   |
-|:---------------------|:-------------------------|
-| Command line         | `--reader-threads-count` |
-| YAML                 | `ReaderThreadsCount`     |
-| Environment variable | `READER_THREADS_COUNT`   | 
+| Format               | Syntax                            |
+|:---------------------|:----------------------------------|
+| Command line         | `--reader-threads-count`          |
+| YAML                 | `ReaderThreadsCount`              |
+| Environment variable | `EVENTSTORE_READER_THREADS_COUNT` |
 
 The option is set to 0 by default, which enables autoconfiguration. The default on previous versions of
 EventStoreDb was 4 threads.
@@ -363,11 +363,11 @@ The `WorkerThreads` option configures the number of threads available to the poo
 At startup the number of worker threads will be set to 10 if there are more than 4 reader threads. Otherwise,
 it will be set to have 5 threads available.
 
-| Format               | Syntax             |
-|:---------------------|:-------------------|
-| Command line         | `--worker-threads` |
-| YAML                 | `WorkerThreads`    |
-| Environment variable | `WORKER_THREADS`   | 
+| Format               | Syntax                      |
+|:---------------------|:----------------------------|
+| Command line         | `--worker-threads`          |
+| YAML                 | `WorkerThreads`             |
+| Environment variable | `EVENTSTORE_WORKER_THREADS` |
 
 The option is set to 0 by default, which enables autoconfiguration. The default on previous versions of
 EventStoreDb was 5 threads.

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -20,8 +20,8 @@ HTTP is the primary protocol for EventStoreDB. It is used in gRPC communication 
 
 Unlike for [TCP protocol](#tcp-configuration), there is no separation between internal and external communication. The HTTP endpoint always binds to the IP address configured in the `NodeIp` setting (previously referred to as `ExtIp`).
 
-| Format               | Syntax              |
-|:---------------------|:--------------------|
+| Format               | Syntax               |
+|:---------------------|:---------------------|
 | Command line         | `--node-ip`          |
 | YAML                 | `NodeIp`             |
 | Environment variable | `EVENTSTORE_NODE_IP` |
@@ -64,11 +64,11 @@ You can customise the following Keepalive settings:
 
 After a duration of `keepAliveInterval` (in milliseconds), if the server doesn't see any activity, it pings the client to see if the transport is still alive.
 
-| Format               | Syntax                  |
-|:---------------------|:------------------------|
-| Command line         | `--keep-alive-interval` |
-| YAML                 | `KeepAliveInterval`     |
-| Environment variable | `KEEP_ALIVE_INTERVAL`   |
+| Format               | Syntax                           |
+|:---------------------|:---------------------------------|
+| Command line         | `--keep-alive-interval`          |
+| YAML                 | `KeepAliveInterval`              |
+| Environment variable | `EVENTSTORE_KEEP_ALIVE_INTERVAL` |
 
 **Default**: `10000` (ms, 10 sec)
 
@@ -76,11 +76,11 @@ After a duration of `keepAliveInterval` (in milliseconds), if the server doesn't
 
 After having pinged for keepalive check, the server waits for a duration of `keepAliveTimeout` (in milliseconds). If the connection doesn't have any activity even after that, it gets closed.
 
-| Format               | Syntax                 |
-|:---------------------|:-----------------------|
-| Command line         | `--keep-alive-timeout` |
-| YAML                 | `KeepAliveTimeout`     |
-| Environment variable | `KEEP_ALIVE_TIMEOUT`   |
+| Format               | Syntax                          |
+|:---------------------|:--------------------------------|
+| Command line         | `--keep-alive-timeout`          |
+| YAML                 | `KeepAliveTimeout`              |
+| Environment variable | `EVENTSTORE_KEEP_ALIVE_TIMEOUT` |
 
 **Default**: `10000` (ms, 10 sec)
 
@@ -92,11 +92,11 @@ The AtomPub application protocol over HTTP is disabled by default since v20. We 
 
 In Event Store Cloud, the AtomPub protocol is enabled. For self-hosted instances, use the configuration setting to enable AtomPub.
 
-| Format               | Syntax                        |
-|:---------------------|:------------------------------|
-| Command line         | `--enable-atom-pub-over-http` |
-| YAML                 | `EnableAtomPubOverHttp`       |
-| Environment variable | `ENABLE_ATOM_PUB_OVER_HTTP`   |
+| Format               | Syntax                                 |
+|:---------------------|:---------------------------------------|
+| Command line         | `--enable-atom-pub-over-http`          |
+| YAML                 | `EnableAtomPubOverHttp`                |
+| Environment variable | `EVENTSTORE_ENABLE_ATOM_PUB_OVER_HTTP` |
 
 **Default**: `false` (AtomPub is disabled)
 


### PR DESCRIPTION
Added missing `EVENTSTORE` environment variable prefixes in some parts of the documentation