### PR TITLE
Drive Versioninfo from a version.properties file at runtime

### DIFF
--- a/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
+++ b/src/EventStore.ClusterNode/EventStore.ClusterNode.csproj
@@ -17,6 +17,10 @@
 		<ProjectReference Include="..\EventStore.Projections.Core\EventStore.Projections.Core.csproj" />
 	</ItemGroup>
 	<ItemGroup>
+		<None Include="..\EventStore.Common\Utils\version.properties">
+			<Link>version.properties</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 		<None Include="..\EventStore.Common\Log\logconfig.json">
 			<Link>logconfig.json</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/EventStore.ClusterNode/Program.cs
+++ b/src/EventStore.ClusterNode/Program.cs
@@ -63,8 +63,8 @@ namespace EventStore.ClusterNode {
 					return 0;
 				}
 
-				Log.Information("\n{description,-25} {version} ({branch}/{hashtag}, {timestamp})", "ES VERSION:",
-					VersionInfo.Version, VersionInfo.Tag, VersionInfo.Hashtag, VersionInfo.Timestamp);
+				Log.Information("\n{description,-25} {version} {edition} ({buildId}/{commitSha}, {timestamp})", "ES VERSION:",
+					VersionInfo.Version, VersionInfo.Edition, VersionInfo.BuildId, VersionInfo.CommitSha, VersionInfo.Timestamp);
 				Log.Information("{description,-25} {osArchitecture} ", "OS ARCHITECTURE:",
 					RuntimeInformation.OSArchitecture);
 				Log.Information("{description,-25} {osFlavor} ({osVersion})", "OS:", OS.OsFlavor,

--- a/src/EventStore.Common/EventStore.Common.csproj
+++ b/src/EventStore.Common/EventStore.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
 	</PropertyGroup>
@@ -28,6 +28,11 @@
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.Common.Utils\EventStore.Common.Utils.csproj" />
+	</ItemGroup>
+	<ItemGroup>
+	  <None Update="Utils\version.properties">
+	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+	  </None>
 	</ItemGroup>
 
 </Project>

--- a/src/EventStore.Common/Utils/VersionInfo.cs
+++ b/src/EventStore.Common/Utils/VersionInfo.cs
@@ -1,17 +1,56 @@
-using System.Reflection;
+using System;
+using System.IO;
+using System.Collections.Generic;
 
 namespace EventStore.Common.Utils {
 	public static class VersionInfo {
-		public const string DefaultVersion = "0.0.0.0"; 
-		public const string UnknownVersion = "unknown_version";
+		public const string DefaultVersion = "0.0.0-prerelease";
 		public const string OldVersion = "old_version";
-		public static string Version => typeof(VersionInfo).Assembly
-			.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? DefaultVersion;
+		public const string UnknownVersion = "unknown_version";
 
-		public static string Tag => ThisAssembly.Git.Tag;
-		public static string Hashtag => ThisAssembly.Git.Commit;
-		public static readonly string Timestamp = ThisAssembly.Git.CommitDate;
+		public static string BuildId { get; private set; } = "";
+		public static string Edition { get; private set; } = "";
+		public static string Version { get; private set; } = DefaultVersion;
 
-		public static string Text => $"EventStoreDB version {Version} ({Tag}/{Hashtag}, {Timestamp})";
+		public static string CommitSha { get; private set; } = ThisAssembly.Git.Commit;
+		public static string Timestamp { get; private set; } = ThisAssembly.Git.CommitDate;
+
+		public static string Text => $"EventStoreDB version {Version} {Edition} ({BuildId}/{CommitSha})";
+
+		static VersionInfo() {
+			var versionFilePath = Path.Join(
+				Path.GetDirectoryName(AppDomain.CurrentDomain.BaseDirectory),
+				"version.properties");
+			var properties = LoadProperties(versionFilePath);
+
+			if (properties.TryGetValue("version", out var version))
+				Version = version;
+
+			if (properties.TryGetValue("commit_sha", out var commitSha))
+				CommitSha = commitSha;
+
+			if (properties.TryGetValue("timestamp", out var timestamp))
+				Timestamp = timestamp;
+
+			if (properties.TryGetValue("build_id", out var buildId))
+				BuildId = buildId;
+
+			if (properties.TryGetValue("edition", out var edition))
+				Edition = edition;
+		}
+
+		private static Dictionary<string, string> LoadProperties(string file) {
+			using var reader = new StreamReader(file);
+
+			var properties = new Dictionary<string, string>();
+			string line;
+			while ((line = reader.ReadLine()) != null) {
+				var parts = line.Split('=', 2);
+				if (parts.Length == 2)
+					properties[parts[0]] = parts[1];
+			}
+
+			return properties;
+		}
 	}
 }

--- a/src/EventStore.Common/Utils/version.properties
+++ b/src/EventStore.Common/Utils/version.properties
@@ -1,0 +1,1 @@
+version=24.4.0-prerelease

--- a/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
+++ b/src/EventStore.Core.Tests/EventStore.Core.Tests.csproj
@@ -54,6 +54,12 @@
 		</None>
 	</ItemGroup>
 	<ItemGroup>
+		<None Include="..\EventStore.Common\Utils\version.properties">
+			<Link>version.properties</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
 		<None Remove="FakePlugin\**" />
 		<Compile Remove="FakePlugin\**" />
 		<Content Include="FakePlugin\**" CopyToOutputDirectory="Always" />

--- a/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniClusterNode.cs
@@ -157,7 +157,7 @@ namespace EventStore.Core.Tests.Helpers {
 			Log.Information(
 				"\n{0,-25} {1} ({2}/{3}, {4})\n" + "{5,-25} {6} ({7})\n" + "{8,-25} {9} ({10}-bit)\n"
 				+ "{11,-25} {12}\n" + "{13,-25} {14}\n" + "{15,-25} {16}\n" + "{17,-25} {18}\n\n",
-				"ES VERSION:", VersionInfo.Version, VersionInfo.Tag, VersionInfo.Hashtag, VersionInfo.Timestamp,
+				"ES VERSION:", VersionInfo.Version, VersionInfo.Edition, VersionInfo.CommitSha, VersionInfo.Timestamp,
 				"OS:", OS.OsFlavor, Environment.OSVersion, "RUNTIME:", OS.GetRuntimeVersion(),
 				Marshal.SizeOf(typeof(IntPtr)) * 8, "GC:",
 				GC.MaxGeneration == 0

--- a/src/EventStore.Core.Tests/Helpers/MiniNode.cs
+++ b/src/EventStore.Core.Tests/Helpers/MiniNode.cs
@@ -151,7 +151,7 @@ namespace EventStore.Core.Tests.Helpers {
 					 + "{13,-25} {14}\n"
 					 + "{15,-25} {16}\n"
 					 + "{17,-25} {18}\n\n",
-				"ES VERSION:", VersionInfo.Version, VersionInfo.Tag, VersionInfo.Hashtag, VersionInfo.Timestamp,
+				"ES VERSION:", VersionInfo.Version, VersionInfo.Edition, VersionInfo.CommitSha, VersionInfo.Timestamp,
 				"OS:", OS.OsFlavor, Environment.OSVersion,
 				"RUNTIME:", OS.GetRuntimeVersion(), Marshal.SizeOf(typeof(IntPtr)) * 8,
 				"GC:",

--- a/src/EventStore.Core.Tests/TestsInitFixture.cs
+++ b/src/EventStore.Core.Tests/TestsInitFixture.cs
@@ -21,7 +21,7 @@ namespace EventStore.Core.Tests {
 					 + "{5,-25} {6} ({7})\n"
 					 + "{8,-25} {9} ({10}-bit)\n"
 					 + "{11,-25} {12}\n\n",
-				"ES VERSION:", VersionInfo.Version, VersionInfo.Tag, VersionInfo.Hashtag, VersionInfo.Timestamp,
+				"ES VERSION:", VersionInfo.Version, VersionInfo.Edition, VersionInfo.CommitSha, VersionInfo.Timestamp,
 				"OS:", OS.OsFlavor, Environment.OSVersion,
 				"RUNTIME:", OS.GetRuntimeVersion(), Marshal.SizeOf(typeof(IntPtr)) * 8,
 				"GC:",

--- a/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
+++ b/src/EventStore.Core.XUnit.Tests/EventStore.Core.XUnit.Tests.csproj
@@ -26,5 +26,9 @@
 	  <None Update="xunit.runner.json">
 	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	  </None>
+		<None Include="..\EventStore.Common\Utils\version.properties">
+			<Link>version.properties</Link>
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 </Project>

--- a/src/EventStore.Core/Telemetry/TelemetryService.cs
+++ b/src/EventStore.Core/Telemetry/TelemetryService.cs
@@ -120,7 +120,7 @@ public sealed class TelemetryService : IDisposable,
 			"version", JsonValue.Create(VersionInfo.Version)));
 
 		message.Envelope.ReplyWith(new TelemetryMessage.Response(
-			"tag", JsonValue.Create(VersionInfo.Tag)));
+			"edition", JsonValue.Create(VersionInfo.Edition)));
 
 		message.Envelope.ReplyWith(new TelemetryMessage.Response(
 			"uptime", JsonValue.Create(DateTime.UtcNow - _startTime)));


### PR DESCRIPTION
Added: Support for new packaging pipeline

- Allows packages to be promoted without recompilation.
- The build pipeline will populate the version.properties file
- A default version.properties file is included for local builds, we will update this when we create new release branches since the version will be driven from this file rather than from a git tag.
- Tag is removed as no longer relevant. Tier is added instead (EE/CE)