### PR TITLE
Add check for empty uuidOption while making a gRPC call

### DIFF
--- a/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/RpcExceptions.cs
@@ -237,9 +237,12 @@ namespace EventStore.Core.Services.Transport.Grpc {
 		public static RpcException InvalidArgument<T>(T argument) =>
 			new(new Status(StatusCode.InvalidArgument, $"'{argument}' is not a valid {typeof(T)}"));
 
+		public static RpcException RequiredArgument<T>(string name, T argument) =>
+			new(new Status(StatusCode.InvalidArgument, $" `{name}` is a required argument of type {typeof(T)}"));
+
 		public static RpcException InvalidCombination<T>(T combination) where T : ITuple
 			=> new(new Status(StatusCode.InvalidArgument, $"The combination of {combination} is invalid."));
-		
+
 		public static RpcException InvalidPositionException() =>
 			new(new Status(StatusCode.InvalidArgument, $"Trying to read from an invalid position."));
 	}

--- a/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
+++ b/src/EventStore.Core/Services/Transport/Grpc/Streams.Read.cs
@@ -38,6 +38,11 @@ namespace EventStore.Core.Services.Transport.Grpc {
 				var user = context.GetHttpContext().User;
 				var requiresLeader = GetRequiresLeader(context.RequestHeaders);
 
+				var uuidOption = options.UuidOption;
+				if (uuidOption == null) {
+					throw RpcExceptions.RequiredArgument(nameof(uuidOption), uuidOption);
+				}
+
 				var op = streamOptionsCase switch {
 					StreamOptionOneofCase.Stream => ReadOperation.WithParameter(
 						Plugins.Authorization.Operations.Streams.Parameters.StreamId(
@@ -69,7 +74,7 @@ namespace EventStore.Core.Services.Transport.Grpc {
 					await using (enumerator) {
 						await using (context.CancellationToken.Register(DisposeEnumerator)) {
 							while (await enumerator.MoveNextAsync()) {
-								if (TryConvertReadResponse(enumerator.Current, options.UuidOption, out var readResponse))
+								if (TryConvertReadResponse(enumerator.Current, uuidOption, out var readResponse))
 									await responseStream.WriteAsync(readResponse);
 							}
 						}


### PR DESCRIPTION
Fixed: Add a check for the empty uuidOption. 

Fixes https://linear.app/eventstore/issue/DB-504/when-uuid-option-is-not-set-grpc-read-request-hangs

Currently the EventStoreDB (master branch with Enumerator changes) sends an Unknown error exception if the uuidOption is null in the gRPC call. The goal of this PR is to  inform the user with a suitable message. 

EventStoreDB 23.10 and previous versions, we are not catching the exception when the uuid is null and the request hangs.
 
<img width="617" alt="Current behaviour on master branch" src="https://github.com/EventStore/EventStore/assets/25709924/a02b4187-ea69-4eb9-84c3-59db45b19755">

<img width="1514" alt="After" src="https://github.com/EventStore/EventStore/assets/25709924/c43f6d52-bfe0-4209-b86e-69c7a7b12192">

