### PR TITLE
Remove xunit MaxParallelThreads concurrency limit

### DIFF
--- a/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
@@ -22,4 +22,9 @@
 		<ProjectReference Include="..\EventStore.Core\EventStore.Core.csproj" />
 		<ProjectReference Include="..\EventStore.SourceGenerators\EventStore.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
 	</ItemGroup>
+	<ItemGroup>
+	  <None Update="xunit.runner.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
+	</ItemGroup>
 </Project>

--- a/src/EventStore.Core.XUnit.Tests/xunit.runner.json
+++ b/src/EventStore.Core.XUnit.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+	"$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+	"maxParallelThreads": -1
+}


### PR DESCRIPTION
Fixed: concurrency limits in tests

Xunit provides a synchronization context by default which limits the number of concurrent calls according to the number of CPUs. This PR disables that, resulting in a null synchronization context.