### PR TITLE
Add the elections counter metric

### DIFF
--- a/src/EventStore.ClusterNode/metricsconfig.json
+++ b/src/EventStore.ClusterNode/metricsconfig.json
@@ -12,6 +12,8 @@
 		"Scavenge": true
 	},
 
+	"ElectionsCount": true,
+
 	"Checkpoints": {
 		"Writer": true,
 		"Index": true,

--- a/src/EventStore.Common/Configuration/MetricsConfiguration.cs
+++ b/src/EventStore.Common/Configuration/MetricsConfiguration.cs
@@ -137,7 +137,9 @@ namespace EventStore.Common.Configuration {
 		public Dictionary<EventTracker, bool> Events { get; set; } = new();
 
 		public Dictionary<Cache, bool> CacheHitsMisses { get; set; } = new();
-		
+
+		public bool ElectionsCount { get; set; } = false;
+
 		public bool CacheResources { get; set; } = false;
 
 		// must be 0, 1, 5, 10 or a multiple of 15

--- a/src/EventStore.Core.XUnit.Tests/Metrics/ElectionsCounterTrackerTests.cs
+++ b/src/EventStore.Core.XUnit.Tests/Metrics/ElectionsCounterTrackerTests.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Net;
+using System.Runtime.CompilerServices;
+using EventStore.Core.Data;
+using EventStore.Core.Messages;
+using EventStore.Core.Metrics;
+using EventStore.Core.Tests;
+using Xunit;
+
+namespace EventStore.Core.XUnit.Tests.Metrics;
+
+public class ElectionsCounterTrackerTests : IDisposable {
+	private readonly Disposables _disposables = new();
+	private readonly ElectionMessage.ElectionsDone _electionsDoneMessage;
+
+	public ElectionsCounterTrackerTests() {
+		var endPoint = new DnsEndPoint("127.0.0.1", 1113);
+		var memberInfo = Cluster.MemberInfo.Initial(Guid.Empty, DateTime.UtcNow,
+			VNodeState.Unknown, true,
+			endPoint, endPoint, endPoint, endPoint, endPoint,
+			null, 0, 0, 0, false);
+		_electionsDoneMessage = new ElectionMessage.ElectionsDone(1, 1, memberInfo);
+	}
+
+	public void Dispose() {
+		_disposables?.Dispose();
+	}
+
+	private (ElectionsCounterTracker, TestMeterListener<long>) GenSut(
+		[CallerMemberName] string callerName = "") {
+
+		var meter = new Meter($"{typeof(ElectionsCounterTrackerTests)}--{callerName}").DisposeWith(_disposables);
+		var listener = new TestMeterListener<long>(meter).DisposeWith(_disposables);
+		var metric = new CounterMetric(meter, "test-metric", unit: "");
+		var sut = new ElectionsCounterTracker(new CounterSubMetric(metric, []));
+
+		return (sut, listener);
+	}
+
+	[Fact]
+	public void test_election_count_for_one_election() {
+		var (sut, listener) = GenSut();
+		sut.Handle(_electionsDoneMessage);
+
+		AssertMeasurements(listener, AssertMeasurement(1));
+	}
+
+	[Fact]
+	public void test_election_count_for_five_elections() {
+		var (sut, listener) = GenSut();
+		sut.Handle(_electionsDoneMessage);
+		sut.Handle(_electionsDoneMessage);
+		sut.Handle(_electionsDoneMessage);
+		sut.Handle(_electionsDoneMessage);
+		sut.Handle(_electionsDoneMessage);
+
+		AssertMeasurements(listener, AssertMeasurement(5));
+	}
+
+	static Action<TestMeterListener<long>.TestMeasurement> AssertMeasurement(
+		int expectedValue) =>
+		actualMeasurement => {
+			Assert.Equal(expectedValue, actualMeasurement.Value);
+		};
+
+	static void AssertMeasurements(
+		TestMeterListener<long> listener,
+		params Action<TestMeterListener<long>.TestMeasurement>[] actions) {
+
+		listener.Observe();
+		Assert.Collection(listener.RetrieveMeasurements("test-metric"), actions);
+	}
+}

--- a/src/EventStore.Core/ClusterVNode.cs
+++ b/src/EventStore.Core/ClusterVNode.cs
@@ -1465,6 +1465,9 @@ namespace EventStore.Core {
 				GossipAdvertiseInfo.AdvertiseTcpPortToClientAs,
 				options.Cluster.NodePriority, options.Cluster.ReadOnlyReplica, VersionInfo.Version);
 
+			// ELECTIONS TRACKER
+			_mainBus.Subscribe<ElectionMessage.ElectionsDone>(trackers.ElectionCounterTracker);
+
 			// TELEMETRY
 			var telemetryService = new TelemetryService(
 				Db.Manager,

--- a/src/EventStore.Core/Metrics/CounterMetric.cs
+++ b/src/EventStore.Core/Metrics/CounterMetric.cs
@@ -7,9 +7,13 @@ namespace EventStore.Core.Metrics {
 		private readonly object _lock = new();
 
 		public CounterMetric(Meter meter, string name, string unit) {
-			meter.CreateObservableCounter(name + "-" + unit, Observe);
+			if (!string.IsNullOrWhiteSpace(unit)) {
+				name = name + "-" + unit;
+			}
+
+			meter.CreateObservableCounter(name, Observe);
 		}
-		
+
 		public void Add(CounterSubMetric subMetric) {
 			lock (_lock) {
 				_subMetrics.Add(subMetric);

--- a/src/EventStore.Core/Metrics/ElectionsCounterTracker.cs
+++ b/src/EventStore.Core/Metrics/ElectionsCounterTracker.cs
@@ -1,0 +1,25 @@
+﻿using EventStore.Core.Bus;
+using EventStore.Core.Messages;
+
+
+namespace EventStore.Core.Metrics;
+
+public interface IElectionCounterTracker : IHandle<ElectionMessage.ElectionsDone> {
+}
+
+public class ElectionsCounterTracker : IElectionCounterTracker {
+	private readonly CounterSubMetric _electionsCounter;
+
+	public ElectionsCounterTracker(CounterSubMetric electionsCounter) {
+		_electionsCounter = electionsCounter;
+	}
+
+	public void Handle(ElectionMessage.ElectionsDone message) {
+		_electionsCounter.Add(1);
+	}
+
+	public class NoOp : IElectionCounterTracker {
+		public void Handle(ElectionMessage.ElectionsDone message) {
+		}
+	}
+}

--- a/src/EventStore.Core/MetricsBootstrapper.cs
+++ b/src/EventStore.Core/MetricsBootstrapper.cs
@@ -31,6 +31,7 @@ public class Trackers {
 	public IDurationMaxTracker WriterFlushDurationTracker { get; set; } = new DurationMaxTracker.NoOp();
 	public ICacheHitsMissesTracker CacheHitsMissesTracker { get; set; } = new CacheHitsMissesTracker.NoOp();
 	public ICacheResourcesTracker CacheResourcesTracker { get; set; } = new CacheResourcesTracker.NoOp();
+	public IElectionCounterTracker ElectionCounterTracker { get; set; } = new ElectionsCounterTracker.NoOp();
 }
 
 public class GrpcTrackers {
@@ -84,6 +85,7 @@ public static class MetricsBootstrapper {
 		var queueBusyMetric = new AverageMetric(coreMeter, "eventstore-queue-busy", "seconds", label => new("queue", label));
 		var byteMetric = new CounterMetric(coreMeter, "eventstore-io", unit: "bytes");
 		var eventMetric = new CounterMetric(coreMeter, "eventstore-io", unit: "events");
+		var electionsCounterMetric = new CounterMetric(coreMeter, "eventstore-elections-count", unit: "");
 
 		// incoming grpc calls
 		var enabledCalls = conf.IncomingGrpcCalls.Where(kvp => kvp.Value).Select(kvp => kvp.Key).ToArray();
@@ -109,6 +111,11 @@ public static class MetricsBootstrapper {
 		if (conf.CacheResources) {
 			var metrics = new CacheResourcesMetrics(coreMeter, "eventstore-cache-resources");
 			trackers.CacheResourcesTracker = new CacheResourcesTracker(metrics);
+		}
+
+		// elections count
+		if (conf.ElectionsCount) {
+			trackers.ElectionCounterTracker = new ElectionsCounterTracker(new CounterSubMetric(electionsCounterMetric, []));
 		}
 
 		// events


### PR DESCRIPTION
Added: Add the elections counter metric so users can set alerts if the number of elections over a certain period of time exceeds some number.

Fixes https://linear.app/eventstore/issue/DB-599/add-the-elections-counter-to-metrics