### PR TITLE
[DB-630] Make metrics series work with OTLP exporter as well as Prometheus

### DIFF
--- a/src/EventStore.Core/ClusterVNodeStartup.cs
+++ b/src/EventStore.Core/ClusterVNodeStartup.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using MidFunc = System.Func<

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -16,8 +16,8 @@
 		</PackageReference>
 		<PackageReference Include="HdrHistogram" Version="2.5.0" />
 		<PackageReference Include="Microsoft.FASTER.Core" Version="1.9.16" />
-		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.6.0-rc.1" />
-		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.6.0" />
+		<PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.1" />
+		<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0-rc.1" />
 		<PackageReference Include="Quickenshtein" Version="1.5.1" />
 		<PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
 		<PackageReference Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />

--- a/src/EventStore.Core/Metrics/AverageMetric.cs
+++ b/src/EventStore.Core/Metrics/AverageMetric.cs
@@ -12,7 +12,7 @@ namespace EventStore.Core.Metrics {
 
 		public AverageMetric(Meter meter, string name, string unit, Func<string, Tag> genTag) {
 			_genTag = genTag;
-			meter.CreateObservableCounter(name, Observe, unit);
+			meter.CreateObservableCounter(name + "-" + unit, Observe);
 		}
 
 		public void Register(string group, Func<double> subMetric) {

--- a/src/EventStore.Core/Metrics/CacheResourcesMetrics.cs
+++ b/src/EventStore.Core/Metrics/CacheResourcesMetrics.cs
@@ -10,8 +10,8 @@ public class CacheResourcesMetrics {
 	private readonly ObservableUpDownMetric<long> _entriesMetric;
 
 	public CacheResourcesMetrics(Meter meter, string name) {
-		_bytesMetric = new ObservableUpDownMetric<long>(meter, name, "bytes");
-		_entriesMetric = new ObservableUpDownMetric<long>(meter, name, "entries");
+		_bytesMetric = new ObservableUpDownMetric<long>(meter, name + "-bytes");
+		_entriesMetric = new ObservableUpDownMetric<long>(meter, name + "-entries");
 	}
 
 	public void Register(string cache, ResizerUnit unit, Func<CacheStats> getStats) {

--- a/src/EventStore.Core/Metrics/CounterMetric.cs
+++ b/src/EventStore.Core/Metrics/CounterMetric.cs
@@ -6,8 +6,8 @@ namespace EventStore.Core.Metrics {
 		private readonly List<CounterSubMetric> _subMetrics = new();
 		private readonly object _lock = new();
 
-		public CounterMetric(Meter meter, string name, string unit = null) {
-			meter.CreateObservableCounter(name, Observe, unit);
+		public CounterMetric(Meter meter, string name, string unit) {
+			meter.CreateObservableCounter(name + "-" + unit, Observe);
 		}
 		
 		public void Add(CounterSubMetric subMetric) {

--- a/src/EventStore.Core/Metrics/DurationMaxMetric.cs
+++ b/src/EventStore.Core/Metrics/DurationMaxMetric.cs
@@ -9,7 +9,7 @@ public class DurationMaxMetric {
 	public DurationMaxMetric(Meter meter, string name) {
 		// gauge rather than updowncounter because the dimensions wont make sense to sum,
 		// because they are maxes and not necessarily from the same moment
-		meter.CreateObservableGauge(name, Observe, "seconds");
+		meter.CreateObservableGauge(name + "-seconds", Observe);
 	}
 
 	public void Add(DurationMaxTracker tracker) {

--- a/src/EventStore.Core/Metrics/DurationMetric.cs
+++ b/src/EventStore.Core/Metrics/DurationMetric.cs
@@ -9,7 +9,7 @@ namespace EventStore.Core.Metrics {
 
 		public DurationMetric(Meter meter, string name, IClock clock = null) {
 			_clock = clock ?? Clock.Instance;
-			_histogram = meter.CreateHistogram<double>(name, "seconds");
+			_histogram = meter.CreateHistogram<double>(name + "-seconds");
 		}
 
 		public Duration Start(string durationName) =>

--- a/src/EventStore.Core/Metrics/ProcessMetrics.cs
+++ b/src/EventStore.Core/Metrics/ProcessMetrics.cs
@@ -54,8 +54,10 @@ public class ProcessMetrics {
 		void CreateObservableUpDownCounter<T>(ProcessTracker tracker, Func<T> observe, string? unit = null)
 			where T : struct {
 
-			if (enabledNames.TryGetValue(tracker, out var name))
-				_meter.CreateObservableUpDownCounter(name, observe, unit);
+			if (enabledNames.TryGetValue(tracker, out var name)) {
+				unit = unit is null ? "" : "-" + unit;
+				_meter.CreateObservableUpDownCounter(name + unit, observe);
+			}
 		}
 
 		void CreateObservableCounter<T>(ProcessTracker tracker, Func<T> observe, string? unit = null)
@@ -104,7 +106,7 @@ public class ProcessMetrics {
 		dims.Register(ProcessTracker.MemVirtualBytes, () => _getCurrentProc().VirtualMemorySize64);
 
 		if (dims.AnyRegistered())
-			_meter.CreateObservableGauge(metricName, dims.GenObserve(), "bytes");
+			_meter.CreateObservableGauge(metricName + "-bytes", dims.GenObserve());
 	}
 
 	public void CreateGcGenerationSizeMetric(string metricName, Dictionary<ProcessTracker, string> dimNames) {
@@ -120,7 +122,7 @@ public class ProcessMetrics {
 		dims.Register(ProcessTracker.LohSize, () => (long)getGcGenerationSize(3));
 
 		if (dims.AnyRegistered())
-			_meter.CreateObservableUpDownCounter(metricName, dims.GenObserve(), "bytes");
+			_meter.CreateObservableUpDownCounter(metricName + "-bytes", dims.GenObserve());
 	}
 
 	public void CreateGcCollectionCountMetric(string metricName, Dictionary<ProcessTracker, string> dimNames) {
@@ -141,7 +143,7 @@ public class ProcessMetrics {
 		dims.Register(ProcessTracker.DiskWrittenBytes, () => (long)(_getDiskIo()?.WrittenBytes ?? 0));
 
 		if (dims.AnyRegistered())
-			_meter.CreateObservableCounter(metricName, dims.GenObserve(), "bytes");
+			_meter.CreateObservableCounter(metricName + "-bytes", dims.GenObserve());
 	}
 
 	public void CreateDiskOpsMetric(string name, Dictionary<ProcessTracker, string> dimNames) {
@@ -151,6 +153,6 @@ public class ProcessMetrics {
 		dims.Register(ProcessTracker.DiskWrittenOps, () => (long)(_getDiskIo()?.WriteOps ?? 0));
 
 		if (dims.AnyRegistered())
-			_meter.CreateObservableCounter(name, dims.GenObserve(), "operations");
+			_meter.CreateObservableCounter(name + "-operations", dims.GenObserve());
 	}
 }

--- a/src/EventStore.Core/Metrics/SystemMetrics.cs
+++ b/src/EventStore.Core/Metrics/SystemMetrics.cs
@@ -66,7 +66,7 @@ public class SystemMetrics {
 		}
 
 		if (dims.AnyRegistered())
-			_meter.CreateObservableGauge(metricName, dims.GenObserve(), "bytes");
+			_meter.CreateObservableGauge(metricName + "-bytes", dims.GenObserve());
 	}
 
 	public void CreateDiskMetric(string metricName, string dbPath, Dictionary<SystemTracker, string> dimNames) {
@@ -91,6 +91,6 @@ public class SystemMetrics {
 		dims.Register(SystemTracker.DriveTotalBytes, GenMeasure(info => info.TotalBytes));
 
 		if (dims.AnyRegistered())
-			_meter.CreateObservableGauge(metricName, dims.GenObserve(), "bytes");
+			_meter.CreateObservableGauge(metricName + "-bytes", dims.GenObserve());
 	}
 }


### PR DESCRIPTION
Added: internal changes

This addresses two problems

1. newer versions of OpenTelemetry.Exporter.Prometheus.AspNetCore have changed the names of the exported series (e.g. adding _totals to the end of counters), breaking our dashboard.

for now we are reverting to an older version of the library.

2. OpenTelemetry.Exporter.Prometheus.AspNetCore appends the units to the metrics names but OpenTelemetry.Exporter.OpenTelemetryProtocol does not, meaning the latter will not work with our dashboard.

it's possible to apply transformations in the OTEL collector but we avoid this so that users don't have to update their collector configuration when we add more metrics.

instead for now we are putting the units directly in the metric names. this causes both exporters to export the same series.

this feels a bit strange and i may well be misunderstanding something here. we will revisit when we (re)upgrade the otel library versions.