### PR TITLE
DB-272: Use RandomAccess to reduce file handles to one per chunk

### DIFF
--- a/src/EventStore.Core.Tests/TransactionLog/Unbuffered/UnbufferedTests.cs
+++ b/src/EventStore.Core.Tests/TransactionLog/Unbuffered/UnbufferedTests.cs
@@ -11,7 +11,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			stream.SetLength(4096 * 1024);
 			stream.Close();
 			Assert.AreEqual(4096 * 1024, new FileInfo(filename).Length);
@@ -22,7 +22,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -43,7 +43,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -64,7 +64,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -85,7 +85,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -106,7 +106,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -127,7 +127,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -148,7 +148,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -169,7 +169,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -190,7 +190,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096);
+				FileShare.ReadWrite, 4096, 4096, false, 4096);
 			
 			var initialFileSize = 4096 * 1024;
 			stream.SetLength(initialFileSize); //initial size of 4MB
@@ -211,7 +211,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(255);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Write(bytes, 0, bytes.Length);
 				Assert.AreEqual(bytes.Length, stream.Position);
 				Assert.AreEqual(0, new FileInfo(filename).Length);
@@ -223,7 +223,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(9000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Write(bytes, 0, bytes.Length);
 				Assert.AreEqual(4096 * 2, new FileInfo(filename).Length);
 				var read = ReadAllBytesShared(filename);
@@ -238,7 +238,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(255);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Write(bytes, 0, bytes.Length);
 			}
 
@@ -256,7 +256,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var GIGABYTE = 1024L * 1024L * 1024L;
 			try {
 				using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-					FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+					FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 					stream.SetLength(4L * GIGABYTE);
 					stream.Seek(3L * GIGABYTE, SeekOrigin.Begin);
 				}
@@ -270,7 +270,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(255);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Write(bytes, 0, bytes.Length);
 				stream.Seek(0, SeekOrigin.Begin);
 				Assert.AreEqual(0, stream.Position);
@@ -288,7 +288,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(4096);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Write(bytes, 0, bytes.Length);
 				Assert.AreEqual(4096, stream.Position);
 				bytes = GetBytes(15);
@@ -310,7 +310,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(8192);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Write(bytes, 0, 5012);
 				Assert.AreEqual(5012, stream.Position);
 				stream.Seek(4096, SeekOrigin.Begin);
@@ -336,7 +336,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			MakeFile(filename, 4096 * 64);
 			var bytes = GetBytes(512);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Seek(128, SeekOrigin.Begin);
 				stream.Write(bytes, 0, bytes.Length);
 				stream.Flush();
@@ -356,7 +356,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(256);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Write(bytes, 0, bytes.Length);
 				Assert.AreEqual(256, stream.Position);
 				stream.Flush();
@@ -380,7 +380,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			MakeFile(filename, 20000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Seek(4096 + 15, SeekOrigin.Begin);
 				var read = new byte[1000];
 				stream.Read(read, 0, 500);
@@ -398,7 +398,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			MakeFile(filename, 20000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				var read = new byte[1000];
 				stream.Read(read, 0, 500);
 				Assert.AreEqual(500, stream.Position);
@@ -415,7 +415,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			MakeFile(filename, 20000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				var read = new byte[6000];
 				stream.Read(read, 0, 3000);
 				Assert.AreEqual(3000, stream.Position);
@@ -433,7 +433,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			MakeFile(filename, 20000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				var read = new byte[6000];
 				stream.Read(read, 0, 3000);
 				Assert.AreEqual(3000, stream.Position);
@@ -455,7 +455,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			MakeFile(filename, 4096 * 100 + 50);
 			Span<byte> expected = GetBytes(4096);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				var read = new byte[4096];
 				for (var i = 0; i < 100; i++) {
 					var total = stream.Read(read, 0, 4096);
@@ -487,7 +487,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			Span<byte> expected = GetBytes(4096 + 50);
 			expected = expected[50..];
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Seek(50, SeekOrigin.Begin);
 				var read = new byte[4096];
 				for (var i = 0; i < 100; i++) {
@@ -510,7 +510,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			var bytes = GetBytes(9000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Write(bytes, 0, bytes.Length);
 				stream.Close();
 				Assert.AreEqual(4096 * 3, new FileInfo(filename).Length);
@@ -526,7 +526,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			MakeFile(filename, 20000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				var read = new byte[4096];
 				stream.Read(read, 0, 4096);
 				for (var i = 0; i < 4096; i++) {
@@ -540,7 +540,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			MakeFile(filename, 20000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Seek(15, SeekOrigin.Begin);
 				var read = new byte[999];
 				stream.Read(read, 0, read.Length);
@@ -555,7 +555,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			MakeFile(filename, 20000);
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Seek(4096 + 15, SeekOrigin.Begin);
 				Assert.AreEqual(4096 + 15, stream.Position);
 				var read = new byte[999];
@@ -572,7 +572,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Seek(0, SeekOrigin.End);
 				Assert.AreEqual(stream.Length, stream.Position);
 			}
@@ -583,7 +583,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				stream.Seek(-30, SeekOrigin.End);
 				Assert.AreEqual(stream.Length - 30, stream.Position);
 			}
@@ -595,7 +595,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				Assert.Throws<NotImplementedException>(() => stream.Seek(0, SeekOrigin.Current));
 			}
 		}
@@ -605,7 +605,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 		public void seek_write_seek_read_in_buffer() {
 			var filename = GetFilePathFor(Guid.NewGuid().ToString());
 			using (var stream = UnbufferedFileStream.Create(filename, FileMode.CreateNew, FileAccess.ReadWrite,
-				FileShare.ReadWrite, false, 4096, 4096, false, 4096)) {
+				FileShare.ReadWrite, 4096, 4096, false, 4096)) {
 				var buffer = GetBytes(255);
 				stream.Seek(4096 + 15, SeekOrigin.Begin);
 				stream.Write(buffer, 0, buffer.Length);
@@ -625,7 +625,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			File.WriteAllBytes(filename, bytes);
 			using (var f = new FileStream(filename, FileMode.Open, FileAccess.Read)) {
 				using (var b = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.Read, FileShare.Read,
-					false, 4096, 4096, false, 4096)) {
+					4096, 4096, false, 4096)) {
 					Span<byte> readf = new byte[4096];
 					var readb = new byte[4096];
 					for (var i = 0; i < 128; i++) {
@@ -650,7 +650,7 @@ namespace EventStore.Core.Tests.TransactionLog.Unbuffered {
 			File.WriteAllBytes(filename, bytes);
 			using (var f = new FileStream(filename, FileMode.Open, FileAccess.Read)) {
 				using (var b = UnbufferedFileStream.Create(filename, FileMode.Open, FileAccess.Read, FileShare.Read,
-					false, 4096, 4096 * 4, false, 4096)) {
+					4096, 4096 * 4, false, 4096)) {
 					Span<byte> readf = new byte[4096];
 					var readb = new byte[4096];
 					for (var i = 0; i < 128; i++) {

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/ChunkFooterTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/ChunkFooterTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using EventStore.Common.Utils;
+using EventStore.Core.TransactionLog.Chunks;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
+
+public class ChunkFooterTests {
+	[Theory]
+	[InlineData(false, false)]
+	[InlineData(false, true)]
+	[InlineData(true, false)]
+	[InlineData(true, true)]
+	public void can_round_trip(bool isCompleted, bool isMap12Bytes) {
+		var hash = new byte[ChunkFooter.ChecksumSize];
+		Random.Shared.NextBytes(hash);
+
+		var source = new ChunkFooter(
+			isCompleted: isCompleted,
+			isMap12Bytes: isMap12Bytes,
+			physicalDataSize: Random.Shared.Next(500, 600),
+			logicalDataSize: Random.Shared.Next(600, 700),
+			mapSize: Random.Shared.Next(500, 600).RoundUpToMultipleOf(24),
+			md5Hash: hash);
+
+		var destination = new ChunkFooter(source.AsByteArray());
+
+		Assert.Equal(source.IsCompleted, destination.IsCompleted);
+		Assert.Equal(source.IsMap12Bytes, destination.IsMap12Bytes);
+		Assert.Equal(source.PhysicalDataSize, destination.PhysicalDataSize);
+		Assert.Equal(source.LogicalDataSize, destination.LogicalDataSize);
+		Assert.Equal(source.MapSize, destination.MapSize);
+		Assert.Equal(source.MD5Hash, destination.MD5Hash);
+	}
+}

--- a/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/ChunkHeaderTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/TransactionLog/Chunks/ChunkHeaderTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using EventStore.Core.TransactionLog.Chunks;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.TransactionLog.Chunks;
+
+public class ChunkHeaderTests {
+	[Theory]
+	[InlineData(true)]
+	[InlineData(false)]
+	public void can_round_trip(bool isScavenged) {
+		var source = new ChunkHeader(
+			version: (byte)Random.Shared.Next(8),
+			chunkSize: Random.Shared.Next(500, 600),
+			chunkStartNumber: Random.Shared.Next(500, 600),
+			chunkEndNumber: Random.Shared.Next(700, 800),
+			isScavenged: isScavenged,
+			chunkId: Guid.NewGuid());
+
+		var destination = new ChunkHeader(source.AsByteArray());
+
+		Assert.Equal(source.Version, destination.Version);
+		Assert.Equal(source.ChunkSize, destination.ChunkSize);
+		Assert.Equal(source.ChunkStartNumber, destination.ChunkStartNumber);
+		Assert.Equal(source.ChunkEndNumber, destination.ChunkEndNumber);
+		Assert.Equal(source.IsScavenged, destination.IsScavenged);
+		Assert.Equal(source.ChunkId, destination.ChunkId);
+	}
+}

--- a/src/EventStore.Core/EventStore.Core.csproj
+++ b/src/EventStore.Core/EventStore.Core.csproj
@@ -27,9 +27,10 @@
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.452401" />
 		<PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="3.1.6" />
-		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 		<PackageReference Include="HostStat.NET" Version="1.0.2" />
 		<PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.0" />
+		<PackageReference Include="DotNext.IO" Version="5.1.0" />
+		<PackageReference Include="NETStandard.Library" Version="2.0.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\EventStore.Common.Utils\EventStore.Common.Utils.csproj" />

--- a/src/EventStore.Core/Index/PTable.cs
+++ b/src/EventStore.Core/Index/PTable.cs
@@ -290,7 +290,7 @@ namespace EventStore.Core.Index {
 				workItem = GetWorkItem();
 				stream = workItem.Stream;
 			} else {
-				stream = UnbufferedFileStream.Create(_filename, FileMode.Open, FileAccess.Read, FileShare.Read, false,
+				stream = UnbufferedFileStream.Create(_filename, FileMode.Open, FileAccess.Read, FileShare.Read,
 					4096, 4096, false, 4096);
 			}
 

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/PosMap.cs
@@ -1,7 +1,11 @@
+using System;
+using System.Diagnostics;
 using System.IO;
+using DotNext.Buffers;
+using DotNext.Buffers.Binary;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
-	public struct PosMap {
+	public struct PosMap : IBinaryFormattable<PosMap> {
 		public const int FullSize = sizeof(long) + sizeof(int);
 		public const int DeprecatedSize = sizeof(int) + sizeof(int);
 
@@ -13,25 +17,56 @@ namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
 			ActualPos = actualPos;
 		}
 
+		// for new format only
+		public PosMap(ReadOnlySpan<byte> source){
+			Debug.Assert(source.Length >= FullSize);
+
+			SpanReader<byte> reader = new(source);
+			ActualPos = reader.ReadLittleEndian<int>();
+			LogPos = reader.ReadLittleEndian<long>();
+		}
+
+		static int IBinaryFormattable<PosMap>.Size => FullSize;
+
+		static PosMap IBinaryFormattable<PosMap>.Parse(ReadOnlySpan<byte> source)
+			=> FromNewFormat(source);
+
+		public static PosMap FromNewFormat(ReadOnlySpan<byte> source)
+			=> new(source);
+
 		public static PosMap FromNewFormat(BinaryReader reader) {
 			var actualPos = reader.ReadInt32();
 			var logPos = reader.ReadInt64();
 			return new PosMap(logPos, actualPos);
 		}
 
-		public static PosMap FromOldFormat(BinaryReader reader) {
-			var posmap = reader.ReadUInt64();
-			var logPos = (int)(posmap >> 32);
+		public static PosMap FromOldFormat(ReadOnlySpan<byte> source) {
+			SpanReader<byte> reader = new(source);
+			var posmap = reader.ReadLittleEndian<ulong>();
+			var logPos = (int)(posmap >>> 32);
 			var actualPos = (int)(posmap & 0xFFFFFFFF);
-			return new PosMap(logPos, actualPos);
+			return new(logPos, actualPos);
 		}
 
-		public void Write(BinaryWriter writer) {
-			writer.Write(ActualPos);
-			writer.Write(LogPos);
+		public static PosMap FromOldFormat(BinaryReader reader) {
+			Span<byte> buffer = stackalloc byte[DeprecatedSize];
+			var bytesRead = reader.Read(buffer);
+			return FromOldFormat(buffer.Slice(0, bytesRead));
 		}
 
-		public override string ToString() {
+		public readonly void Write(BinaryWriter writer) {
+			Span<byte> buffer = stackalloc byte[FullSize];
+			Format(buffer);
+			writer.Write(buffer);
+		}
+
+		public readonly void Format(Span<byte> destination){
+			SpanWriter<byte> writer = new(destination);
+			writer.WriteLittleEndian(ActualPos);
+			writer.WriteLittleEndian(LogPos);
+		}
+
+		public readonly override string ToString() {
 			return string.Format("LogPos: {0}, ActualPos: {1}", LogPos, ActualPos);
 		}
 	}

--- a/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
+++ b/src/EventStore.Core/TransactionLog/Chunks/TFChunk/ReaderWorkItem.cs
@@ -1,15 +1,23 @@
 using System.IO;
+using DotNext.IO;
+using Microsoft.Win32.SafeHandles;
 
 namespace EventStore.Core.TransactionLog.Chunks.TFChunk {
-	internal class ReaderWorkItem {
+	internal sealed class ReaderWorkItem {
+		public const int BufferSize = 8192;
 		public readonly Stream Stream;
 		public readonly BinaryReader Reader;
-		public readonly bool IsMemory;
 
-		public ReaderWorkItem(Stream stream, BinaryReader reader, bool isMemory) {
-			Stream = stream;
-			Reader = reader;
-			IsMemory = isMemory;
+		public unsafe ReaderWorkItem(nint memoryPtr, int length) {
+			Stream = new UnmanagedMemoryStream((byte*)memoryPtr, length, length, FileAccess.Read);
+			Reader = new(Stream);
 		}
+
+		public ReaderWorkItem(SafeFileHandle handle) {
+			Stream = new BufferedStream(handle.AsUnbufferedStream(FileAccess.Read), BufferSize);
+			Reader = new(Stream);
+		}
+
+		public bool IsMemory => Stream is UnmanagedMemoryStream;
 	}
 }

--- a/src/EventStore.Core/TransactionLog/Unbuffered/UnbufferedFileStream.cs
+++ b/src/EventStore.Core/TransactionLog/Unbuffered/UnbufferedFileStream.cs
@@ -56,7 +56,6 @@ namespace EventStore.Core.TransactionLog.Unbuffered {
 			FileMode mode,
 			FileAccess acc,
 			FileShare share,
-			bool sequential,
 			int internalWriteBufferSize,
 			int internalReadBufferSize,
 			bool writeThrough,


### PR DESCRIPTION
Changed: Reduced FileHandle usage by 80%. Now 1 per chunk instead of 5+

This PR suggests RandomAccess I/O for TFChunk with the following significant optimization: use only one file handle per chunk regardless a number of readers
Fixed DB-272