### PR TITLE
[DB-606] Add filtered $all subscription enumerator checkpoint tests 

### DIFF
--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.AllSubscriptionFiltered.Tests.cs
@@ -20,6 +20,8 @@ public partial class EnumeratorTests {
 		IPublisher publisher,
 		Position? startPosition,
 		IEventFilter eventFilter = null,
+		uint? maxSearchWindow = null,
+		uint checkpointIntervalMultiplier = 1,
 		ClaimsPrincipal user = null) {
 
 		return new EnumeratorWrapper(new Enumerator.AllSubscriptionFiltered(
@@ -30,8 +32,8 @@ public partial class EnumeratorTests {
 			eventFilter: eventFilter,
 			user: user ?? SystemAccounts.System,
 			requiresLeader: false,
-			maxSearchWindow: null,
-			checkpointIntervalMultiplier: 1,
+			maxSearchWindow: maxSearchWindow,
+			checkpointIntervalMultiplier: checkpointIntervalMultiplier,
 			cancellationToken: CancellationToken.None));
 	}
 

--- a/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.Tests.cs
+++ b/src/EventStore.Core.Tests/Services/Transport/Enumerators/Enumerator.Tests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EventStore.Core.Data;
+using EventStore.Core.Services.Transport.Common;
 using EventStore.Core.Services.Transport.Enumerators;
 using NUnit.Framework;
 
@@ -14,6 +15,7 @@ public partial class EnumeratorTests {
 	public record SubscriptionConfirmation() : SubscriptionResponse { }
 	public record CaughtUp : SubscriptionResponse { }
 	public record FellBehind : SubscriptionResponse { }
+	public record Checkpoint(Position CheckpointPosition) : SubscriptionResponse { }
 
 	public class EnumeratorWrapper : IAsyncDisposable {
 		private readonly IAsyncEnumerator<ReadResponse> _enumerator;
@@ -36,6 +38,7 @@ public partial class EnumeratorTests {
 				ReadResponse.SubscriptionConfirmed => new SubscriptionConfirmation(),
 				ReadResponse.SubscriptionCaughtUp => new CaughtUp(),
 				ReadResponse.SubscriptionFellBehind => new FellBehind(),
+				ReadResponse.CheckpointReceived checkpointReceived => new Checkpoint(new Position(checkpointReceived.CommitPosition, checkpointReceived.PreparePosition)),
 				_ => throw new ArgumentOutOfRangeException(nameof(resp), resp, null),
 			};
 		}

--- a/src/EventStore.Core/Services/Transport/Common/Position.cs
+++ b/src/EventStore.Core/Services/Transport/Common/Position.cs
@@ -152,7 +152,7 @@ namespace EventStore.Core.Services.Transport.Common {
 		/// <filterpriority>2</filterpriority>
 		public override string ToString() => this == End ? "End" : $"C:{CommitPosition}/P:{PreparePosition}";
 
-		internal readonly (long commitPosition, long preparePosition) ToInt64() => Equals(End)
+		public readonly (long commitPosition, long preparePosition) ToInt64() => Equals(End)
 			? (-1, -1)
 			: ((long)CommitPosition, (long)PreparePosition);
 	}


### PR DESCRIPTION
Added: Filtered $all subscription enumerator checkpoint tests

This is a follow-up PR to https://github.com/EventStore/EventStore/pull/4132 that adds checkpoint tests

Notes:
i) the tests don't verify that a checkpoint is issued after exactly `checkpoint interval` events but they instead verify that at least one checkpoint is issued for every `checkpoint interval` events.
ii) the tests don't explicitly cover cases where checkpoints should be received when events that don't match the filter are written (this is not too easy to do with the current test fixture as the same db is used by all the tests)