### PR TITLE
Update tag-docker-images.yml to only run on main repository

### DIFF
--- a/.github/workflows/tag-docker-images.yml
+++ b/.github/workflows/tag-docker-images.yml
@@ -5,6 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   tag-docker-images:
+    if: github.repository == 'EventStore/EventStore'
     runs-on: ubuntu-latest
     steps:
       - name: Set up Docker Buildx


### PR DESCRIPTION
Now the nightly tagging happens also in forked repositories and fails every time:  https://github.com/lahma/EventStore/actions/workflows/tag-docker-images.yml

GitHub's guidance is to check for the repository:

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository